### PR TITLE
fix: revert dependency bumps for Flutter 3.38.4 compatibility

### DIFF
--- a/packages/soliplex_agent/pubspec.yaml
+++ b/packages/soliplex_agent/pubspec.yaml
@@ -22,5 +22,5 @@ dependencies:
 
 dev_dependencies:
   mocktail: ^1.0.0
-  test: ^1.30.0
-  very_good_analysis: ^10.2.0
+  test: ^1.24.0
+  very_good_analysis: ^10.0.0

--- a/packages/soliplex_client/pubspec.yaml
+++ b/packages/soliplex_client/pubspec.yaml
@@ -20,5 +20,5 @@ dependencies:
 
 dev_dependencies:
   mocktail: ^1.0.0
-  test: ^1.30.0
-  very_good_analysis: ^10.2.0
+  test: ^1.24.0
+  very_good_analysis: ^10.0.0

--- a/packages/soliplex_client_native/pubspec.yaml
+++ b/packages/soliplex_client_native/pubspec.yaml
@@ -21,4 +21,4 @@ dev_dependencies:
   flutter_test:
     sdk: flutter
   mocktail: ^1.0.0
-  very_good_analysis: ^10.2.0
+  very_good_analysis: ^10.0.0

--- a/packages/soliplex_logging/pubspec.yaml
+++ b/packages/soliplex_logging/pubspec.yaml
@@ -12,5 +12,5 @@ dependencies:
   meta: ^1.9.0
 
 dev_dependencies:
-  test: ^1.30.0
-  very_good_analysis: ^10.2.0
+  test: ^1.24.0
+  very_good_analysis: ^10.0.0

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -70,10 +70,10 @@ packages:
     dependency: transitive
     description:
       name: characters
-      sha256: faf38497bda5ead2a8c7615f4f7939df04333478bf32e4173fcb06d428b5716b
+      sha256: f71061c654a3380576a52b451dd5532377954cf9dbd272a78fc8479606670803
       url: "https://pub.dev"
     source: hosted
-    version: "1.4.1"
+    version: "1.4.0"
   checked_yaml:
     dependency: transitive
     description:
@@ -417,6 +417,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.0.5"
+  js:
+    dependency: transitive
+    description:
+      name: js
+      sha256: "53385261521cc4a0c4658fd0ad07a7d14591cf8fc33abbceae306ddb974888dc"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.7.2"
   json_annotation:
     dependency: transitive
     description:
@@ -477,18 +485,18 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: dc0b7dc7651697ea4ff3e69ef44b0407ea32c487a39fff6a4004fa585e901861
+      sha256: dc58c723c3c24bf8d3e2d3ad3f2f9d7bd9cf43ec6feaa64181775e60190153f2
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.19"
+    version: "0.12.17"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: "9c337007e82b1889149c82ed242ed1cb24a66044e30979c44912381e9be4c48b"
+      sha256: f7142bb1154231d7ea5f96bc7bde4bda2a0945d2806bb11670e30b850d56bdec
       url: "https://pub.dev"
     source: hosted
-    version: "0.13.0"
+    version: "0.11.1"
   meta:
     dependency: transitive
     description:
@@ -850,26 +858,26 @@ packages:
     dependency: transitive
     description:
       name: test
-      sha256: "280d6d890011ca966ad08df7e8a4ddfab0fb3aa49f96ed6de56e3521347a9ae7"
+      sha256: "75906bf273541b676716d1ca7627a17e4c4070a3a16272b7a3dc7da3b9f3f6b7"
       url: "https://pub.dev"
     source: hosted
-    version: "1.30.0"
+    version: "1.26.3"
   test_api:
     dependency: transitive
     description:
       name: test_api
-      sha256: "8161c84903fd860b26bfdefb7963b3f0b68fee7adea0f59ef805ecca346f0c7a"
+      sha256: ab2726c1a94d3176a45960b6234466ec367179b87dd74f1611adb1f3b5fb9d55
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.10"
+    version: "0.7.7"
   test_core:
     dependency: transitive
     description:
       name: test_core
-      sha256: "0381bd1585d1a924763c308100f2138205252fb90c9d4eeaf28489ee65ccde51"
+      sha256: "0cc24b5ff94b38d2ae73e1eb43cc302b77964fbf67abad1e296025b78deb53d0"
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.16"
+    version: "0.6.12"
   typed_data:
     dependency: transitive
     description:
@@ -986,10 +994,10 @@ packages:
     dependency: transitive
     description:
       name: very_good_analysis
-      sha256: d1cb1d66a5aae2c702d68caca6c8347306d35e728fd94555fa21fa0448a972e0
+      sha256: "27927d1140ce1b140f998b6340f730a626faa5b95110b3e34a238ff254d731d0"
       url: "https://pub.dev"
     source: hosted
-    version: "10.2.0"
+    version: "10.1.0"
   vm_service:
     dependency: transitive
     description:
@@ -1071,5 +1079,5 @@ packages:
     source: hosted
     version: "3.1.3"
 sdks:
-  dart: ">=3.11.0 <4.0.0"
+  dart: ">=3.10.3 <4.0.0"
   flutter: ">=3.38.4"


### PR DESCRIPTION
## Summary

- Reverts `very_good_analysis` from `^10.2.0` back to `^10.0.0` (4 packages)
- Reverts `test` from `^1.30.0` back to `^1.24.0` (3 packages)
- `very_good_analysis` 10.2.0 requires Dart `>=3.11.0`, incompatible with Flutter 3.38.4
- `test` 1.30.0 requires `test_api 0.7.10`, but Flutter 3.38.4 pins `test_api 0.7.7`

Companion change: revert soliplex/afsoc-rag@1518bc54 (Flutter 3.38.4 → 3.38.7 upgrade)

## Test plan

- [x] `flutter pub get` resolves successfully
- [x] `flutter analyze` — zero warnings
- [x] `flutter test` — all 656 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)