### PR TITLE
chore: handle new ag_ui reasoning and activity events

### DIFF
--- a/packages/soliplex_agent/lib/src/runtime/agent_session.dart
+++ b/packages/soliplex_agent/lib/src/runtime/agent_session.dart
@@ -337,52 +337,8 @@ class AgentSession implements ToolExecutionContext {
   /// consumers observing [lastExecutionEvent] see streaming text, thinking,
   /// server tool calls, and terminal events without polling [runState].
   void _bridgeBaseEvent(BaseEvent event) {
-    switch (event) {
-      case TextMessageContentEvent(:final delta):
-        emitEvent(TextDelta(delta: delta));
-      case ThinkingTextMessageStartEvent():
-        emitEvent(const ThinkingStarted());
-      case ThinkingTextMessageContentEvent(:final delta):
-        emitEvent(ThinkingContent(delta: delta));
-      case ToolCallStartEvent(:final toolCallId, :final toolCallName):
-        emitEvent(
-          ServerToolCallStarted(toolCallId: toolCallId, toolName: toolCallName),
-        );
-      case ToolCallResultEvent(:final toolCallId, :final content):
-        emitEvent(
-          ServerToolCallCompleted(toolCallId: toolCallId, result: content),
-        );
-      case RunFinishedEvent():
-        emitEvent(const RunCompleted());
-      case RunErrorEvent(:final message):
-        emitEvent(RunFailed(error: message));
-      case ActivitySnapshotEvent(:final activityType, :final content):
-        emitEvent(
-          ActivitySnapshot(activityType: activityType, content: content),
-        );
-      case StepStartedEvent(:final stepName):
-        emitEvent(StepProgress(stepName: stepName));
-
-      // Events that don't need ExecutionEvent bridging.
-      case RunStartedEvent() ||
-            TextMessageStartEvent() ||
-            TextMessageEndEvent() ||
-            ThinkingStartEvent() ||
-            ThinkingTextMessageEndEvent() ||
-            ThinkingEndEvent() ||
-            ThinkingContentEvent() ||
-            ToolCallArgsEvent() ||
-            ToolCallEndEvent() ||
-            StateSnapshotEvent() ||
-            StateDeltaEvent() ||
-            StepFinishedEvent() ||
-            TextMessageChunkEvent() ||
-            ToolCallChunkEvent() ||
-            MessagesSnapshotEvent() ||
-            RawEvent() ||
-            CustomEvent():
-        break;
-    }
+    final executionEvent = bridgeBaseEvent(event);
+    if (executionEvent != null) emitEvent(executionEvent);
   }
 
   // ---------------------------------------------------------------------------
@@ -513,4 +469,58 @@ class AgentSession implements ToolExecutionContext {
       _state == AgentSessionState.completed ||
       _state == AgentSessionState.failed ||
       _state == AgentSessionState.cancelled;
+}
+
+/// Translates a raw AG-UI [BaseEvent] into the [ExecutionEvent] that
+/// consumers of [AgentSession.lastExecutionEvent] should observe, or
+/// `null` when the event does not map to an execution-event emission.
+///
+/// Exposed for testing the translation table independently of the
+/// [AgentSession] fixture overhead.
+@visibleForTesting
+ExecutionEvent? bridgeBaseEvent(BaseEvent event) {
+  return switch (event) {
+    TextMessageContentEvent(:final delta) => TextDelta(delta: delta),
+    ThinkingTextMessageStartEvent() ||
+    ReasoningMessageStartEvent() =>
+      const ThinkingStarted(),
+    ThinkingTextMessageContentEvent(:final delta) ||
+    ReasoningMessageContentEvent(:final delta) =>
+      ThinkingContent(delta: delta),
+    ToolCallStartEvent(:final toolCallId, :final toolCallName) =>
+      ServerToolCallStarted(toolCallId: toolCallId, toolName: toolCallName),
+    ToolCallResultEvent(:final toolCallId, :final content) =>
+      ServerToolCallCompleted(toolCallId: toolCallId, result: content),
+    RunFinishedEvent() => const RunCompleted(),
+    RunErrorEvent(:final message) => RunFailed(error: message),
+    ActivitySnapshotEvent(:final activityType, :final content) =>
+      ActivitySnapshot(activityType: activityType, content: content),
+    StepStartedEvent(:final stepName) => StepProgress(stepName: stepName),
+
+    // Events that don't need ExecutionEvent bridging.
+    RunStartedEvent() ||
+    TextMessageStartEvent() ||
+    TextMessageEndEvent() ||
+    ThinkingStartEvent() ||
+    ThinkingTextMessageEndEvent() ||
+    ThinkingEndEvent() ||
+    ThinkingContentEvent() ||
+    ToolCallArgsEvent() ||
+    ToolCallEndEvent() ||
+    StateSnapshotEvent() ||
+    StateDeltaEvent() ||
+    StepFinishedEvent() ||
+    TextMessageChunkEvent() ||
+    ToolCallChunkEvent() ||
+    MessagesSnapshotEvent() ||
+    RawEvent() ||
+    CustomEvent() ||
+    ReasoningStartEvent() ||
+    ReasoningEndEvent() ||
+    ReasoningMessageEndEvent() ||
+    ReasoningMessageChunkEvent() ||
+    ReasoningEncryptedValueEvent() ||
+    ActivityDeltaEvent() =>
+      null,
+  };
 }

--- a/packages/soliplex_agent/test/runtime/bridge_base_event_test.dart
+++ b/packages/soliplex_agent/test/runtime/bridge_base_event_test.dart
@@ -1,0 +1,34 @@
+import 'package:ag_ui/ag_ui.dart';
+import 'package:soliplex_agent/src/orchestration/execution_event.dart';
+import 'package:soliplex_agent/src/runtime/agent_session.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('bridgeBaseEvent', () {
+    test('routes ReasoningMessageStartEvent to ThinkingStarted', () {
+      const event = ReasoningMessageStartEvent(messageId: 'reas-1');
+      expect(bridgeBaseEvent(event), const ThinkingStarted());
+    });
+
+    test('routes ReasoningMessageContentEvent delta to ThinkingContent', () {
+      const event = ReasoningMessageContentEvent(
+        messageId: 'reas-1',
+        delta: 'reasoning step',
+      );
+      expect(
+        bridgeBaseEvent(event),
+        const ThinkingContent(delta: 'reasoning step'),
+      );
+    });
+
+    test('routes ThinkingTextMessageStartEvent to ThinkingStarted', () {
+      const event = ThinkingTextMessageStartEvent();
+      expect(bridgeBaseEvent(event), const ThinkingStarted());
+    });
+
+    test('routes ThinkingTextMessageContentEvent delta to ThinkingContent', () {
+      const event = ThinkingTextMessageContentEvent(delta: 'hmm');
+      expect(bridgeBaseEvent(event), const ThinkingContent(delta: 'hmm'));
+    });
+  });
+}

