### PR TITLE
Local thread list mutations + menu-unmount fix

### DIFF
--- a/lib/src/modules/room/room_state.dart
+++ b/lib/src/modules/room/room_state.dart
@@ -126,10 +126,10 @@ class RoomState {
   /// Deletes a thread. Disposes the active view if it belongs to this
   /// thread. Navigates to the next available thread, or null if none.
   Future<void> deleteThread(String threadId) async {
-    // Pick the next thread BEFORE the mutation. threadList.deleteThread
-    // may flip the list into a transient Loading state (its non-Loaded
-    // fallback path calls _fetch()); reading after the await would miss
-    // the list we actually had and land the user on an empty screen.
+    // Pick the next thread from the list we can *see now*. Reading after
+    // the await risks seeing a list that a concurrent fetch has replaced
+    // (e.g., with ThreadsLoading). If we can't see a Loaded list now,
+    // there's no successor to pick and we'll navigate to null.
     final nextThreadId = _pickNextThreadId(excluding: threadId);
 
     await threadList.deleteThread(threadId);

--- a/lib/src/modules/room/room_state.dart
+++ b/lib/src/modules/room/room_state.dart
@@ -108,11 +108,11 @@ class RoomState {
   Future<String?> createThread() async {
     _lastError.value = null;
     try {
-      final (threadInfo, aguiState) =
-          await _connection.api.createThread(_roomId);
+      final result = await threadList.createThread();
+      if (result == null) return null; // disposed
+      final (threadInfo, aguiState) = result;
       if (_isDisposed) return threadInfo.id;
       runtime.seedThreadState(threadInfo.id, aguiState);
-      threadList.refresh();
       selectThread(threadInfo.id);
       onNavigateToThread?.call(threadInfo.id);
       return threadInfo.id;
@@ -142,13 +142,6 @@ class RoomState {
         onNavigateToThread?.call(null);
       }
     }
-
-    unawaited(threadList.refresh());
-  }
-
-  Future<void> renameThread(String threadId, String name) async {
-    await threadList.renameThread(threadId, name);
-    unawaited(threadList.refresh());
   }
 
   /// Implicit thread creation (send message with no thread selected).
@@ -190,7 +183,16 @@ class RoomState {
       final key = session.threadKey;
       _registry.register(key, session);
       if (_isDisposed) return;
-      threadList.refresh();
+      // Spawn only exposes a threadKey — no ThreadInfo. Insert a stub so
+      // the sidebar reflects the new thread immediately. The backend
+      // generates the thread's name lazily after the run finishes; the
+      // sidebar picks that up on the next natural refresh (room change,
+      // pull-to-refresh, re-entry).
+      threadList.noteSpawnedThread(ThreadInfo(
+        id: key.threadId,
+        roomId: _roomId,
+        createdAt: DateTime.now(),
+      ));
       selectThread(key.threadId);
       _activeThreadView!.attachSession(session);
       onNavigateToThread?.call(key.threadId);

--- a/lib/src/modules/room/room_state.dart
+++ b/lib/src/modules/room/room_state.dart
@@ -126,6 +126,12 @@ class RoomState {
   /// Deletes a thread. Disposes the active view if it belongs to this
   /// thread. Navigates to the next available thread, or null if none.
   Future<void> deleteThread(String threadId) async {
+    // Pick the next thread BEFORE the mutation. threadList.deleteThread
+    // may flip the list into a transient Loading state (its non-Loaded
+    // fallback path calls _fetch()); reading after the await would miss
+    // the list we actually had and land the user on an empty screen.
+    final nextThreadId = _pickNextThreadId(excluding: threadId);
+
     await threadList.deleteThread(threadId);
 
     if (_activeThreadView?.threadId == threadId) {
@@ -133,15 +139,18 @@ class RoomState {
       _activeThreadView?.dispose();
       _activeThreadView = null;
 
-      final current = threadList.threads.value;
-      if (current is ThreadsLoaded && current.threads.isNotEmpty) {
-        final nextId = current.threads.first.id;
-        selectThread(nextId);
-        onNavigateToThread?.call(nextId);
-      } else {
-        onNavigateToThread?.call(null);
-      }
+      if (nextThreadId != null) selectThread(nextThreadId);
+      onNavigateToThread?.call(nextThreadId);
     }
+  }
+
+  String? _pickNextThreadId({required String excluding}) {
+    final current = threadList.threads.value;
+    if (current is! ThreadsLoaded) return null;
+    for (final t in current.threads) {
+      if (t.id != excluding) return t.id;
+    }
+    return null;
   }
 
   /// Implicit thread creation (send message with no thread selected).

--- a/lib/src/modules/room/thread_list_state.dart
+++ b/lib/src/modules/room/thread_list_state.dart
@@ -100,7 +100,13 @@ class ThreadListState {
   }
 
   Future<void> renameThread(String threadId, String name) async {
-    assert(name.trim().isNotEmpty, 'caller must not submit an empty name');
+    // Defense-in-depth: the RenameDialog UI prevents empty submissions, but
+    // the backend accepts empty strings and would silently store a thread
+    // with name="". FormatException is caught by AsyncActionDialog and
+    // surfaced inline, unlike Error subclasses.
+    if (name.trim().isEmpty) {
+      throw const FormatException('Thread name must not be empty');
+    }
     if (_isDisposed) return;
 
     // The backend replaces all metadata on update, so we must re-send

--- a/lib/src/modules/room/thread_list_state.dart
+++ b/lib/src/modules/room/thread_list_state.dart
@@ -37,15 +37,69 @@ class ThreadListState {
 
   Future<void> refresh() => _fetch();
 
+  /// Cancels any in-flight fetch so its completion can't overwrite a local
+  /// mutation. Only safe to call when we're about to write authoritative
+  /// state derived from an existing [ThreadsLoaded] baseline — otherwise
+  /// we'd be cancelling work we have nothing to replace with.
+  void _cancelInFlightFetch() {
+    _cancelToken?.cancel('local mutation');
+    _cancelToken = null;
+  }
+
+  /// Creates a new thread on the backend and reflects it in the local list.
+  ///
+  /// Returns the server's [ThreadInfo] plus the initial AGUI state the
+  /// caller needs to seed into the agent runtime, or `null` if this state
+  /// was disposed before the call could complete.
+  Future<(ThreadInfo, Map<String, dynamic>)?> createThread() async {
+    if (_isDisposed) return null;
+    final result = await _connection.api.createThread(_roomId);
+    if (_isDisposed) return null;
+    _insertLocally(result.$1);
+    return result;
+  }
+
+  /// Reflects a thread that was created outside this class — specifically,
+  /// by the agent runtime during an implicit spawn (see
+  /// [RoomState.sendToNewThread]). Does **not** call the backend: the
+  /// thread already exists server-side by the time this runs.
+  void noteSpawnedThread(ThreadInfo thread) {
+    if (_isDisposed) return;
+    _insertLocally(thread);
+  }
+
+  void _insertLocally(ThreadInfo thread) {
+    final current = _threads.value;
+    if (current is ThreadsLoaded) {
+      _cancelInFlightFetch();
+      if (current.threads.any((t) => t.id == thread.id)) return;
+      final updated = [...current.threads, thread]
+        ..sort((a, b) => b.createdAt.compareTo(a.createdAt));
+      _threads.value = ThreadsLoaded(updated);
+      return;
+    }
+    // No loaded baseline to merge into. The thread already exists
+    // server-side, so a fresh fetch will include it. Don't clobber an
+    // in-flight fetch with a single-element list — that would lose any
+    // threads the fetch is about to return.
+    unawaited(_fetch());
+  }
+
   Future<void> deleteThread(String threadId) async {
     if (_isDisposed) return;
+    // Unlike [renameThread], delete has no Loaded-state precondition:
+    // removing by id doesn't need access to existing metadata.
     await _connection.api.deleteThread(_roomId, threadId);
-
+    if (_isDisposed) return;
     final latest = _threads.value;
     if (latest is ThreadsLoaded) {
+      _cancelInFlightFetch();
       final updated = latest.threads.where((t) => t.id != threadId).toList();
       _threads.value = ThreadsLoaded(updated);
+      return;
     }
+    // Same reasoning as [_insertLocally]: no baseline to merge into; re-fetch.
+    unawaited(_fetch());
   }
 
   Future<void> renameThread(String threadId, String name) async {
@@ -79,15 +133,19 @@ class ThreadListState {
       name: name,
       description: description,
     );
+    if (_isDisposed) return;
 
-    final latest = _threads.value;
-    if (latest is ThreadsLoaded) {
-      final updated = latest.threads.map((t) {
-        if (t.id == threadId) return t.copyWith(name: name);
-        return t;
-      }).toList();
-      _threads.value = ThreadsLoaded(updated);
-    }
+    // Invariant: state was Loaded when we started, and Loaded → non-Loaded
+    // transitions don't happen during awaits — _fetch preserves Loaded on
+    // both success and failure. The cast throws if a future change breaks
+    // that invariant, surfacing the bug instead of masking it.
+    final latest = _threads.value as ThreadsLoaded;
+    _cancelInFlightFetch();
+    final updated = latest.threads.map((t) {
+      if (t.id == threadId) return t.copyWith(name: name);
+      return t;
+    }).toList();
+    _threads.value = ThreadsLoaded(updated);
   }
 
   Future<void> _fetch() async {

--- a/lib/src/modules/room/thread_list_state.dart
+++ b/lib/src/modules/room/thread_list_state.dart
@@ -79,16 +79,13 @@ class ThreadListState {
       return;
     }
     // No loaded baseline to merge into. The thread already exists
-    // server-side, so a fresh fetch will include it. Don't clobber an
-    // in-flight fetch with a single-element list — that would lose any
-    // threads the fetch is about to return.
+    // server-side; let a fresh fetch populate the full list rather than
+    // synthesizing a single-element ThreadsLoaded here.
     unawaited(_fetch());
   }
 
   Future<void> deleteThread(String threadId) async {
     if (_isDisposed) return;
-    // Unlike [renameThread], delete has no Loaded-state precondition:
-    // removing by id doesn't need access to existing metadata.
     await _connection.api.deleteThread(_roomId, threadId);
     if (_isDisposed) return;
     final latest = _threads.value;
@@ -135,17 +132,20 @@ class ThreadListState {
     );
     if (_isDisposed) return;
 
-    // Invariant: state was Loaded when we started, and Loaded → non-Loaded
-    // transitions don't happen during awaits — _fetch preserves Loaded on
-    // both success and failure. The cast throws if a future change breaks
-    // that invariant, surfacing the bug instead of masking it.
-    final latest = _threads.value as ThreadsLoaded;
-    _cancelInFlightFetch();
-    final updated = latest.threads.map((t) {
-      if (t.id == threadId) return t.copyWith(name: name);
-      return t;
-    }).toList();
-    _threads.value = ThreadsLoaded(updated);
+    final latest = _threads.value;
+    if (latest is ThreadsLoaded) {
+      _cancelInFlightFetch();
+      final updated = latest.threads.map((t) {
+        if (t.id == threadId) return t.copyWith(name: name);
+        return t;
+      }).toList();
+      _threads.value = ThreadsLoaded(updated);
+      return;
+    }
+    // State transitioned to non-Loaded during the await (no current code
+    // path does this, but it's cheap to handle). Server already has the
+    // new name; a fresh fetch reconciles.
+    unawaited(_fetch());
   }
 
   Future<void> _fetch() async {

--- a/lib/src/modules/room/thread_list_state.dart
+++ b/lib/src/modules/room/thread_list_state.dart
@@ -100,9 +100,7 @@ class ThreadListState {
   }
 
   Future<void> renameThread(String threadId, String name) async {
-    if (name.trim().isEmpty) {
-      throw ArgumentError.value(name, 'name', 'must not be empty');
-    }
+    assert(name.trim().isNotEmpty, 'caller must not submit an empty name');
     if (_isDisposed) return;
 
     // The backend replaces all metadata on update, so we must re-send

--- a/lib/src/modules/room/ui/room_screen.dart
+++ b/lib/src/modules/room/ui/room_screen.dart
@@ -146,7 +146,6 @@ class _RoomScreenState extends State<RoomScreen> {
         _autoSelectFirstThread();
       }
     } else if (widget.threadId != oldWidget.threadId) {
-      unawaited(_state.threadList.refresh());
       if (widget.threadId != null) {
         _cancelAutoSelect();
         _chatController.clear();
@@ -286,7 +285,7 @@ class _RoomScreenState extends State<RoomScreen> {
       context: context,
       builder: (_) => RenameDialog(
         initialName: currentName,
-        onAction: (name) => _state.renameThread(threadId, name),
+        onAction: (name) => _state.threadList.renameThread(threadId, name),
       ),
     );
   }

--- a/lib/src/modules/room/ui/thread_tile.dart
+++ b/lib/src/modules/room/ui/thread_tile.dart
@@ -27,6 +27,7 @@ class ThreadTile extends StatefulWidget {
 
 class _ThreadTileState extends State<ThreadTile> {
   bool _isHovered = false;
+  bool _isMenuOpen = false;
 
   static bool get _isDesktop => switch (defaultTargetPlatform) {
         TargetPlatform.macOS ||
@@ -39,7 +40,8 @@ class _ThreadTileState extends State<ThreadTile> {
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
-    final showMenu = widget.isSelected || _isHovered || !_isDesktop;
+    final showMenu =
+        widget.isSelected || _isHovered || _isMenuOpen || !_isDesktop;
 
     return MouseRegion(
       onEnter: (_) => setState(() => _isHovered = true),
@@ -73,7 +75,14 @@ class _ThreadTileState extends State<ThreadTile> {
       tooltip: 'Thread options',
       padding: EdgeInsets.zero,
       constraints: const BoxConstraints(),
+      // Keep the menu button "shown" while the popup overlay is open, so
+      // the button isn't unmounted when the pointer leaves the tile. Without
+      // this, PopupMenuButton.showButtonMenu's `if (!mounted) return null`
+      // silently drops onSelected for non-selected threads on desktop.
+      onOpened: () => setState(() => _isMenuOpen = true),
+      onCanceled: () => setState(() => _isMenuOpen = false),
       onSelected: (action) {
+        setState(() => _isMenuOpen = false);
         switch (action) {
           case _ThreadAction.rename:
             widget.onRename();

--- a/lib/src/modules/room/ui/thread_tile.dart
+++ b/lib/src/modules/room/ui/thread_tile.dart
@@ -50,7 +50,7 @@ class _ThreadTileState extends State<ThreadTile> {
         selected: widget.isSelected,
         selectedTileColor: theme.colorScheme.primaryContainer,
         title: Text(
-          widget.thread.hasName ? widget.thread.name : 'Untitled',
+          widget.thread.hasName ? widget.thread.name : 'New Thread',
           maxLines: 1,
           overflow: TextOverflow.ellipsis,
         ),

--- a/lib/src/modules/room/ui/thread_tile.dart
+++ b/lib/src/modules/room/ui/thread_tile.dart
@@ -76,9 +76,10 @@ class _ThreadTileState extends State<ThreadTile> {
       padding: EdgeInsets.zero,
       constraints: const BoxConstraints(),
       // Keep the menu button "shown" while the popup overlay is open, so
-      // the button isn't unmounted when the pointer leaves the tile. Without
-      // this, PopupMenuButton.showButtonMenu's `if (!mounted) return null`
-      // silently drops onSelected for non-selected threads on desktop.
+      // the button isn't unmounted when the pointer leaves the tile. If the
+      // button unmounts while the popup is open, the showMenu future's
+      // completion callback short-circuits on `!mounted` and silently drops
+      // onSelected for non-selected threads on desktop.
       onOpened: () => setState(() => _isMenuOpen = true),
       onCanceled: () => setState(() => _isMenuOpen = false),
       onSelected: (action) {

--- a/test/modules/room/room_state_test.dart
+++ b/test/modules/room/room_state_test.dart
@@ -4,6 +4,7 @@ import 'package:soliplex_agent/soliplex_agent.dart';
 import 'package:soliplex_frontend/src/modules/room/agent_runtime_manager.dart';
 import 'package:soliplex_frontend/src/modules/room/room_state.dart';
 import 'package:soliplex_frontend/src/modules/room/run_registry.dart';
+import 'package:soliplex_frontend/src/modules/room/thread_list_state.dart';
 
 import '../../helpers/fakes.dart';
 
@@ -122,6 +123,38 @@ void main() {
     state.dispose();
   });
 
+  test('sendToNewThread adds thread to list locally', () async {
+    final createdThread = ThreadInfo(
+      id: 'spawned-thread',
+      roomId: 'room-1',
+      name: '',
+      createdAt: DateTime(2026, 3, 25),
+    );
+    api.nextRoom = Room(id: 'room-1', name: 'Test');
+    api.nextCreateThread = (createdThread, <String, dynamic>{});
+    api.nextThreads = [];
+    api.nextThreadHistory = ThreadHistory(messages: const []);
+
+    final state = RoomState(
+      connection: connection,
+      roomId: 'room-1',
+      runtimeManager: runtimeManager,
+      registry: registry,
+    );
+
+    await Future<void>.delayed(Duration.zero);
+
+    await state.sendToNewThread('Hello');
+    for (var i = 0; i < 10; i++) {
+      await Future<void>.delayed(Duration.zero);
+    }
+
+    final loaded = state.threadList.threads.value as ThreadsLoaded;
+    expect(loaded.threads.any((t) => t.id == 'spawned-thread'), isTrue);
+
+    state.dispose();
+  });
+
   test('sessionState is spawning during sendToNewThread', () async {
     api.nextRoom = Room(id: 'room-1', name: 'Test');
     api.nextThreads = [];
@@ -175,7 +208,7 @@ void main() {
     expect(state.lastError.value, isNull);
   });
 
-  test('createThread calls API, refreshes list, and selects thread', () async {
+  test('createThread adds thread to list locally and selects it', () async {
     final createdThread = ThreadInfo(
       id: 'new-thread',
       roomId: 'room-1',
@@ -198,14 +231,12 @@ void main() {
 
     await Future<void>.delayed(Duration.zero);
 
-    // After create, set list to return the new thread
-    api.nextThreads = [createdThread];
-
     final threadId = await state.createThread();
     expect(threadId, 'new-thread');
 
-    // Wait for thread list refresh
-    await Future<void>.delayed(Duration.zero);
+    // Thread should appear in the local list without a server refresh.
+    final loaded = state.threadList.threads.value as ThreadsLoaded;
+    expect(loaded.threads.any((t) => t.id == 'new-thread'), isTrue);
 
     expect(state.activeThreadView, isNotNull);
     expect(state.activeThreadView!.threadId, 'new-thread');
@@ -306,8 +337,6 @@ void main() {
       state.selectThread('thread-1');
       expect(state.activeThreadView!.threadId, 'thread-1');
 
-      // After delete, list returns only thread-2.
-      api.nextThreads = [threads[1]];
       await state.deleteThread('thread-1');
 
       expect(state.activeThreadView!.threadId, 'thread-2');
@@ -422,64 +451,6 @@ void main() {
       // thread-1 should still be selected, no navigation fired.
       expect(state.activeThreadView!.threadId, 'thread-1');
       expect(navigatedId, 'sentinel');
-
-      state.dispose();
-    });
-  });
-
-  group('renameThread', () {
-    test('delegates to threadList', () async {
-      final threads = [
-        ThreadInfo(
-          id: 'thread-1',
-          roomId: 'room-1',
-          name: 'Old Name',
-          createdAt: DateTime(2026, 3, 1),
-        ),
-      ];
-      api.nextRoom = Room(id: 'room-1', name: 'Test');
-      api.nextThreads = threads;
-
-      final state = RoomState(
-        connection: connection,
-        roomId: 'room-1',
-        runtimeManager: runtimeManager,
-        registry: registry,
-      );
-      await Future<void>.delayed(Duration.zero);
-
-      await state.renameThread('thread-1', 'New Name');
-
-      expect(api.updateMetadataCallCount, 1);
-      expect(api.lastUpdatedName, 'New Name');
-
-      state.dispose();
-    });
-
-    test('propagates API error', () async {
-      api.nextRoom = Room(id: 'room-1', name: 'Test');
-      api.nextThreads = [
-        ThreadInfo(
-          id: 'thread-1',
-          roomId: 'room-1',
-          name: 'Test',
-          createdAt: DateTime(2026, 3, 1),
-        ),
-      ];
-
-      final state = RoomState(
-        connection: connection,
-        roomId: 'room-1',
-        runtimeManager: runtimeManager,
-        registry: registry,
-      );
-      await Future<void>.delayed(Duration.zero);
-
-      api.nextUpdateMetadataError = Exception('server error');
-      expect(
-        () => state.renameThread('thread-1', 'New'),
-        throwsA(isA<Exception>()),
-      );
 
       state.dispose();
     });

--- a/test/modules/room/room_state_test.dart
+++ b/test/modules/room/room_state_test.dart
@@ -378,6 +378,34 @@ void main() {
       state.dispose();
     });
 
+    test('navigates to null when thread list is not Loaded', () async {
+      // Initial thread-list fetch fails so ThreadListState is in
+      // ThreadsFailed, not ThreadsLoaded.
+      api.nextRoom = Room(id: 'room-1', name: 'Test');
+      api.nextThreadsError = Exception('list fetch failed');
+      api.nextThreadHistory = ThreadHistory(messages: const []);
+
+      String? navigatedId = 'not-called';
+      final state = RoomState(
+        connection: connection,
+        roomId: 'room-1',
+        runtimeManager: runtimeManager,
+        registry: registry,
+        onNavigateToThread: (id) => navigatedId = id,
+      );
+      await Future<void>.delayed(Duration.zero);
+
+      state.selectThread('thread-1');
+      // Allow the subsequent delete API call to succeed.
+      api.nextThreadsError = null;
+      await state.deleteThread('thread-1');
+
+      expect(state.activeThreadView, isNull);
+      expect(navigatedId, isNull);
+
+      state.dispose();
+    });
+
     test('preserves active view on API error', () async {
       final threads = [
         ThreadInfo(

--- a/test/modules/room/thread_list_state_test.dart
+++ b/test/modules/room/thread_list_state_test.dart
@@ -366,6 +366,129 @@ void main() {
     expect(api.deleteThreadCallCount, 0);
   });
 
+  test('deleteThread disposed during await does not mutate list', () async {
+    final thread = ThreadInfo(
+      id: 'thread-1',
+      roomId: 'room-1',
+      name: 'Test',
+      createdAt: DateTime(2026, 1, 1),
+    );
+    api.nextThreads = [thread];
+
+    final state = ThreadListState(
+      connection: connection,
+      roomId: 'room-1',
+    );
+    await Future<void>.delayed(Duration.zero);
+
+    // Start delete, synchronously dispose before the API future resolves.
+    final pending = state.deleteThread('thread-1');
+    state.dispose();
+    await pending;
+
+    // API was called, but local list must not have been updated.
+    expect(api.deleteThreadCallCount, 1);
+    final loaded = state.threads.value as ThreadsLoaded;
+    expect(loaded.threads.single.id, 'thread-1');
+  });
+
+  test('renameThread disposed during await does not mutate list', () async {
+    final thread = ThreadInfo(
+      id: 'thread-1',
+      roomId: 'room-1',
+      name: 'Old Name',
+      createdAt: DateTime(2026, 1, 1),
+    );
+    api.nextThreads = [thread];
+
+    final state = ThreadListState(
+      connection: connection,
+      roomId: 'room-1',
+    );
+    await Future<void>.delayed(Duration.zero);
+
+    final pending = state.renameThread('thread-1', 'New Name');
+    state.dispose();
+    await pending;
+
+    expect(api.updateMetadataCallCount, 1);
+    final loaded = state.threads.value as ThreadsLoaded;
+    expect(loaded.threads.single.name, 'Old Name');
+  });
+
+  group('createThread', () {
+    test('returns server result and inserts thread into loaded list', () async {
+      api.nextThreads = [];
+      final state = ThreadListState(
+        connection: connection,
+        roomId: 'room-1',
+      );
+      await Future<void>.delayed(Duration.zero);
+
+      final created = ThreadInfo(
+        id: 'thread-new',
+        roomId: 'room-1',
+        name: 'Fresh',
+        createdAt: DateTime(2026, 3, 1),
+      );
+      final initialAguiState = {'messages': <dynamic>[]};
+      api.nextCreateThread = (created, initialAguiState);
+
+      final result = await state.createThread();
+
+      expect(result, isNotNull);
+      expect(result!.$1.id, 'thread-new');
+      expect(result.$2, same(initialAguiState));
+      final loaded = state.threads.value as ThreadsLoaded;
+      expect(loaded.threads.single.id, 'thread-new');
+
+      state.dispose();
+    });
+
+    test('disposed before call returns null without hitting API', () async {
+      api.nextThreads = [];
+      final state = ThreadListState(
+        connection: connection,
+        roomId: 'room-1',
+      );
+      await Future<void>.delayed(Duration.zero);
+
+      state.dispose();
+      final result = await state.createThread();
+
+      expect(result, isNull);
+      // nextCreateThread was never set; if the API had been called it would
+      // have thrown StateError.
+    });
+
+    test('disposed during await returns null without mutating list', () async {
+      api.nextThreads = [];
+      final state = ThreadListState(
+        connection: connection,
+        roomId: 'room-1',
+      );
+      await Future<void>.delayed(Duration.zero);
+
+      api.nextCreateThread = (
+        ThreadInfo(
+          id: 'thread-new',
+          roomId: 'room-1',
+          name: 'Fresh',
+          createdAt: DateTime(2026, 3, 1),
+        ),
+        <String, dynamic>{},
+      );
+
+      final pending = state.createThread();
+      state.dispose();
+      final result = await pending;
+
+      expect(result, isNull);
+      final loaded = state.threads.value as ThreadsLoaded;
+      expect(loaded.threads, isEmpty);
+    });
+  });
+
   test(
       'deleteThread from non-loaded state calls the API and schedules a '
       'fresh fetch to reconcile', () async {

--- a/test/modules/room/thread_list_state_test.dart
+++ b/test/modules/room/thread_list_state_test.dart
@@ -194,56 +194,6 @@ void main() {
     state.dispose();
   });
 
-  test('renameThread rejects empty name', () async {
-    api.nextThreads = [
-      ThreadInfo(
-        id: 'thread-1',
-        roomId: 'room-1',
-        name: 'Test',
-        createdAt: DateTime(2026, 3, 1),
-      ),
-    ];
-
-    final state = ThreadListState(
-      connection: connection,
-      roomId: 'room-1',
-    );
-    await Future<void>.delayed(Duration.zero);
-
-    expect(
-      () => state.renameThread('thread-1', ''),
-      throwsA(isA<ArgumentError>()),
-    );
-    expect(api.updateMetadataCallCount, 0);
-
-    state.dispose();
-  });
-
-  test('renameThread rejects whitespace-only name', () async {
-    api.nextThreads = [
-      ThreadInfo(
-        id: 'thread-1',
-        roomId: 'room-1',
-        name: 'Test',
-        createdAt: DateTime(2026, 3, 1),
-      ),
-    ];
-
-    final state = ThreadListState(
-      connection: connection,
-      roomId: 'room-1',
-    );
-    await Future<void>.delayed(Duration.zero);
-
-    expect(
-      () => state.renameThread('thread-1', '   '),
-      throwsA(isA<ArgumentError>()),
-    );
-    expect(api.updateMetadataCallCount, 0);
-
-    state.dispose();
-  });
-
   test('renameThread throws StateError when threads not loaded', () async {
     api.nextThreadsError = Exception('network error');
 

--- a/test/modules/room/thread_list_state_test.dart
+++ b/test/modules/room/thread_list_state_test.dart
@@ -367,9 +367,9 @@ void main() {
   });
 
   test(
-      'deleteThread when threads still loading calls API but skips local update',
-      () async {
-    // Never resolve the initial fetch — threads stay in loading state.
+      'deleteThread from non-loaded state calls the API and schedules a '
+      'fresh fetch to reconcile', () async {
+    // Initial fetch fails: state ends up in ThreadsFailed.
     api.nextThreadsError = Exception('slow network');
 
     final state = ThreadListState(
@@ -379,15 +379,149 @@ void main() {
     await Future<void>.delayed(Duration.zero);
     expect(state.threads.value, isA<ThreadsFailed>());
 
-    // Clear the error so deleteThread itself succeeds.
+    // Clear the error and seed the next fetch with the post-delete
+    // server state.
     api.nextThreadsError = null;
+    api.nextThreads = [
+      ThreadInfo(
+        id: 'thread-other',
+        roomId: 'room-1',
+        name: 'Other',
+        createdAt: DateTime(2026, 2, 1),
+      ),
+    ];
+
     await state.deleteThread('thread-1');
+    // deleteThread scheduled a fresh fetch; let it resolve.
+    await Future<void>.delayed(Duration.zero);
 
     expect(api.deleteThreadCallCount, 1);
-    // Threads status unchanged — no optimistic removal possible.
-    expect(state.threads.value, isA<ThreadsFailed>());
+    expect(state.threads.value, isA<ThreadsLoaded>());
+    final loaded = state.threads.value as ThreadsLoaded;
+    expect(loaded.threads.single.id, 'thread-other');
 
     state.dispose();
+  });
+
+  group('noteSpawnedThread', () {
+    test('inserts thread into loaded list sorted by createdAt descending',
+        () async {
+      final existing = ThreadInfo(
+        id: 'thread-1',
+        roomId: 'room-1',
+        name: 'Existing',
+        createdAt: DateTime(2026, 1, 1),
+      );
+      api.nextThreads = [existing];
+
+      final state = ThreadListState(
+        connection: connection,
+        roomId: 'room-1',
+      );
+      await Future<void>.delayed(Duration.zero);
+
+      final newer = ThreadInfo(
+        id: 'thread-2',
+        roomId: 'room-1',
+        name: 'Newer',
+        createdAt: DateTime(2026, 3, 1),
+      );
+      state.noteSpawnedThread(newer);
+
+      final loaded = state.threads.value as ThreadsLoaded;
+      expect(loaded.threads.length, 2);
+      expect(loaded.threads.first.id, 'thread-2'); // newer first
+      expect(loaded.threads.last.id, 'thread-1');
+
+      state.dispose();
+    });
+
+    test('ignores duplicate thread id', () async {
+      final existing = ThreadInfo(
+        id: 'thread-1',
+        roomId: 'room-1',
+        name: 'Existing',
+        createdAt: DateTime(2026, 1, 1),
+      );
+      api.nextThreads = [existing];
+
+      final state = ThreadListState(
+        connection: connection,
+        roomId: 'room-1',
+      );
+      await Future<void>.delayed(Duration.zero);
+
+      state.noteSpawnedThread(existing);
+
+      final loaded = state.threads.value as ThreadsLoaded;
+      expect(loaded.threads.length, 1);
+
+      state.dispose();
+    });
+
+    test(
+        'from non-loaded state, defers to a fresh fetch instead of '
+        'clobbering with a single-element list', () async {
+      // Initial fetch fails: state ends up in ThreadsFailed.
+      api.nextThreadsError = Exception('slow network');
+
+      final state = ThreadListState(
+        connection: connection,
+        roomId: 'room-1',
+      );
+      await Future<void>.delayed(Duration.zero);
+      expect(state.threads.value, isA<ThreadsFailed>());
+
+      // Now the server has the user's newly-created thread plus the
+      // pre-existing ones. A subsequent fetch should bring them all in.
+      final newThread = ThreadInfo(
+        id: 'thread-1',
+        roomId: 'room-1',
+        name: 'New',
+        createdAt: DateTime(2026, 3, 1),
+      );
+      final preExisting = ThreadInfo(
+        id: 'thread-0',
+        roomId: 'room-1',
+        name: 'Pre-existing',
+        createdAt: DateTime(2026, 1, 1),
+      );
+      api.nextThreadsError = null;
+      api.nextThreads = [preExisting, newThread];
+
+      state.noteSpawnedThread(newThread);
+      // noteSpawnedThread does not transition to Loaded synchronously — it
+      // schedules a fetch.
+      expect(state.threads.value, isA<ThreadsLoading>());
+
+      await Future<void>.delayed(Duration.zero);
+
+      final loaded = state.threads.value as ThreadsLoaded;
+      expect(loaded.threads.map((t) => t.id).toSet(), {'thread-0', 'thread-1'});
+
+      state.dispose();
+    });
+
+    test('does nothing when disposed', () async {
+      api.nextThreads = [];
+
+      final state = ThreadListState(
+        connection: connection,
+        roomId: 'room-1',
+      );
+      await Future<void>.delayed(Duration.zero);
+
+      state.dispose();
+      state.noteSpawnedThread(ThreadInfo(
+        id: 'thread-1',
+        roomId: 'room-1',
+        name: 'New',
+        createdAt: DateTime(2026, 3, 1),
+      ));
+
+      final loaded = state.threads.value as ThreadsLoaded;
+      expect(loaded.threads, isEmpty);
+    });
   });
 
   test('refresh() returns a Future that completes after fetch', () async {

--- a/test/modules/room/ui/thread_tile_test.dart
+++ b/test/modules/room/ui/thread_tile_test.dart
@@ -1,3 +1,5 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:soliplex_agent/soliplex_agent.dart';
@@ -52,6 +54,7 @@ void main() {
     await tester.pumpAndSettle();
 
     expect(renameCalled, isTrue);
+    debugDefaultTargetPlatformOverride = null;
   });
 
   testWidgets('tapping Delete fires onDelete callback', (tester) async {
@@ -74,6 +77,101 @@ void main() {
     await tester.pumpAndSettle();
 
     expect(deleteCalled, isTrue);
+    debugDefaultTargetPlatformOverride = null;
+  });
+
+  testWidgets(
+      'on desktop, non-selected thread: tapping Rename still fires callback '
+      'after the tile is no longer hovered (menu opens on the overlay, '
+      'the PopupMenuButton must stay mounted until the user picks an item)',
+      (tester) async {
+    debugDefaultTargetPlatformOverride = TargetPlatform.macOS;
+
+    bool renameCalled = false;
+    await tester.pumpWidget(MaterialApp(
+      home: Scaffold(
+        body: Align(
+          alignment: Alignment.topLeft,
+          child: SizedBox(
+            width: 300,
+            child: ThreadTile(
+              thread: thread,
+              isSelected: false,
+              onTap: () {},
+              onRename: () => renameCalled = true,
+              onDelete: () {},
+            ),
+          ),
+        ),
+      ),
+    ));
+
+    // Simulate pointer hover to reveal the menu button on desktop.
+    final gesture = await tester.createGesture(kind: PointerDeviceKind.mouse);
+    addTearDown(gesture.removePointer);
+    await gesture.addPointer(location: Offset.zero);
+    await gesture.moveTo(tester.getCenter(find.byType(ThreadTile)));
+    await tester.pumpAndSettle();
+
+    // Tap the overflow icon to open the popup menu.
+    await tester.tap(find.byIcon(Icons.more_vert));
+    await tester.pumpAndSettle();
+
+    // Opening the popup moves the pointer onto the overlay, so the tile's
+    // MouseRegion fires onExit. Simulate that.
+    await gesture.moveTo(const Offset(1000, 1000));
+    await tester.pump();
+
+    // Now pick Rename. If the PopupMenuButton was unmounted by the hover
+    // loss, onSelected (and therefore onRename) would never fire.
+    await tester.tap(find.text('Rename'));
+    await tester.pumpAndSettle();
+
+    expect(renameCalled, isTrue);
+    debugDefaultTargetPlatformOverride = null;
+  });
+
+  testWidgets(
+      'on desktop, non-selected thread: tapping Delete still fires callback '
+      'after the tile is no longer hovered', (tester) async {
+    debugDefaultTargetPlatformOverride = TargetPlatform.macOS;
+
+    bool deleteCalled = false;
+    await tester.pumpWidget(MaterialApp(
+      home: Scaffold(
+        body: Align(
+          alignment: Alignment.topLeft,
+          child: SizedBox(
+            width: 300,
+            child: ThreadTile(
+              thread: thread,
+              isSelected: false,
+              onTap: () {},
+              onRename: () {},
+              onDelete: () => deleteCalled = true,
+            ),
+          ),
+        ),
+      ),
+    ));
+
+    final gesture = await tester.createGesture(kind: PointerDeviceKind.mouse);
+    addTearDown(gesture.removePointer);
+    await gesture.addPointer(location: Offset.zero);
+    await gesture.moveTo(tester.getCenter(find.byType(ThreadTile)));
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.byIcon(Icons.more_vert));
+    await tester.pumpAndSettle();
+
+    await gesture.moveTo(const Offset(1000, 1000));
+    await tester.pump();
+
+    await tester.tap(find.text('Delete'));
+    await tester.pumpAndSettle();
+
+    expect(deleteCalled, isTrue);
+    debugDefaultTargetPlatformOverride = null;
   });
 
   testWidgets('Delete menu item uses error color', (tester) async {

--- a/test/modules/room/ui/thread_tile_test.dart
+++ b/test/modules/room/ui/thread_tile_test.dart
@@ -14,6 +14,27 @@ void main() {
     createdAt: DateTime(2026, 3, 1),
   );
 
+  testWidgets('renders "New Thread" for a thread with no name', (tester) async {
+    final nameless = ThreadInfo(
+      id: 't-2',
+      roomId: 'room-1',
+      createdAt: DateTime(2026, 3, 1),
+    );
+    await tester.pumpWidget(MaterialApp(
+      home: Scaffold(
+        body: ThreadTile(
+          thread: nameless,
+          isSelected: false,
+          onTap: () {},
+          onRename: () {},
+          onDelete: () {},
+        ),
+      ),
+    ));
+
+    expect(find.text('New Thread'), findsOneWidget);
+  });
+
   testWidgets('overflow menu shows Rename and Delete options', (tester) async {
     await tester.pumpWidget(MaterialApp(
       home: Scaffold(


### PR DESCRIPTION
## Summary

- Replace post-mutation `threadList.refresh()` calls with local list mutations so the sidebar reflects thread create / delete / implicit spawn immediately without a server round-trip.
- Unify the non-Loaded fallback across `createThread` / `deleteThread` / `renameThread`: if the list is Loaded, mutate locally; otherwise let `_fetch()` reconcile from the server.
- Fix `ThreadTile` menu-button unmounting when the pointer leaves the tile while the popup is open (previously silently dropped `onSelected` for non-selected threads on desktop).
- Snapshot the next thread to navigate to *before* `deleteThread` so a non-Loaded fallback can't land the user on an empty screen.
- Align nameless-thread fallback with the backend's `DEFAULT_THREAD_NAME` sentinel (`"New Thread"` instead of `"Untitled"`).
- Reject empty-name renames at the state layer with `FormatException` so the validation survives release builds and surfaces inline via `AsyncActionDialog`.

## Test plan

- [x] `flutter analyze` — zero warnings
- [x] Full test suite green
- [x] New unit tests: `createThread` (happy / dispose-before / dispose-during-await), `noteSpawnedThread` (sort, dedup, non-Loaded fallback, dispose), `deleteThread` (dispose-during-await, non-Loaded reconciliation, navigation when list is not Loaded), `renameThread` (dispose-during-await).
- [x] New widget tests: `ThreadTile` menu-opens-after-hover-exit for non-selected thread on desktop; "New Thread" rendered for a nameless thread.
- [ ] Manual: create / delete / rename threads; send from no-thread state; hover-then-exit a non-selected tile's overflow menu.

🤖 Generated with [Claude Code](https://claude.com/claude-code)