### PR TITLE
fix(http): cap parallel requests to prevent 429

### DIFF
--- a/lib/src/flavors/standard.dart
+++ b/lib/src/flavors/standard.dart
@@ -152,6 +152,7 @@ Future<ShellConfig> standard({
       plainClient.close();
       runtimeManager.dispose();
       registry.dispose();
+      inspector.dispose();
     },
     modules: [
       diagnosticsModule(inspector: inspector),

--- a/lib/src/flavors/standard.dart
+++ b/lib/src/flavors/standard.dart
@@ -90,6 +90,7 @@ Future<ShellConfig> standard({
         observers: [inspector],
         getToken: getToken,
         tokenRefresher: tokenRefresher,
+        maxConcurrent: 10,
       );
 
   final plainClient = buildClient();

--- a/lib/src/flavors/standard.dart
+++ b/lib/src/flavors/standard.dart
@@ -80,6 +80,15 @@ Future<ShellConfig> standard({
 }) async {
   logo ??= Image.asset(_defaultLogoAsset, width: _logoSize, height: _logoSize);
   final inspector = NetworkInspector();
+  final httpLogger = LogManager.instance.getLogger('http_stack');
+
+  void onHttpDiagnostic(
+    Object error,
+    StackTrace stackTrace, {
+    required String message,
+  }) {
+    httpLogger.error(message, error: error, stackTrace: stackTrace);
+  }
 
   SoliplexHttpClient buildClient({
     String? Function()? getToken,
@@ -90,7 +99,7 @@ Future<ShellConfig> standard({
         observers: [inspector],
         getToken: getToken,
         tokenRefresher: tokenRefresher,
-        maxConcurrent: 10,
+        onDiagnostic: onHttpDiagnostic,
       );
 
   final plainClient = buildClient();

--- a/lib/src/modules/diagnostics/network_inspector.dart
+++ b/lib/src/modules/diagnostics/network_inspector.dart
@@ -11,8 +11,13 @@ class NetworkInspector
     with ChangeNotifier
     implements HttpObserver, ConcurrencyObserver {
   NetworkInspector({int maxEvents = 1000})
-      : assert(maxEvents > 0, 'maxEvents must be positive'),
-        _maxEvents = maxEvents;
+      : _maxEvents = maxEvents > 0
+            ? maxEvents
+            : throw ArgumentError.value(
+                maxEvents,
+                'maxEvents',
+                'must be positive',
+              );
 
   final int _maxEvents;
   final ListQueue<HttpEvent> _events = ListQueue<HttpEvent>();

--- a/lib/src/modules/diagnostics/network_inspector.dart
+++ b/lib/src/modules/diagnostics/network_inspector.dart
@@ -2,13 +2,20 @@ import 'package:flutter/foundation.dart';
 import 'package:soliplex_agent/soliplex_agent.dart';
 
 /// Collects HTTP events for the network inspector UI.
-class NetworkInspector with ChangeNotifier implements HttpObserver {
+class NetworkInspector
+    with ChangeNotifier
+    implements HttpObserver, ConcurrencyObserver {
   final List<HttpEvent> _events = [];
+  final List<HttpConcurrencyWaitEvent> _concurrencyEvents = [];
 
   List<HttpEvent> get events => List.unmodifiable(_events);
 
+  List<HttpConcurrencyWaitEvent> get concurrencyEvents =>
+      List.unmodifiable(_concurrencyEvents);
+
   void clear() {
     _events.clear();
+    _concurrencyEvents.clear();
     notifyListeners();
   }
 
@@ -31,4 +38,10 @@ class NetworkInspector with ChangeNotifier implements HttpObserver {
 
   @override
   void onStreamEnd(HttpStreamEndEvent event) => _add(event);
+
+  @override
+  void onConcurrencyWait(HttpConcurrencyWaitEvent event) {
+    _concurrencyEvents.add(event);
+    notifyListeners();
+  }
 }

--- a/lib/src/modules/diagnostics/network_inspector.dart
+++ b/lib/src/modules/diagnostics/network_inspector.dart
@@ -29,6 +29,7 @@ class NetworkInspector
 
   @override
   void dispose() {
+    if (_disposed) return;
     _disposed = true;
     super.dispose();
   }

--- a/lib/src/modules/diagnostics/network_inspector.dart
+++ b/lib/src/modules/diagnostics/network_inspector.dart
@@ -1,17 +1,28 @@
+import 'dart:collection';
+
 import 'package:flutter/foundation.dart';
 import 'package:soliplex_agent/soliplex_agent.dart';
 
 /// Collects HTTP events for the network inspector UI.
+///
+/// Events are bounded per list: on overflow, the oldest event is dropped
+/// so a long-running dev session cannot grow memory without bound.
 class NetworkInspector
     with ChangeNotifier
     implements HttpObserver, ConcurrencyObserver {
-  final List<HttpEvent> _events = [];
-  final List<HttpConcurrencyWaitEvent> _concurrencyEvents = [];
+  NetworkInspector({int maxEvents = 1000})
+      : assert(maxEvents > 0, 'maxEvents must be positive'),
+        _maxEvents = maxEvents;
+
+  final int _maxEvents;
+  final ListQueue<HttpEvent> _events = ListQueue<HttpEvent>();
+  final ListQueue<ConcurrencyWaitEvent> _concurrencyEvents =
+      ListQueue<ConcurrencyWaitEvent>();
   bool _disposed = false;
 
   List<HttpEvent> get events => List.unmodifiable(_events);
 
-  List<HttpConcurrencyWaitEvent> get concurrencyEvents =>
+  List<ConcurrencyWaitEvent> get concurrencyEvents =>
       List.unmodifiable(_concurrencyEvents);
 
   void clear() {
@@ -23,7 +34,8 @@ class NetworkInspector
 
   void _add(HttpEvent event) {
     if (_disposed) return;
-    _events.add(event);
+    _events.addLast(event);
+    if (_events.length > _maxEvents) _events.removeFirst();
     notifyListeners();
   }
 
@@ -50,9 +62,12 @@ class NetworkInspector
   void onStreamEnd(HttpStreamEndEvent event) => _add(event);
 
   @override
-  void onConcurrencyWait(HttpConcurrencyWaitEvent event) {
+  void onConcurrencyWait(ConcurrencyWaitEvent event) {
     if (_disposed) return;
-    _concurrencyEvents.add(event);
+    _concurrencyEvents.addLast(event);
+    if (_concurrencyEvents.length > _maxEvents) {
+      _concurrencyEvents.removeFirst();
+    }
     notifyListeners();
   }
 }

--- a/lib/src/modules/diagnostics/network_inspector.dart
+++ b/lib/src/modules/diagnostics/network_inspector.dart
@@ -7,6 +7,7 @@ class NetworkInspector
     implements HttpObserver, ConcurrencyObserver {
   final List<HttpEvent> _events = [];
   final List<HttpConcurrencyWaitEvent> _concurrencyEvents = [];
+  bool _disposed = false;
 
   List<HttpEvent> get events => List.unmodifiable(_events);
 
@@ -14,14 +15,22 @@ class NetworkInspector
       List.unmodifiable(_concurrencyEvents);
 
   void clear() {
+    if (_disposed) return;
     _events.clear();
     _concurrencyEvents.clear();
     notifyListeners();
   }
 
   void _add(HttpEvent event) {
+    if (_disposed) return;
     _events.add(event);
     notifyListeners();
+  }
+
+  @override
+  void dispose() {
+    _disposed = true;
+    super.dispose();
   }
 
   @override
@@ -41,6 +50,7 @@ class NetworkInspector
 
   @override
   void onConcurrencyWait(HttpConcurrencyWaitEvent event) {
+    if (_disposed) return;
     _concurrencyEvents.add(event);
     notifyListeners();
   }

--- a/lib/src/modules/diagnostics/ui/concurrency_summary_panel.dart
+++ b/lib/src/modules/diagnostics/ui/concurrency_summary_panel.dart
@@ -49,7 +49,7 @@ class ConcurrencySummaryPanel extends StatelessWidget {
                   '${stats.maxDepthAtEnqueue}',
                   style: labelStyle,
                 ),
-                if (stats.avgWaitMs != null)
+                if (stats.queuedCount > 0)
                   Text('avg ${stats.avgWaitMs}ms', style: labelStyle),
                 if (stats.maxWaitMs > 0)
                   Text('max ${stats.maxWaitMs}ms', style: labelStyle),
@@ -95,7 +95,7 @@ class _ConcurrencyStats {
       queuedCount: queuedCount,
       maxDepthAtEnqueue: maxDepth,
       peakSlotsInUse: peakSlots,
-      avgWaitMs: queuedCount == 0 ? null : queuedWaitSumMs ~/ queuedCount,
+      avgWaitMs: queuedCount == 0 ? 0 : queuedWaitSumMs ~/ queuedCount,
       maxWaitMs: maxWaitMs,
     );
   }
@@ -104,6 +104,6 @@ class _ConcurrencyStats {
   final int queuedCount;
   final int maxDepthAtEnqueue;
   final int peakSlotsInUse;
-  final int? avgWaitMs;
+  final int avgWaitMs;
   final int maxWaitMs;
 }

--- a/lib/src/modules/diagnostics/ui/concurrency_summary_panel.dart
+++ b/lib/src/modules/diagnostics/ui/concurrency_summary_panel.dart
@@ -11,7 +11,7 @@ import 'package:soliplex_agent/soliplex_agent.dart';
 class ConcurrencySummaryPanel extends StatelessWidget {
   const ConcurrencySummaryPanel({required this.events, super.key});
 
-  final List<HttpConcurrencyWaitEvent> events;
+  final List<ConcurrencyWaitEvent> events;
 
   @override
   Widget build(BuildContext context) {
@@ -72,7 +72,7 @@ class _ConcurrencyStats {
     required this.maxWaitMs,
   });
 
-  factory _ConcurrencyStats.from(List<HttpConcurrencyWaitEvent> events) {
+  factory _ConcurrencyStats.from(List<ConcurrencyWaitEvent> events) {
     var maxDepth = 0;
     var peakSlots = 0;
     var maxWaitMs = 0;

--- a/lib/src/modules/diagnostics/ui/concurrency_summary_panel.dart
+++ b/lib/src/modules/diagnostics/ui/concurrency_summary_panel.dart
@@ -6,8 +6,8 @@ import 'package:soliplex_agent/soliplex_agent.dart';
 /// Compact header strip showing aggregate queue health from the HTTP
 /// concurrency limiter.
 ///
-/// Renders nothing when [events] is empty — the inspector's HTTP event
-/// pipeline runs unchanged until the limiter actually queues a request.
+/// Renders nothing until the limiter has emitted at least one event
+/// (i.e. at least one HTTP request has acquired a slot).
 class ConcurrencySummaryPanel extends StatelessWidget {
   const ConcurrencySummaryPanel({required this.events, super.key});
 

--- a/lib/src/modules/diagnostics/ui/concurrency_summary_panel.dart
+++ b/lib/src/modules/diagnostics/ui/concurrency_summary_panel.dart
@@ -1,0 +1,109 @@
+import 'dart:math' as math;
+
+import 'package:flutter/material.dart';
+import 'package:soliplex_agent/soliplex_agent.dart';
+
+/// Compact header strip showing aggregate queue health from the HTTP
+/// concurrency limiter.
+///
+/// Renders nothing when [events] is empty — the inspector's HTTP event
+/// pipeline runs unchanged until the limiter actually queues a request.
+class ConcurrencySummaryPanel extends StatelessWidget {
+  const ConcurrencySummaryPanel({required this.events, super.key});
+
+  final List<HttpConcurrencyWaitEvent> events;
+
+  @override
+  Widget build(BuildContext context) {
+    if (events.isEmpty) return const SizedBox.shrink();
+
+    final stats = _ConcurrencyStats.from(events);
+    final theme = Theme.of(context);
+    final labelStyle = theme.textTheme.labelSmall?.copyWith(
+      color: theme.colorScheme.onSurfaceVariant,
+    );
+
+    return Container(
+      width: double.infinity,
+      padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+      color: theme.colorScheme.surfaceContainerHighest,
+      child: Row(
+        children: [
+          Icon(
+            Icons.hourglass_empty,
+            size: 16,
+            color: theme.colorScheme.onSurfaceVariant,
+          ),
+          const SizedBox(width: 8),
+          Expanded(
+            child: Wrap(
+              spacing: 12,
+              runSpacing: 4,
+              children: [
+                Text(
+                  'queued ${stats.queuedCount} of ${stats.total}',
+                  style: labelStyle,
+                ),
+                Text(
+                  'peak slots ${stats.peakSlotsInUse} / max depth '
+                  '${stats.maxDepthAtEnqueue}',
+                  style: labelStyle,
+                ),
+                if (stats.avgWaitMs != null)
+                  Text('avg ${stats.avgWaitMs}ms', style: labelStyle),
+                if (stats.maxWaitMs > 0)
+                  Text('max ${stats.maxWaitMs}ms', style: labelStyle),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _ConcurrencyStats {
+  const _ConcurrencyStats({
+    required this.total,
+    required this.queuedCount,
+    required this.maxDepthAtEnqueue,
+    required this.peakSlotsInUse,
+    required this.avgWaitMs,
+    required this.maxWaitMs,
+  });
+
+  factory _ConcurrencyStats.from(List<HttpConcurrencyWaitEvent> events) {
+    var maxDepth = 0;
+    var peakSlots = 0;
+    var maxWaitMs = 0;
+    var queuedWaitSumMs = 0;
+    var queuedCount = 0;
+
+    for (final e in events) {
+      maxDepth = math.max(maxDepth, e.queueDepthAtEnqueue);
+      peakSlots = math.max(peakSlots, e.slotsInUseAfterAcquire);
+      final waitMs = e.waitDuration.inMilliseconds;
+      maxWaitMs = math.max(maxWaitMs, waitMs);
+      if (e.waitDuration > Duration.zero) {
+        queuedWaitSumMs += waitMs;
+        queuedCount++;
+      }
+    }
+
+    return _ConcurrencyStats(
+      total: events.length,
+      queuedCount: queuedCount,
+      maxDepthAtEnqueue: maxDepth,
+      peakSlotsInUse: peakSlots,
+      avgWaitMs: queuedCount == 0 ? null : queuedWaitSumMs ~/ queuedCount,
+      maxWaitMs: maxWaitMs,
+    );
+  }
+
+  final int total;
+  final int queuedCount;
+  final int maxDepthAtEnqueue;
+  final int peakSlotsInUse;
+  final int? avgWaitMs;
+  final int maxWaitMs;
+}

--- a/lib/src/modules/diagnostics/ui/network_inspector_screen.dart
+++ b/lib/src/modules/diagnostics/ui/network_inspector_screen.dart
@@ -3,6 +3,7 @@ import 'package:flutter/material.dart';
 import '../models/http_event_group.dart';
 import '../models/http_event_grouper.dart';
 import '../network_inspector.dart';
+import 'concurrency_summary_panel.dart';
 import 'http_event_tile.dart';
 import 'request_detail_view.dart';
 
@@ -32,7 +33,8 @@ class _NetworkInspectorScreenState extends State<NetworkInspectorScreen> {
             actions: [
               IconButton(
                 icon: const Icon(Icons.delete_outline),
-                onPressed: widget.inspector.events.isEmpty
+                onPressed: widget.inspector.events.isEmpty &&
+                        widget.inspector.concurrencyEvents.isEmpty
                     ? null
                     : () {
                         widget.inspector.clear();
@@ -42,15 +44,26 @@ class _NetworkInspectorScreenState extends State<NetworkInspectorScreen> {
               ),
             ],
           ),
-          body: LayoutBuilder(
-            builder: (context, constraints) {
-              if (sortedGroups.isEmpty) return _buildEmptyState(context);
-              final isWide = constraints.maxWidth >= 600;
-              if (isWide) {
-                return _buildMasterDetailLayout(context, sortedGroups);
-              }
-              return _buildListLayout(context, sortedGroups);
-            },
+          body: Column(
+            children: [
+              ConcurrencySummaryPanel(
+                events: widget.inspector.concurrencyEvents,
+              ),
+              Expanded(
+                child: LayoutBuilder(
+                  builder: (context, constraints) {
+                    if (sortedGroups.isEmpty) {
+                      return _buildEmptyState(context);
+                    }
+                    final isWide = constraints.maxWidth >= 600;
+                    if (isWide) {
+                      return _buildMasterDetailLayout(context, sortedGroups);
+                    }
+                    return _buildListLayout(context, sortedGroups);
+                  },
+                ),
+              ),
+            ],
           ),
         );
       },

--- a/packages/soliplex_agent/lib/soliplex_agent.dart
+++ b/packages/soliplex_agent/lib/soliplex_agent.dart
@@ -14,6 +14,7 @@ export 'package:signals_core/signals_core.dart'
 export 'package:soliplex_client/soliplex_client.dart'
     hide
         AuthenticatedHttpClient,
+        ConcurrencyLimitingHttpClient,
         DartHttpClient,
         HttpTransport,
         ObservableHttpClient,

--- a/packages/soliplex_agent/lib/src/http/create_agent_http_client.dart
+++ b/packages/soliplex_agent/lib/src/http/create_agent_http_client.dart
@@ -1,16 +1,20 @@
 import 'package:soliplex_client/soliplex_client.dart';
 
-/// Creates an HTTP client for agent connections with optional observability
-/// and authentication.
+/// Creates an HTTP client for agent connections with observability,
+/// concurrency limiting, and authentication.
 ///
 /// Layers are applied inside-out in this order:
 /// 1. [innerClient] (or `DartHttpClient()` by default)
 /// 2. [ObservableHttpClient] — when [observers] is non-empty
-/// 3. [AuthenticatedHttpClient] — when [getToken] is provided
-/// 4. [RefreshingHttpClient] — when [tokenRefresher] is provided
+/// 3. [ConcurrencyLimitingHttpClient] — caps in-flight requests at
+///    [maxConcurrent]. Observers in [observers] that also implement
+///    [ConcurrencyObserver] receive queue-wait events.
+/// 4. [AuthenticatedHttpClient] — when [getToken] is provided
+/// 5. [RefreshingHttpClient] — when [tokenRefresher] is provided
 ///
-/// Observer is innermost so the network inspector sees what actually hits
-/// the wire, including Bearer headers and retried requests after refresh.
+/// Observer is innermost so the network inspector sees every wire
+/// attempt. Concurrency below auth so queued requests don't hold
+/// stale tokens.
 ///
 /// [innerClient] defaults to a [DartHttpClient] when not provided.
 /// For platform-specific clients, pass one from `soliplex_client_native`.
@@ -25,6 +29,7 @@ SoliplexHttpClient createAgentHttpClient({
   List<HttpObserver>? observers,
   String? Function()? getToken,
   TokenRefresher? tokenRefresher,
+  int maxConcurrent = 10,
 }) {
   assert(
     tokenRefresher == null || getToken != null,
@@ -36,6 +41,12 @@ SoliplexHttpClient createAgentHttpClient({
   if (observers != null && observers.isNotEmpty) {
     client = ObservableHttpClient(client: client, observers: observers);
   }
+
+  client = ConcurrencyLimitingHttpClient(
+    inner: client,
+    maxConcurrent: maxConcurrent,
+    observers: observers?.whereType<ConcurrencyObserver>().toList() ?? const [],
+  );
 
   if (getToken != null) {
     client = AuthenticatedHttpClient(client, getToken);

--- a/packages/soliplex_agent/lib/src/http/create_agent_http_client.dart
+++ b/packages/soliplex_agent/lib/src/http/create_agent_http_client.dart
@@ -3,33 +3,19 @@ import 'package:soliplex_client/soliplex_client.dart';
 /// Creates an HTTP client for agent connections with observability,
 /// concurrency limiting, and authentication.
 ///
-/// Layers are applied inside-out in this order:
-/// 1. [innerClient] (or `DartHttpClient()` by default)
-/// 2. [ObservableHttpClient] — when [observers] is non-empty
-/// 3. [ConcurrencyLimitingHttpClient] — caps in-flight requests at
-///    [maxConcurrent]. Observers in [observers] that also implement
-///    [ConcurrencyObserver] receive queue-wait events.
-/// 4. [AuthenticatedHttpClient] — when [getToken] is provided
-/// 5. [RefreshingHttpClient] — when [tokenRefresher] is provided
+/// [tokenRefresher] must use a SEPARATE HTTP client (not this one) to
+/// avoid deadlock — a refresh triggered while the pool is exhausted
+/// would try to acquire a slot from the pool it's unblocking.
 ///
-/// Observer is innermost so the network inspector sees every wire
-/// attempt. Concurrency below auth so queued requests don't hold
-/// stale tokens.
-///
-/// [innerClient] defaults to a [DartHttpClient] when not provided.
-/// For platform-specific clients, pass one from `soliplex_client_native`.
-///
-/// [tokenRefresher] requires [getToken] — without token injection, refresh
-/// retries go out unauthenticated.
-///
-/// The caller owns the returned client and must call `close()` when done.
-/// Closing cascades through the entire decorator stack.
+/// See `package:soliplex_client/CLAUDE.md` for the decorator stack
+/// rationale.
 SoliplexHttpClient createAgentHttpClient({
   SoliplexHttpClient? innerClient,
   List<HttpObserver>? observers,
   String? Function()? getToken,
   TokenRefresher? tokenRefresher,
   int maxConcurrent = 10,
+  HttpDiagnosticHandler? onDiagnostic,
 }) {
   assert(
     tokenRefresher == null || getToken != null,
@@ -39,14 +25,12 @@ SoliplexHttpClient createAgentHttpClient({
   var client = innerClient ?? DartHttpClient();
 
   if (observers != null && observers.isNotEmpty) {
-    client = ObservableHttpClient(client: client, observers: observers);
+    client = ObservableHttpClient(
+      client: client,
+      observers: observers,
+      onDiagnostic: onDiagnostic,
+    );
   }
-
-  client = ConcurrencyLimitingHttpClient(
-    inner: client,
-    maxConcurrent: maxConcurrent,
-    observers: observers?.whereType<ConcurrencyObserver>().toList() ?? const [],
-  );
 
   if (getToken != null) {
     client = AuthenticatedHttpClient(client, getToken);
@@ -56,5 +40,10 @@ SoliplexHttpClient createAgentHttpClient({
     client = RefreshingHttpClient(inner: client, refresher: tokenRefresher);
   }
 
-  return client;
+  return ConcurrencyLimitingHttpClient(
+    inner: client,
+    maxConcurrent: maxConcurrent,
+    observers: observers?.whereType<ConcurrencyObserver>().toList() ?? const [],
+    onDiagnostic: onDiagnostic,
+  );
 }

--- a/packages/soliplex_agent/lib/src/http/create_agent_http_client.dart
+++ b/packages/soliplex_agent/lib/src/http/create_agent_http_client.dart
@@ -7,6 +7,14 @@ import 'package:soliplex_client/soliplex_client.dart';
 /// avoid deadlock — a refresh triggered while the pool is exhausted
 /// would try to acquire a slot from the pool it's unblocking.
 ///
+/// [maxConcurrent] caps simultaneous in-flight requests. The default of
+/// 6 aligns with the per-host HTTP/1.1 connection cap that browsers,
+/// `URLSession`, and Dart's `HttpClient` all impose, which makes this
+/// layer's queue the authoritative one — queue-wait events surface in
+/// observer diagnostics instead of being absorbed silently by the
+/// platform client. 6 sits under the backend's per-client 10-connection
+/// cap with headroom. Raise it when moving to an HTTP/2 backend.
+///
 /// See `package:soliplex_client/CLAUDE.md` for the decorator stack
 /// rationale.
 SoliplexHttpClient createAgentHttpClient({
@@ -14,7 +22,7 @@ SoliplexHttpClient createAgentHttpClient({
   List<HttpObserver>? observers,
   String? Function()? getToken,
   TokenRefresher? tokenRefresher,
-  int maxConcurrent = 10,
+  int maxConcurrent = 6,
   HttpDiagnosticHandler? onDiagnostic,
 }) {
   assert(
@@ -40,6 +48,9 @@ SoliplexHttpClient createAgentHttpClient({
     client = RefreshingHttpClient(inner: client, refresher: tokenRefresher);
   }
 
+  // Observers that implement both [HttpObserver] and [ConcurrencyObserver]
+  // receive both kinds of events. Observers implementing only one are
+  // silently filtered from the other channel.
   return ConcurrencyLimitingHttpClient(
     inner: client,
     maxConcurrent: maxConcurrent,

--- a/packages/soliplex_agent/test/http/create_agent_http_client_test.dart
+++ b/packages/soliplex_agent/test/http/create_agent_http_client_test.dart
@@ -1,10 +1,12 @@
+import 'dart:async';
+import 'dart:typed_data';
+
 import 'package:mocktail/mocktail.dart';
 import 'package:soliplex_agent/soliplex_agent.dart';
 import 'package:soliplex_client/soliplex_client.dart'
     show
         AuthenticatedHttpClient,
-        DartHttpClient,
-        ObservableHttpClient,
+        ConcurrencyLimitingHttpClient,
         RefreshingHttpClient;
 import 'package:test/test.dart';
 
@@ -14,42 +16,95 @@ class _MockObserver extends Mock implements HttpObserver {}
 
 class _MockTokenRefresher extends Mock implements TokenRefresher {}
 
+class _ConcurrencyTrackingInner implements SoliplexHttpClient {
+  int _inFlight = 0;
+  int maxInFlight = 0;
+  final _gate = Completer<void>();
+
+  void releaseAll() {
+    if (!_gate.isCompleted) _gate.complete();
+  }
+
+  @override
+  Future<HttpResponse> request(
+    String method,
+    Uri uri, {
+    Map<String, String>? headers,
+    Object? body,
+    Duration? timeout,
+  }) async {
+    _inFlight++;
+    if (_inFlight > maxInFlight) maxInFlight = _inFlight;
+    try {
+      await _gate.future;
+      return HttpResponse(statusCode: 200, bodyBytes: Uint8List(0));
+    } finally {
+      _inFlight--;
+    }
+  }
+
+  @override
+  Future<StreamedHttpResponse> requestStream(
+    String method,
+    Uri uri, {
+    Map<String, String>? headers,
+    Object? body,
+    CancelToken? cancelToken,
+  }) async =>
+      const StreamedHttpResponse(statusCode: 200, body: Stream.empty());
+
+  @override
+  void close() {}
+}
+
+class _RecordingConcurrencyObserver
+    implements HttpObserver, ConcurrencyObserver {
+  final events = <HttpConcurrencyWaitEvent>[];
+
+  @override
+  void onConcurrencyWait(HttpConcurrencyWaitEvent event) => events.add(event);
+  @override
+  void onRequest(HttpRequestEvent event) {}
+  @override
+  void onResponse(HttpResponseEvent event) {}
+  @override
+  void onError(HttpErrorEvent event) {}
+  @override
+  void onStreamStart(HttpStreamStartEvent event) {}
+  @override
+  void onStreamEnd(HttpStreamEndEvent event) {}
+}
+
 void main() {
   group('createAgentHttpClient', () {
-    test('no args returns a DartHttpClient', () {
+    test('no args wraps a DartHttpClient in a ConcurrencyLimitingHttpClient',
+        () {
       final client = createAgentHttpClient();
       addTearDown(client.close);
-      expect(client, isA<DartHttpClient>());
+      expect(client, isA<ConcurrencyLimitingHttpClient>());
     });
 
-    test('with innerClient uses the provided client', () {
+    test('with innerClient wraps the provided client in the concurrency layer',
+        () {
       final inner = _MockHttpClient();
       final client = createAgentHttpClient(innerClient: inner);
-      expect(client, same(inner));
+      expect(client, isA<ConcurrencyLimitingHttpClient>());
+      expect(client, isNot(same(inner)));
     });
 
-    test('with observers wraps in ObservableHttpClient', () {
+    test('with observers wraps in ObservableHttpClient and concurrency', () {
       final observer = _MockObserver();
       final client = createAgentHttpClient(observers: [observer]);
       addTearDown(client.close);
-      expect(client, isA<ObservableHttpClient>());
+      // Outermost is the concurrency layer (observers are inside it).
+      expect(client, isA<ConcurrencyLimitingHttpClient>());
     });
 
-    test('with empty observers does not wrap', () {
+    test('with empty observers still wraps in ConcurrencyLimitingHttpClient',
+        () {
       final client = createAgentHttpClient(observers: <HttpObserver>[]);
       addTearDown(client.close);
-      expect(client, isA<DartHttpClient>());
-    });
-
-    test('with innerClient and observers wraps provided client', () {
-      final inner = _MockHttpClient();
-      final observer = _MockObserver();
-      final client = createAgentHttpClient(
-        innerClient: inner,
-        observers: [observer],
-      );
-      addTearDown(client.close);
-      expect(client, isA<ObservableHttpClient>());
+      expect(client, isA<ConcurrencyLimitingHttpClient>());
     });
 
     test('close cascades through decorator stack', () {
@@ -59,6 +114,56 @@ void main() {
         observers: [_MockObserver()],
       ).close();
       verify(inner.close).called(1);
+    });
+
+    test('enforces concurrency limit via ConcurrencyLimitingHttpClient layer',
+        () async {
+      final inner = _ConcurrencyTrackingInner();
+      final client = createAgentHttpClient(
+        innerClient: inner,
+        maxConcurrent: 2,
+      );
+
+      final futures = [
+        client.request('GET', Uri.parse('https://api/1')),
+        client.request('GET', Uri.parse('https://api/2')),
+        client.request('GET', Uri.parse('https://api/3')),
+        client.request('GET', Uri.parse('https://api/4')),
+      ];
+
+      await Future<void>.delayed(const Duration(milliseconds: 20));
+
+      expect(
+        inner.maxInFlight,
+        lessThanOrEqualTo(2),
+        reason: 'maxConcurrent=2 must cap in-flight to 2',
+      );
+
+      inner.releaseAll();
+      await Future.wait<void>(futures);
+    });
+
+    test(
+        'routes ConcurrencyObserver entries in the observers list '
+        'to the limiter', () async {
+      final inner = _ConcurrencyTrackingInner();
+      final observer = _RecordingConcurrencyObserver();
+      final client = createAgentHttpClient(
+        innerClient: inner,
+        observers: [observer],
+        maxConcurrent: 1,
+      );
+
+      final futures = [
+        client.request('GET', Uri.parse('https://api/a')),
+        client.request('GET', Uri.parse('https://api/b')),
+      ];
+
+      await Future<void>.delayed(const Duration(milliseconds: 20));
+      inner.releaseAll();
+      await Future.wait<void>(futures);
+
+      expect(observer.events.length, equals(2));
     });
 
     group('auth', () {

--- a/packages/soliplex_agent/test/http/create_agent_http_client_test.dart
+++ b/packages/soliplex_agent/test/http/create_agent_http_client_test.dart
@@ -260,7 +260,7 @@ void main() {
       await Future.wait<void>(futures);
     });
 
-    test('default maxConcurrent caps in-flight at 10', () async {
+    test('default maxConcurrent caps in-flight at 6', () async {
       final inner = _ConcurrencyTrackingInner();
       final client = createAgentHttpClient(innerClient: inner);
 
@@ -273,9 +273,10 @@ void main() {
 
       expect(
         inner.maxInFlight,
-        equals(10),
-        reason: 'default cap must match the upstream connection limit; '
-            'lowering this would overshoot the origin and trigger 429s',
+        equals(6),
+        reason: 'default cap matches the HTTP/1.1 per-host cap shared by '
+            'browsers, URLSession, and Dart HttpClient; keeps this layer '
+            'authoritative and sits under the backend per-client 10-cap',
       );
 
       inner.releaseAll();

--- a/packages/soliplex_agent/test/http/create_agent_http_client_test.dart
+++ b/packages/soliplex_agent/test/http/create_agent_http_client_test.dart
@@ -4,11 +4,17 @@ import 'dart:typed_data';
 import 'package:mocktail/mocktail.dart';
 import 'package:soliplex_agent/soliplex_agent.dart';
 import 'package:soliplex_client/soliplex_client.dart'
-    show
-        AuthenticatedHttpClient,
-        ConcurrencyLimitingHttpClient,
-        RefreshingHttpClient;
+    show ConcurrencyLimitingHttpClient;
 import 'package:test/test.dart';
+
+/// Pumps the microtask queue repeatedly so all scheduled awaits through
+/// the decorator stack settle. Deterministic alternative to wall-clock
+/// `Duration(milliseconds: N)` waits.
+Future<void> _pumpEventQueue([int iterations = 20]) async {
+  for (var i = 0; i < iterations; i++) {
+    await Future<void>.delayed(Duration.zero);
+  }
+}
 
 class _MockHttpClient extends Mock implements SoliplexHttpClient {}
 
@@ -59,10 +65,10 @@ class _ConcurrencyTrackingInner implements SoliplexHttpClient {
 
 class _RecordingConcurrencyObserver
     implements HttpObserver, ConcurrencyObserver {
-  final events = <HttpConcurrencyWaitEvent>[];
+  final events = <ConcurrencyWaitEvent>[];
 
   @override
-  void onConcurrencyWait(HttpConcurrencyWaitEvent event) => events.add(event);
+  void onConcurrencyWait(ConcurrencyWaitEvent event) => events.add(event);
   @override
   void onRequest(HttpRequestEvent event) {}
   @override
@@ -75,36 +81,147 @@ class _RecordingConcurrencyObserver
   void onStreamEnd(HttpStreamEndEvent event) {}
 }
 
+class _ThrowingConcurrencyObserver
+    implements HttpObserver, ConcurrencyObserver {
+  @override
+  void onConcurrencyWait(ConcurrencyWaitEvent event) {
+    throw StateError('observer is broken');
+  }
+
+  @override
+  void onRequest(HttpRequestEvent event) {}
+  @override
+  void onResponse(HttpResponseEvent event) {}
+  @override
+  void onError(HttpErrorEvent event) {}
+  @override
+  void onStreamStart(HttpStreamStartEvent event) {}
+  @override
+  void onStreamEnd(HttpStreamEndEvent event) {}
+}
+
+class _ThrowingHttpObserver implements HttpObserver {
+  @override
+  void onRequest(HttpRequestEvent event) {
+    throw StateError('http observer is broken');
+  }
+
+  @override
+  void onResponse(HttpResponseEvent event) {}
+  @override
+  void onError(HttpErrorEvent event) {}
+  @override
+  void onStreamStart(HttpStreamStartEvent event) {}
+  @override
+  void onStreamEnd(HttpStreamEndEvent event) {}
+}
+
+/// Inner client that records request order and returns 401 on the
+/// first call whose URI matches [uri401], then 200 for all subsequent
+/// requests (including the retry for the 401'd URI).
+class _OrderedInner implements SoliplexHttpClient {
+  _OrderedInner({required this.uri401});
+
+  final Uri uri401;
+  final List<String> executionOrder = [];
+  bool _saw401 = false;
+
+  @override
+  Future<HttpResponse> request(
+    String method,
+    Uri uri, {
+    Map<String, String>? headers,
+    Object? body,
+    Duration? timeout,
+  }) async {
+    executionOrder.add(uri.path);
+    if (uri == uri401 && !_saw401) {
+      _saw401 = true;
+      return HttpResponse(statusCode: 401, bodyBytes: Uint8List(0));
+    }
+    return HttpResponse(statusCode: 200, bodyBytes: Uint8List(0));
+  }
+
+  @override
+  Future<StreamedHttpResponse> requestStream(
+    String method,
+    Uri uri, {
+    Map<String, String>? headers,
+    Object? body,
+    CancelToken? cancelToken,
+  }) async =>
+      const StreamedHttpResponse(statusCode: 200, body: Stream.empty());
+
+  @override
+  void close() {}
+}
+
+/// TokenRefresher that performs its refresh by issuing an HTTP request
+/// through [client]. Simulates the `TokenRefreshService(httpClient:
+/// plainClient)` wiring in `standard.dart` — the refresher client MUST
+/// be separate from the authed client, or the refresh deadlocks when
+/// the authed client's pool is exhausted.
+class _RefresherViaClient implements TokenRefresher {
+  _RefresherViaClient(this.client);
+
+  final SoliplexHttpClient client;
+  int refreshCalls = 0;
+
+  @override
+  bool get needsRefresh => false;
+
+  @override
+  Future<void> refreshIfExpiringSoon() async {
+    // Proactive refresh no-op: the tests care about reactive-refresh
+    // behavior via tryRefresh, not proactive.
+  }
+
+  @override
+  Future<bool> tryRefresh() async {
+    refreshCalls++;
+    await client.request('POST', Uri.parse('https://auth.example/refresh'));
+    return true;
+  }
+}
+
 void main() {
   group('createAgentHttpClient', () {
-    test('no args wraps a DartHttpClient in a ConcurrencyLimitingHttpClient',
-        () {
-      final client = createAgentHttpClient();
-      addTearDown(client.close);
-      expect(client, isA<ConcurrencyLimitingHttpClient>());
-    });
-
-    test('with innerClient wraps the provided client in the concurrency layer',
-        () {
-      final inner = _MockHttpClient();
-      final client = createAgentHttpClient(innerClient: inner);
-      expect(client, isA<ConcurrencyLimitingHttpClient>());
-      expect(client, isNot(same(inner)));
-    });
-
-    test('with observers wraps in ObservableHttpClient and concurrency', () {
-      final observer = _MockObserver();
-      final client = createAgentHttpClient(observers: [observer]);
-      addTearDown(client.close);
-      // Outermost is the concurrency layer (observers are inside it).
-      expect(client, isA<ConcurrencyLimitingHttpClient>());
-    });
-
-    test('with empty observers still wraps in ConcurrencyLimitingHttpClient',
-        () {
-      final client = createAgentHttpClient(observers: <HttpObserver>[]);
-      addTearDown(client.close);
-      expect(client, isA<ConcurrencyLimitingHttpClient>());
+    test(
+        'always returns ConcurrencyLimitingHttpClient as the outermost '
+        'decorator across all input combinations', () {
+      final cases = <String, SoliplexHttpClient Function()>{
+        'no args': createAgentHttpClient,
+        'with innerClient': () =>
+            createAgentHttpClient(innerClient: _MockHttpClient()),
+        'with observers': () =>
+            createAgentHttpClient(observers: [_MockObserver()]),
+        'with empty observers': () =>
+            createAgentHttpClient(observers: <HttpObserver>[]),
+        'with getToken': () => createAgentHttpClient(getToken: () => 'token'),
+        'with getToken and observers': () => createAgentHttpClient(
+              getToken: () => 'token',
+              observers: [_MockObserver()],
+            ),
+        'with getToken and tokenRefresher': () => createAgentHttpClient(
+              getToken: () => 'token',
+              tokenRefresher: _MockTokenRefresher(),
+            ),
+        'with all parameters': () => createAgentHttpClient(
+              observers: [_MockObserver()],
+              getToken: () => 'token',
+              tokenRefresher: _MockTokenRefresher(),
+            ),
+      };
+      for (final entry in cases.entries) {
+        final client = entry.value();
+        addTearDown(client.close);
+        expect(
+          client,
+          isA<ConcurrencyLimitingHttpClient>(),
+          reason: '${entry.key}: concurrency limiter must be outermost so '
+              'auth runs at dispatch, not enqueue',
+        );
+      }
     });
 
     test('close cascades through decorator stack', () {
@@ -131,7 +248,7 @@ void main() {
         client.request('GET', Uri.parse('https://api/4')),
       ];
 
-      await Future<void>.delayed(const Duration(milliseconds: 20));
+      await _pumpEventQueue();
 
       expect(
         inner.maxInFlight,
@@ -141,6 +258,78 @@ void main() {
 
       inner.releaseAll();
       await Future.wait<void>(futures);
+    });
+
+    test('default maxConcurrent caps in-flight at 10', () async {
+      final inner = _ConcurrencyTrackingInner();
+      final client = createAgentHttpClient(innerClient: inner);
+
+      final futures = List.generate(
+        15,
+        (i) => client.request('GET', Uri.parse('https://api/$i')),
+      );
+
+      await _pumpEventQueue();
+
+      expect(
+        inner.maxInFlight,
+        equals(10),
+        reason: 'default cap must match the upstream connection limit; '
+            'lowering this would overshoot the origin and trigger 429s',
+      );
+
+      inner.releaseAll();
+      await Future.wait<void>(futures);
+    });
+
+    test(
+        'decorator order: concurrency wraps auth '
+        '(getToken fires at dispatch, not enqueue)', () async {
+      final inner = _ConcurrencyTrackingInner();
+      var getTokenCalls = 0;
+      final client = createAgentHttpClient(
+        innerClient: inner,
+        maxConcurrent: 1,
+        getToken: () {
+          getTokenCalls++;
+          return 'token-$getTokenCalls';
+        },
+      );
+
+      final futures = [
+        client.request('GET', Uri.parse('https://api/1')),
+        client.request('GET', Uri.parse('https://api/2')),
+        client.request('GET', Uri.parse('https://api/3')),
+      ];
+
+      await _pumpEventQueue();
+
+      // Pins the decorator order. ConcurrencyLimitingHttpClient is the
+      // outermost decorator, so getToken fires per dispatch (after a
+      // slot is acquired), not per enqueue. With only 1 slot, only 1
+      // request has reached the auth layer; the other 2 are still
+      // queued in the concurrency layer and have NOT called getToken.
+      //
+      // If this assertion ever flips to 3, the decorator order was
+      // reversed — tokens would be fetched at enqueue and could go
+      // stale during queue wait, silently breaking streams (which
+      // cannot be retried on 401).
+      expect(inner.maxInFlight, 1);
+      expect(
+        getTokenCalls,
+        1,
+        reason: 'concurrency wraps auth: only the dispatched request '
+            'has hit the auth layer so far',
+      );
+
+      inner.releaseAll();
+      await Future.wait<void>(futures);
+      expect(
+        getTokenCalls,
+        3,
+        reason: 'after all 3 requests dequeue and dispatch, each should '
+            'have called getToken exactly once',
+      );
     });
 
     test(
@@ -159,7 +348,7 @@ void main() {
         client.request('GET', Uri.parse('https://api/b')),
       ];
 
-      await Future<void>.delayed(const Duration(milliseconds: 20));
+      await _pumpEventQueue();
       inner.releaseAll();
       await Future.wait<void>(futures);
 
@@ -167,42 +356,6 @@ void main() {
     });
 
     group('auth', () {
-      test('with getToken wraps in AuthenticatedHttpClient', () {
-        final client = createAgentHttpClient(getToken: () => 'token');
-        addTearDown(client.close);
-        expect(client, isA<AuthenticatedHttpClient>());
-      });
-
-      test('with getToken and observers applies both layers', () {
-        final client = createAgentHttpClient(
-          getToken: () => 'token',
-          observers: [_MockObserver()],
-        );
-        addTearDown(client.close);
-        // Outermost is AuthenticatedHttpClient
-        expect(client, isA<AuthenticatedHttpClient>());
-      });
-
-      test('with tokenRefresher wraps in RefreshingHttpClient', () {
-        final client = createAgentHttpClient(
-          getToken: () => 'token',
-          tokenRefresher: _MockTokenRefresher(),
-        );
-        addTearDown(client.close);
-        expect(client, isA<RefreshingHttpClient>());
-      });
-
-      test('with all parameters composes full decorator stack', () {
-        final client = createAgentHttpClient(
-          observers: [_MockObserver()],
-          getToken: () => 'token',
-          tokenRefresher: _MockTokenRefresher(),
-        );
-        addTearDown(client.close);
-        // Outermost is RefreshingHttpClient
-        expect(client, isA<RefreshingHttpClient>());
-      });
-
       test('tokenRefresher without getToken throws assertion', () {
         expect(
           () => createAgentHttpClient(tokenRefresher: _MockTokenRefresher()),
@@ -220,6 +373,161 @@ void main() {
         ).close();
         verify(inner.close).called(1);
       });
+    });
+
+    group('diagnostic plumbing', () {
+      test('onDiagnostic fires when a concurrency observer throws', () async {
+        final inner = _ConcurrencyTrackingInner();
+        final captured = <String>[];
+        final client = createAgentHttpClient(
+          innerClient: inner,
+          observers: [_ThrowingConcurrencyObserver()],
+          onDiagnostic: (_, __, {required message}) => captured.add(message),
+        );
+
+        final future = client.request('GET', Uri.parse('https://api/x'));
+        inner.releaseAll();
+        await future;
+
+        expect(
+          captured,
+          hasLength(1),
+          reason: 'onDiagnostic must be invoked by the limiter when a '
+              'ConcurrencyObserver throws',
+        );
+        expect(captured.single, contains('ConcurrencyObserver'));
+      });
+
+      test('onDiagnostic fires when an HttpObserver throws', () async {
+        final inner = _ConcurrencyTrackingInner();
+        final captured = <String>[];
+        final client = createAgentHttpClient(
+          innerClient: inner,
+          observers: [_ThrowingHttpObserver()],
+          onDiagnostic: (_, __, {required message}) => captured.add(message),
+        );
+
+        final future = client.request('GET', Uri.parse('https://api/x'));
+        inner.releaseAll();
+        await future;
+
+        expect(
+          captured.any((m) => m.contains('_ThrowingHttpObserver')),
+          isTrue,
+          reason: 'onDiagnostic must be invoked by the observable layer '
+              'when an HttpObserver throws',
+        );
+      });
+    });
+
+    group('decorator composition invariants', () {
+      test(
+        'refresh via a separate client does not deadlock when the authed '
+        "client's pool is exhausted",
+        () async {
+          // `standard.dart` creates per-server authed clients via
+          // createAgentHttpClient and a refresh-service client via a
+          // separate createAgentHttpClient call. Each call returns a
+          // client with its OWN limiter — the refresher does not
+          // contend for the authed client's slot.
+          //
+          // If a future refactor hoists the limiter to a shared
+          // instance, the refresh path (triggered by 401) would try to
+          // acquire a slot from the same pool the authed request is
+          // holding → deadlock. This test would then hang and time
+          // out, which is precisely the signal we want.
+          final refresherInner = _OrderedInner(
+            uri401: Uri.parse('https://never.fires'),
+          );
+          final plainClient = createAgentHttpClient(
+            innerClient: refresherInner,
+            maxConcurrent: 1,
+          );
+          addTearDown(plainClient.close);
+
+          final authedInner = _OrderedInner(
+            uri401: Uri.parse('https://api/work'),
+          );
+          final refresher = _RefresherViaClient(plainClient);
+          final authedClient = createAgentHttpClient(
+            innerClient: authedInner,
+            maxConcurrent: 1,
+            getToken: () => 'token',
+            tokenRefresher: refresher,
+          );
+          addTearDown(authedClient.close);
+
+          final response = await authedClient
+              .request('GET', Uri.parse('https://api/work'))
+              .timeout(
+                const Duration(seconds: 2),
+                onTimeout: () => throw TimeoutException(
+                  'refresh deadlocked — the refresher is contending for '
+                  "the authed client's concurrency slot. The decorator "
+                  'factory must mint an independent limiter per call; '
+                  'if you refactored to share limiters across clients, '
+                  'that change re-introduces the original 429 deadlock.',
+                ),
+              );
+
+          expect(response.statusCode, 200);
+          expect(refresher.refreshCalls, 1);
+        },
+      );
+
+      test(
+        'decorator order: concurrency wraps refreshing '
+        '(401 retries do not release and reacquire concurrency slots)',
+        () async {
+          // A single client with maxConcurrent: 1. Request A is served
+          // 401 on first attempt, then 200 on the retry inside the
+          // refresh path. Request B is fired concurrently.
+          //
+          // Correct order (Concurrency wraps Refreshing): A holds the
+          // slot across its 401 → refresh → retry, so B waits the
+          // entire time. Execution order at the inner is [A, A, B].
+          //
+          // Broken order (Refreshing wraps Concurrency): A's 401 would
+          // release the slot, B would grab it, and A's retry would
+          // queue behind B. Execution order becomes [A, B, A]. Failing
+          // this test is the signal that the decorator stack was
+          // reordered and the docstring claim about slot continuity no
+          // longer holds.
+          final refresherInner = _OrderedInner(
+            uri401: Uri.parse('https://never.fires'),
+          );
+          final plainClient = createAgentHttpClient(
+            innerClient: refresherInner,
+            maxConcurrent: 2,
+          );
+          addTearDown(plainClient.close);
+
+          final authedInner = _OrderedInner(
+            uri401: Uri.parse('https://api/A'),
+          );
+          final authedClient = createAgentHttpClient(
+            innerClient: authedInner,
+            maxConcurrent: 1,
+            getToken: () => 'token',
+            tokenRefresher: _RefresherViaClient(plainClient),
+          );
+          addTearDown(authedClient.close);
+
+          final futures = [
+            authedClient.request('GET', Uri.parse('https://api/A')),
+            authedClient.request('GET', Uri.parse('https://api/B')),
+          ];
+
+          await Future.wait<HttpResponse>(futures);
+
+          expect(
+            authedInner.executionOrder,
+            equals(['/A', '/A', '/B']),
+            reason: 'concurrency wraps refreshing: A must hold its slot '
+                'through the 401 + retry before B can dispatch',
+          );
+        },
+      );
     });
   });
 }

--- a/packages/soliplex_client/CLAUDE.md
+++ b/packages/soliplex_client/CLAUDE.md
@@ -36,12 +36,14 @@ error, stream start, stream end.
 ## HTTP Decorator Chain
 
 ```text
-HttpTransport -> RefreshingHttpClient -> AuthenticatedHttpClient
-  -> ObservableHttpClient -> Platform Client
+HttpTransport -> ConcurrencyLimitingHttpClient -> RefreshingHttpClient
+  -> AuthenticatedHttpClient -> ObservableHttpClient -> Platform Client
 ```
 
 Each decorator implements `SoliplexHttpClient` and delegates to an inner
-client. See `docs/architecture/http-stack.md` for full details.
+client. Concurrency is outermost so that per-request auth work (token
+fetch, proactive refresh) runs at dispatch time rather than at enqueue
+time — keeping queued requests from holding stale tokens.
 
 ## Directory Structure
 

--- a/packages/soliplex_client/lib/src/http/concurrency_limiting_http_client.dart
+++ b/packages/soliplex_client/lib/src/http/concurrency_limiting_http_client.dart
@@ -321,14 +321,14 @@ class _Semaphore {
   }
 
   void release() {
-    // Skip waiters that were already completed by CancelToken — handing
-    // them the permit would waste it (the caller already threw).
-    while (_waiters.isNotEmpty) {
-      final next = _waiters.removeFirst();
-      if (!next.isCompleted) {
-        next.complete();
-        return;
-      }
+    // Invariant: every completer in [_waiters] is uncompleted. The
+    // cancel handler in [acquire] atomically removes a completer from
+    // the queue and completes it with an error, so completed completers
+    // never linger. That lets release() hand the permit to the head
+    // without a skip-loop.
+    if (_waiters.isNotEmpty) {
+      _waiters.removeFirst().complete();
+      return;
     }
     _available++;
   }

--- a/packages/soliplex_client/lib/src/http/concurrency_limiting_http_client.dart
+++ b/packages/soliplex_client/lib/src/http/concurrency_limiting_http_client.dart
@@ -22,8 +22,14 @@ import 'package:soliplex_client/src/utils/cancel_token.dart';
 /// [requestStream] holds its slot for the response body's entire
 /// lifetime — released when the body stream completes, errors, or is
 /// cancelled. This accurately models what the upstream sees (an open
-/// connection). Default [maxConcurrent] is 10, matching Nginx's
-/// `limit_conn conn 10`.
+/// connection).
+///
+/// ## Observer correlation
+///
+/// The [HttpConcurrencyWaitEvent.requestId] is generated inside this
+/// decorator and does NOT correlate with the `requestId` used by
+/// other HTTP observers for the same logical request. Observers that
+/// need cross-layer correlation should match by URI + timestamp.
 ///
 /// ## Decorator order
 ///
@@ -38,38 +44,48 @@ class ConcurrencyLimitingHttpClient implements SoliplexHttpClient {
   /// Creates a concurrency-limiting HTTP client.
   ///
   /// - [inner]: The wrapped HTTP client.
-  /// - [maxConcurrent]: Maximum in-flight requests (default 10).
+  /// - [maxConcurrent]: Maximum in-flight requests. Must be at least 1.
+  ///   Sized to match the upstream's connection limit.
   /// - [observers]: Observers notified of queue-wait events.
   /// - [generateRequestId]: Optional ID generator; defaults to a
-  ///   timestamp+counter scheme.
+  ///   per-instance timestamp+counter scheme.
   /// - [clock]: Test injection point for deterministic `waitDuration`.
   ConcurrencyLimitingHttpClient({
     required SoliplexHttpClient inner,
-    this.maxConcurrent = 10,
+    required this.maxConcurrent,
     List<ConcurrencyObserver> observers = const [],
     String Function()? generateRequestId,
     DateTime Function()? clock,
-  })  : assert(maxConcurrent >= 1, 'maxConcurrent must be at least 1'),
-        _inner = inner,
+  })  : _inner = inner,
         _observers = List.unmodifiable(observers),
-        _generateRequestId = generateRequestId ?? _defaultRequestIdGenerator,
+        _overrideGenerateRequestId = generateRequestId,
         _clock = clock ?? DateTime.now,
-        _semaphore = _Semaphore(maxConcurrent);
+        _semaphore = _Semaphore(maxConcurrent) {
+    if (maxConcurrent < 1) {
+      throw RangeError.range(maxConcurrent, 1, null, 'maxConcurrent');
+    }
+  }
 
   final SoliplexHttpClient _inner;
   final List<ConcurrencyObserver> _observers;
-  final String Function() _generateRequestId;
+  final String Function()? _overrideGenerateRequestId;
   final DateTime Function() _clock;
   final _Semaphore _semaphore;
+  int _counter = 0;
 
   /// Maximum in-flight requests.
   final int maxConcurrent;
 
-  static int _requestCounter = 0;
+  String _generateRequestId() =>
+      _overrideGenerateRequestId?.call() ??
+      'cc-${DateTime.now().millisecondsSinceEpoch}-${_counter++}';
 
-  static String _defaultRequestIdGenerator() =>
-      'cc-${DateTime.now().millisecondsSinceEpoch}-${_requestCounter++}';
-
+  /// Performs a one-shot HTTP request, respecting the concurrency cap.
+  ///
+  /// [SoliplexHttpClient.request] has no `CancelToken`, so queued
+  /// non-stream requests cannot be cancelled at this layer — they wait
+  /// for their slot, dispatch, and can only be cancelled by a timeout
+  /// on the inner client. For cancel-aware behavior use [requestStream].
   @override
   Future<HttpResponse> request(
     String method,
@@ -82,17 +98,16 @@ class ConcurrencyLimitingHttpClient implements SoliplexHttpClient {
     final enqueuedAt = _clock();
     final depthAtEnqueue = _semaphore.inUseCount + _semaphore.waitingCount;
 
-    // request() has no CancelToken in the SoliplexHttpClient interface,
-    // so we can't cancel queued non-stream requests.
-    final wasQueued = await _semaphore.acquire();
+    final outcome = await _semaphore.acquire();
 
     final acquiredAt = _clock();
     _emitConcurrencyWait(
       requestId: requestId,
       uri: uri,
       timestamp: acquiredAt,
-      waitDuration:
-          wasQueued ? acquiredAt.difference(enqueuedAt) : Duration.zero,
+      waitDuration: outcome == _AcquireOutcome.queued
+          ? acquiredAt.difference(enqueuedAt)
+          : Duration.zero,
       queueDepthAtEnqueue: depthAtEnqueue,
     );
 
@@ -109,9 +124,9 @@ class ConcurrencyLimitingHttpClient implements SoliplexHttpClient {
     }
   }
 
-  /// Acquires a semaphore slot, delegates to the inner client, and
-  /// wraps the response body so the slot is released on stream
-  /// complete/error/cancel.
+  /// Acquires a semaphore slot and delegates to the inner client. The
+  /// returned body stream is wrapped so the slot is released when the
+  /// body completes, errors, or is cancelled.
   ///
   /// **Precondition:** callers MUST listen to the returned
   /// [StreamedHttpResponse.body]. An unlistened body stream will hold
@@ -130,7 +145,7 @@ class ConcurrencyLimitingHttpClient implements SoliplexHttpClient {
     final enqueuedAt = _clock();
     final depthAtEnqueue = _semaphore.inUseCount + _semaphore.waitingCount;
 
-    final wasQueued = await _semaphore.acquire(cancelToken: cancelToken);
+    final outcome = await _semaphore.acquire(cancelToken: cancelToken);
 
     StreamedHttpResponse response;
     try {
@@ -141,8 +156,9 @@ class ConcurrencyLimitingHttpClient implements SoliplexHttpClient {
         requestId: requestId,
         uri: uri,
         timestamp: acquiredAt,
-        waitDuration:
-            wasQueued ? acquiredAt.difference(enqueuedAt) : Duration.zero,
+        waitDuration: outcome == _AcquireOutcome.queued
+            ? acquiredAt.difference(enqueuedAt)
+            : Duration.zero,
         queueDepthAtEnqueue: depthAtEnqueue,
       );
 
@@ -168,6 +184,11 @@ class ConcurrencyLimitingHttpClient implements SoliplexHttpClient {
 
   /// Wraps a body stream so the semaphore slot is released when the
   /// stream completes, errors, or is cancelled.
+  ///
+  /// Uses `sync: true` to avoid a per-chunk microtask hop on high-rate
+  /// byte streams (e.g., SSE). Backpressure is propagated by the
+  /// explicit `onPause`/`onResume` forwarding below, not by the sync
+  /// mode.
   Stream<List<int>> _wrapBodyWithRelease(Stream<List<int>> source) {
     var released = false;
     void releaseOnce() {
@@ -231,12 +252,26 @@ class ConcurrencyLimitingHttpClient implements SoliplexHttpClient {
     for (final observer in _observers) {
       try {
         observer.onConcurrencyWait(event);
-      } on Object {
-        // Observer failures must not disrupt the request flow.
+      } on Object catch (error, stackTrace) {
+        // Observer failures must not disrupt the request flow, but
+        // surface the error in debug so a broken observer is visible.
+        assert(
+          () {
+            // ignore: avoid_print
+            print('ConcurrencyObserver ${observer.runtimeType} threw: '
+                '$error\n$stackTrace');
+            return true;
+          }(),
+          'observer logging assert',
+        );
       }
     }
   }
 }
+
+/// Outcome of a semaphore acquisition — whether the caller was queued
+/// or acquired a permit immediately.
+enum _AcquireOutcome { immediate, queued }
 
 /// Cancel-aware FIFO semaphore.
 ///
@@ -255,12 +290,12 @@ class _Semaphore {
 
   int get waitingCount => _waiters.length;
 
-  /// Returns `true` if the caller was queued, `false` if a permit was
-  /// available immediately.
-  Future<bool> acquire({CancelToken? cancelToken}) {
+  /// Returns [_AcquireOutcome.queued] if the caller had to wait, or
+  /// [_AcquireOutcome.immediate] if a permit was available.
+  Future<_AcquireOutcome> acquire({CancelToken? cancelToken}) {
     if (_available > 0) {
       _available--;
-      return Future<bool>.value(false);
+      return Future<_AcquireOutcome>.value(_AcquireOutcome.immediate);
     }
     cancelToken?.throwIfCancelled();
 
@@ -268,6 +303,10 @@ class _Semaphore {
     _waiters.add(completer);
 
     if (cancelToken != null) {
+      // The callback runs as a single synchronous block with no await,
+      // so the isCompleted check and subsequent completeError cannot be
+      // interleaved by a concurrent release() — Dart microtasks never
+      // preempt synchronous execution.
       cancelToken.whenCancelled.then((_) {
         if (!completer.isCompleted) {
           _waiters.remove(completer);
@@ -278,7 +317,7 @@ class _Semaphore {
       });
     }
 
-    return completer.future.then((_) => true);
+    return completer.future.then((_) => _AcquireOutcome.queued);
   }
 
   void release() {

--- a/packages/soliplex_client/lib/src/http/concurrency_limiting_http_client.dart
+++ b/packages/soliplex_client/lib/src/http/concurrency_limiting_http_client.dart
@@ -259,9 +259,15 @@ class ConcurrencyLimitingHttpClient implements SoliplexHttpClient {
       // client, tearing down the socket.
       try {
         source.listen(null).cancel();
-      } on Object {
-        // source may already be errored or in a weird state; the slot
-        // release below is what matters for the pool.
+      } on Object catch (error, stackTrace) {
+        // Best-effort drain; slot release below is what matters for the
+        // pool. A consistently-failing drain may indicate a platform
+        // client bug, so surface it to diagnostics.
+        _onDiagnostic(
+          error,
+          stackTrace,
+          message: 'Unlistened body drain failed (slot released anyway)',
+        );
       }
       slot.release();
     });
@@ -377,6 +383,8 @@ class _Semaphore {
   int get waitingCount => _waiters.length;
 
   Future<_SlotHandle> acquire({CancelToken? cancelToken}) {
+    cancelToken?.throwIfCancelled();
+
     if (_closed) {
       return Future<_SlotHandle>.error(
         const CancelledException(reason: 'HTTP client closed'),
@@ -394,7 +402,6 @@ class _Semaphore {
         _SlotHandle._(this, _AcquireOutcome.immediate),
       );
     }
-    cancelToken?.throwIfCancelled();
 
     final completer = Completer<void>();
     _waiters.add(completer);

--- a/packages/soliplex_client/lib/src/http/concurrency_limiting_http_client.dart
+++ b/packages/soliplex_client/lib/src/http/concurrency_limiting_http_client.dart
@@ -29,13 +29,8 @@ import 'package:soliplex_client/src/utils/cancel_token.dart';
 class ConcurrencyLimitingHttpClient implements SoliplexHttpClient {
   /// Creates a concurrency-limiting HTTP client.
   ///
-  /// - [inner]: The wrapped HTTP client.
-  /// - [maxConcurrent]: Maximum in-flight requests. Must be at least 1.
-  ///   Sized to match the upstream's connection limit.
-  /// - [observers]: Observers notified of queue-wait events.
-  /// - [generateAcquisitionId]: Optional ID generator.
-  /// - [clock]: Optional clock override (tests only).
-  /// - [onDiagnostic]: Handler for contained internal errors.
+  /// [maxConcurrent] must be at least 1 and should match the upstream's
+  /// connection limit. [clock] is intended for tests only.
   ConcurrencyLimitingHttpClient({
     required SoliplexHttpClient inner,
     required int maxConcurrent,
@@ -43,20 +38,21 @@ class ConcurrencyLimitingHttpClient implements SoliplexHttpClient {
     String Function()? generateAcquisitionId,
     DateTime Function()? clock,
     HttpDiagnosticHandler? onDiagnostic,
-  })  : maxConcurrent = maxConcurrent >= 1
-            ? maxConcurrent
+  })  : _inner = inner,
+        _observers = List.unmodifiable(observers),
+        _overrideGenerateAcquisitionId = generateAcquisitionId,
+        _clock = clock ?? DateTime.now,
+        _onDiagnostic = safeDiagnosticHandler(
+          onDiagnostic ?? defaultHttpDiagnosticHandler,
+        ),
+        _semaphore = maxConcurrent >= 1
+            ? _Semaphore(maxCount: maxConcurrent)
             : throw RangeError.range(
                 maxConcurrent,
                 1,
                 null,
                 'maxConcurrent',
-              ),
-        _inner = inner,
-        _observers = List.unmodifiable(observers),
-        _overrideGenerateAcquisitionId = generateAcquisitionId,
-        _clock = clock ?? DateTime.now,
-        _onDiagnostic = onDiagnostic ?? defaultHttpDiagnosticHandler,
-        _semaphore = _Semaphore(maxCount: maxConcurrent);
+              );
 
   final SoliplexHttpClient _inner;
   final List<ConcurrencyObserver> _observers;
@@ -65,14 +61,12 @@ class ConcurrencyLimitingHttpClient implements SoliplexHttpClient {
   final _Semaphore _semaphore;
   final HttpDiagnosticHandler _onDiagnostic;
 
-  /// Monotonic counter that never resets — it tie-breaks IDs within a
-  /// single millisecond. Resetting would risk collisions when a new
-  /// epoch's counter coincides with a prior timestamp, and an `int`
-  /// takes fixed memory regardless of magnitude.
+  /// Monotonic counter that never resets — tie-breaks IDs within a
+  /// single millisecond. Resetting could collide with a prior timestamp.
   int _counter = 0;
 
   /// Maximum in-flight requests.
-  final int maxConcurrent;
+  int get maxConcurrent => _semaphore.maxCount;
 
   String _generateAcquisitionId() =>
       _overrideGenerateAcquisitionId?.call() ??
@@ -128,11 +122,12 @@ class ConcurrencyLimitingHttpClient implements SoliplexHttpClient {
   /// body completes, errors, or is cancelled.
   ///
   /// **Precondition:** callers MUST listen to the returned
-  /// [StreamedHttpResponse.body]. An unlistened body holds the
-  /// semaphore slot indefinitely, starving other requests and
-  /// eventually exhausting the pool. A debug-only detector logs after
-  /// 10 seconds to catch this during development; release builds do
-  /// not detect the leak.
+  /// [StreamedHttpResponse.body] within 60 seconds. An unlistened body
+  /// holds the semaphore slot, and with the default cap as few as ten
+  /// such leaks would brick the pool. After 60 seconds without a
+  /// listener, the upstream is drained, the slot is released, and a
+  /// late listener receives a [StateError]. The timeout logs via the
+  /// diagnostic handler so caller bugs are visible in production.
   @override
   Future<StreamedHttpResponse> requestStream(
     String method,
@@ -149,7 +144,6 @@ class ConcurrencyLimitingHttpClient implements SoliplexHttpClient {
 
     final slot = await _semaphore.acquire(cancelToken: cancelToken);
 
-    StreamedHttpResponse response;
     try {
       cancelToken?.throwIfCancelled();
 
@@ -164,24 +158,24 @@ class ConcurrencyLimitingHttpClient implements SoliplexHttpClient {
         queueDepthAtEnqueue: depthAtEnqueue,
       );
 
-      response = await _inner.requestStream(
+      final response = await _inner.requestStream(
         method,
         uri,
         headers: headers,
         body: body,
         cancelToken: cancelToken,
       );
+
+      return StreamedHttpResponse(
+        statusCode: response.statusCode,
+        headers: response.headers,
+        reasonPhrase: response.reasonPhrase,
+        body: _wrapBodyWithRelease(response.body, uri, slot),
+      );
     } on Object {
       slot.release();
       rethrow;
     }
-
-    return StreamedHttpResponse(
-      statusCode: response.statusCode,
-      headers: response.headers,
-      reasonPhrase: response.reasonPhrase,
-      body: _wrapBodyWithRelease(response.body, uri, slot),
-    );
   }
 
   /// Wraps a body stream so [slot] is released when the stream
@@ -189,9 +183,11 @@ class ConcurrencyLimitingHttpClient implements SoliplexHttpClient {
   /// idempotent, so multiple callback paths (onDone + onCancel,
   /// onListen-catch + onCancel) are safe.
   ///
-  /// `sync: true` avoids a per-chunk microtask hop on high-rate byte
-  /// streams (e.g., SSE). Backpressure is propagated by the explicit
-  /// `onPause`/`onResume` forwarding below, not by the sync mode.
+  /// A 60-second timer drains the upstream and releases the slot if
+  /// the caller never attaches a listener. Callers that attach after
+  /// the timeout receive a [StateError]. This is defense in depth
+  /// against third-party consumers of `SoliplexHttpAdapter` that may
+  /// forget to drain on error paths.
   Stream<List<int>> _wrapBodyWithRelease(
     Stream<List<int>> source,
     Uri uri,
@@ -200,17 +196,26 @@ class ConcurrencyLimitingHttpClient implements SoliplexHttpClient {
     late StreamController<List<int>> controller;
     StreamSubscription<List<int>>? subscription;
     Timer? leakDetector;
+    var timedOut = false;
 
     controller = StreamController<List<int>>(
       sync: true,
       onListen: () {
-        assert(
-          () {
-            leakDetector?.cancel();
-            return true;
-          }(),
-          'cancel leak detector on listen',
-        );
+        leakDetector?.cancel();
+        if (timedOut) {
+          slot.release();
+          controller
+            ..addError(
+              StateError(
+                'Response body was drained by the 60s unlistened-body '
+                'timeout. Caller must listen within 60 seconds of '
+                'receiving the response.',
+              ),
+              StackTrace.current,
+            )
+            ..close();
+          return;
+        }
         try {
           subscription = source.listen(
             controller.add,
@@ -236,37 +241,35 @@ class ConcurrencyLimitingHttpClient implements SoliplexHttpClient {
       onPause: () => subscription?.pause(),
       onResume: () => subscription?.resume(),
       onCancel: () {
-        assert(
-          () {
-            leakDetector?.cancel();
-            return true;
-          }(),
-          'cancel leak detector on body cancel',
-        );
+        leakDetector?.cancel();
         slot.release();
         return subscription?.cancel();
       },
     );
 
-    assert(
-      () {
-        leakDetector = Timer(const Duration(seconds: 10), () {
-          if (!controller.hasListener) {
-            _onDiagnostic(
-              StateError(
-                'Concurrency slot held by unlistened response body for >10s. '
-                'Callers must listen to StreamedHttpResponse.body.',
-              ),
-              StackTrace.current,
-              message: 'Unlistened body stream leak (URI: '
-                  '${HttpRedactor.redactUri(uri)})',
-            );
-          }
-        });
-        return true;
-      }(),
-      'install debug-only unlistened-body leak detector',
-    );
+    leakDetector = Timer(const Duration(seconds: 60), () {
+      if (controller.hasListener || controller.isClosed) return;
+      timedOut = true;
+      _onDiagnostic(
+        StateError(
+          'Concurrency slot held by unlistened response body for >60s. '
+          'Draining upstream and releasing the slot to protect the pool.',
+        ),
+        StackTrace.current,
+        message: 'Unlistened body stream leak (URI: '
+            '${HttpRedactor.redactUri(uri)})',
+      );
+      // Drain via listen(null).cancel() — not drain(), which would wait
+      // for all data. cancel() propagates an abort to the platform
+      // client, tearing down the socket.
+      try {
+        source.listen(null).cancel();
+      } on Object {
+        // source may already be errored or in a weird state; the slot
+        // release below is what matters for the pool.
+      }
+      slot.release();
+    });
 
     return controller.stream;
   }
@@ -387,6 +390,11 @@ class _Semaphore {
 
     if (_available > 0) {
       _available--;
+      assert(
+        _available >= 0 && _available <= maxCount,
+        'permit conservation violated after acquire: '
+        '_available=$_available, maxCount=$maxCount',
+      );
       return Future<_SlotHandle>.value(
         _SlotHandle._(this, _AcquireOutcome.immediate),
       );
@@ -396,27 +404,29 @@ class _Semaphore {
     final completer = Completer<void>();
     _waiters.add(completer);
 
+    // Subscribe (rather than Future.then) so the listener can be
+    // detached once the slot is acquired. A CancelToken reused across
+    // many queued requests would otherwise accumulate zombie closures
+    // pinning the semaphore until the token is cancelled or GC'd.
+    StreamSubscription<void>? cancelSub;
     if (cancelToken != null) {
-      // Dart's single-threaded run-to-completion guarantees no
-      // interleaving between the isCompleted check and completeError.
-      unawaited(
-        cancelToken.whenCancelled.then((_) {
-          if (!completer.isCompleted) {
-            _waiters.remove(completer);
-            completer.completeError(
-              CancelledException(reason: cancelToken.reason),
-            );
-          }
-        }),
-      );
+      cancelSub = cancelToken.whenCancelled.asStream().listen((_) {
+        // Dart's single-threaded run-to-completion guarantees no
+        // interleaving between the isCompleted check and completeError.
+        if (!completer.isCompleted) {
+          _waiters.remove(completer);
+          completer.completeError(
+            CancelledException(reason: cancelToken.reason),
+          );
+        }
+      });
     }
 
-    return completer.future
-        .then((_) => _SlotHandle._(this, _AcquireOutcome.queued));
+    return completer.future.whenComplete(() => cancelSub?.cancel()).then(
+          (_) => _SlotHandle._(this, _AcquireOutcome.queued),
+        );
   }
 
-  /// Hands the permit to the next queued waiter, or returns it to
-  /// the pool.
   void _onSlotReleased() {
     // Invariant: every completer in [_waiters] is uncompleted (the
     // cancel handler in [acquire] removes completed completers from the
@@ -427,6 +437,11 @@ class _Semaphore {
       return;
     }
     _available++;
+    assert(
+      _available >= 0 && _available <= maxCount,
+      'permit conservation violated after release: '
+      '_available=$_available, maxCount=$maxCount',
+    );
   }
 
   /// Errors out all queued waiters and refuses future acquires.

--- a/packages/soliplex_client/lib/src/http/concurrency_limiting_http_client.dart
+++ b/packages/soliplex_client/lib/src/http/concurrency_limiting_http_client.dart
@@ -3,6 +3,7 @@ import 'dart:collection';
 
 import 'package:soliplex_client/src/errors/exceptions.dart';
 import 'package:soliplex_client/src/http/concurrency_observer.dart';
+import 'package:soliplex_client/src/http/http_diagnostic.dart';
 import 'package:soliplex_client/src/http/http_redactor.dart';
 import 'package:soliplex_client/src/http/http_response.dart';
 import 'package:soliplex_client/src/http/soliplex_http_client.dart';
@@ -14,32 +15,17 @@ import 'package:soliplex_client/src/utils/cancel_token.dart';
 /// release their slots. Queued stream requests drop out of the queue
 /// immediately when their [CancelToken] fires — no slot is acquired.
 ///
-/// Emits [HttpConcurrencyWaitEvent] to observers on every slot
+/// Emits [ConcurrencyWaitEvent] to observers on every slot
 /// acquisition, including acquisitions with `waitDuration == 0`.
-///
-/// ## Streams
 ///
 /// [requestStream] holds its slot for the response body's entire
 /// lifetime — released when the body stream completes, errors, or is
 /// cancelled. This accurately models what the upstream sees (an open
 /// connection).
 ///
-/// ## Observer correlation
-///
-/// The [HttpConcurrencyWaitEvent.requestId] is generated inside this
-/// decorator and does NOT correlate with the `requestId` used by
-/// other HTTP observers for the same logical request. Observers that
-/// need cross-layer correlation should match by URI + timestamp.
-///
-/// ## Decorator order
-///
-/// Place below `AuthenticatedHttpClient` so queued requests don't hold
-/// stale tokens, and above `ObservableHttpClient` so each wire attempt
-/// is observed individually.
-///
-/// ```text
-/// Refreshing -> Authenticated -> Concurrency -> Observable -> Platform
-/// ```
+/// Place at the outermost layer of the auth-aware stack so per-request
+/// auth work (token fetch, proactive refresh) runs at dispatch time, not
+/// at enqueue time — queued requests therefore never hold stale tokens.
 class ConcurrencyLimitingHttpClient implements SoliplexHttpClient {
   /// Creates a concurrency-limiting HTTP client.
   ///
@@ -47,45 +33,58 @@ class ConcurrencyLimitingHttpClient implements SoliplexHttpClient {
   /// - [maxConcurrent]: Maximum in-flight requests. Must be at least 1.
   ///   Sized to match the upstream's connection limit.
   /// - [observers]: Observers notified of queue-wait events.
-  /// - [generateRequestId]: Optional ID generator; defaults to a
-  ///   per-instance timestamp+counter scheme.
-  /// - [clock]: Test injection point for deterministic `waitDuration`.
+  /// - [generateAcquisitionId]: Optional ID generator.
+  /// - [clock]: Optional clock override (tests only).
+  /// - [onDiagnostic]: Handler for contained internal errors.
   ConcurrencyLimitingHttpClient({
     required SoliplexHttpClient inner,
-    required this.maxConcurrent,
+    required int maxConcurrent,
     List<ConcurrencyObserver> observers = const [],
-    String Function()? generateRequestId,
+    String Function()? generateAcquisitionId,
     DateTime Function()? clock,
-  })  : _inner = inner,
+    HttpDiagnosticHandler? onDiagnostic,
+  })  : maxConcurrent = maxConcurrent >= 1
+            ? maxConcurrent
+            : throw RangeError.range(
+                maxConcurrent,
+                1,
+                null,
+                'maxConcurrent',
+              ),
+        _inner = inner,
         _observers = List.unmodifiable(observers),
-        _overrideGenerateRequestId = generateRequestId,
+        _overrideGenerateAcquisitionId = generateAcquisitionId,
         _clock = clock ?? DateTime.now,
-        _semaphore = _Semaphore(maxConcurrent) {
-    if (maxConcurrent < 1) {
-      throw RangeError.range(maxConcurrent, 1, null, 'maxConcurrent');
-    }
-  }
+        _onDiagnostic = onDiagnostic ?? defaultHttpDiagnosticHandler,
+        _semaphore = _Semaphore(maxCount: maxConcurrent);
 
   final SoliplexHttpClient _inner;
   final List<ConcurrencyObserver> _observers;
-  final String Function()? _overrideGenerateRequestId;
+  final String Function()? _overrideGenerateAcquisitionId;
   final DateTime Function() _clock;
   final _Semaphore _semaphore;
+  final HttpDiagnosticHandler _onDiagnostic;
+
+  /// Monotonic counter that never resets — it tie-breaks IDs within a
+  /// single millisecond. Resetting would risk collisions when a new
+  /// epoch's counter coincides with a prior timestamp, and an `int`
+  /// takes fixed memory regardless of magnitude.
   int _counter = 0;
 
   /// Maximum in-flight requests.
   final int maxConcurrent;
 
-  String _generateRequestId() =>
-      _overrideGenerateRequestId?.call() ??
-      'cc-${DateTime.now().millisecondsSinceEpoch}-${_counter++}';
+  String _generateAcquisitionId() =>
+      _overrideGenerateAcquisitionId?.call() ??
+      'acq-${_clock().millisecondsSinceEpoch}-${_counter++}';
 
   /// Performs a one-shot HTTP request, respecting the concurrency cap.
   ///
   /// [SoliplexHttpClient.request] has no `CancelToken`, so queued
   /// non-stream requests cannot be cancelled at this layer — they wait
   /// for their slot, dispatch, and can only be cancelled by a timeout
-  /// on the inner client. For cancel-aware behavior use [requestStream].
+  /// on the inner client. Note that the timeout governs only the
+  /// post-acquisition request, not queue-wait time.
   @override
   Future<HttpResponse> request(
     String method,
@@ -94,24 +93,24 @@ class ConcurrencyLimitingHttpClient implements SoliplexHttpClient {
     Object? body,
     Duration? timeout,
   }) async {
-    final requestId = _generateRequestId();
+    final acquisitionId = _generateAcquisitionId();
     final enqueuedAt = _clock();
     final depthAtEnqueue = _semaphore.inUseCount + _semaphore.waitingCount;
 
-    final outcome = await _semaphore.acquire();
-
-    final acquiredAt = _clock();
-    _emitConcurrencyWait(
-      requestId: requestId,
-      uri: uri,
-      timestamp: acquiredAt,
-      waitDuration: outcome == _AcquireOutcome.queued
-          ? acquiredAt.difference(enqueuedAt)
-          : Duration.zero,
-      queueDepthAtEnqueue: depthAtEnqueue,
-    );
+    final slot = await _semaphore.acquire();
 
     try {
+      final acquiredAt = _clock();
+      _emitConcurrencyWait(
+        acquisitionId: acquisitionId,
+        uri: uri,
+        timestamp: acquiredAt,
+        waitDuration: slot.outcome == _AcquireOutcome.queued
+            ? _nonNegative(acquiredAt.difference(enqueuedAt))
+            : Duration.zero,
+        queueDepthAtEnqueue: depthAtEnqueue,
+      );
+
       return await _inner.request(
         method,
         uri,
@@ -120,7 +119,7 @@ class ConcurrencyLimitingHttpClient implements SoliplexHttpClient {
         timeout: timeout,
       );
     } finally {
-      _semaphore.release();
+      slot.release();
     }
   }
 
@@ -129,8 +128,11 @@ class ConcurrencyLimitingHttpClient implements SoliplexHttpClient {
   /// body completes, errors, or is cancelled.
   ///
   /// **Precondition:** callers MUST listen to the returned
-  /// [StreamedHttpResponse.body]. An unlistened body stream will hold
-  /// the semaphore slot indefinitely, starving other requests.
+  /// [StreamedHttpResponse.body]. An unlistened body holds the
+  /// semaphore slot indefinitely, starving other requests and
+  /// eventually exhausting the pool. A debug-only detector logs after
+  /// 10 seconds to catch this during development; release builds do
+  /// not detect the leak.
   @override
   Future<StreamedHttpResponse> requestStream(
     String method,
@@ -141,11 +143,11 @@ class ConcurrencyLimitingHttpClient implements SoliplexHttpClient {
   }) async {
     cancelToken?.throwIfCancelled();
 
-    final requestId = _generateRequestId();
+    final acquisitionId = _generateAcquisitionId();
     final enqueuedAt = _clock();
     final depthAtEnqueue = _semaphore.inUseCount + _semaphore.waitingCount;
 
-    final outcome = await _semaphore.acquire(cancelToken: cancelToken);
+    final slot = await _semaphore.acquire(cancelToken: cancelToken);
 
     StreamedHttpResponse response;
     try {
@@ -153,11 +155,11 @@ class ConcurrencyLimitingHttpClient implements SoliplexHttpClient {
 
       final acquiredAt = _clock();
       _emitConcurrencyWait(
-        requestId: requestId,
+        acquisitionId: acquisitionId,
         uri: uri,
         timestamp: acquiredAt,
-        waitDuration: outcome == _AcquireOutcome.queued
-            ? acquiredAt.difference(enqueuedAt)
+        waitDuration: slot.outcome == _AcquireOutcome.queued
+            ? _nonNegative(acquiredAt.difference(enqueuedAt))
             : Duration.zero,
         queueDepthAtEnqueue: depthAtEnqueue,
       );
@@ -170,7 +172,7 @@ class ConcurrencyLimitingHttpClient implements SoliplexHttpClient {
         cancelToken: cancelToken,
       );
     } on Object {
-      _semaphore.release();
+      slot.release();
       rethrow;
     }
 
@@ -178,60 +180,105 @@ class ConcurrencyLimitingHttpClient implements SoliplexHttpClient {
       statusCode: response.statusCode,
       headers: response.headers,
       reasonPhrase: response.reasonPhrase,
-      body: _wrapBodyWithRelease(response.body),
+      body: _wrapBodyWithRelease(response.body, uri, slot),
     );
   }
 
-  /// Wraps a body stream so the semaphore slot is released when the
-  /// stream completes, errors, or is cancelled.
+  /// Wraps a body stream so [slot] is released when the stream
+  /// completes, errors, or is cancelled. [_SlotHandle.release] is
+  /// idempotent, so multiple callback paths (onDone + onCancel,
+  /// onListen-catch + onCancel) are safe.
   ///
-  /// Uses `sync: true` to avoid a per-chunk microtask hop on high-rate
-  /// byte streams (e.g., SSE). Backpressure is propagated by the
-  /// explicit `onPause`/`onResume` forwarding below, not by the sync
-  /// mode.
-  Stream<List<int>> _wrapBodyWithRelease(Stream<List<int>> source) {
-    var released = false;
-    void releaseOnce() {
-      if (!released) {
-        released = true;
-        _semaphore.release();
-      }
-    }
-
+  /// `sync: true` avoids a per-chunk microtask hop on high-rate byte
+  /// streams (e.g., SSE). Backpressure is propagated by the explicit
+  /// `onPause`/`onResume` forwarding below, not by the sync mode.
+  Stream<List<int>> _wrapBodyWithRelease(
+    Stream<List<int>> source,
+    Uri uri,
+    _SlotHandle slot,
+  ) {
     late StreamController<List<int>> controller;
     StreamSubscription<List<int>>? subscription;
+    Timer? leakDetector;
 
     controller = StreamController<List<int>>(
       sync: true,
       onListen: () {
-        subscription = source.listen(
-          controller.add,
-          onError: (Object error, StackTrace stackTrace) {
-            releaseOnce();
-            controller.addError(error, stackTrace);
-          },
-          onDone: () {
-            releaseOnce();
-            controller.close();
-          },
+        assert(
+          () {
+            leakDetector?.cancel();
+            return true;
+          }(),
+          'cancel leak detector on listen',
         );
+        try {
+          subscription = source.listen(
+            controller.add,
+            onError: (Object error, StackTrace stackTrace) {
+              slot.release();
+              controller.addError(error, stackTrace);
+            },
+            onDone: () {
+              slot.release();
+              controller.close();
+            },
+          );
+        } on Object catch (error, stackTrace) {
+          // source.listen can throw synchronously (e.g. StateError on
+          // double-listen). Without this catch, no onDone/onError ever
+          // fires and the slot leaks permanently.
+          slot.release();
+          controller
+            ..addError(error, stackTrace)
+            ..close();
+        }
       },
       onPause: () => subscription?.pause(),
       onResume: () => subscription?.resume(),
       onCancel: () {
-        releaseOnce();
+        assert(
+          () {
+            leakDetector?.cancel();
+            return true;
+          }(),
+          'cancel leak detector on body cancel',
+        );
+        slot.release();
         return subscription?.cancel();
       },
+    );
+
+    assert(
+      () {
+        leakDetector = Timer(const Duration(seconds: 10), () {
+          if (!controller.hasListener) {
+            _onDiagnostic(
+              StateError(
+                'Concurrency slot held by unlistened response body for >10s. '
+                'Callers must listen to StreamedHttpResponse.body.',
+              ),
+              StackTrace.current,
+              message: 'Unlistened body stream leak (URI: '
+                  '${HttpRedactor.redactUri(uri)})',
+            );
+          }
+        });
+        return true;
+      }(),
+      'install debug-only unlistened-body leak detector',
     );
 
     return controller.stream;
   }
 
   @override
-  void close() => _inner.close();
+  void close() {
+    _semaphore.closeAndDrain();
+    _inner.close();
+  }
 
   void _emitConcurrencyWait({
-    required String requestId,
+    required String acquisitionId,
     required Uri uri,
     required DateTime timestamp,
     required Duration waitDuration,
@@ -240,32 +287,51 @@ class ConcurrencyLimitingHttpClient implements SoliplexHttpClient {
     if (_observers.isEmpty) return;
 
     final redactedUri = HttpRedactor.redactUri(uri);
-    final event = HttpConcurrencyWaitEvent(
-      requestId: requestId,
-      timestamp: timestamp,
-      uri: redactedUri,
-      waitDuration: waitDuration,
-      queueDepthAtEnqueue: queueDepthAtEnqueue,
-      slotsInUseAfterAcquire: _semaphore.inUseCount,
-    );
+    final ConcurrencyWaitEvent event;
+    try {
+      event = ConcurrencyWaitEvent(
+        acquisitionId: acquisitionId,
+        timestamp: timestamp,
+        uri: redactedUri,
+        waitDuration: waitDuration,
+        queueDepthAtEnqueue: queueDepthAtEnqueue,
+        slotsInUseAfterAcquire: _semaphore.inUseCount,
+      );
+    } on Object catch (error, stackTrace) {
+      // Construction invariant violated (debug assert fired, or a
+      // future runtime check). Skip this event rather than crash the
+      // in-flight request.
+      _onDiagnostic(
+        error,
+        stackTrace,
+        message: 'ConcurrencyWaitEvent construction failed',
+      );
+      return;
+    }
 
     for (final observer in _observers) {
       try {
         observer.onConcurrencyWait(event);
       } on Object catch (error, stackTrace) {
-        // Observer failures must not disrupt the request flow, but
-        // surface the error in debug so a broken observer is visible.
-        assert(
-          () {
-            // ignore: avoid_print
-            print('ConcurrencyObserver ${observer.runtimeType} threw: '
-                '$error\n$stackTrace');
-            return true;
-          }(),
-          'observer logging assert',
+        _onDiagnostic(
+          error,
+          stackTrace,
+          message: 'ConcurrencyObserver ${observer.runtimeType} threw',
         );
       }
     }
+  }
+
+  /// Clamps negative durations from clock skew (e.g., NTP adjustments)
+  /// to [Duration.zero]. Logs the skew so it is visible in diagnostics.
+  Duration _nonNegative(Duration duration) {
+    if (!duration.isNegative) return duration;
+    _onDiagnostic(
+      StateError('Negative waitDuration from clock skew: $duration'),
+      StackTrace.current,
+      message: 'Clock went backward during request; clamping waitDuration',
+    );
+    return Duration.zero;
   }
 }
 
@@ -273,29 +339,57 @@ class ConcurrencyLimitingHttpClient implements SoliplexHttpClient {
 /// or acquired a permit immediately.
 enum _AcquireOutcome { immediate, queued }
 
+/// Represents ownership of a single semaphore permit. [release] is
+/// idempotent: calling it more than once is a no-op. Ownership lives
+/// only within the file; handles are never exposed to library callers.
+class _SlotHandle {
+  _SlotHandle._(this._semaphore, this.outcome);
+
+  final _Semaphore _semaphore;
+  final _AcquireOutcome outcome;
+  bool _released = false;
+
+  void release() {
+    if (_released) return;
+    _released = true;
+    _semaphore._onSlotReleased();
+  }
+}
+
 /// Cancel-aware FIFO semaphore.
 ///
-/// [acquire] returns immediately if a permit is available; otherwise
-/// the caller is queued. If a [CancelToken] is passed and fires while
-/// the caller is queued, the completer is removed from the queue and
-/// completed with a [CancelledException] — no permit is acquired.
+/// [acquire] returns a [_SlotHandle] immediately if a permit is
+/// available; otherwise the caller is queued. If a [CancelToken] is
+/// passed and fires while the caller is queued, the completer is
+/// removed from the queue and completed with a [CancelledException] —
+/// no permit is acquired.
+///
+/// After [closeAndDrain], all queued waiters and future acquires error
+/// with [CancelledException].
 class _Semaphore {
-  _Semaphore(this.maxCount) : _available = maxCount;
+  _Semaphore({required this.maxCount}) : _available = maxCount;
 
   final int maxCount;
   int _available;
   final Queue<Completer<void>> _waiters = Queue<Completer<void>>();
+  bool _closed = false;
 
   int get inUseCount => maxCount - _available;
 
   int get waitingCount => _waiters.length;
 
-  /// Returns [_AcquireOutcome.queued] if the caller had to wait, or
-  /// [_AcquireOutcome.immediate] if a permit was available.
-  Future<_AcquireOutcome> acquire({CancelToken? cancelToken}) {
+  Future<_SlotHandle> acquire({CancelToken? cancelToken}) {
+    if (_closed) {
+      return Future<_SlotHandle>.error(
+        const CancelledException(reason: 'HTTP client closed'),
+      );
+    }
+
     if (_available > 0) {
       _available--;
-      return Future<_AcquireOutcome>.value(_AcquireOutcome.immediate);
+      return Future<_SlotHandle>.value(
+        _SlotHandle._(this, _AcquireOutcome.immediate),
+      );
     }
     cancelToken?.throwIfCancelled();
 
@@ -303,33 +397,50 @@ class _Semaphore {
     _waiters.add(completer);
 
     if (cancelToken != null) {
-      // The callback runs as a single synchronous block with no await,
-      // so the isCompleted check and subsequent completeError cannot be
-      // interleaved by a concurrent release() — Dart microtasks never
-      // preempt synchronous execution.
-      cancelToken.whenCancelled.then((_) {
-        if (!completer.isCompleted) {
-          _waiters.remove(completer);
-          completer.completeError(
-            CancelledException(reason: cancelToken.reason),
-          );
-        }
-      });
+      // Dart's single-threaded run-to-completion guarantees no
+      // interleaving between the isCompleted check and completeError.
+      unawaited(
+        cancelToken.whenCancelled.then((_) {
+          if (!completer.isCompleted) {
+            _waiters.remove(completer);
+            completer.completeError(
+              CancelledException(reason: cancelToken.reason),
+            );
+          }
+        }),
+      );
     }
 
-    return completer.future.then((_) => _AcquireOutcome.queued);
+    return completer.future
+        .then((_) => _SlotHandle._(this, _AcquireOutcome.queued));
   }
 
-  void release() {
-    // Invariant: every completer in [_waiters] is uncompleted. The
-    // cancel handler in [acquire] atomically removes a completer from
-    // the queue and completes it with an error, so completed completers
-    // never linger. That lets release() hand the permit to the head
-    // without a skip-loop.
+  /// Hands the permit to the next queued waiter, or returns it to
+  /// the pool.
+  void _onSlotReleased() {
+    // Invariant: every completer in [_waiters] is uncompleted (the
+    // cancel handler in [acquire] removes completed completers from the
+    // queue before completing them). So we can hand the permit to the
+    // head without a skip-loop.
     if (_waiters.isNotEmpty) {
       _waiters.removeFirst().complete();
       return;
     }
     _available++;
+  }
+
+  /// Errors out all queued waiters and refuses future acquires.
+  /// Idempotent. In-flight slots are left alone — they release normally
+  /// when their requests complete.
+  void closeAndDrain() {
+    if (_closed) return;
+    _closed = true;
+    while (_waiters.isNotEmpty) {
+      _waiters.removeFirst().completeError(
+            const CancelledException(
+              reason: 'HTTP client closed before slot acquired',
+            ),
+          );
+    }
   }
 }

--- a/packages/soliplex_client/lib/src/http/concurrency_limiting_http_client.dart
+++ b/packages/soliplex_client/lib/src/http/concurrency_limiting_http_client.dart
@@ -1,0 +1,296 @@
+import 'dart:async';
+import 'dart:collection';
+
+import 'package:soliplex_client/src/errors/exceptions.dart';
+import 'package:soliplex_client/src/http/concurrency_observer.dart';
+import 'package:soliplex_client/src/http/http_redactor.dart';
+import 'package:soliplex_client/src/http/http_response.dart';
+import 'package:soliplex_client/src/http/soliplex_http_client.dart';
+import 'package:soliplex_client/src/utils/cancel_token.dart';
+
+/// HTTP client decorator that caps in-flight requests at [maxConcurrent].
+///
+/// Excess requests queue in FIFO order and dispatch as earlier requests
+/// release their slots. Queued stream requests drop out of the queue
+/// immediately when their [CancelToken] fires — no slot is acquired.
+///
+/// Emits [HttpConcurrencyWaitEvent] to observers on every slot
+/// acquisition, including acquisitions with `waitDuration == 0`.
+///
+/// ## Streams
+///
+/// [requestStream] holds its slot for the response body's entire
+/// lifetime — released when the body stream completes, errors, or is
+/// cancelled. This accurately models what the upstream sees (an open
+/// connection). Default [maxConcurrent] is 10, matching Nginx's
+/// `limit_conn conn 10`.
+///
+/// ## Decorator order
+///
+/// Place below `AuthenticatedHttpClient` so queued requests don't hold
+/// stale tokens, and above `ObservableHttpClient` so each wire attempt
+/// is observed individually.
+///
+/// ```text
+/// Refreshing -> Authenticated -> Concurrency -> Observable -> Platform
+/// ```
+class ConcurrencyLimitingHttpClient implements SoliplexHttpClient {
+  /// Creates a concurrency-limiting HTTP client.
+  ///
+  /// - [inner]: The wrapped HTTP client.
+  /// - [maxConcurrent]: Maximum in-flight requests (default 10).
+  /// - [observers]: Observers notified of queue-wait events.
+  /// - [generateRequestId]: Optional ID generator; defaults to a
+  ///   timestamp+counter scheme.
+  /// - [clock]: Test injection point for deterministic `waitDuration`.
+  ConcurrencyLimitingHttpClient({
+    required SoliplexHttpClient inner,
+    this.maxConcurrent = 10,
+    List<ConcurrencyObserver> observers = const [],
+    String Function()? generateRequestId,
+    DateTime Function()? clock,
+  })  : assert(maxConcurrent >= 1, 'maxConcurrent must be at least 1'),
+        _inner = inner,
+        _observers = List.unmodifiable(observers),
+        _generateRequestId = generateRequestId ?? _defaultRequestIdGenerator,
+        _clock = clock ?? DateTime.now,
+        _semaphore = _Semaphore(maxConcurrent);
+
+  final SoliplexHttpClient _inner;
+  final List<ConcurrencyObserver> _observers;
+  final String Function() _generateRequestId;
+  final DateTime Function() _clock;
+  final _Semaphore _semaphore;
+
+  /// Maximum in-flight requests.
+  final int maxConcurrent;
+
+  static int _requestCounter = 0;
+
+  static String _defaultRequestIdGenerator() =>
+      'cc-${DateTime.now().millisecondsSinceEpoch}-${_requestCounter++}';
+
+  @override
+  Future<HttpResponse> request(
+    String method,
+    Uri uri, {
+    Map<String, String>? headers,
+    Object? body,
+    Duration? timeout,
+  }) async {
+    final requestId = _generateRequestId();
+    final enqueuedAt = _clock();
+    final depthAtEnqueue = _semaphore.inUseCount + _semaphore.waitingCount;
+
+    // request() has no CancelToken in the SoliplexHttpClient interface,
+    // so we can't cancel queued non-stream requests.
+    final wasQueued = await _semaphore.acquire();
+
+    final acquiredAt = _clock();
+    _emitConcurrencyWait(
+      requestId: requestId,
+      uri: uri,
+      timestamp: acquiredAt,
+      waitDuration:
+          wasQueued ? acquiredAt.difference(enqueuedAt) : Duration.zero,
+      queueDepthAtEnqueue: depthAtEnqueue,
+    );
+
+    try {
+      return await _inner.request(
+        method,
+        uri,
+        headers: headers,
+        body: body,
+        timeout: timeout,
+      );
+    } finally {
+      _semaphore.release();
+    }
+  }
+
+  /// Acquires a semaphore slot, delegates to the inner client, and
+  /// wraps the response body so the slot is released on stream
+  /// complete/error/cancel.
+  ///
+  /// **Precondition:** callers MUST listen to the returned
+  /// [StreamedHttpResponse.body]. An unlistened body stream will hold
+  /// the semaphore slot indefinitely, starving other requests.
+  @override
+  Future<StreamedHttpResponse> requestStream(
+    String method,
+    Uri uri, {
+    Map<String, String>? headers,
+    Object? body,
+    CancelToken? cancelToken,
+  }) async {
+    cancelToken?.throwIfCancelled();
+
+    final requestId = _generateRequestId();
+    final enqueuedAt = _clock();
+    final depthAtEnqueue = _semaphore.inUseCount + _semaphore.waitingCount;
+
+    final wasQueued = await _semaphore.acquire(cancelToken: cancelToken);
+
+    StreamedHttpResponse response;
+    try {
+      cancelToken?.throwIfCancelled();
+
+      final acquiredAt = _clock();
+      _emitConcurrencyWait(
+        requestId: requestId,
+        uri: uri,
+        timestamp: acquiredAt,
+        waitDuration:
+            wasQueued ? acquiredAt.difference(enqueuedAt) : Duration.zero,
+        queueDepthAtEnqueue: depthAtEnqueue,
+      );
+
+      response = await _inner.requestStream(
+        method,
+        uri,
+        headers: headers,
+        body: body,
+        cancelToken: cancelToken,
+      );
+    } on Object {
+      _semaphore.release();
+      rethrow;
+    }
+
+    return StreamedHttpResponse(
+      statusCode: response.statusCode,
+      headers: response.headers,
+      reasonPhrase: response.reasonPhrase,
+      body: _wrapBodyWithRelease(response.body),
+    );
+  }
+
+  /// Wraps a body stream so the semaphore slot is released when the
+  /// stream completes, errors, or is cancelled.
+  Stream<List<int>> _wrapBodyWithRelease(Stream<List<int>> source) {
+    var released = false;
+    void releaseOnce() {
+      if (!released) {
+        released = true;
+        _semaphore.release();
+      }
+    }
+
+    late StreamController<List<int>> controller;
+    StreamSubscription<List<int>>? subscription;
+
+    controller = StreamController<List<int>>(
+      sync: true,
+      onListen: () {
+        subscription = source.listen(
+          controller.add,
+          onError: (Object error, StackTrace stackTrace) {
+            releaseOnce();
+            controller.addError(error, stackTrace);
+          },
+          onDone: () {
+            releaseOnce();
+            controller.close();
+          },
+        );
+      },
+      onPause: () => subscription?.pause(),
+      onResume: () => subscription?.resume(),
+      onCancel: () {
+        releaseOnce();
+        return subscription?.cancel();
+      },
+    );
+
+    return controller.stream;
+  }
+
+  @override
+  void close() => _inner.close();
+
+  void _emitConcurrencyWait({
+    required String requestId,
+    required Uri uri,
+    required DateTime timestamp,
+    required Duration waitDuration,
+    required int queueDepthAtEnqueue,
+  }) {
+    if (_observers.isEmpty) return;
+
+    final redactedUri = HttpRedactor.redactUri(uri);
+    final event = HttpConcurrencyWaitEvent(
+      requestId: requestId,
+      timestamp: timestamp,
+      uri: redactedUri,
+      waitDuration: waitDuration,
+      queueDepthAtEnqueue: queueDepthAtEnqueue,
+      slotsInUseAfterAcquire: _semaphore.inUseCount,
+    );
+
+    for (final observer in _observers) {
+      try {
+        observer.onConcurrencyWait(event);
+      } on Object {
+        // Observer failures must not disrupt the request flow.
+      }
+    }
+  }
+}
+
+/// Cancel-aware FIFO semaphore.
+///
+/// [acquire] returns immediately if a permit is available; otherwise
+/// the caller is queued. If a [CancelToken] is passed and fires while
+/// the caller is queued, the completer is removed from the queue and
+/// completed with a [CancelledException] — no permit is acquired.
+class _Semaphore {
+  _Semaphore(this.maxCount) : _available = maxCount;
+
+  final int maxCount;
+  int _available;
+  final Queue<Completer<void>> _waiters = Queue<Completer<void>>();
+
+  int get inUseCount => maxCount - _available;
+
+  int get waitingCount => _waiters.length;
+
+  /// Returns `true` if the caller was queued, `false` if a permit was
+  /// available immediately.
+  Future<bool> acquire({CancelToken? cancelToken}) {
+    if (_available > 0) {
+      _available--;
+      return Future<bool>.value(false);
+    }
+    cancelToken?.throwIfCancelled();
+
+    final completer = Completer<void>();
+    _waiters.add(completer);
+
+    if (cancelToken != null) {
+      cancelToken.whenCancelled.then((_) {
+        if (!completer.isCompleted) {
+          _waiters.remove(completer);
+          completer.completeError(
+            CancelledException(reason: cancelToken.reason),
+          );
+        }
+      });
+    }
+
+    return completer.future.then((_) => true);
+  }
+
+  void release() {
+    // Skip waiters that were already completed by CancelToken — handing
+    // them the permit would waste it (the caller already threw).
+    while (_waiters.isNotEmpty) {
+      final next = _waiters.removeFirst();
+      if (!next.isCompleted) {
+        next.complete();
+        return;
+      }
+    }
+    _available++;
+  }
+}

--- a/packages/soliplex_client/lib/src/http/concurrency_limiting_http_client.dart
+++ b/packages/soliplex_client/lib/src/http/concurrency_limiting_http_client.dart
@@ -122,12 +122,12 @@ class ConcurrencyLimitingHttpClient implements SoliplexHttpClient {
   /// body completes, errors, or is cancelled.
   ///
   /// **Precondition:** callers MUST listen to the returned
-  /// [StreamedHttpResponse.body] within 60 seconds. An unlistened body
-  /// holds the semaphore slot, and with the default cap as few as ten
-  /// such leaks would brick the pool. After 60 seconds without a
-  /// listener, the upstream is drained, the slot is released, and a
-  /// late listener receives a [StateError]. The timeout logs via the
-  /// diagnostic handler so caller bugs are visible in production.
+  /// [StreamedHttpResponse.body] within 60 seconds. Unlistened bodies
+  /// hold semaphore slots, and accumulated leaks eventually brick the
+  /// pool. After 60 seconds without a listener, the upstream is
+  /// drained, the slot is released, and a late listener receives a
+  /// [StateError]. The timeout logs via the diagnostic handler so
+  /// caller bugs are visible in production.
   @override
   Future<StreamedHttpResponse> requestStream(
     String method,
@@ -178,16 +178,9 @@ class ConcurrencyLimitingHttpClient implements SoliplexHttpClient {
     }
   }
 
-  /// Wraps a body stream so [slot] is released when the stream
-  /// completes, errors, or is cancelled. [_SlotHandle.release] is
-  /// idempotent, so multiple callback paths (onDone + onCancel,
-  /// onListen-catch + onCancel) are safe.
-  ///
-  /// A 60-second timer drains the upstream and releases the slot if
-  /// the caller never attaches a listener. Callers that attach after
-  /// the timeout receive a [StateError]. This is defense in depth
-  /// against third-party consumers of `SoliplexHttpAdapter` that may
-  /// forget to drain on error paths.
+  /// Wraps a body stream so [slot] is released on completion, error,
+  /// or cancellation. [_SlotHandle.release] is idempotent because
+  /// several callback paths can fire for the same stream.
   Stream<List<int>> _wrapBodyWithRelease(
     Stream<List<int>> source,
     Uri uri,
@@ -203,7 +196,9 @@ class ConcurrencyLimitingHttpClient implements SoliplexHttpClient {
       onListen: () {
         leakDetector?.cancel();
         if (timedOut) {
-          slot.release();
+          // Timer already released the slot; upstream drain was
+          // best-effort. We only need to surface the error to the
+          // late listener and close the wrapper.
           controller
             ..addError(
               StateError(

--- a/packages/soliplex_client/lib/src/http/concurrency_observer.dart
+++ b/packages/soliplex_client/lib/src/http/concurrency_observer.dart
@@ -1,19 +1,15 @@
 import 'package:meta/meta.dart';
-// ignore: unused_import
-import 'package:soliplex_client/src/http/http_observer.dart';
-// ignore: unused_import
-import 'package:soliplex_client/src/http/observable_http_client.dart';
 
 /// Observer interface for the concurrency limiter.
 ///
 /// Implementations receive [HttpConcurrencyWaitEvent] notifications when a
-/// request acquires a slot from the semaphore. Kept separate from
-/// [HttpObserver] so existing observer implementations don't need to
-/// change (Dart `implements` strips default method bodies, making
-/// additive changes to existing interfaces a breaking change).
+/// request acquires a slot from the semaphore.
 ///
-/// An observer that wants both HTTP and concurrency visibility can
-/// `implements HttpObserver, ConcurrencyObserver` side-by-side.
+/// Kept separate from `HttpObserver` because Dart `implements` does not
+/// carry default method bodies, so adding a method to `HttpObserver`
+/// would be a breaking change for every implementer. An observer that
+/// wants both HTTP and concurrency visibility can implement both
+/// interfaces side-by-side.
 ///
 /// Example:
 /// ```dart
@@ -40,14 +36,14 @@ abstract interface class ConcurrencyObserver {
 /// Event emitted by the concurrency limiter when a request acquires a
 /// slot from the semaphore.
 ///
-/// `waitDuration` is zero for requests that acquired immediately (no
+/// [waitDuration] is zero for requests that acquired immediately (no
 /// queue contention).
 ///
 /// Note: [requestId] is generated inside the limiter and does NOT
-/// correlate with the `requestId` that [ObservableHttpClient] generates
-/// for the same logical request — the two decorators run independent
-/// ID generators. Observers that want to correlate events across layers
-/// should match by [uri] + [timestamp] proximity.
+/// correlate with the `requestId` that other HTTP observers use for the
+/// same logical request — the limiter and the observable decorator run
+/// independent ID generators. Observers that want to correlate events
+/// across layers should match by [uri] + [timestamp] proximity.
 @immutable
 class HttpConcurrencyWaitEvent {
   /// Creates a concurrency-wait event.
@@ -75,8 +71,8 @@ class HttpConcurrencyWaitEvent {
   /// Zero when a slot was available immediately.
   final Duration waitDuration;
 
-  /// Number of requests already queued ahead of this one when it
-  /// arrived. Zero when the queue was empty.
+  /// Number of requests already in the system (in-flight + waiting) when
+  /// this request arrived. Zero when the system was idle.
   final int queueDepthAtEnqueue;
 
   /// Number of in-flight slots occupied immediately after this request
@@ -86,10 +82,23 @@ class HttpConcurrencyWaitEvent {
   @override
   bool operator ==(Object other) =>
       identical(this, other) ||
-      other is HttpConcurrencyWaitEvent && requestId == other.requestId;
+      other is HttpConcurrencyWaitEvent &&
+          requestId == other.requestId &&
+          timestamp == other.timestamp &&
+          uri == other.uri &&
+          waitDuration == other.waitDuration &&
+          queueDepthAtEnqueue == other.queueDepthAtEnqueue &&
+          slotsInUseAfterAcquire == other.slotsInUseAfterAcquire;
 
   @override
-  int get hashCode => requestId.hashCode;
+  int get hashCode => Object.hash(
+        requestId,
+        timestamp,
+        uri,
+        waitDuration,
+        queueDepthAtEnqueue,
+        slotsInUseAfterAcquire,
+      );
 
   @override
   String toString() => 'HttpConcurrencyWaitEvent('

--- a/packages/soliplex_client/lib/src/http/concurrency_observer.dart
+++ b/packages/soliplex_client/lib/src/http/concurrency_observer.dart
@@ -2,35 +2,18 @@ import 'package:meta/meta.dart';
 
 /// Observer interface for the concurrency limiter.
 ///
-/// Implementations receive [HttpConcurrencyWaitEvent] notifications when a
+/// Implementations receive [ConcurrencyWaitEvent] notifications when a
 /// request acquires a slot from the semaphore.
 ///
-/// Kept separate from `HttpObserver` because Dart `implements` does not
-/// carry default method bodies, so adding a method to `HttpObserver`
-/// would be a breaking change for every implementer. An observer that
-/// wants both HTTP and concurrency visibility can implement both
-/// interfaces side-by-side.
-///
-/// Example:
-/// ```dart
-/// class MyInspector implements HttpObserver, ConcurrencyObserver {
-///   @override
-///   void onRequest(HttpRequestEvent event) { /* ... */ }
-///   // ... other HttpObserver methods ...
-///
-///   @override
-///   void onConcurrencyWait(HttpConcurrencyWaitEvent event) {
-///     print('Queue wait: ${event.waitDuration}');
-///   }
-/// }
-/// ```
+/// Separate from `HttpObserver` so concurrency events can be added
+/// without forcing existing `HttpObserver` implementers to update —
+/// Dart `implements` does not forward default method bodies. An
+/// observer that wants both HTTP and concurrency visibility can
+/// implement both interfaces side-by-side.
 // ignore: one_member_abstracts
 abstract interface class ConcurrencyObserver {
   /// Called when a request acquires a slot from the concurrency limiter.
-  ///
-  /// [event] reports how long the request waited, the queue depth at
-  /// enqueue, and the current slots-in-use count.
-  void onConcurrencyWait(HttpConcurrencyWaitEvent event);
+  void onConcurrencyWait(ConcurrencyWaitEvent event);
 }
 
 /// Event emitted by the concurrency limiter when a request acquires a
@@ -39,36 +22,43 @@ abstract interface class ConcurrencyObserver {
 /// [waitDuration] is zero for requests that acquired immediately (no
 /// queue contention).
 ///
-/// Note: [requestId] is generated inside the limiter and does NOT
-/// correlate with the `requestId` that other HTTP observers use for the
-/// same logical request — the limiter and the observable decorator run
-/// independent ID generators. Observers that want to correlate events
-/// across layers should match by [uri] + [timestamp] proximity.
+/// This event is not in the `HttpEvent` family — one concurrency slot
+/// can span multiple HTTP attempts (original + 401 refresh + retry),
+/// so there is no stable one-to-one mapping with `HttpEvent.requestId`.
 @immutable
-class HttpConcurrencyWaitEvent {
+class ConcurrencyWaitEvent {
   /// Creates a concurrency-wait event.
-  const HttpConcurrencyWaitEvent({
-    required this.requestId,
+  const ConcurrencyWaitEvent({
+    required this.acquisitionId,
     required this.timestamp,
     required this.uri,
     required this.waitDuration,
     required this.queueDepthAtEnqueue,
     required this.slotsInUseAfterAcquire,
-  });
+  })  : assert(acquisitionId != '', 'acquisitionId must not be empty'),
+        assert(
+          queueDepthAtEnqueue >= 0,
+          'queueDepthAtEnqueue must be non-negative',
+        ),
+        assert(
+          slotsInUseAfterAcquire >= 1,
+          'slotsInUseAfterAcquire must be at least 1',
+        );
 
-  /// Unique identifier for this acquisition. Does not correlate with
-  /// other HTTP event IDs across decorator layers.
-  final String requestId;
+  /// Unique identifier for this slot acquisition. Scoped to the
+  /// concurrency layer; does not correlate with `HttpEvent.requestId`
+  /// because one acquisition may contain multiple HTTP attempts
+  /// (e.g., a 401 triggering a refresh and a retry).
+  final String acquisitionId;
 
   /// When the slot was acquired.
   final DateTime timestamp;
 
-  /// The request URI (with sensitive parts redacted).
+  /// The request URI, with sensitive parts redacted.
   final Uri uri;
 
-  /// Time spent waiting in the queue before acquiring a slot.
-  ///
-  /// Zero when a slot was available immediately.
+  /// Time spent waiting in the queue before acquiring a slot. Zero when
+  /// a slot was available immediately.
   final Duration waitDuration;
 
   /// Number of requests already in the system (in-flight + waiting) when
@@ -82,8 +72,8 @@ class HttpConcurrencyWaitEvent {
   @override
   bool operator ==(Object other) =>
       identical(this, other) ||
-      other is HttpConcurrencyWaitEvent &&
-          requestId == other.requestId &&
+      other is ConcurrencyWaitEvent &&
+          acquisitionId == other.acquisitionId &&
           timestamp == other.timestamp &&
           uri == other.uri &&
           waitDuration == other.waitDuration &&
@@ -92,7 +82,7 @@ class HttpConcurrencyWaitEvent {
 
   @override
   int get hashCode => Object.hash(
-        requestId,
+        acquisitionId,
         timestamp,
         uri,
         waitDuration,
@@ -101,7 +91,7 @@ class HttpConcurrencyWaitEvent {
       );
 
   @override
-  String toString() => 'HttpConcurrencyWaitEvent('
-      '$requestId, waited ${waitDuration.inMilliseconds}ms, '
+  String toString() => 'ConcurrencyWaitEvent('
+      '$acquisitionId, waited ${waitDuration.inMilliseconds}ms, '
       'depth $queueDepthAtEnqueue, slots $slotsInUseAfterAcquire)';
 }

--- a/packages/soliplex_client/lib/src/http/concurrency_observer.dart
+++ b/packages/soliplex_client/lib/src/http/concurrency_observer.dart
@@ -2,14 +2,8 @@ import 'package:meta/meta.dart';
 
 /// Observer interface for the concurrency limiter.
 ///
-/// Implementations receive [ConcurrencyWaitEvent] notifications when a
-/// request acquires a slot from the semaphore.
-///
-/// Separate from `HttpObserver` so concurrency events can be added
-/// without forcing existing `HttpObserver` implementers to update —
-/// Dart `implements` does not forward default method bodies. An
-/// observer that wants both HTTP and concurrency visibility can
-/// implement both interfaces side-by-side.
+/// Separate from `HttpObserver` so adding concurrency events does not
+/// break existing `HttpObserver` implementers.
 // ignore: one_member_abstracts
 abstract interface class ConcurrencyObserver {
   /// Called when a request acquires a slot from the concurrency limiter.

--- a/packages/soliplex_client/lib/src/http/concurrency_observer.dart
+++ b/packages/soliplex_client/lib/src/http/concurrency_observer.dart
@@ -1,0 +1,98 @@
+import 'package:meta/meta.dart';
+// ignore: unused_import
+import 'package:soliplex_client/src/http/http_observer.dart';
+// ignore: unused_import
+import 'package:soliplex_client/src/http/observable_http_client.dart';
+
+/// Observer interface for the concurrency limiter.
+///
+/// Implementations receive [HttpConcurrencyWaitEvent] notifications when a
+/// request acquires a slot from the semaphore. Kept separate from
+/// [HttpObserver] so existing observer implementations don't need to
+/// change (Dart `implements` strips default method bodies, making
+/// additive changes to existing interfaces a breaking change).
+///
+/// An observer that wants both HTTP and concurrency visibility can
+/// `implements HttpObserver, ConcurrencyObserver` side-by-side.
+///
+/// Example:
+/// ```dart
+/// class MyInspector implements HttpObserver, ConcurrencyObserver {
+///   @override
+///   void onRequest(HttpRequestEvent event) { /* ... */ }
+///   // ... other HttpObserver methods ...
+///
+///   @override
+///   void onConcurrencyWait(HttpConcurrencyWaitEvent event) {
+///     print('Queue wait: ${event.waitDuration}');
+///   }
+/// }
+/// ```
+// ignore: one_member_abstracts
+abstract interface class ConcurrencyObserver {
+  /// Called when a request acquires a slot from the concurrency limiter.
+  ///
+  /// [event] reports how long the request waited, the queue depth at
+  /// enqueue, and the current slots-in-use count.
+  void onConcurrencyWait(HttpConcurrencyWaitEvent event);
+}
+
+/// Event emitted by the concurrency limiter when a request acquires a
+/// slot from the semaphore.
+///
+/// `waitDuration` is zero for requests that acquired immediately (no
+/// queue contention).
+///
+/// Note: [requestId] is generated inside the limiter and does NOT
+/// correlate with the `requestId` that [ObservableHttpClient] generates
+/// for the same logical request — the two decorators run independent
+/// ID generators. Observers that want to correlate events across layers
+/// should match by [uri] + [timestamp] proximity.
+@immutable
+class HttpConcurrencyWaitEvent {
+  /// Creates a concurrency-wait event.
+  const HttpConcurrencyWaitEvent({
+    required this.requestId,
+    required this.timestamp,
+    required this.uri,
+    required this.waitDuration,
+    required this.queueDepthAtEnqueue,
+    required this.slotsInUseAfterAcquire,
+  });
+
+  /// Unique identifier for this acquisition. Does not correlate with
+  /// other HTTP event IDs across decorator layers.
+  final String requestId;
+
+  /// When the slot was acquired.
+  final DateTime timestamp;
+
+  /// The request URI (with sensitive parts redacted).
+  final Uri uri;
+
+  /// Time spent waiting in the queue before acquiring a slot.
+  ///
+  /// Zero when a slot was available immediately.
+  final Duration waitDuration;
+
+  /// Number of requests already queued ahead of this one when it
+  /// arrived. Zero when the queue was empty.
+  final int queueDepthAtEnqueue;
+
+  /// Number of in-flight slots occupied immediately after this request
+  /// acquired its slot. Between 1 and the limiter's configured max.
+  final int slotsInUseAfterAcquire;
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is HttpConcurrencyWaitEvent && requestId == other.requestId;
+
+  @override
+  int get hashCode => requestId.hashCode;
+
+  @override
+  String toString() => 'HttpConcurrencyWaitEvent('
+      '$requestId, waited ${waitDuration.inMilliseconds}ms, '
+      'depth $queueDepthAtEnqueue, slots $slotsInUseAfterAcquire)';
+}

--- a/packages/soliplex_client/lib/src/http/http.dart
+++ b/packages/soliplex_client/lib/src/http/http.dart
@@ -1,5 +1,6 @@
 export 'agui_stream_client.dart';
 export 'authenticated_http_client.dart';
+export 'concurrency_limiting_http_client.dart';
 export 'concurrency_observer.dart';
 export 'dart_http_client.dart';
 export 'http_observer.dart';

--- a/packages/soliplex_client/lib/src/http/http.dart
+++ b/packages/soliplex_client/lib/src/http/http.dart
@@ -3,6 +3,7 @@ export 'authenticated_http_client.dart';
 export 'concurrency_limiting_http_client.dart';
 export 'concurrency_observer.dart';
 export 'dart_http_client.dart';
+export 'http_diagnostic.dart';
 export 'http_observer.dart';
 export 'http_response.dart';
 export 'http_transport.dart';

--- a/packages/soliplex_client/lib/src/http/http.dart
+++ b/packages/soliplex_client/lib/src/http/http.dart
@@ -1,5 +1,6 @@
 export 'agui_stream_client.dart';
 export 'authenticated_http_client.dart';
+export 'concurrency_observer.dart';
 export 'dart_http_client.dart';
 export 'http_observer.dart';
 export 'http_response.dart';

--- a/packages/soliplex_client/lib/src/http/http_diagnostic.dart
+++ b/packages/soliplex_client/lib/src/http/http_diagnostic.dart
@@ -28,19 +28,10 @@ void defaultHttpDiagnosticHandler(
   );
 }
 
-/// Wraps [handler] so any throw (synchronous or from a fire-and-forget
-/// async operation initiated by the handler) falls back to
-/// `dart:developer.log`. Diagnostic handlers are the last line of
-/// defense inside the HTTP stack; if one throws into the caller, the
-/// contract "internal errors are contained without crashing the
-/// request" is broken.
-///
-/// Use this wrapper when storing a user-provided handler as a field:
-/// ```dart
-/// _onDiagnostic = safeDiagnosticHandler(
-///   onDiagnostic ?? defaultHttpDiagnosticHandler,
-/// );
-/// ```
+/// Wraps [handler] so any throw — sync or from an unawaited async path
+/// it started — falls back to `dart:developer.log`. The HTTP stack
+/// relies on diagnostic handlers to contain internal errors; a handler
+/// that escapes into the caller breaks that contract.
 HttpDiagnosticHandler safeDiagnosticHandler(HttpDiagnosticHandler handler) {
   return (Object error, StackTrace stackTrace, {required String message}) {
     runZonedGuarded(

--- a/packages/soliplex_client/lib/src/http/http_diagnostic.dart
+++ b/packages/soliplex_client/lib/src/http/http_diagnostic.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:developer' as developer;
 
 /// Handles a diagnostic from inside the HTTP stack — an internal error
@@ -25,4 +26,35 @@ void defaultHttpDiagnosticHandler(
     level: 1000, // SEVERE
     name: 'soliplex_client.http',
   );
+}
+
+/// Wraps [handler] so any throw (synchronous or from a fire-and-forget
+/// async operation initiated by the handler) falls back to
+/// `dart:developer.log`. Diagnostic handlers are the last line of
+/// defense inside the HTTP stack; if one throws into the caller, the
+/// contract "internal errors are contained without crashing the
+/// request" is broken.
+///
+/// Use this wrapper when storing a user-provided handler as a field:
+/// ```dart
+/// _onDiagnostic = safeDiagnosticHandler(
+///   onDiagnostic ?? defaultHttpDiagnosticHandler,
+/// );
+/// ```
+HttpDiagnosticHandler safeDiagnosticHandler(HttpDiagnosticHandler handler) {
+  return (Object error, StackTrace stackTrace, {required String message}) {
+    runZonedGuarded(
+      () => handler(error, stackTrace, message: message),
+      (handlerError, handlerStack) {
+        developer.log(
+          'Diagnostic handler threw while processing: "$message". '
+          'Original error: $error',
+          error: handlerError,
+          stackTrace: handlerStack,
+          level: 1000, // SEVERE
+          name: 'soliplex_client.http',
+        );
+      },
+    );
+  };
 }

--- a/packages/soliplex_client/lib/src/http/http_diagnostic.dart
+++ b/packages/soliplex_client/lib/src/http/http_diagnostic.dart
@@ -1,0 +1,28 @@
+import 'dart:developer' as developer;
+
+/// Handles a diagnostic from inside the HTTP stack — an internal error
+/// that was contained without crashing the request (observer throws,
+/// event construction failures, clock skew).
+///
+/// Routed to `dart:developer.log` by default. Production callers should
+/// wire a proper error sink (e.g., `soliplex_logging`).
+typedef HttpDiagnosticHandler = void Function(
+  Object error,
+  StackTrace stackTrace, {
+  required String message,
+});
+
+/// Default [HttpDiagnosticHandler] — logs at SEVERE via `dart:developer`.
+void defaultHttpDiagnosticHandler(
+  Object error,
+  StackTrace stackTrace, {
+  required String message,
+}) {
+  developer.log(
+    message,
+    error: error,
+    stackTrace: stackTrace,
+    level: 1000, // SEVERE
+    name: 'soliplex_client.http',
+  );
+}

--- a/packages/soliplex_client/lib/src/http/http_observer.dart
+++ b/packages/soliplex_client/lib/src/http/http_observer.dart
@@ -4,9 +4,10 @@ import 'package:soliplex_client/src/errors/exceptions.dart';
 /// Observer interface for HTTP traffic monitoring.
 ///
 /// Implementations can log requests, track metrics, or display debug info.
-/// Observers should NOT modify requests/responses or throw exceptions that
-/// would break the request flow. Any exceptions thrown by observers are
-/// caught and ignored by `ObservableHttpClient`.
+/// Observers should not modify requests/responses. Observers that throw
+/// do not break the request flow — exceptions are routed to the
+/// `HttpDiagnosticHandler` configured on `ObservableHttpClient` — but
+/// throwing observers obscure real issues, so treat exceptions as bugs.
 ///
 /// Example:
 /// ```dart

--- a/packages/soliplex_client/lib/src/http/observable_http_client.dart
+++ b/packages/soliplex_client/lib/src/http/observable_http_client.dart
@@ -284,12 +284,10 @@ class ObservableHttpClient implements SoliplexHttpClient {
     _client.close();
   }
 
-  /// Redacts the request body based on content type and URI.
-  ///
-  /// Wrapped in an outer safety net: redaction is a best-effort path
-  /// feeding observability. Any unexpected throw is logged and replaced
-  /// with a placeholder so the observer sees *something* and the
-  /// request itself never fails because of redaction.
+  /// Redacts the request body based on content type and URI. Never
+  /// throws; redaction failures are logged and yield
+  /// `'<redaction failed>'` so observer dispatch and the request itself
+  /// both proceed.
   dynamic _redactRequestBody(
     Object? body,
     Map<String, String>? headers,
@@ -342,11 +340,9 @@ class ObservableHttpClient implements SoliplexHttpClient {
     return body.toString();
   }
 
-  /// Redacts the response body based on content type and URI.
-  ///
-  /// Wrapped in an outer safety net for the same reason as
-  /// [_redactRequestBody]: binary bodies with invalid encoding or a
-  /// redactor bug must not break the observer dispatch.
+  /// Redacts the response body based on content type and URI. See
+  /// [_redactRequestBody]: same contract (never throws; failures
+  /// become `'<redaction failed>'`).
   dynamic _redactResponseBody(HttpResponse response, Uri uri) {
     try {
       return _redactResponseBodyInner(response, uri);

--- a/packages/soliplex_client/lib/src/http/observable_http_client.dart
+++ b/packages/soliplex_client/lib/src/http/observable_http_client.dart
@@ -226,6 +226,9 @@ class ObservableHttpClient implements SoliplexHttpClient {
     late StreamController<List<int>> controller;
     StreamSubscription<List<int>>? subscription;
 
+    // `sync: true` avoids a per-chunk microtask hop on high-rate byte
+    // streams (e.g. SSE). Backpressure is propagated by the explicit
+    // `onPause`/`onResume` forwarding below, not by the sync mode.
     controller = StreamController<List<int>>(
       sync: true,
       onListen: () {

--- a/packages/soliplex_client/lib/src/http/observable_http_client.dart
+++ b/packages/soliplex_client/lib/src/http/observable_http_client.dart
@@ -50,7 +50,9 @@ class ObservableHttpClient implements SoliplexHttpClient {
   })  : _client = client,
         _observers = List.unmodifiable(observers),
         _generateRequestId = generateRequestId ?? _defaultRequestIdGenerator,
-        _onDiagnostic = onDiagnostic ?? defaultHttpDiagnosticHandler;
+        _onDiagnostic = safeDiagnosticHandler(
+          onDiagnostic ?? defaultHttpDiagnosticHandler,
+        );
 
   final SoliplexHttpClient _client;
   final List<HttpObserver> _observers;
@@ -283,7 +285,29 @@ class ObservableHttpClient implements SoliplexHttpClient {
   }
 
   /// Redacts the request body based on content type and URI.
+  ///
+  /// Wrapped in an outer safety net: redaction is a best-effort path
+  /// feeding observability. Any unexpected throw is logged and replaced
+  /// with a placeholder so the observer sees *something* and the
+  /// request itself never fails because of redaction.
   dynamic _redactRequestBody(
+    Object? body,
+    Map<String, String>? headers,
+    Uri uri,
+  ) {
+    try {
+      return _redactRequestBodyInner(body, headers, uri);
+    } on Object catch (error, stackTrace) {
+      _onDiagnostic(
+        error,
+        stackTrace,
+        message: 'Request body redaction failed unexpectedly',
+      );
+      return '<redaction failed>';
+    }
+  }
+
+  dynamic _redactRequestBodyInner(
     Object? body,
     Map<String, String>? headers,
     Uri uri,
@@ -297,7 +321,7 @@ class ObservableHttpClient implements SoliplexHttpClient {
         return '<binary upload: ${body.length} bytes>';
       }
       final decoded = utf8.decode(body, allowMalformed: true);
-      return _redactRequestBody(decoded, headers, uri);
+      return _redactRequestBodyInner(decoded, headers, uri);
     }
 
     // List<int> is handled above, so this branch is only for decoded
@@ -312,16 +336,6 @@ class ObservableHttpClient implements SoliplexHttpClient {
         return HttpRedactor.redactJsonBody(parsed, uri);
       } on FormatException {
         return HttpRedactor.redactString(body, uri);
-      } on Object catch (error, stackTrace) {
-        // Pathological input or redactor bug — fall through so the
-        // request still completes, but surface the anomaly so we find
-        // out if this ever fires in practice.
-        _onDiagnostic(
-          error,
-          stackTrace,
-          message: 'Request body redaction failed unexpectedly',
-        );
-        return HttpRedactor.redactString(body, uri);
       }
     }
 
@@ -329,7 +343,24 @@ class ObservableHttpClient implements SoliplexHttpClient {
   }
 
   /// Redacts the response body based on content type and URI.
+  ///
+  /// Wrapped in an outer safety net for the same reason as
+  /// [_redactRequestBody]: binary bodies with invalid encoding or a
+  /// redactor bug must not break the observer dispatch.
   dynamic _redactResponseBody(HttpResponse response, Uri uri) {
+    try {
+      return _redactResponseBodyInner(response, uri);
+    } on Object catch (error, stackTrace) {
+      _onDiagnostic(
+        error,
+        stackTrace,
+        message: 'Response body redaction failed unexpectedly',
+      );
+      return '<redaction failed>';
+    }
+  }
+
+  dynamic _redactResponseBodyInner(HttpResponse response, Uri uri) {
     final contentType = response.headers['content-type'] ?? '';
 
     if (contentType.contains('application/json')) {
@@ -338,21 +369,7 @@ class ObservableHttpClient implements SoliplexHttpClient {
         return HttpRedactor.redactJsonBody(parsed, uri);
       } on FormatException {
         return HttpRedactor.redactString(response.body, uri);
-      } on Object catch (error, stackTrace) {
-        // Pathological input or redactor bug — fall through so the
-        // request still completes, but surface the anomaly so we find
-        // out if this ever fires in practice.
-        _onDiagnostic(
-          error,
-          stackTrace,
-          message: 'Response body redaction failed unexpectedly',
-        );
-        return HttpRedactor.redactString(response.body, uri);
       }
-    }
-
-    if (contentType.contains('text/')) {
-      return HttpRedactor.redactString(response.body, uri);
     }
 
     return HttpRedactor.redactString(response.body, uri);

--- a/packages/soliplex_client/lib/src/http/observable_http_client.dart
+++ b/packages/soliplex_client/lib/src/http/observable_http_client.dart
@@ -128,9 +128,17 @@ class ObservableHttpClient implements SoliplexHttpClient {
       });
 
       return response;
-    } on SoliplexException catch (e) {
+    } on Object catch (error, stackTrace) {
       final endTime = DateTime.now();
       final duration = endTime.difference(startTime);
+
+      final exception = error is SoliplexException
+          ? error
+          : NetworkException(
+              message: 'Unexpected error: $error',
+              originalError: error,
+              stackTrace: stackTrace,
+            );
 
       _notifyObservers((observer) {
         observer.onError(
@@ -139,7 +147,7 @@ class ObservableHttpClient implements SoliplexHttpClient {
             timestamp: endTime,
             method: method,
             uri: redactedUri,
-            exception: e,
+            exception: exception,
             duration: duration,
           ),
         );

--- a/packages/soliplex_client/lib/src/http/observable_http_client.dart
+++ b/packages/soliplex_client/lib/src/http/observable_http_client.dart
@@ -227,6 +227,7 @@ class ObservableHttpClient implements SoliplexHttpClient {
     StreamSubscription<List<int>>? subscription;
 
     controller = StreamController<List<int>>(
+      sync: true,
       onListen: () {
         subscription = response.body.listen(
           (data) {

--- a/packages/soliplex_client/lib/src/http/observable_http_client.dart
+++ b/packages/soliplex_client/lib/src/http/observable_http_client.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 import 'dart:convert';
 
 import 'package:soliplex_client/src/errors/exceptions.dart';
+import 'package:soliplex_client/src/http/http_diagnostic.dart';
 import 'package:soliplex_client/src/http/http_observer.dart';
 import 'package:soliplex_client/src/http/http_redactor.dart';
 import 'package:soliplex_client/src/http/http_response.dart';
@@ -17,8 +18,8 @@ import 'package:soliplex_client/src/utils/cancel_token.dart';
 /// before being emitted to observers. Sensitive data never crosses the
 /// observer boundary.
 ///
-/// Observers that throw exceptions are caught and ignored to prevent
-/// disrupting the request flow.
+/// Observer exceptions are routed to the [HttpDiagnosticHandler] and
+/// do not disrupt the request flow.
 ///
 /// Example:
 /// ```dart
@@ -45,21 +46,21 @@ class ObservableHttpClient implements SoliplexHttpClient {
     required SoliplexHttpClient client,
     List<HttpObserver> observers = const [],
     String Function()? generateRequestId,
+    HttpDiagnosticHandler? onDiagnostic,
   })  : _client = client,
         _observers = List.unmodifiable(observers),
-        _generateRequestId = generateRequestId ?? _defaultRequestIdGenerator;
+        _generateRequestId = generateRequestId ?? _defaultRequestIdGenerator,
+        _onDiagnostic = onDiagnostic ?? defaultHttpDiagnosticHandler;
 
   final SoliplexHttpClient _client;
   final List<HttpObserver> _observers;
   final String Function() _generateRequestId;
+  final HttpDiagnosticHandler _onDiagnostic;
 
-  /// Counter for request ID generation.
   static int _requestCounter = 0;
 
-  /// Maximum buffer size for SSE streams (500KB).
   static const _maxStreamBufferSize = 500 * 1024;
 
-  /// Default request ID generator using timestamp and counter.
   static String _defaultRequestIdGenerator() {
     return '${DateTime.now().millisecondsSinceEpoch}-${_requestCounter++}';
   }
@@ -75,12 +76,10 @@ class ObservableHttpClient implements SoliplexHttpClient {
     final requestId = _generateRequestId();
     final startTime = DateTime.now();
 
-    // Redact sensitive data before emitting to observers
     final redactedUri = HttpRedactor.redactUri(uri);
     final redactedHeaders = HttpRedactor.redactHeaders(headers ?? const {});
     final redactedBody = _redactRequestBody(body, headers, uri);
 
-    // Notify request start
     _notifyObservers((observer) {
       observer.onRequest(
         HttpRequestEvent(
@@ -106,13 +105,11 @@ class ObservableHttpClient implements SoliplexHttpClient {
       final endTime = DateTime.now();
       final duration = endTime.difference(startTime);
 
-      // Capture and redact response
       final redactedResponseBody = _redactResponseBody(response, uri);
       final redactedResponseHeaders = HttpRedactor.redactHeaders(
         response.headers,
       );
 
-      // Notify successful response
       _notifyObservers((observer) {
         observer.onResponse(
           HttpResponseEvent(
@@ -133,7 +130,6 @@ class ObservableHttpClient implements SoliplexHttpClient {
       final endTime = DateTime.now();
       final duration = endTime.difference(startTime);
 
-      // Notify error (URI already redacted)
       _notifyObservers((observer) {
         observer.onError(
           HttpErrorEvent(
@@ -163,15 +159,12 @@ class ObservableHttpClient implements SoliplexHttpClient {
     final startTime = DateTime.now();
     var bytesReceived = 0;
 
-    // SSE buffer with rolling truncation
     final streamBuffer = _StreamBuffer(_maxStreamBufferSize);
 
-    // Redact sensitive data before emitting to observers
     final redactedUri = HttpRedactor.redactUri(uri);
     final redactedHeaders = HttpRedactor.redactHeaders(headers ?? const {});
     final redactedBody = _redactRequestBody(body, headers, uri);
 
-    // Notify stream start
     _notifyObservers((observer) {
       observer.onStreamStart(
         HttpStreamStartEvent(
@@ -185,14 +178,6 @@ class ObservableHttpClient implements SoliplexHttpClient {
       );
     });
 
-    final response = await _client.requestStream(
-      method,
-      uri,
-      headers: headers,
-      body: body,
-      cancelToken: cancelToken,
-    );
-
     var emittedEnd = false;
 
     void emitEnd({Object? error, StackTrace? stackTrace}) {
@@ -205,7 +190,7 @@ class ObservableHttpClient implements SoliplexHttpClient {
           : (error is SoliplexException
               ? error
               : NetworkException(
-                  message: error.toString(),
+                  message: HttpRedactor.redactString(error.toString(), uri),
                   originalError: error,
                   stackTrace: stackTrace,
                 ));
@@ -223,6 +208,22 @@ class ObservableHttpClient implements SoliplexHttpClient {
       });
     }
 
+    final StreamedHttpResponse response;
+    try {
+      response = await _client.requestStream(
+        method,
+        uri,
+        headers: headers,
+        body: body,
+        cancelToken: cancelToken,
+      );
+    } on Object catch (error, stackTrace) {
+      // Inner call failed after onStreamStart. Emit onStreamEnd so
+      // observers don't see a dangling "stream open" forever.
+      emitEnd(error: error, stackTrace: stackTrace);
+      rethrow;
+    }
+
     late StreamController<List<int>> controller;
     StreamSubscription<List<int>>? subscription;
 
@@ -232,21 +233,33 @@ class ObservableHttpClient implements SoliplexHttpClient {
     controller = StreamController<List<int>>(
       sync: true,
       onListen: () {
-        subscription = response.body.listen(
-          (data) {
-            bytesReceived += data.length;
-            streamBuffer.add(data);
-            controller.add(data);
-          },
-          onError: (Object error, StackTrace stackTrace) {
-            emitEnd(error: error, stackTrace: stackTrace);
-            controller.addError(error, stackTrace);
-          },
-          onDone: () {
-            emitEnd();
-            controller.close();
-          },
-        );
+        try {
+          subscription = response.body.listen(
+            (data) {
+              bytesReceived += data.length;
+              streamBuffer.add(data);
+              controller.add(data);
+            },
+            onError: (Object error, StackTrace stackTrace) {
+              emitEnd(error: error, stackTrace: stackTrace);
+              controller.addError(error, stackTrace);
+            },
+            onDone: () {
+              emitEnd();
+              controller.close();
+            },
+          );
+        } on Object catch (error, stackTrace) {
+          // response.body.listen can throw synchronously (e.g.
+          // StateError when the inner stream was already listened to).
+          // Without this catch, emitEnd never fires and observers see a
+          // dangling onStreamStart. The error is forwarded to the
+          // caller via controller.addError so the bug is not masked.
+          emitEnd(error: error, stackTrace: stackTrace);
+          controller
+            ..addError(error, stackTrace)
+            ..close();
+        }
       },
       onPause: () => subscription?.pause(),
       onResume: () => subscription?.resume(),
@@ -277,7 +290,6 @@ class ObservableHttpClient implements SoliplexHttpClient {
   ) {
     if (body == null) return null;
 
-    // If body is raw bytes, check content-type before decoding
     if (body is List<int>) {
       final contentType = headers?['content-type']?.toLowerCase() ?? '';
       if (contentType.contains('multipart/form-data') ||
@@ -288,24 +300,31 @@ class ObservableHttpClient implements SoliplexHttpClient {
       return _redactRequestBody(decoded, headers, uri);
     }
 
-    // If body is already a map (JSON-like), redact it directly
-    // Note: List<int> is handled above, so this is only for decoded JSON lists
+    // List<int> is handled above, so this branch is only for decoded
+    // JSON lists (not raw bytes).
     if (body is Map || (body is List && body is! List<int>)) {
       return HttpRedactor.redactJsonBody(body, uri);
     }
 
-    // If body is a string, check if it's JSON
     if (body is String) {
       try {
         final parsed = jsonDecode(body);
         return HttpRedactor.redactJsonBody(parsed, uri);
-      } catch (_) {
-        // Not JSON - redact as string for auth endpoints
+      } on FormatException {
+        return HttpRedactor.redactString(body, uri);
+      } on Object catch (error, stackTrace) {
+        // Pathological input or redactor bug — fall through so the
+        // request still completes, but surface the anomaly so we find
+        // out if this ever fires in practice.
+        _onDiagnostic(
+          error,
+          stackTrace,
+          message: 'Request body redaction failed unexpectedly',
+        );
         return HttpRedactor.redactString(body, uri);
       }
     }
 
-    // For other types, just return a string representation
     return body.toString();
   }
 
@@ -313,48 +332,44 @@ class ObservableHttpClient implements SoliplexHttpClient {
   dynamic _redactResponseBody(HttpResponse response, Uri uri) {
     final contentType = response.headers['content-type'] ?? '';
 
-    // Check if it's JSON content
     if (contentType.contains('application/json')) {
       try {
         final parsed = jsonDecode(response.body);
         return HttpRedactor.redactJsonBody(parsed, uri);
-      } catch (_) {
-        // JSON parse failed - redact as string for auth endpoints
+      } on FormatException {
+        return HttpRedactor.redactString(response.body, uri);
+      } on Object catch (error, stackTrace) {
+        // Pathological input or redactor bug — fall through so the
+        // request still completes, but surface the anomaly so we find
+        // out if this ever fires in practice.
+        _onDiagnostic(
+          error,
+          stackTrace,
+          message: 'Response body redaction failed unexpectedly',
+        );
         return HttpRedactor.redactString(response.body, uri);
       }
     }
 
-    // For text content, return as string (redact for auth endpoints)
     if (contentType.contains('text/')) {
       return HttpRedactor.redactString(response.body, uri);
     }
 
-    // For other content types, apply string redaction as fallback
     return HttpRedactor.redactString(response.body, uri);
   }
 
-  /// Safely notifies all observers, catching and ignoring any exceptions.
-  ///
-  /// Observer exceptions should never break the request flow.
+  /// Safely notifies all observers. Observer exceptions are caught and
+  /// routed to [_onDiagnostic] so they never break the request flow but
+  /// remain visible in production logs.
   void _notifyObservers(void Function(HttpObserver observer) notify) {
     for (final observer in _observers) {
       try {
         notify(observer);
-      } catch (e, stackTrace) {
-        // Observer threw exception - log but don't break request flow.
-        // Use assert pattern to only log in debug mode (assertions enabled).
-        assert(
-          () {
-            // ignore: avoid_print
-            print(
-              'Warning: HttpObserver ${observer.runtimeType} '
-              'threw exception: $e',
-            );
-            // ignore: avoid_print
-            print(stackTrace);
-            return true;
-          }(),
-          'Observer exception logged',
+      } on Object catch (error, stackTrace) {
+        _onDiagnostic(
+          error,
+          stackTrace,
+          message: 'HttpObserver ${observer.runtimeType} threw',
         );
       }
     }

--- a/packages/soliplex_client/lib/src/http/refreshing_http_client.dart
+++ b/packages/soliplex_client/lib/src/http/refreshing_http_client.dart
@@ -19,7 +19,8 @@ import 'package:soliplex_client/src/utils/cancel_token.dart';
 /// is cleared synchronously before completing to ensure subsequent requests
 /// start fresh refresh attempts if needed.
 ///
-/// Decorator order: `Refreshing -> Authenticated -> Observable -> Platform`
+/// Decorator order:
+/// `Concurrency -> Refreshing -> Authenticated -> Observable -> Platform`
 class RefreshingHttpClient implements SoliplexHttpClient {
   /// Creates a refreshing HTTP client.
   ///
@@ -103,10 +104,9 @@ class RefreshingHttpClient implements SoliplexHttpClient {
   /// afterward `.future` returns the cached result forever. Without clearing,
   /// new 401s would receive stale results instead of refreshing.
   Future<bool> _tryRefreshOnce() async {
-    // If refresh already in progress, wait for it.
-    // Race condition safety: Dart's single-threaded event loop guarantees no
-    // interleaving between the null check and assignment below. Code only
-    // yields at `await` points, so this check-then-assign is atomic.
+    // Dart's single-threaded event loop guarantees no interleaving
+    // between the null check and assignment below — code only yields
+    // at `await` points, so this check-then-assign is atomic.
     if (_refreshInProgress != null) {
       return _refreshInProgress!.future;
     }
@@ -116,15 +116,11 @@ class RefreshingHttpClient implements SoliplexHttpClient {
     try {
       final result = await _refresher.tryRefresh();
       completer.complete(result);
-      // REQUIRED: Clear the Completer reference after completion.
-      // A Completer can only complete once—after that, .future returns the
-      // cached result forever. Without clearing, subsequent 401s would get
-      // stale results instead of triggering fresh refresh attempts.
       _refreshInProgress = null;
       return result;
-    } catch (e) {
-      completer.completeError(e);
-      _refreshInProgress = null; // Same reason: allow fresh attempts
+    } catch (e, stackTrace) {
+      completer.completeError(e, stackTrace);
+      _refreshInProgress = null;
       rethrow;
     }
   }

--- a/packages/soliplex_client/lib/src/http/refreshing_http_client.dart
+++ b/packages/soliplex_client/lib/src/http/refreshing_http_client.dart
@@ -118,7 +118,7 @@ class RefreshingHttpClient implements SoliplexHttpClient {
       completer.complete(result);
       _refreshInProgress = null;
       return result;
-    } catch (e, stackTrace) {
+    } on Object catch (e, stackTrace) {
       completer.completeError(e, stackTrace);
       _refreshInProgress = null;
       rethrow;

--- a/packages/soliplex_client/pubspec.yaml
+++ b/packages/soliplex_client/pubspec.yaml
@@ -19,6 +19,7 @@ dependencies:
     path: ../soliplex_logging
 
 dev_dependencies:
+  fake_async: ^1.3.1
   mocktail: ^1.0.0
   test: ^1.24.0
   very_good_analysis: ^10.0.0

--- a/packages/soliplex_client/test/http/concurrency_limiting_http_client_test.dart
+++ b/packages/soliplex_client/test/http/concurrency_limiting_http_client_test.dart
@@ -669,37 +669,44 @@ void main() {
     });
 
     test(
-        'permit accounting does not drift after many sequential bursts — '
-        'the semaphore returns to idle state each cycle so the cap stays '
-        'honest over a long session', () async {
-      // Drift regression: an off-by-one in _onSlotReleased would leak
-      // permits, erode the cap, and eventually cause silent
-      // over-commitment. Many bursts amplify a small per-cycle drift
-      // into an observable cap violation.
+        'permit accounting does not drift after many sequential bursts that '
+        'exceed the cap — both immediate and queued-acquire paths are '
+        'exercised so the waiter hand-off branch of _onSlotReleased is '
+        'covered', () async {
+      // Drift regression: an off-by-one in _onSlotReleased's
+      // increment/hand-off would leak permits, erode the cap, and
+      // eventually cause silent over-commitment. Each cycle queues
+      // requests beyond the cap to exercise the hand-off branch.
       final inner = _GatedInner();
       final observer = _RecordingObserver();
+      const cap = 2;
+      const perCycle = 4;
       final client = ConcurrencyLimitingHttpClient(
         inner: inner,
-        maxConcurrent: 3,
+        maxConcurrent: cap,
         observers: [observer],
       );
 
       for (var cycle = 0; cycle < 50; cycle++) {
-        final pendings = List.generate(3, (_) => inner.queueNextRequest());
+        final pendings =
+            List.generate(perCycle, (_) => inner.queueNextRequest());
         final futures = List.generate(
-          3,
+          perCycle,
           (i) => client.request('GET', Uri.parse('https://x/$cycle/$i')),
         );
         await Future<void>.delayed(Duration.zero);
+        // Complete in order — each completion hands the permit to the
+        // next queued waiter via _onSlotReleased's waiter branch.
         for (final p in pendings) {
           p.complete();
+          await Future<void>.delayed(Duration.zero);
         }
         await Future.wait(futures);
       }
 
-      // After 50 full bursts (150 acquisitions), a fresh request must
-      // acquire immediately with zero queue depth and a single slot in
-      // use — proving no accumulated drift.
+      // After 200 acquisitions (100 of them via the queued branch), a
+      // fresh request must acquire immediately with zero queue depth
+      // and a single slot in use — proving no accumulated drift.
       final probePending = inner.queueNextRequest();
       final probeFuture = client.request('GET', Uri.parse('https://x/probe'));
       probePending.complete();
@@ -927,14 +934,21 @@ void main() {
     });
 
     test(
-        'a single cancel token reused across many queued requests does not '
-        'cause late cancellation to disrupt already-dispatched requests',
-        () async {
-      // Regression: each queued request subscribes to whenCancelled. The
-      // subscription must detach once the slot is acquired, so cancelling
-      // the token after dispatch is a no-op. Before the fix, every queued
-      // request pinned a zombie closure for the token's lifetime.
-      final inner = _StreamBodyInner(const Stream<List<int>>.empty());
+        'cancel token shared across queued requests — cancelling after each '
+        'has dispatched does not disrupt the dispatched requests, and the '
+        'token still fails fast for a fresh acquire', () async {
+      // Regression: queued requests subscribe to whenCancelled. Each
+      // subscription must detach when its slot is acquired so a later
+      // token.cancel() does not fire handlers for completed waiters
+      // (and so closures do not accumulate for the token's lifetime).
+      // The test queues two requests behind a held slot so the
+      // subscription-attached branch in _Semaphore.acquire is exercised.
+      final bodyControllers = <StreamController<List<int>>>[];
+      final inner = _FreshStreamBodyInner(() {
+        final c = StreamController<List<int>>();
+        bodyControllers.add(c);
+        return c.stream;
+      });
       final client = ConcurrencyLimitingHttpClient(
         inner: inner,
         maxConcurrent: 1,
@@ -942,24 +956,56 @@ void main() {
 
       final token = CancelToken();
 
-      // Three streaming requests serialized through a cap of 1, each
-      // drained so its slot releases before the next dispatches.
-      for (var i = 0; i < 3; i++) {
-        final response = await client.requestStream(
-          'GET',
-          Uri.parse('https://x/$i'),
-          cancelToken: token,
-        );
-        await response.body.drain<void>();
-      }
+      // Fire all three concurrently. First takes the slot immediately
+      // (no subscription created). The other two queue and register
+      // cancel subscriptions.
+      final responses = <StreamedHttpResponse?>[null, null, null];
+      final dispatched = List.generate(
+        3,
+        (i) => client
+            .requestStream(
+              'GET',
+              Uri.parse('https://x/$i'),
+              cancelToken: token,
+            )
+            .then((r) => responses[i] = r),
+      );
+      await Future<void>.delayed(Duration.zero);
+      expect(
+        responses[0],
+        isNotNull,
+        reason: 'First request must acquire immediately.',
+      );
+      expect(
+        responses[1],
+        isNull,
+        reason: 'Second request must be queued behind the held slot.',
+      );
+      expect(
+        responses[2],
+        isNull,
+        reason: 'Third request must also be queued.',
+      );
 
-      // All three have acquired and released. Cancelling now must not
-      // affect anything — no exceptions propagate to the caller zone.
+      // Release each slot in order — listen+close drains the body, so
+      // the wrapper's onDone fires and the next waiter acquires
+      // (detaching its cancel subscription via whenComplete).
+      for (var i = 0; i < 3; i++) {
+        while (responses[i] == null) {
+          await Future<void>.delayed(Duration.zero);
+        }
+        responses[i]!.body.listen((_) {});
+        await bodyControllers[i].close();
+        await Future<void>.delayed(Duration.zero);
+      }
+      await Future.wait(dispatched);
+
+      // All three dispatched and released. Cancelling now must not
+      // fire any handler for the already-completed waiters.
       token.cancel('after all dispatched');
 
-      // A fourth fresh request with the same (now-cancelled) token must
-      // fail fast with CancelledException at the pre-acquire check,
-      // proving the token's cancel is still observable where expected.
+      // Fresh request with the same (now-cancelled) token must fail
+      // fast at the pre-acquire check.
       await expectLater(
         client.requestStream(
           'GET',
@@ -1491,7 +1537,8 @@ void main() {
     );
 
     test(
-      'late listener after 60s receives a StateError describing the timeout',
+      'late listener after 60s receives a StateError describing the timeout '
+      'and the semaphore survives the double-release path',
       () {
         fakeAsync((async) {
           final source = StreamController<List<int>>();
@@ -1537,6 +1584,25 @@ void main() {
             isTrue,
             reason: 'Stream must close after the error so the listener '
                 'does not hang waiting for more data.',
+          );
+
+          // The timer and the late-listener branch both call
+          // slot.release(); _SlotHandle.release is idempotent, but the
+          // permit-conservation assert would fire if _available drifted.
+          // Prove the semaphore is back to idle by acquiring a fresh
+          // slot without queueing.
+          var followUpAcquired = false;
+          unawaited(
+            client.request('GET', Uri.parse('https://x/follow-up')).then(
+                  (_) => followUpAcquired = true,
+                ),
+          );
+          async.flushMicrotasks();
+          expect(
+            followUpAcquired,
+            isTrue,
+            reason: 'Follow-up request must acquire immediately — a drift '
+                'from the double-release path would make it queue.',
           );
 
           source.close();

--- a/packages/soliplex_client/test/http/concurrency_limiting_http_client_test.dart
+++ b/packages/soliplex_client/test/http/concurrency_limiting_http_client_test.dart
@@ -582,7 +582,7 @@ void main() {
   test('close delegates to inner', () {
     var closed = 0;
     final inner = _CloseCounter(() => closed++);
-    ConcurrencyLimitingHttpClient(inner: inner).close();
+    ConcurrencyLimitingHttpClient(inner: inner, maxConcurrent: 1).close();
     expect(closed, 1);
   });
 }

--- a/packages/soliplex_client/test/http/concurrency_limiting_http_client_test.dart
+++ b/packages/soliplex_client/test/http/concurrency_limiting_http_client_test.dart
@@ -1,0 +1,588 @@
+import 'dart:async';
+import 'dart:typed_data';
+
+import 'package:soliplex_client/soliplex_client.dart' hide CancelToken;
+import 'package:soliplex_client/src/utils/cancel_token.dart';
+import 'package:test/test.dart';
+
+/// Fake inner client that gates every response on a Completer so tests
+/// can control request/response timing precisely.
+class _GatedInner implements SoliplexHttpClient {
+  final List<_PendingRequest> pending = [];
+  int requestCallCount = 0;
+  int streamCallCount = 0;
+
+  _PendingRequest queueNextRequest() {
+    final p = _PendingRequest();
+    pending.add(p);
+    return p;
+  }
+
+  @override
+  Future<HttpResponse> request(
+    String method,
+    Uri uri, {
+    Map<String, String>? headers,
+    Object? body,
+    Duration? timeout,
+  }) async {
+    requestCallCount++;
+    if (pending.isEmpty) {
+      return HttpResponse(statusCode: 200, bodyBytes: Uint8List(0));
+    }
+    return pending.removeAt(0).future;
+  }
+
+  @override
+  Future<StreamedHttpResponse> requestStream(
+    String method,
+    Uri uri, {
+    Map<String, String>? headers,
+    Object? body,
+    CancelToken? cancelToken,
+  }) async {
+    streamCallCount++;
+    return const StreamedHttpResponse(statusCode: 200, body: Stream.empty());
+  }
+
+  @override
+  void close() {}
+}
+
+class _PendingRequest {
+  final _completer = Completer<HttpResponse>();
+  Future<HttpResponse> get future => _completer.future;
+
+  void complete() => _completer.complete(
+        HttpResponse(statusCode: 200, bodyBytes: Uint8List(0)),
+      );
+  void fail(Object error) => _completer.completeError(error);
+}
+
+class _RecordingObserver implements ConcurrencyObserver {
+  final events = <HttpConcurrencyWaitEvent>[];
+
+  @override
+  void onConcurrencyWait(HttpConcurrencyWaitEvent event) => events.add(event);
+}
+
+/// Observer that throws on every call. Verifies the decorator's
+/// try-catch around observer dispatch prevents a broken observer from
+/// crashing the request flow.
+class _ThrowingObserver implements ConcurrencyObserver {
+  int callCount = 0;
+
+  @override
+  void onConcurrencyWait(HttpConcurrencyWaitEvent event) {
+    callCount++;
+    throw Exception('observer is broken');
+  }
+}
+
+/// Inner that returns a stream with a controllable body, so tests can
+/// hold the body open and verify the slot is held for its lifetime.
+class _StreamBodyInner implements SoliplexHttpClient {
+  _StreamBodyInner(this._body);
+  final Stream<List<int>> _body;
+
+  @override
+  Future<HttpResponse> request(
+    String method,
+    Uri uri, {
+    Map<String, String>? headers,
+    Object? body,
+    Duration? timeout,
+  }) async =>
+      HttpResponse(statusCode: 200, bodyBytes: Uint8List(0));
+
+  @override
+  Future<StreamedHttpResponse> requestStream(
+    String method,
+    Uri uri, {
+    Map<String, String>? headers,
+    Object? body,
+    CancelToken? cancelToken,
+  }) async =>
+      StreamedHttpResponse(statusCode: 200, body: _body);
+
+  @override
+  void close() {}
+}
+
+class _CloseCounter implements SoliplexHttpClient {
+  _CloseCounter(this._onClose);
+  final void Function() _onClose;
+
+  @override
+  Future<HttpResponse> request(
+    String method,
+    Uri uri, {
+    Map<String, String>? headers,
+    Object? body,
+    Duration? timeout,
+  }) async =>
+      HttpResponse(statusCode: 200, bodyBytes: Uint8List(0));
+
+  @override
+  Future<StreamedHttpResponse> requestStream(
+    String method,
+    Uri uri, {
+    Map<String, String>? headers,
+    Object? body,
+    CancelToken? cancelToken,
+  }) async =>
+      const StreamedHttpResponse(statusCode: 200, body: Stream.empty());
+
+  @override
+  void close() => _onClose();
+}
+
+/// Inner that throws synchronously on request() when [throwOnNext] is true.
+/// Verifies the decorator's try/finally releases the slot even when the
+/// inner throws before returning a Future (as opposed to inside an awaited
+/// future).
+class _SyncThrowingInner implements SoliplexHttpClient {
+  bool throwOnNext = true;
+
+  @override
+  Future<HttpResponse> request(
+    String method,
+    Uri uri, {
+    Map<String, String>? headers,
+    Object? body,
+    Duration? timeout,
+  }) {
+    if (throwOnNext) {
+      throw const NetworkException(message: 'sync boom');
+    }
+    return Future.value(
+      HttpResponse(statusCode: 200, bodyBytes: Uint8List(0)),
+    );
+  }
+
+  @override
+  Future<StreamedHttpResponse> requestStream(
+    String method,
+    Uri uri, {
+    Map<String, String>? headers,
+    Object? body,
+    CancelToken? cancelToken,
+  }) async =>
+      const StreamedHttpResponse(statusCode: 200, body: Stream.empty());
+
+  @override
+  void close() {}
+}
+
+/// Mutable clock for deterministic waitDuration assertions.
+class _MockClock {
+  DateTime now = DateTime(2026);
+  DateTime call() => now;
+  void advance(Duration d) => now = now.add(d);
+}
+
+void main() {
+  group('ConcurrencyLimitingHttpClient.request', () {
+    test('single request passes through immediately', () async {
+      final inner = _GatedInner();
+      final client = ConcurrencyLimitingHttpClient(
+        inner: inner,
+        maxConcurrent: 2,
+      );
+
+      final response = await client.request(
+        'GET',
+        Uri.parse('https://x/y'),
+      );
+
+      expect(response.statusCode, 200);
+      expect(inner.requestCallCount, 1);
+    });
+
+    test('caps in-flight requests at maxConcurrent', () async {
+      final inner = _GatedInner();
+      final client = ConcurrencyLimitingHttpClient(
+        inner: inner,
+        maxConcurrent: 2,
+      );
+
+      final pending = [
+        inner.queueNextRequest(),
+        inner.queueNextRequest(),
+        inner.queueNextRequest(),
+      ];
+
+      final futures = [
+        client.request('GET', Uri.parse('https://x/1')),
+        client.request('GET', Uri.parse('https://x/2')),
+        client.request('GET', Uri.parse('https://x/3')),
+      ];
+
+      await Future<void>.delayed(Duration.zero);
+
+      expect(
+        inner.requestCallCount,
+        2,
+        reason: 'Third request must queue until a slot frees',
+      );
+
+      pending[0].complete();
+      await Future<void>.delayed(Duration.zero);
+      expect(inner.requestCallCount, 3);
+
+      pending[1].complete();
+      pending[2].complete();
+      await Future.wait<void>(futures);
+    });
+
+    test('queue is FIFO', () async {
+      final inner = _GatedInner();
+      final client = ConcurrencyLimitingHttpClient(
+        inner: inner,
+        maxConcurrent: 1,
+      );
+
+      final acquiredOrder = <int>[];
+      final pending = [
+        inner.queueNextRequest(),
+        inner.queueNextRequest(),
+        inner.queueNextRequest(),
+      ];
+
+      final futures = [
+        client.request('GET', Uri.parse('https://x/a')).then((_) {
+          acquiredOrder.add(1);
+        }),
+        client.request('GET', Uri.parse('https://x/b')).then((_) {
+          acquiredOrder.add(2);
+        }),
+        client.request('GET', Uri.parse('https://x/c')).then((_) {
+          acquiredOrder.add(3);
+        }),
+      ];
+
+      await Future<void>.delayed(Duration.zero);
+
+      pending[0].complete();
+      await Future<void>.delayed(Duration.zero);
+      pending[1].complete();
+      await Future<void>.delayed(Duration.zero);
+      pending[2].complete();
+
+      await Future.wait<void>(futures);
+
+      expect(acquiredOrder, equals([1, 2, 3]));
+    });
+
+    test('releases slot after inner throws', () async {
+      final inner = _GatedInner();
+      final client = ConcurrencyLimitingHttpClient(
+        inner: inner,
+        maxConcurrent: 1,
+      );
+
+      final first = inner.queueNextRequest();
+      final second = inner.queueNextRequest();
+
+      final firstFuture = client.request('GET', Uri.parse('https://x/1'));
+      final secondFuture = client.request('GET', Uri.parse('https://x/2'));
+
+      await Future<void>.delayed(Duration.zero);
+      expect(inner.requestCallCount, 1);
+
+      first.fail(const NetworkException(message: 'blip'));
+      await expectLater(firstFuture, throwsA(isA<NetworkException>()));
+
+      second.complete();
+      await secondFuture;
+      expect(inner.requestCallCount, 2);
+    });
+
+    test('releases slot when inner throws synchronously', () async {
+      final inner = _SyncThrowingInner();
+      final client = ConcurrencyLimitingHttpClient(
+        inner: inner,
+        maxConcurrent: 1,
+      );
+
+      await expectLater(
+        () => client.request('GET', Uri.parse('https://x/1')),
+        throwsA(isA<NetworkException>()),
+      );
+
+      inner.throwOnNext = false;
+      final response = await client.request('GET', Uri.parse('https://x/2'));
+      expect(response.statusCode, 200);
+    });
+  });
+
+  group('ConcurrencyLimitingHttpClient observers', () {
+    test('emits onConcurrencyWait with waitDuration=0 when not queued',
+        () async {
+      final inner = _GatedInner();
+      final observer = _RecordingObserver();
+      final client = ConcurrencyLimitingHttpClient(
+        inner: inner,
+        maxConcurrent: 2,
+        observers: [observer],
+      );
+
+      await client.request('GET', Uri.parse('https://x/y'));
+
+      expect(observer.events.length, 1);
+      final event = observer.events[0];
+      expect(event.waitDuration, Duration.zero);
+      expect(event.queueDepthAtEnqueue, 0);
+      expect(event.slotsInUseAfterAcquire, 1);
+      expect(event.uri.toString(), equals('https://x/y'));
+    });
+
+    test(
+        'emits onConcurrencyWait with deterministic non-zero waitDuration '
+        'when queued', () async {
+      final inner = _GatedInner();
+      final observer = _RecordingObserver();
+      final clock = _MockClock();
+      final client = ConcurrencyLimitingHttpClient(
+        inner: inner,
+        maxConcurrent: 1,
+        observers: [observer],
+        clock: clock.call,
+      );
+
+      final first = inner.queueNextRequest();
+      final second = inner.queueNextRequest();
+
+      final firstFuture = client.request('GET', Uri.parse('https://x/1'));
+      final secondFuture = client.request('GET', Uri.parse('https://x/2'));
+
+      await Future<void>.delayed(Duration.zero);
+
+      clock.advance(const Duration(milliseconds: 50));
+
+      first.complete();
+      await firstFuture;
+      second.complete();
+      await secondFuture;
+
+      expect(observer.events.length, 2);
+      expect(observer.events[0].waitDuration, Duration.zero);
+      expect(
+        observer.events[1].waitDuration,
+        equals(const Duration(milliseconds: 50)),
+      );
+      expect(observer.events[1].queueDepthAtEnqueue, 1);
+    });
+
+    test('swallows observer exceptions without breaking the request', () async {
+      final inner = _GatedInner();
+      final throwingObserver = _ThrowingObserver();
+      final client = ConcurrencyLimitingHttpClient(
+        inner: inner,
+        maxConcurrent: 2,
+        observers: [throwingObserver],
+      );
+
+      final response = await client.request(
+        'GET',
+        Uri.parse('https://x/y'),
+      );
+
+      expect(response.statusCode, 200);
+      expect(throwingObserver.callCount, 1);
+    });
+
+    test('continues notifying remaining observers after one throws', () async {
+      final inner = _GatedInner();
+      final throwingObserver = _ThrowingObserver();
+      final recordingObserver = _RecordingObserver();
+      final client = ConcurrencyLimitingHttpClient(
+        inner: inner,
+        maxConcurrent: 2,
+        observers: [throwingObserver, recordingObserver],
+      );
+
+      await client.request('GET', Uri.parse('https://x/y'));
+
+      expect(throwingObserver.callCount, 1);
+      expect(
+        recordingObserver.events.length,
+        1,
+        reason: 'Second observer must still receive the event',
+      );
+    });
+  });
+
+  group('ConcurrencyLimitingHttpClient.requestStream', () {
+    test('holds slot until body stream closes, then releases', () async {
+      final bodyController = StreamController<List<int>>();
+      final inner = _StreamBodyInner(bodyController.stream);
+      final client = ConcurrencyLimitingHttpClient(
+        inner: inner,
+        maxConcurrent: 1,
+      );
+
+      final response = await client.requestStream(
+        'GET',
+        Uri.parse('https://x/stream'),
+      );
+      expect(response.statusCode, 200);
+
+      var secondStarted = false;
+      final secondFuture =
+          client.request('GET', Uri.parse('https://x/rest')).then((r) {
+        secondStarted = true;
+        return r;
+      });
+      await Future<void>.delayed(Duration.zero);
+      expect(
+        secondStarted,
+        isFalse,
+        reason: 'Slot held by stream; second request must wait',
+      );
+
+      final drainFuture = response.body.drain<void>();
+      await bodyController.close();
+      await drainFuture;
+
+      await secondFuture;
+      expect(secondStarted, isTrue);
+    });
+
+    test('releases slot when body stream errors', () async {
+      final bodyController = StreamController<List<int>>();
+      final inner = _StreamBodyInner(bodyController.stream);
+      final client = ConcurrencyLimitingHttpClient(
+        inner: inner,
+        maxConcurrent: 1,
+      );
+
+      final response = await client.requestStream(
+        'GET',
+        Uri.parse('https://x/stream'),
+      );
+
+      final drainFuture = response.body.drain<void>().catchError((_) {});
+      bodyController.addError(Exception('stream broke'));
+      await bodyController.close();
+      await drainFuture;
+
+      final second = await client.request('GET', Uri.parse('https://x/rest'));
+      expect(second.statusCode, 200);
+    });
+
+    test(
+        'throws CancelledException and does not acquire when cancelled '
+        'before acquire', () async {
+      final inner = _GatedInner();
+      final client = ConcurrencyLimitingHttpClient(
+        inner: inner,
+        maxConcurrent: 1,
+      );
+
+      final cancelToken = CancelToken()..cancel('pre-emptive');
+
+      await expectLater(
+        () => client.requestStream(
+          'GET',
+          Uri.parse('https://x/stream'),
+          cancelToken: cancelToken,
+        ),
+        throwsA(isA<CancelledException>()),
+      );
+      expect(inner.streamCallCount, 0);
+    });
+
+    test('queued stream cancel drops out of queue without acquiring', () async {
+      final inner = _GatedInner();
+      final client = ConcurrencyLimitingHttpClient(
+        inner: inner,
+        maxConcurrent: 1,
+      );
+
+      final firstPending = inner.queueNextRequest();
+      final firstFuture = client.request('GET', Uri.parse('https://x/first'));
+
+      await Future<void>.delayed(Duration.zero);
+      expect(inner.requestCallCount, 1);
+
+      final cancelToken = CancelToken();
+      final streamFuture = client.requestStream(
+        'GET',
+        Uri.parse('https://x/stream'),
+        cancelToken: cancelToken,
+      );
+      await Future<void>.delayed(Duration.zero);
+
+      cancelToken.cancel('navigated away');
+
+      await expectLater(streamFuture, throwsA(isA<CancelledException>()));
+      expect(inner.streamCallCount, 0);
+
+      firstPending.complete();
+      await firstFuture;
+      expect(inner.streamCallCount, 0);
+    });
+  });
+
+  group('ConcurrencyLimitingHttpClient mixed request/stream queue', () {
+    test('FIFO applies across request and requestStream uniformly', () async {
+      final inner = _GatedInner();
+      final client = ConcurrencyLimitingHttpClient(
+        inner: inner,
+        maxConcurrent: 1,
+      );
+
+      final dispatchOrder = <String>[];
+
+      final firstPending = inner.queueNextRequest();
+      final thirdPending = inner.queueNextRequest();
+
+      final firstFuture = client
+          .request('GET', Uri.parse('https://x/1'))
+          .then((_) => dispatchOrder.add('request-1'));
+      await Future<void>.delayed(Duration.zero);
+      expect(inner.requestCallCount, 1);
+
+      final streamFuture =
+          client.requestStream('GET', Uri.parse('https://x/2')).then((r) {
+        dispatchOrder.add('stream-2');
+        return r;
+      });
+      final thirdFuture = client
+          .request('GET', Uri.parse('https://x/3'))
+          .then((_) => dispatchOrder.add('request-3'));
+      await Future<void>.delayed(Duration.zero);
+
+      expect(inner.requestCallCount, 1);
+      expect(inner.streamCallCount, 0);
+
+      firstPending.complete();
+      await firstFuture;
+      await Future<void>.delayed(Duration.zero);
+      expect(inner.streamCallCount, 1);
+
+      // The stream's body is Stream.empty() — draining it releases the slot.
+      final streamResponse = await streamFuture;
+      await streamResponse.body.drain<void>();
+      await Future<void>.delayed(Duration.zero);
+      expect(inner.requestCallCount, 2);
+
+      thirdPending.complete();
+      await thirdFuture;
+
+      expect(
+        dispatchOrder,
+        equals(['request-1', 'stream-2', 'request-3']),
+        reason: 'Mixed queue must dispatch in arrival order regardless of type',
+      );
+    });
+  });
+
+  test('close delegates to inner', () {
+    var closed = 0;
+    final inner = _CloseCounter(() => closed++);
+    ConcurrencyLimitingHttpClient(inner: inner).close();
+    expect(closed, 1);
+  });
+}

--- a/packages/soliplex_client/test/http/concurrency_limiting_http_client_test.dart
+++ b/packages/soliplex_client/test/http/concurrency_limiting_http_client_test.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 import 'dart:typed_data';
 
+import 'package:fake_async/fake_async.dart';
 import 'package:soliplex_client/soliplex_client.dart' hide CancelToken;
 import 'package:soliplex_client/src/utils/cancel_token.dart';
 import 'package:test/test.dart';
@@ -60,10 +61,10 @@ class _PendingRequest {
 }
 
 class _RecordingObserver implements ConcurrencyObserver {
-  final events = <HttpConcurrencyWaitEvent>[];
+  final events = <ConcurrencyWaitEvent>[];
 
   @override
-  void onConcurrencyWait(HttpConcurrencyWaitEvent event) => events.add(event);
+  void onConcurrencyWait(ConcurrencyWaitEvent event) => events.add(event);
 }
 
 /// Observer that throws on every call. Verifies the decorator's
@@ -73,7 +74,7 @@ class _ThrowingObserver implements ConcurrencyObserver {
   int callCount = 0;
 
   @override
-  void onConcurrencyWait(HttpConcurrencyWaitEvent event) {
+  void onConcurrencyWait(ConcurrencyWaitEvent event) {
     callCount++;
     throw Exception('observer is broken');
   }
@@ -265,6 +266,57 @@ class _MockClock {
   DateTime now = DateTime(2026);
   DateTime call() => now;
   void advance(Duration d) => now = now.add(d);
+}
+
+/// Stream whose `listen` throws synchronously. Models a stream whose
+/// subscription setup fails (e.g., a single-subscription stream already
+/// listened elsewhere, which Dart's single-subscription contract
+/// surfaces as a `StateError`).
+class _ListenThrowingStream extends Stream<List<int>> {
+  _ListenThrowingStream(this._error);
+  final Error _error;
+
+  @override
+  StreamSubscription<List<int>> listen(
+    void Function(List<int> data)? onData, {
+    Function? onError,
+    void Function()? onDone,
+    bool? cancelOnError,
+  }) {
+    throw _error;
+  }
+}
+
+/// Inner whose stream body throws on `listen`.
+class _ListenThrowingBodyInner implements SoliplexHttpClient {
+  _ListenThrowingBodyInner(this._error);
+  final Error _error;
+
+  @override
+  Future<HttpResponse> request(
+    String method,
+    Uri uri, {
+    Map<String, String>? headers,
+    Object? body,
+    Duration? timeout,
+  }) async =>
+      HttpResponse(statusCode: 200, bodyBytes: Uint8List(0));
+
+  @override
+  Future<StreamedHttpResponse> requestStream(
+    String method,
+    Uri uri, {
+    Map<String, String>? headers,
+    Object? body,
+    CancelToken? cancelToken,
+  }) async =>
+      StreamedHttpResponse(
+        statusCode: 200,
+        body: _ListenThrowingStream(_error),
+      );
+
+  @override
+  void close() {}
 }
 
 void main() {
@@ -463,10 +515,13 @@ void main() {
     test('swallows observer exceptions without breaking the request', () async {
       final inner = _GatedInner();
       final throwingObserver = _ThrowingObserver();
+      final capturedMessages = <String>[];
       final client = ConcurrencyLimitingHttpClient(
         inner: inner,
         maxConcurrent: 2,
         observers: [throwingObserver],
+        onDiagnostic: (_, __, {required message}) =>
+            capturedMessages.add(message),
       );
 
       final response = await client.request(
@@ -476,6 +531,110 @@ void main() {
 
       expect(response.statusCode, 200);
       expect(throwingObserver.callCount, 1);
+      expect(
+        capturedMessages,
+        hasLength(1),
+        reason: 'onDiagnostic must surface the throwing-observer event so '
+            'broken observers are visible in production logs',
+      );
+      expect(capturedMessages.single, contains('ConcurrencyObserver'));
+    });
+
+    test(
+        'reports accurate queueDepth and slotsInUse for the third of three '
+        'concurrent requests under maxConcurrent=2', () async {
+      final inner = _GatedInner();
+      final observer = _RecordingObserver();
+      final clock = _MockClock();
+      final client = ConcurrencyLimitingHttpClient(
+        inner: inner,
+        maxConcurrent: 2,
+        observers: [observer],
+        clock: clock.call,
+      );
+
+      final first = inner.queueNextRequest();
+      final second = inner.queueNextRequest();
+      final third = inner.queueNextRequest();
+
+      final f1 = client.request('GET', Uri.parse('https://x/1'));
+      final f2 = client.request('GET', Uri.parse('https://x/2'));
+      final f3 = client.request('GET', Uri.parse('https://x/3'));
+
+      await Future<void>.delayed(Duration.zero);
+
+      // First two acquire immediately; the third queues behind them.
+      expect(inner.requestCallCount, 2);
+
+      first.complete();
+      await f1;
+      // After first releases, third dispatches.
+      second.complete();
+      third.complete();
+      await Future.wait<void>([f2, f3]);
+
+      expect(observer.events, hasLength(3));
+      final thirdEvent = observer.events[2];
+      expect(
+        thirdEvent.queueDepthAtEnqueue,
+        2,
+        reason: 'Two requests were already in the system when the third '
+            'enqueued',
+      );
+      expect(
+        thirdEvent.slotsInUseAfterAcquire,
+        2,
+        reason: 'Request 2 is still in-flight when request 3 acquires the '
+            'freed slot, so both slots are now in use',
+      );
+    });
+
+    test(
+        'clamps negative waitDuration from clock skew and fires '
+        'onDiagnostic', () async {
+      final inner = _GatedInner();
+      final observer = _RecordingObserver();
+      final clock = _MockClock();
+      final capturedMessages = <String>[];
+      final client = ConcurrencyLimitingHttpClient(
+        inner: inner,
+        maxConcurrent: 1,
+        observers: [observer],
+        clock: clock.call,
+        onDiagnostic: (_, __, {required message}) =>
+            capturedMessages.add(message),
+      );
+
+      // First request holds the single slot.
+      final first = inner.queueNextRequest();
+      final firstFuture = client.request('GET', Uri.parse('https://x/1'));
+      await Future<void>.delayed(Duration.zero);
+
+      // Second request queues; its enqueuedAt is recorded at the current
+      // clock.
+      final secondFuture = client.request('GET', Uri.parse('https://x/2'));
+      await Future<void>.delayed(Duration.zero);
+
+      // Clock rewinds (e.g. NTP correction) before the second acquires.
+      clock.now = clock.now.subtract(const Duration(milliseconds: 100));
+
+      first.complete();
+      await firstFuture;
+      await secondFuture;
+
+      expect(observer.events, hasLength(2));
+      expect(
+        observer.events[1].waitDuration,
+        Duration.zero,
+        reason: '_nonNegative must clamp the backward-clock duration',
+      );
+      expect(
+        capturedMessages,
+        hasLength(1),
+        reason: 'onDiagnostic must log the clock-skew clamp so rewinds '
+            'are visible in diagnostics',
+      );
+      expect(capturedMessages.single, contains('Clock went backward'));
     });
 
     test('continues notifying remaining observers after one throws', () async {
@@ -494,7 +653,7 @@ void main() {
       expect(
         recordingObserver.events.length,
         1,
-        reason: 'Second observer must still receive the event',
+        reason: 'Second observer must receive the event',
       );
     });
   });
@@ -665,7 +824,7 @@ void main() {
     });
   });
 
-  group('ConcurrencyLimitingHttpClient slot lifecycle regressions', () {
+  group('ConcurrencyLimitingHttpClient slot lifecycle', () {
     test('releases slot when inner.requestStream throws asynchronously',
         () async {
       final inner = _StreamThrowingInner();
@@ -809,7 +968,7 @@ void main() {
       expect(
         gated.requestCallCount,
         1,
-        reason: 'Cap must still be 1 after body error+done — no double '
+        reason: 'Cap must remain 1 after body error+done — no double '
             'release into _available',
       );
 
@@ -848,6 +1007,38 @@ void main() {
       final follow = await client.request('GET', Uri.parse('https://x/ok'));
       expect(follow.statusCode, 200);
     });
+
+    test(
+        'releases slot when body source.listen throws synchronously '
+        '(e.g. single-subscription double-listen)', () async {
+      final inner = _ListenThrowingBodyInner(
+        StateError('stream has already been listened to'),
+      );
+      final client = ConcurrencyLimitingHttpClient(
+        inner: inner,
+        maxConcurrent: 1,
+      );
+
+      final response = await client.requestStream(
+        'GET',
+        Uri.parse('https://x/stream'),
+      );
+
+      // Listening triggers the wrapper's onListen, which calls
+      // source.listen on the throwing stream. The decorator must
+      // catch the synchronous throw, release the slot, and surface
+      // the error through the wrapped controller.
+      final errors = <Object>[];
+      response.body.listen((_) {}, onError: errors.add);
+      await Future<void>.delayed(Duration.zero);
+
+      expect(errors, hasLength(1));
+      expect(errors.first, isA<StateError>());
+
+      // If the slot leaked, this request would hang forever.
+      final follow = await client.request('GET', Uri.parse('https://x/ok'));
+      expect(follow.statusCode, 200);
+    });
   });
 
   test('close delegates to inner', () {
@@ -855,5 +1046,202 @@ void main() {
     final inner = _CloseCounter(() => closed++);
     ConcurrencyLimitingHttpClient(inner: inner, maxConcurrent: 1).close();
     expect(closed, 1);
+  });
+
+  group('maxConcurrent validation', () {
+    test('throws RangeError when maxConcurrent is 0', () {
+      expect(
+        () => ConcurrencyLimitingHttpClient(
+          inner: _GatedInner(),
+          maxConcurrent: 0,
+        ),
+        throwsA(isA<RangeError>()),
+      );
+    });
+
+    test('throws RangeError when maxConcurrent is negative', () {
+      expect(
+        () => ConcurrencyLimitingHttpClient(
+          inner: _GatedInner(),
+          maxConcurrent: -1,
+        ),
+        throwsA(isA<RangeError>()),
+      );
+    });
+
+    test('accepts maxConcurrent of 1 (lowest valid value)', () {
+      final client = ConcurrencyLimitingHttpClient(
+        inner: _GatedInner(),
+        maxConcurrent: 1,
+      );
+      expect(client.maxConcurrent, 1);
+    });
+  });
+
+  group('close drains queued waiters', () {
+    test('errors pending acquires with CancelledException', () async {
+      final inner = _GatedInner();
+      final client = ConcurrencyLimitingHttpClient(
+        inner: inner,
+        maxConcurrent: 1,
+      );
+
+      // First request holds the only slot.
+      final first = inner.queueNextRequest();
+      final firstFuture = client.request('GET', Uri.parse('https://x/1'));
+
+      // Second queues.
+      final secondFuture = client.request('GET', Uri.parse('https://x/2'));
+      await Future<void>.delayed(Duration.zero);
+
+      // Close before the slot is released.
+      client.close();
+
+      await expectLater(secondFuture, throwsA(isA<CancelledException>()));
+
+      // Unblock the first so its future settles.
+      first.complete();
+      await firstFuture;
+    });
+
+    test('close is idempotent', () {
+      final inner = _GatedInner();
+      final client = ConcurrencyLimitingHttpClient(
+        inner: inner,
+        maxConcurrent: 1,
+      );
+      expect(
+        () => client
+          ..close()
+          ..close(),
+        returnsNormally,
+      );
+    });
+
+    test('acquire after close errors immediately', () async {
+      final inner = _GatedInner();
+      final client = ConcurrencyLimitingHttpClient(
+        inner: inner,
+        maxConcurrent: 1,
+      )..close();
+
+      await expectLater(
+        client.request('GET', Uri.parse('https://x/after-close')),
+        throwsA(isA<CancelledException>()),
+      );
+    });
+  });
+
+  group('post-acquire cancel (stream path)', () {
+    test('cancel after acquire-but-before-sync-check releases the slot',
+        () async {
+      final inner = _GatedInner();
+      final client = ConcurrencyLimitingHttpClient(
+        inner: inner,
+        maxConcurrent: 1,
+      );
+
+      // First request holds the only slot.
+      final first = inner.queueNextRequest();
+      final firstFuture = client.request('GET', Uri.parse('https://x/1'));
+      await Future<void>.delayed(Duration.zero);
+
+      // Second request queues with a cancel token.
+      final token = CancelToken();
+      final secondFuture = client.requestStream(
+        'GET',
+        Uri.parse('https://x/2'),
+        cancelToken: token,
+      );
+      await Future<void>.delayed(Duration.zero);
+
+      // Race: release the slot AND cancel the token synchronously. The
+      // slot is acquired first (via release's removeFirst.complete), but
+      // the post-acquire throwIfCancelled check sees the cancel and
+      // throws — the catch block must release the slot.
+      first.complete();
+      token.cancel('test cancel');
+
+      await expectLater(secondFuture, throwsA(isA<CancelledException>()));
+
+      // Slot must be free: third request acquires.
+      final third = inner.queueNextRequest();
+      final thirdFuture = client.request('GET', Uri.parse('https://x/3'));
+      await Future<void>.delayed(Duration.zero);
+      expect(inner.requestCallCount, 2);
+      third.complete();
+      await thirdFuture;
+      await firstFuture;
+    });
+  });
+
+  group('debug-only leak detector', () {
+    test(
+      'fires onDiagnostic after 10s when the response body is never listened',
+      () {
+        fakeAsync((async) {
+          final inner = _StreamBodyInner(const Stream<List<int>>.empty());
+          final captured = <String>[];
+          final client = ConcurrencyLimitingHttpClient(
+            inner: inner,
+            maxConcurrent: 1,
+            onDiagnostic: (_, __, {required message}) => captured.add(message),
+          );
+
+          unawaited(client.requestStream('GET', Uri.parse('https://x/y')));
+          async
+            ..flushMicrotasks()
+            // Just before the 10s threshold — detector must not fire yet.
+            ..elapse(const Duration(seconds: 9, milliseconds: 999));
+          expect(captured, isEmpty);
+
+          async.elapse(const Duration(milliseconds: 2));
+          expect(
+            captured,
+            hasLength(1),
+            reason: 'Detector must fire once after 10s when the body was '
+                'never listened to, so caller bugs are visible in dev.',
+          );
+          expect(captured.single, contains('Unlistened body stream leak'));
+        });
+      },
+    );
+
+    test(
+      'does not fire when the body is listened to within the threshold',
+      () {
+        fakeAsync((async) {
+          final controller = StreamController<List<int>>();
+          final inner = _StreamBodyInner(controller.stream);
+          final captured = <String>[];
+          final client = ConcurrencyLimitingHttpClient(
+            inner: inner,
+            maxConcurrent: 1,
+            onDiagnostic: (_, __, {required message}) => captured.add(message),
+          );
+
+          unawaited(
+            client.requestStream('GET', Uri.parse('https://x/y')).then((
+              response,
+            ) {
+              // Listen immediately — the leak timer must be cancelled.
+              response.body.listen((_) {});
+            }),
+          );
+          async
+            ..flushMicrotasks()
+            ..elapse(const Duration(seconds: 30));
+          expect(
+            captured,
+            isEmpty,
+            reason: 'Detector must be cancelled on listen — a caller who '
+                'listens promptly must not trigger a false positive.',
+          );
+
+          controller.close();
+          async.flushMicrotasks();
+        });
+      },
+    );
   });
 }

--- a/packages/soliplex_client/test/http/concurrency_limiting_http_client_test.dart
+++ b/packages/soliplex_client/test/http/concurrency_limiting_http_client_test.dart
@@ -174,6 +174,92 @@ class _SyncThrowingInner implements SoliplexHttpClient {
   void close() {}
 }
 
+/// Inner that throws from `requestStream` after the caller has acquired
+/// a slot. Separate sync/async failure modes — the decorator's
+/// `on Object { release; rethrow; }` block must handle both.
+class _StreamThrowingInner implements SoliplexHttpClient {
+  _StreamThrowingInner({this.synchronous = false});
+  final bool synchronous;
+
+  @override
+  Future<HttpResponse> request(
+    String method,
+    Uri uri, {
+    Map<String, String>? headers,
+    Object? body,
+    Duration? timeout,
+  }) async =>
+      HttpResponse(statusCode: 200, bodyBytes: Uint8List(0));
+
+  @override
+  Future<StreamedHttpResponse> requestStream(
+    String method,
+    Uri uri, {
+    Map<String, String>? headers,
+    Object? body,
+    CancelToken? cancelToken,
+  }) {
+    if (synchronous) {
+      throw const NetworkException(message: 'stream sync boom');
+    }
+    return Future<StreamedHttpResponse>.error(
+      const NetworkException(message: 'stream async boom'),
+    );
+  }
+
+  @override
+  void close() {}
+}
+
+/// Inner whose `requestStream` runs a scripted sequence of responses;
+/// anything past the script delegates to [fallback] for `request`.
+/// `request` always delegates to [fallback].
+class _SequentialInner implements SoliplexHttpClient {
+  _SequentialInner(this._streamScript, {required this.fallback});
+  final List<Future<StreamedHttpResponse> Function()> _streamScript;
+  final SoliplexHttpClient fallback;
+  int _streamIndex = 0;
+
+  @override
+  Future<HttpResponse> request(
+    String method,
+    Uri uri, {
+    Map<String, String>? headers,
+    Object? body,
+    Duration? timeout,
+  }) =>
+      fallback.request(
+        method,
+        uri,
+        headers: headers,
+        body: body,
+        timeout: timeout,
+      );
+
+  @override
+  Future<StreamedHttpResponse> requestStream(
+    String method,
+    Uri uri, {
+    Map<String, String>? headers,
+    Object? body,
+    CancelToken? cancelToken,
+  }) {
+    if (_streamIndex < _streamScript.length) {
+      return _streamScript[_streamIndex++]();
+    }
+    return fallback.requestStream(
+      method,
+      uri,
+      headers: headers,
+      body: body,
+      cancelToken: cancelToken,
+    );
+  }
+
+  @override
+  void close() => fallback.close();
+}
+
 /// Mutable clock for deterministic waitDuration assertions.
 class _MockClock {
   DateTime now = DateTime(2026);
@@ -576,6 +662,191 @@ void main() {
         equals(['request-1', 'stream-2', 'request-3']),
         reason: 'Mixed queue must dispatch in arrival order regardless of type',
       );
+    });
+  });
+
+  group('ConcurrencyLimitingHttpClient slot lifecycle regressions', () {
+    test('releases slot when inner.requestStream throws asynchronously',
+        () async {
+      final inner = _StreamThrowingInner();
+      final client = ConcurrencyLimitingHttpClient(
+        inner: inner,
+        maxConcurrent: 1,
+      );
+
+      await expectLater(
+        () => client.requestStream('GET', Uri.parse('https://x/stream')),
+        throwsA(isA<NetworkException>()),
+      );
+
+      // If the slot leaked, the next request would hang forever.
+      final response = await client.request('GET', Uri.parse('https://x/ok'));
+      expect(response.statusCode, 200);
+    });
+
+    test('releases slot when inner.requestStream throws synchronously',
+        () async {
+      final inner = _StreamThrowingInner(synchronous: true);
+      final client = ConcurrencyLimitingHttpClient(
+        inner: inner,
+        maxConcurrent: 1,
+      );
+
+      await expectLater(
+        () => client.requestStream('GET', Uri.parse('https://x/stream')),
+        throwsA(isA<NetworkException>()),
+      );
+
+      final response = await client.request('GET', Uri.parse('https://x/ok'));
+      expect(response.statusCode, 200);
+    });
+
+    test('cancelled waiter in queue is skipped; next live waiter dispatches',
+        () async {
+      final inner = _GatedInner();
+      final client = ConcurrencyLimitingHttpClient(
+        inner: inner,
+        maxConcurrent: 1,
+      );
+
+      // Hold the single slot with a non-completing request.
+      final heldPending = inner.queueNextRequest();
+      final heldFuture = client.request('GET', Uri.parse('https://x/held'));
+      await Future<void>.delayed(Duration.zero);
+      expect(inner.requestCallCount, 1);
+
+      // Enqueue three stream requests behind the held slot.
+      final cancelA = CancelToken();
+      final cancelB = CancelToken();
+      final cancelC = CancelToken();
+      final streamA = client.requestStream(
+        'GET',
+        Uri.parse('https://x/a'),
+        cancelToken: cancelA,
+      );
+      final streamB = client.requestStream(
+        'GET',
+        Uri.parse('https://x/b'),
+        cancelToken: cancelB,
+      );
+      final streamC = client.requestStream(
+        'GET',
+        Uri.parse('https://x/c'),
+        cancelToken: cancelC,
+      );
+      await Future<void>.delayed(Duration.zero);
+
+      // Cancel the MIDDLE waiter. Its completer is marked cancelled but
+      // stays nominally in the queue ordering — release() must skip it.
+      cancelB.cancel('skip me');
+      await expectLater(streamB, throwsA(isA<CancelledException>()));
+
+      // Release the held slot. Our regression-sensitive path:
+      // release() iterates waiters, sees cancelled B, skips it, hands
+      // the permit to A (not C).
+      heldPending.complete();
+      await heldFuture;
+      await Future<void>.delayed(Duration.zero);
+
+      expect(
+        inner.streamCallCount,
+        1,
+        reason: 'Exactly one of the live waiters should have dispatched',
+      );
+
+      // Clean up remaining waiters.
+      cancelA.cancel('cleanup');
+      cancelC.cancel('cleanup');
+      // A already dispatched (inner.streamCallCount == 1), so we expect
+      // its stream to resolve normally; C was still queued and should
+      // throw.
+      await expectLater(streamC, throwsA(isA<CancelledException>()));
+      await streamA;
+    });
+
+    test('body that emits error then done releases the slot exactly once',
+        () async {
+      // An inner that serves one error-terminated body stream, then
+      // delegates subsequent requests to a gated fake. If the body
+      // wrapper over-released (two decrements, so effectively +1 slot),
+      // the cap would rise from 1 to 2 and two gated requests would
+      // dispatch concurrently. The regression signal is cap violation.
+      final errorBody = StreamController<List<int>>();
+      final gated = _GatedInner();
+      final inner = _SequentialInner(
+        [
+          () async => StreamedHttpResponse(
+                statusCode: 200,
+                body: errorBody.stream,
+              ),
+        ],
+        fallback: gated,
+      );
+
+      final client = ConcurrencyLimitingHttpClient(
+        inner: inner,
+        maxConcurrent: 1,
+      );
+
+      final response = await client.requestStream(
+        'GET',
+        Uri.parse('https://x/stream'),
+      );
+      // Start draining before closing the source so the listener is
+      // attached; otherwise close() blocks on no subscriber.
+      final drained = response.body.drain<void>().catchError((_) {});
+      errorBody.addError(Exception('boom'));
+      await errorBody.close();
+      await drained;
+
+      // Slot should be back to 1 available. Fire two gated requests.
+      final q1 = gated.queueNextRequest();
+      gated.queueNextRequest(); // second one must queue
+      final f1 = client.request('GET', Uri.parse('https://x/1'));
+      final f2 = client.request('GET', Uri.parse('https://x/2'));
+      await Future<void>.delayed(Duration.zero);
+
+      expect(
+        gated.requestCallCount,
+        1,
+        reason: 'Cap must still be 1 after body error+done — no double '
+            'release into _available',
+      );
+
+      q1.complete();
+      await f1;
+      // The second queued request then dispatches; let it finish.
+      gated.pending.first.complete();
+      await f2;
+    });
+
+    test('cancelling the body subscription mid-flight releases the slot',
+        () async {
+      final body = StreamController<List<int>>();
+      final client = ConcurrencyLimitingHttpClient(
+        inner: _StreamBodyInner(body.stream),
+        maxConcurrent: 1,
+      );
+
+      final response = await client.requestStream(
+        'GET',
+        Uri.parse('https://x/stream'),
+      );
+      final received = <List<int>>[];
+      final sub = response.body.listen(received.add);
+
+      body.add([1, 2, 3]);
+      await Future<void>.delayed(Duration.zero);
+      expect(received, hasLength(1));
+
+      // Cancel the subscription mid-flight. The body wrapper's
+      // onCancel must release the slot.
+      await sub.cancel();
+      await body.close();
+
+      // If the slot leaked, this next request would hang forever.
+      final follow = await client.request('GET', Uri.parse('https://x/ok'));
+      expect(follow.statusCode, 200);
     });
   });
 

--- a/packages/soliplex_client/test/http/concurrency_limiting_http_client_test.dart
+++ b/packages/soliplex_client/test/http/concurrency_limiting_http_client_test.dart
@@ -110,6 +110,37 @@ class _StreamBodyInner implements SoliplexHttpClient {
   void close() {}
 }
 
+/// Inner that returns a fresh body per `requestStream` call. Real HTTP
+/// clients return a new single-subscription stream per request; tests
+/// that exercise multiple sequential requests need this shape.
+class _FreshStreamBodyInner implements SoliplexHttpClient {
+  _FreshStreamBodyInner(this._makeBody);
+  final Stream<List<int>> Function() _makeBody;
+
+  @override
+  Future<HttpResponse> request(
+    String method,
+    Uri uri, {
+    Map<String, String>? headers,
+    Object? body,
+    Duration? timeout,
+  }) async =>
+      HttpResponse(statusCode: 200, bodyBytes: Uint8List(0));
+
+  @override
+  Future<StreamedHttpResponse> requestStream(
+    String method,
+    Uri uri, {
+    Map<String, String>? headers,
+    Object? body,
+    CancelToken? cancelToken,
+  }) async =>
+      StreamedHttpResponse(statusCode: 200, body: _makeBody());
+
+  @override
+  void close() {}
+}
+
 class _CloseCounter implements SoliplexHttpClient {
   _CloseCounter(this._onClose);
   final void Function() _onClose;
@@ -637,6 +668,108 @@ void main() {
       expect(capturedMessages.single, contains('Clock went backward'));
     });
 
+    test(
+        'permit accounting does not drift after many sequential bursts — '
+        'the semaphore returns to idle state each cycle so the cap stays '
+        'honest over a long session', () async {
+      // Drift regression: an off-by-one in _onSlotReleased would leak
+      // permits, erode the cap, and eventually cause silent
+      // over-commitment. Many bursts amplify a small per-cycle drift
+      // into an observable cap violation.
+      final inner = _GatedInner();
+      final observer = _RecordingObserver();
+      final client = ConcurrencyLimitingHttpClient(
+        inner: inner,
+        maxConcurrent: 3,
+        observers: [observer],
+      );
+
+      for (var cycle = 0; cycle < 50; cycle++) {
+        final pendings = List.generate(3, (_) => inner.queueNextRequest());
+        final futures = List.generate(
+          3,
+          (i) => client.request('GET', Uri.parse('https://x/$cycle/$i')),
+        );
+        await Future<void>.delayed(Duration.zero);
+        for (final p in pendings) {
+          p.complete();
+        }
+        await Future.wait(futures);
+      }
+
+      // After 50 full bursts (150 acquisitions), a fresh request must
+      // acquire immediately with zero queue depth and a single slot in
+      // use — proving no accumulated drift.
+      final probePending = inner.queueNextRequest();
+      final probeFuture = client.request('GET', Uri.parse('https://x/probe'));
+      probePending.complete();
+      await probeFuture;
+
+      final last = observer.events.last;
+      expect(
+        last.queueDepthAtEnqueue,
+        0,
+        reason: 'Idle semaphore must report zero depth on probe acquire.',
+      );
+      expect(
+        last.slotsInUseAfterAcquire,
+        1,
+        reason: 'Only the probe should be in flight — drift would push '
+            'this above 1.',
+      );
+      expect(
+        last.waitDuration,
+        Duration.zero,
+        reason: 'Probe must not queue against leaked permits.',
+      );
+    });
+
+    test(
+        'generates pairwise-distinct acquisitionIds even when many requests '
+        'share the same clock timestamp — the counter suffix is the last '
+        'line of defense against collisions', () async {
+      // Frozen clock: every acquisitionId would share the same
+      // millisecondsSinceEpoch component. Uniqueness must come from the
+      // monotonic counter suffix. A future refactor that scopes the
+      // counter to a per-millisecond epoch would silently collide here.
+      final inner = _GatedInner();
+      final observer = _RecordingObserver();
+      final frozenClock = _MockClock();
+      final client = ConcurrencyLimitingHttpClient(
+        inner: inner,
+        maxConcurrent: 10,
+        observers: [observer],
+        clock: frozenClock.call,
+      );
+
+      const concurrent = 10;
+      final pendings = List.generate(
+        concurrent,
+        (_) => inner.queueNextRequest(),
+      );
+      final futures = List.generate(
+        concurrent,
+        (i) => client.request('GET', Uri.parse('https://x/$i')),
+      );
+
+      // Clock does NOT advance. All acquisitions share the same
+      // timestamp — counter alone must disambiguate.
+      for (final p in pendings) {
+        p.complete();
+      }
+      await Future.wait(futures);
+
+      expect(observer.events, hasLength(concurrent));
+      final ids = observer.events.map((e) => e.acquisitionId).toSet();
+      expect(
+        ids,
+        hasLength(concurrent),
+        reason: 'All $concurrent acquisitionIds must be distinct even under '
+            'a frozen clock — the counter component carries the '
+            'uniqueness guarantee.',
+      );
+    });
+
     test('continues notifying remaining observers after one throws', () async {
       final inner = _GatedInner();
       final throwingObserver = _ThrowingObserver();
@@ -654,6 +787,30 @@ void main() {
         recordingObserver.events.length,
         1,
         reason: 'Second observer must receive the event',
+      );
+    });
+
+    test(
+        'request completes normally even when the diagnostic handler itself '
+        'throws — failure must not propagate past the safety wrapper',
+        () async {
+      // A throwing observer forces the decorator to invoke _onDiagnostic.
+      // The handler then throws, simulating a Sentry-style sink failing
+      // transiently. safeDiagnosticHandler must swallow the failure.
+      final inner = _GatedInner();
+      final client = ConcurrencyLimitingHttpClient(
+        inner: inner,
+        maxConcurrent: 1,
+        observers: [_ThrowingObserver()],
+        onDiagnostic: (_, __, {required message}) {
+          throw StateError('diagnostic sink down');
+        },
+      );
+
+      await expectLater(
+        client.request('GET', Uri.parse('https://x/y')),
+        completes,
+        reason: 'A broken diagnostic sink must not break request flow.',
       );
     });
   });
@@ -767,6 +924,50 @@ void main() {
       firstPending.complete();
       await firstFuture;
       expect(inner.streamCallCount, 0);
+    });
+
+    test(
+        'a single cancel token reused across many queued requests does not '
+        'cause late cancellation to disrupt already-dispatched requests',
+        () async {
+      // Regression: each queued request subscribes to whenCancelled. The
+      // subscription must detach once the slot is acquired, so cancelling
+      // the token after dispatch is a no-op. Before the fix, every queued
+      // request pinned a zombie closure for the token's lifetime.
+      final inner = _StreamBodyInner(const Stream<List<int>>.empty());
+      final client = ConcurrencyLimitingHttpClient(
+        inner: inner,
+        maxConcurrent: 1,
+      );
+
+      final token = CancelToken();
+
+      // Three streaming requests serialized through a cap of 1, each
+      // drained so its slot releases before the next dispatches.
+      for (var i = 0; i < 3; i++) {
+        final response = await client.requestStream(
+          'GET',
+          Uri.parse('https://x/$i'),
+          cancelToken: token,
+        );
+        await response.body.drain<void>();
+      }
+
+      // All three have acquired and released. Cancelling now must not
+      // affect anything — no exceptions propagate to the caller zone.
+      token.cancel('after all dispatched');
+
+      // A fourth fresh request with the same (now-cancelled) token must
+      // fail fast with CancelledException at the pre-acquire check,
+      // proving the token's cancel is still observable where expected.
+      await expectLater(
+        client.requestStream(
+          'GET',
+          Uri.parse('https://x/4'),
+          cancelToken: token,
+        ),
+        throwsA(isA<CancelledException>()),
+      );
     });
   });
 
@@ -1130,6 +1331,57 @@ void main() {
         throwsA(isA<CancelledException>()),
       );
     });
+
+    test(
+        'close during an active stream body leaves the in-flight slot alone; '
+        'the body drains normally and only post-close acquires fail', () async {
+      // Documents the _Semaphore.closeAndDrain contract: "In-flight
+      // slots are left alone — they release normally when their
+      // requests complete." A regression here would either leak the
+      // slot (no release on body completion) or abort the active
+      // stream prematurely.
+      final bodyController = StreamController<List<int>>();
+      final inner = _StreamBodyInner(bodyController.stream);
+      final client = ConcurrencyLimitingHttpClient(
+        inner: inner,
+        maxConcurrent: 1,
+      );
+
+      final response = await client.requestStream(
+        'GET',
+        Uri.parse('https://x/stream'),
+      );
+      final chunks = <List<int>>[];
+      final doneCompleter = Completer<void>();
+      response.body.listen(
+        chunks.add,
+        onDone: doneCompleter.complete,
+      );
+
+      // Close while the body is actively streaming.
+      bodyController.add([1, 2, 3]);
+      await Future<void>.delayed(Duration.zero);
+      client.close();
+
+      // Body must continue delivering until it completes naturally.
+      bodyController.add([4, 5]);
+      await bodyController.close();
+      await doneCompleter.future;
+      expect(
+        chunks,
+        equals([
+          [1, 2, 3],
+          [4, 5],
+        ]),
+      );
+
+      // Any new acquire after close fails with CancelledException —
+      // confirms the slot transition through close is consistent.
+      await expectLater(
+        client.request('GET', Uri.parse('https://x/after')),
+        throwsA(isA<CancelledException>()),
+      );
+    });
   });
 
   group('post-acquire cancel (stream path)', () {
@@ -1175,12 +1427,21 @@ void main() {
     });
   });
 
-  group('debug-only leak detector', () {
+  group('unlistened-body leak handler (60s production)', () {
     test(
-      'fires onDiagnostic after 10s when the response body is never listened',
+      'releases the slot after 60s so the cap recovers for later requests',
       () {
         fakeAsync((async) {
-          final inner = _StreamBodyInner(const Stream<List<int>>.empty());
+          // Fresh stream per call so the queued second request gets its
+          // own subscription-capable body — real HTTP clients do the
+          // same. Without the leak handler, the slot would be held
+          // indefinitely and the second request would queue forever.
+          final sources = <StreamController<List<int>>>[];
+          final inner = _FreshStreamBodyInner(() {
+            final c = StreamController<List<int>>();
+            sources.add(c);
+            return c.stream;
+          });
           final captured = <String>[];
           final client = ConcurrencyLimitingHttpClient(
             inner: inner,
@@ -1188,31 +1449,108 @@ void main() {
             onDiagnostic: (_, __, {required message}) => captured.add(message),
           );
 
+          // First request — caller never listens.
           unawaited(client.requestStream('GET', Uri.parse('https://x/y')));
-          async
-            ..flushMicrotasks()
-            // Just before the 10s threshold — detector must not fire yet.
-            ..elapse(const Duration(seconds: 9, milliseconds: 999));
-          expect(captured, isEmpty);
+          async.flushMicrotasks();
 
-          async.elapse(const Duration(milliseconds: 2));
+          // Second request — must queue because cap is 1.
+          var secondAcquired = false;
+          unawaited(
+            client.requestStream('GET', Uri.parse('https://x/z')).then((resp) {
+              secondAcquired = true;
+              resp.body.listen((_) {});
+            }),
+          );
+          async.flushMicrotasks();
+          expect(
+            secondAcquired,
+            isFalse,
+            reason: 'Second request must queue while first holds the slot.',
+          );
+
+          async.elapse(const Duration(seconds: 61));
           expect(
             captured,
             hasLength(1),
-            reason: 'Detector must fire once after 10s when the body was '
-                'never listened to, so caller bugs are visible in dev.',
+            reason: 'Force-drain must log exactly one diagnostic.',
           );
           expect(captured.single, contains('Unlistened body stream leak'));
+          expect(
+            secondAcquired,
+            isTrue,
+            reason: 'Cap must recover after force-drain so the queued '
+                'request can dispatch.',
+          );
+
+          for (final c in sources) {
+            c.close();
+          }
+          async.flushMicrotasks();
         });
       },
     );
 
     test(
-      'does not fire when the body is listened to within the threshold',
+      'late listener after 60s receives a StateError describing the timeout',
       () {
         fakeAsync((async) {
-          final controller = StreamController<List<int>>();
-          final inner = _StreamBodyInner(controller.stream);
+          final source = StreamController<List<int>>();
+          final inner = _StreamBodyInner(source.stream);
+          final client = ConcurrencyLimitingHttpClient(
+            inner: inner,
+            maxConcurrent: 1,
+            onDiagnostic: (_, __, {required message}) {},
+          );
+
+          StreamedHttpResponse? response;
+          unawaited(
+            client
+                .requestStream('GET', Uri.parse('https://x/y'))
+                .then((r) => response = r),
+          );
+          async
+            ..flushMicrotasks()
+            ..elapse(const Duration(seconds: 61));
+
+          final errors = <Object>[];
+          var doneFired = false;
+          response!.body.listen(
+            (_) {},
+            onError: errors.add,
+            onDone: () => doneFired = true,
+          );
+          async.flushMicrotasks();
+
+          expect(
+            errors,
+            hasLength(1),
+            reason: 'Late listener must receive exactly one StateError '
+                'so the failure is loud and self-describing.',
+          );
+          expect(errors.single, isA<StateError>());
+          expect(
+            (errors.single as StateError).message,
+            contains('60s unlistened-body timeout'),
+          );
+          expect(
+            doneFired,
+            isTrue,
+            reason: 'Stream must close after the error so the listener '
+                'does not hang waiting for more data.',
+          );
+
+          source.close();
+          async.flushMicrotasks();
+        });
+      },
+    );
+
+    test(
+      'does not fire when the body is listened within 60s',
+      () {
+        fakeAsync((async) {
+          final source = StreamController<List<int>>();
+          final inner = _StreamBodyInner(source.stream);
           final captured = <String>[];
           final client = ConcurrencyLimitingHttpClient(
             inner: inner,
@@ -1221,24 +1559,52 @@ void main() {
           );
 
           unawaited(
-            client.requestStream('GET', Uri.parse('https://x/y')).then((
-              response,
-            ) {
-              // Listen immediately — the leak timer must be cancelled.
-              response.body.listen((_) {});
-            }),
+            client
+                .requestStream('GET', Uri.parse('https://x/y'))
+                .then((resp) => resp.body.listen((_) {})),
           );
           async
             ..flushMicrotasks()
-            ..elapse(const Duration(seconds: 30));
-          expect(
-            captured,
-            isEmpty,
-            reason: 'Detector must be cancelled on listen — a caller who '
-                'listens promptly must not trigger a false positive.',
+            // Elapse well past 60s — early listener must have cancelled
+            // the timer. A regression here would spam the diagnostic
+            // channel for every normal streaming request.
+            ..elapse(const Duration(seconds: 120));
+          expect(captured, isEmpty);
+
+          source.close();
+          async.flushMicrotasks();
+        });
+      },
+    );
+
+    test(
+      'drains the upstream source on timeout so the socket can close',
+      () {
+        fakeAsync((async) {
+          var sourceWasListenedTo = false;
+          final source = StreamController<List<int>>(
+            onListen: () => sourceWasListenedTo = true,
+          );
+          final inner = _StreamBodyInner(source.stream);
+          final client = ConcurrencyLimitingHttpClient(
+            inner: inner,
+            maxConcurrent: 1,
+            onDiagnostic: (_, __, {required message}) {},
           );
 
-          controller.close();
+          unawaited(client.requestStream('GET', Uri.parse('https://x/y')));
+          async
+            ..flushMicrotasks()
+            ..elapse(const Duration(seconds: 61));
+
+          expect(
+            sourceWasListenedTo,
+            isTrue,
+            reason: 'Force-drain must listen-then-cancel on the upstream '
+                'source so the platform client tears down the socket.',
+          );
+
+          source.close();
           async.flushMicrotasks();
         });
       },

--- a/packages/soliplex_client/test/http/concurrency_limiting_http_client_test.dart
+++ b/packages/soliplex_client/test/http/concurrency_limiting_http_client_test.dart
@@ -141,34 +141,6 @@ class _FreshStreamBodyInner implements SoliplexHttpClient {
   void close() {}
 }
 
-class _CloseCounter implements SoliplexHttpClient {
-  _CloseCounter(this._onClose);
-  final void Function() _onClose;
-
-  @override
-  Future<HttpResponse> request(
-    String method,
-    Uri uri, {
-    Map<String, String>? headers,
-    Object? body,
-    Duration? timeout,
-  }) async =>
-      HttpResponse(statusCode: 200, bodyBytes: Uint8List(0));
-
-  @override
-  Future<StreamedHttpResponse> requestStream(
-    String method,
-    Uri uri, {
-    Map<String, String>? headers,
-    Object? body,
-    CancelToken? cancelToken,
-  }) async =>
-      const StreamedHttpResponse(statusCode: 200, body: Stream.empty());
-
-  @override
-  void close() => _onClose();
-}
-
 /// Inner that throws synchronously on request() when [throwOnNext] is true.
 /// Verifies the decorator's try/finally releases the slot even when the
 /// inner throws before returning a Future (as opposed to inside an awaited
@@ -1286,13 +1258,6 @@ void main() {
       final follow = await client.request('GET', Uri.parse('https://x/ok'));
       expect(follow.statusCode, 200);
     });
-  });
-
-  test('close delegates to inner', () {
-    var closed = 0;
-    final inner = _CloseCounter(() => closed++);
-    ConcurrencyLimitingHttpClient(inner: inner, maxConcurrent: 1).close();
-    expect(closed, 1);
   });
 
   group('maxConcurrent validation', () {

--- a/packages/soliplex_client/test/http/concurrency_limiting_http_client_test.dart
+++ b/packages/soliplex_client/test/http/concurrency_limiting_http_client_test.dart
@@ -701,8 +701,9 @@ void main() {
       expect(response.statusCode, 200);
     });
 
-    test('cancelled waiter in queue is skipped; next live waiter dispatches',
-        () async {
+    test(
+        'cancelled middle waiter drops out of the queue; next live waiter '
+        'dispatches when slot frees', () async {
       final inner = _GatedInner();
       final client = ConcurrencyLimitingHttpClient(
         inner: inner,
@@ -736,14 +737,14 @@ void main() {
       );
       await Future<void>.delayed(Duration.zero);
 
-      // Cancel the MIDDLE waiter. Its completer is marked cancelled but
-      // stays nominally in the queue ordering — release() must skip it.
-      cancelB.cancel('skip me');
+      // Cancel the MIDDLE waiter. The cancel handler atomically removes
+      // its completer from the queue, so when release() fires later it
+      // must find A at the head (not B, not C).
+      cancelB.cancel('removed');
       await expectLater(streamB, throwsA(isA<CancelledException>()));
 
-      // Release the held slot. Our regression-sensitive path:
-      // release() iterates waiters, sees cancelled B, skips it, hands
-      // the permit to A (not C).
+      // Release the held slot. A is expected to dispatch; C remains
+      // queued behind it.
       heldPending.complete();
       await heldFuture;
       await Future<void>.delayed(Duration.zero);
@@ -751,15 +752,14 @@ void main() {
       expect(
         inner.streamCallCount,
         1,
-        reason: 'Exactly one of the live waiters should have dispatched',
+        reason: 'A, not the cancelled B or the behind C, must dispatch',
       );
 
       // Clean up remaining waiters.
       cancelA.cancel('cleanup');
       cancelC.cancel('cleanup');
-      // A already dispatched (inner.streamCallCount == 1), so we expect
-      // its stream to resolve normally; C was still queued and should
-      // throw.
+      // A already dispatched, its stream resolves normally; C was still
+      // queued and throws.
       await expectLater(streamC, throwsA(isA<CancelledException>()));
       await streamA;
     });

--- a/packages/soliplex_client/test/http/concurrency_observer_test.dart
+++ b/packages/soliplex_client/test/http/concurrency_observer_test.dart
@@ -29,10 +29,33 @@ void main() {
       expect(event.slotsInUseAfterAcquire, equals(6));
     });
 
-    test('events with same requestId compare equal', () {
+    test('events with identical fields are equal', () {
+      final now = DateTime.now();
       final a = HttpConcurrencyWaitEvent(
         requestId: 'req-1',
-        timestamp: DateTime.now(),
+        timestamp: now,
+        uri: Uri.parse('https://api.example.com/x'),
+        waitDuration: const Duration(milliseconds: 100),
+        queueDepthAtEnqueue: 2,
+        slotsInUseAfterAcquire: 5,
+      );
+      final b = HttpConcurrencyWaitEvent(
+        requestId: 'req-1',
+        timestamp: now,
+        uri: Uri.parse('https://api.example.com/x'),
+        waitDuration: const Duration(milliseconds: 100),
+        queueDepthAtEnqueue: 2,
+        slotsInUseAfterAcquire: 5,
+      );
+      expect(a, equals(b));
+      expect(a.hashCode, equals(b.hashCode));
+    });
+
+    test('events differing in waitDuration are not equal', () {
+      final now = DateTime.now();
+      final a = HttpConcurrencyWaitEvent(
+        requestId: 'req-1',
+        timestamp: now,
         uri: Uri.parse('https://api.example.com/x'),
         waitDuration: Duration.zero,
         queueDepthAtEnqueue: 0,
@@ -40,14 +63,34 @@ void main() {
       );
       final b = HttpConcurrencyWaitEvent(
         requestId: 'req-1',
-        timestamp: DateTime.now().add(const Duration(seconds: 1)),
-        uri: Uri.parse('https://api.example.com/y'),
+        timestamp: now,
+        uri: Uri.parse('https://api.example.com/x'),
         waitDuration: const Duration(milliseconds: 500),
-        queueDepthAtEnqueue: 5,
-        slotsInUseAfterAcquire: 6,
+        queueDepthAtEnqueue: 0,
+        slotsInUseAfterAcquire: 1,
       );
-      expect(a, equals(b));
-      expect(a.hashCode, equals(b.hashCode));
+      expect(a, isNot(equals(b)));
+    });
+
+    test('events with different requestId are not equal', () {
+      final now = DateTime.now();
+      final a = HttpConcurrencyWaitEvent(
+        requestId: 'req-1',
+        timestamp: now,
+        uri: Uri.parse('https://api.example.com/x'),
+        waitDuration: Duration.zero,
+        queueDepthAtEnqueue: 0,
+        slotsInUseAfterAcquire: 1,
+      );
+      final b = HttpConcurrencyWaitEvent(
+        requestId: 'req-2',
+        timestamp: now,
+        uri: Uri.parse('https://api.example.com/x'),
+        waitDuration: Duration.zero,
+        queueDepthAtEnqueue: 0,
+        slotsInUseAfterAcquire: 1,
+      );
+      expect(a, isNot(equals(b)));
     });
 
     test('toString includes key fields', () {

--- a/packages/soliplex_client/test/http/concurrency_observer_test.dart
+++ b/packages/soliplex_client/test/http/concurrency_observer_test.dart
@@ -2,18 +2,18 @@ import 'package:soliplex_client/soliplex_client.dart';
 import 'package:test/test.dart';
 
 class _RecordingObserver implements ConcurrencyObserver {
-  final events = <HttpConcurrencyWaitEvent>[];
+  final events = <ConcurrencyWaitEvent>[];
 
   @override
-  void onConcurrencyWait(HttpConcurrencyWaitEvent event) => events.add(event);
+  void onConcurrencyWait(ConcurrencyWaitEvent event) => events.add(event);
 }
 
 void main() {
-  group('HttpConcurrencyWaitEvent', () {
+  group('ConcurrencyWaitEvent', () {
     test('stores all required fields', () {
       final now = DateTime.now();
-      final event = HttpConcurrencyWaitEvent(
-        requestId: 'req-1',
+      final event = ConcurrencyWaitEvent(
+        acquisitionId: 'req-1',
         timestamp: now,
         uri: Uri.parse('https://api.example.com/x'),
         waitDuration: const Duration(milliseconds: 250),
@@ -21,7 +21,7 @@ void main() {
         slotsInUseAfterAcquire: 6,
       );
 
-      expect(event.requestId, equals('req-1'));
+      expect(event.acquisitionId, equals('req-1'));
       expect(event.timestamp, equals(now));
       expect(event.uri.toString(), equals('https://api.example.com/x'));
       expect(event.waitDuration, equals(const Duration(milliseconds: 250)));
@@ -31,16 +31,16 @@ void main() {
 
     test('events with identical fields are equal', () {
       final now = DateTime.now();
-      final a = HttpConcurrencyWaitEvent(
-        requestId: 'req-1',
+      final a = ConcurrencyWaitEvent(
+        acquisitionId: 'req-1',
         timestamp: now,
         uri: Uri.parse('https://api.example.com/x'),
         waitDuration: const Duration(milliseconds: 100),
         queueDepthAtEnqueue: 2,
         slotsInUseAfterAcquire: 5,
       );
-      final b = HttpConcurrencyWaitEvent(
-        requestId: 'req-1',
+      final b = ConcurrencyWaitEvent(
+        acquisitionId: 'req-1',
         timestamp: now,
         uri: Uri.parse('https://api.example.com/x'),
         waitDuration: const Duration(milliseconds: 100),
@@ -53,16 +53,16 @@ void main() {
 
     test('events differing in waitDuration are not equal', () {
       final now = DateTime.now();
-      final a = HttpConcurrencyWaitEvent(
-        requestId: 'req-1',
+      final a = ConcurrencyWaitEvent(
+        acquisitionId: 'req-1',
         timestamp: now,
         uri: Uri.parse('https://api.example.com/x'),
         waitDuration: Duration.zero,
         queueDepthAtEnqueue: 0,
         slotsInUseAfterAcquire: 1,
       );
-      final b = HttpConcurrencyWaitEvent(
-        requestId: 'req-1',
+      final b = ConcurrencyWaitEvent(
+        acquisitionId: 'req-1',
         timestamp: now,
         uri: Uri.parse('https://api.example.com/x'),
         waitDuration: const Duration(milliseconds: 500),
@@ -72,18 +72,18 @@ void main() {
       expect(a, isNot(equals(b)));
     });
 
-    test('events with different requestId are not equal', () {
+    test('events with different acquisitionId are not equal', () {
       final now = DateTime.now();
-      final a = HttpConcurrencyWaitEvent(
-        requestId: 'req-1',
+      final a = ConcurrencyWaitEvent(
+        acquisitionId: 'req-1',
         timestamp: now,
         uri: Uri.parse('https://api.example.com/x'),
         waitDuration: Duration.zero,
         queueDepthAtEnqueue: 0,
         slotsInUseAfterAcquire: 1,
       );
-      final b = HttpConcurrencyWaitEvent(
-        requestId: 'req-2',
+      final b = ConcurrencyWaitEvent(
+        acquisitionId: 'req-2',
         timestamp: now,
         uri: Uri.parse('https://api.example.com/x'),
         waitDuration: Duration.zero,
@@ -94,8 +94,8 @@ void main() {
     });
 
     test('toString includes key fields', () {
-      final event = HttpConcurrencyWaitEvent(
-        requestId: 'req-1',
+      final event = ConcurrencyWaitEvent(
+        acquisitionId: 'req-1',
         timestamp: DateTime.now(),
         uri: Uri.parse('https://api.example.com/x'),
         waitDuration: const Duration(milliseconds: 250),
@@ -107,11 +107,55 @@ void main() {
     });
   });
 
+  group('ConcurrencyWaitEvent invariants', () {
+    test('rejects empty acquisitionId', () {
+      expect(
+        () => ConcurrencyWaitEvent(
+          acquisitionId: '',
+          timestamp: DateTime.now(),
+          uri: Uri.parse('https://x/y'),
+          waitDuration: Duration.zero,
+          queueDepthAtEnqueue: 0,
+          slotsInUseAfterAcquire: 1,
+        ),
+        throwsA(isA<AssertionError>()),
+      );
+    });
+
+    test('rejects negative queueDepthAtEnqueue', () {
+      expect(
+        () => ConcurrencyWaitEvent(
+          acquisitionId: 'req-1',
+          timestamp: DateTime.now(),
+          uri: Uri.parse('https://x/y'),
+          waitDuration: Duration.zero,
+          queueDepthAtEnqueue: -1,
+          slotsInUseAfterAcquire: 1,
+        ),
+        throwsA(isA<AssertionError>()),
+      );
+    });
+
+    test('rejects slotsInUseAfterAcquire below 1', () {
+      expect(
+        () => ConcurrencyWaitEvent(
+          acquisitionId: 'req-1',
+          timestamp: DateTime.now(),
+          uri: Uri.parse('https://x/y'),
+          waitDuration: Duration.zero,
+          queueDepthAtEnqueue: 0,
+          slotsInUseAfterAcquire: 0,
+        ),
+        throwsA(isA<AssertionError>()),
+      );
+    });
+  });
+
   group('ConcurrencyObserver', () {
     test('observers receive events via onConcurrencyWait', () {
       final observer = _RecordingObserver();
-      final event = HttpConcurrencyWaitEvent(
-        requestId: 'req-1',
+      final event = ConcurrencyWaitEvent(
+        acquisitionId: 'req-1',
         timestamp: DateTime.now(),
         uri: Uri.parse('https://api.example.com/x'),
         waitDuration: const Duration(milliseconds: 100),

--- a/packages/soliplex_client/test/http/concurrency_observer_test.dart
+++ b/packages/soliplex_client/test/http/concurrency_observer_test.dart
@@ -1,0 +1,84 @@
+import 'package:soliplex_client/soliplex_client.dart';
+import 'package:test/test.dart';
+
+class _RecordingObserver implements ConcurrencyObserver {
+  final events = <HttpConcurrencyWaitEvent>[];
+
+  @override
+  void onConcurrencyWait(HttpConcurrencyWaitEvent event) => events.add(event);
+}
+
+void main() {
+  group('HttpConcurrencyWaitEvent', () {
+    test('stores all required fields', () {
+      final now = DateTime.now();
+      final event = HttpConcurrencyWaitEvent(
+        requestId: 'req-1',
+        timestamp: now,
+        uri: Uri.parse('https://api.example.com/x'),
+        waitDuration: const Duration(milliseconds: 250),
+        queueDepthAtEnqueue: 3,
+        slotsInUseAfterAcquire: 6,
+      );
+
+      expect(event.requestId, equals('req-1'));
+      expect(event.timestamp, equals(now));
+      expect(event.uri.toString(), equals('https://api.example.com/x'));
+      expect(event.waitDuration, equals(const Duration(milliseconds: 250)));
+      expect(event.queueDepthAtEnqueue, equals(3));
+      expect(event.slotsInUseAfterAcquire, equals(6));
+    });
+
+    test('events with same requestId compare equal', () {
+      final a = HttpConcurrencyWaitEvent(
+        requestId: 'req-1',
+        timestamp: DateTime.now(),
+        uri: Uri.parse('https://api.example.com/x'),
+        waitDuration: Duration.zero,
+        queueDepthAtEnqueue: 0,
+        slotsInUseAfterAcquire: 1,
+      );
+      final b = HttpConcurrencyWaitEvent(
+        requestId: 'req-1',
+        timestamp: DateTime.now().add(const Duration(seconds: 1)),
+        uri: Uri.parse('https://api.example.com/y'),
+        waitDuration: const Duration(milliseconds: 500),
+        queueDepthAtEnqueue: 5,
+        slotsInUseAfterAcquire: 6,
+      );
+      expect(a, equals(b));
+      expect(a.hashCode, equals(b.hashCode));
+    });
+
+    test('toString includes key fields', () {
+      final event = HttpConcurrencyWaitEvent(
+        requestId: 'req-1',
+        timestamp: DateTime.now(),
+        uri: Uri.parse('https://api.example.com/x'),
+        waitDuration: const Duration(milliseconds: 250),
+        queueDepthAtEnqueue: 3,
+        slotsInUseAfterAcquire: 6,
+      );
+      expect(event.toString(), contains('req-1'));
+      expect(event.toString(), contains('250'));
+    });
+  });
+
+  group('ConcurrencyObserver', () {
+    test('observers receive events via onConcurrencyWait', () {
+      final observer = _RecordingObserver();
+      final event = HttpConcurrencyWaitEvent(
+        requestId: 'req-1',
+        timestamp: DateTime.now(),
+        uri: Uri.parse('https://api.example.com/x'),
+        waitDuration: const Duration(milliseconds: 100),
+        queueDepthAtEnqueue: 2,
+        slotsInUseAfterAcquire: 5,
+      );
+
+      observer.onConcurrencyWait(event);
+
+      expect(observer.events, equals([event]));
+    });
+  });
+}

--- a/packages/soliplex_client/test/http/concurrency_observer_test.dart
+++ b/packages/soliplex_client/test/http/concurrency_observer_test.dart
@@ -10,25 +10,6 @@ class _RecordingObserver implements ConcurrencyObserver {
 
 void main() {
   group('ConcurrencyWaitEvent', () {
-    test('stores all required fields', () {
-      final now = DateTime.now();
-      final event = ConcurrencyWaitEvent(
-        acquisitionId: 'req-1',
-        timestamp: now,
-        uri: Uri.parse('https://api.example.com/x'),
-        waitDuration: const Duration(milliseconds: 250),
-        queueDepthAtEnqueue: 3,
-        slotsInUseAfterAcquire: 6,
-      );
-
-      expect(event.acquisitionId, equals('req-1'));
-      expect(event.timestamp, equals(now));
-      expect(event.uri.toString(), equals('https://api.example.com/x'));
-      expect(event.waitDuration, equals(const Duration(milliseconds: 250)));
-      expect(event.queueDepthAtEnqueue, equals(3));
-      expect(event.slotsInUseAfterAcquire, equals(6));
-    });
-
     test('events with identical fields are equal', () {
       final now = DateTime.now();
       final a = ConcurrencyWaitEvent(
@@ -49,61 +30,6 @@ void main() {
       );
       expect(a, equals(b));
       expect(a.hashCode, equals(b.hashCode));
-    });
-
-    test('events differing in waitDuration are not equal', () {
-      final now = DateTime.now();
-      final a = ConcurrencyWaitEvent(
-        acquisitionId: 'req-1',
-        timestamp: now,
-        uri: Uri.parse('https://api.example.com/x'),
-        waitDuration: Duration.zero,
-        queueDepthAtEnqueue: 0,
-        slotsInUseAfterAcquire: 1,
-      );
-      final b = ConcurrencyWaitEvent(
-        acquisitionId: 'req-1',
-        timestamp: now,
-        uri: Uri.parse('https://api.example.com/x'),
-        waitDuration: const Duration(milliseconds: 500),
-        queueDepthAtEnqueue: 0,
-        slotsInUseAfterAcquire: 1,
-      );
-      expect(a, isNot(equals(b)));
-    });
-
-    test('events with different acquisitionId are not equal', () {
-      final now = DateTime.now();
-      final a = ConcurrencyWaitEvent(
-        acquisitionId: 'req-1',
-        timestamp: now,
-        uri: Uri.parse('https://api.example.com/x'),
-        waitDuration: Duration.zero,
-        queueDepthAtEnqueue: 0,
-        slotsInUseAfterAcquire: 1,
-      );
-      final b = ConcurrencyWaitEvent(
-        acquisitionId: 'req-2',
-        timestamp: now,
-        uri: Uri.parse('https://api.example.com/x'),
-        waitDuration: Duration.zero,
-        queueDepthAtEnqueue: 0,
-        slotsInUseAfterAcquire: 1,
-      );
-      expect(a, isNot(equals(b)));
-    });
-
-    test('toString includes key fields', () {
-      final event = ConcurrencyWaitEvent(
-        acquisitionId: 'req-1',
-        timestamp: DateTime.now(),
-        uri: Uri.parse('https://api.example.com/x'),
-        waitDuration: const Duration(milliseconds: 250),
-        queueDepthAtEnqueue: 3,
-        slotsInUseAfterAcquire: 6,
-      );
-      expect(event.toString(), contains('req-1'));
-      expect(event.toString(), contains('250'));
     });
   });
 

--- a/packages/soliplex_client/test/http/http_diagnostic_test.dart
+++ b/packages/soliplex_client/test/http/http_diagnostic_test.dart
@@ -1,0 +1,85 @@
+import 'dart:async';
+
+import 'package:soliplex_client/src/http/http_diagnostic.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('safeDiagnosticHandler', () {
+    test('passes arguments through to the wrapped handler when it succeeds',
+        () {
+      Object? capturedError;
+      StackTrace? capturedStack;
+      String? capturedMessage;
+      void inner(
+        Object error,
+        StackTrace stackTrace, {
+        required String message,
+      }) {
+        capturedError = error;
+        capturedStack = stackTrace;
+        capturedMessage = message;
+      }
+
+      final safe = safeDiagnosticHandler(inner);
+      final error = StateError('the original error');
+      final stack = StackTrace.current;
+
+      safe(error, stack, message: 'context');
+
+      expect(capturedError, same(error));
+      expect(capturedStack, same(stack));
+      expect(capturedMessage, 'context');
+    });
+
+    test(
+        'does not propagate when the wrapped handler throws synchronously — '
+        'the caller continues as if nothing happened', () {
+      void throwing(Object _, StackTrace __, {required String message}) {
+        throw StateError('broken sink');
+      }
+
+      final safe = safeDiagnosticHandler(throwing);
+
+      // If the wrapper re-threw, this expression would throw.
+      expect(
+        () => safe(
+          StateError('anything'),
+          StackTrace.current,
+          message: 'ctx',
+        ),
+        returnsNormally,
+        reason: 'Diagnostic handlers are the last line of defense. A throwing '
+            'sink must not break the decorator contract that internal '
+            'errors are contained.',
+      );
+    });
+
+    test(
+        'does not propagate when the wrapped handler initiates a '
+        'fire-and-forget async error', () async {
+      void asyncThrowing(Object _, StackTrace __, {required String message}) {
+        // Simulates a Sentry-style sink that schedules work and drops the
+        // error future — runZonedGuarded must catch this too.
+        unawaited(Future<void>.error(StateError('async sink failure')));
+      }
+
+      final safe = safeDiagnosticHandler(asyncThrowing);
+
+      await runZonedGuarded(() async {
+        safe(
+          StateError('anything'),
+          StackTrace.current,
+          message: 'ctx',
+        );
+        // Give the microtask a chance to run. If the wrapper failed to
+        // contain the async error, it would surface in this outer zone.
+        await Future<void>.delayed(Duration.zero);
+      }, (error, stack) {
+        fail(
+          'Async error from a misbehaving diagnostic handler leaked '
+          'into the caller zone: $error',
+        );
+      });
+    });
+  });
+}

--- a/packages/soliplex_client/test/http/http_stack_integration_test.dart
+++ b/packages/soliplex_client/test/http/http_stack_integration_test.dart
@@ -454,4 +454,67 @@ void main() {
       expect(platform.closed, isTrue);
     });
   });
+
+  group('mixed HttpObserver + ConcurrencyObserver ordering', () {
+    test(
+        'one observer implementing both interfaces sees '
+        'ConcurrencyWaitEvent → HttpRequestEvent → HttpResponseEvent '
+        'for a single REST request', () async {
+      // The concurrency layer dispatches BEFORE auth/platform, so an
+      // observer correlating concurrency events with HTTP events via
+      // timestamps relies on this ordering. A decorator reorder that
+      // placed the limiter inside the observable would silently invert
+      // the sequence and break correlation in the network inspector.
+      final mixedObserver = _MixedObserver();
+      final platform = FakePlatformClient()
+        ..nextResponse = HttpResponse(
+          statusCode: 200,
+          bodyBytes: Uint8List.fromList(utf8.encode('{}')),
+          headers: const {'content-type': 'application/json'},
+        );
+      final observable = ObservableHttpClient(
+        client: platform,
+        observers: [mixedObserver],
+      );
+      final limiter = ConcurrencyLimitingHttpClient(
+        inner: observable,
+        maxConcurrent: 4,
+        observers: [mixedObserver],
+      );
+      final transport = HttpTransport(client: limiter);
+
+      await transport.request<Map<String, dynamic>>('GET', testUri);
+
+      expect(
+        mixedObserver.events.map((e) => e.runtimeType).toList(),
+        equals([
+          ConcurrencyWaitEvent,
+          HttpRequestEvent,
+          HttpResponseEvent,
+        ]),
+        reason: 'Concurrency acquisition must precede the HTTP request '
+            'event, and the HTTP request must precede the response. '
+            'Any other order breaks observer correlation.',
+      );
+    });
+  });
+}
+
+/// Single observer implementing both interfaces; appends every event into
+/// a shared list to capture cross-interface ordering.
+class _MixedObserver implements HttpObserver, ConcurrencyObserver {
+  final events = <Object>[];
+
+  @override
+  void onRequest(HttpRequestEvent event) => events.add(event);
+  @override
+  void onResponse(HttpResponseEvent event) => events.add(event);
+  @override
+  void onError(HttpErrorEvent event) => events.add(event);
+  @override
+  void onStreamStart(HttpStreamStartEvent event) => events.add(event);
+  @override
+  void onStreamEnd(HttpStreamEndEvent event) => events.add(event);
+  @override
+  void onConcurrencyWait(ConcurrencyWaitEvent event) => events.add(event);
 }

--- a/packages/soliplex_client/test/http/http_stack_integration_test.dart
+++ b/packages/soliplex_client/test/http/http_stack_integration_test.dart
@@ -291,27 +291,6 @@ void main() {
       },
     );
 
-    test('SSE connection error propagates through all layers', () async {
-      platform.nextStreamError = const NetworkException(
-        message: 'SSE connection failed',
-      );
-
-      Object? caughtError;
-      try {
-        await transport.requestStream('GET', testUri);
-      } catch (e) {
-        caughtError = e;
-      }
-
-      expect(caughtError, isA<NetworkException>());
-
-      // Observer fires onStreamStart but the connection error
-      // propagates before the stream body is set up, so no
-      // onStreamEnd or onError event is emitted.
-      final starts = observer.ofType<HttpStreamStartEvent>();
-      expect(starts, hasLength(1));
-    });
-
     test('SSE 401 on connection throws AuthException from transport', () async {
       final controller = StreamController<List<int>>();
       platform.nextStreamResponse = StreamedHttpResponse(
@@ -417,7 +396,8 @@ void main() {
     );
 
     test(
-      'observer sees stream start but no end for connection error',
+      'connection error during requestStream emits both onStreamStart and '
+      'onStreamEnd(error)',
       () async {
         platform.nextStreamError = const NetworkException(
           message: 'Stream setup failed',
@@ -427,14 +407,17 @@ void main() {
           await transport.requestStream('GET', testUri);
         } catch (_) {}
 
-        // Connection errors occur during await of requestStream,
-        // after onStreamStart but before the body stream is wrapped.
-        // No onStreamEnd is emitted in this case.
         final starts = observer.ofType<HttpStreamStartEvent>();
         expect(starts, hasLength(1));
 
         final ends = observer.ofType<HttpStreamEndEvent>();
-        expect(ends, isEmpty);
+        expect(
+          ends,
+          hasLength(1),
+          reason: 'onStreamEnd must fire even when the inner requestStream '
+              'throws, so observers do not see a dangling open request',
+        );
+        expect(ends.single.error, isA<NetworkException>());
       },
     );
   });

--- a/packages/soliplex_client/test/http/observable_http_client_test.dart
+++ b/packages/soliplex_client/test/http/observable_http_client_test.dart
@@ -790,6 +790,40 @@ void main() {
 
         observableClient.close();
       });
+
+      test(
+          'request completes when the diagnostic handler itself throws — the '
+          'safety wrapper must contain a broken sink', () async {
+        // ThrowingObserver forces the decorator to call _onDiagnostic.
+        // The handler then throws, simulating a transient Sentry failure.
+        final observableClient = ObservableHttpClient(
+          client: mockClient,
+          observers: [ThrowingObserver()],
+          onDiagnostic: (_, __, {required message}) {
+            throw StateError('diagnostic sink down');
+          },
+        );
+
+        when(
+          () => mockClient.request(
+            any(),
+            any(),
+            headers: any(named: 'headers'),
+            body: any(named: 'body'),
+            timeout: any(named: 'timeout'),
+          ),
+        ).thenAnswer(
+          (_) async => HttpResponse(statusCode: 200, bodyBytes: Uint8List(0)),
+        );
+
+        await expectLater(
+          observableClient.request('GET', Uri.parse('https://example.com')),
+          completes,
+          reason: 'A broken diagnostic sink must not break request flow.',
+        );
+
+        observableClient.close();
+      });
     });
 
     group('observer error isolation', () {

--- a/packages/soliplex_client/test/http/observable_http_client_test.dart
+++ b/packages/soliplex_client/test/http/observable_http_client_test.dart
@@ -32,6 +32,14 @@ class RecordingObserver implements HttpObserver {
   List<T> eventsOfType<T extends HttpEvent>() => events.whereType<T>().toList();
 }
 
+/// Object whose toString throws. Used to exercise the redaction
+/// safety-net's outermost catch: _redactRequestBody falls through to
+/// body.toString() for unknown types.
+class _ThrowingToStringBody {
+  @override
+  String toString() => throw StateError('toString is broken');
+}
+
 /// Observer that throws on every callback.
 class ThrowingObserver implements HttpObserver {
   @override
@@ -787,6 +795,110 @@ void main() {
         // Both recording observers should still receive events
         expect(recorder1.events, hasLength(2));
         expect(recorder2.events, hasLength(2));
+
+        observableClient.close();
+      });
+
+      test(
+          'request body redaction failure yields <redaction failed> '
+          'placeholder, logs a diagnostic, and does not break the request',
+          () async {
+        // Regression for the outer try/catch around _redactRequestBody:
+        // if the redactor throws on pathological input (here: an object
+        // whose toString throws), observers must see a placeholder and
+        // the request must still complete.
+        final diagnostics = <String>[];
+        final observableClient = ObservableHttpClient(
+          client: mockClient,
+          observers: [recorder],
+          onDiagnostic: (_, __, {required message}) => diagnostics.add(message),
+        );
+
+        when(
+          () => mockClient.request(
+            any(),
+            any(),
+            headers: any(named: 'headers'),
+            body: any(named: 'body'),
+            timeout: any(named: 'timeout'),
+          ),
+        ).thenAnswer(
+          (_) async => HttpResponse(statusCode: 200, bodyBytes: Uint8List(0)),
+        );
+
+        await observableClient.request(
+          'POST',
+          Uri.parse('https://example.com/api'),
+          body: _ThrowingToStringBody(),
+        );
+
+        final requests = recorder.eventsOfType<HttpRequestEvent>();
+        expect(requests, hasLength(1));
+        expect(
+          requests.single.body,
+          '<redaction failed>',
+          reason: 'Observer must receive the placeholder when redaction '
+              'throws — never the raw body, never a missing event.',
+        );
+        expect(
+          diagnostics,
+          contains('Request body redaction failed unexpectedly'),
+          reason: 'Redaction failure must be visible in diagnostics so '
+              'the bug can be found in production logs.',
+        );
+
+        observableClient.close();
+      });
+
+      test(
+          'response body redaction failure yields <redaction failed> '
+          'placeholder when the body getter throws on invalid UTF-8', () async {
+        // HttpResponse.body calls utf8.decode(bodyBytes); invalid UTF-8
+        // throws FormatException. With content-type application/json,
+        // the inner method catches FormatException from jsonDecode but
+        // then calls redactString which re-invokes the body getter —
+        // the second throw escapes the inner method and is caught by
+        // the outer safety net.
+        final diagnostics = <String>[];
+        final observableClient = ObservableHttpClient(
+          client: mockClient,
+          observers: [recorder],
+          onDiagnostic: (_, __, {required message}) => diagnostics.add(message),
+        );
+
+        when(
+          () => mockClient.request(
+            any(),
+            any(),
+            headers: any(named: 'headers'),
+            body: any(named: 'body'),
+            timeout: any(named: 'timeout'),
+          ),
+        ).thenAnswer(
+          (_) async => HttpResponse(
+            statusCode: 200,
+            bodyBytes: Uint8List.fromList(const [0xFF, 0xFE, 0xFD]),
+            headers: const {'content-type': 'application/json'},
+          ),
+        );
+
+        await observableClient.request(
+          'GET',
+          Uri.parse('https://example.com/api'),
+        );
+
+        final responses = recorder.eventsOfType<HttpResponseEvent>();
+        expect(responses, hasLength(1));
+        expect(
+          responses.single.body,
+          '<redaction failed>',
+          reason: 'Observer must receive the placeholder when body '
+              'decoding fails during redaction.',
+        );
+        expect(
+          diagnostics,
+          contains('Response body redaction failed unexpectedly'),
+        );
 
         observableClient.close();
       });

--- a/packages/soliplex_client/test/http/observable_http_client_test.dart
+++ b/packages/soliplex_client/test/http/observable_http_client_test.dart
@@ -363,6 +363,73 @@ void main() {
 
     group('stream lifecycle - error', () {
       test(
+        'sync-throw on response.body.listen emits onStreamEnd(error) and '
+        'surfaces the error to the caller',
+        () async {
+          // A single-subscription stream that has already been listened
+          // to elsewhere will throw a synchronous StateError on the
+          // ObservableHttpClient's listen call. Without protection, the
+          // decorator leaks a dangling onStreamStart (no onStreamEnd).
+          final innerController = StreamController<List<int>>();
+          innerController.stream.listen((_) {});
+
+          when(
+            () => mockClient.requestStream(
+              any(),
+              any(),
+              headers: any(named: 'headers'),
+              body: any(named: 'body'),
+            ),
+          ).thenAnswer(
+            (_) async => StreamedHttpResponse(
+              statusCode: 200,
+              body: innerController.stream,
+            ),
+          );
+
+          final response = await observableClient.requestStream(
+            'GET',
+            Uri.parse('https://example.com/stream'),
+          );
+
+          final errors = <Object>[];
+          final completer = Completer<void>();
+
+          response.body.listen(
+            (_) {},
+            onError: (Object e) {
+              errors.add(e);
+              if (!completer.isCompleted) completer.complete();
+            },
+            onDone: () {
+              if (!completer.isCompleted) completer.complete();
+            },
+          );
+
+          await completer.future;
+
+          expect(
+            errors,
+            hasLength(1),
+            reason: 'Caller must still see the synchronous listen error — '
+                'the protection must not mask the bug.',
+          );
+          expect(errors.single, isA<StateError>());
+
+          final endEvents = recorder.eventsOfType<HttpStreamEndEvent>();
+          expect(
+            endEvents,
+            hasLength(1),
+            reason: 'onStreamEnd must fire so observers do not see a '
+                'dangling onStreamStart when the inner body is not listenable.',
+          );
+          expect(endEvents.single.isSuccess, isFalse);
+
+          await innerController.close();
+        },
+      );
+
+      test(
         'notifies observer on stream error with SoliplexException',
         () async {
           final controller = StreamController<List<int>>();
@@ -515,6 +582,94 @@ void main() {
             endEvents,
             hasLength(1),
             reason: 'Should emit exactly one onStreamEnd, not two',
+          );
+        },
+      );
+
+      test(
+        'emits onStreamEnd when requestStream itself throws after '
+        'onStreamStart',
+        () async {
+          when(
+            () => mockClient.requestStream(
+              any(),
+              any(),
+              headers: any(named: 'headers'),
+              body: any(named: 'body'),
+            ),
+          ).thenThrow(const NetworkException(message: 'connect refused'));
+
+          await expectLater(
+            () => observableClient.requestStream(
+              'GET',
+              Uri.parse('https://example.com/stream'),
+            ),
+            throwsA(isA<NetworkException>()),
+          );
+
+          final startEvents = recorder.eventsOfType<HttpStreamStartEvent>();
+          final endEvents = recorder.eventsOfType<HttpStreamEndEvent>();
+          expect(startEvents, hasLength(1));
+          expect(
+            endEvents,
+            hasLength(1),
+            reason: 'onStreamStart must have a matching onStreamEnd; '
+                'otherwise observers see a forever-open request',
+          );
+          expect(endEvents.first.error, isA<NetworkException>());
+        },
+      );
+
+      test(
+        'redacts URI secrets when wrapping non-SoliplexException in '
+        'NetworkException.message',
+        () async {
+          final controller = StreamController<List<int>>();
+
+          when(
+            () => mockClient.requestStream(
+              any(),
+              any(),
+              headers: any(named: 'headers'),
+              body: any(named: 'body'),
+            ),
+          ).thenAnswer(
+            (_) async =>
+                StreamedHttpResponse(statusCode: 200, body: controller.stream),
+          );
+
+          // Auth-endpoint URI triggers full-body redaction in HttpRedactor.
+          final response = await observableClient.requestStream(
+            'GET',
+            Uri.parse('https://example.com/oauth/token?code=secret-abc-123'),
+          );
+
+          final completer = Completer<void>();
+          response.body.listen(
+            (_) {},
+            onError: (_) {},
+            onDone: () {
+              if (!completer.isCompleted) completer.complete();
+            },
+          );
+
+          // A non-SoliplexException whose toString contains the full URI.
+          controller.addError(
+            Exception(
+              'fetch failed for '
+              'https://example.com/oauth/token?code=secret-abc-123',
+            ),
+          );
+          await controller.close();
+          await completer.future;
+
+          final endEvent = recorder.eventsOfType<HttpStreamEndEvent>().first;
+          final message = (endEvent.error! as NetworkException).message;
+          expect(
+            message,
+            isNot(contains('secret-abc-123')),
+            reason: 'NetworkException.message must be URI-redacted before '
+                'emission so tokens do not leak through observers',
           );
         },
       );

--- a/test/helpers/http_event_factories.dart
+++ b/test/helpers/http_event_factories.dart
@@ -94,3 +94,21 @@ HttpStreamEndEvent createStreamEndEvent({
     body: body,
   );
 }
+
+HttpConcurrencyWaitEvent createConcurrencyWaitEvent({
+  String requestId = 'cc-1',
+  DateTime? timestamp,
+  Uri? uri,
+  Duration waitDuration = const Duration(milliseconds: 50),
+  int queueDepthAtEnqueue = 0,
+  int slotsInUseAfterAcquire = 1,
+}) {
+  return HttpConcurrencyWaitEvent(
+    requestId: requestId,
+    timestamp: timestamp ?? DateTime.utc(2026, 4, 16, 12),
+    uri: uri ?? Uri.parse('https://api.example.com/x'),
+    waitDuration: waitDuration,
+    queueDepthAtEnqueue: queueDepthAtEnqueue,
+    slotsInUseAfterAcquire: slotsInUseAfterAcquire,
+  );
+}

--- a/test/helpers/http_event_factories.dart
+++ b/test/helpers/http_event_factories.dart
@@ -95,16 +95,16 @@ HttpStreamEndEvent createStreamEndEvent({
   );
 }
 
-HttpConcurrencyWaitEvent createConcurrencyWaitEvent({
-  String requestId = 'cc-1',
+ConcurrencyWaitEvent createConcurrencyWaitEvent({
+  String acquisitionId = 'acq-1',
   DateTime? timestamp,
   Uri? uri,
   Duration waitDuration = const Duration(milliseconds: 50),
   int queueDepthAtEnqueue = 0,
   int slotsInUseAfterAcquire = 1,
 }) {
-  return HttpConcurrencyWaitEvent(
-    requestId: requestId,
+  return ConcurrencyWaitEvent(
+    acquisitionId: acquisitionId,
     timestamp: timestamp ?? DateTime.utc(2026, 4, 16, 12),
     uri: uri ?? Uri.parse('https://api.example.com/x'),
     waitDuration: waitDuration,

--- a/test/modules/diagnostics/network_inspector_test.dart
+++ b/test/modules/diagnostics/network_inspector_test.dart
@@ -16,11 +16,8 @@ void main() {
       inspector.dispose();
     });
 
-    test('starts with empty events list', () {
+    test('starts with empty event lists', () {
       expect(inspector.events, isEmpty);
-    });
-
-    test('starts with empty concurrencyEvents list', () {
       expect(inspector.concurrencyEvents, isEmpty);
     });
 
@@ -59,14 +56,6 @@ void main() {
       expect(inspector.events, isEmpty);
     });
 
-    test('concurrencyEvents getter returns unmodifiable list', () {
-      inspector.onConcurrencyWait(createConcurrencyWaitEvent());
-      expect(
-        () => inspector.concurrencyEvents.add(createConcurrencyWaitEvent()),
-        throwsUnsupportedError,
-      );
-    });
-
     test('accumulates multiple events in order', () {
       final req = createRequestEvent();
       final resp = createResponseEvent();
@@ -75,14 +64,6 @@ void main() {
       expect(inspector.events, hasLength(2));
       expect(inspector.events[0], req);
       expect(inspector.events[1], resp);
-    });
-
-    test('events getter returns unmodifiable list', () {
-      inspector.onRequest(createRequestEvent());
-      expect(
-        () => inspector.events.add(createResponseEvent()),
-        throwsUnsupportedError,
-      );
     });
 
     test('clear() empties the events list', () {

--- a/test/modules/diagnostics/network_inspector_test.dart
+++ b/test/modules/diagnostics/network_inspector_test.dart
@@ -118,6 +118,24 @@ void main() {
       expect(notifyCount, 1);
     });
 
+    test('is safe to receive events after dispose', () {
+      inspector
+        ..onRequest(createRequestEvent())
+        ..dispose();
+
+      // Post-dispose events are silently dropped instead of throwing
+      // a "Cannot use disposed ChangeNotifier" error. The HTTP stack
+      // often outlives the UI — logout, route teardown, etc.
+      expect(
+        () => inspector.onConcurrencyWait(createConcurrencyWaitEvent()),
+        returnsNormally,
+      );
+      expect(
+        () => inspector.onRequest(createRequestEvent()),
+        returnsNormally,
+      );
+    });
+
     test('notifyListeners fires on clear()', () {
       inspector.onRequest(createRequestEvent());
 

--- a/test/modules/diagnostics/network_inspector_test.dart
+++ b/test/modules/diagnostics/network_inspector_test.dart
@@ -1,4 +1,5 @@
 import 'package:flutter_test/flutter_test.dart';
+import 'package:soliplex_agent/soliplex_agent.dart';
 import 'package:soliplex_frontend/src/modules/diagnostics/network_inspector.dart';
 
 import '../../helpers/http_event_factories.dart';
@@ -144,6 +145,52 @@ void main() {
 
       inspector.clear();
       expect(notifyCount, 1);
+    });
+  });
+
+  group('NetworkInspector bounded queues', () {
+    test('events queue caps at maxEvents and drops the oldest first', () {
+      final inspector = NetworkInspector(maxEvents: 3);
+      addTearDown(inspector.dispose);
+
+      final events =
+          List.generate(5, (i) => createRequestEvent(requestId: 'r$i'));
+      for (final e in events) {
+        inspector.onRequest(e);
+      }
+
+      expect(inspector.events, hasLength(3));
+      expect(
+        inspector.events.map((e) => (e as HttpRequestEvent).requestId),
+        ['r2', 'r3', 'r4'],
+        reason: 'oldest entries must drop first (FIFO)',
+      );
+    });
+
+    test('concurrencyEvents queue caps independently of events queue', () {
+      final inspector = NetworkInspector(maxEvents: 2);
+      addTearDown(inspector.dispose);
+
+      for (var i = 0; i < 4; i++) {
+        inspector.onConcurrencyWait(createConcurrencyWaitEvent());
+      }
+      for (var i = 0; i < 4; i++) {
+        inspector.onRequest(createRequestEvent());
+      }
+
+      expect(inspector.concurrencyEvents, hasLength(2));
+      expect(inspector.events, hasLength(2));
+    });
+
+    test('rejects non-positive maxEvents', () {
+      expect(
+        () => NetworkInspector(maxEvents: 0),
+        throwsA(isA<AssertionError>()),
+      );
+      expect(
+        () => NetworkInspector(maxEvents: -1),
+        throwsA(isA<AssertionError>()),
+      );
     });
   });
 }

--- a/test/modules/diagnostics/network_inspector_test.dart
+++ b/test/modules/diagnostics/network_inspector_test.dart
@@ -185,11 +185,11 @@ void main() {
     test('rejects non-positive maxEvents', () {
       expect(
         () => NetworkInspector(maxEvents: 0),
-        throwsA(isA<AssertionError>()),
+        throwsA(isA<ArgumentError>()),
       );
       expect(
         () => NetworkInspector(maxEvents: -1),
-        throwsA(isA<AssertionError>()),
+        throwsA(isA<ArgumentError>()),
       );
     });
   });

--- a/test/modules/diagnostics/network_inspector_test.dart
+++ b/test/modules/diagnostics/network_inspector_test.dart
@@ -19,6 +19,10 @@ void main() {
       expect(inspector.events, isEmpty);
     });
 
+    test('starts with empty concurrencyEvents list', () {
+      expect(inspector.concurrencyEvents, isEmpty);
+    });
+
     test('collects request events via onRequest', () {
       inspector.onRequest(createRequestEvent());
       expect(inspector.events, hasLength(1));
@@ -42,6 +46,24 @@ void main() {
     test('collects stream end events via onStreamEnd', () {
       inspector.onStreamEnd(createStreamEndEvent());
       expect(inspector.events, hasLength(1));
+    });
+
+    test('collects concurrency wait events via onConcurrencyWait', () {
+      inspector.onConcurrencyWait(createConcurrencyWaitEvent());
+      expect(inspector.concurrencyEvents, hasLength(1));
+    });
+
+    test('concurrency events do not pollute the http events list', () {
+      inspector.onConcurrencyWait(createConcurrencyWaitEvent());
+      expect(inspector.events, isEmpty);
+    });
+
+    test('concurrencyEvents getter returns unmodifiable list', () {
+      inspector.onConcurrencyWait(createConcurrencyWaitEvent());
+      expect(
+        () => inspector.concurrencyEvents.add(createConcurrencyWaitEvent()),
+        throwsUnsupportedError,
+      );
     });
 
     test('accumulates multiple events in order', () {
@@ -69,6 +91,14 @@ void main() {
       expect(inspector.events, isEmpty);
     });
 
+    test('clear() empties both events and concurrencyEvents', () {
+      inspector.onRequest(createRequestEvent());
+      inspector.onConcurrencyWait(createConcurrencyWaitEvent());
+      inspector.clear();
+      expect(inspector.events, isEmpty);
+      expect(inspector.concurrencyEvents, isEmpty);
+    });
+
     test('notifyListeners fires when event is added', () {
       var notifyCount = 0;
       inspector.addListener(() => notifyCount++);
@@ -78,6 +108,14 @@ void main() {
 
       inspector.onResponse(createResponseEvent());
       expect(notifyCount, 2);
+    });
+
+    test('notifyListeners fires when concurrency event is added', () {
+      var notifyCount = 0;
+      inspector.addListener(() => notifyCount++);
+
+      inspector.onConcurrencyWait(createConcurrencyWaitEvent());
+      expect(notifyCount, 1);
     });
 
     test('notifyListeners fires on clear()', () {

--- a/test/modules/diagnostics/ui/concurrency_summary_panel_test.dart
+++ b/test/modules/diagnostics/ui/concurrency_summary_panel_test.dart
@@ -7,7 +7,7 @@ import '../../../helpers/http_event_factories.dart';
 
 Future<void> _pump(
   WidgetTester tester,
-  List<HttpConcurrencyWaitEvent> events,
+  List<ConcurrencyWaitEvent> events,
 ) async {
   await tester.pumpWidget(
     MaterialApp(
@@ -31,19 +31,19 @@ void main() {
     testWidgets('renders totals, peak slots, and max depth', (tester) async {
       await _pump(tester, [
         createConcurrencyWaitEvent(
-          requestId: 'cc-1',
+          acquisitionId: 'acq-1',
           waitDuration: Duration.zero,
           queueDepthAtEnqueue: 0,
           slotsInUseAfterAcquire: 1,
         ),
         createConcurrencyWaitEvent(
-          requestId: 'cc-2',
+          acquisitionId: 'acq-2',
           waitDuration: const Duration(milliseconds: 200),
           queueDepthAtEnqueue: 3,
           slotsInUseAfterAcquire: 4,
         ),
         createConcurrencyWaitEvent(
-          requestId: 'cc-3',
+          acquisitionId: 'acq-3',
           waitDuration: const Duration(milliseconds: 100),
           queueDepthAtEnqueue: 2,
           slotsInUseAfterAcquire: 5,
@@ -59,11 +59,11 @@ void main() {
     testWidgets('computes avg wait across queued events only', (tester) async {
       await _pump(tester, [
         createConcurrencyWaitEvent(
-          requestId: 'cc-fast',
+          acquisitionId: 'acq-fast',
           waitDuration: Duration.zero,
         ),
         createConcurrencyWaitEvent(
-          requestId: 'cc-slow',
+          acquisitionId: 'acq-slow',
           waitDuration: const Duration(milliseconds: 100),
         ),
       ]);
@@ -76,7 +76,7 @@ void main() {
     testWidgets('omits avg when nothing was queued', (tester) async {
       await _pump(tester, [
         createConcurrencyWaitEvent(
-          requestId: 'cc-fast',
+          acquisitionId: 'acq-fast',
           waitDuration: Duration.zero,
         ),
       ]);

--- a/test/modules/diagnostics/ui/concurrency_summary_panel_test.dart
+++ b/test/modules/diagnostics/ui/concurrency_summary_panel_test.dart
@@ -1,0 +1,88 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:soliplex_agent/soliplex_agent.dart';
+import 'package:soliplex_frontend/src/modules/diagnostics/ui/concurrency_summary_panel.dart';
+
+import '../../../helpers/http_event_factories.dart';
+
+Future<void> _pump(
+  WidgetTester tester,
+  List<HttpConcurrencyWaitEvent> events,
+) async {
+  await tester.pumpWidget(
+    MaterialApp(
+      home: Scaffold(
+        body: ConcurrencySummaryPanel(events: events),
+      ),
+    ),
+  );
+}
+
+void main() {
+  group('ConcurrencySummaryPanel', () {
+    testWidgets('renders nothing when events list is empty', (tester) async {
+      await _pump(tester, const []);
+
+      // With an empty list the panel collapses to a zero-size placeholder.
+      expect(find.byIcon(Icons.hourglass_empty), findsNothing);
+      expect(find.textContaining('queued'), findsNothing);
+    });
+
+    testWidgets('renders totals, peak slots, and max depth', (tester) async {
+      await _pump(tester, [
+        createConcurrencyWaitEvent(
+          requestId: 'cc-1',
+          waitDuration: Duration.zero,
+          queueDepthAtEnqueue: 0,
+          slotsInUseAfterAcquire: 1,
+        ),
+        createConcurrencyWaitEvent(
+          requestId: 'cc-2',
+          waitDuration: const Duration(milliseconds: 200),
+          queueDepthAtEnqueue: 3,
+          slotsInUseAfterAcquire: 4,
+        ),
+        createConcurrencyWaitEvent(
+          requestId: 'cc-3',
+          waitDuration: const Duration(milliseconds: 100),
+          queueDepthAtEnqueue: 2,
+          slotsInUseAfterAcquire: 5,
+        ),
+      ]);
+
+      expect(find.byIcon(Icons.hourglass_empty), findsOneWidget);
+      expect(find.text('queued 2 of 3'), findsOneWidget);
+      expect(find.text('peak slots 5 / max depth 3'), findsOneWidget);
+      expect(find.text('max 200ms'), findsOneWidget);
+    });
+
+    testWidgets('computes avg wait across queued events only', (tester) async {
+      await _pump(tester, [
+        createConcurrencyWaitEvent(
+          requestId: 'cc-fast',
+          waitDuration: Duration.zero,
+        ),
+        createConcurrencyWaitEvent(
+          requestId: 'cc-slow',
+          waitDuration: const Duration(milliseconds: 100),
+        ),
+      ]);
+
+      // The Duration.zero event must be excluded from the average; otherwise
+      // the mean would be 50ms instead of 100ms.
+      expect(find.text('avg 100ms'), findsOneWidget);
+    });
+
+    testWidgets('omits avg when nothing was queued', (tester) async {
+      await _pump(tester, [
+        createConcurrencyWaitEvent(
+          requestId: 'cc-fast',
+          waitDuration: Duration.zero,
+        ),
+      ]);
+
+      expect(find.text('queued 0 of 1'), findsOneWidget);
+      expect(find.textContaining('avg'), findsNothing);
+    });
+  });
+}

--- a/test/modules/diagnostics/ui/network_inspector_screen_test.dart
+++ b/test/modules/diagnostics/ui/network_inspector_screen_test.dart
@@ -80,5 +80,50 @@ void main() {
 
       expect(find.text('No HTTP requests yet'), findsOneWidget);
     });
+
+    testWidgets('clear button is enabled when only concurrency events exist',
+        (tester) async {
+      inspector.onConcurrencyWait(createConcurrencyWaitEvent());
+
+      await tester.pumpWidget(
+        MaterialApp(home: NetworkInspectorScreen(inspector: inspector)),
+      );
+
+      final button = tester.widget<IconButton>(find.byType(IconButton));
+      expect(
+        button.onPressed,
+        isNotNull,
+        reason: 'Trash-can must activate when concurrency events exist '
+            'even if HTTP events list is empty',
+      );
+    });
+
+    testWidgets(
+        'clear button clears concurrency events and hides the summary panel',
+        (tester) async {
+      inspector
+        ..onConcurrencyWait(createConcurrencyWaitEvent(requestId: 'cc-1'))
+        ..onConcurrencyWait(
+          createConcurrencyWaitEvent(
+            requestId: 'cc-2',
+            waitDuration: const Duration(milliseconds: 120),
+            queueDepthAtEnqueue: 2,
+          ),
+        );
+
+      await tester.pumpWidget(
+        MaterialApp(home: NetworkInspectorScreen(inspector: inspector)),
+      );
+
+      // Panel is visible when concurrency events exist.
+      expect(find.byIcon(Icons.hourglass_empty), findsOneWidget);
+
+      await tester.tap(find.byType(IconButton));
+      await tester.pump();
+
+      // Panel hides itself when the list is empty.
+      expect(find.byIcon(Icons.hourglass_empty), findsNothing);
+      expect(inspector.concurrencyEvents, isEmpty);
+    });
   });
 }

--- a/test/modules/diagnostics/ui/network_inspector_screen_test.dart
+++ b/test/modules/diagnostics/ui/network_inspector_screen_test.dart
@@ -102,10 +102,10 @@ void main() {
         'clear button clears concurrency events and hides the summary panel',
         (tester) async {
       inspector
-        ..onConcurrencyWait(createConcurrencyWaitEvent(requestId: 'cc-1'))
+        ..onConcurrencyWait(createConcurrencyWaitEvent(acquisitionId: 'acq-1'))
         ..onConcurrencyWait(
           createConcurrencyWaitEvent(
-            requestId: 'cc-2',
+            acquisitionId: 'acq-2',
             waitDuration: const Duration(milliseconds: 120),
             queueDepthAtEnqueue: 2,
           ),


### PR DESCRIPTION
## Summary

- Adds `ConcurrencyLimitingHttpClient` as the outermost decorator in the agent HTTP stack, capping simultaneous in-flight requests with a FIFO-queued semaphore. Default `maxConcurrent = 6` — aligned with the per-host HTTP/1.1 cap browsers, `URLSession`, and Dart's `HttpClient` all enforce, sitting under the backend's per-client 10-connection cap.
- Slot ownership is idempotent via a private `_SlotHandle`; stream responses hold their slot until the body stream ends, errors, or is cancelled, with a 60s unlistened-body leak detector that drains the upstream and releases the slot.
- Network inspector gains a `ConcurrencySummaryPanel` and records `ConcurrencyWaitEvent`s so queue pressure surfaces in the diagnostics UI.

## Review findings addressed

- `ObservableHttpClient.request` catches `on Object` and wraps non-`SoliplexException` errors so `onRequest` always pairs with `onError`.
- `_Semaphore.acquire` checks `cancelToken.throwIfCancelled()` on both fast and slow paths.
- Leak-detector drain errors route through `_onDiagnostic` instead of silent swallow.
- `NetworkInspector.dispose()` wired into shell teardown; constructor throws `ArgumentError` rather than a debug-only `assert`.
- `ConcurrencySummaryPanel.avgWaitMs` is non-nullable; renderer gates on `queuedCount > 0`.
- `createAgentHttpClient` dartdoc explains the default rationale and the `whereType<ConcurrencyObserver>` filtering.

## Known follow-ups

The PR intentionally does not add a queue-wait timeout or fix the multi-client exposure where `plainClient` + per-server clients each carry independent semaphores. Both are tracked in `docs/plans/http-pool-architecture/proposal.md` (not included in this commit) for a separate effort.

## Test plan

- [x] `dart format .` clean
- [x] `flutter analyze` — no issues
- [x] `flutter test` — 998 passed
- [x] `cd packages/soliplex_client && dart test -x integration test/http/` — 465 passed
- [x] `cd packages/soliplex_agent && dart test -x integration test/http/` — 14 passed
- [x] Manual smoke: launch the app, open the network inspector, drive 7+ concurrent REST actions, confirm `ConcurrencySummaryPanel` shows a non-zero `queued` count