### PR TITLE
chore: re-enable document filtering

### DIFF
--- a/lib/src/flavors/standard.dart
+++ b/lib/src/flavors/standard.dart
@@ -150,7 +150,7 @@ Future<ShellConfig> standard({
         serverManager: serverManager,
         runtimeManager: runtimeManager,
         registry: registry,
-        enableDocumentFilter: false,
+        enableDocumentFilter: true,
       ),
       quizModule(serverManager: serverManager),
       authModule(


### PR DESCRIPTION
## Summary
- Re-enables the document filter UI by flipping `enableDocumentFilter` from `false` to `true` in the standard flavor
- Feature was gated in 5522ed1 while stabilizing; AG-UI state flow verified end-to-end
- Known future improvements tracked in #76

## Test plan
- [x] All 839 existing tests pass
- [x] Manual: open a room, verify filter button appears in chat input
- [x] Manual: select documents, send a message, verify filtered results
- [x] Manual: switch threads, verify selections persist per-thread

🤖 Generated with [Claude Code](https://claude.com/claude-code)