--- a/packages/soliplex_client/lib/src/application/agui_event_processor.dart
+++ b/packages/soliplex_client/lib/src/application/agui_event_processor.dart
@@ -58,29 +58,23 @@ EventProcessingResult processEvent(
         streaming: const AwaitingText(),
       ),
 
-    // Thinking lifecycle — both outer (ThinkingStart/End) and inner
-    // (ThinkingTextMessageStart/End) use the same idempotent handlers.
-    ThinkingStartEvent() => _processThinkingStart(
-        conversation,
-        streaming,
-      ),
-    ThinkingEndEvent() => _processThinkingEnd(
-        conversation,
-        streaming,
-      ),
-    ThinkingTextMessageStartEvent() => _processThinkingStart(
-        conversation,
-        streaming,
-      ),
-    ThinkingTextMessageContentEvent(:final delta) => _processThinkingContent(
-        conversation,
-        streaming,
-        delta,
-      ),
-    ThinkingTextMessageEndEvent() => _processThinkingEnd(
-        conversation,
-        streaming,
-      ),
+    // Thinking / reasoning lifecycle — outer (Thinking/ReasoningStart/End),
+    // inner thinking (ThinkingTextMessageStart/End), and reasoning message
+    // (ReasoningMessageStart/Content/End) all route through the same
+    // idempotent handlers.
+    ThinkingStartEvent() ||
+    ReasoningStartEvent() ||
+    ThinkingTextMessageStartEvent() ||
+    ReasoningMessageStartEvent() =>
+      _processThinkingStart(conversation, streaming),
+    ThinkingEndEvent() ||
+    ReasoningEndEvent() ||
+    ThinkingTextMessageEndEvent() ||
+    ReasoningMessageEndEvent() =>
+      _processThinkingEnd(conversation, streaming),
+    ThinkingTextMessageContentEvent(:final delta) ||
+    ReasoningMessageContentEvent(:final delta) =>
+      _processThinkingContent(conversation, streaming, delta),
 
     // Text message streaming events
     TextMessageStartEvent(:final messageId, :final role) => _processTextStart(
@@ -160,6 +154,18 @@ EventProcessingResult processEvent(
         timestamp,
       ),
 
+    // Opaque provider-signed blob anchoring a reasoning message to the LLM
+    // provider on follow-up turns. Round-trip preservation requires an
+    // encryptedValue field on TextMessage (and on ag_ui's Message). See
+    // github.com/soliplex/frontend/issues/117.
+    ReasoningEncryptedValueEvent(:final entityId) =>
+      _processReasoningEncryptedValue(conversation, streaming, entityId),
+
+    // JSON Patch against an activity's state; requires a per-message
+    // activity store that does not exist in the domain.
+    ActivityDeltaEvent(:final messageId, :final activityType) =>
+      _processActivityDelta(conversation, streaming, messageId, activityType),
+
     // Unhandled event types — pass through unchanged.
     // Explicit cases ensure a compile error if ag_ui adds new event types.
     ThinkingContentEvent() ||
@@ -169,7 +175,8 @@ EventProcessingResult processEvent(
     StepStartedEvent() ||
     StepFinishedEvent() ||
     RawEvent() ||
-    CustomEvent() =>
+    CustomEvent() ||
+    ReasoningMessageChunkEvent() =>
       EventProcessingResult(
         conversation: conversation,
         streaming: streaming,
@@ -504,6 +511,45 @@ EventProcessingResult _processStateDelta(
   final newState = applyJsonPatch(conversation.aguiState, delta);
   return EventProcessingResult(
     conversation: conversation.copyWith(aguiState: newState),
+    streaming: streaming,
+  );
+}
+
+// Logged pass-through for events we do not yet integrate into the domain.
+
+EventProcessingResult _processReasoningEncryptedValue(
+  Conversation conversation,
+  StreamingState streaming,
+  String entityId,
+) {
+  developer.log(
+    'ReasoningEncryptedValueEvent dropped (entityId=$entityId): '
+    'round-trip preservation requires encryptedValue on TextMessage '
+    '— see github.com/soliplex/frontend/issues/117',
+    name: 'soliplex_client.event_processor',
+    level: 900,
+  );
+  return EventProcessingResult(
+    conversation: conversation,
+    streaming: streaming,
+  );
+}
+
+EventProcessingResult _processActivityDelta(
+  Conversation conversation,
+  StreamingState streaming,
+  String messageId,
+  String activityType,
+) {
+  developer.log(
+    'ActivityDeltaEvent dropped '
+    '(messageId=$messageId, activityType=$activityType): '
+    'no per-message activity store in the domain',
+    name: 'soliplex_client.event_processor',
+    level: 800,
+  );
+  return EventProcessingResult(
+    conversation: conversation,
     streaming: streaming,
   );
 }

--- a/packages/soliplex_client/test/application/agui_event_processor_test.dart
+++ b/packages/soliplex_client/test/application/agui_event_processor_test.dart
@@ -1091,6 +1091,62 @@ void main() {
       );
     });
 
+    group('reasoning events', () {
+      test('ReasoningStartEvent sets isThinkingStreaming and activity', () {
+        const event = ReasoningStartEvent(messageId: 'reas-1');
+
+        final result = processEvent(conversation, streaming, event);
+
+        final awaitingText = result.streaming as app_streaming.AwaitingText;
+        expect(awaitingText.isThinkingStreaming, isTrue);
+        expect(
+          awaitingText.currentActivity,
+          isA<app_streaming.ThinkingActivity>(),
+        );
+      });
+
+      test('ReasoningEndEvent sets isThinkingStreaming to false', () {
+        const reasoningState = app_streaming.AwaitingText(
+          isThinkingStreaming: true,
+          currentActivity: app_streaming.ThinkingActivity(),
+        );
+        const event = ReasoningEndEvent(messageId: 'reas-1');
+
+        final result = processEvent(conversation, reasoningState, event);
+
+        final awaitingText = result.streaming as app_streaming.AwaitingText;
+        expect(awaitingText.isThinkingStreaming, isFalse);
+      });
+
+      test(
+        'TextMessageEndEvent preserves reasoning-sourced thinkingText',
+        () {
+          const event = ReasoningMessageContentEvent(
+            messageId: 'reas-1',
+            delta: 'Inner reasoning',
+          );
+          final afterReasoning = processEvent(conversation, streaming, event);
+
+          const textStart = TextMessageStartEvent(messageId: 'msg-1');
+          final afterStart = processEvent(
+            afterReasoning.conversation,
+            afterReasoning.streaming,
+            textStart,
+          );
+
+          const textEnd = TextMessageEndEvent(messageId: 'msg-1');
+          final result = processEvent(
+            afterStart.conversation,
+            afterStart.streaming,
+            textEnd,
+          );
+
+          final message = result.conversation.messages.first as TextMessage;
+          expect(message.thinkingText, equals('Inner reasoning'));
+        },
+      );
+    });
+
     group('state events', () {
       test('StateSnapshotEvent replaces aguiState', () {
         const event = StateSnapshotEvent(snapshot: {'key': 'value'});

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -14,7 +14,7 @@ packages:
     description:
       path: "sdks/community/dart"
       ref: HEAD
-      resolved-ref: "18087b3926d7bbea19564dfa577f4f44ae88c6fc"
+      resolved-ref: "29ae5b90c763ef4df3117b8e6f3b863755f41e7e"
       url: "https://github.com/soliplex/ag-ui.git"
     source: git
     version: "0.1.0"


### PR DESCRIPTION
## Summary
- Bump ag_ui to pull in REASONING_* / ACTIVITY_DELTA events + ActivityMessage role
- Route 5 reasoning lifecycle events through existing thinking handlers (reasoning surfaces in ExecutionThinkingBlock alongside thinking)
- Log-drop REASONING_ENCRYPTED_VALUE (round-trip preservation tracked in #117) and ACTIVITY_DELTA
- Extract bridgeBaseEvent as a pure @visibleForTesting function so the translation table is testable without session fixtures

## Test plan
- [x] dart analyze — zero warnings
- [x] Unit tests — 1276 client + 455 agent tests pass
- [x] Flutter tests — 995 widget/unit tests pass
- [x] Compatibility audit vs soliplex/ag-ui (pinned SHA) and backend adapter — no blockers found
- [x] Manual smoke against a running backend to confirm no "Invalid event type" crashes in logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)