### PR TITLE
fix: minor UI improvements

### DIFF
--- a/lib/src/modules/room/ui/execution/thinking_block.dart
+++ b/lib/src/modules/room/ui/execution/thinking_block.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:signals_flutter/signals_flutter.dart';
 
 import '../../execution_tracker.dart';
+import '../copy_button.dart';
 
 class ExecutionThinkingBlock extends StatefulWidget {
   const ExecutionThinkingBlock({super.key, required this.tracker});
@@ -66,6 +67,12 @@ class _ExecutionThinkingBlockState extends State<ExecutionThinkingBlock> {
                       ),
                     ),
                   ],
+                  const Spacer(),
+                  CopyButton(
+                    text: thinkingBlocks.join('\n\n'),
+                    tooltip: 'Copy thinking',
+                    iconSize: 16,
+                  ),
                 ],
               ),
               if (_expanded) ...[

--- a/lib/src/modules/room/ui/markdown/flutter_markdown_plus_renderer.dart
+++ b/lib/src/modules/room/ui/markdown/flutter_markdown_plus_renderer.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_markdown_plus/flutter_markdown_plus.dart';
+import 'package:flutter_markdown_plus_latex/flutter_markdown_plus_latex.dart';
 
 import 'code_block_builder.dart';
 import 'inline_code_builder.dart';
@@ -38,6 +39,8 @@ class FlutterMarkdownPlusRenderer extends MarkdownRenderer {
       styleSheet: markdownTheme?.toMarkdownStyleSheet(
         codeFontStyle: monoStyle,
       ),
+      blockSyntaxes: [LatexBlockSyntax()],
+      inlineSyntaxes: [LatexInlineSyntax()],
       onTapLink: onLinkTap == null
           ? null
           : (_, href, title) {
@@ -48,6 +51,7 @@ class FlutterMarkdownPlusRenderer extends MarkdownRenderer {
         'pre': CodeBlockBuilder(
           preferredStyle: monoStyle.copyWith(fontSize: 14),
         ),
+        'latex': LatexElementBuilder(),
       },
     );
   }

--- a/lib/src/modules/room/ui/room_screen.dart
+++ b/lib/src/modules/room/ui/room_screen.dart
@@ -721,6 +721,7 @@ class _RoomScreenState extends State<RoomScreen> {
                       fallback: _threadEmptyFallback(context),
                     )
                   : MessageTimeline(
+                      key: ValueKey(threadView.threadId),
                       messages: messages,
                       messageStates: messageStates,
                       streamingState: streaming,

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -263,6 +263,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.0.7"
+  flutter_markdown_plus_latex:
+    dependency: "direct main"
+    description:
+      name: flutter_markdown_plus_latex
+      sha256: "2e7698b291f0657ca445efab730bb25a8c5851037e882cb7bf47d16a5c218de7"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.5"
+  flutter_math_fork:
+    dependency: transitive
+    description:
+      name: flutter_math_fork
+      sha256: "6d5f2f1aa57ae539ffb0a04bb39d2da67af74601d685a161aff7ce5bda5fa407"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.7.4"
   flutter_native_splash:
     dependency: "direct dev"
     description:
@@ -577,6 +593,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.17.6"
+  nested:
+    dependency: transitive
+    description:
+      name: nested
+      sha256: "03bac4c528c64c95c722ec99280375a6f2fc708eec17c7b3f07253b626cd2a20"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.0"
   node_preamble:
     dependency: transitive
     description:
@@ -713,6 +737,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.9.4"
+  provider:
+    dependency: transitive
+    description:
+      name: provider
+      sha256: "4e82183fa20e5ca25703ead7e05de9e4cceed1fbd1eadc1ac3cb6f565a09f272"
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.1.5+1"
   pub_semver:
     dependency: transitive
     description:
@@ -926,6 +958,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.6.12"
+  tuple:
+    dependency: transitive
+    description:
+      name: tuple
+      sha256: a97ce2013f240b2f3807bcbaf218765b6f301c3eff91092bcfa23a039e7dd151
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.2"
   typed_data:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -21,6 +21,7 @@ dependencies:
   flutter_appauth: ^12.0.0
   flutter_highlight: ^0.7.0
   flutter_markdown_plus: ^1.0.7
+  flutter_markdown_plus_latex: ^1.0.5
   flutter_riverpod: ^3.1.0
   flutter_secure_storage: ^10.0.0
   flutter_svg: ^2.0.17

--- a/test/modules/room/ui/execution/thinking_block_test.dart
+++ b/test/modules/room/ui/execution/thinking_block_test.dart
@@ -71,7 +71,7 @@ void main() {
 
       expect(find.text('Let me think about this'), findsNothing);
 
-      await tester.tap(find.byType(GestureDetector));
+      await tester.tap(find.textContaining('Thinking'));
       await tester.pump();
 
       expect(find.text('Let me think about this'), findsOneWidget);
@@ -84,12 +84,12 @@ void main() {
       await tester.pumpWidget(wrap(ExecutionThinkingBlock(tracker: tracker)));
       await tester.pump();
 
-      await tester.tap(find.byType(GestureDetector));
+      await tester.tap(find.textContaining('Thinking'));
       await tester.pump();
 
       expect(find.text('Let me think about this'), findsOneWidget);
 
-      await tester.tap(find.byType(GestureDetector));
+      await tester.tap(find.textContaining('Thinking'));
       await tester.pump();
 
       expect(find.text('Let me think about this'), findsNothing);
@@ -132,7 +132,7 @@ void main() {
       await tester.pumpWidget(wrap(ExecutionThinkingBlock(tracker: tracker)));
       await tester.pump();
 
-      await tester.tap(find.byType(GestureDetector));
+      await tester.tap(find.textContaining('Thinking'));
       await tester.pump();
 
       // Only the non-empty block should appear


### PR DESCRIPTION
## Summary

- **Fix thread-switch scroll position** (soliplex/frontend#96): Key `MessageTimeline` by `threadId` so Flutter creates fresh state per thread. Previously, when switching to a thread whose run was cached in the registry, the synchronous restore skipped the loading intermediate — reusing the existing scroll controller with stale offset and inflated `maxScrollExtent`, leaving content off-screen.
- **Add copy button to ExecutionThinkingBlock**: Matches the existing `CopyButton` on `_ThinkingBlock` (static thinking). Joins all thinking blocks with double newlines for copy text.
- **Add LaTeX math rendering**: Add `flutter_markdown_plus_latex` to render inline (`$...$`) and block (`$$...$$`) math expressions in chat messages.

## Test plan

- [x] Existing tests pass (982 tests)
- [ ] Manual: switch between threads with completed runs — content should be visible immediately without scrolling
- [ ] Manual: expand a thinking block, verify copy button appears and copies content
- [ ] Manual: send a message that triggers a math response, verify LaTeX renders as formatted equations

🤖 Generated with [Claude Code](https://claude.com/claude-code)