### PR TITLE
Upload pipeline: server-synced list, hardened failures, simpler UX

### DIFF
--- a/lib/src/modules/room/pick_file.dart
+++ b/lib/src/modules/room/pick_file.dart
@@ -16,17 +16,77 @@ class PickedFile {
   final String mimeType;
 }
 
-/// Opens the platform file picker and returns the selected file with
-/// bytes loaded, or null if the user cancelled or the file couldn't
-/// be read.
+/// Base for failures raised from [pickFile].
+///
+/// Callers surface a user-facing row via the upload tracker; the
+/// wrapped [cause] is preserved for logging and diagnostics.
+sealed class PickFileException implements Exception {
+  const PickFileException({required this.cause});
+
+  /// The underlying error that triggered the pick failure.
+  final Object cause;
+}
+
+/// Thrown when the platform file picker itself fails — plugin not
+/// wired for the current platform, OS-level picker error, or an
+/// invariant violation where the picker returned neither bytes nor a
+/// usable path.
+class PickFilePickerException extends PickFileException {
+  const PickFilePickerException({this.filename, required super.cause});
+
+  /// Filename, when the failure happened after the picker identified a
+  /// file (e.g., the bytes-nor-path invariant). `null` when the picker
+  /// itself threw before returning any file.
+  final String? filename;
+
+  @override
+  String toString() => filename == null
+      ? 'File picker failed: $cause'
+      : 'File picker failed for $filename: $cause';
+}
+
+/// Thrown when the user picked a file but its bytes could not be read
+/// from disk.
+class PickFileReadException extends PickFileException {
+  const PickFileReadException({required this.filename, required super.cause});
+
+  final String filename;
+
+  @override
+  String toString() => 'Failed to read $filename: $cause';
+}
+
+/// Opens the platform file picker.
+///
+/// Returns `null` when the user cancels. Throws a [PickFileException]
+/// subtype on any failure so callers can surface inline feedback
+/// instead of silently no-op-ing.
 Future<PickedFile?> pickFile() async {
-  final result = await FilePicker.pickFiles(withData: true);
+  final FilePickerResult? result;
+  try {
+    result = await FilePicker.pickFiles(withData: true);
+  } on Object catch (error) {
+    throw PickFilePickerException(cause: error);
+  }
   if (result == null || result.files.isEmpty) return null;
   final file = result.files.first;
-  if (file.bytes == null && file.path == null) return null;
+  if (file.bytes == null && file.path == null) {
+    throw PickFilePickerException(
+      filename: file.name,
+      cause: StateError('picker returned no bytes or path for ${file.name}'),
+    );
+  }
 
-  final bytes = file.bytes ?? await readFileBytes(file.path!);
-  if (bytes == null) return null;
+  final List<int> bytes;
+  if (file.bytes != null) {
+    bytes = file.bytes!;
+  } else {
+    try {
+      bytes = await readFileBytes(file.path!);
+    } on Object catch (error) {
+      throw PickFileReadException(filename: file.name, cause: error);
+    }
+  }
 
   final mimeType = lookupMimeType(file.name) ?? 'application/octet-stream';
   return PickedFile(name: file.name, bytes: bytes, mimeType: mimeType);

--- a/lib/src/modules/room/read_file_bytes.dart
+++ b/lib/src/modules/room/read_file_bytes.dart
@@ -1,11 +1,8 @@
 import 'dart:io';
 
 /// Reads file bytes from a path (native platforms where file_picker
-/// provides a path instead of bytes).
-Future<List<int>?> readFileBytes(String path) async {
-  try {
-    return await File(path).readAsBytes();
-  } on Object {
-    return null;
-  }
+/// provides a path instead of bytes). Propagates I/O errors so the
+/// caller can surface them.
+Future<List<int>> readFileBytes(String path) async {
+  return File(path).readAsBytes();
 }

--- a/lib/src/modules/room/read_file_bytes_web.dart
+++ b/lib/src/modules/room/read_file_bytes_web.dart
@@ -1,2 +1,14 @@
-/// Stub for web — file_picker always provides bytes on web.
-Future<List<int>?> readFileBytes(String path) async => null;
+import 'dart:developer' as dev;
+
+/// Stub for web — file_picker always provides bytes on web, so this
+/// entrypoint is never called at runtime. If it ever is, that's a
+/// coding bug worth flagging loudly; the thrown [UnsupportedError]
+/// propagates to the caller as a typed pick failure.
+Future<List<int>> readFileBytes(String path) async {
+  dev.log(
+    'readFileBytes called on web; file_picker should have provided bytes',
+    name: 'pick_file',
+    level: 1000,
+  );
+  throw UnsupportedError('readFileBytes is not used on the web platform');
+}

--- a/lib/src/modules/room/room_module.dart
+++ b/lib/src/modules/room/room_module.dart
@@ -8,6 +8,7 @@ import 'document_selections.dart';
 import 'run_registry.dart';
 import 'ui/room_info_screen.dart';
 import 'ui/room_screen.dart';
+import 'upload_tracker_registry.dart';
 
 ModuleContribution roomModule({
   required ServerManager serverManager,
@@ -16,6 +17,7 @@ ModuleContribution roomModule({
   bool enableDocumentFilter = false,
 }) {
   final documentSelections = DocumentSelections();
+  final uploadRegistry = UploadTrackerRegistry(servers: serverManager.servers);
   return ModuleContribution(
     routes: [
       GoRoute(
@@ -32,6 +34,7 @@ ModuleContribution roomModule({
               serverEntry: entry,
               roomId: state.pathParameters['roomId']!,
               toolRegistryResolver: runtimeManager.toolRegistryResolver,
+              uploadRegistry: uploadRegistry,
             ),
           );
         },
@@ -41,6 +44,7 @@ ModuleContribution roomModule({
         serverManager,
         runtimeManager,
         registry,
+        uploadRegistry,
         enableDocumentFilter,
         documentSelections,
       ),
@@ -49,6 +53,7 @@ ModuleContribution roomModule({
         serverManager,
         runtimeManager,
         registry,
+        uploadRegistry,
         enableDocumentFilter,
         documentSelections,
       ),
@@ -61,6 +66,7 @@ GoRoute _buildRoute(
   ServerManager serverManager,
   AgentRuntimeManager runtimeManager,
   RunRegistry registry,
+  UploadTrackerRegistry uploadRegistry,
   bool enableDocumentFilter,
   DocumentSelections documentSelections,
 ) {
@@ -80,6 +86,7 @@ GoRoute _buildRoute(
           threadId: state.pathParameters['threadId'],
           runtimeManager: runtimeManager,
           registry: registry,
+          uploadRegistry: uploadRegistry,
           enableDocumentFilter: enableDocumentFilter,
           documentSelections: documentSelections,
         ),

--- a/lib/src/modules/room/room_state.dart
+++ b/lib/src/modules/room/room_state.dart
@@ -46,7 +46,10 @@ class RoomState {
         uploadTracker =
             uploadRegistry.trackerFor(entry: serverEntry, roomId: roomId) {
     _fetchRoom();
-    uploadTracker.fetchRoomUploads(_roomId);
+    // Every room entry forces a refresh so the list reflects server
+    // state from other devices and self-heals any pending record that
+    // got stuck behind a transient refresh failure.
+    unawaited(uploadTracker.refreshRoom(_roomId));
   }
 
   final ServerConnection _connection;
@@ -109,7 +112,10 @@ class RoomState {
         runtime.seedThreadHistory(id, history);
       },
     );
-    uploadTracker.fetchThreadUploads(_roomId, threadId);
+    // Thread switch → force a refresh for the same reasons as room
+    // entry. Reselecting the same thread is a no-op earlier in the
+    // method, so this doesn't fire spuriously.
+    unawaited(uploadTracker.refreshThread(_roomId, threadId));
   }
 
   /// Explicit thread creation (the "+" button path).

--- a/lib/src/modules/room/room_state.dart
+++ b/lib/src/modules/room/room_state.dart
@@ -57,8 +57,7 @@ class RoomState {
 
   final ThreadListState threadList;
 
-  /// Shared tracker for this (server, room); lifecycle is owned by the
-  /// `UploadTrackerRegistry`, not by this state object.
+  /// Shared tracker; lifecycle owned by [UploadTrackerRegistry].
   final UploadTracker uploadTracker;
   ThreadViewState? _activeThreadView;
   CancelToken? _roomFetchToken;

--- a/lib/src/modules/room/room_state.dart
+++ b/lib/src/modules/room/room_state.dart
@@ -1,6 +1,6 @@
 import 'dart:async' show unawaited;
+import 'dart:developer' as dev;
 
-import 'package:flutter/foundation.dart' show debugPrint;
 import 'package:soliplex_agent/soliplex_agent.dart';
 
 import '../auth/server_entry.dart';
@@ -179,8 +179,14 @@ class RoomState {
     unawaited(pending.then((s) {
       s.cancel();
       s.dispose();
-    }).catchError((Object e) {
-      debugPrint('Cancelled spawn cleanup failed: $e');
+    }).catchError((Object e, StackTrace st) {
+      dev.log(
+        'Cancelled spawn cleanup failed',
+        error: e,
+        stackTrace: st,
+        name: 'RoomState',
+        level: 1000,
+      );
     }));
   }
 
@@ -233,9 +239,6 @@ class RoomState {
   void dispose() {
     _isDisposed = true;
     _roomFetchToken?.cancel('disposed');
-    // uploadTracker is owned by UploadTrackerRegistry; do not dispose
-    // it here — it must survive widget remounts and cross-screen
-    // navigation.
     threadList.dispose();
     _activeThreadView?.dispose();
   }

--- a/lib/src/modules/room/room_state.dart
+++ b/lib/src/modules/room/room_state.dart
@@ -3,11 +3,13 @@ import 'dart:async' show unawaited;
 import 'package:flutter/foundation.dart' show debugPrint;
 import 'package:soliplex_agent/soliplex_agent.dart';
 
+import '../auth/server_entry.dart';
 import 'agent_runtime_manager.dart';
 import 'run_registry.dart';
 import 'thread_list_state.dart';
 import 'thread_view_state.dart';
 import 'upload_tracker.dart';
+import 'upload_tracker_registry.dart';
 
 export 'send_error.dart';
 
@@ -27,21 +29,24 @@ class RoomFailed extends RoomStatus {
 
 class RoomState {
   RoomState({
-    required ServerConnection connection,
+    required ServerEntry serverEntry,
     required String roomId,
     required AgentRuntimeManager runtimeManager,
     required RunRegistry registry,
+    required UploadTrackerRegistry uploadRegistry,
     this.onNavigateToThread,
-  })  : _connection = connection,
+  })  : _connection = serverEntry.connection,
         _roomId = roomId,
         _runtimeManager = runtimeManager,
         _registry = registry,
         threadList = ThreadListState(
-          connection: connection,
+          connection: serverEntry.connection,
           roomId: roomId,
         ),
-        uploadTracker = UploadTracker() {
+        uploadTracker =
+            uploadRegistry.trackerFor(entry: serverEntry, roomId: roomId) {
     _fetchRoom();
+    uploadTracker.fetchRoomUploads(_roomId);
   }
 
   final ServerConnection _connection;
@@ -51,6 +56,9 @@ class RoomState {
   final void Function(String? threadId)? onNavigateToThread;
 
   final ThreadListState threadList;
+
+  /// Shared tracker for this (server, room); lifecycle is owned by the
+  /// `UploadTrackerRegistry`, not by this state object.
   final UploadTracker uploadTracker;
   ThreadViewState? _activeThreadView;
   CancelToken? _roomFetchToken;
@@ -102,6 +110,7 @@ class RoomState {
         runtime.seedThreadHistory(id, history);
       },
     );
+    uploadTracker.fetchThreadUploads(_roomId, threadId);
   }
 
   /// Explicit thread creation (the "+" button path).
@@ -219,7 +228,9 @@ class RoomState {
   void dispose() {
     _isDisposed = true;
     _roomFetchToken?.cancel('disposed');
-    uploadTracker.dispose();
+    // uploadTracker is owned by UploadTrackerRegistry; do not dispose
+    // it here — it must survive widget remounts and cross-screen
+    // navigation.
     threadList.dispose();
     _activeThreadView?.dispose();
   }

--- a/lib/src/modules/room/ui/room_info_screen.dart
+++ b/lib/src/modules/room/ui/room_info_screen.dart
@@ -1,3 +1,5 @@
+import 'dart:async' show unawaited;
+
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
 import 'package:signals_flutter/signals_flutter.dart';
@@ -371,7 +373,7 @@ class _UploadedFilesCardState extends State<_UploadedFilesCard> {
       entry: widget.serverEntry,
       roomId: widget.roomId,
     );
-    _tracker.fetchRoomUploads(widget.roomId);
+    unawaited(_tracker.refreshRoom(widget.roomId));
   }
 
   // Not disposed here — the registry owns the tracker's lifecycle.

--- a/lib/src/modules/room/ui/room_info_screen.dart
+++ b/lib/src/modules/room/ui/room_info_screen.dart
@@ -1,11 +1,14 @@
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
+import 'package:signals_flutter/signals_flutter.dart';
 import 'package:soliplex_agent/soliplex_agent.dart' hide State;
 import 'package:soliplex_client/soliplex_client.dart' hide Room, State;
 
 import '../pick_file.dart';
 
 import '../../auth/server_entry.dart';
+import '../upload_tracker.dart';
+import '../upload_tracker_registry.dart';
 import 'room_info/client_tools_card.dart';
 import 'room_info/documents_card.dart';
 import 'room_info/expandable_list_card.dart';
@@ -21,11 +24,13 @@ class RoomInfoScreen extends StatefulWidget {
     required this.serverEntry,
     required this.roomId,
     required this.toolRegistryResolver,
+    required this.uploadRegistry,
   });
 
   final ServerEntry serverEntry;
   final String roomId;
   final Future<ToolRegistry> Function(String roomId) toolRegistryResolver;
+  final UploadTrackerRegistry uploadRegistry;
 
   @override
   State<RoomInfoScreen> createState() => _RoomInfoScreenState();
@@ -100,12 +105,14 @@ class _RoomInfoScreenState extends State<RoomInfoScreen> {
           return _RoomInfoBody(
             room: snapshot.data!,
             serverUrl: widget.serverEntry.serverUrl,
+            serverEntry: widget.serverEntry,
             api: widget.serverEntry.connection.api,
             serverAlias: widget.serverEntry.alias,
             roomId: widget.roomId,
             documentsFuture: _documentsFuture,
             clientToolsFuture: _clientToolsFuture,
             onRetryDocuments: _retryDocuments,
+            uploadRegistry: widget.uploadRegistry,
           );
         },
       ),
@@ -117,22 +124,26 @@ class _RoomInfoBody extends StatelessWidget {
   const _RoomInfoBody({
     required this.room,
     required this.serverUrl,
+    required this.serverEntry,
     required this.api,
     required this.serverAlias,
     required this.roomId,
     required this.documentsFuture,
     required this.clientToolsFuture,
     required this.onRetryDocuments,
+    required this.uploadRegistry,
   });
 
   final Room room;
   final Uri serverUrl;
+  final ServerEntry serverEntry;
   final SoliplexApi api;
   final String serverAlias;
   final String roomId;
   final Future<List<RagDocument>> documentsFuture;
   final Future<List<Tool>> clientToolsFuture;
   final VoidCallback onRetryDocuments;
+  final UploadTrackerRegistry uploadRegistry;
 
   @override
   Widget build(BuildContext context) {
@@ -224,9 +235,11 @@ class _RoomInfoBody extends StatelessWidget {
           ),
           ClientToolsCard(clientToolsFuture: clientToolsFuture),
           if (room.enableAttachments)
-            // TODO(backend): Replace with fetched file list once
-            // GET /v1/uploads/{room_id} endpoint exists.
-            _UploadedFilesCard(api: api, roomId: roomId),
+            _UploadedFilesCard(
+              uploadRegistry: uploadRegistry,
+              serverEntry: serverEntry,
+              roomId: roomId,
+            ),
           DocumentsCard(
             documentsFuture: documentsFuture,
             onRetry: onRetryDocuments,
@@ -335,11 +348,13 @@ class _AgentCard extends StatelessWidget {
 
 class _UploadedFilesCard extends StatefulWidget {
   const _UploadedFilesCard({
-    required this.api,
+    required this.uploadRegistry,
+    required this.serverEntry,
     required this.roomId,
   });
 
-  final SoliplexApi api;
+  final UploadTrackerRegistry uploadRegistry;
+  final ServerEntry serverEntry;
   final String roomId;
 
   @override
@@ -347,121 +362,51 @@ class _UploadedFilesCard extends StatefulWidget {
 }
 
 class _UploadedFilesCardState extends State<_UploadedFilesCard> {
-  final _uploads = <_UploadInfo>[];
-  bool _uploading = false;
-  int _nextId = 0;
+  late final UploadTracker _tracker;
+
+  @override
+  void initState() {
+    super.initState();
+    _tracker = widget.uploadRegistry.trackerFor(
+      entry: widget.serverEntry,
+      roomId: widget.roomId,
+    );
+    _tracker.fetchRoomUploads(widget.roomId);
+  }
+
+  // Not disposed here — the registry owns the tracker's lifecycle.
 
   Future<void> _pickAndUpload() async {
     final file = await pickFile();
     if (file == null || !mounted) return;
-
-    final id = _nextId++;
-    setState(() {
-      _uploading = true;
-      _uploads.add(_UploadInfo(id, file.name, _UploadStatus.uploading));
-    });
-
-    try {
-      await widget.api.uploadFileToRoom(
-        widget.roomId,
-        filename: file.name,
-        fileBytes: file.bytes,
-        mimeType: file.mimeType,
-      );
-      if (!mounted) return;
-      setState(() {
-        _updateStatus(id, file.name, _UploadStatus.success);
-        _uploading = false;
-      });
-    } on Object catch (e) {
-      if (!mounted) return;
-      setState(() {
-        _updateStatus(id, file.name, _UploadStatus.error, '$e');
-        _uploading = false;
-      });
-    }
-  }
-
-  void _updateStatus(
-    int id,
-    String filename,
-    _UploadStatus status, [
-    String? error,
-  ]) {
-    final i = _uploads.indexWhere((u) => u.id == id);
-    if (i >= 0) {
-      _uploads[i] = _UploadInfo(id, filename, status, error);
-    }
+    _tracker.uploadToRoom(
+      roomId: widget.roomId,
+      filename: file.name,
+      fileBytes: file.bytes,
+      mimeType: file.mimeType,
+    );
   }
 
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
-    final successCount =
-        _uploads.where((u) => u.status == _UploadStatus.success).length;
-    final title =
-        successCount > 0 ? 'UPLOADED FILES ($successCount)' : 'UPLOADED FILES';
+    final status = _tracker.roomUploads(widget.roomId).watch(context);
+    final uploads = status is UploadsLoaded ? status.uploads : null;
+    final persistedCount = uploads?.whereType<PersistedUpload>().length ?? 0;
+    final hasPending = uploads?.any((u) => u is PendingUpload) ?? false;
+    final title = persistedCount > 0
+        ? 'UPLOADED FILES ($persistedCount)'
+        : 'UPLOADED FILES';
+
     return SectionCard(
       title: title,
       children: [
-        if (_uploads.isEmpty)
-          const EmptyMessage(label: 'uploaded files (pending backend)'),
-        if (_uploads.isNotEmpty) ...[
-          const SizedBox(height: 8),
-          for (final upload in _uploads)
-            Padding(
-              padding: const EdgeInsets.symmetric(vertical: 2),
-              child: Row(
-                children: [
-                  if (upload.status == _UploadStatus.uploading)
-                    const SizedBox(
-                      width: 16,
-                      height: 16,
-                      child: CircularProgressIndicator(
-                        strokeWidth: 2,
-                      ),
-                    )
-                  else if (upload.status == _UploadStatus.success)
-                    Icon(
-                      Icons.check_circle_outline,
-                      size: 16,
-                      color: theme.colorScheme.primary,
-                    )
-                  else
-                    Icon(
-                      Icons.error_outline,
-                      size: 16,
-                      color: theme.colorScheme.error,
-                    ),
-                  const SizedBox(width: 8),
-                  Expanded(
-                    child: Text(
-                      upload.filename,
-                      style: theme.textTheme.bodySmall,
-                      overflow: TextOverflow.ellipsis,
-                    ),
-                  ),
-                  if (upload.error != null)
-                    Expanded(
-                      child: Text(
-                        upload.error!,
-                        style: theme.textTheme.bodySmall?.copyWith(
-                          color: theme.colorScheme.error,
-                          fontSize: 11,
-                        ),
-                        maxLines: 1,
-                        overflow: TextOverflow.ellipsis,
-                      ),
-                    ),
-                ],
-              ),
-            ),
-        ],
+        _buildBody(status, theme),
         const SizedBox(height: 8),
         Align(
           alignment: Alignment.centerLeft,
           child: FilledButton.icon(
-            onPressed: _uploading ? null : _pickAndUpload,
+            onPressed: hasPending ? null : _pickAndUpload,
             icon: const Icon(Icons.upload_file, size: 18),
             label: const Text('Upload file to room'),
           ),
@@ -469,14 +414,111 @@ class _UploadedFilesCardState extends State<_UploadedFilesCard> {
       ],
     );
   }
+
+  Widget _buildBody(UploadsStatus status, ThemeData theme) {
+    return switch (status) {
+      UploadsLoading() => const Padding(
+          padding: EdgeInsets.symmetric(vertical: 8),
+          child: SizedBox(
+            width: 16,
+            height: 16,
+            child: CircularProgressIndicator(strokeWidth: 2),
+          ),
+        ),
+      UploadsLoaded(uploads: final list) when list.isEmpty =>
+        const EmptyMessage(label: 'uploaded files'),
+      UploadsLoaded(uploads: final list) => Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            const SizedBox(height: 8),
+            for (final entry in list)
+              _UploadEntryRow(entry: entry, onDismiss: _tracker.dismiss),
+          ],
+        ),
+      UploadsFailed(error: final error) => Padding(
+          padding: const EdgeInsets.symmetric(vertical: 8),
+          child: Text(
+            'Failed to load uploaded files: $error',
+            style: theme.textTheme.bodySmall?.copyWith(
+              color: theme.colorScheme.error,
+            ),
+          ),
+        ),
+    };
+  }
 }
 
-enum _UploadStatus { uploading, success, error }
+class _UploadEntryRow extends StatelessWidget {
+  const _UploadEntryRow({
+    required this.entry,
+    required this.onDismiss,
+  });
 
-class _UploadInfo {
-  _UploadInfo(this.id, this.filename, this.status, [this.error]);
-  final int id;
-  final String filename;
-  final _UploadStatus status;
-  final String? error;
+  final DisplayUpload entry;
+  final void Function(String entryId) onDismiss;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final (icon, color, errorMessage, dismissId) = switch (entry) {
+      PersistedUpload() => (
+          Icons.check_circle_outline,
+          theme.colorScheme.primary,
+          null,
+          null,
+        ),
+      PendingUpload() => (null, theme.colorScheme.primary, null, null),
+      FailedUpload(id: final id, message: final m) => (
+          Icons.error_outline,
+          theme.colorScheme.error,
+          m,
+          id,
+        ),
+    };
+
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: 2),
+      child: Row(
+        children: [
+          if (icon != null)
+            Icon(icon, size: 16, color: color)
+          else
+            const SizedBox(
+              width: 16,
+              height: 16,
+              child: CircularProgressIndicator(strokeWidth: 2),
+            ),
+          const SizedBox(width: 8),
+          Expanded(
+            child: Text(
+              entry.filename,
+              style: theme.textTheme.bodySmall,
+              overflow: TextOverflow.ellipsis,
+            ),
+          ),
+          if (errorMessage != null)
+            Expanded(
+              child: Text(
+                errorMessage,
+                style: theme.textTheme.bodySmall?.copyWith(
+                  color: theme.colorScheme.error,
+                  fontSize: 11,
+                ),
+                maxLines: 1,
+                overflow: TextOverflow.ellipsis,
+              ),
+            ),
+          if (dismissId != null)
+            IconButton(
+              icon: const Icon(Icons.close, size: 14),
+              onPressed: () => onDismiss(dismissId),
+              padding: EdgeInsets.zero,
+              constraints: const BoxConstraints(),
+              visualDensity: VisualDensity.compact,
+            ),
+        ],
+      ),
+    );
+  }
 }

--- a/lib/src/modules/room/ui/room_info_screen.dart
+++ b/lib/src/modules/room/ui/room_info_screen.dart
@@ -462,6 +462,7 @@ class _UploadEntryRow extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
+    final isFailed = entry is FailedUpload;
     final (icon, color, errorMessage, dismissId) = switch (entry) {
       PersistedUpload() => (
           Icons.check_circle_outline,
@@ -472,14 +473,23 @@ class _UploadEntryRow extends StatelessWidget {
       PendingUpload() => (null, theme.colorScheme.primary, null, null),
       FailedUpload(id: final id, message: final m) => (
           Icons.error_outline,
-          theme.colorScheme.error,
+          theme.colorScheme.onErrorContainer,
           m,
           id,
         ),
     };
 
-    return Padding(
-      padding: const EdgeInsets.symmetric(vertical: 2),
+    return Container(
+      margin: const EdgeInsets.symmetric(vertical: 2),
+      padding: isFailed
+          ? const EdgeInsets.symmetric(horizontal: 8, vertical: 4)
+          : null,
+      decoration: isFailed
+          ? BoxDecoration(
+              color: theme.colorScheme.errorContainer,
+              borderRadius: BorderRadius.circular(6),
+            )
+          : null,
       child: Row(
         children: [
           if (icon != null)
@@ -494,7 +504,9 @@ class _UploadEntryRow extends StatelessWidget {
           Expanded(
             child: Text(
               entry.filename,
-              style: theme.textTheme.bodySmall,
+              style: theme.textTheme.bodySmall?.copyWith(
+                color: isFailed ? theme.colorScheme.onErrorContainer : null,
+              ),
               overflow: TextOverflow.ellipsis,
             ),
           ),
@@ -503,7 +515,7 @@ class _UploadEntryRow extends StatelessWidget {
               child: Text(
                 errorMessage,
                 style: theme.textTheme.bodySmall?.copyWith(
-                  color: theme.colorScheme.error,
+                  color: theme.colorScheme.onErrorContainer,
                   fontSize: 11,
                 ),
                 maxLines: 1,
@@ -513,6 +525,7 @@ class _UploadEntryRow extends StatelessWidget {
           if (dismissId != null)
             IconButton(
               icon: const Icon(Icons.close, size: 14),
+              color: theme.colorScheme.onErrorContainer,
               onPressed: () => onDismiss(dismissId),
               padding: EdgeInsets.zero,
               constraints: const BoxConstraints(),

--- a/lib/src/modules/room/ui/room_info_screen.dart
+++ b/lib/src/modules/room/ui/room_info_screen.dart
@@ -393,7 +393,6 @@ class _UploadedFilesCardState extends State<_UploadedFilesCard> {
     final status = _tracker.roomUploads(widget.roomId).watch(context);
     final uploads = status is UploadsLoaded ? status.uploads : null;
     final persistedCount = uploads?.whereType<PersistedUpload>().length ?? 0;
-    final hasPending = uploads?.any((u) => u is PendingUpload) ?? false;
     final title = persistedCount > 0
         ? 'UPLOADED FILES ($persistedCount)'
         : 'UPLOADED FILES';
@@ -406,7 +405,7 @@ class _UploadedFilesCardState extends State<_UploadedFilesCard> {
         Align(
           alignment: Alignment.centerLeft,
           child: FilledButton.icon(
-            onPressed: hasPending ? null : _pickAndUpload,
+            onPressed: _pickAndUpload,
             icon: const Icon(Icons.upload_file, size: 18),
             label: const Text('Upload file to room'),
           ),

--- a/lib/src/modules/room/ui/room_info_screen.dart
+++ b/lib/src/modules/room/ui/room_info_screen.dart
@@ -1,4 +1,5 @@
 import 'dart:async' show unawaited;
+import 'dart:developer' as dev;
 
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
@@ -373,13 +374,46 @@ class _UploadedFilesCardState extends State<_UploadedFilesCard> {
       entry: widget.serverEntry,
       roomId: widget.roomId,
     );
-    unawaited(_tracker.refreshRoom(widget.roomId));
+    // Refresh only if no other screen has populated the shared tracker
+    // yet. When `RoomState` is already mounted it has refreshed on room
+    // entry, so navigating Room → Info skips a redundant GET.
+    if (_tracker.roomUploads(widget.roomId).value is UploadsLoading) {
+      unawaited(_tracker.refreshRoom(widget.roomId));
+    }
   }
 
   // Not disposed here — the registry owns the tracker's lifecycle.
 
   Future<void> _pickAndUpload() async {
-    final file = await pickFile();
+    final PickedFile? file;
+    try {
+      file = await pickFile();
+    } on PickFileException catch (e, st) {
+      if (!mounted) return;
+      dev.log(
+        'File pick failed',
+        error: e.cause,
+        stackTrace: st,
+        name: 'RoomInfoScreen',
+        level: 1000,
+      );
+      final (filename, message) = switch (e) {
+        PickFileReadException(:final filename) => (
+            filename,
+            'Failed to read file',
+          ),
+        PickFilePickerException(:final filename) => (
+            filename ?? '(unknown)',
+            'Could not open file picker',
+          ),
+      };
+      _tracker.recordClientError(
+        roomId: widget.roomId,
+        filename: filename,
+        message: message,
+      );
+      return;
+    }
     if (file == null || !mounted) return;
     _tracker.uploadToRoom(
       roomId: widget.roomId,
@@ -434,7 +468,7 @@ class _UploadedFilesCardState extends State<_UploadedFilesCard> {
           children: [
             const SizedBox(height: 8),
             for (final entry in list)
-              _UploadEntryRow(entry: entry, onDismiss: _tracker.dismiss),
+              _UploadEntryRow(entry: entry, onDismiss: _tracker.dismissFailed),
           ],
         ),
       UploadsFailed(error: final error) => Padding(

--- a/lib/src/modules/room/ui/room_info_screen.dart
+++ b/lib/src/modules/room/ui/room_info_screen.dart
@@ -439,7 +439,7 @@ class _UploadedFilesCardState extends State<_UploadedFilesCard> {
       UploadsFailed(error: final error) => Padding(
           padding: const EdgeInsets.symmetric(vertical: 8),
           child: Text(
-            'Failed to load uploaded files: $error',
+            'Failed to load uploaded files: ${uploadErrorMessage(error)}',
             style: theme.textTheme.bodySmall?.copyWith(
               color: theme.colorScheme.error,
             ),

--- a/lib/src/modules/room/ui/room_screen.dart
+++ b/lib/src/modules/room/ui/room_screen.dart
@@ -29,6 +29,7 @@ import 'async_action_dialog.dart';
 import 'room_welcome.dart';
 import 'thread_sidebar.dart';
 import '../upload_tracker.dart';
+import '../upload_tracker_registry.dart';
 
 const double _sidebarWidth = 300;
 const double _wideBreakpoint = 600;
@@ -52,6 +53,7 @@ class RoomScreen extends StatefulWidget {
     required this.threadId,
     required this.runtimeManager,
     required this.registry,
+    required this.uploadRegistry,
     this.enableDocumentFilter = false,
     required this.documentSelections,
   });
@@ -61,6 +63,7 @@ class RoomScreen extends StatefulWidget {
   final String? threadId;
   final AgentRuntimeManager runtimeManager;
   final RunRegistry registry;
+  final UploadTrackerRegistry uploadRegistry;
   final bool enableDocumentFilter;
   final DocumentSelections documentSelections;
 
@@ -178,10 +181,11 @@ class _RoomScreenState extends State<RoomScreen> {
   }
 
   RoomState _createRoomState() => RoomState(
-        connection: widget.serverEntry.connection,
+        serverEntry: widget.serverEntry,
         roomId: widget.roomId,
         runtimeManager: widget.runtimeManager,
         registry: widget.registry,
+        uploadRegistry: widget.uploadRegistry,
         onNavigateToThread: (id) => _navigateToThread(id),
       );
 
@@ -231,7 +235,6 @@ class _RoomScreenState extends State<RoomScreen> {
     final file = await pickFile();
     if (file == null || !mounted) return;
     _state.uploadTracker.uploadToRoom(
-      api: widget.serverEntry.connection.api,
       roomId: widget.roomId,
       filename: file.name,
       fileBytes: file.bytes,
@@ -243,7 +246,6 @@ class _RoomScreenState extends State<RoomScreen> {
     final file = await pickFile();
     if (file == null || !mounted) return;
     _state.uploadTracker.uploadToThread(
-      api: widget.serverEntry.connection.api,
       roomId: widget.roomId,
       threadId: threadId,
       filename: file.name,
@@ -260,7 +262,6 @@ class _RoomScreenState extends State<RoomScreen> {
     if (threadId == null || !mounted) return;
 
     _state.uploadTracker.uploadToThread(
-      api: widget.serverEntry.connection.api,
       roomId: widget.roomId,
       threadId: threadId,
       filename: file.name,
@@ -416,25 +417,20 @@ class _RoomScreenState extends State<RoomScreen> {
     final threadView = _state.activeThreadView;
     final attachEnabled = room?.enableAttachments ?? false;
 
-    final roomEntries = attachEnabled
+    final UploadsStatus roomStatus = attachEnabled
         ? _state.uploadTracker.roomUploads(widget.roomId).watch(context)
-        : <UploadEntry>[];
+        : const UploadsLoaded(<DisplayUpload>[]);
     final threadId = threadView?.threadId;
-    final threadEntries = attachEnabled && threadId != null
+    final UploadsStatus threadStatus = attachEnabled && threadId != null
         ? _state.uploadTracker
             .threadUploads(widget.roomId, threadId)
             .watch(context)
-        : <UploadEntry>[];
+        : const UploadsLoaded(<DisplayUpload>[]);
 
     return Column(
       children: [
-        _buildRoomHeader(
-          room,
-          attachEnabled,
-          roomEntries,
-          threadEntries,
-        ),
-        if (_filesExpanded) _buildFilePanel(roomEntries, threadEntries),
+        _buildRoomHeader(room, attachEnabled, roomStatus, threadStatus),
+        if (_filesExpanded) _buildFilePanel(roomStatus, threadStatus),
         Expanded(
           child: threadView == null
               ? _buildNoThreadBody(room)
@@ -447,15 +443,12 @@ class _RoomScreenState extends State<RoomScreen> {
   Widget _buildRoomHeader(
     Room? room,
     bool attachEnabled,
-    List<UploadEntry> roomEntries,
-    List<UploadEntry> threadEntries,
+    UploadsStatus roomStatus,
+    UploadsStatus threadStatus,
   ) {
     final theme = Theme.of(context);
     final roomName = room?.name ?? widget.roomId;
-    final allEntries = [...roomEntries, ...threadEntries];
-    final hasFiles = allEntries.isNotEmpty;
-    final anyUploading = allEntries.any((e) => e.status is UploadUploading);
-    final anyFailed = allEntries.any((e) => e.status is UploadError);
+    final chip = _buildChip(roomStatus, threadStatus, theme);
 
     return Padding(
       padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
@@ -468,56 +461,7 @@ class _RoomScreenState extends State<RoomScreen> {
               overflow: TextOverflow.ellipsis,
             ),
           ),
-          if (hasFiles)
-            GestureDetector(
-              behavior: HitTestBehavior.opaque,
-              onTap: () => setState(() => _filesExpanded = !_filesExpanded),
-              child: Row(
-                mainAxisSize: MainAxisSize.min,
-                children: [
-                  if (anyUploading)
-                    SizedBox(
-                      width: 14,
-                      height: 14,
-                      child: CircularProgressIndicator(
-                        strokeWidth: 2,
-                        color: theme.colorScheme.primary,
-                      ),
-                    )
-                  else if (anyFailed)
-                    Icon(
-                      Icons.error_outline,
-                      size: 16,
-                      color: theme.colorScheme.error,
-                    )
-                  else
-                    Icon(
-                      Icons.attach_file,
-                      size: 16,
-                      color: theme.colorScheme.primary,
-                    ),
-                  const SizedBox(width: 4),
-                  Text(
-                    _chipLabel(
-                      roomEntries.length,
-                      threadEntries.length,
-                    ),
-                    style: theme.textTheme.bodySmall?.copyWith(
-                      color: anyFailed
-                          ? theme.colorScheme.error
-                          : theme.colorScheme.primary,
-                    ),
-                  ),
-                  Icon(
-                    _filesExpanded ? Icons.expand_less : Icons.expand_more,
-                    size: 16,
-                    color: anyFailed
-                        ? theme.colorScheme.error
-                        : theme.colorScheme.primary,
-                  ),
-                ],
-              ),
-            ),
+          if (chip != null) chip,
           if (attachEnabled && room != null)
             IconButton(
               icon: const Icon(Icons.upload_file, size: 20),
@@ -529,14 +473,90 @@ class _RoomScreenState extends State<RoomScreen> {
     );
   }
 
-  String _chipLabel(int roomCount, int threadCount) =>
-      uploadChipLabel(roomCount, threadCount);
+  /// Returns the chip widget for the current (room, thread) upload
+  /// status, or null to hide it (both scopes Loaded-empty, matching
+  /// the current space-constrained header behavior).
+  Widget? _buildChip(
+    UploadsStatus roomStatus,
+    UploadsStatus threadStatus,
+    ThemeData theme,
+  ) {
+    final roomFiles = _uploadsOrNull(roomStatus);
+    final threadFiles = _uploadsOrNull(threadStatus);
+
+    final anyLoading =
+        roomStatus is UploadsLoading || threadStatus is UploadsLoading;
+    final anyFailed =
+        roomStatus is UploadsFailed || threadStatus is UploadsFailed;
+
+    if (!anyLoading &&
+        !anyFailed &&
+        (roomFiles == null || roomFiles.isEmpty) &&
+        (threadFiles == null || threadFiles.isEmpty)) {
+      return null;
+    }
+
+    final all = [...?roomFiles, ...?threadFiles];
+    final anyPending = all.any((e) => e is PendingUpload);
+    final anyUploadFailed = all.any((e) => e is FailedUpload);
+    final color = (anyFailed || anyUploadFailed)
+        ? theme.colorScheme.error
+        : theme.colorScheme.primary;
+
+    final Widget leading;
+    if (anyLoading || anyPending) {
+      leading = SizedBox(
+        width: 14,
+        height: 14,
+        child: CircularProgressIndicator(strokeWidth: 2, color: color),
+      );
+    } else if (anyFailed || anyUploadFailed) {
+      leading = Icon(Icons.error_outline, size: 16, color: color);
+    } else {
+      leading = Icon(Icons.attach_file, size: 16, color: color);
+    }
+
+    final label = (roomFiles != null && threadFiles != null)
+        ? uploadChipLabel(roomFiles.length, threadFiles.length)
+        : 'Files';
+
+    return GestureDetector(
+      behavior: HitTestBehavior.opaque,
+      onTap: () => setState(() => _filesExpanded = !_filesExpanded),
+      child: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          leading,
+          const SizedBox(width: 4),
+          Text(
+            label,
+            style: theme.textTheme.bodySmall?.copyWith(color: color),
+          ),
+          Icon(
+            _filesExpanded ? Icons.expand_less : Icons.expand_more,
+            size: 16,
+            color: color,
+          ),
+        ],
+      ),
+    );
+  }
+
+  List<DisplayUpload>? _uploadsOrNull(UploadsStatus s) =>
+      s is UploadsLoaded ? s.uploads : null;
 
   Widget _buildFilePanel(
-    List<UploadEntry> roomEntries,
-    List<UploadEntry> threadEntries,
+    UploadsStatus roomStatus,
+    UploadsStatus threadStatus,
   ) {
     final theme = Theme.of(context);
+    final roomFiles = _uploadsOrNull(roomStatus);
+    final threadFiles = _uploadsOrNull(threadStatus);
+    final bothEmpty = (roomFiles?.isEmpty ?? true) &&
+        (threadFiles?.isEmpty ?? true) &&
+        roomStatus is UploadsLoaded &&
+        threadStatus is UploadsLoaded;
+
     return Padding(
       padding: const EdgeInsets.symmetric(horizontal: 8),
       child: Container(
@@ -550,25 +570,25 @@ class _RoomScreenState extends State<RoomScreen> {
           crossAxisAlignment: CrossAxisAlignment.start,
           mainAxisSize: MainAxisSize.min,
           children: [
-            if (roomEntries.isNotEmpty) ...[
+            if (bothEmpty)
               Text(
-                'Room',
-                style: theme.textTheme.labelSmall?.copyWith(
+                'No files attached.',
+                style: theme.textTheme.bodySmall?.copyWith(
                   color: theme.colorScheme.outline,
                 ),
-              ),
-              for (final e in roomEntries) _buildFileRow(e),
-            ],
-            if (roomEntries.isNotEmpty && threadEntries.isNotEmpty)
-              const Divider(height: 12),
-            if (threadEntries.isNotEmpty) ...[
-              Text(
-                'Thread',
-                style: theme.textTheme.labelSmall?.copyWith(
-                  color: theme.colorScheme.outline,
-                ),
-              ),
-              for (final e in threadEntries) _buildFileRow(e),
+              )
+            else ...[
+              _buildScopeSection('Room', roomStatus, theme),
+              if (roomFiles != null &&
+                  roomFiles.isNotEmpty &&
+                  threadStatus is! UploadsLoaded)
+                const Divider(height: 12)
+              else if (roomFiles != null &&
+                  roomFiles.isNotEmpty &&
+                  threadFiles != null &&
+                  threadFiles.isNotEmpty)
+                const Divider(height: 12),
+              _buildScopeSection('Thread', threadStatus, theme),
             ],
           ],
         ),
@@ -576,16 +596,81 @@ class _RoomScreenState extends State<RoomScreen> {
     );
   }
 
-  Widget _buildFileRow(UploadEntry entry) {
-    final theme = Theme.of(context);
-    final (icon, color) = switch (entry.status) {
-      UploadUploading() => (null, theme.colorScheme.primary),
-      UploadSuccess() => (
-          Icons.check_circle_outline,
-          theme.colorScheme.primary
+  Widget _buildScopeSection(
+    String label,
+    UploadsStatus status,
+    ThemeData theme,
+  ) {
+    return switch (status) {
+      UploadsLoading() => Row(
+          children: [
+            _sectionLabel(label, theme),
+            const SizedBox(width: 8),
+            const SizedBox(
+              width: 12,
+              height: 12,
+              child: CircularProgressIndicator(strokeWidth: 2),
+            ),
+          ],
         ),
-      UploadError() => (Icons.error_outline, theme.colorScheme.error),
+      UploadsLoaded(uploads: final list) when list.isEmpty => const SizedBox(),
+      UploadsLoaded(uploads: final list) => Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            _sectionLabel(label, theme),
+            for (final entry in list) _buildFileRow(entry),
+          ],
+        ),
+      UploadsFailed(error: final error) => Row(
+          children: [
+            _sectionLabel(label, theme),
+            const SizedBox(width: 8),
+            Expanded(
+              child: Text(
+                'Failed to load: $error',
+                style: theme.textTheme.bodySmall?.copyWith(
+                  color: theme.colorScheme.error,
+                ),
+                maxLines: 1,
+                overflow: TextOverflow.ellipsis,
+              ),
+            ),
+          ],
+        ),
     };
+  }
+
+  Widget _sectionLabel(String label, ThemeData theme) {
+    return Text(
+      label,
+      style: theme.textTheme.labelSmall?.copyWith(
+        color: theme.colorScheme.outline,
+      ),
+    );
+  }
+
+  Widget _buildFileRow(DisplayUpload entry) {
+    final theme = Theme.of(context);
+    final (icon, color, errorMessage, dismissible) = switch (entry) {
+      PersistedUpload() => (
+          Icons.check_circle_outline,
+          theme.colorScheme.primary,
+          null,
+          false,
+        ),
+      PendingUpload() => (null, theme.colorScheme.primary, null, false),
+      FailedUpload(message: final m) => (
+          Icons.error_outline,
+          theme.colorScheme.error,
+          m,
+          true,
+        ),
+    };
+
+    String? dismissId;
+    if (entry is PendingUpload) dismissId = entry.id;
+    if (entry is FailedUpload) dismissId = entry.id;
 
     return Padding(
       padding: const EdgeInsets.symmetric(vertical: 2),
@@ -597,10 +682,7 @@ class _RoomScreenState extends State<RoomScreen> {
             SizedBox(
               width: 16,
               height: 16,
-              child: CircularProgressIndicator(
-                strokeWidth: 2,
-                color: color,
-              ),
+              child: CircularProgressIndicator(strokeWidth: 2, color: color),
             ),
           const SizedBox(width: 8),
           Expanded(
@@ -612,9 +694,9 @@ class _RoomScreenState extends State<RoomScreen> {
                   style: theme.textTheme.bodySmall,
                   overflow: TextOverflow.ellipsis,
                 ),
-                if (entry.status is UploadError)
+                if (errorMessage != null)
                   Text(
-                    (entry.status as UploadError).message,
+                    errorMessage,
                     style: theme.textTheme.bodySmall?.copyWith(
                       color: theme.colorScheme.error,
                       fontSize: 11,
@@ -625,10 +707,10 @@ class _RoomScreenState extends State<RoomScreen> {
               ],
             ),
           ),
-          if (entry.status is! UploadUploading)
+          if (dismissible && dismissId != null)
             IconButton(
               icon: const Icon(Icons.close, size: 14),
-              onPressed: () => _state.uploadTracker.dismiss(entry.id),
+              onPressed: () => _state.uploadTracker.dismiss(dismissId!),
               padding: EdgeInsets.zero,
               constraints: const BoxConstraints(),
               visualDensity: VisualDensity.compact,

--- a/lib/src/modules/room/ui/room_screen.dart
+++ b/lib/src/modules/room/ui/room_screen.dart
@@ -550,6 +550,12 @@ class _RoomScreenState extends State<RoomScreen> {
   List<DisplayUpload>? _uploadsOrNull(UploadsStatus s) =>
       s is UploadsLoaded ? s.uploads : null;
 
+  bool _scopeRendersContent(UploadsStatus s) => switch (s) {
+        UploadsLoading() => true,
+        UploadsLoaded(uploads: final u) => u.isNotEmpty,
+        UploadsFailed() => true,
+      };
+
   Widget _buildFilePanel(
     UploadsStatus roomStatus,
     UploadsStatus threadStatus,
@@ -584,14 +590,11 @@ class _RoomScreenState extends State<RoomScreen> {
               )
             else ...[
               _buildScopeSection('Room', roomStatus, theme),
-              if (roomFiles != null &&
-                  roomFiles.isNotEmpty &&
-                  threadStatus is! UploadsLoaded)
-                const Divider(height: 12)
-              else if (roomFiles != null &&
-                  roomFiles.isNotEmpty &&
-                  threadFiles != null &&
-                  threadFiles.isNotEmpty)
+              // The divider sits between two visible sections. A scope
+              // is "visible" when it's Loading or Failed (those render
+              // a section row), or Loaded with at least one file.
+              if (_scopeRendersContent(roomStatus) &&
+                  _scopeRendersContent(threadStatus))
                 const Divider(height: 12),
               _buildScopeSection('Thread', threadStatus, theme),
             ],

--- a/lib/src/modules/room/ui/room_screen.dart
+++ b/lib/src/modules/room/ui/room_screen.dart
@@ -454,34 +454,92 @@ class _RoomScreenState extends State<RoomScreen> {
   ) {
     final theme = Theme.of(context);
     final roomName = room?.name ?? widget.roomId;
-    final chip = _buildChip(roomStatus, threadStatus, theme);
+    final controls = _buildControlsCluster(
+      roomStatus,
+      threadStatus,
+      theme,
+      room,
+      attachEnabled,
+    );
 
     return Padding(
       padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
       child: Row(
+        crossAxisAlignment: CrossAxisAlignment.center,
         children: [
           Expanded(
             child: Text(
               roomName,
               style: theme.textTheme.titleMedium,
-              overflow: TextOverflow.ellipsis,
+              // Long room names wrap to as many lines as needed
+              // rather than truncate.
             ),
           ),
-          if (chip != null) chip,
-          if (attachEnabled && room != null)
-            IconButton(
-              icon: const Icon(Icons.upload_file, size: 20),
-              tooltip: 'Upload file to room',
-              onPressed: () => _pickAndUploadToRoom(room),
-            ),
+          if (controls != null) controls,
         ],
       ),
     );
   }
 
-  /// Returns the chip widget, or null to hide it when both scopes are
-  /// Loaded-empty.
-  Widget? _buildChip(
+  /// Wraps the file chip and the upload icon in a single tonal
+  /// container so they read as one related pair of controls rather
+  /// than two detached buttons with mismatched heights.
+  Widget? _buildControlsCluster(
+    UploadsStatus roomStatus,
+    UploadsStatus threadStatus,
+    ThemeData theme,
+    Room? room,
+    bool attachEnabled,
+  ) {
+    final chip = _buildChipSegment(roomStatus, threadStatus, theme);
+    final uploadSegment = (attachEnabled && room != null)
+        ? _buildUploadSegment(room, theme)
+        : null;
+
+    if (chip == null && uploadSegment == null) return null;
+
+    return Material(
+      color: theme.colorScheme.secondaryContainer,
+      borderRadius: BorderRadius.circular(20),
+      clipBehavior: Clip.antiAlias,
+      child: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          if (chip != null) chip,
+          if (chip != null && uploadSegment != null)
+            Container(
+              width: 1,
+              height: 20,
+              color: theme.colorScheme.outlineVariant,
+            ),
+          if (uploadSegment != null) uploadSegment,
+        ],
+      ),
+    );
+  }
+
+  Widget _buildUploadSegment(Room room, ThemeData theme) {
+    return InkWell(
+      onTap: () => _pickAndUploadToRoom(room),
+      child: Tooltip(
+        message: 'Upload file to room',
+        child: Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+          child: Icon(
+            Icons.upload_file,
+            size: 20,
+            color: theme.colorScheme.onSecondaryContainer,
+          ),
+        ),
+      ),
+    );
+  }
+
+  /// Returns the chip segment, or null to hide it when both scopes are
+  /// Loaded-empty. The segment is embedded in the tonal controls
+  /// cluster built by [_buildControlsCluster] and so has no container
+  /// of its own.
+  Widget? _buildChipSegment(
     UploadsStatus roomStatus,
     UploadsStatus threadStatus,
     ThemeData theme,
@@ -506,7 +564,7 @@ class _RoomScreenState extends State<RoomScreen> {
     final anyUploadFailed = all.any((e) => e is FailedUpload);
     final color = (anyFailed || anyUploadFailed)
         ? theme.colorScheme.error
-        : theme.colorScheme.primary;
+        : theme.colorScheme.onSecondaryContainer;
 
     final Widget leading;
     if (anyLoading || anyPending) {
@@ -525,24 +583,27 @@ class _RoomScreenState extends State<RoomScreen> {
         ? uploadChipLabel(roomFiles.length, threadFiles.length)
         : 'Files';
 
-    return GestureDetector(
-      behavior: HitTestBehavior.opaque,
+    return InkWell(
       onTap: () => setState(() => _filesExpanded = !_filesExpanded),
-      child: Row(
-        mainAxisSize: MainAxisSize.min,
-        children: [
-          leading,
-          const SizedBox(width: 4),
-          Text(
-            label,
-            style: theme.textTheme.bodySmall?.copyWith(color: color),
-          ),
-          Icon(
-            _filesExpanded ? Icons.expand_less : Icons.expand_more,
-            size: 16,
-            color: color,
-          ),
-        ],
+      child: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+        child: Row(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            leading,
+            const SizedBox(width: 6),
+            Text(
+              label,
+              style: theme.textTheme.bodySmall?.copyWith(color: color),
+            ),
+            const SizedBox(width: 2),
+            Icon(
+              _filesExpanded ? Icons.expand_less : Icons.expand_more,
+              size: 16,
+              color: color,
+            ),
+          ],
+        ),
       ),
     );
   }
@@ -651,15 +712,17 @@ class _RoomScreenState extends State<RoomScreen> {
 
   Widget _sectionLabel(String label, ThemeData theme) {
     return Text(
-      label,
+      label.toUpperCase(),
       style: theme.textTheme.labelSmall?.copyWith(
-        color: theme.colorScheme.outline,
+        color: theme.colorScheme.onSurfaceVariant,
+        letterSpacing: 0.5,
       ),
     );
   }
 
   Widget _buildFileRow(DisplayUpload entry) {
     final theme = Theme.of(context);
+    final isFailed = entry is FailedUpload;
     final (icon, color, errorMessage, dismissible) = switch (entry) {
       PersistedUpload() => (
           Icons.check_circle_outline,
@@ -670,7 +733,7 @@ class _RoomScreenState extends State<RoomScreen> {
       PendingUpload() => (null, theme.colorScheme.primary, null, false),
       FailedUpload(message: final m) => (
           Icons.error_outline,
-          theme.colorScheme.error,
+          theme.colorScheme.onErrorContainer,
           m,
           true,
         ),
@@ -680,8 +743,17 @@ class _RoomScreenState extends State<RoomScreen> {
     if (entry is PendingUpload) dismissId = entry.id;
     if (entry is FailedUpload) dismissId = entry.id;
 
-    return Padding(
-      padding: const EdgeInsets.symmetric(vertical: 2),
+    return Container(
+      margin: const EdgeInsets.symmetric(vertical: 2),
+      padding: isFailed
+          ? const EdgeInsets.symmetric(horizontal: 8, vertical: 4)
+          : null,
+      decoration: isFailed
+          ? BoxDecoration(
+              color: theme.colorScheme.errorContainer,
+              borderRadius: BorderRadius.circular(6),
+            )
+          : null,
       child: Row(
         children: [
           if (icon != null)
@@ -699,14 +771,16 @@ class _RoomScreenState extends State<RoomScreen> {
               children: [
                 Text(
                   entry.filename,
-                  style: theme.textTheme.bodySmall,
+                  style: theme.textTheme.bodySmall?.copyWith(
+                    color: isFailed ? theme.colorScheme.onErrorContainer : null,
+                  ),
                   overflow: TextOverflow.ellipsis,
                 ),
                 if (errorMessage != null)
                   Text(
                     errorMessage,
                     style: theme.textTheme.bodySmall?.copyWith(
-                      color: theme.colorScheme.error,
+                      color: theme.colorScheme.onErrorContainer,
                       fontSize: 11,
                     ),
                     maxLines: 1,
@@ -718,6 +792,7 @@ class _RoomScreenState extends State<RoomScreen> {
           if (dismissible && dismissId != null)
             IconButton(
               icon: const Icon(Icons.close, size: 14),
+              color: theme.colorScheme.onErrorContainer,
               onPressed: () => _state.uploadTracker.dismiss(dismissId!),
               padding: EdgeInsets.zero,
               constraints: const BoxConstraints(),

--- a/lib/src/modules/room/ui/room_screen.dart
+++ b/lib/src/modules/room/ui/room_screen.dart
@@ -267,18 +267,7 @@ class _RoomScreenState extends State<RoomScreen> {
     }
   }
 
-  Future<void> _pickAndUploadToRoom(Room room) async {
-    final file = await _pickWithErrorSurfacing();
-    if (file == null || !mounted) return;
-    _state.uploadTracker.uploadToRoom(
-      roomId: widget.roomId,
-      filename: file.name,
-      fileBytes: file.bytes,
-      mimeType: file.mimeType,
-    );
-  }
-
-  Future<void> _pickAndUploadToThread(Room room, String threadId) async {
+  Future<void> _pickAndUploadToThread(String threadId) async {
     final file = await _pickWithErrorSurfacing(threadId: threadId);
     if (file == null || !mounted) return;
     _state.uploadTracker.uploadToThread(
@@ -290,7 +279,7 @@ class _RoomScreenState extends State<RoomScreen> {
     );
   }
 
-  Future<void> _pickAndUploadToNewThread(Room room) async {
+  Future<void> _pickAndUploadToNewThread() async {
     // Read errors before thread creation attach to the room scope
     // since there's no thread yet to route them to.
     final file = await _pickWithErrorSurfacing();
@@ -467,7 +456,7 @@ class _RoomScreenState extends State<RoomScreen> {
 
     return Column(
       children: [
-        _buildRoomHeader(room, attachEnabled, roomStatus, threadStatus),
+        _buildRoomHeader(room, roomStatus, threadStatus),
         if (_filesExpanded) _buildFilePanel(roomStatus, threadStatus),
         Expanded(
           child: threadView == null
@@ -480,19 +469,12 @@ class _RoomScreenState extends State<RoomScreen> {
 
   Widget _buildRoomHeader(
     Room? room,
-    bool attachEnabled,
     UploadsStatus roomStatus,
     UploadsStatus threadStatus,
   ) {
     final theme = Theme.of(context);
     final roomName = room?.name ?? widget.roomId;
-    final controls = _buildControlsCluster(
-      roomStatus,
-      threadStatus,
-      theme,
-      room,
-      attachEnabled,
-    );
+    final chip = _buildChipSegment(roomStatus, threadStatus, theme);
 
     return Padding(
       padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
@@ -505,61 +487,14 @@ class _RoomScreenState extends State<RoomScreen> {
               style: theme.textTheme.titleMedium,
             ),
           ),
-          if (controls != null) controls,
-        ],
-      ),
-    );
-  }
-
-  /// Wraps the file chip and the upload icon in a single tonal
-  /// container so they read as one related pair of controls.
-  Widget? _buildControlsCluster(
-    UploadsStatus roomStatus,
-    UploadsStatus threadStatus,
-    ThemeData theme,
-    Room? room,
-    bool attachEnabled,
-  ) {
-    final chip = _buildChipSegment(roomStatus, threadStatus, theme);
-    final uploadSegment = (attachEnabled && room != null)
-        ? _buildUploadSegment(room, theme)
-        : null;
-
-    if (chip == null && uploadSegment == null) return null;
-
-    return Material(
-      color: theme.colorScheme.secondaryContainer,
-      borderRadius: BorderRadius.circular(20),
-      clipBehavior: Clip.antiAlias,
-      child: Row(
-        mainAxisSize: MainAxisSize.min,
-        children: [
-          if (chip != null) chip,
-          if (chip != null && uploadSegment != null)
-            Container(
-              width: 1,
-              height: 20,
-              color: theme.colorScheme.outlineVariant,
+          if (chip != null)
+            Material(
+              color: theme.colorScheme.secondaryContainer,
+              borderRadius: BorderRadius.circular(20),
+              clipBehavior: Clip.antiAlias,
+              child: chip,
             ),
-          if (uploadSegment != null) uploadSegment,
         ],
-      ),
-    );
-  }
-
-  Widget _buildUploadSegment(Room room, ThemeData theme) {
-    return InkWell(
-      onTap: () => _pickAndUploadToRoom(room),
-      child: Tooltip(
-        message: 'Upload file to room',
-        child: Padding(
-          padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
-          child: Icon(
-            Icons.upload_file,
-            size: 20,
-            color: theme.colorScheme.onSecondaryContainer,
-          ),
-        ),
       ),
     );
   }
@@ -875,8 +810,8 @@ class _RoomScreenState extends State<RoomScreen> {
                     Set.of(_selectedDocuments)..remove(doc),
                   )
               : null,
-          onAttachFile: (room?.enableAttachments ?? false) && room != null
-              ? () => _pickAndUploadToNewThread(room)
+          onAttachFile: (room?.enableAttachments ?? false)
+              ? _pickAndUploadToNewThread
               : null,
         ),
       ],
@@ -978,8 +913,8 @@ class _RoomScreenState extends State<RoomScreen> {
                     Set.of(_selectedDocuments)..remove(doc),
                   )
               : null,
-          onAttachFile: attachEnabled && room != null
-              ? () => _pickAndUploadToThread(room, threadView.threadId)
+          onAttachFile: attachEnabled
+              ? () => _pickAndUploadToThread(threadView.threadId)
               : null,
         ),
       ],

--- a/lib/src/modules/room/ui/room_screen.dart
+++ b/lib/src/modules/room/ui/room_screen.dart
@@ -36,8 +36,14 @@ const double _wideBreakpoint = 600;
 
 /// Builds the label for the file indicator chip in the room header.
 ///
-/// Shows separate counts for room and thread uploads.
+/// Shows separate counts for room and thread uploads. At least one of
+/// [roomCount] / [threadCount] must be positive — the caller is
+/// responsible for hiding the chip when both are zero.
 String uploadChipLabel(int roomCount, int threadCount) {
+  assert(
+    roomCount > 0 || threadCount > 0,
+    'uploadChipLabel called with both counts zero; the chip should be hidden',
+  );
   if (roomCount > 0 && threadCount > 0) {
     return '$roomCount room \u00b7 $threadCount thread';
   }
@@ -473,9 +479,8 @@ class _RoomScreenState extends State<RoomScreen> {
     );
   }
 
-  /// Returns the chip widget for the current (room, thread) upload
-  /// status, or null to hide it (both scopes Loaded-empty, matching
-  /// the current space-constrained header behavior).
+  /// Returns the chip widget, or null to hide it when both scopes are
+  /// Loaded-empty.
   Widget? _buildChip(
     UploadsStatus roomStatus,
     UploadsStatus threadStatus,
@@ -628,7 +633,7 @@ class _RoomScreenState extends State<RoomScreen> {
             const SizedBox(width: 8),
             Expanded(
               child: Text(
-                'Failed to load: $error',
+                'Failed to load: ${uploadErrorMessage(error)}',
                 style: theme.textTheme.bodySmall?.copyWith(
                   color: theme.colorScheme.error,
                 ),

--- a/lib/src/modules/room/ui/room_screen.dart
+++ b/lib/src/modules/room/ui/room_screen.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+import 'dart:developer' as dev;
 
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
@@ -37,14 +38,10 @@ const double _wideBreakpoint = 600;
 
 /// Builds the label for the file indicator chip in the room header.
 ///
-/// Shows separate counts for room and thread uploads. At least one of
-/// [roomCount] / [threadCount] must be positive — the caller is
-/// responsible for hiding the chip when both are zero.
+/// Shows separate counts for room and thread uploads. At least one
+/// count must be positive.
 String uploadChipLabel(int roomCount, int threadCount) {
-  assert(
-    roomCount > 0 || threadCount > 0,
-    'uploadChipLabel called with both counts zero; the chip should be hidden',
-  );
+  assert(roomCount > 0 || threadCount > 0);
   if (roomCount > 0 && threadCount > 0) {
     return '$roomCount room \u00b7 $threadCount thread';
   }
@@ -238,8 +235,40 @@ class _RoomScreenState extends State<RoomScreen> {
     context.push('/room/${widget.serverEntry.alias}/${widget.roomId}/info');
   }
 
+  Future<PickedFile?> _pickWithErrorSurfacing({String? threadId}) async {
+    try {
+      return await pickFile();
+    } on PickFileException catch (e, st) {
+      if (!mounted) return null;
+      dev.log(
+        'File pick failed',
+        error: e.cause,
+        stackTrace: st,
+        name: 'RoomScreen',
+        level: 1000,
+      );
+      final (filename, message) = switch (e) {
+        PickFileReadException(:final filename) => (
+            filename,
+            'Failed to read file',
+          ),
+        PickFilePickerException(:final filename) => (
+            filename ?? '(unknown)',
+            'Could not open file picker',
+          ),
+      };
+      _state.uploadTracker.recordClientError(
+        roomId: widget.roomId,
+        threadId: threadId,
+        filename: filename,
+        message: message,
+      );
+      return null;
+    }
+  }
+
   Future<void> _pickAndUploadToRoom(Room room) async {
-    final file = await pickFile();
+    final file = await _pickWithErrorSurfacing();
     if (file == null || !mounted) return;
     _state.uploadTracker.uploadToRoom(
       roomId: widget.roomId,
@@ -250,7 +279,7 @@ class _RoomScreenState extends State<RoomScreen> {
   }
 
   Future<void> _pickAndUploadToThread(Room room, String threadId) async {
-    final file = await pickFile();
+    final file = await _pickWithErrorSurfacing(threadId: threadId);
     if (file == null || !mounted) return;
     _state.uploadTracker.uploadToThread(
       roomId: widget.roomId,
@@ -262,7 +291,9 @@ class _RoomScreenState extends State<RoomScreen> {
   }
 
   Future<void> _pickAndUploadToNewThread(Room room) async {
-    final file = await pickFile();
+    // Read errors before thread creation attach to the room scope
+    // since there's no thread yet to route them to.
+    final file = await _pickWithErrorSurfacing();
     if (file == null || !mounted) return;
 
     final threadId = await _state.createThread();
@@ -472,8 +503,6 @@ class _RoomScreenState extends State<RoomScreen> {
             child: Text(
               roomName,
               style: theme.textTheme.titleMedium,
-              // Long room names wrap to as many lines as needed
-              // rather than truncate.
             ),
           ),
           if (controls != null) controls,
@@ -483,8 +512,7 @@ class _RoomScreenState extends State<RoomScreen> {
   }
 
   /// Wraps the file chip and the upload icon in a single tonal
-  /// container so they read as one related pair of controls rather
-  /// than two detached buttons with mismatched heights.
+  /// container so they read as one related pair of controls.
   Widget? _buildControlsCluster(
     UploadsStatus roomStatus,
     UploadsStatus threadStatus,
@@ -536,10 +564,8 @@ class _RoomScreenState extends State<RoomScreen> {
     );
   }
 
-  /// Returns the chip segment, or null to hide it when both scopes are
-  /// Loaded-empty. The segment is embedded in the tonal controls
-  /// cluster built by [_buildControlsCluster] and so has no container
-  /// of its own.
+  /// Returns the chip segment, or null to hide it when both scopes
+  /// are Loaded-empty.
   Widget? _buildChipSegment(
     UploadsStatus roomStatus,
     UploadsStatus threadStatus,
@@ -740,9 +766,7 @@ class _RoomScreenState extends State<RoomScreen> {
         ),
     };
 
-    String? dismissId;
-    if (entry is PendingUpload) dismissId = entry.id;
-    if (entry is FailedUpload) dismissId = entry.id;
+    final dismissId = entry is FailedUpload ? entry.id : null;
 
     return Container(
       margin: const EdgeInsets.symmetric(vertical: 2),
@@ -794,7 +818,7 @@ class _RoomScreenState extends State<RoomScreen> {
             IconButton(
               icon: const Icon(Icons.close, size: 14),
               color: theme.colorScheme.onErrorContainer,
-              onPressed: () => _state.uploadTracker.dismiss(dismissId!),
+              onPressed: () => _state.uploadTracker.dismissFailed(dismissId),
               padding: EdgeInsets.zero,
               constraints: const BoxConstraints(),
               visualDensity: VisualDensity.compact,

--- a/lib/src/modules/room/ui/room_screen.dart
+++ b/lib/src/modules/room/ui/room_screen.dart
@@ -28,6 +28,7 @@ import 'message_timeline.dart';
 import 'async_action_dialog.dart';
 import 'room_welcome.dart';
 import 'thread_sidebar.dart';
+import 'upload_event_banner.dart';
 import '../upload_tracker.dart';
 import '../upload_tracker_registry.dart';
 
@@ -828,6 +829,12 @@ class _RoomScreenState extends State<RoomScreen> {
             error: roomError,
             onDismiss: _state.clearError,
           ),
+        if (room?.enableAttachments ?? false)
+          UploadEventBanner(
+            tracker: _state.uploadTracker,
+            roomId: widget.roomId,
+            threadId: null,
+          ),
         ChatInput(
           onSend: (text) => _state.sendToNewThread(
             text,
@@ -922,6 +929,12 @@ class _RoomScreenState extends State<RoomScreen> {
           _SendErrorBanner(
             error: sendError,
             onDismiss: () => threadView.clearSendError(),
+          ),
+        if (attachEnabled)
+          UploadEventBanner(
+            tracker: _state.uploadTracker,
+            roomId: widget.roomId,
+            threadId: threadView.threadId,
           ),
         ChatInput(
           onSend: (text) => threadView.sendMessage(

--- a/lib/src/modules/room/ui/upload_event_banner.dart
+++ b/lib/src/modules/room/ui/upload_event_banner.dart
@@ -178,12 +178,15 @@ class _UploadEventBannerState extends State<UploadEventBanner> {
   }
 
   Widget _failurePill(ThemeData theme) {
-    if (_failures.isEmpty) return const SizedBox.shrink();
+    if (_failures.isEmpty) {
+      return const SizedBox.shrink(key: ValueKey('failure-empty'));
+    }
     final message = _failures.length == 1
         ? 'Failed to upload ${_failures.first.filename}: '
             '${_failures.first.message}'
         : 'Failed to upload ${_failures.length} files';
     return _Pill(
+      key: ValueKey('failure:$message'),
       icon: Icons.error_outline,
       background: theme.colorScheme.errorContainer,
       foreground: theme.colorScheme.onErrorContainer,
@@ -193,7 +196,9 @@ class _UploadEventBannerState extends State<UploadEventBanner> {
   }
 
   Widget _successPill(ThemeData theme) {
-    if (_successes.isEmpty) return const SizedBox.shrink();
+    if (_successes.isEmpty) {
+      return const SizedBox.shrink(key: ValueKey('success-empty'));
+    }
     final message = _successes.length == 1
         ? 'Uploaded ${_successes.first}'
         : 'Uploaded ${_successes.first} and ${_successes.length - 1} more';
@@ -201,6 +206,7 @@ class _UploadEventBannerState extends State<UploadEventBanner> {
     // Material shades so success reads distinctly from the primary
     // color without competing with the errorContainer on failures.
     return _Pill(
+      key: ValueKey('success:$message'),
       icon: Icons.check_circle_outline,
       background: Colors.green.shade100,
       foreground: Colors.green.shade900,
@@ -231,6 +237,7 @@ class _Pill extends StatelessWidget {
     required this.foreground,
     required this.message,
     required this.onDismiss,
+    super.key,
   });
 
   final IconData icon;

--- a/lib/src/modules/room/ui/upload_event_banner.dart
+++ b/lib/src/modules/room/ui/upload_event_banner.dart
@@ -1,0 +1,296 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:soliplex_frontend/src/modules/room/upload_tracker.dart';
+
+/// Transient inline notifications that announce upload transitions the
+/// user may have missed while focused on the composer.
+///
+/// Derives events by diffing `UploadsStatus` snapshots for the current
+/// room scope and (when set) thread scope. Successes aggregate and
+/// auto-dismiss after 4 seconds; failures stay sticky until dismissed.
+/// Pre-existing state on scope entry does not fire a pill — the chip
+/// and file panel already communicate it.
+class UploadEventBanner extends StatefulWidget {
+  const UploadEventBanner({
+    required this.tracker,
+    required this.roomId,
+    required this.threadId,
+    super.key,
+  });
+
+  final UploadTracker tracker;
+  final String roomId;
+  final String? threadId;
+
+  @override
+  State<UploadEventBanner> createState() => _UploadEventBannerState();
+}
+
+class _UploadEventBannerState extends State<UploadEventBanner> {
+  static const _successDismissDelay = Duration(seconds: 4);
+
+  List<DisplayUpload>? _prevRoom;
+  List<DisplayUpload>? _prevThread;
+  final List<String> _successes = [];
+  final List<_FailureEvent> _failures = [];
+  Timer? _successTimer;
+  VoidCallback? _unsubRoom;
+  VoidCallback? _unsubThread;
+
+  @override
+  void initState() {
+    super.initState();
+    _subscribe();
+  }
+
+  @override
+  void didUpdateWidget(covariant UploadEventBanner oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    final scopeChanged = oldWidget.tracker != widget.tracker ||
+        oldWidget.roomId != widget.roomId ||
+        oldWidget.threadId != widget.threadId;
+    if (!scopeChanged) return;
+    _unsubscribe();
+    _prevRoom = null;
+    _prevThread = null;
+    _successes.clear();
+    _failures.clear();
+    _successTimer?.cancel();
+    _successTimer = null;
+    _subscribe();
+  }
+
+  @override
+  void dispose() {
+    _unsubscribe();
+    _successTimer?.cancel();
+    super.dispose();
+  }
+
+  void _subscribe() {
+    _unsubRoom = widget.tracker
+        .roomUploads(widget.roomId)
+        .subscribe((status) => _onSnapshot(status, isRoom: true));
+    final threadId = widget.threadId;
+    if (threadId != null) {
+      _unsubThread = widget.tracker
+          .threadUploads(widget.roomId, threadId)
+          .subscribe((status) => _onSnapshot(status, isRoom: false));
+    }
+  }
+
+  void _unsubscribe() {
+    _unsubRoom?.call();
+    _unsubThread?.call();
+    _unsubRoom = null;
+    _unsubThread = null;
+  }
+
+  void _onSnapshot(UploadsStatus status, {required bool isRoom}) {
+    if (!mounted) return;
+    final current = status is UploadsLoaded ? status.uploads : null;
+    if (current == null) return;
+    final prev = isRoom ? _prevRoom : _prevThread;
+    final events = _diff(prev, current);
+    if (isRoom) {
+      _prevRoom = current;
+    } else {
+      _prevThread = current;
+    }
+    if (events.isEmpty) return;
+
+    setState(() {
+      for (final event in events) {
+        switch (event) {
+          case _CompletedEvent(:final filename):
+            _successes.add(filename);
+          case _FailureEvent():
+            _failures.add(event);
+        }
+      }
+      if (_successes.isNotEmpty) {
+        _successTimer?.cancel();
+        _successTimer = Timer(_successDismissDelay, _clearSuccesses);
+      }
+    });
+  }
+
+  /// Returns the list of transition events between [prev] and [current].
+  /// Null [prev] means this is the baseline snapshot — no events.
+  List<_Event> _diff(List<DisplayUpload>? prev, List<DisplayUpload> current) {
+    if (prev == null) return const [];
+    final events = <_Event>[];
+    final currentById = {
+      for (final e in current)
+        if (e is PendingUpload) e.id: e else if (e is FailedUpload) e.id: e,
+    };
+    final persistedNames = {
+      for (final e in current)
+        if (e is PersistedUpload) e.filename,
+    };
+    for (final entry in prev) {
+      if (entry is! PendingUpload) continue;
+      final match = currentById[entry.id];
+      if (match is FailedUpload) {
+        events.add(_FailureEvent(entry.filename, match.message));
+      } else if (match == null && persistedNames.contains(entry.filename)) {
+        events.add(_CompletedEvent(entry.filename));
+      }
+    }
+    return events;
+  }
+
+  void _clearSuccesses() {
+    if (!mounted) return;
+    setState(() {
+      _successes.clear();
+      _successTimer = null;
+    });
+  }
+
+  void _dismissSuccesses() {
+    _successTimer?.cancel();
+    setState(() {
+      _successes.clear();
+      _successTimer = null;
+    });
+  }
+
+  void _dismissFailures() {
+    setState(() => _failures.clear());
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return SizedBox(
+      width: double.infinity,
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          _AnimatedPill(child: _failurePill(theme)),
+          _AnimatedPill(child: _successPill(theme)),
+        ],
+      ),
+    );
+  }
+
+  Widget _failurePill(ThemeData theme) {
+    if (_failures.isEmpty) return const SizedBox.shrink();
+    final message = _failures.length == 1
+        ? 'Failed to upload ${_failures.first.filename}: '
+            '${_failures.first.message}'
+        : 'Failed to upload ${_failures.length} files';
+    return _Pill(
+      icon: Icons.error_outline,
+      background: theme.colorScheme.errorContainer,
+      foreground: theme.colorScheme.onErrorContainer,
+      message: message,
+      onDismiss: _dismissFailures,
+    );
+  }
+
+  Widget _successPill(ThemeData theme) {
+    if (_successes.isEmpty) return const SizedBox.shrink();
+    final message = _successes.length == 1
+        ? 'Uploaded ${_successes.first}'
+        : 'Uploaded ${_successes.first} and ${_successes.length - 1} more';
+    // Material doesn't have a "success" color token; use light-green
+    // Material shades so success reads distinctly from the primary
+    // color without competing with the errorContainer on failures.
+    return _Pill(
+      icon: Icons.check_circle_outline,
+      background: Colors.green.shade100,
+      foreground: Colors.green.shade900,
+      message: message,
+      onDismiss: _dismissSuccesses,
+    );
+  }
+}
+
+class _AnimatedPill extends StatelessWidget {
+  const _AnimatedPill({required this.child});
+
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context) {
+    return AnimatedSwitcher(
+      duration: const Duration(milliseconds: 150),
+      child: child,
+    );
+  }
+}
+
+class _Pill extends StatelessWidget {
+  const _Pill({
+    required this.icon,
+    required this.background,
+    required this.foreground,
+    required this.message,
+    required this.onDismiss,
+  });
+
+  final IconData icon;
+  final Color background;
+  final Color foreground;
+  final String message;
+  final VoidCallback onDismiss;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      margin: const EdgeInsets.only(left: 12, bottom: 4),
+      padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+      decoration: BoxDecoration(
+        color: background,
+        borderRadius: BorderRadius.circular(20),
+      ),
+      constraints: const BoxConstraints(maxWidth: 420),
+      child: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Icon(icon, size: 16, color: foreground),
+          const SizedBox(width: 8),
+          Flexible(
+            child: Text(
+              message,
+              style: Theme.of(context)
+                  .textTheme
+                  .bodySmall
+                  ?.copyWith(color: foreground),
+              maxLines: 1,
+              overflow: TextOverflow.ellipsis,
+            ),
+          ),
+          const SizedBox(width: 4),
+          IconButton(
+            icon: const Icon(Icons.close, size: 14),
+            color: foreground,
+            onPressed: onDismiss,
+            padding: EdgeInsets.zero,
+            constraints: const BoxConstraints(),
+            visualDensity: VisualDensity.compact,
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+sealed class _Event {
+  const _Event();
+}
+
+class _CompletedEvent extends _Event {
+  const _CompletedEvent(this.filename);
+  final String filename;
+}
+
+class _FailureEvent extends _Event {
+  const _FailureEvent(this.filename, this.message);
+  final String filename;
+  final String message;
+}

--- a/lib/src/modules/room/upload_tracker.dart
+++ b/lib/src/modules/room/upload_tracker.dart
@@ -6,9 +6,9 @@ import 'package:soliplex_client/soliplex_client.dart';
 
 /// Sealed status for a single upload scope (a room or a thread).
 ///
-/// `Loaded` once the server list is known (even if empty). `Failed`
-/// only from a non-`Loaded` baseline — a refresh failure preserves
-/// the prior `Loaded` list and logs.
+/// A refresh failure from a `Loaded` state is logged but not surfaced
+/// — the prior list stays visible. `Failed` only fires from a
+/// non-`Loaded` baseline.
 sealed class UploadsStatus {
   const UploadsStatus();
 }
@@ -24,14 +24,9 @@ class UploadsLoaded extends UploadsStatus {
 
 class UploadsFailed extends UploadsStatus {
   const UploadsFailed(this.error);
-  final Object error;
+  final SoliplexException error;
 }
 
-/// Sealed display variant for a single row in the merged uploads list.
-///
-/// Persisted rows come from the server LIST endpoint; Pending and
-/// Failed rows are local optimistic entries driven by in-flight or
-/// recently-failed POST uploads.
 sealed class DisplayUpload {
   const DisplayUpload({required this.filename});
   final String filename;
@@ -66,11 +61,9 @@ String uploadErrorMessage(Object error) {
   return 'Something went wrong. Please try again.';
 }
 
-/// Internal record for a local upload row. Sealed so pending/failed
-/// states each carry exactly the fields they need — a pending record
-/// cannot accidentally hold an error message, and a failed record
-/// cannot lack one. Failed rows replace pending rows by index in the
-/// `_pending` list rather than mutate in place.
+/// Internal record for a local upload row. Sealed and immutable:
+/// transitions happen by replacing the record at the same index, not
+/// by mutation.
 sealed class _PendingRecord {
   const _PendingRecord({required this.id, required this.filename});
   final String id;
@@ -78,19 +71,15 @@ sealed class _PendingRecord {
 }
 
 class _Pending extends _PendingRecord {
-  _Pending({required super.id, required super.filename});
+  const _Pending({required super.id, required super.filename});
+}
 
-  /// Flipped to `true` by `_runUpload` once the POST has completed
-  /// server-side. A successful `_fetch` drops the record only when
-  /// this is set AND the filename is in the refreshed persisted list.
-  /// Guards against: (a) concurrent uploads where one refresh
-  /// cancels another (the next refresh's success still cleans up),
-  /// (b) refresh failures after a successful POST (pending stays
-  /// visible as a spinner; the next refresh resolves it), and (c)
-  /// pre-existing same-name files on the server (the filename
-  /// already matches but the post is still in flight, so we don't
-  /// drop prematurely).
-  bool postCompleted = false;
+/// Server-confirmed via POST but not yet observed in the persisted
+/// list. A concurrent refresh may cancel the one that would have
+/// cleaned this record up; the next refresh whose response contains
+/// the filename finally drops it.
+class _Posted extends _PendingRecord {
+  const _Posted({required super.id, required super.filename});
 }
 
 class _Failed extends _PendingRecord {
@@ -119,9 +108,8 @@ class _ScopeState {
 /// Tracks file uploads across rooms and threads, merging a
 /// server-fetched list with an in-flight optimistic view.
 ///
-/// Owned by `UploadTrackerRegistry`, not by any single widget, so
-/// uploads started on one screen survive when the user navigates away
-/// before the POST resolves.
+/// Owned by the registry so uploads started on one screen survive
+/// when the user navigates away before the POST resolves.
 class UploadTracker {
   UploadTracker({required SoliplexApi api}) : _api = api;
 
@@ -130,9 +118,7 @@ class UploadTracker {
   bool _isDisposed = false;
   int _nextId = 0;
 
-  /// True after [dispose] has been called. Primarily for the
-  /// `UploadTrackerRegistry` eviction tests to verify that evicted
-  /// trackers are actually disposed, not just removed from the map.
+  /// True after [dispose] has been called.
   bool get isDisposed => _isDisposed;
 
   static String _roomKey(String roomId) => 'room:$roomId';
@@ -145,14 +131,24 @@ class UploadTracker {
   // Public signals
   // --------------------------------------------------------
 
-  ReadonlySignal<UploadsStatus> roomUploads(String roomId) =>
-      _scope(_roomKey(roomId)).signal;
+  ReadonlySignal<UploadsStatus> roomUploads(String roomId) {
+    _requireNotDisposed();
+    return _scope(_roomKey(roomId)).signal;
+  }
 
   ReadonlySignal<UploadsStatus> threadUploads(
     String roomId,
     String threadId,
-  ) =>
-      _scope(_threadKey(roomId, threadId)).signal;
+  ) {
+    _requireNotDisposed();
+    return _scope(_threadKey(roomId, threadId)).signal;
+  }
+
+  void _requireNotDisposed() {
+    if (_isDisposed) {
+      throw StateError('UploadTracker has been disposed');
+    }
+  }
 
   // --------------------------------------------------------
   // Refresh triggers
@@ -200,18 +196,20 @@ class UploadTracker {
       scope.fetchToken = null;
       scope.persisted = list;
 
-      // Clean up pending records whose upload has server-settled
-      // (postCompleted) and whose filename now appears in persisted.
-      // This is owned here — not by `_runUpload` — so a refresh that
-      // was cancelled by a concurrent one doesn't leave a completed
-      // upload stuck in the pending list.
+      // Clean up posted records once their filename lands in the
+      // server list. Handled here rather than in `_runUpload` so a
+      // refresh cancelled by a concurrent one doesn't strand the
+      // posted record.
       final names = list.map((f) => f.filename).toSet();
       scope.pending.removeWhere(
-        (r) => r is _Pending && r.postCompleted && names.contains(r.filename),
+        (r) => r is _Posted && names.contains(r.filename),
       );
 
       _emit(scope);
-    } on Exception catch (error) {
+    } on CancelledException {
+      // Fetch was superseded or the tracker is tearing down.
+      return;
+    } on SoliplexException catch (error) {
       if (token.isCancelled || _isDisposed) return;
       scope.fetchToken = null;
       if (scope.signal.value is UploadsLoaded) {
@@ -223,6 +221,28 @@ class UploadTracker {
       } else {
         scope.signal.value = UploadsFailed(error);
       }
+    } on Object catch (error, stackTrace) {
+      // Belt-and-braces: anything that isn't a SoliplexException
+      // (including `Error` subtypes like TypeError from a bad cast)
+      // would otherwise leave the scope in UploadsLoading with a live
+      // fetchToken, wedging future refreshes. Wrap and surface.
+      if (token.isCancelled || _isDisposed) return;
+      scope.fetchToken = null;
+      dev.log(
+        'Unexpected error in upload list refresh',
+        error: error,
+        stackTrace: stackTrace,
+        name: 'UploadTracker',
+        level: 1000,
+      );
+      if (scope.signal.value is UploadsLoaded) {
+        return;
+      }
+      scope.signal.value = UploadsFailed(UnexpectedException(
+        message: 'Unexpected error while loading uploads',
+        originalError: error,
+        stackTrace: stackTrace,
+      ));
     }
   }
 
@@ -304,33 +324,41 @@ class UploadTracker {
       await post();
       if (_isDisposed) return;
 
-      // Mark the pending record as server-settled. The actual removal
-      // from `_pending` happens inside `_fetch` once the filename
-      // appears in persisted — which handles concurrent-upload races
-      // and refresh failures without silently dropping the file.
+      // Replace _Pending with _Posted at the same index. The actual
+      // removal happens in `_fetch` once the filename appears in the
+      // server list.
       final idx = scope.pending.indexWhere((r) => r.id == id);
-      if (idx < 0) {
-        // Dismissed during POST; nothing to do.
-        return;
-      }
+      if (idx < 0) return; // Dismissed during POST.
       final record = scope.pending[idx];
       if (record is _Pending) {
-        record.postCompleted = true;
+        scope.pending[idx] = _Posted(id: id, filename: record.filename);
       }
 
       unawaited(refresh());
-    } on Exception catch (error) {
+    } on Object catch (error, stackTrace) {
       if (_isDisposed) return;
+      if (error is! SoliplexException) {
+        // Non-Soliplex throw indicates a bug (e.g., TypeError from a
+        // mapper, StateError from a plugin). Log loudly; the user
+        // still sees a Failed row via uploadErrorMessage's fallback.
+        dev.log(
+          'Unexpected error during upload POST',
+          error: error,
+          stackTrace: stackTrace,
+          name: 'UploadTracker',
+          level: 1000,
+        );
+      }
       final idx = scope.pending.indexWhere((r) => r.id == id);
       if (idx < 0) {
-        // The record was dismissed (or otherwise removed) during the
-        // upload — nothing to mark as failed. Log so a future caller
-        // removing records by some other mechanism surfaces the
-        // swallowed failure.
+        // The dismiss path shouldn't be reachable (UI dismisses only
+        // Failed rows); log loudly if it ever fires so the swallowed
+        // exception is investigated.
         dev.log(
           'Upload completed after its pending record was removed',
           error: error,
           name: 'UploadTracker',
+          level: 1000,
         );
         return;
       }
@@ -344,26 +372,54 @@ class UploadTracker {
   }
 
   // --------------------------------------------------------
+  // Client-side failures
+  // --------------------------------------------------------
+
+  /// Records an upload failure that happened before any POST was
+  /// attempted (e.g., local file read error). Surfaces as a
+  /// `FailedUpload` row so the user sees the same inline feedback
+  /// as a server-side failure.
+  void recordClientError({
+    required String roomId,
+    String? threadId,
+    required String filename,
+    required String message,
+  }) {
+    if (_isDisposed) return;
+    final key =
+        threadId == null ? _roomKey(roomId) : _threadKey(roomId, threadId);
+    final scope = _scope(key);
+    final id = 'upload-${_nextId++}';
+    scope.pending.add(_Failed(id: id, filename: filename, message: message));
+    _emit(scope);
+  }
+
+  // --------------------------------------------------------
   // Dismissal
   // --------------------------------------------------------
 
-  /// Removes a Pending or Failed entry by its id. Persisted entries
-  /// come from the server and cannot be dismissed from the client.
+  /// Removes a Failed entry by its id.
   ///
-  /// Invariant: call only on Failed records. Dismissing a Pending
-  /// record mid-flight makes `UploadEventBanner` misread the removal
-  /// as a "Completed" transition when the filename is already in the
-  /// persisted list. The UI currently wires the dismiss button only
-  /// to Failed rows, preserving this invariant.
-  void dismiss(String entryId) {
+  /// Restricted to Failed records because removing a Pending or
+  /// Posted mid-flight would misrepresent the upload's state to
+  /// observers that diff the signal.
+  void dismissFailed(String entryId) {
     if (_isDisposed) return;
     for (final scope in _scopes.values) {
-      final before = scope.pending.length;
-      scope.pending.removeWhere((r) => r.id == entryId);
-      if (scope.pending.length != before) {
-        _emit(scope);
+      final idx = scope.pending.indexWhere((r) => r.id == entryId);
+      if (idx < 0) continue;
+      final record = scope.pending[idx];
+      if (record is! _Failed) {
+        assert(
+          false,
+          'dismissFailed called on ${record.runtimeType}; '
+          'only Failed records may be dismissed',
+        );
         return;
       }
+      scope.pending.removeAt(idx);
+      _emit(scope);
+      return;
     }
   }
 
@@ -380,7 +436,9 @@ class UploadTracker {
           PersistedUpload(filename: f.filename, url: f.url),
       for (final p in scope.pending)
         switch (p) {
-          _Pending() => PendingUpload(id: p.id, filename: p.filename),
+          _Pending() ||
+          _Posted() =>
+            PendingUpload(id: p.id, filename: p.filename),
           _Failed() => FailedUpload(
               id: p.id,
               filename: p.filename,

--- a/lib/src/modules/room/upload_tracker.dart
+++ b/lib/src/modules/room/upload_tracker.dart
@@ -6,10 +6,9 @@ import 'package:soliplex_client/soliplex_client.dart';
 
 /// Sealed status for a single upload scope (a room or a thread).
 ///
-/// Mirrors `ThreadListStatus` in `thread_list_state.dart`: Loading
-/// initially, Loaded once the server list is known (even if empty),
-/// Failed only from a non-Loaded baseline. A refresh failure preserves
-/// the prior Loaded list and logs.
+/// `Loaded` once the server list is known (even if empty). `Failed`
+/// only from a non-`Loaded` baseline — a refresh failure preserves
+/// the prior `Loaded` list and logs.
 sealed class UploadsStatus {
   const UploadsStatus();
 }
@@ -58,26 +57,37 @@ class FailedUpload extends DisplayUpload {
   final String message;
 }
 
-enum _PendingStatus { pending, failed }
+/// Formats an error for user display without leaking raw exception
+/// internals (stack frames, request URLs, auth headers). Extracts the
+/// message from known [SoliplexException] subtypes; falls back to a
+/// fixed, translatable string for anything else.
+String uploadErrorMessage(Object error) {
+  if (error is SoliplexException) return error.message;
+  return 'Something went wrong. Please try again.';
+}
 
-/// Internal record for a local upload the client initiated. `fileBytes`
-/// is kept so a future retry feature can re-trigger the POST without
-/// re-picking the file; bytes are released when the record is removed
-/// (on upload success, dismiss, or scope disposal).
-class _PendingRecord {
-  _PendingRecord({
-    required this.id,
-    required this.filename,
-    required this.fileBytes,
-    required this.mimeType,
-  });
-
+/// Internal record for a local upload row. Sealed so pending/failed
+/// states each carry exactly the fields they need — a pending record
+/// cannot accidentally hold an error message, and a failed record
+/// cannot lack one. Failed rows replace pending rows by index in the
+/// `_pending` list rather than mutate in place.
+sealed class _PendingRecord {
+  const _PendingRecord({required this.id, required this.filename});
   final String id;
   final String filename;
-  final List<int> fileBytes;
-  final String mimeType;
-  _PendingStatus status = _PendingStatus.pending;
-  String? errorMessage;
+}
+
+class _Pending extends _PendingRecord {
+  const _Pending({required super.id, required super.filename});
+}
+
+class _Failed extends _PendingRecord {
+  const _Failed({
+    required super.id,
+    required super.filename,
+    required this.message,
+  });
+  final String message;
 }
 
 class _ScopeState {
@@ -97,14 +107,9 @@ class _ScopeState {
 /// Tracks file uploads across rooms and threads, merging a
 /// server-fetched list with an in-flight optimistic view.
 ///
-/// State per scope is modeled as sealed `UploadsStatus`:
-/// `UploadsLoading` until the first successful fetch, `UploadsLoaded`
-/// with a merged list thereafter, `UploadsFailed` only if the initial
-/// fetch fails. A later refresh failure is logged and the prior
-/// Loaded list is preserved.
-///
-/// Owned by `UploadTrackerRegistry`, not by any single widget; see the
-/// design in `docs/plans/upload-list-merge/plan.md`.
+/// Owned by `UploadTrackerRegistry`, not by any single widget, so
+/// uploads started on one screen survive when the user navigates away
+/// before the POST resolves.
 class UploadTracker {
   UploadTracker({required SoliplexApi api}) : _api = api;
 
@@ -146,7 +151,6 @@ class UploadTracker {
     );
   }
 
-  /// Thread-scoped counterpart to [fetchRoomUploads].
   void fetchThreadUploads(String roomId, String threadId) {
     _ensureFetched(
       key: _threadKey(roomId, threadId),
@@ -155,7 +159,6 @@ class UploadTracker {
     );
   }
 
-  /// Forces a room list refetch regardless of current scope status.
   Future<void> refreshRoom(String roomId) {
     return _refresh(
       key: _roomKey(roomId),
@@ -163,7 +166,6 @@ class UploadTracker {
     );
   }
 
-  /// Forces a thread list refetch regardless of current scope status.
   Future<void> refreshThread(String roomId, String threadId) {
     return _refresh(
       key: _threadKey(roomId, threadId),
@@ -209,7 +211,7 @@ class UploadTracker {
       scope.fetchToken = null;
       scope.persisted = list;
       _emit(scope);
-    } on Object catch (error) {
+    } on Exception catch (error) {
       if (token.isCancelled || _isDisposed) return;
       scope.fetchToken = null;
       if (scope.signal.value is UploadsLoaded) {
@@ -238,8 +240,6 @@ class UploadTracker {
     _startUpload(
       key: key,
       filename: filename,
-      fileBytes: fileBytes,
-      mimeType: mimeType,
       post: () => _api.uploadFileToRoom(
         roomId,
         filename: filename,
@@ -264,8 +264,6 @@ class UploadTracker {
     _startUpload(
       key: key,
       filename: filename,
-      fileBytes: fileBytes,
-      mimeType: mimeType,
       post: () => _api.uploadFileToThread(
         roomId,
         threadId,
@@ -284,20 +282,13 @@ class UploadTracker {
   void _startUpload({
     required String key,
     required String filename,
-    required List<int> fileBytes,
-    required String mimeType,
     required Future<void> Function() post,
     required Future<void> Function() refresh,
   }) {
     if (_isDisposed) return;
     final scope = _scope(key);
     final id = 'upload-${_nextId++}';
-    scope.pending.add(_PendingRecord(
-      id: id,
-      filename: filename,
-      fileBytes: fileBytes,
-      mimeType: mimeType,
-    ));
+    scope.pending.add(_Pending(id: id, filename: filename));
     _emit(scope);
 
     unawaited(_runUpload(scope: scope, id: id, post: post, refresh: refresh));
@@ -320,15 +311,26 @@ class UploadTracker {
 
       scope.pending.removeWhere((r) => r.id == id);
       _emit(scope);
-    } on Object catch (error) {
+    } on Exception catch (error) {
       if (_isDisposed) return;
       final idx = scope.pending.indexWhere((r) => r.id == id);
-      // If the record was dismissed during the upload, nothing to mark
-      // as failed.
-      if (idx < 0) return;
-      scope.pending[idx]
-        ..status = _PendingStatus.failed
-        ..errorMessage = _errorMessage(error);
+      if (idx < 0) {
+        // The record was dismissed (or otherwise removed) during the
+        // upload — nothing to mark as failed. Log so a future caller
+        // removing records by some other mechanism surfaces the
+        // swallowed failure.
+        dev.log(
+          'Upload completed after its pending record was removed',
+          error: error,
+          name: 'UploadTracker',
+        );
+        return;
+      }
+      scope.pending[idx] = _Failed(
+        id: id,
+        filename: scope.pending[idx].filename,
+        message: uploadErrorMessage(error),
+      );
       _emit(scope);
     }
   }
@@ -363,26 +365,21 @@ class UploadTracker {
         for (final f in persisted)
           PersistedUpload(filename: f.filename, url: f.url),
       for (final p in scope.pending)
-        if (p.status == _PendingStatus.pending)
-          PendingUpload(id: p.id, filename: p.filename)
-        else
-          FailedUpload(
-            id: p.id,
-            filename: p.filename,
-            message: p.errorMessage ?? 'Upload failed',
-          ),
+        switch (p) {
+          _Pending() => PendingUpload(id: p.id, filename: p.filename),
+          _Failed() => FailedUpload(
+              id: p.id,
+              filename: p.filename,
+              message: p.message,
+            ),
+        },
     ];
 
     // No server list yet and nothing local: keep the current Loading
     // or Failed status; don't prematurely emit Loaded([]).
     if (persisted == null && merged.isEmpty) return;
 
-    scope.signal.value = UploadsLoaded(merged);
-  }
-
-  static String _errorMessage(Object error) {
-    if (error is SoliplexException) return error.message;
-    return error.toString();
+    scope.signal.value = UploadsLoaded(List.unmodifiable(merged));
   }
 
   // --------------------------------------------------------

--- a/lib/src/modules/room/upload_tracker.dart
+++ b/lib/src/modules/room/upload_tracker.dart
@@ -349,6 +349,12 @@ class UploadTracker {
 
   /// Removes a Pending or Failed entry by its id. Persisted entries
   /// come from the server and cannot be dismissed from the client.
+  ///
+  /// Invariant: call only on Failed records. Dismissing a Pending
+  /// record mid-flight makes `UploadEventBanner` misread the removal
+  /// as a "Completed" transition when the filename is already in the
+  /// persisted list. The UI currently wires the dismiss button only
+  /// to Failed rows, preserving this invariant.
   void dismiss(String entryId) {
     if (_isDisposed) return;
     for (final scope in _scopes.values) {

--- a/lib/src/modules/room/upload_tracker.dart
+++ b/lib/src/modules/room/upload_tracker.dart
@@ -155,26 +155,8 @@ class UploadTracker {
       _scope(_threadKey(roomId, threadId)).signal;
 
   // --------------------------------------------------------
-  // Fetch triggers
+  // Refresh triggers
   // --------------------------------------------------------
-
-  /// Fetches the room's upload list on first call; subsequent calls
-  /// are no-ops while the scope is already Loaded (use [refreshRoom]
-  /// to force a reload).
-  void fetchRoomUploads(String roomId) {
-    _ensureFetched(
-      key: _roomKey(roomId),
-      fetch: (token) => _api.getRoomUploads(roomId, cancelToken: token),
-    );
-  }
-
-  void fetchThreadUploads(String roomId, String threadId) {
-    _ensureFetched(
-      key: _threadKey(roomId, threadId),
-      fetch: (token) =>
-          _api.getThreadUploads(roomId, threadId, cancelToken: token),
-    );
-  }
 
   Future<void> refreshRoom(String roomId) {
     return _refresh(
@@ -189,16 +171,6 @@ class UploadTracker {
       fetch: (token) =>
           _api.getThreadUploads(roomId, threadId, cancelToken: token),
     );
-  }
-
-  void _ensureFetched({
-    required String key,
-    required Future<List<FileUpload>> Function(CancelToken) fetch,
-  }) {
-    if (_isDisposed) return;
-    final scope = _scope(key);
-    if (scope.signal.value is UploadsLoaded) return;
-    unawaited(_fetch(scope: scope, fetch: fetch));
   }
 
   Future<void> _refresh({

--- a/lib/src/modules/room/upload_tracker.dart
+++ b/lib/src/modules/room/upload_tracker.dart
@@ -1,115 +1,259 @@
 import 'dart:async' show unawaited;
+import 'dart:developer' as dev;
 
 import 'package:signals_flutter/signals_flutter.dart';
 import 'package:soliplex_client/soliplex_client.dart';
 
-/// Upload status for a single file.
-sealed class UploadStatus {
-  const UploadStatus();
-  static const uploading = UploadUploading();
-  static const success = UploadSuccess();
+/// Sealed status for a single upload scope (a room or a thread).
+///
+/// Mirrors `ThreadListStatus` in `thread_list_state.dart`: Loading
+/// initially, Loaded once the server list is known (even if empty),
+/// Failed only from a non-Loaded baseline. A refresh failure preserves
+/// the prior Loaded list and logs.
+sealed class UploadsStatus {
+  const UploadsStatus();
 }
 
-class UploadUploading extends UploadStatus {
-  const UploadUploading();
+class UploadsLoading extends UploadsStatus {
+  const UploadsLoading();
 }
 
-class UploadSuccess extends UploadStatus {
-  const UploadSuccess();
+class UploadsLoaded extends UploadsStatus {
+  const UploadsLoaded(this.uploads);
+  final List<DisplayUpload> uploads;
 }
 
-class UploadError extends UploadStatus {
-  const UploadError(this.message);
+class UploadsFailed extends UploadsStatus {
+  const UploadsFailed(this.error);
+  final Object error;
+}
+
+/// Sealed display variant for a single row in the merged uploads list.
+///
+/// Persisted rows come from the server LIST endpoint; Pending and
+/// Failed rows are local optimistic entries driven by in-flight or
+/// recently-failed POST uploads.
+sealed class DisplayUpload {
+  const DisplayUpload({required this.filename});
+  final String filename;
+}
+
+class PersistedUpload extends DisplayUpload {
+  const PersistedUpload({required super.filename, required this.url});
+  final Uri url;
+}
+
+class PendingUpload extends DisplayUpload {
+  const PendingUpload({required this.id, required super.filename});
+  final String id;
+}
+
+class FailedUpload extends DisplayUpload {
+  const FailedUpload({
+    required this.id,
+    required super.filename,
+    required this.message,
+  });
+  final String id;
   final String message;
 }
 
-/// A single tracked upload.
-class UploadEntry {
-  UploadEntry({
+enum _PendingStatus { pending, failed }
+
+/// Internal record for a local upload the client initiated. `fileBytes`
+/// is kept so a future retry feature can re-trigger the POST without
+/// re-picking the file; bytes are released when the record is removed
+/// (on upload success, dismiss, or scope disposal).
+class _PendingRecord {
+  _PendingRecord({
     required this.id,
     required this.filename,
-    required this.status,
-    required this.scope,
+    required this.fileBytes,
+    required this.mimeType,
   });
 
   final String id;
   final String filename;
-  final UploadStatus status;
-
-  /// The scope key this entry belongs to (room or room+thread).
-  final String scope;
-
-  UploadEntry _withStatus(UploadStatus newStatus) => UploadEntry(
-        id: id,
-        filename: filename,
-        status: newStatus,
-        scope: scope,
-      );
+  final List<int> fileBytes;
+  final String mimeType;
+  _PendingStatus status = _PendingStatus.pending;
+  String? errorMessage;
 }
 
-/// Tracks file upload state across rooms and threads.
-///
-/// Each upload is fire-and-forget: it starts immediately and transitions
-/// through uploading → success/error. The tracker exposes signals per
-/// scope so the UI can react.
-///
-/// This only tracks uploads initiated in this session. There is no
-/// backend endpoint to list previously uploaded files.
-// TODO(backend): Add GET /v1/uploads/{room_id} and
-// GET /v1/uploads/{room_id}/{thread_id} endpoints to list uploaded files,
-// then replace session-only tracking with server-fetched lists.
-class UploadTracker {
-  final Map<String, Signal<List<UploadEntry>>> _scopes = {};
-  int _nextId = 0;
-  bool _disposed = false;
+class _ScopeState {
+  _ScopeState() : signal = Signal<UploadsStatus>(const UploadsLoading());
 
-  Signal<List<UploadEntry>> _scopeSignal(String key) =>
-      _scopes.putIfAbsent(key, () => Signal<List<UploadEntry>>([]));
+  List<FileUpload>? persisted;
+  final List<_PendingRecord> pending = [];
+  CancelToken? fetchToken;
+  final Signal<UploadsStatus> signal;
+
+  void dispose() {
+    fetchToken?.cancel('disposed');
+    signal.dispose();
+  }
+}
+
+/// Tracks file uploads across rooms and threads, merging a
+/// server-fetched list with an in-flight optimistic view.
+///
+/// State per scope is modeled as sealed `UploadsStatus`:
+/// `UploadsLoading` until the first successful fetch, `UploadsLoaded`
+/// with a merged list thereafter, `UploadsFailed` only if the initial
+/// fetch fails. A later refresh failure is logged and the prior
+/// Loaded list is preserved.
+///
+/// Owned by `UploadTrackerRegistry`, not by any single widget; see the
+/// design in `docs/plans/upload-list-merge/plan.md`.
+class UploadTracker {
+  UploadTracker({required SoliplexApi api}) : _api = api;
+
+  final SoliplexApi _api;
+  final Map<String, _ScopeState> _scopes = {};
+  bool _isDisposed = false;
+  int _nextId = 0;
 
   static String _roomKey(String roomId) => 'room:$roomId';
-
   static String _threadKey(String roomId, String threadId) =>
       'thread:$roomId:$threadId';
 
-  /// Signal of uploads for a room scope.
-  ReadonlySignal<List<UploadEntry>> roomUploads(String roomId) =>
-      _scopeSignal(_roomKey(roomId));
+  _ScopeState _scope(String key) => _scopes.putIfAbsent(key, _ScopeState.new);
 
-  /// Signal of uploads for a thread scope.
-  ReadonlySignal<List<UploadEntry>> threadUploads(
+  // --------------------------------------------------------
+  // Public signals
+  // --------------------------------------------------------
+
+  ReadonlySignal<UploadsStatus> roomUploads(String roomId) =>
+      _scope(_roomKey(roomId)).signal;
+
+  ReadonlySignal<UploadsStatus> threadUploads(
     String roomId,
     String threadId,
   ) =>
-      _scopeSignal(_threadKey(roomId, threadId));
+      _scope(_threadKey(roomId, threadId)).signal;
 
-  /// Starts a room-level upload.
+  // --------------------------------------------------------
+  // Fetch triggers
+  // --------------------------------------------------------
+
+  /// Fetches the room's upload list on first call; subsequent calls
+  /// are no-ops while the scope is already Loaded (use [refreshRoom]
+  /// to force a reload).
+  void fetchRoomUploads(String roomId) {
+    _ensureFetched(
+      key: _roomKey(roomId),
+      fetch: (token) => _api.getRoomUploads(roomId, cancelToken: token),
+    );
+  }
+
+  /// Thread-scoped counterpart to [fetchRoomUploads].
+  void fetchThreadUploads(String roomId, String threadId) {
+    _ensureFetched(
+      key: _threadKey(roomId, threadId),
+      fetch: (token) =>
+          _api.getThreadUploads(roomId, threadId, cancelToken: token),
+    );
+  }
+
+  /// Forces a room list refetch regardless of current scope status.
+  Future<void> refreshRoom(String roomId) {
+    return _refresh(
+      key: _roomKey(roomId),
+      fetch: (token) => _api.getRoomUploads(roomId, cancelToken: token),
+    );
+  }
+
+  /// Forces a thread list refetch regardless of current scope status.
+  Future<void> refreshThread(String roomId, String threadId) {
+    return _refresh(
+      key: _threadKey(roomId, threadId),
+      fetch: (token) =>
+          _api.getThreadUploads(roomId, threadId, cancelToken: token),
+    );
+  }
+
+  void _ensureFetched({
+    required String key,
+    required Future<List<FileUpload>> Function(CancelToken) fetch,
+  }) {
+    if (_isDisposed) return;
+    final scope = _scope(key);
+    if (scope.signal.value is UploadsLoaded) return;
+    unawaited(_fetch(scope: scope, fetch: fetch));
+  }
+
+  Future<void> _refresh({
+    required String key,
+    required Future<List<FileUpload>> Function(CancelToken) fetch,
+  }) {
+    if (_isDisposed) return Future<void>.value();
+    return _fetch(scope: _scope(key), fetch: fetch);
+  }
+
+  Future<void> _fetch({
+    required _ScopeState scope,
+    required Future<List<FileUpload>> Function(CancelToken) fetch,
+  }) async {
+    if (_isDisposed) return;
+    scope.fetchToken?.cancel('re-fetch');
+    final token = CancelToken();
+    scope.fetchToken = token;
+
+    if (scope.signal.value is! UploadsLoaded) {
+      scope.signal.value = const UploadsLoading();
+    }
+
+    try {
+      final list = await fetch(token);
+      if (token.isCancelled || _isDisposed) return;
+      scope.fetchToken = null;
+      scope.persisted = list;
+      _emit(scope);
+    } on Object catch (error) {
+      if (token.isCancelled || _isDisposed) return;
+      scope.fetchToken = null;
+      if (scope.signal.value is UploadsLoaded) {
+        dev.log(
+          'Upload list refresh failed, keeping stale list',
+          error: error,
+          name: 'UploadTracker',
+        );
+      } else {
+        scope.signal.value = UploadsFailed(error);
+      }
+    }
+  }
+
+  // --------------------------------------------------------
+  // Upload actions
+  // --------------------------------------------------------
+
   void uploadToRoom({
-    required SoliplexApi api,
     required String roomId,
     required String filename,
     required List<int> fileBytes,
     String mimeType = 'application/octet-stream',
   }) {
     final key = _roomKey(roomId);
-    final entry = _addEntry(key, filename);
-    unawaited(
-      api
-          .uploadFileToRoom(
-            roomId,
-            filename: filename,
-            fileBytes: fileBytes,
-            mimeType: mimeType,
-          )
-          .then((_) => _updateStatus(key, entry.id, UploadStatus.success))
-          .catchError((Object error) {
-        _updateStatus(key, entry.id, UploadError(_errorMessage(error)));
-      }),
+    _startUpload(
+      key: key,
+      filename: filename,
+      fileBytes: fileBytes,
+      mimeType: mimeType,
+      post: () => _api.uploadFileToRoom(
+        roomId,
+        filename: filename,
+        fileBytes: fileBytes,
+        mimeType: mimeType,
+      ),
+      refresh: () => _refresh(
+        key: key,
+        fetch: (token) => _api.getRoomUploads(roomId, cancelToken: token),
+      ),
     );
   }
 
-  /// Starts a thread-level upload.
   void uploadToThread({
-    required SoliplexApi api,
     required String roomId,
     required String threadId,
     required String filename,
@@ -117,56 +261,123 @@ class UploadTracker {
     String mimeType = 'application/octet-stream',
   }) {
     final key = _threadKey(roomId, threadId);
-    final entry = _addEntry(key, filename);
-    unawaited(
-      api
-          .uploadFileToThread(
-            roomId,
-            threadId,
-            filename: filename,
-            fileBytes: fileBytes,
-            mimeType: mimeType,
-          )
-          .then((_) => _updateStatus(key, entry.id, UploadStatus.success))
-          .catchError((Object error) {
-        _updateStatus(key, entry.id, UploadError(_errorMessage(error)));
-      }),
+    _startUpload(
+      key: key,
+      filename: filename,
+      fileBytes: fileBytes,
+      mimeType: mimeType,
+      post: () => _api.uploadFileToThread(
+        roomId,
+        threadId,
+        filename: filename,
+        fileBytes: fileBytes,
+        mimeType: mimeType,
+      ),
+      refresh: () => _refresh(
+        key: key,
+        fetch: (token) =>
+            _api.getThreadUploads(roomId, threadId, cancelToken: token),
+      ),
     );
   }
 
-  /// Removes an entry (e.g., user dismisses an error or completed upload).
+  void _startUpload({
+    required String key,
+    required String filename,
+    required List<int> fileBytes,
+    required String mimeType,
+    required Future<void> Function() post,
+    required Future<void> Function() refresh,
+  }) {
+    if (_isDisposed) return;
+    final scope = _scope(key);
+    final id = 'upload-${_nextId++}';
+    scope.pending.add(_PendingRecord(
+      id: id,
+      filename: filename,
+      fileBytes: fileBytes,
+      mimeType: mimeType,
+    ));
+    _emit(scope);
+
+    unawaited(_runUpload(scope: scope, id: id, post: post, refresh: refresh));
+  }
+
+  Future<void> _runUpload({
+    required _ScopeState scope,
+    required String id,
+    required Future<void> Function() post,
+    required Future<void> Function() refresh,
+  }) async {
+    try {
+      await post();
+      if (_isDisposed) return;
+
+      // Refresh BEFORE dropping the pending record so the UI never
+      // shows a gap between "Pending" and "Persisted".
+      await refresh();
+      if (_isDisposed) return;
+
+      scope.pending.removeWhere((r) => r.id == id);
+      _emit(scope);
+    } on Object catch (error) {
+      if (_isDisposed) return;
+      final idx = scope.pending.indexWhere((r) => r.id == id);
+      // If the record was dismissed during the upload, nothing to mark
+      // as failed.
+      if (idx < 0) return;
+      scope.pending[idx]
+        ..status = _PendingStatus.failed
+        ..errorMessage = _errorMessage(error);
+      _emit(scope);
+    }
+  }
+
+  // --------------------------------------------------------
+  // Dismissal
+  // --------------------------------------------------------
+
+  /// Removes a Pending or Failed entry by its id. Persisted entries
+  /// come from the server and cannot be dismissed from the client.
   void dismiss(String entryId) {
-    for (final signal in _scopes.values) {
-      final list = signal.value;
-      final index = list.indexWhere((e) => e.id == entryId);
-      if (index >= 0) {
-        signal.value = [...list]..removeAt(index);
+    if (_isDisposed) return;
+    for (final scope in _scopes.values) {
+      final before = scope.pending.length;
+      scope.pending.removeWhere((r) => r.id == entryId);
+      if (scope.pending.length != before) {
+        _emit(scope);
         return;
       }
     }
   }
 
-  UploadEntry _addEntry(String scopeKey, String filename) {
-    final id = 'upload-${_nextId++}';
-    final entry = UploadEntry(
-      id: id,
-      filename: filename,
-      status: UploadStatus.uploading,
-      scope: scopeKey,
-    );
-    final signal = _scopeSignal(scopeKey);
-    signal.value = [...signal.value, entry];
-    return entry;
-  }
+  // --------------------------------------------------------
+  // Signal emission
+  // --------------------------------------------------------
 
-  void _updateStatus(String scopeKey, String entryId, UploadStatus status) {
-    if (_disposed) return;
-    final signal = _scopes[scopeKey];
-    if (signal == null) return;
-    signal.value = [
-      for (final e in signal.value)
-        if (e.id == entryId) e._withStatus(status) else e,
+  void _emit(_ScopeState scope) {
+    if (_isDisposed) return;
+    final persisted = scope.persisted;
+    final merged = <DisplayUpload>[
+      if (persisted != null)
+        for (final f in persisted)
+          PersistedUpload(filename: f.filename, url: f.url),
+      for (final p in scope.pending)
+        if (p.status == _PendingStatus.pending)
+          PendingUpload(id: p.id, filename: p.filename)
+        else
+          FailedUpload(
+            id: p.id,
+            filename: p.filename,
+            message: p.errorMessage ?? 'Upload failed',
+          ),
     ];
+
+    // No server list yet and nothing local: keep the current Loading
+    // or Failed status; don't prematurely emit Loaded([]).
+    if (persisted == null && merged.isEmpty) return;
+
+    scope.signal.value = UploadsLoaded(merged);
   }
 
   static String _errorMessage(Object error) {
@@ -174,10 +385,15 @@ class UploadTracker {
     return error.toString();
   }
 
+  // --------------------------------------------------------
+  // Lifecycle
+  // --------------------------------------------------------
+
   void dispose() {
-    _disposed = true;
-    for (final signal in _scopes.values) {
-      signal.dispose();
+    if (_isDisposed) return;
+    _isDisposed = true;
+    for (final scope in _scopes.values) {
+      scope.dispose();
     }
     _scopes.clear();
   }

--- a/lib/src/modules/room/upload_tracker.dart
+++ b/lib/src/modules/room/upload_tracker.dart
@@ -78,7 +78,19 @@ sealed class _PendingRecord {
 }
 
 class _Pending extends _PendingRecord {
-  const _Pending({required super.id, required super.filename});
+  _Pending({required super.id, required super.filename});
+
+  /// Flipped to `true` by `_runUpload` once the POST has completed
+  /// server-side. A successful `_fetch` drops the record only when
+  /// this is set AND the filename is in the refreshed persisted list.
+  /// Guards against: (a) concurrent uploads where one refresh
+  /// cancels another (the next refresh's success still cleans up),
+  /// (b) refresh failures after a successful POST (pending stays
+  /// visible as a spinner; the next refresh resolves it), and (c)
+  /// pre-existing same-name files on the server (the filename
+  /// already matches but the post is still in flight, so we don't
+  /// drop prematurely).
+  bool postCompleted = false;
 }
 
 class _Failed extends _PendingRecord {
@@ -117,6 +129,11 @@ class UploadTracker {
   final Map<String, _ScopeState> _scopes = {};
   bool _isDisposed = false;
   int _nextId = 0;
+
+  /// True after [dispose] has been called. Primarily for the
+  /// `UploadTrackerRegistry` eviction tests to verify that evicted
+  /// trackers are actually disposed, not just removed from the map.
+  bool get isDisposed => _isDisposed;
 
   static String _roomKey(String roomId) => 'room:$roomId';
   static String _threadKey(String roomId, String threadId) =>
@@ -210,6 +227,17 @@ class UploadTracker {
       if (token.isCancelled || _isDisposed) return;
       scope.fetchToken = null;
       scope.persisted = list;
+
+      // Clean up pending records whose upload has server-settled
+      // (postCompleted) and whose filename now appears in persisted.
+      // This is owned here — not by `_runUpload` — so a refresh that
+      // was cancelled by a concurrent one doesn't leave a completed
+      // upload stuck in the pending list.
+      final names = list.map((f) => f.filename).toSet();
+      scope.pending.removeWhere(
+        (r) => r is _Pending && r.postCompleted && names.contains(r.filename),
+      );
+
       _emit(scope);
     } on Exception catch (error) {
       if (token.isCancelled || _isDisposed) return;
@@ -304,13 +332,21 @@ class UploadTracker {
       await post();
       if (_isDisposed) return;
 
-      // Refresh BEFORE dropping the pending record so the UI never
-      // shows a gap between "Pending" and "Persisted".
-      await refresh();
-      if (_isDisposed) return;
+      // Mark the pending record as server-settled. The actual removal
+      // from `_pending` happens inside `_fetch` once the filename
+      // appears in persisted — which handles concurrent-upload races
+      // and refresh failures without silently dropping the file.
+      final idx = scope.pending.indexWhere((r) => r.id == id);
+      if (idx < 0) {
+        // Dismissed during POST; nothing to do.
+        return;
+      }
+      final record = scope.pending[idx];
+      if (record is _Pending) {
+        record.postCompleted = true;
+      }
 
-      scope.pending.removeWhere((r) => r.id == id);
-      _emit(scope);
+      unawaited(refresh());
     } on Exception catch (error) {
       if (_isDisposed) return;
       final idx = scope.pending.indexWhere((r) => r.id == id);

--- a/lib/src/modules/room/upload_tracker_registry.dart
+++ b/lib/src/modules/room/upload_tracker_registry.dart
@@ -18,6 +18,12 @@ import 'upload_tracker.dart';
 /// disposes every tracker whose `serverId` disappears from that map
 /// (typically when the user disconnects a server). All remaining
 /// trackers are disposed when the registry itself is disposed.
+///
+/// Lifetime: the registry is process-scoped by design. Production
+/// shell teardown does not call [dispose]; an upload started on one
+/// screen must survive navigation to another, which the per-server
+/// eviction path already handles. [dispose] exists for tests and for
+/// the per-tracker cleanup invoked from eviction.
 class UploadTrackerRegistry {
   UploadTrackerRegistry({
     required ReadonlySignal<Map<String, ServerEntry>> servers,
@@ -39,12 +45,9 @@ class UploadTrackerRegistry {
   /// a server that is never (or no longer) live will not be subject
   /// to the server-removal eviction path.
   ///
-  /// Note: identity is keyed on `(serverId, roomId)` only. This
-  /// assumes `ServerManager` never hot-swaps an entry's `connection`
-  /// without first going through `removeServer` (which evicts the
-  /// tracker). If that ever changes, the registry must also be
-  /// invalidated or re-keyed to avoid returning a tracker holding a
-  /// stale [SoliplexApi].
+  /// Identity is keyed on `(serverId, roomId)` only — assumes
+  /// `ServerManager` never hot-swaps an entry's `connection` without
+  /// first going through `removeServer` (which evicts the tracker).
   UploadTracker trackerFor({
     required ServerEntry entry,
     required String roomId,

--- a/lib/src/modules/room/upload_tracker_registry.dart
+++ b/lib/src/modules/room/upload_tracker_registry.dart
@@ -38,6 +38,13 @@ class UploadTrackerRegistry {
   /// present in the injected `servers` signal; a tracker created for
   /// a server that is never (or no longer) live will not be subject
   /// to the server-removal eviction path.
+  ///
+  /// Note: identity is keyed on `(serverId, roomId)` only. This
+  /// assumes `ServerManager` never hot-swaps an entry's `connection`
+  /// without first going through `removeServer` (which evicts the
+  /// tracker). If that ever changes, the registry must also be
+  /// invalidated or re-keyed to avoid returning a tracker holding a
+  /// stale [SoliplexApi].
   UploadTracker trackerFor({
     required ServerEntry entry,
     required String roomId,

--- a/lib/src/modules/room/upload_tracker_registry.dart
+++ b/lib/src/modules/room/upload_tracker_registry.dart
@@ -1,0 +1,70 @@
+import 'package:signals_flutter/signals_flutter.dart';
+
+import '../auth/server_entry.dart';
+import 'upload_tracker.dart';
+
+/// Module-scoped registry that hands out one `UploadTracker` per
+/// `(serverId, roomId)`.
+///
+/// Trackers must outlive the widgets that mount them — an upload
+/// started on the room-info screen may complete *after* the user taps
+/// back, which would orphan a per-screen tracker. This registry is
+/// constructed once in `room_module.dart` (alongside
+/// `AgentRuntimeManager` and `RunRegistry`) and threaded into
+/// `RoomScreen` and `RoomInfoScreen` so both read from the same
+/// underlying tracker instance.
+///
+/// Eviction: the registry subscribes to `ServerManager.servers` and
+/// disposes every tracker whose `serverId` disappears from that map
+/// (typically when the user disconnects a server). All remaining
+/// trackers are disposed when the registry itself is disposed.
+class UploadTrackerRegistry {
+  UploadTrackerRegistry({
+    required ReadonlySignal<Map<String, ServerEntry>> servers,
+  }) : _servers = servers {
+    _unsubscribe = _servers.subscribe(_evictRemoved);
+  }
+
+  final ReadonlySignal<Map<String, ServerEntry>> _servers;
+  final Map<(String, String), UploadTracker> _trackers = {};
+  late final void Function() _unsubscribe;
+  bool _isDisposed = false;
+
+  /// Returns (or lazily creates) the tracker for the given
+  /// `(serverId, roomId)`. Throws [StateError] if the registry has
+  /// been disposed.
+  UploadTracker trackerFor({
+    required ServerEntry entry,
+    required String roomId,
+  }) {
+    if (_isDisposed) {
+      throw StateError('UploadTrackerRegistry has been disposed');
+    }
+    final key = (entry.serverId, roomId);
+    return _trackers.putIfAbsent(
+      key,
+      () => UploadTracker(api: entry.connection.api),
+    );
+  }
+
+  void _evictRemoved(Map<String, ServerEntry> snapshot) {
+    if (_isDisposed) return;
+    final liveIds = snapshot.keys.toSet();
+    final dead =
+        _trackers.entries.where((e) => !liveIds.contains(e.key.$1)).toList();
+    for (final entry in dead) {
+      entry.value.dispose();
+      _trackers.remove(entry.key);
+    }
+  }
+
+  void dispose() {
+    if (_isDisposed) return;
+    _isDisposed = true;
+    _unsubscribe();
+    for (final tracker in _trackers.values) {
+      tracker.dispose();
+    }
+    _trackers.clear();
+  }
+}

--- a/lib/src/modules/room/upload_tracker_registry.dart
+++ b/lib/src/modules/room/upload_tracker_registry.dart
@@ -33,6 +33,11 @@ class UploadTrackerRegistry {
   /// Returns (or lazily creates) the tracker for the given
   /// `(serverId, roomId)`. Throws [StateError] if the registry has
   /// been disposed.
+  ///
+  /// Callers should pass a [ServerEntry] whose `serverId` is still
+  /// present in the injected `servers` signal; a tracker created for
+  /// a server that is never (or no longer) live will not be subject
+  /// to the server-removal eviction path.
   UploadTracker trackerFor({
     required ServerEntry entry,
     required String roomId,

--- a/packages/soliplex_client/lib/src/api/mappers.dart
+++ b/packages/soliplex_client/lib/src/api/mappers.dart
@@ -1,6 +1,7 @@
 import 'dart:developer' as developer;
 
 import 'package:soliplex_client/src/domain/backend_version_info.dart';
+import 'package:soliplex_client/src/domain/file_upload.dart';
 import 'package:soliplex_client/src/domain/mcp_client_toolset.dart';
 import 'package:soliplex_client/src/domain/quiz.dart';
 import 'package:soliplex_client/src/domain/rag_document.dart';
@@ -393,6 +394,21 @@ Map<String, dynamic> ragDocumentToJson(RagDocument doc) {
     if (doc.createdAt != null) 'created_at': formatTimestamp(doc.createdAt!),
     if (doc.updatedAt != null) 'updated_at': formatTimestamp(doc.updatedAt!),
   };
+}
+
+// ============================================================
+// FileUpload mappers
+// ============================================================
+
+/// Creates a [FileUpload] from JSON.
+///
+/// Throws [FormatException] if `filename` or `url` is missing or
+/// malformed.
+FileUpload fileUploadFromJson(Map<String, dynamic> json) {
+  return FileUpload(
+    filename: _requireString(json, 'filename', 'file upload'),
+    url: Uri.parse(_requireString(json, 'url', 'file upload')),
+  );
 }
 
 // ============================================================

--- a/packages/soliplex_client/lib/src/api/soliplex_api.dart
+++ b/packages/soliplex_client/lib/src/api/soliplex_api.dart
@@ -9,6 +9,7 @@ import 'package:soliplex_client/src/domain/backend_version_info.dart';
 import 'package:soliplex_client/src/domain/chunk_visualization.dart';
 import 'package:soliplex_client/src/domain/conversation.dart';
 import 'package:soliplex_client/src/domain/feedback_type.dart';
+import 'package:soliplex_client/src/domain/file_upload.dart';
 import 'package:soliplex_client/src/domain/message_state.dart';
 import 'package:soliplex_client/src/domain/quiz.dart';
 import 'package:soliplex_client/src/domain/rag_document.dart';
@@ -980,6 +981,69 @@ class SoliplexApi {
   // Uploads
   // ============================================================
 
+  /// Lists files uploaded to a room's shared upload directory.
+  ///
+  /// Parameters:
+  /// - [roomId]: The room ID (must not be empty)
+  ///
+  /// Returns a list of [FileUpload] entries. Malformed entries in the
+  /// response are logged and skipped.
+  ///
+  /// Throws:
+  /// - [ArgumentError] if [roomId] is empty
+  /// - [NotFoundException] if room not found (404)
+  /// - [AuthException] if not authenticated (401/403)
+  /// - [NetworkException] if connection fails
+  /// - [ApiException] for other server errors
+  /// - [CancelledException] if cancelled via [cancelToken]
+  Future<List<FileUpload>> getRoomUploads(
+    String roomId, {
+    CancelToken? cancelToken,
+  }) async {
+    _requireNonEmpty(roomId, 'roomId');
+
+    final response = await _transport.request<Map<String, dynamic>>(
+      'GET',
+      _urlBuilder.build(pathSegments: ['uploads', roomId]),
+      cancelToken: cancelToken,
+    );
+
+    return _parseUploadsList(response);
+  }
+
+  /// Lists files uploaded to a thread within a room.
+  ///
+  /// Parameters:
+  /// - [roomId]: The room ID (must not be empty)
+  /// - [threadId]: The thread ID (must not be empty)
+  ///
+  /// Returns a list of [FileUpload] entries. Malformed entries in the
+  /// response are logged and skipped.
+  ///
+  /// Throws:
+  /// - [ArgumentError] if [roomId] or [threadId] is empty
+  /// - [NotFoundException] if room or thread not found (404)
+  /// - [AuthException] if not authenticated (401/403)
+  /// - [NetworkException] if connection fails
+  /// - [ApiException] for other server errors
+  /// - [CancelledException] if cancelled via [cancelToken]
+  Future<List<FileUpload>> getThreadUploads(
+    String roomId,
+    String threadId, {
+    CancelToken? cancelToken,
+  }) async {
+    _requireNonEmpty(roomId, 'roomId');
+    _requireNonEmpty(threadId, 'threadId');
+
+    final response = await _transport.request<Map<String, dynamic>>(
+      'GET',
+      _urlBuilder.build(pathSegments: ['uploads', roomId, threadId]),
+      cancelToken: cancelToken,
+    );
+
+    return _parseUploadsList(response);
+  }
+
   /// Uploads a file to a room's shared upload directory.
   ///
   /// The backend stores the file at `{upload_path}/rooms/{roomId}/`.
@@ -1050,5 +1114,27 @@ class SoliplexApi {
     if (value.isEmpty) {
       throw ArgumentError.value(value, name, 'must not be empty');
     }
+  }
+
+  /// Extracts `FileUpload` entries from an uploads-list response.
+  ///
+  /// Malformed entries are logged and skipped so one bad row can't
+  /// break the whole list.
+  List<FileUpload> _parseUploadsList(Map<String, dynamic> response) {
+    final uploads = response['uploads'] as List<dynamic>?;
+    if (uploads == null || uploads.isEmpty) return const [];
+    final result = <FileUpload>[];
+    for (final entry in uploads) {
+      try {
+        result.add(fileUploadFromJson(entry as Map<String, dynamic>));
+      } on Object catch (e) {
+        developer.log(
+          'Malformed file upload ignored: $e',
+          name: 'soliplex_client.api',
+          level: 900,
+        );
+      }
+    }
+    return result;
   }
 }

--- a/packages/soliplex_client/lib/src/api/soliplex_api.dart
+++ b/packages/soliplex_client/lib/src/api/soliplex_api.dart
@@ -1118,13 +1118,30 @@ class SoliplexApi {
 
   /// Extracts `FileUpload` entries from an uploads-list response.
   ///
-  /// Malformed entries are logged and skipped so one bad row can't
-  /// break the whole list.
+  /// Missing `uploads` key is logged and treated as an empty list so a
+  /// transient server omission doesn't break the UI. A non-list value
+  /// under `uploads` indicates a schema mismatch and is raised as
+  /// [UnexpectedException] so callers surface a real error. Malformed
+  /// per-entry rows are logged and skipped.
   List<FileUpload> _parseUploadsList(Map<String, dynamic> response) {
-    final uploads = response['uploads'] as List<dynamic>?;
-    if (uploads == null || uploads.isEmpty) return const [];
+    final raw = response['uploads'];
+    if (raw == null) {
+      developer.log(
+        'Upload list response missing "uploads" key; treating as empty',
+        name: 'soliplex_client.api',
+        level: 900,
+      );
+      return const [];
+    }
+    if (raw is! List) {
+      throw UnexpectedException(
+        message: 'Upload list response has non-list "uploads" field: '
+            '${raw.runtimeType}',
+      );
+    }
+    if (raw.isEmpty) return const [];
     final result = <FileUpload>[];
-    for (final entry in uploads) {
+    for (final entry in raw) {
       if (entry is! Map<String, dynamic>) {
         developer.log(
           'Malformed file upload ignored: expected a JSON object, '

--- a/packages/soliplex_client/lib/src/api/soliplex_api.dart
+++ b/packages/soliplex_client/lib/src/api/soliplex_api.dart
@@ -1125,9 +1125,18 @@ class SoliplexApi {
     if (uploads == null || uploads.isEmpty) return const [];
     final result = <FileUpload>[];
     for (final entry in uploads) {
+      if (entry is! Map<String, dynamic>) {
+        developer.log(
+          'Malformed file upload ignored: expected a JSON object, '
+          'got ${entry.runtimeType}',
+          name: 'soliplex_client.api',
+          level: 900,
+        );
+        continue;
+      }
       try {
-        result.add(fileUploadFromJson(entry as Map<String, dynamic>));
-      } on Object catch (e) {
+        result.add(fileUploadFromJson(entry));
+      } on FormatException catch (e) {
         developer.log(
           'Malformed file upload ignored: $e',
           name: 'soliplex_client.api',

--- a/packages/soliplex_client/lib/src/api/soliplex_api.dart
+++ b/packages/soliplex_client/lib/src/api/soliplex_api.dart
@@ -1037,7 +1037,7 @@ class SoliplexApi {
 
     final response = await _transport.request<Map<String, dynamic>>(
       'GET',
-      _urlBuilder.build(pathSegments: ['uploads', roomId, threadId]),
+      _urlBuilder.build(pathSegments: ['uploads', roomId, 'thread', threadId]),
       cancelToken: cancelToken,
     );
 

--- a/packages/soliplex_client/lib/src/domain/domain.dart
+++ b/packages/soliplex_client/lib/src/domain/domain.dart
@@ -4,6 +4,7 @@ export 'chat_message.dart';
 export 'chunk_visualization.dart';
 export 'conversation.dart';
 export 'feedback_type.dart';
+export 'file_upload.dart';
 export 'llm_event.dart';
 export 'llm_tool.dart';
 export 'mcp_client_toolset.dart';

--- a/packages/soliplex_client/lib/src/domain/file_upload.dart
+++ b/packages/soliplex_client/lib/src/domain/file_upload.dart
@@ -19,17 +19,6 @@ class FileUpload {
   /// URL for downloading the file.
   final Uri url;
 
-  /// Creates a copy of this entry with the given fields replaced.
-  FileUpload copyWith({
-    String? filename,
-    Uri? url,
-  }) {
-    return FileUpload(
-      filename: filename ?? this.filename,
-      url: url ?? this.url,
-    );
-  }
-
   @override
   bool operator ==(Object other) {
     if (identical(this, other)) return true;

--- a/packages/soliplex_client/lib/src/domain/file_upload.dart
+++ b/packages/soliplex_client/lib/src/domain/file_upload.dart
@@ -1,0 +1,46 @@
+import 'package:meta/meta.dart';
+
+/// A file persisted in the backend's upload directory for a room or
+/// thread.
+///
+/// Returned by `GET /uploads/{room_id}` and
+/// `GET /uploads/{room_id}/{thread_id}`.
+@immutable
+class FileUpload {
+  /// Creates a file upload entry.
+  const FileUpload({
+    required this.filename,
+    required this.url,
+  });
+
+  /// User-visible filename as stored by the backend.
+  final String filename;
+
+  /// URL for downloading the file.
+  final Uri url;
+
+  /// Creates a copy of this entry with the given fields replaced.
+  FileUpload copyWith({
+    String? filename,
+    Uri? url,
+  }) {
+    return FileUpload(
+      filename: filename ?? this.filename,
+      url: url ?? this.url,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    return other is FileUpload &&
+        other.filename == filename &&
+        other.url == url;
+  }
+
+  @override
+  int get hashCode => Object.hash(filename, url);
+
+  @override
+  String toString() => 'FileUpload(filename: $filename, url: $url)';
+}

--- a/packages/soliplex_client/lib/src/errors/exceptions.dart
+++ b/packages/soliplex_client/lib/src/errors/exceptions.dart
@@ -155,3 +155,23 @@ class CancelledException extends SoliplexException {
     return 'CancelledException';
   }
 }
+
+/// Exception thrown when an unexpected, non-Soliplex error must be
+/// surfaced through the client's error channel.
+///
+/// Use to wrap `Error` subtypes (e.g., `TypeError` from a schema
+/// mismatch) or any other throwable that is not already a
+/// [SoliplexException]. Keeps the `All exceptions must be
+/// SoliplexException subtypes` invariant intact at the client boundary
+/// without swallowing the cause.
+class UnexpectedException extends SoliplexException {
+  /// Creates an unexpected exception.
+  const UnexpectedException({
+    required super.message,
+    super.originalError,
+    super.stackTrace,
+  });
+
+  @override
+  String toString() => 'UnexpectedException: $message';
+}

--- a/packages/soliplex_client/test/api/mappers_test.dart
+++ b/packages/soliplex_client/test/api/mappers_test.dart
@@ -1,4 +1,5 @@
 import 'package:soliplex_client/src/api/mappers.dart';
+import 'package:soliplex_client/src/domain/file_upload.dart';
 import 'package:soliplex_client/src/domain/quiz.dart';
 import 'package:soliplex_client/src/domain/rag_document.dart';
 import 'package:soliplex_client/src/domain/room.dart';
@@ -1877,6 +1878,68 @@ void main() {
         threadMetadataToJson(name: 'My Thread', description: 'A description'),
         equals({'name': 'My Thread', 'description': 'A description'}),
       );
+    });
+  });
+
+  group('FileUpload mappers', () {
+    group('fileUploadFromJson', () {
+      test('parses correctly with all fields', () {
+        final result = fileUploadFromJson({
+          'filename': 'report.pdf',
+          'url': 'https://example.com/uploads/room-1/report.pdf',
+        });
+
+        expect(result.filename, 'report.pdf');
+        expect(
+          result.url.toString(),
+          'https://example.com/uploads/room-1/report.pdf',
+        );
+        expect(result, isA<FileUpload>());
+      });
+
+      test('throws FormatException when filename is missing', () {
+        expect(
+          () => fileUploadFromJson({'url': 'https://example.com/a'}),
+          throwsFormatException,
+        );
+      });
+
+      test('throws FormatException when url is missing', () {
+        expect(
+          () => fileUploadFromJson({'filename': 'a.pdf'}),
+          throwsFormatException,
+        );
+      });
+
+      test('throws FormatException when filename is non-string', () {
+        expect(
+          () => fileUploadFromJson({
+            'filename': 42,
+            'url': 'https://example.com/a',
+          }),
+          throwsFormatException,
+        );
+      });
+
+      test('throws FormatException when url is non-string', () {
+        expect(
+          () => fileUploadFromJson({
+            'filename': 'a.pdf',
+            'url': ['not', 'a', 'string'],
+          }),
+          throwsFormatException,
+        );
+      });
+
+      test('throws FormatException when url is not a valid URI', () {
+        expect(
+          () => fileUploadFromJson({
+            'filename': 'a.pdf',
+            'url': 'http://[::1',
+          }),
+          throwsFormatException,
+        );
+      });
     });
   });
 }

--- a/packages/soliplex_client/test/api/upload_test.dart
+++ b/packages/soliplex_client/test/api/upload_test.dart
@@ -318,7 +318,7 @@ void main() {
       expect(uploads.first.filename, 'thread.pdf');
     });
 
-    test('uses /uploads/{roomId}/{threadId} URL', () async {
+    test('uses /uploads/{roomId}/thread/{threadId} URL', () async {
       when(
         () => mockTransport.request<Map<String, dynamic>>(
           'GET',
@@ -345,7 +345,7 @@ void main() {
         ),
       ).captured.single as Uri;
 
-      expect(captured.path, endsWith('/uploads/room-abc/thread-xyz'));
+      expect(captured.path, endsWith('/uploads/room-abc/thread/thread-xyz'));
     });
 
     test('throws ArgumentError for empty roomId', () {

--- a/packages/soliplex_client/test/api/upload_test.dart
+++ b/packages/soliplex_client/test/api/upload_test.dart
@@ -191,6 +191,28 @@ void main() {
       expect(await api.getRoomUploads('room-123'), isEmpty);
     });
 
+    test('throws UnexpectedException when uploads field is not a list',
+        () async {
+      when(
+        () => mockTransport.request<Map<String, dynamic>>(
+          'GET',
+          any(),
+          cancelToken: any(named: 'cancelToken'),
+          fromJson: any(named: 'fromJson'),
+          body: any(named: 'body'),
+          headers: any(named: 'headers'),
+          timeout: any(named: 'timeout'),
+        ),
+      ).thenAnswer(
+        (_) async => {'room_id': 'room-123', 'uploads': 'not-a-list'},
+      );
+
+      await expectLater(
+        api.getRoomUploads('room-123'),
+        throwsA(isA<UnexpectedException>()),
+      );
+    });
+
     test('skips malformed entries and returns valid ones', () async {
       when(
         () => mockTransport.request<Map<String, dynamic>>(
@@ -250,36 +272,6 @@ void main() {
       ).captured.single as Uri;
 
       expect(captured.path, endsWith('/uploads/room-abc'));
-    });
-
-    test('forwards cancelToken to transport', () async {
-      final cancelToken = CancelToken();
-
-      when(
-        () => mockTransport.request<Map<String, dynamic>>(
-          'GET',
-          any(),
-          cancelToken: cancelToken,
-          fromJson: any(named: 'fromJson'),
-          body: any(named: 'body'),
-          headers: any(named: 'headers'),
-          timeout: any(named: 'timeout'),
-        ),
-      ).thenAnswer((_) async => <String, dynamic>{});
-
-      await api.getRoomUploads('room-1', cancelToken: cancelToken);
-
-      verify(
-        () => mockTransport.request<Map<String, dynamic>>(
-          'GET',
-          any(),
-          cancelToken: cancelToken,
-          fromJson: any(named: 'fromJson'),
-          body: any(named: 'body'),
-          headers: any(named: 'headers'),
-          timeout: any(named: 'timeout'),
-        ),
-      ).called(1);
     });
 
     test('throws ArgumentError for empty roomId', () {
@@ -360,40 +352,6 @@ void main() {
         () => api.getThreadUploads('room-1', ''),
         throwsA(isA<ArgumentError>()),
       );
-    });
-
-    test('forwards cancelToken to transport', () async {
-      final cancelToken = CancelToken();
-
-      when(
-        () => mockTransport.request<Map<String, dynamic>>(
-          'GET',
-          any(),
-          cancelToken: cancelToken,
-          fromJson: any(named: 'fromJson'),
-          body: any(named: 'body'),
-          headers: any(named: 'headers'),
-          timeout: any(named: 'timeout'),
-        ),
-      ).thenAnswer((_) async => <String, dynamic>{});
-
-      await api.getThreadUploads(
-        'room-1',
-        'thread-1',
-        cancelToken: cancelToken,
-      );
-
-      verify(
-        () => mockTransport.request<Map<String, dynamic>>(
-          'GET',
-          any(),
-          cancelToken: cancelToken,
-          fromJson: any(named: 'fromJson'),
-          body: any(named: 'body'),
-          headers: any(named: 'headers'),
-          timeout: any(named: 'timeout'),
-        ),
-      ).called(1);
     });
   });
 }

--- a/packages/soliplex_client/test/api/upload_test.dart
+++ b/packages/soliplex_client/test/api/upload_test.dart
@@ -117,4 +117,249 @@ void main() {
       );
     });
   });
+
+  group('getRoomUploads', () {
+    test('returns FileUpload entries from server payload', () async {
+      when(
+        () => mockTransport.request<Map<String, dynamic>>(
+          'GET',
+          any(),
+          cancelToken: any(named: 'cancelToken'),
+          fromJson: any(named: 'fromJson'),
+          body: any(named: 'body'),
+          headers: any(named: 'headers'),
+          timeout: any(named: 'timeout'),
+        ),
+      ).thenAnswer(
+        (_) async => {
+          'room_id': 'room-123',
+          'uploads': [
+            {
+              'filename': 'a.pdf',
+              'url': 'https://example.com/uploads/room-123/a.pdf',
+            },
+            {
+              'filename': 'b.txt',
+              'url': 'https://example.com/uploads/room-123/b.txt',
+            },
+          ],
+        },
+      );
+
+      final uploads = await api.getRoomUploads('room-123');
+
+      expect(uploads, hasLength(2));
+      expect(uploads[0].filename, 'a.pdf');
+      expect(
+        uploads[0].url.toString(),
+        'https://example.com/uploads/room-123/a.pdf',
+      );
+      expect(uploads[1].filename, 'b.txt');
+    });
+
+    test('returns empty list when uploads array is empty', () async {
+      when(
+        () => mockTransport.request<Map<String, dynamic>>(
+          'GET',
+          any(),
+          cancelToken: any(named: 'cancelToken'),
+          fromJson: any(named: 'fromJson'),
+          body: any(named: 'body'),
+          headers: any(named: 'headers'),
+          timeout: any(named: 'timeout'),
+        ),
+      ).thenAnswer(
+        (_) async => {'room_id': 'room-123', 'uploads': <dynamic>[]},
+      );
+
+      expect(await api.getRoomUploads('room-123'), isEmpty);
+    });
+
+    test('returns empty list when uploads field is missing', () async {
+      when(
+        () => mockTransport.request<Map<String, dynamic>>(
+          'GET',
+          any(),
+          cancelToken: any(named: 'cancelToken'),
+          fromJson: any(named: 'fromJson'),
+          body: any(named: 'body'),
+          headers: any(named: 'headers'),
+          timeout: any(named: 'timeout'),
+        ),
+      ).thenAnswer((_) async => {'room_id': 'room-123'});
+
+      expect(await api.getRoomUploads('room-123'), isEmpty);
+    });
+
+    test('skips malformed entries and returns valid ones', () async {
+      when(
+        () => mockTransport.request<Map<String, dynamic>>(
+          'GET',
+          any(),
+          cancelToken: any(named: 'cancelToken'),
+          fromJson: any(named: 'fromJson'),
+          body: any(named: 'body'),
+          headers: any(named: 'headers'),
+          timeout: any(named: 'timeout'),
+        ),
+      ).thenAnswer(
+        (_) async => {
+          'room_id': 'room-123',
+          'uploads': [
+            {'filename': 'good.pdf', 'url': 'https://example.com/good'},
+            {'filename': 'missing-url'},
+            'not a map',
+            {
+              'filename': 'also-good.pdf',
+              'url': 'https://example.com/good2',
+            },
+          ],
+        },
+      );
+
+      final uploads = await api.getRoomUploads('room-123');
+
+      expect(uploads.map((u) => u.filename), ['good.pdf', 'also-good.pdf']);
+    });
+
+    test('uses /uploads/{roomId} URL', () async {
+      when(
+        () => mockTransport.request<Map<String, dynamic>>(
+          'GET',
+          any(),
+          cancelToken: any(named: 'cancelToken'),
+          fromJson: any(named: 'fromJson'),
+          body: any(named: 'body'),
+          headers: any(named: 'headers'),
+          timeout: any(named: 'timeout'),
+        ),
+      ).thenAnswer((_) async => <String, dynamic>{});
+
+      await api.getRoomUploads('room-abc');
+
+      final captured = verify(
+        () => mockTransport.request<Map<String, dynamic>>(
+          'GET',
+          captureAny(),
+          cancelToken: any(named: 'cancelToken'),
+          fromJson: any(named: 'fromJson'),
+          body: any(named: 'body'),
+          headers: any(named: 'headers'),
+          timeout: any(named: 'timeout'),
+        ),
+      ).captured.single as Uri;
+
+      expect(captured.path, endsWith('/uploads/room-abc'));
+    });
+
+    test('forwards cancelToken to transport', () async {
+      final cancelToken = CancelToken();
+
+      when(
+        () => mockTransport.request<Map<String, dynamic>>(
+          'GET',
+          any(),
+          cancelToken: cancelToken,
+          fromJson: any(named: 'fromJson'),
+          body: any(named: 'body'),
+          headers: any(named: 'headers'),
+          timeout: any(named: 'timeout'),
+        ),
+      ).thenAnswer((_) async => <String, dynamic>{});
+
+      await api.getRoomUploads('room-1', cancelToken: cancelToken);
+
+      verify(
+        () => mockTransport.request<Map<String, dynamic>>(
+          'GET',
+          any(),
+          cancelToken: cancelToken,
+          fromJson: any(named: 'fromJson'),
+          body: any(named: 'body'),
+          headers: any(named: 'headers'),
+          timeout: any(named: 'timeout'),
+        ),
+      ).called(1);
+    });
+
+    test('throws ArgumentError for empty roomId', () {
+      expect(() => api.getRoomUploads(''), throwsA(isA<ArgumentError>()));
+    });
+  });
+
+  group('getThreadUploads', () {
+    test('returns FileUpload entries from server payload', () async {
+      when(
+        () => mockTransport.request<Map<String, dynamic>>(
+          'GET',
+          any(),
+          cancelToken: any(named: 'cancelToken'),
+          fromJson: any(named: 'fromJson'),
+          body: any(named: 'body'),
+          headers: any(named: 'headers'),
+          timeout: any(named: 'timeout'),
+        ),
+      ).thenAnswer(
+        (_) async => {
+          'room_id': 'room-123',
+          'uploads': [
+            {
+              'filename': 'thread.pdf',
+              'url':
+                  'https://example.com/uploads/room-123/thread-456/thread.pdf',
+            },
+          ],
+        },
+      );
+
+      final uploads = await api.getThreadUploads('room-123', 'thread-456');
+
+      expect(uploads, hasLength(1));
+      expect(uploads.first.filename, 'thread.pdf');
+    });
+
+    test('uses /uploads/{roomId}/{threadId} URL', () async {
+      when(
+        () => mockTransport.request<Map<String, dynamic>>(
+          'GET',
+          any(),
+          cancelToken: any(named: 'cancelToken'),
+          fromJson: any(named: 'fromJson'),
+          body: any(named: 'body'),
+          headers: any(named: 'headers'),
+          timeout: any(named: 'timeout'),
+        ),
+      ).thenAnswer((_) async => <String, dynamic>{});
+
+      await api.getThreadUploads('room-abc', 'thread-xyz');
+
+      final captured = verify(
+        () => mockTransport.request<Map<String, dynamic>>(
+          'GET',
+          captureAny(),
+          cancelToken: any(named: 'cancelToken'),
+          fromJson: any(named: 'fromJson'),
+          body: any(named: 'body'),
+          headers: any(named: 'headers'),
+          timeout: any(named: 'timeout'),
+        ),
+      ).captured.single as Uri;
+
+      expect(captured.path, endsWith('/uploads/room-abc/thread-xyz'));
+    });
+
+    test('throws ArgumentError for empty roomId', () {
+      expect(
+        () => api.getThreadUploads('', 'thread-1'),
+        throwsA(isA<ArgumentError>()),
+      );
+    });
+
+    test('throws ArgumentError for empty threadId', () {
+      expect(
+        () => api.getThreadUploads('room-1', ''),
+        throwsA(isA<ArgumentError>()),
+      );
+    });
+  });
 }

--- a/packages/soliplex_client/test/api/upload_test.dart
+++ b/packages/soliplex_client/test/api/upload_test.dart
@@ -361,5 +361,39 @@ void main() {
         throwsA(isA<ArgumentError>()),
       );
     });
+
+    test('forwards cancelToken to transport', () async {
+      final cancelToken = CancelToken();
+
+      when(
+        () => mockTransport.request<Map<String, dynamic>>(
+          'GET',
+          any(),
+          cancelToken: cancelToken,
+          fromJson: any(named: 'fromJson'),
+          body: any(named: 'body'),
+          headers: any(named: 'headers'),
+          timeout: any(named: 'timeout'),
+        ),
+      ).thenAnswer((_) async => <String, dynamic>{});
+
+      await api.getThreadUploads(
+        'room-1',
+        'thread-1',
+        cancelToken: cancelToken,
+      );
+
+      verify(
+        () => mockTransport.request<Map<String, dynamic>>(
+          'GET',
+          any(),
+          cancelToken: cancelToken,
+          fromJson: any(named: 'fromJson'),
+          body: any(named: 'body'),
+          headers: any(named: 'headers'),
+          timeout: any(named: 'timeout'),
+        ),
+      ).called(1);
+    });
   });
 }

--- a/packages/soliplex_client/test/domain/file_upload_test.dart
+++ b/packages/soliplex_client/test/domain/file_upload_test.dart
@@ -1,0 +1,81 @@
+import 'package:soliplex_client/src/domain/file_upload.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('FileUpload', () {
+    group('equality', () {
+      test('equals by filename and url', () {
+        final a = FileUpload(
+          filename: 'report.pdf',
+          url: Uri.parse('https://example.com/rooms/r/uploads/report.pdf'),
+        );
+        final b = FileUpload(
+          filename: 'report.pdf',
+          url: Uri.parse('https://example.com/rooms/r/uploads/report.pdf'),
+        );
+
+        expect(a, equals(b));
+        expect(a.hashCode, equals(b.hashCode));
+      });
+
+      test('not equals with different filename', () {
+        final a = FileUpload(
+          filename: 'a.pdf',
+          url: Uri.parse('https://example.com/a'),
+        );
+        final b = FileUpload(
+          filename: 'b.pdf',
+          url: Uri.parse('https://example.com/a'),
+        );
+
+        expect(a, isNot(equals(b)));
+      });
+
+      test('not equals with different url', () {
+        final a = FileUpload(
+          filename: 'a.pdf',
+          url: Uri.parse('https://example.com/a'),
+        );
+        final b = FileUpload(
+          filename: 'a.pdf',
+          url: Uri.parse('https://example.com/b'),
+        );
+
+        expect(a, isNot(equals(b)));
+      });
+    });
+
+    group('copyWith', () {
+      test('overrides filename', () {
+        final a = FileUpload(
+          filename: 'a.pdf',
+          url: Uri.parse('https://example.com/a'),
+        );
+        final b = a.copyWith(filename: 'b.pdf');
+
+        expect(b.filename, 'b.pdf');
+        expect(b.url, a.url);
+      });
+
+      test('overrides url', () {
+        final a = FileUpload(
+          filename: 'a.pdf',
+          url: Uri.parse('https://example.com/a'),
+        );
+        final b = a.copyWith(url: Uri.parse('https://example.com/b'));
+
+        expect(b.filename, a.filename);
+        expect(b.url.toString(), 'https://example.com/b');
+      });
+
+      test('no args returns equal instance', () {
+        final a = FileUpload(
+          filename: 'a.pdf',
+          url: Uri.parse('https://example.com/a'),
+        );
+
+        expect(a.copyWith(), equals(a));
+      });
+    });
+  });
+}

--- a/packages/soliplex_client/test/domain/file_upload_test.dart
+++ b/packages/soliplex_client/test/domain/file_upload_test.dart
@@ -44,38 +44,5 @@ void main() {
         expect(a, isNot(equals(b)));
       });
     });
-
-    group('copyWith', () {
-      test('overrides filename', () {
-        final a = FileUpload(
-          filename: 'a.pdf',
-          url: Uri.parse('https://example.com/a'),
-        );
-        final b = a.copyWith(filename: 'b.pdf');
-
-        expect(b.filename, 'b.pdf');
-        expect(b.url, a.url);
-      });
-
-      test('overrides url', () {
-        final a = FileUpload(
-          filename: 'a.pdf',
-          url: Uri.parse('https://example.com/a'),
-        );
-        final b = a.copyWith(url: Uri.parse('https://example.com/b'));
-
-        expect(b.filename, a.filename);
-        expect(b.url.toString(), 'https://example.com/b');
-      });
-
-      test('no args returns equal instance', () {
-        final a = FileUpload(
-          filename: 'a.pdf',
-          url: Uri.parse('https://example.com/a'),
-        );
-
-        expect(a.copyWith(), equals(a));
-      });
-    });
   });
 }

--- a/packages/soliplex_client/test/errors/exceptions_test.dart
+++ b/packages/soliplex_client/test/errors/exceptions_test.dart
@@ -286,6 +286,17 @@ void main() {
     });
   });
 
+  group('UnexpectedException', () {
+    test('toString includes message', () {
+      const exception = UnexpectedException(message: 'Unknown schema');
+
+      expect(
+        exception.toString(),
+        equals('UnexpectedException: Unknown schema'),
+      );
+    });
+  });
+
   group('SoliplexException hierarchy', () {
     test('all exceptions can be caught as SoliplexException', () {
       final exceptions = <SoliplexException>[
@@ -294,6 +305,7 @@ void main() {
         const ApiException(message: 'API error', statusCode: 500),
         const NotFoundException(message: 'Not found'),
         const CancelledException(),
+        const UnexpectedException(message: 'Unexpected error'),
       ];
 
       for (final exception in exceptions) {
@@ -329,6 +341,11 @@ void main() {
           stackTrace: trace,
         ),
         CancelledException(originalError: originalError, stackTrace: trace),
+        UnexpectedException(
+          message: 'Unexpected',
+          originalError: originalError,
+          stackTrace: trace,
+        ),
       ];
 
       for (final exception in exceptions) {

--- a/test/helpers/fakes.dart
+++ b/test/helpers/fakes.dart
@@ -273,12 +273,15 @@ class FakeSoliplexApi extends SoliplexApi {
   Exception? nextRoomUploadsError;
   List<FileUpload>? nextThreadUploads;
   Exception? nextThreadUploadsError;
+  int getRoomUploadsCount = 0;
+  int getThreadUploadsCount = 0;
 
   @override
   Future<List<FileUpload>> getRoomUploads(
     String roomId, {
     CancelToken? cancelToken,
   }) async {
+    getRoomUploadsCount++;
     if (nextRoomUploadsError != null) throw nextRoomUploadsError!;
     return nextRoomUploads ?? const [];
   }
@@ -289,6 +292,7 @@ class FakeSoliplexApi extends SoliplexApi {
     String threadId, {
     CancelToken? cancelToken,
   }) async {
+    getThreadUploadsCount++;
     if (nextThreadUploadsError != null) throw nextThreadUploadsError!;
     return nextThreadUploads ?? const [];
   }

--- a/test/helpers/fakes.dart
+++ b/test/helpers/fakes.dart
@@ -3,6 +3,7 @@ import 'dart:async';
 import 'package:soliplex_agent/soliplex_agent.dart' hide AuthException;
 import 'package:soliplex_client/soliplex_client.dart'
     show
+        FileUpload,
         HttpTransport,
         Quiz,
         QuizAnswerResult,
@@ -266,6 +267,30 @@ class FakeSoliplexApi extends SoliplexApi {
   }) async {
     if (nextDocumentsError != null) throw nextDocumentsError!;
     return nextDocuments ?? const [];
+  }
+
+  List<FileUpload>? nextRoomUploads;
+  Exception? nextRoomUploadsError;
+  List<FileUpload>? nextThreadUploads;
+  Exception? nextThreadUploadsError;
+
+  @override
+  Future<List<FileUpload>> getRoomUploads(
+    String roomId, {
+    CancelToken? cancelToken,
+  }) async {
+    if (nextRoomUploadsError != null) throw nextRoomUploadsError!;
+    return nextRoomUploads ?? const [];
+  }
+
+  @override
+  Future<List<FileUpload>> getThreadUploads(
+    String roomId,
+    String threadId, {
+    CancelToken? cancelToken,
+  }) async {
+    if (nextThreadUploadsError != null) throw nextThreadUploadsError!;
+    return nextThreadUploads ?? const [];
   }
 
   @override

--- a/test/modules/room/pick_file_test.dart
+++ b/test/modules/room/pick_file_test.dart
@@ -1,0 +1,106 @@
+import 'dart:typed_data';
+
+import 'package:file_picker/file_picker.dart';
+// ignore: implementation_imports
+import 'package:file_picker/src/platform/file_picker_platform_interface.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:soliplex_frontend/src/modules/room/pick_file.dart';
+
+class _FakeFilePicker extends FilePickerPlatform {
+  _FakeFilePicker.result(FilePickerResult this._result) : _thrown = null;
+  _FakeFilePicker.throwing(Object this._thrown) : _result = null;
+
+  final FilePickerResult? _result;
+  final Object? _thrown;
+
+  @override
+  Future<FilePickerResult?> pickFiles({
+    String? dialogTitle,
+    String? initialDirectory,
+    FileType type = FileType.any,
+    List<String>? allowedExtensions,
+    Function(FilePickerStatus)? onFileLoading,
+    int compressionQuality = 0,
+    bool allowMultiple = false,
+    bool withData = false,
+    bool withReadStream = false,
+    bool lockParentWindow = false,
+    bool readSequential = false,
+    bool cancelUploadOnWindowBlur = true,
+  }) async {
+    if (_thrown != null) throw _thrown;
+    return _result;
+  }
+}
+
+void main() {
+  late FilePickerPlatform originalPlatform;
+
+  setUp(() {
+    originalPlatform = FilePickerPlatform.instance;
+  });
+
+  tearDown(() {
+    FilePickerPlatform.instance = originalPlatform;
+  });
+
+  test('returns null when user cancels the picker', () async {
+    FilePickerPlatform.instance = _FakeFilePicker.result(
+      FilePickerResult(const []),
+    );
+    expect(await pickFile(), isNull);
+  });
+
+  test('wraps picker errors in PickFilePickerException', () async {
+    final cause = StateError('plugin not available');
+    FilePickerPlatform.instance = _FakeFilePicker.throwing(cause);
+
+    expect(
+      pickFile(),
+      throwsA(
+        isA<PickFilePickerException>()
+            .having((e) => e.cause, 'cause', cause)
+            .having((e) => e.filename, 'filename', isNull),
+      ),
+    );
+  });
+
+  test(
+    'throws PickFilePickerException when picker returns neither bytes nor '
+    'path',
+    () async {
+      FilePickerPlatform.instance = _FakeFilePicker.result(
+        FilePickerResult([PlatformFile(name: 'x.pdf', size: 0)]),
+      );
+
+      expect(
+        pickFile(),
+        throwsA(
+          isA<PickFilePickerException>()
+              .having((e) => e.filename, 'filename', 'x.pdf')
+              .having((e) => e.cause, 'cause', isA<StateError>()),
+        ),
+      );
+    },
+  );
+
+  test('returns PickedFile with bytes and derived MIME when bytes present',
+      () async {
+    FilePickerPlatform.instance = _FakeFilePicker.result(
+      FilePickerResult([
+        PlatformFile(
+          name: 'doc.pdf',
+          size: 3,
+          bytes: Uint8List.fromList(const [1, 2, 3]),
+        ),
+      ]),
+    );
+
+    final picked = await pickFile();
+
+    expect(picked, isNotNull);
+    expect(picked!.name, 'doc.pdf');
+    expect(picked.bytes, [1, 2, 3]);
+    expect(picked.mimeType, 'application/pdf');
+  });
+}

--- a/test/modules/room/room_state_test.dart
+++ b/test/modules/room/room_state_test.dart
@@ -1,12 +1,17 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:soliplex_agent/soliplex_agent.dart';
 
+import 'package:soliplex_frontend/src/modules/auth/auth_session.dart';
+import 'package:soliplex_frontend/src/modules/auth/server_entry.dart';
 import 'package:soliplex_frontend/src/modules/room/agent_runtime_manager.dart';
 import 'package:soliplex_frontend/src/modules/room/room_state.dart';
 import 'package:soliplex_frontend/src/modules/room/run_registry.dart';
 import 'package:soliplex_frontend/src/modules/room/thread_list_state.dart';
+import 'package:soliplex_frontend/src/modules/room/upload_tracker_registry.dart';
 
 import '../../helpers/fakes.dart';
+
+class _FakeAuthSession extends Fake implements AuthSession {}
 
 ServerConnection _fakeConnection(FakeSoliplexApi api) => ServerConnection(
       serverId: 'test-server',
@@ -14,26 +19,43 @@ ServerConnection _fakeConnection(FakeSoliplexApi api) => ServerConnection(
       agUiStreamClient: FakeAgUiStreamClient(),
     );
 
+ServerEntry _fakeServerEntry(ServerConnection connection) => ServerEntry(
+      serverId: connection.serverId,
+      alias: connection.serverId,
+      serverUrl: Uri.parse('https://${connection.serverId}.example.com'),
+      auth: _FakeAuthSession(),
+      httpClient: FakeHttpClient(),
+      connection: connection,
+    );
+
 void main() {
   late FakeSoliplexApi api;
   late ServerConnection connection;
+  late ServerEntry serverEntry;
   late AgentRuntimeManager runtimeManager;
   late RunRegistry registry;
+  late Signal<Map<String, ServerEntry>> servers;
+  late UploadTrackerRegistry uploadRegistry;
 
   setUp(() {
     api = FakeSoliplexApi();
     connection = _fakeConnection(api);
+    serverEntry = _fakeServerEntry(connection);
     runtimeManager = AgentRuntimeManager(
       platform: TestPlatformConstraints(),
       toolRegistryResolver: (_) async => const ToolRegistry(),
       logger: testLogger(),
     );
     registry = RunRegistry();
+    servers = Signal({serverEntry.serverId: serverEntry});
+    uploadRegistry = UploadTrackerRegistry(servers: servers);
   });
 
   tearDown(() async {
     await runtimeManager.dispose();
     registry.dispose();
+    uploadRegistry.dispose();
+    servers.dispose();
   });
 
   test('selectThread creates ThreadViewState', () async {
@@ -42,10 +64,11 @@ void main() {
     api.nextThreadHistory = ThreadHistory(messages: const []);
 
     final state = RoomState(
-      connection: connection,
+      serverEntry: serverEntry,
       roomId: 'room-1',
       runtimeManager: runtimeManager,
       registry: registry,
+      uploadRegistry: uploadRegistry,
     );
     expect(state.activeThreadView, isNull);
 
@@ -62,10 +85,11 @@ void main() {
     api.nextThreadHistory = ThreadHistory(messages: const []);
 
     final state = RoomState(
-      connection: connection,
+      serverEntry: serverEntry,
       roomId: 'room-1',
       runtimeManager: runtimeManager,
       registry: registry,
+      uploadRegistry: uploadRegistry,
     );
 
     state.selectThread('thread-1');
@@ -84,10 +108,11 @@ void main() {
     api.nextCreateThreadError = Exception('server error');
 
     final state = RoomState(
-      connection: connection,
+      serverEntry: serverEntry,
       roomId: 'room-1',
       runtimeManager: runtimeManager,
       registry: registry,
+      uploadRegistry: uploadRegistry,
     );
 
     await Future<void>.delayed(Duration.zero);
@@ -105,10 +130,11 @@ void main() {
     api.nextThreads = [];
 
     final state = RoomState(
-      connection: connection,
+      serverEntry: serverEntry,
       roomId: 'room-1',
       runtimeManager: runtimeManager,
       registry: registry,
+      uploadRegistry: uploadRegistry,
     );
 
     await Future<void>.delayed(Duration.zero);
@@ -136,10 +162,11 @@ void main() {
     api.nextThreadHistory = ThreadHistory(messages: const []);
 
     final state = RoomState(
-      connection: connection,
+      serverEntry: serverEntry,
       roomId: 'room-1',
       runtimeManager: runtimeManager,
       registry: registry,
+      uploadRegistry: uploadRegistry,
     );
 
     await Future<void>.delayed(Duration.zero);
@@ -161,10 +188,11 @@ void main() {
     api.nextThreadHistory = ThreadHistory(messages: const []);
 
     final state = RoomState(
-      connection: connection,
+      serverEntry: serverEntry,
       roomId: 'room-1',
       runtimeManager: runtimeManager,
       registry: registry,
+      uploadRegistry: uploadRegistry,
     );
 
     await Future<void>.delayed(Duration.zero);
@@ -186,10 +214,11 @@ void main() {
     api.nextThreadHistory = ThreadHistory(messages: const []);
 
     final state = RoomState(
-      connection: connection,
+      serverEntry: serverEntry,
       roomId: 'room-1',
       runtimeManager: runtimeManager,
       registry: registry,
+      uploadRegistry: uploadRegistry,
     );
 
     await Future<void>.delayed(Duration.zero);
@@ -222,10 +251,11 @@ void main() {
 
     String? navigatedThreadId;
     final state = RoomState(
-      connection: connection,
+      serverEntry: serverEntry,
       roomId: 'room-1',
       runtimeManager: runtimeManager,
       registry: registry,
+      uploadRegistry: uploadRegistry,
       onNavigateToThread: (id) => navigatedThreadId = id,
     );
 
@@ -251,10 +281,11 @@ void main() {
     api.nextThreads = [];
 
     final state = RoomState(
-      connection: connection,
+      serverEntry: serverEntry,
       roomId: 'room-1',
       runtimeManager: runtimeManager,
       registry: registry,
+      uploadRegistry: uploadRegistry,
     );
 
     expect(state.room.value, isA<RoomLoading>());
@@ -273,10 +304,11 @@ void main() {
     api.nextThreads = [];
 
     final state = RoomState(
-      connection: connection,
+      serverEntry: serverEntry,
       roomId: 'room-1',
       runtimeManager: runtimeManager,
       registry: registry,
+      uploadRegistry: uploadRegistry,
     );
 
     await Future<void>.delayed(Duration.zero);
@@ -291,10 +323,11 @@ void main() {
     api.nextThreads = [];
 
     final state = RoomState(
-      connection: connection,
+      serverEntry: serverEntry,
       roomId: 'room-1',
       runtimeManager: runtimeManager,
       registry: registry,
+      uploadRegistry: uploadRegistry,
     );
 
     await Future<void>.delayed(Duration.zero);
@@ -326,10 +359,11 @@ void main() {
 
       String? navigatedId;
       final state = RoomState(
-        connection: connection,
+        serverEntry: serverEntry,
         roomId: 'room-1',
         runtimeManager: runtimeManager,
         registry: registry,
+        uploadRegistry: uploadRegistry,
         onNavigateToThread: (id) => navigatedId = id,
       );
       await Future<void>.delayed(Duration.zero);
@@ -360,10 +394,11 @@ void main() {
 
       String? navigatedId = 'not-called';
       final state = RoomState(
-        connection: connection,
+        serverEntry: serverEntry,
         roomId: 'room-1',
         runtimeManager: runtimeManager,
         registry: registry,
+        uploadRegistry: uploadRegistry,
         onNavigateToThread: (id) => navigatedId = id,
       );
       await Future<void>.delayed(Duration.zero);
@@ -387,10 +422,11 @@ void main() {
 
       String? navigatedId = 'not-called';
       final state = RoomState(
-        connection: connection,
+        serverEntry: serverEntry,
         roomId: 'room-1',
         runtimeManager: runtimeManager,
         registry: registry,
+        uploadRegistry: uploadRegistry,
         onNavigateToThread: (id) => navigatedId = id,
       );
       await Future<void>.delayed(Duration.zero);
@@ -420,10 +456,11 @@ void main() {
       api.nextThreadHistory = ThreadHistory(messages: const []);
 
       final state = RoomState(
-        connection: connection,
+        serverEntry: serverEntry,
         roomId: 'room-1',
         runtimeManager: runtimeManager,
         registry: registry,
+        uploadRegistry: uploadRegistry,
       );
       await Future<void>.delayed(Duration.zero);
 
@@ -463,10 +500,11 @@ void main() {
 
       String? navigatedId = 'sentinel';
       final state = RoomState(
-        connection: connection,
+        serverEntry: serverEntry,
         roomId: 'room-1',
         runtimeManager: runtimeManager,
         registry: registry,
+        uploadRegistry: uploadRegistry,
         onNavigateToThread: (id) => navigatedId = id,
       );
       await Future<void>.delayed(Duration.zero);

--- a/test/modules/room/ui/room_info_screen_test.dart
+++ b/test/modules/room/ui/room_info_screen_test.dart
@@ -58,6 +58,39 @@ Widget _buildScreen({
   );
 }
 
+/// Build variant that hands back the [ServerEntry] and
+/// [UploadTrackerRegistry] so tests can interact with the tracker
+/// (e.g., pre-populate it before the screen mounts).
+({
+  Widget widget,
+  ServerEntry entry,
+  UploadTrackerRegistry uploadRegistry,
+}) _buildScreenWithRegistry({
+  Room? room,
+  FakeSoliplexApi? api,
+  Future<ToolRegistry> Function(String)? toolRegistryResolver,
+}) {
+  final fakeApi = api ?? FakeSoliplexApi();
+  fakeApi.nextRoom ??= room ?? _testRoom;
+  final entry = createTestServerEntry(api: fakeApi);
+  final registry = UploadTrackerRegistry(
+    servers: Signal<Map<String, ServerEntry>>({entry.serverId: entry}),
+  );
+  return (
+    widget: MaterialApp(
+      home: RoomInfoScreen(
+        serverEntry: entry,
+        roomId: 'room-1',
+        toolRegistryResolver:
+            toolRegistryResolver ?? (_) async => const ToolRegistry(),
+        uploadRegistry: registry,
+      ),
+    ),
+    entry: entry,
+    uploadRegistry: registry,
+  );
+}
+
 void main() {
   group('RoomInfoScreen', () {
     testWidgets('shows loading then room content', (tester) async {
@@ -307,6 +340,41 @@ void main() {
       );
       expect(find.text('Failed to load documents'), findsOneWidget);
       expect(find.text('Retry'), findsOneWidget);
+    });
+  });
+
+  group('uploaded files refresh dedupe', () {
+    testWidgets('fetches uploads when the tracker is still Loading',
+        (tester) async {
+      final api = FakeSoliplexApi()..nextRoomUploads = const [];
+      await tester.pumpWidget(_buildScreen(api: api));
+      await tester.pumpAndSettle();
+
+      expect(api.getRoomUploadsCount, 1);
+    });
+
+    testWidgets('skips the fetch when the tracker already has a Loaded list',
+        (tester) async {
+      final api = FakeSoliplexApi()..nextRoomUploads = const [];
+      final built = _buildScreenWithRegistry(api: api);
+
+      // Simulate Room → Info navigation by priming the shared tracker
+      // the same way RoomState's constructor would.
+      final tracker = built.uploadRegistry.trackerFor(
+        entry: built.entry,
+        roomId: 'room-1',
+      );
+      await tracker.refreshRoom('room-1');
+      expect(api.getRoomUploadsCount, 1);
+
+      await tester.pumpWidget(built.widget);
+      await tester.pumpAndSettle();
+
+      expect(
+        api.getRoomUploadsCount,
+        1,
+        reason: 'info-screen must not refetch when tracker is already Loaded',
+      );
     });
   });
 }

--- a/test/modules/room/ui/room_info_screen_test.dart
+++ b/test/modules/room/ui/room_info_screen_test.dart
@@ -4,7 +4,9 @@ import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:soliplex_agent/soliplex_agent.dart';
 
+import 'package:soliplex_frontend/src/modules/auth/server_entry.dart';
 import 'package:soliplex_frontend/src/modules/room/ui/room_info_screen.dart';
+import 'package:soliplex_frontend/src/modules/room/upload_tracker_registry.dart';
 
 import '../../../helpers/fakes.dart';
 import '../../../helpers/test_server_entry.dart';
@@ -41,12 +43,17 @@ Widget _buildScreen({
 }) {
   final fakeApi = api ?? FakeSoliplexApi();
   fakeApi.nextRoom ??= room ?? _testRoom;
+  final entry = createTestServerEntry(api: fakeApi);
+  final uploadRegistry = UploadTrackerRegistry(
+    servers: Signal<Map<String, ServerEntry>>({entry.serverId: entry}),
+  );
   return MaterialApp(
     home: RoomInfoScreen(
-      serverEntry: createTestServerEntry(api: fakeApi),
+      serverEntry: entry,
       roomId: 'room-1',
       toolRegistryResolver:
           toolRegistryResolver ?? (_) async => const ToolRegistry(),
+      uploadRegistry: uploadRegistry,
     ),
   );
 }

--- a/test/modules/room/ui/room_screen_test.dart
+++ b/test/modules/room/ui/room_screen_test.dart
@@ -394,6 +394,39 @@ void main() {
     expect(find.text('1 room'), findsOneWidget);
   });
 
+  testWidgets('chip shows error_outline when room uploads refresh fails',
+      (tester) async {
+    tester.view.physicalSize = const Size(1200, 800);
+    tester.view.devicePixelRatio = 1.0;
+    addTearDown(tester.view.resetPhysicalSize);
+
+    api.nextRoom = const Room(
+      id: 'room-1',
+      name: 'Attachable',
+      enableAttachments: true,
+    );
+    api.nextThreads = const [];
+    api.nextRoomUploadsError =
+        const ApiException(statusCode: 500, message: 'boom');
+
+    await tester.pumpWidget(MaterialApp(
+      home: RoomScreen(
+        serverEntry: entry,
+        roomId: 'room-1',
+        threadId: null,
+        runtimeManager: runtimeManager,
+        registry: registry,
+        uploadRegistry: uploadRegistry,
+        documentSelections: DocumentSelections(),
+      ),
+    ));
+    await tester.pumpAndSettle();
+
+    // The chip leading icon should be error_outline (not the attach
+    // icon) when the scope is UploadsFailed.
+    expect(find.byIcon(Icons.error_outline), findsWidgets);
+  });
+
   testWidgets('ChatInput is disabled during MessagesLoading', (tester) async {
     // Use a blocking API to keep thread history in loading state
     final blockingApi = _BlockingThreadsApi();

--- a/test/modules/room/ui/room_screen_test.dart
+++ b/test/modules/room/ui/room_screen_test.dart
@@ -282,6 +282,75 @@ void main() {
     blockingApi.completeThreads(const []);
   });
 
+  testWidgets('hides file chip when both room and thread scopes are empty',
+      (tester) async {
+    tester.view.physicalSize = const Size(1200, 800);
+    tester.view.devicePixelRatio = 1.0;
+    addTearDown(tester.view.resetPhysicalSize);
+
+    api.nextRoom = const Room(
+      id: 'room-1',
+      name: 'Attachable',
+      enableAttachments: true,
+    );
+    api.nextThreads = const [];
+    // nextRoomUploads / nextThreadUploads default to empty → the chip
+    // must not render when both scopes are Loaded([]).
+
+    await tester.pumpWidget(MaterialApp(
+      home: RoomScreen(
+        serverEntry: entry,
+        roomId: 'room-1',
+        threadId: null,
+        runtimeManager: runtimeManager,
+        registry: registry,
+        uploadRegistry: uploadRegistry,
+        documentSelections: DocumentSelections(),
+      ),
+    ));
+    await tester.pumpAndSettle();
+
+    // The chip always renders an expand_more/less icon; its absence
+    // confirms the chip itself isn't present.
+    expect(find.byIcon(Icons.expand_more), findsNothing);
+    expect(find.byIcon(Icons.expand_less), findsNothing);
+  });
+
+  testWidgets('shows file chip when room has uploads', (tester) async {
+    tester.view.physicalSize = const Size(1200, 800);
+    tester.view.devicePixelRatio = 1.0;
+    addTearDown(tester.view.resetPhysicalSize);
+
+    api.nextRoom = const Room(
+      id: 'room-1',
+      name: 'Attachable',
+      enableAttachments: true,
+    );
+    api.nextThreads = const [];
+    api.nextRoomUploads = [
+      FileUpload(
+        filename: 'shared.pdf',
+        url: Uri.parse('https://example.com/shared.pdf'),
+      ),
+    ];
+
+    await tester.pumpWidget(MaterialApp(
+      home: RoomScreen(
+        serverEntry: entry,
+        roomId: 'room-1',
+        threadId: null,
+        runtimeManager: runtimeManager,
+        registry: registry,
+        uploadRegistry: uploadRegistry,
+        documentSelections: DocumentSelections(),
+      ),
+    ));
+    await tester.pumpAndSettle();
+
+    expect(find.byIcon(Icons.expand_more), findsOneWidget);
+    expect(find.text('1 room'), findsOneWidget);
+  });
+
   testWidgets('ChatInput is disabled during MessagesLoading', (tester) async {
     // Use a blocking API to keep thread history in loading state
     final blockingApi = _BlockingThreadsApi();

--- a/test/modules/room/ui/room_screen_test.dart
+++ b/test/modules/room/ui/room_screen_test.dart
@@ -353,8 +353,8 @@ void main() {
     await tester.tap(find.byIcon(Icons.expand_more));
     await tester.pumpAndSettle();
 
-    expect(find.text('Room'), findsOneWidget);
-    expect(find.text('Thread'), findsNothing,
+    expect(find.text('ROOM'), findsOneWidget);
+    expect(find.text('THREAD'), findsNothing,
         reason: 'empty thread scope should not render a Thread label');
     expect(find.text('shared.pdf'), findsOneWidget);
   });

--- a/test/modules/room/ui/room_screen_test.dart
+++ b/test/modules/room/ui/room_screen_test.dart
@@ -9,6 +9,7 @@ import 'package:soliplex_frontend/src/modules/room/agent_runtime_manager.dart';
 import 'package:soliplex_frontend/src/modules/room/document_selections.dart';
 import 'package:soliplex_frontend/src/modules/room/run_registry.dart';
 import 'package:soliplex_frontend/src/modules/room/ui/room_screen.dart';
+import 'package:soliplex_frontend/src/modules/room/upload_tracker_registry.dart';
 import 'package:soliplex_frontend/src/modules/auth/server_entry.dart';
 
 import '../../../helpers/fakes.dart';
@@ -33,6 +34,7 @@ Widget _buildRouted({
   required ServerEntry entry,
   required AgentRuntimeManager runtimeManager,
   required RunRegistry registry,
+  required UploadTrackerRegistry uploadRegistry,
   String roomId = 'room-1',
   String? threadId,
 }) {
@@ -49,6 +51,7 @@ Widget _buildRouted({
           threadId: null,
           runtimeManager: runtimeManager,
           registry: registry,
+          uploadRegistry: uploadRegistry,
           documentSelections: DocumentSelections(),
         ),
         routes: [
@@ -60,6 +63,7 @@ Widget _buildRouted({
               threadId: state.pathParameters['threadId'],
               runtimeManager: runtimeManager,
               registry: registry,
+              uploadRegistry: uploadRegistry,
               documentSelections: DocumentSelections(),
             ),
           ),
@@ -75,6 +79,8 @@ void main() {
   late ServerEntry entry;
   late AgentRuntimeManager runtimeManager;
   late RunRegistry registry;
+  late Signal<Map<String, ServerEntry>> servers;
+  late UploadTrackerRegistry uploadRegistry;
 
   setUp(() {
     api = FakeSoliplexApi();
@@ -94,11 +100,15 @@ void main() {
       logger: testLogger(),
     );
     registry = RunRegistry();
+    servers = Signal({entry.serverId: entry});
+    uploadRegistry = UploadTrackerRegistry(servers: servers);
   });
 
   tearDown(() async {
     await runtimeManager.dispose();
     registry.dispose();
+    uploadRegistry.dispose();
+    servers.dispose();
   });
 
   testWidgets('wide layout shows thread sidebar', (tester) async {
@@ -113,6 +123,7 @@ void main() {
         threadId: null,
         runtimeManager: runtimeManager,
         registry: registry,
+        uploadRegistry: uploadRegistry,
         documentSelections: DocumentSelections(),
       ),
     ));
@@ -133,6 +144,7 @@ void main() {
         threadId: null,
         runtimeManager: runtimeManager,
         registry: registry,
+        uploadRegistry: uploadRegistry,
         documentSelections: DocumentSelections(),
       ),
     ));
@@ -156,6 +168,7 @@ void main() {
         threadId: null,
         runtimeManager: runtimeManager,
         registry: registry,
+        uploadRegistry: uploadRegistry,
         documentSelections: DocumentSelections(),
       ),
     ));
@@ -189,6 +202,7 @@ void main() {
         threadId: null,
         runtimeManager: runtimeManager,
         registry: registry,
+        uploadRegistry: uploadRegistry,
         documentSelections: DocumentSelections(),
       ),
     ));
@@ -212,6 +226,7 @@ void main() {
         threadId: null,
         runtimeManager: runtimeManager,
         registry: registry,
+        uploadRegistry: uploadRegistry,
         documentSelections: DocumentSelections(),
       ),
     ));
@@ -229,6 +244,7 @@ void main() {
       entry: entry,
       runtimeManager: runtimeManager,
       registry: registry,
+      uploadRegistry: uploadRegistry,
     ));
     await tester.pumpAndSettle();
 
@@ -255,6 +271,7 @@ void main() {
         threadId: null,
         runtimeManager: runtimeManager,
         registry: registry,
+        uploadRegistry: uploadRegistry,
         documentSelections: DocumentSelections(),
       ),
     ));
@@ -285,6 +302,7 @@ void main() {
         threadId: 'thread-1',
         runtimeManager: runtimeManager,
         registry: registry,
+        uploadRegistry: uploadRegistry,
         documentSelections: DocumentSelections(),
       ),
     ));

--- a/test/modules/room/ui/room_screen_test.dart
+++ b/test/modules/room/ui/room_screen_test.dart
@@ -316,6 +316,49 @@ void main() {
     expect(find.byIcon(Icons.expand_less), findsNothing);
   });
 
+  testWidgets(
+      'expanded file panel omits the Thread section when thread scope is empty',
+      (tester) async {
+    tester.view.physicalSize = const Size(1200, 800);
+    tester.view.devicePixelRatio = 1.0;
+    addTearDown(tester.view.resetPhysicalSize);
+
+    api.nextRoom = const Room(
+      id: 'room-1',
+      name: 'Attachable',
+      enableAttachments: true,
+    );
+    api.nextThreads = const [];
+    api.nextRoomUploads = [
+      FileUpload(
+        filename: 'shared.pdf',
+        url: Uri.parse('https://example.com/shared.pdf'),
+      ),
+    ];
+
+    await tester.pumpWidget(MaterialApp(
+      home: RoomScreen(
+        serverEntry: entry,
+        roomId: 'room-1',
+        threadId: null,
+        runtimeManager: runtimeManager,
+        registry: registry,
+        uploadRegistry: uploadRegistry,
+        documentSelections: DocumentSelections(),
+      ),
+    ));
+    await tester.pumpAndSettle();
+
+    // Tap the chip to expand the file panel.
+    await tester.tap(find.byIcon(Icons.expand_more));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Room'), findsOneWidget);
+    expect(find.text('Thread'), findsNothing,
+        reason: 'empty thread scope should not render a Thread label');
+    expect(find.text('shared.pdf'), findsOneWidget);
+  });
+
   testWidgets('shows file chip when room has uploads', (tester) async {
     tester.view.physicalSize = const Size(1200, 800);
     tester.view.devicePixelRatio = 1.0;

--- a/test/modules/room/ui/upload_event_banner_test.dart
+++ b/test/modules/room/ui/upload_event_banner_test.dart
@@ -1,0 +1,403 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:soliplex_client/soliplex_client.dart';
+import 'package:soliplex_frontend/src/modules/room/ui/upload_event_banner.dart';
+import 'package:soliplex_frontend/src/modules/room/upload_tracker.dart';
+
+class _MockApi extends Mock implements SoliplexApi {}
+
+FileUpload _persisted(String filename, [String? url]) {
+  return FileUpload(
+    filename: filename,
+    url: Uri.parse(url ?? 'https://example.com/$filename'),
+  );
+}
+
+void main() {
+  late _MockApi api;
+  late UploadTracker tracker;
+
+  setUpAll(() {
+    registerFallbackValue(CancelToken());
+  });
+
+  setUp(() {
+    api = _MockApi();
+    tracker = UploadTracker(api: api);
+
+    // Defaults: empty server lists, uploads succeed. Individual tests
+    // override as needed.
+    when(
+      () => api.getRoomUploads(
+        any(),
+        cancelToken: any(named: 'cancelToken'),
+      ),
+    ).thenAnswer((_) async => const <FileUpload>[]);
+    when(
+      () => api.getThreadUploads(
+        any(),
+        any(),
+        cancelToken: any(named: 'cancelToken'),
+      ),
+    ).thenAnswer((_) async => const <FileUpload>[]);
+    when(
+      () => api.uploadFileToThread(
+        any(),
+        any(),
+        filename: any(named: 'filename'),
+        fileBytes: any(named: 'fileBytes'),
+        mimeType: any(named: 'mimeType'),
+      ),
+    ).thenAnswer((_) async {});
+  });
+
+  tearDown(() {
+    tracker.dispose();
+    reset(api);
+  });
+
+  Widget frame(String roomId, String? threadId) {
+    return MaterialApp(
+      home: Scaffold(
+        body: UploadEventBanner(
+          tracker: tracker,
+          roomId: roomId,
+          threadId: threadId,
+        ),
+      ),
+    );
+  }
+
+  testWidgets('completion fires success pill with filename', (tester) async {
+    await tester.pumpWidget(frame('room-1', 'thread-1'));
+
+    unawaited(tracker.refreshThread('room-1', 'thread-1'));
+    await tester.pump();
+    await tester.pump();
+
+    tracker.uploadToThread(
+      roomId: 'room-1',
+      threadId: 'thread-1',
+      filename: 'b.pdf',
+      fileBytes: const [1, 2, 3],
+    );
+    // POST resolves; refresh now returns the new file.
+    when(
+      () => api.getThreadUploads(
+        any(),
+        any(),
+        cancelToken: any(named: 'cancelToken'),
+      ),
+    ).thenAnswer((_) async => [_persisted('b.pdf')]);
+
+    await tester.pump();
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 200));
+
+    expect(find.text('Uploaded b.pdf'), findsOneWidget);
+    expect(find.byIcon(Icons.check_circle_outline), findsOneWidget);
+  });
+
+  testWidgets('failure fires failure pill with message', (tester) async {
+    when(
+      () => api.uploadFileToThread(
+        any(),
+        any(),
+        filename: any(named: 'filename'),
+        fileBytes: any(named: 'fileBytes'),
+        mimeType: any(named: 'mimeType'),
+      ),
+    ).thenThrow(const NetworkException(message: 'wifi down'));
+
+    await tester.pumpWidget(frame('room-1', 'thread-1'));
+    unawaited(tracker.refreshThread('room-1', 'thread-1'));
+    await tester.pump();
+    await tester.pump();
+
+    tracker.uploadToThread(
+      roomId: 'room-1',
+      threadId: 'thread-1',
+      filename: 'b.pdf',
+      fileBytes: const [1, 2, 3],
+    );
+    await tester.pump();
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 200));
+
+    expect(find.textContaining('Failed to upload b.pdf'), findsOneWidget);
+    expect(find.textContaining('wifi down'), findsOneWidget);
+    expect(find.byIcon(Icons.error_outline), findsOneWidget);
+  });
+
+  testWidgets('success pill auto-dismisses after 4s', (tester) async {
+    await tester.pumpWidget(frame('room-1', 'thread-1'));
+    unawaited(tracker.refreshThread('room-1', 'thread-1'));
+    await tester.pump();
+    await tester.pump();
+
+    tracker.uploadToThread(
+      roomId: 'room-1',
+      threadId: 'thread-1',
+      filename: 'b.pdf',
+      fileBytes: const [1, 2, 3],
+    );
+    when(
+      () => api.getThreadUploads(
+        any(),
+        any(),
+        cancelToken: any(named: 'cancelToken'),
+      ),
+    ).thenAnswer((_) async => [_persisted('b.pdf')]);
+
+    await tester.pump();
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 200));
+    expect(find.text('Uploaded b.pdf'), findsOneWidget);
+
+    await tester.pump(const Duration(seconds: 4));
+    await tester.pump(const Duration(milliseconds: 200));
+
+    expect(find.text('Uploaded b.pdf'), findsNothing);
+  });
+
+  testWidgets('failure pill does NOT auto-dismiss', (tester) async {
+    when(
+      () => api.uploadFileToThread(
+        any(),
+        any(),
+        filename: any(named: 'filename'),
+        fileBytes: any(named: 'fileBytes'),
+        mimeType: any(named: 'mimeType'),
+      ),
+    ).thenThrow(const NetworkException(message: 'wifi down'));
+
+    await tester.pumpWidget(frame('room-1', 'thread-1'));
+    unawaited(tracker.refreshThread('room-1', 'thread-1'));
+    await tester.pump();
+    await tester.pump();
+
+    tracker.uploadToThread(
+      roomId: 'room-1',
+      threadId: 'thread-1',
+      filename: 'b.pdf',
+      fileBytes: const [1, 2, 3],
+    );
+    await tester.pump();
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 200));
+    expect(find.textContaining('Failed to upload b.pdf'), findsOneWidget);
+
+    await tester.pump(const Duration(seconds: 10));
+    await tester.pump();
+    expect(find.textContaining('Failed to upload b.pdf'), findsOneWidget);
+  });
+
+  testWidgets('X dismisses success and failure pills independently',
+      (tester) async {
+    // First upload succeeds, second fails.
+    var uploadCallCount = 0;
+    when(
+      () => api.uploadFileToThread(
+        any(),
+        any(),
+        filename: any(named: 'filename'),
+        fileBytes: any(named: 'fileBytes'),
+        mimeType: any(named: 'mimeType'),
+      ),
+    ).thenAnswer((_) async {
+      uploadCallCount++;
+      if (uploadCallCount == 2) {
+        throw const NetworkException(message: 'wifi down');
+      }
+    });
+
+    await tester.pumpWidget(frame('room-1', 'thread-1'));
+    unawaited(tracker.refreshThread('room-1', 'thread-1'));
+    await tester.pump();
+    await tester.pump();
+
+    tracker.uploadToThread(
+      roomId: 'room-1',
+      threadId: 'thread-1',
+      filename: 'a.pdf',
+      fileBytes: const [1],
+    );
+    when(
+      () => api.getThreadUploads(
+        any(),
+        any(),
+        cancelToken: any(named: 'cancelToken'),
+      ),
+    ).thenAnswer((_) async => [_persisted('a.pdf')]);
+    await tester.pump();
+    await tester.pump();
+
+    tracker.uploadToThread(
+      roomId: 'room-1',
+      threadId: 'thread-1',
+      filename: 'bad.pdf',
+      fileBytes: const [2],
+    );
+    await tester.pump();
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 200));
+
+    expect(find.text('Uploaded a.pdf'), findsOneWidget);
+    expect(find.textContaining('Failed to upload bad.pdf'), findsOneWidget);
+
+    final successCloseFinder = find.descendant(
+      of: find.ancestor(
+        of: find.text('Uploaded a.pdf'),
+        matching: find.byType(Row),
+      ),
+      matching: find.byIcon(Icons.close),
+    );
+    await tester.tap(successCloseFinder.first);
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 200));
+
+    expect(find.text('Uploaded a.pdf'), findsNothing);
+    expect(find.textContaining('Failed to upload bad.pdf'), findsOneWidget);
+
+    await tester.tap(find.byIcon(Icons.close).first);
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 200));
+
+    expect(find.textContaining('Failed to upload bad.pdf'), findsNothing);
+  });
+
+  testWidgets('scope switch does not fire pill for pre-existing failed',
+      (tester) async {
+    when(
+      () => api.uploadFileToThread(
+        any(),
+        any(),
+        filename: any(named: 'filename'),
+        fileBytes: any(named: 'fileBytes'),
+        mimeType: any(named: 'mimeType'),
+      ),
+    ).thenThrow(const NetworkException(message: 'prior'));
+
+    unawaited(tracker.refreshThread('room-1', 'thread-A'));
+    // Drain the refresh microtask queue without a widget binding: use
+    // pumpEventQueue via pumpWidget + pump to create a bound context.
+    await tester.pumpWidget(const MaterialApp(home: SizedBox.shrink()));
+    await tester.pump();
+    await tester.pump();
+
+    tracker.uploadToThread(
+      roomId: 'room-1',
+      threadId: 'thread-A',
+      filename: 'old.pdf',
+      fileBytes: const [1],
+    );
+    await tester.pump();
+    await tester.pump();
+
+    // Now mount the banner for thread-A — it should see pre-existing
+    // FailedUpload as baseline, not a transition.
+    await tester.pumpWidget(frame('room-1', 'thread-A'));
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 200));
+    expect(find.textContaining('Failed to upload old.pdf'), findsNothing);
+
+    // Switch to thread-B.
+    await tester.pumpWidget(frame('room-1', 'thread-B'));
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 200));
+    expect(find.textContaining('Failed'), findsNothing);
+    expect(find.textContaining('Uploaded'), findsNothing);
+  });
+
+  testWidgets('success aggregation shows first + count', (tester) async {
+    await tester.pumpWidget(frame('room-1', 'thread-1'));
+    unawaited(tracker.refreshThread('room-1', 'thread-1'));
+    await tester.pump();
+    await tester.pump();
+
+    tracker.uploadToThread(
+      roomId: 'room-1',
+      threadId: 'thread-1',
+      filename: 'a.pdf',
+      fileBytes: const [1],
+    );
+    tracker.uploadToThread(
+      roomId: 'room-1',
+      threadId: 'thread-1',
+      filename: 'b.pdf',
+      fileBytes: const [2],
+    );
+    when(
+      () => api.getThreadUploads(
+        any(),
+        any(),
+        cancelToken: any(named: 'cancelToken'),
+      ),
+    ).thenAnswer((_) async => [_persisted('a.pdf'), _persisted('b.pdf')]);
+
+    await tester.pump();
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 200));
+
+    expect(find.textContaining('and 1 more'), findsOneWidget);
+  });
+
+  testWidgets('both pills render when a failure and a success coexist',
+      (tester) async {
+    var uploadCallCount = 0;
+    when(
+      () => api.uploadFileToThread(
+        any(),
+        any(),
+        filename: any(named: 'filename'),
+        fileBytes: any(named: 'fileBytes'),
+        mimeType: any(named: 'mimeType'),
+      ),
+    ).thenAnswer((_) async {
+      uploadCallCount++;
+      if (uploadCallCount == 1) {
+        throw const NetworkException(message: 'bad');
+      }
+    });
+
+    await tester.pumpWidget(frame('room-1', 'thread-1'));
+    unawaited(tracker.refreshThread('room-1', 'thread-1'));
+    await tester.pump();
+    await tester.pump();
+
+    // Fail first.
+    tracker.uploadToThread(
+      roomId: 'room-1',
+      threadId: 'thread-1',
+      filename: 'bad.pdf',
+      fileBytes: const [1],
+    );
+    await tester.pump();
+    await tester.pump();
+
+    // Then succeed.
+    tracker.uploadToThread(
+      roomId: 'room-1',
+      threadId: 'thread-1',
+      filename: 'good.pdf',
+      fileBytes: const [2],
+    );
+    when(
+      () => api.getThreadUploads(
+        any(),
+        any(),
+        cancelToken: any(named: 'cancelToken'),
+      ),
+    ).thenAnswer((_) async => [_persisted('good.pdf')]);
+
+    await tester.pump();
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 200));
+
+    expect(find.text('Uploaded good.pdf'), findsOneWidget);
+    expect(find.textContaining('Failed to upload bad.pdf'), findsOneWidget);
+  });
+}

--- a/test/modules/room/ui/upload_event_banner_test.dart
+++ b/test/modules/room/ui/upload_event_banner_test.dart
@@ -312,6 +312,49 @@ void main() {
     expect(find.textContaining('Uploaded'), findsNothing);
   });
 
+  testWidgets('scope switch mid-success drops the pending timer',
+      (tester) async {
+    await tester.pumpWidget(frame('room-1', 'thread-A'));
+    unawaited(tracker.refreshThread('room-1', 'thread-A'));
+    await tester.pump();
+    await tester.pump();
+
+    tracker.uploadToThread(
+      roomId: 'room-1',
+      threadId: 'thread-A',
+      filename: 'a.pdf',
+      fileBytes: const [1],
+    );
+    when(
+      () => api.getThreadUploads(
+        any(),
+        any(),
+        cancelToken: any(named: 'cancelToken'),
+      ),
+    ).thenAnswer((_) async => [_persisted('a.pdf')]);
+    await tester.pump();
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 200));
+    expect(find.text('Uploaded a.pdf'), findsOneWidget);
+
+    // Switch scope 1s into the 4s auto-dismiss window.
+    await tester.pump(const Duration(seconds: 1));
+    await tester.pumpWidget(frame('room-1', 'thread-B'));
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 200));
+
+    // Pill for thread-A is gone; thread-B shows nothing.
+    expect(find.text('Uploaded a.pdf'), findsNothing);
+
+    // Advance past where the original timer would have fired.
+    await tester.pump(const Duration(seconds: 5));
+    await tester.pump();
+
+    // Still nothing — the cancelled timer didn't resurrect anything.
+    expect(find.textContaining('Uploaded'), findsNothing);
+    expect(find.textContaining('Failed'), findsNothing);
+  });
+
   testWidgets('success aggregation shows first + count', (tester) async {
     await tester.pumpWidget(frame('room-1', 'thread-1'));
     unawaited(tracker.refreshThread('room-1', 'thread-1'));

--- a/test/modules/room/upload_tracker_registry_test.dart
+++ b/test/modules/room/upload_tracker_registry_test.dart
@@ -78,17 +78,19 @@ void main() {
       final t1 = registry.trackerFor(entry: e1, roomId: 'r1');
       final t2 = registry.trackerFor(entry: e2, roomId: 'r1');
 
-      // Disposing a tracker again is a no-op; we verify eviction by
-      // re-requesting after removal and getting a *different* instance.
       servers.value = {'srv-2': e2};
 
+      expect(t1.isDisposed, isTrue,
+          reason: "evicted tracker must be disposed, not just removed");
+      expect(t2.isDisposed, isFalse);
+
+      // The registry gives out a fresh instance on re-request for the
+      // evicted server; the surviving server's tracker is reused.
       final t1b = registry.trackerFor(entry: e1, roomId: 'r1');
       final t2b = registry.trackerFor(entry: e2, roomId: 'r1');
 
-      expect(identical(t1, t1b), isFalse,
-          reason: 'removed server\'s tracker should have been evicted');
-      expect(identical(t2, t2b), isTrue,
-          reason: 'surviving server\'s tracker should be retained');
+      expect(identical(t1, t1b), isFalse);
+      expect(identical(t2, t2b), isTrue);
     });
 
     test('does not touch trackers when the server set is unchanged', () {

--- a/test/modules/room/upload_tracker_registry_test.dart
+++ b/test/modules/room/upload_tracker_registry_test.dart
@@ -1,0 +1,128 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:soliplex_agent/soliplex_agent.dart';
+import 'package:soliplex_client/soliplex_client.dart';
+import 'package:soliplex_frontend/src/modules/auth/auth_session.dart';
+import 'package:soliplex_frontend/src/modules/auth/server_entry.dart';
+import 'package:soliplex_frontend/src/modules/room/upload_tracker_registry.dart';
+
+class _FakeHttpClient extends Fake implements SoliplexHttpClient {}
+
+class _FakeAuthSession extends Fake implements AuthSession {}
+
+class _FakeServerConnection extends Fake implements ServerConnection {
+  _FakeServerConnection(this.api);
+
+  @override
+  final SoliplexApi api;
+}
+
+class _MockSoliplexApi extends Mock implements SoliplexApi {}
+
+ServerEntry _entry(String serverId, {SoliplexApi? api}) {
+  return ServerEntry(
+    serverId: serverId,
+    alias: serverId,
+    serverUrl: Uri.parse('https://$serverId.example.com'),
+    auth: _FakeAuthSession(),
+    httpClient: _FakeHttpClient(),
+    connection: _FakeServerConnection(api ?? _MockSoliplexApi()),
+  );
+}
+
+void main() {
+  late Signal<Map<String, ServerEntry>> servers;
+  late UploadTrackerRegistry registry;
+
+  setUp(() {
+    servers = Signal<Map<String, ServerEntry>>({});
+    registry = UploadTrackerRegistry(servers: servers);
+  });
+
+  tearDown(() {
+    registry.dispose();
+    servers.dispose();
+  });
+
+  group('trackerFor', () {
+    test('returns the same instance for the same (server, room)', () {
+      final entry = _entry('srv-1');
+      final a = registry.trackerFor(entry: entry, roomId: 'r1');
+      final b = registry.trackerFor(entry: entry, roomId: 'r1');
+
+      expect(identical(a, b), isTrue);
+    });
+
+    test('returns distinct instances for different rooms', () {
+      final entry = _entry('srv-1');
+      final a = registry.trackerFor(entry: entry, roomId: 'r1');
+      final b = registry.trackerFor(entry: entry, roomId: 'r2');
+
+      expect(identical(a, b), isFalse);
+    });
+
+    test('returns distinct instances for different servers', () {
+      final a = registry.trackerFor(entry: _entry('srv-1'), roomId: 'r1');
+      final b = registry.trackerFor(entry: _entry('srv-2'), roomId: 'r1');
+
+      expect(identical(a, b), isFalse);
+    });
+  });
+
+  group('eviction on server removal', () {
+    test('disposes and removes trackers for the removed server', () {
+      final e1 = _entry('srv-1');
+      final e2 = _entry('srv-2');
+      servers.value = {'srv-1': e1, 'srv-2': e2};
+
+      final t1 = registry.trackerFor(entry: e1, roomId: 'r1');
+      final t2 = registry.trackerFor(entry: e2, roomId: 'r1');
+
+      // Disposing a tracker again is a no-op; we verify eviction by
+      // re-requesting after removal and getting a *different* instance.
+      servers.value = {'srv-2': e2};
+
+      final t1b = registry.trackerFor(entry: e1, roomId: 'r1');
+      final t2b = registry.trackerFor(entry: e2, roomId: 'r1');
+
+      expect(identical(t1, t1b), isFalse,
+          reason: 'removed server\'s tracker should have been evicted');
+      expect(identical(t2, t2b), isTrue,
+          reason: 'surviving server\'s tracker should be retained');
+    });
+
+    test('does not touch trackers when the server set is unchanged', () {
+      final e1 = _entry('srv-1');
+      servers.value = {'srv-1': e1};
+      final t1 = registry.trackerFor(entry: e1, roomId: 'r1');
+
+      // Emit the same map reference update (same keys).
+      servers.value = {'srv-1': e1};
+
+      final t1b = registry.trackerFor(entry: e1, roomId: 'r1');
+      expect(identical(t1, t1b), isTrue);
+    });
+  });
+
+  group('dispose', () {
+    test('disposes remaining trackers and unsubscribes from servers', () {
+      final e1 = _entry('srv-1');
+      registry.trackerFor(entry: e1, roomId: 'r1');
+      registry.trackerFor(entry: e1, roomId: 'r2');
+
+      registry.dispose();
+
+      // trackerFor throws after dispose: verifies the guard.
+      expect(
+        () => registry.trackerFor(entry: e1, roomId: 'r3'),
+        throwsStateError,
+      );
+    });
+
+    test('is idempotent', () {
+      registry.dispose();
+      // Second dispose shouldn't throw.
+      registry.dispose();
+    });
+  });
+}

--- a/test/modules/room/upload_tracker_test.dart
+++ b/test/modules/room/upload_tracker_test.dart
@@ -1,5 +1,4 @@
 import 'dart:async';
-import 'dart:convert';
 
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
@@ -8,247 +7,509 @@ import 'package:soliplex_frontend/src/modules/room/upload_tracker.dart';
 
 class MockSoliplexApi extends Mock implements SoliplexApi {}
 
+// Lets the event loop drain pending microtasks so awaited Futures
+// chained inside the tracker can run to completion.
+Future<void> _pump() => Future<void>.delayed(Duration.zero);
+
+FileUpload _fileUpload(String filename, [String? url]) {
+  return FileUpload(
+    filename: filename,
+    url: Uri.parse(url ?? 'https://example.com/$filename'),
+  );
+}
+
 void main() {
   late MockSoliplexApi mockApi;
   late UploadTracker tracker;
 
+  setUpAll(() {
+    registerFallbackValue(CancelToken());
+  });
+
   setUp(() {
     mockApi = MockSoliplexApi();
-    tracker = UploadTracker();
+    tracker = UploadTracker(api: mockApi);
   });
 
   tearDown(() {
     tracker.dispose();
+    reset(mockApi);
   });
 
-  group('uploadToRoom', () {
-    test('tracks upload lifecycle: uploading then success', () async {
-      final completer = Completer<void>();
-
-      when(
-        () => mockApi.uploadFileToRoom(
+  // Default: upload methods succeed; override per test as needed.
+  void stubUploadToRoomSuccess() {
+    when(() => mockApi.uploadFileToRoom(
           any(),
           filename: any(named: 'filename'),
           fileBytes: any(named: 'fileBytes'),
           mimeType: any(named: 'mimeType'),
-        ),
-      ).thenAnswer((_) => completer.future);
+        )).thenAnswer((_) async {});
+  }
 
-      tracker.uploadToRoom(
-        api: mockApi,
-        roomId: 'room-1',
-        filename: 'test.txt',
-        fileBytes: utf8.encode('content'),
-      );
+  void stubUploadToThreadSuccess() {
+    when(() => mockApi.uploadFileToThread(
+          any(),
+          any(),
+          filename: any(named: 'filename'),
+          fileBytes: any(named: 'fileBytes'),
+          mimeType: any(named: 'mimeType'),
+        )).thenAnswer((_) async {});
+  }
 
-      // Immediately in uploading state
-      final entries = tracker.roomUploads('room-1').value;
-      expect(entries, hasLength(1));
-      expect(entries.first.filename, 'test.txt');
-      expect(entries.first.status, isA<UploadUploading>());
+  void stubGetRoomUploads(List<FileUpload> uploads) {
+    when(() => mockApi.getRoomUploads(
+          any(),
+          cancelToken: any(named: 'cancelToken'),
+        )).thenAnswer((_) async => uploads);
+  }
 
-      // Complete the upload
-      completer.complete();
-      await Future<void>.delayed(Duration.zero);
+  void stubGetThreadUploads(List<FileUpload> uploads) {
+    when(() => mockApi.getThreadUploads(
+          any(),
+          any(),
+          cancelToken: any(named: 'cancelToken'),
+        )).thenAnswer((_) async => uploads);
+  }
 
-      final updated = tracker.roomUploads('room-1').value;
-      expect(updated.first.status, isA<UploadSuccess>());
+  group('initial fetch', () {
+    test('emits Loading then Loaded with server list', () async {
+      stubGetRoomUploads([_fileUpload('a.pdf'), _fileUpload('b.txt')]);
+
+      tracker.fetchRoomUploads('room-1');
+      expect(tracker.roomUploads('room-1').value, isA<UploadsLoading>());
+
+      await _pump();
+
+      final status = tracker.roomUploads('room-1').value;
+      expect(status, isA<UploadsLoaded>());
+      final uploads = (status as UploadsLoaded).uploads;
+      expect(uploads, hasLength(2));
+      expect(uploads.every((u) => u is PersistedUpload), isTrue);
+      expect(uploads.map((u) => u.filename), ['a.pdf', 'b.txt']);
     });
 
-    test('tracks upload error from API exception', () async {
-      when(
-        () => mockApi.uploadFileToRoom(
-          any(),
-          filename: any(named: 'filename'),
-          fileBytes: any(named: 'fileBytes'),
-          mimeType: any(named: 'mimeType'),
-        ),
-      ).thenAnswer(
-        (_) async => throw const ApiException(
-          statusCode: 500,
-          message: 'Server error',
-        ),
-      );
+    test('emits Loaded with empty list when server returns empty', () async {
+      stubGetRoomUploads([]);
 
-      tracker.uploadToRoom(
-        api: mockApi,
-        roomId: 'room-1',
-        filename: 'fail.txt',
-        fileBytes: [0],
-      );
+      tracker.fetchRoomUploads('room-1');
+      await _pump();
 
-      await Future<void>.delayed(Duration.zero);
-
-      final entries = tracker.roomUploads('room-1').value;
-      expect(entries, hasLength(1));
-      expect(entries.first.status, isA<UploadError>());
-      expect(
-        (entries.first.status as UploadError).message,
-        contains('Server error'),
-      );
+      final status = tracker.roomUploads('room-1').value;
+      expect(status, isA<UploadsLoaded>());
+      expect((status as UploadsLoaded).uploads, isEmpty);
     });
 
-    test('tracks upload error from network exception', () async {
-      when(
-        () => mockApi.uploadFileToRoom(
-          any(),
-          filename: any(named: 'filename'),
-          fileBytes: any(named: 'fileBytes'),
-          mimeType: any(named: 'mimeType'),
-        ),
-      ).thenAnswer(
-        (_) async => throw NetworkException(
-          message: 'Connection refused',
-        ),
-      );
+    test('is idempotent: repeated fetches after Loaded are no-ops', () async {
+      stubGetRoomUploads([_fileUpload('a.pdf')]);
 
-      tracker.uploadToRoom(
-        api: mockApi,
-        roomId: 'room-1',
-        filename: 'fail.txt',
-        fileBytes: [0],
-      );
+      tracker.fetchRoomUploads('room-1');
+      await _pump();
+      tracker.fetchRoomUploads('room-1');
+      tracker.fetchRoomUploads('room-1');
+      await _pump();
 
-      await Future<void>.delayed(Duration.zero);
-
-      final entries = tracker.roomUploads('room-1').value;
-      expect(entries, hasLength(1));
-      expect(entries.first.status, isA<UploadError>());
-      expect(
-        (entries.first.status as UploadError).message,
-        contains('Connection refused'),
-      );
+      verify(() => mockApi.getRoomUploads(
+            'room-1',
+            cancelToken: any(named: 'cancelToken'),
+          )).called(1);
     });
   });
 
-  group('uploadToThread', () {
-    test('tracks upload lifecycle: uploading then success', () async {
-      final completer = Completer<void>();
+  group('fetch failure', () {
+    test('emits UploadsFailed from a non-Loaded state', () async {
+      when(() => mockApi.getRoomUploads(
+            any(),
+            cancelToken: any(named: 'cancelToken'),
+          )).thenThrow(const ApiException(statusCode: 500, message: 'boom'));
 
-      when(
-        () => mockApi.uploadFileToThread(
-          any(),
-          any(),
-          filename: any(named: 'filename'),
-          fileBytes: any(named: 'fileBytes'),
-          mimeType: any(named: 'mimeType'),
-        ),
-      ).thenAnswer((_) => completer.future);
+      tracker.fetchRoomUploads('room-1');
+      await _pump();
 
-      tracker.uploadToThread(
-        api: mockApi,
-        roomId: 'room-1',
-        threadId: 'thread-1',
-        filename: 'report.pdf',
-        fileBytes: [0],
+      final status = tracker.roomUploads('room-1').value;
+      expect(status, isA<UploadsFailed>());
+      expect((status as UploadsFailed).error, isA<ApiException>());
+    });
+
+    test('preserves Loaded list when a refresh fails', () async {
+      stubGetRoomUploads([_fileUpload('a.pdf')]);
+
+      tracker.fetchRoomUploads('room-1');
+      await _pump();
+      expect(tracker.roomUploads('room-1').value, isA<UploadsLoaded>());
+
+      when(() => mockApi.getRoomUploads(
+            any(),
+            cancelToken: any(named: 'cancelToken'),
+          )).thenThrow(
+        NetworkException(message: 'wifi down'),
       );
 
-      final entries = tracker.threadUploads('room-1', 'thread-1').value;
+      await tracker.refreshRoom('room-1');
+
+      final status = tracker.roomUploads('room-1').value;
+      expect(status, isA<UploadsLoaded>());
+      expect((status as UploadsLoaded).uploads, hasLength(1));
+    });
+  });
+
+  group('upload success', () {
+    test('appends Pending, then drops it when refresh surfaces Persisted',
+        () async {
+      stubGetRoomUploads([]);
+      tracker.fetchRoomUploads('room-1');
+      await _pump();
+
+      final uploadCompleter = Completer<void>();
+      when(() => mockApi.uploadFileToRoom(
+            any(),
+            filename: any(named: 'filename'),
+            fileBytes: any(named: 'fileBytes'),
+            mimeType: any(named: 'mimeType'),
+          )).thenAnswer((_) => uploadCompleter.future);
+
+      tracker.uploadToRoom(
+        roomId: 'room-1',
+        filename: 'a.pdf',
+        fileBytes: const [1, 2, 3],
+      );
+
+      // Pending appears immediately, atop the (empty) persisted list.
+      var entries =
+          (tracker.roomUploads('room-1').value as UploadsLoaded).uploads;
       expect(entries, hasLength(1));
-      expect(entries.first.filename, 'report.pdf');
-      expect(entries.first.status, isA<UploadUploading>());
+      expect(entries.single, isA<PendingUpload>());
+      expect(entries.single.filename, 'a.pdf');
 
-      completer.complete();
-      await Future<void>.delayed(Duration.zero);
+      // Next refresh returns the new file.
+      stubGetRoomUploads([_fileUpload('a.pdf')]);
 
-      final updated = tracker.threadUploads('room-1', 'thread-1').value;
-      expect(updated.first.status, isA<UploadSuccess>());
+      uploadCompleter.complete();
+      await _pump();
+
+      entries = (tracker.roomUploads('room-1').value as UploadsLoaded).uploads;
+      expect(entries, hasLength(1));
+      expect(entries.single, isA<PersistedUpload>());
+      expect(entries.single.filename, 'a.pdf');
+    });
+
+    test('overwrite: renders both rows briefly, ends with single Persisted',
+        () async {
+      // Server already has a.pdf.
+      stubGetRoomUploads([_fileUpload('a.pdf', 'https://example.com/old')]);
+      tracker.fetchRoomUploads('room-1');
+      await _pump();
+
+      final uploadCompleter = Completer<void>();
+      when(() => mockApi.uploadFileToRoom(
+            any(),
+            filename: any(named: 'filename'),
+            fileBytes: any(named: 'fileBytes'),
+            mimeType: any(named: 'mimeType'),
+          )).thenAnswer((_) => uploadCompleter.future);
+
+      tracker.uploadToRoom(
+        roomId: 'room-1',
+        filename: 'a.pdf',
+        fileBytes: const [1],
+      );
+
+      // Both rows visible during the POST: old Persisted + new Pending.
+      final duringUpload =
+          (tracker.roomUploads('room-1').value as UploadsLoaded).uploads;
+      expect(duringUpload, hasLength(2));
+      expect(duringUpload.whereType<PersistedUpload>(), hasLength(1));
+      expect(duringUpload.whereType<PendingUpload>(), hasLength(1));
+
+      // Refresh returns the new file (same filename, new url).
+      stubGetRoomUploads([_fileUpload('a.pdf', 'https://example.com/new')]);
+      uploadCompleter.complete();
+      await _pump();
+
+      final after =
+          (tracker.roomUploads('room-1').value as UploadsLoaded).uploads;
+      expect(after, hasLength(1));
+      expect(after.single, isA<PersistedUpload>());
+      expect(
+        (after.single as PersistedUpload).url.toString(),
+        'https://example.com/new',
+      );
+    });
+
+    test('concurrent same-name uploads drop only the matching Pending',
+        () async {
+      stubGetRoomUploads([]);
+      tracker.fetchRoomUploads('room-1');
+      await _pump();
+
+      final firstCompleter = Completer<void>();
+      final secondCompleter = Completer<void>();
+      final completers = <Completer<void>>[firstCompleter, secondCompleter];
+      var callIndex = 0;
+
+      when(() => mockApi.uploadFileToRoom(
+            any(),
+            filename: any(named: 'filename'),
+            fileBytes: any(named: 'fileBytes'),
+            mimeType: any(named: 'mimeType'),
+          )).thenAnswer((_) => completers[callIndex++].future);
+
+      tracker.uploadToRoom(
+        roomId: 'room-1',
+        filename: 'dup.pdf',
+        fileBytes: const [1],
+      );
+      tracker.uploadToRoom(
+        roomId: 'room-1',
+        filename: 'dup.pdf',
+        fileBytes: const [2],
+      );
+
+      var pending = (tracker.roomUploads('room-1').value as UploadsLoaded)
+          .uploads
+          .whereType<PendingUpload>()
+          .toList();
+      expect(pending, hasLength(2));
+      expect(pending.map((e) => e.id).toSet(), hasLength(2));
+
+      // First upload finishes; its refresh still sees no persisted file
+      // (the server list hasn't been regenerated in this stub).
+      firstCompleter.complete();
+      await _pump();
+
+      // One of the two Pending entries should be gone.
+      pending = (tracker.roomUploads('room-1').value as UploadsLoaded)
+          .uploads
+          .whereType<PendingUpload>()
+          .toList();
+      expect(pending, hasLength(1));
+
+      // Finish second upload; no more Pending.
+      secondCompleter.complete();
+      await _pump();
+
+      pending = (tracker.roomUploads('room-1').value as UploadsLoaded)
+          .uploads
+          .whereType<PendingUpload>()
+          .toList();
+      expect(pending, isEmpty);
+    });
+  });
+
+  group('upload failure', () {
+    test('flips Pending to Failed; parent status stays Loaded', () async {
+      stubGetRoomUploads([]);
+      tracker.fetchRoomUploads('room-1');
+      await _pump();
+
+      when(() => mockApi.uploadFileToRoom(
+            any(),
+            filename: any(named: 'filename'),
+            fileBytes: any(named: 'fileBytes'),
+            mimeType: any(named: 'mimeType'),
+          )).thenThrow(const ApiException(statusCode: 500, message: 'nope'));
+
+      tracker.uploadToRoom(
+        roomId: 'room-1',
+        filename: 'fail.pdf',
+        fileBytes: const [1],
+      );
+      await _pump();
+
+      final status = tracker.roomUploads('room-1').value;
+      expect(status, isA<UploadsLoaded>(),
+          reason: 'POST failures must not transition the parent status');
+      final entries = (status as UploadsLoaded).uploads;
+      expect(entries, hasLength(1));
+      final failed = entries.single as FailedUpload;
+      expect(failed.filename, 'fail.pdf');
+      expect(failed.message, contains('nope'));
     });
   });
 
   group('dismiss', () {
-    test('removes entry from list', () async {
-      when(
-        () => mockApi.uploadFileToRoom(
-          any(),
-          filename: any(named: 'filename'),
-          fileBytes: any(named: 'fileBytes'),
-          mimeType: any(named: 'mimeType'),
-        ),
-      ).thenAnswer((_) async {});
+    test('removes a Pending entry by id', () async {
+      stubGetRoomUploads([]);
+      tracker.fetchRoomUploads('room-1');
+      await _pump();
+
+      final never = Completer<void>();
+      when(() => mockApi.uploadFileToRoom(
+            any(),
+            filename: any(named: 'filename'),
+            fileBytes: any(named: 'fileBytes'),
+            mimeType: any(named: 'mimeType'),
+          )).thenAnswer((_) => never.future);
 
       tracker.uploadToRoom(
-        api: mockApi,
         roomId: 'room-1',
-        filename: 'test.txt',
-        fileBytes: [0],
+        filename: 'a.pdf',
+        fileBytes: const [1],
       );
 
-      await Future<void>.delayed(Duration.zero);
+      final pending = (tracker.roomUploads('room-1').value as UploadsLoaded)
+          .uploads
+          .whereType<PendingUpload>()
+          .single;
 
-      final entries = tracker.roomUploads('room-1').value;
-      expect(entries, hasLength(1));
+      tracker.dismiss(pending.id);
 
-      tracker.dismiss(entries.first.id);
+      expect(
+        (tracker.roomUploads('room-1').value as UploadsLoaded)
+            .uploads
+            .whereType<PendingUpload>(),
+        isEmpty,
+      );
+    });
 
-      final updated = tracker.roomUploads('room-1').value;
-      expect(updated, isEmpty);
+    test('removes a Failed entry by id', () async {
+      stubGetRoomUploads([]);
+      tracker.fetchRoomUploads('room-1');
+      await _pump();
+
+      when(() => mockApi.uploadFileToRoom(
+            any(),
+            filename: any(named: 'filename'),
+            fileBytes: any(named: 'fileBytes'),
+            mimeType: any(named: 'mimeType'),
+          )).thenThrow(NetworkException(message: 'dns'));
+
+      tracker.uploadToRoom(
+        roomId: 'room-1',
+        filename: 'a.pdf',
+        fileBytes: const [1],
+      );
+      await _pump();
+
+      final failed = (tracker.roomUploads('room-1').value as UploadsLoaded)
+          .uploads
+          .whereType<FailedUpload>()
+          .single;
+
+      tracker.dismiss(failed.id);
+
+      expect(
+        (tracker.roomUploads('room-1').value as UploadsLoaded).uploads,
+        isEmpty,
+      );
+    });
+
+    test('is a no-op for an unknown id (including a persisted filename)',
+        () async {
+      stubGetRoomUploads([_fileUpload('a.pdf')]);
+      tracker.fetchRoomUploads('room-1');
+      await _pump();
+
+      tracker.dismiss('a.pdf'); // would-be mistaken use of filename as id
+      tracker.dismiss('upload-9999');
+
+      final uploads =
+          (tracker.roomUploads('room-1').value as UploadsLoaded).uploads;
+      expect(uploads, hasLength(1));
+      expect(uploads.single, isA<PersistedUpload>());
     });
   });
 
   group('scoping', () {
-    test('room uploads are scoped per room', () async {
-      when(
-        () => mockApi.uploadFileToRoom(
-          any(),
-          filename: any(named: 'filename'),
-          fileBytes: any(named: 'fileBytes'),
-          mimeType: any(named: 'mimeType'),
-        ),
-      ).thenAnswer((_) async {});
+    test('room and thread scopes hold independent state', () async {
+      stubGetRoomUploads([_fileUpload('room.pdf')]);
+      stubGetThreadUploads([_fileUpload('thread.pdf')]);
+      stubUploadToRoomSuccess();
+      stubUploadToThreadSuccess();
 
-      tracker.uploadToRoom(
-        api: mockApi,
-        roomId: 'room-1',
-        filename: 'a.txt',
-        fileBytes: [0],
-      );
-      tracker.uploadToRoom(
-        api: mockApi,
-        roomId: 'room-2',
-        filename: 'b.txt',
-        fileBytes: [0],
-      );
+      tracker.fetchRoomUploads('room-1');
+      tracker.fetchThreadUploads('room-1', 'thread-1');
+      await _pump();
 
-      expect(tracker.roomUploads('room-1').value, hasLength(1));
-      expect(tracker.roomUploads('room-2').value, hasLength(1));
-      expect(tracker.roomUploads('room-1').value.first.filename, 'a.txt');
+      final roomUploads =
+          (tracker.roomUploads('room-1').value as UploadsLoaded).uploads;
+      final threadUploads =
+          (tracker.threadUploads('room-1', 'thread-1').value as UploadsLoaded)
+              .uploads;
+
+      expect(roomUploads.single.filename, 'room.pdf');
+      expect(threadUploads.single.filename, 'thread.pdf');
     });
 
-    test('thread uploads are scoped per room+thread', () async {
-      when(
-        () => mockApi.uploadFileToThread(
-          any(),
-          any(),
-          filename: any(named: 'filename'),
-          fileBytes: any(named: 'fileBytes'),
-          mimeType: any(named: 'mimeType'),
-        ),
-      ).thenAnswer((_) async {});
+    test('distinct threads under the same room are independent', () async {
+      // Use a call counter so each thread scope gets its own list.
+      var callCount = 0;
+      when(() => mockApi.getThreadUploads(
+            any(),
+            any(),
+            cancelToken: any(named: 'cancelToken'),
+          )).thenAnswer((invocation) async {
+        final threadId = invocation.positionalArguments[1] as String;
+        callCount++;
+        return [_fileUpload('$threadId.pdf')];
+      });
 
-      tracker.uploadToThread(
-        api: mockApi,
-        roomId: 'room-1',
-        threadId: 'thread-1',
-        filename: 'a.txt',
-        fileBytes: [0],
-      );
-      tracker.uploadToThread(
-        api: mockApi,
-        roomId: 'room-1',
-        threadId: 'thread-2',
-        filename: 'b.txt',
-        fileBytes: [0],
-      );
+      tracker.fetchThreadUploads('room-1', 'thread-a');
+      tracker.fetchThreadUploads('room-1', 'thread-b');
+      await _pump();
 
-      expect(
-        tracker.threadUploads('room-1', 'thread-1').value,
-        hasLength(1),
+      expect(callCount, 2);
+      final a =
+          (tracker.threadUploads('room-1', 'thread-a').value as UploadsLoaded)
+              .uploads
+              .single;
+      final b =
+          (tracker.threadUploads('room-1', 'thread-b').value as UploadsLoaded)
+              .uploads
+              .single;
+      expect(a.filename, 'thread-a.pdf');
+      expect(b.filename, 'thread-b.pdf');
+    });
+  });
+
+  group('dispose', () {
+    test('cancels any in-flight list fetch', () async {
+      final never = Completer<List<FileUpload>>();
+      CancelToken? capturedToken;
+
+      when(() => mockApi.getRoomUploads(
+            any(),
+            cancelToken: any(named: 'cancelToken'),
+          )).thenAnswer((invocation) {
+        capturedToken = invocation.namedArguments[#cancelToken] as CancelToken?;
+        return never.future;
+      });
+
+      tracker.fetchRoomUploads('room-1');
+      await _pump();
+
+      expect(capturedToken, isNotNull);
+      expect(capturedToken!.isCancelled, isFalse);
+
+      tracker.dispose();
+
+      expect(capturedToken!.isCancelled, isTrue);
+    });
+
+    test('does not cancel in-flight uploads (POSTs have no CancelToken)',
+        () async {
+      stubGetRoomUploads([]);
+      tracker.fetchRoomUploads('room-1');
+      await _pump();
+
+      // The upload method has no cancelToken parameter — intentional
+      // per plan. Verify the signature in the stub doesn't reference one.
+      when(() => mockApi.uploadFileToRoom(
+            any(),
+            filename: any(named: 'filename'),
+            fileBytes: any(named: 'fileBytes'),
+            mimeType: any(named: 'mimeType'),
+          )).thenAnswer((_) async {});
+
+      tracker.uploadToRoom(
+        roomId: 'room-1',
+        filename: 'x.pdf',
+        fileBytes: const [0],
       );
-      expect(
-        tracker.threadUploads('room-1', 'thread-2').value,
-        hasLength(1),
-      );
+      tracker.dispose();
+
+      // No exception; dispose completes cleanly even with an in-flight
+      // upload Future. (The Future continues but its result is ignored
+      // because _isDisposed is set.)
     });
   });
 }

--- a/test/modules/room/upload_tracker_test.dart
+++ b/test/modules/room/upload_tracker_test.dart
@@ -135,6 +135,45 @@ void main() {
       expect(status, isA<UploadsLoaded>());
       expect((status as UploadsLoaded).uploads, hasLength(1));
     });
+
+    test(
+        'wraps a non-SoliplexException into UploadsFailed(UnexpectedException)',
+        () async {
+      when(() => mockApi.getRoomUploads(
+            any(),
+            cancelToken: any(named: 'cancelToken'),
+          )).thenAnswer((_) async {
+        throw StateError('unexpected non-soliplex error');
+      });
+
+      await tracker.refreshRoom('room-1');
+
+      final status = tracker.roomUploads('room-1').value;
+      expect(status, isA<UploadsFailed>());
+      final failure = status as UploadsFailed;
+      expect(failure.error, isA<UnexpectedException>());
+      expect(failure.error.originalError, isA<StateError>());
+    });
+
+    test('keeps stale Loaded list when a non-SoliplexException refresh fails',
+        () async {
+      stubGetRoomUploads([_fileUpload('a.pdf')]);
+      await tracker.refreshRoom('room-1');
+      expect(tracker.roomUploads('room-1').value, isA<UploadsLoaded>());
+
+      when(() => mockApi.getRoomUploads(
+            any(),
+            cancelToken: any(named: 'cancelToken'),
+          )).thenAnswer((_) async {
+        throw TypeError();
+      });
+
+      await tracker.refreshRoom('room-1');
+
+      final status = tracker.roomUploads('room-1').value;
+      expect(status, isA<UploadsLoaded>());
+      expect((status as UploadsLoaded).uploads, hasLength(1));
+    });
   });
 
   group('upload success', () {
@@ -258,9 +297,9 @@ void main() {
       expect(pending.map((e) => e.id).toSet(), hasLength(2));
 
       // After the first POST completes, its refresh returns the now-
-      // persisted file. The first pending (postCompleted=true, name
+      // persisted file. The first record (now _Posted, filename
       // matches persisted) drops. The second pending remains because
-      // its POST hasn't completed yet (postCompleted=false).
+      // its POST hasn't completed yet.
       stubGetRoomUploads([_fileUpload('dup.pdf')]);
       firstCompleter.complete();
       await _pump();
@@ -319,6 +358,108 @@ void main() {
             any(),
             cancelToken: any(named: 'cancelToken'),
           )).called(1);
+    });
+
+    test('non-Exception throw from POST becomes a Failed row, not a spinner',
+        () async {
+      stubGetRoomUploads([]);
+      unawaited(tracker.refreshRoom('room-1'));
+      await _pump();
+
+      when(() => mockApi.uploadFileToRoom(
+            any(),
+            filename: any(named: 'filename'),
+            fileBytes: any(named: 'fileBytes'),
+            mimeType: any(named: 'mimeType'),
+          )).thenAnswer((_) async {
+        throw StateError('plugin bug');
+      });
+
+      tracker.uploadToRoom(
+        roomId: 'room-1',
+        filename: 'fail.pdf',
+        fileBytes: const [1],
+      );
+      await _pump();
+
+      final entries =
+          (tracker.roomUploads('room-1').value as UploadsLoaded).uploads;
+      expect(entries, hasLength(1));
+      expect(entries.single, isA<FailedUpload>());
+    });
+  });
+
+  group('recordClientError', () {
+    test('surfaces a FailedUpload row on the room scope', () async {
+      stubGetRoomUploads([]);
+      await tracker.refreshRoom('room-1');
+
+      tracker.recordClientError(
+        roomId: 'room-1',
+        filename: 'doc.pdf',
+        message: 'Failed to read file',
+      );
+
+      final entries =
+          (tracker.roomUploads('room-1').value as UploadsLoaded).uploads;
+      expect(entries, hasLength(1));
+      final failed = entries.single as FailedUpload;
+      expect(failed.filename, 'doc.pdf');
+      expect(failed.message, 'Failed to read file');
+    });
+
+    test('routes to the thread scope when threadId is supplied', () async {
+      stubGetRoomUploads([]);
+      stubGetThreadUploads([]);
+      await tracker.refreshRoom('room-1');
+      await tracker.refreshThread('room-1', 'thread-1');
+
+      tracker.recordClientError(
+        roomId: 'room-1',
+        threadId: 'thread-1',
+        filename: 'doc.pdf',
+        message: 'Failed to read file',
+      );
+
+      expect(
+        (tracker.roomUploads('room-1').value as UploadsLoaded).uploads,
+        isEmpty,
+      );
+      final threadEntries =
+          (tracker.threadUploads('room-1', 'thread-1').value as UploadsLoaded)
+              .uploads;
+      expect(threadEntries.single, isA<FailedUpload>());
+      expect(threadEntries.single.filename, 'doc.pdf');
+    });
+
+    test('assigns unique ids so each row is independently dismissible',
+        () async {
+      stubGetRoomUploads([]);
+      await tracker.refreshRoom('room-1');
+
+      tracker.recordClientError(
+        roomId: 'room-1',
+        filename: 'one.pdf',
+        message: 'fail',
+      );
+      tracker.recordClientError(
+        roomId: 'room-1',
+        filename: 'two.pdf',
+        message: 'fail',
+      );
+
+      final entries = (tracker.roomUploads('room-1').value as UploadsLoaded)
+          .uploads
+          .whereType<FailedUpload>()
+          .toList();
+      expect(entries, hasLength(2));
+      expect(entries[0].id, isNot(equals(entries[1].id)));
+
+      tracker.dismissFailed(entries.first.id);
+      final remaining = (tracker.roomUploads('room-1').value as UploadsLoaded)
+          .uploads
+          .whereType<FailedUpload>();
+      expect(remaining.single.filename, 'two.pdf');
     });
   });
 
@@ -439,41 +580,7 @@ void main() {
     });
   });
 
-  group('dismiss', () {
-    test('removes a Pending entry by id', () async {
-      stubGetRoomUploads([]);
-      unawaited(tracker.refreshRoom('room-1'));
-      await _pump();
-
-      final never = Completer<void>();
-      when(() => mockApi.uploadFileToRoom(
-            any(),
-            filename: any(named: 'filename'),
-            fileBytes: any(named: 'fileBytes'),
-            mimeType: any(named: 'mimeType'),
-          )).thenAnswer((_) => never.future);
-
-      tracker.uploadToRoom(
-        roomId: 'room-1',
-        filename: 'a.pdf',
-        fileBytes: const [1],
-      );
-
-      final pending = (tracker.roomUploads('room-1').value as UploadsLoaded)
-          .uploads
-          .whereType<PendingUpload>()
-          .single;
-
-      tracker.dismiss(pending.id);
-
-      expect(
-        (tracker.roomUploads('room-1').value as UploadsLoaded)
-            .uploads
-            .whereType<PendingUpload>(),
-        isEmpty,
-      );
-    });
-
+  group('dismissFailed', () {
     test('removes a Failed entry by id', () async {
       stubGetRoomUploads([]);
       unawaited(tracker.refreshRoom('room-1'));
@@ -498,7 +605,7 @@ void main() {
           .whereType<FailedUpload>()
           .single;
 
-      tracker.dismiss(failed.id);
+      tracker.dismissFailed(failed.id);
 
       expect(
         (tracker.roomUploads('room-1').value as UploadsLoaded).uploads,
@@ -506,19 +613,54 @@ void main() {
       );
     });
 
-    test('is a no-op for an unknown id (including a persisted filename)',
-        () async {
+    test('is a no-op for an unknown id', () async {
       stubGetRoomUploads([_fileUpload('a.pdf')]);
       unawaited(tracker.refreshRoom('room-1'));
       await _pump();
 
-      tracker.dismiss('a.pdf'); // would-be mistaken use of filename as id
-      tracker.dismiss('upload-9999');
+      tracker.dismissFailed('a.pdf'); // mistaken use of filename as id
+      tracker.dismissFailed('upload-9999');
 
       final uploads =
           (tracker.roomUploads('room-1').value as UploadsLoaded).uploads;
       expect(uploads, hasLength(1));
       expect(uploads.single, isA<PersistedUpload>());
+    });
+
+    test('asserts when called on a Pending record', () async {
+      stubGetRoomUploads([]);
+      unawaited(tracker.refreshRoom('room-1'));
+      await _pump();
+
+      final never = Completer<void>();
+      when(() => mockApi.uploadFileToRoom(
+            any(),
+            filename: any(named: 'filename'),
+            fileBytes: any(named: 'fileBytes'),
+            mimeType: any(named: 'mimeType'),
+          )).thenAnswer((_) => never.future);
+
+      tracker.uploadToRoom(
+        roomId: 'room-1',
+        filename: 'a.pdf',
+        fileBytes: const [1],
+      );
+
+      final pending = (tracker.roomUploads('room-1').value as UploadsLoaded)
+          .uploads
+          .whereType<PendingUpload>()
+          .single;
+
+      expect(() => tracker.dismissFailed(pending.id), throwsAssertionError);
+
+      // The pending record survives — assertion fires but release-mode
+      // behavior still refuses the removal.
+      expect(
+        (tracker.roomUploads('room-1').value as UploadsLoaded)
+            .uploads
+            .whereType<PendingUpload>(),
+        hasLength(1),
+      );
     });
   });
 
@@ -623,6 +765,19 @@ void main() {
       // No exception; dispose completes cleanly even with an in-flight
       // upload Future. (The Future continues but its result is ignored
       // because _isDisposed is set.)
+    });
+
+    test('roomUploads throws StateError after dispose', () {
+      tracker.dispose();
+      expect(() => tracker.roomUploads('room-1'), throwsStateError);
+    });
+
+    test('threadUploads throws StateError after dispose', () {
+      tracker.dispose();
+      expect(
+        () => tracker.threadUploads('room-1', 'thread-1'),
+        throwsStateError,
+      );
     });
   });
 }

--- a/test/modules/room/upload_tracker_test.dart
+++ b/test/modules/room/upload_tracker_test.dart
@@ -323,6 +323,57 @@ void main() {
       final failed = entries.single as FailedUpload;
       expect(failed.filename, 'fail.pdf');
       expect(failed.message, contains('nope'));
+
+      // No extra list fetch was triggered by the failure — the catch
+      // path must not call refresh. (Initial fetch is the one call.)
+      verify(() => mockApi.getRoomUploads(
+            any(),
+            cancelToken: any(named: 'cancelToken'),
+          )).called(1);
+    });
+  });
+
+  group('re-fetch races', () {
+    test('late response from a cancelled fetch does not overwrite state',
+        () async {
+      final first = Completer<List<FileUpload>>();
+      final second = Completer<List<FileUpload>>();
+      final completers = [first, second];
+      var callIndex = 0;
+
+      when(() => mockApi.getRoomUploads(
+            any(),
+            cancelToken: any(named: 'cancelToken'),
+          )).thenAnswer((_) => completers[callIndex++].future);
+
+      tracker.fetchRoomUploads('room-1');
+      // Kick a second fetch; internally this cancels the first token.
+      unawaited(tracker.refreshRoom('room-1'));
+
+      // Complete the NEW fetch first, so the scope becomes Loaded
+      // with its result.
+      second.complete([_fileUpload('winner.pdf')]);
+      await _pump();
+      expect(
+        (tracker.roomUploads('room-1').value as UploadsLoaded)
+            .uploads
+            .single
+            .filename,
+        'winner.pdf',
+      );
+
+      // Now complete the cancelled fetch. Its guard must swallow the
+      // result; the scope must still show the newer list.
+      first.complete([_fileUpload('loser.pdf')]);
+      await _pump();
+
+      expect(
+        (tracker.roomUploads('room-1').value as UploadsLoaded)
+            .uploads
+            .single
+            .filename,
+        'winner.pdf',
+      );
     });
   });
 

--- a/test/modules/room/upload_tracker_test.dart
+++ b/test/modules/room/upload_tracker_test.dart
@@ -235,8 +235,9 @@ void main() {
       );
     });
 
-    test('concurrent same-name uploads drop only the matching Pending',
-        () async {
+    test(
+        'concurrent same-name uploads: first completion drops only the '
+        'first pending; second completion drops the second', () async {
       stubGetRoomUploads([]);
       tracker.fetchRoomUploads('room-1');
       await _pump();
@@ -271,19 +272,22 @@ void main() {
       expect(pending, hasLength(2));
       expect(pending.map((e) => e.id).toSet(), hasLength(2));
 
-      // First upload finishes; its refresh still sees no persisted file
-      // (the server list hasn't been regenerated in this stub).
+      // After the first POST completes, its refresh returns the now-
+      // persisted file. The first pending (postCompleted=true, name
+      // matches persisted) drops. The second pending remains because
+      // its POST hasn't completed yet (postCompleted=false).
+      stubGetRoomUploads([_fileUpload('dup.pdf')]);
       firstCompleter.complete();
       await _pump();
 
-      // One of the two Pending entries should be gone.
       pending = (tracker.roomUploads('room-1').value as UploadsLoaded)
           .uploads
           .whereType<PendingUpload>()
           .toList();
       expect(pending, hasLength(1));
 
-      // Finish second upload; no more Pending.
+      // After the second POST completes, its refresh confirms the
+      // (overwritten) file. The second pending drops.
       secondCompleter.complete();
       await _pump();
 
@@ -334,6 +338,79 @@ void main() {
   });
 
   group('re-fetch races', () {
+    test("cancelled upload-refresh doesn't strand a completed upload",
+        () async {
+      // Initial fetch: empty room.
+      stubGetRoomUploads([]);
+      tracker.fetchRoomUploads('room-1');
+      await _pump();
+
+      final postA = Completer<void>();
+      final postB = Completer<void>();
+      final posts = [postA, postB];
+      var postIdx = 0;
+
+      when(() => mockApi.uploadFileToRoom(
+            any(),
+            filename: any(named: 'filename'),
+            fileBytes: any(named: 'fileBytes'),
+            mimeType: any(named: 'mimeType'),
+          )).thenAnswer((_) => posts[postIdx++].future);
+
+      // Each upload-triggered refresh gets its own completer so we
+      // can resolve them out of order.
+      final fetchA = Completer<List<FileUpload>>();
+      final fetchB = Completer<List<FileUpload>>();
+      final fetches = [fetchA, fetchB];
+      var fetchIdx = 0;
+
+      when(() => mockApi.getRoomUploads(
+            any(),
+            cancelToken: any(named: 'cancelToken'),
+          )).thenAnswer((_) => fetches[fetchIdx++].future);
+
+      tracker.uploadToRoom(
+        roomId: 'room-1',
+        filename: 'a.pdf',
+        fileBytes: const [1],
+      );
+      tracker.uploadToRoom(
+        roomId: 'room-1',
+        filename: 'b.pdf',
+        fileBytes: const [2],
+      );
+
+      postA.complete();
+      await _pump();
+      // A's refresh is now in flight (fetchA).
+
+      postB.complete();
+      await _pump();
+      // B's refresh cancels A's token and starts fetchB.
+
+      // fetchA completes late — cancelled token, value ignored.
+      fetchA.complete([_fileUpload('a.pdf')]);
+      await _pump();
+
+      // fetchB completes with both persisted files.
+      fetchB.complete([_fileUpload('a.pdf'), _fileUpload('b.pdf')]);
+      await _pump();
+
+      final uploads =
+          (tracker.roomUploads('room-1').value as UploadsLoaded).uploads;
+      expect(
+        uploads.whereType<PersistedUpload>().map((e) => e.filename),
+        containsAll(['a.pdf', 'b.pdf']),
+      );
+      expect(
+        uploads.whereType<PendingUpload>(),
+        isEmpty,
+        reason: 'both uploads completed and appear in persisted; '
+            "neither should be stranded as pending even though A's "
+            'refresh was cancelled by B',
+      );
+    });
+
     test('late response from a cancelled fetch does not overwrite state',
         () async {
       final first = Completer<List<FileUpload>>();

--- a/test/modules/room/upload_tracker_test.dart
+++ b/test/modules/room/upload_tracker_test.dart
@@ -75,7 +75,7 @@ void main() {
     test('emits Loading then Loaded with server list', () async {
       stubGetRoomUploads([_fileUpload('a.pdf'), _fileUpload('b.txt')]);
 
-      tracker.fetchRoomUploads('room-1');
+      unawaited(tracker.refreshRoom('room-1'));
       expect(tracker.roomUploads('room-1').value, isA<UploadsLoading>());
 
       await _pump();
@@ -91,27 +91,12 @@ void main() {
     test('emits Loaded with empty list when server returns empty', () async {
       stubGetRoomUploads([]);
 
-      tracker.fetchRoomUploads('room-1');
+      unawaited(tracker.refreshRoom('room-1'));
       await _pump();
 
       final status = tracker.roomUploads('room-1').value;
       expect(status, isA<UploadsLoaded>());
       expect((status as UploadsLoaded).uploads, isEmpty);
-    });
-
-    test('is idempotent: repeated fetches after Loaded are no-ops', () async {
-      stubGetRoomUploads([_fileUpload('a.pdf')]);
-
-      tracker.fetchRoomUploads('room-1');
-      await _pump();
-      tracker.fetchRoomUploads('room-1');
-      tracker.fetchRoomUploads('room-1');
-      await _pump();
-
-      verify(() => mockApi.getRoomUploads(
-            'room-1',
-            cancelToken: any(named: 'cancelToken'),
-          )).called(1);
     });
   });
 
@@ -122,7 +107,7 @@ void main() {
             cancelToken: any(named: 'cancelToken'),
           )).thenThrow(const ApiException(statusCode: 500, message: 'boom'));
 
-      tracker.fetchRoomUploads('room-1');
+      unawaited(tracker.refreshRoom('room-1'));
       await _pump();
 
       final status = tracker.roomUploads('room-1').value;
@@ -133,7 +118,7 @@ void main() {
     test('preserves Loaded list when a refresh fails', () async {
       stubGetRoomUploads([_fileUpload('a.pdf')]);
 
-      tracker.fetchRoomUploads('room-1');
+      unawaited(tracker.refreshRoom('room-1'));
       await _pump();
       expect(tracker.roomUploads('room-1').value, isA<UploadsLoaded>());
 
@@ -156,7 +141,7 @@ void main() {
     test('appends Pending, then drops it when refresh surfaces Persisted',
         () async {
       stubGetRoomUploads([]);
-      tracker.fetchRoomUploads('room-1');
+      unawaited(tracker.refreshRoom('room-1'));
       await _pump();
 
       final uploadCompleter = Completer<void>();
@@ -196,7 +181,7 @@ void main() {
         () async {
       // Server already has a.pdf.
       stubGetRoomUploads([_fileUpload('a.pdf', 'https://example.com/old')]);
-      tracker.fetchRoomUploads('room-1');
+      unawaited(tracker.refreshRoom('room-1'));
       await _pump();
 
       final uploadCompleter = Completer<void>();
@@ -239,7 +224,7 @@ void main() {
         'concurrent same-name uploads: first completion drops only the '
         'first pending; second completion drops the second', () async {
       stubGetRoomUploads([]);
-      tracker.fetchRoomUploads('room-1');
+      unawaited(tracker.refreshRoom('room-1'));
       await _pump();
 
       final firstCompleter = Completer<void>();
@@ -302,7 +287,7 @@ void main() {
   group('upload failure', () {
     test('flips Pending to Failed; parent status stays Loaded', () async {
       stubGetRoomUploads([]);
-      tracker.fetchRoomUploads('room-1');
+      unawaited(tracker.refreshRoom('room-1'));
       await _pump();
 
       when(() => mockApi.uploadFileToRoom(
@@ -342,7 +327,7 @@ void main() {
         () async {
       // Initial fetch: empty room.
       stubGetRoomUploads([]);
-      tracker.fetchRoomUploads('room-1');
+      unawaited(tracker.refreshRoom('room-1'));
       await _pump();
 
       final postA = Completer<void>();
@@ -423,7 +408,7 @@ void main() {
             cancelToken: any(named: 'cancelToken'),
           )).thenAnswer((_) => completers[callIndex++].future);
 
-      tracker.fetchRoomUploads('room-1');
+      unawaited(tracker.refreshRoom('room-1'));
       // Kick a second fetch; internally this cancels the first token.
       unawaited(tracker.refreshRoom('room-1'));
 
@@ -457,7 +442,7 @@ void main() {
   group('dismiss', () {
     test('removes a Pending entry by id', () async {
       stubGetRoomUploads([]);
-      tracker.fetchRoomUploads('room-1');
+      unawaited(tracker.refreshRoom('room-1'));
       await _pump();
 
       final never = Completer<void>();
@@ -491,7 +476,7 @@ void main() {
 
     test('removes a Failed entry by id', () async {
       stubGetRoomUploads([]);
-      tracker.fetchRoomUploads('room-1');
+      unawaited(tracker.refreshRoom('room-1'));
       await _pump();
 
       when(() => mockApi.uploadFileToRoom(
@@ -524,7 +509,7 @@ void main() {
     test('is a no-op for an unknown id (including a persisted filename)',
         () async {
       stubGetRoomUploads([_fileUpload('a.pdf')]);
-      tracker.fetchRoomUploads('room-1');
+      unawaited(tracker.refreshRoom('room-1'));
       await _pump();
 
       tracker.dismiss('a.pdf'); // would-be mistaken use of filename as id
@@ -544,8 +529,8 @@ void main() {
       stubUploadToRoomSuccess();
       stubUploadToThreadSuccess();
 
-      tracker.fetchRoomUploads('room-1');
-      tracker.fetchThreadUploads('room-1', 'thread-1');
+      unawaited(tracker.refreshRoom('room-1'));
+      unawaited(tracker.refreshThread('room-1', 'thread-1'));
       await _pump();
 
       final roomUploads =
@@ -571,8 +556,8 @@ void main() {
         return [_fileUpload('$threadId.pdf')];
       });
 
-      tracker.fetchThreadUploads('room-1', 'thread-a');
-      tracker.fetchThreadUploads('room-1', 'thread-b');
+      unawaited(tracker.refreshThread('room-1', 'thread-a'));
+      unawaited(tracker.refreshThread('room-1', 'thread-b'));
       await _pump();
 
       expect(callCount, 2);
@@ -602,7 +587,7 @@ void main() {
         return never.future;
       });
 
-      tracker.fetchRoomUploads('room-1');
+      unawaited(tracker.refreshRoom('room-1'));
       await _pump();
 
       expect(capturedToken, isNotNull);
@@ -616,7 +601,7 @@ void main() {
     test('does not cancel in-flight uploads (POSTs have no CancelToken)',
         () async {
       stubGetRoomUploads([]);
-      tracker.fetchRoomUploads('room-1');
+      unawaited(tracker.refreshRoom('room-1'));
       await _pump();
 
       // The upload method has no cancelToken parameter — intentional


### PR DESCRIPTION
## Summary

- **Server-synced tracker**: `GET /uploads/{room_id}` and `/uploads/{room_id}/{thread_id}` endpoints feed a shared `UploadTracker` that merges persisted files with in-flight optimistic rows via a module-scoped `UploadTrackerRegistry`. Trackers outlive widgets so uploads started on one screen survive navigation away.
- **Hardened failure surfacing**: non-`Exception` throwables (e.g. `TypeError`, `StateError`) can no longer wedge a scope in `UploadsLoading` with a live `fetchToken` or leave a `_Pending` record as an eternal spinner. New `UnexpectedException` subtype wraps these at the tracker / `_parseUploadsList` boundary. Sealed `PickFileException` hierarchy routes picker-layer and byte-read failures through `uploadTracker.recordClientError` so the banner surfaces a failed pill instead of a silent no-op.
- **Inline event pills** above the composer announce upload success / failure with scope-aware diffing and an auto-dismiss timer (4s for success, manual-dismiss for failure).
- **Simpler room UI**: the header `Icons.upload_file` button is gone; room-scope uploads now live exclusively in the room info screen's "Upload file to room" card. ChatInput's paperclip continues to handle thread uploads.
- **Dedupe**: info-screen `initState` refresh is gated on `UploadsLoading`, so Room → Info navigation no longer wastes a GET.
- **Operability**: `cancelSpawn` error logging now works in release (`debugPrint` → `dev.log(level: 1000)`); missing / malformed upload-list responses are logged distinctly.

## Test plan

- [x] Pick a file, cancel the dialog → no banner, no error-level log
- [x] Pick + upload succeeds → pending pill → persisted row; success pill auto-dismisses after 4s
- [ ] Force a read failure (revoke disk permission) → failed pill with dismiss; cause logged at level 1000
- [x] Force a POST failure (5xx) → failed pill with server-derived message
- [ ] Force a refresh failure while scope is `UploadsLoaded` → list stays visible; warning logged
- [x] Navigate Room → Info with network inspector: one GET (no duplicate)
- [x] Deep-link to `/info`: one GET fires
- [x] ChatInput paperclip still uploads to current thread
- [x] ChatInput paperclip with no thread creates a thread and uploads
- [x] Room info "Upload file to room" still works
- [x] Chip leading icon reflects state (spinner / error / attach)
- [x] Expanded file panel renders `UploadsFailed` rows in red

🤖 Generated with [Claude Code](https://claude.com/claude-code)