### PR TITLE
feat(soliplex_client): persist ActivitySnapshotEvents on Conversation (S0)

### DIFF
--- a/packages/soliplex_client/lib/src/application/agui_event_processor.dart
+++ b/packages/soliplex_client/lib/src/application/agui_event_processor.dart
@@ -4,6 +4,7 @@ import 'package:ag_ui/ag_ui.dart';
 import 'package:meta/meta.dart';
 import 'package:soliplex_client/src/application/json_patch.dart';
 import 'package:soliplex_client/src/application/streaming_state.dart';
+import 'package:soliplex_client/src/domain/activity_record.dart';
 import 'package:soliplex_client/src/domain/chat_message.dart';
 import 'package:soliplex_client/src/domain/conversation.dart';
 
@@ -46,17 +47,17 @@ EventProcessingResult processEvent(
   return switch (event) {
     // Run lifecycle events
     RunStartedEvent(:final runId) => EventProcessingResult(
-        conversation: conversation.withStatus(Running(runId: runId)),
-        streaming: streaming,
-      ),
+      conversation: conversation.withStatus(Running(runId: runId)),
+      streaming: streaming,
+    ),
     RunFinishedEvent() => EventProcessingResult(
-        conversation: conversation.withStatus(const Completed()),
-        streaming: const AwaitingText(),
-      ),
+      conversation: conversation.withStatus(const Completed()),
+      streaming: const AwaitingText(),
+    ),
     RunErrorEvent(:final message) => EventProcessingResult(
-        conversation: conversation.withStatus(Failed(error: message)),
-        streaming: const AwaitingText(),
-      ),
+      conversation: conversation.withStatus(Failed(error: message)),
+      streaming: const AwaitingText(),
+    ),
 
     // Thinking / reasoning lifecycle — outer (Thinking/ReasoningStart/End),
     // inner thinking (ThinkingTextMessageStart/End), and reasoning message
@@ -65,31 +66,33 @@ EventProcessingResult processEvent(
     ThinkingStartEvent() ||
     ReasoningStartEvent() ||
     ThinkingTextMessageStartEvent() ||
-    ReasoningMessageStartEvent() =>
-      _processThinkingStart(conversation, streaming),
+    ReasoningMessageStartEvent() => _processThinkingStart(
+      conversation,
+      streaming,
+    ),
     ThinkingEndEvent() ||
     ReasoningEndEvent() ||
     ThinkingTextMessageEndEvent() ||
-    ReasoningMessageEndEvent() =>
-      _processThinkingEnd(conversation, streaming),
+    ReasoningMessageEndEvent() => _processThinkingEnd(conversation, streaming),
     ThinkingTextMessageContentEvent(:final delta) ||
-    ReasoningMessageContentEvent(:final delta) =>
-      _processThinkingContent(conversation, streaming, delta),
+    ReasoningMessageContentEvent(
+      :final delta,
+    ) => _processThinkingContent(conversation, streaming, delta),
 
     // Text message streaming events
     TextMessageStartEvent(:final messageId, :final role) => _processTextStart(
-        conversation,
-        streaming,
-        messageId,
-        role,
-      ),
+      conversation,
+      streaming,
+      messageId,
+      role,
+    ),
     TextMessageContentEvent(:final messageId, :final delta) =>
       _processTextContent(conversation, streaming, messageId, delta),
     TextMessageEndEvent(:final messageId) => _processTextEnd(
-        conversation,
-        streaming,
-        messageId,
-      ),
+      conversation,
+      streaming,
+      messageId,
+    ),
 
     // Tool call events — accumulate tool names on start, args via deltas,
     // transition to pending on end (tool stays in conversation.toolCalls).
@@ -114,43 +117,47 @@ EventProcessingResult processEvent(
         ),
       ),
     ToolCallArgsEvent(:final toolCallId, :final delta) => _processToolCallArgs(
-        conversation,
-        streaming,
-        toolCallId,
-        delta,
-      ),
+      conversation,
+      streaming,
+      toolCallId,
+      delta,
+    ),
     ToolCallEndEvent(:final toolCallId) => _processToolCallEnd(
-        conversation,
-        streaming,
-        toolCallId,
-      ),
+      conversation,
+      streaming,
+      toolCallId,
+    ),
     ToolCallResultEvent(:final toolCallId, :final content) =>
       _processToolCallResult(conversation, streaming, toolCallId, content),
 
     // State events - apply to conversation.aguiState
     StateSnapshotEvent(:final snapshot) => EventProcessingResult(
-        conversation: conversation.copyWith(
-          aguiState: snapshot as Map<String, dynamic>,
-        ),
-        streaming: streaming,
+      conversation: conversation.copyWith(
+        aguiState: snapshot as Map<String, dynamic>,
       ),
+      streaming: streaming,
+    ),
     StateDeltaEvent(:final delta) => _processStateDelta(
-        conversation,
-        streaming,
-        delta,
-      ),
+      conversation,
+      streaming,
+      delta,
+    ),
 
     // Activity snapshot events
     ActivitySnapshotEvent(
+      :final messageId,
       :final activityType,
       :final content,
+      :final replace,
       :final timestamp,
     ) =>
       _processActivitySnapshot(
         conversation,
         streaming,
+        messageId,
         activityType,
         content,
+        replace,
         timestamp,
       ),
 
@@ -176,11 +183,10 @@ EventProcessingResult processEvent(
     StepFinishedEvent() ||
     RawEvent() ||
     CustomEvent() ||
-    ReasoningMessageChunkEvent() =>
-      EventProcessingResult(
-        conversation: conversation,
-        streaming: streaming,
-      ),
+    ReasoningMessageChunkEvent() => EventProcessingResult(
+      conversation: conversation,
+      streaming: streaming,
+    ),
   };
 }
 
@@ -269,8 +275,9 @@ EventProcessingResult _processTextStart(
   TextMessageRole role,
 ) {
   // Transfer any buffered thinking from AwaitingText to TextStreaming
-  final thinkingText =
-      streaming is AwaitingText ? streaming.bufferedThinkingText : '';
+  final thinkingText = streaming is AwaitingText
+      ? streaming.bufferedThinkingText
+      : '';
   final isThinkingStreaming =
       streaming is AwaitingText && streaming.isThinkingStreaming;
 
@@ -427,10 +434,49 @@ EventProcessingResult _processToolCallResult(
 EventProcessingResult _processActivitySnapshot(
   Conversation conversation,
   StreamingState streaming,
+  String messageId,
   String activityType,
   Map<String, dynamic> content,
+  bool replace,
   int? timestamp,
 ) {
+  final resolvedTimestamp = timestamp ?? DateTime.now().millisecondsSinceEpoch;
+
+  // Persist the snapshot in conversation.activities per ag-ui spec:
+  //   replace=true  → overwrite the record with the same messageId
+  //   replace=false → ignore if a record with that messageId already exists
+  final existingIndex = conversation.activities.indexWhere(
+    (a) => a.messageId == messageId,
+  );
+  final List<ActivityRecord> updatedActivities;
+  if (existingIndex >= 0) {
+    if (replace) {
+      updatedActivities = [...conversation.activities]
+        ..[existingIndex] = ActivityRecord(
+          messageId: messageId,
+          activityType: activityType,
+          content: content,
+          timestamp: resolvedTimestamp,
+        );
+    } else {
+      updatedActivities = conversation.activities;
+    }
+  } else {
+    updatedActivities = [
+      ...conversation.activities,
+      ActivityRecord(
+        messageId: messageId,
+        activityType: activityType,
+        content: content,
+        timestamp: resolvedTimestamp,
+      ),
+    ];
+  }
+  final updatedConversation =
+      identical(updatedActivities, conversation.activities)
+      ? conversation
+      : conversation.copyWith(activities: updatedActivities);
+
   if (activityType == 'skill_tool_call') {
     final toolName = content['tool_name'];
     // Pass through if tool_name is missing or not a String — the backend
@@ -443,16 +489,16 @@ EventProcessingResult _processActivitySnapshot(
         level: 900,
       );
       return EventProcessingResult(
-        conversation: conversation,
+        conversation: updatedConversation,
         streaming: streaming,
       );
     }
     return EventProcessingResult(
-      conversation: conversation,
+      conversation: updatedConversation,
       streaming: _withToolCallActivity(
         streaming,
         toolName,
-        timestamp: timestamp ?? DateTime.now().millisecondsSinceEpoch,
+        timestamp: resolvedTimestamp,
       ),
     );
   }
@@ -463,7 +509,7 @@ EventProcessingResult _processActivitySnapshot(
     level: 800,
   );
   return EventProcessingResult(
-    conversation: conversation,
+    conversation: updatedConversation,
     streaming: streaming,
   );
 }
@@ -484,15 +530,15 @@ StreamingState _withToolCallActivity(
 
   final newActivity = switch (currentActivity) {
     ToolCallActivity() => currentActivity.withToolName(
-        toolName,
-        latestToolCallId: latestToolCallId,
-        timestamp: timestamp,
-      ),
+      toolName,
+      latestToolCallId: latestToolCallId,
+      timestamp: timestamp,
+    ),
     _ => ToolCallActivity(
-        toolName: toolName,
-        latestToolCallId: latestToolCallId,
-        timestamp: timestamp,
-      ),
+      toolName: toolName,
+      latestToolCallId: latestToolCallId,
+      timestamp: timestamp,
+    ),
   };
 
   return switch (streaming) {

--- a/packages/soliplex_client/lib/src/domain/activity_record.dart
+++ b/packages/soliplex_client/lib/src/domain/activity_record.dart
@@ -1,0 +1,72 @@
+import 'package:collection/collection.dart';
+import 'package:meta/meta.dart';
+
+/// A persisted AG-UI activity snapshot.
+///
+/// One record per `ActivitySnapshotEvent` the backend emits. The raw
+/// `content` payload is stored as-is; consumers decode the fields they
+/// need (e.g. `skill_tool_call` activities store a double-encoded
+/// `args` string under `content['args']`).
+@immutable
+class ActivityRecord {
+  /// Creates an activity record.
+  const ActivityRecord({
+    required this.messageId,
+    required this.activityType,
+    required this.content,
+    required this.timestamp,
+  });
+
+  /// Identifier for the target `ActivityMessage`. Snapshots with the
+  /// same [messageId] update the same record.
+  final String messageId;
+
+  /// Activity discriminator, e.g. `"skill_tool_call"`.
+  final String activityType;
+
+  /// Structured payload describing the full activity state. Shape is
+  /// specific to [activityType].
+  final Map<String, dynamic> content;
+
+  /// Event timestamp, or a wall-clock fallback if the event had none.
+  final int timestamp;
+
+  /// Creates a copy with the given fields replaced.
+  ActivityRecord copyWith({
+    String? messageId,
+    String? activityType,
+    Map<String, dynamic>? content,
+    int? timestamp,
+  }) {
+    return ActivityRecord(
+      messageId: messageId ?? this.messageId,
+      activityType: activityType ?? this.activityType,
+      content: content ?? this.content,
+      timestamp: timestamp ?? this.timestamp,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    if (other is! ActivityRecord) return false;
+    const mapEquals = DeepCollectionEquality();
+    return messageId == other.messageId &&
+        activityType == other.activityType &&
+        timestamp == other.timestamp &&
+        mapEquals.equals(content, other.content);
+  }
+
+  @override
+  int get hashCode => Object.hash(
+    messageId,
+    activityType,
+    timestamp,
+    const DeepCollectionEquality().hash(content),
+  );
+
+  @override
+  String toString() =>
+      'ActivityRecord(messageId: $messageId, '
+      'activityType: $activityType, timestamp: $timestamp)';
+}

--- a/packages/soliplex_client/lib/src/domain/conversation.dart
+++ b/packages/soliplex_client/lib/src/domain/conversation.dart
@@ -1,6 +1,7 @@
 import 'package:collection/collection.dart';
 import 'package:meta/meta.dart';
 
+import 'package:soliplex_client/src/domain/activity_record.dart';
 import 'package:soliplex_client/src/domain/chat_message.dart';
 import 'package:soliplex_client/src/domain/message_state.dart';
 
@@ -138,6 +139,7 @@ class Conversation {
     this.status = const Idle(),
     this.aguiState = const {},
     this.messageStates = const {},
+    this.activities = const [],
   });
 
   /// Creates an empty conversation for the given thread.
@@ -170,6 +172,11 @@ class Conversation {
   /// by correlating AG-UI state changes.
   final Map<String, MessageState> messageStates;
 
+  /// Persisted activity snapshots from `ActivitySnapshotEvent`, keyed by
+  /// `messageId`. One record per unique `messageId`; `replace:true` updates
+  /// in place, `replace:false` is ignored if a record already exists.
+  final List<ActivityRecord> activities;
+
   /// Whether a run is currently active.
   bool get isRunning => status is Running;
 
@@ -201,6 +208,7 @@ class Conversation {
     ConversationStatus? status,
     Map<String, dynamic>? aguiState,
     Map<String, MessageState>? messageStates,
+    List<ActivityRecord>? activities,
   }) {
     return Conversation(
       threadId: threadId ?? this.threadId,
@@ -209,6 +217,7 @@ class Conversation {
       status: status ?? this.status,
       aguiState: aguiState ?? this.aguiState,
       messageStates: messageStates ?? this.messageStates,
+      activities: activities ?? this.activities,
     );
   }
 
@@ -220,26 +229,30 @@ class Conversation {
     const toolCallListEquals = ListEquality<ToolCallInfo>();
     const mapEquals = DeepCollectionEquality();
     const messageStateMapEquals = MapEquality<String, MessageState>();
+    const activityListEquals = ListEquality<ActivityRecord>();
     return threadId == other.threadId &&
         listEquals.equals(messages, other.messages) &&
         toolCallListEquals.equals(toolCalls, other.toolCalls) &&
         status == other.status &&
         mapEquals.equals(aguiState, other.aguiState) &&
-        messageStateMapEquals.equals(messageStates, other.messageStates);
+        messageStateMapEquals.equals(messageStates, other.messageStates) &&
+        activityListEquals.equals(activities, other.activities);
   }
 
   @override
   int get hashCode => Object.hash(
-        threadId,
-        const ListEquality<ChatMessage>().hash(messages),
-        const ListEquality<ToolCallInfo>().hash(toolCalls),
-        status,
-        const DeepCollectionEquality().hash(aguiState),
-        const MapEquality<String, MessageState>().hash(messageStates),
-      );
+    threadId,
+    const ListEquality<ChatMessage>().hash(messages),
+    const ListEquality<ToolCallInfo>().hash(toolCalls),
+    status,
+    const DeepCollectionEquality().hash(aguiState),
+    const MapEquality<String, MessageState>().hash(messageStates),
+    const ListEquality<ActivityRecord>().hash(activities),
+  );
 
   @override
-  String toString() => 'Conversation(threadId: $threadId, '
+  String toString() =>
+      'Conversation(threadId: $threadId, '
       'messages: ${messages.length}, '
       'toolCalls: ${toolCalls.length}, '
       'status: $status)';

--- a/packages/soliplex_client/lib/src/domain/domain.dart
+++ b/packages/soliplex_client/lib/src/domain/domain.dart
@@ -1,3 +1,4 @@
+export 'activity_record.dart';
 export 'auth_provider_config.dart';
 export 'backend_version_info.dart';
 export 'chat_message.dart';

--- a/packages/soliplex_client/test/application/agui_event_processor_test.dart
+++ b/packages/soliplex_client/test/application/agui_event_processor_test.dart
@@ -189,11 +189,7 @@ void main() {
         );
         const event = TextMessageEndEvent(messageId: 'msg-1');
 
-        final result = processEvent(
-          conversationWithMsg,
-          streamingState,
-          event,
-        );
+        final result = processEvent(conversationWithMsg, streamingState, event);
 
         // Should skip — conversation still has exactly 1 message
         expect(result.conversation.messages, hasLength(1));
@@ -696,8 +692,7 @@ void main() {
       });
 
       group('ToolCallActivity equality', () {
-        test(
-            'consecutive starts of same tool produce unequal activities '
+        test('consecutive starts of same tool produce unequal activities '
             '(different toolCallId)', () {
           const event1 = ToolCallStartEvent(
             toolCallId: 'tc-1',
@@ -730,8 +725,9 @@ void main() {
 
           final result = processEvent(conversation, streaming, event);
 
-          final activity = (result.streaming as app_streaming.AwaitingText)
-              .currentActivity as app_streaming.ToolCallActivity;
+          final activity =
+              (result.streaming as app_streaming.AwaitingText).currentActivity
+                  as app_streaming.ToolCallActivity;
           expect(activity.latestToolCallId, equals('tc-1'));
         });
 
@@ -744,8 +740,9 @@ void main() {
 
           final result = processEvent(conversation, streaming, event);
 
-          final activity = (result.streaming as app_streaming.AwaitingText)
-              .currentActivity as app_streaming.ToolCallActivity;
+          final activity =
+              (result.streaming as app_streaming.AwaitingText).currentActivity
+                  as app_streaming.ToolCallActivity;
           expect(activity.timestamp, equals(1000));
         });
       });
@@ -926,22 +923,165 @@ void main() {
         expect(activity.timestamp, equals(2000));
       });
 
-      test('skill_tool_call without timestamp synthesizes wall-clock value',
-          () {
-        final before = DateTime.now().millisecondsSinceEpoch;
+      test(
+        'skill_tool_call without timestamp synthesizes wall-clock value',
+        () {
+          final before = DateTime.now().millisecondsSinceEpoch;
+          const event = ActivitySnapshotEvent(
+            messageId: 'msg-1',
+            activityType: 'skill_tool_call',
+            content: {'tool_name': 'search'},
+          );
+
+          final result = processEvent(conversation, streaming, event);
+          final after = DateTime.now().millisecondsSinceEpoch;
+
+          final activity =
+              (result.streaming as app_streaming.AwaitingText).currentActivity
+                  as app_streaming.ToolCallActivity;
+          expect(activity.timestamp, greaterThanOrEqualTo(before));
+          expect(activity.timestamp, lessThanOrEqualTo(after));
+        },
+      );
+
+      test('persists snapshot as ActivityRecord on conversation', () {
         const event = ActivitySnapshotEvent(
-          messageId: 'msg-1',
+          messageId: 'rag:call_1',
           activityType: 'skill_tool_call',
-          content: {'tool_name': 'search'},
+          content: {'tool_name': 'ask', 'args': '{"q":"hi"}'},
+          timestamp: 1234,
         );
 
         final result = processEvent(conversation, streaming, event);
-        final after = DateTime.now().millisecondsSinceEpoch;
 
-        final activity = (result.streaming as app_streaming.AwaitingText)
-            .currentActivity as app_streaming.ToolCallActivity;
-        expect(activity.timestamp, greaterThanOrEqualTo(before));
-        expect(activity.timestamp, lessThanOrEqualTo(after));
+        expect(result.conversation.activities, hasLength(1));
+        final record = result.conversation.activities.first;
+        expect(record.messageId, 'rag:call_1');
+        expect(record.activityType, 'skill_tool_call');
+        expect(record.content['tool_name'], 'ask');
+        expect(record.content['args'], '{"q":"hi"}');
+        expect(record.timestamp, 1234);
+      });
+
+      test('unknown activityType is persisted', () {
+        const event = ActivitySnapshotEvent(
+          messageId: 'plan:1',
+          activityType: 'plan',
+          content: {'steps': 3},
+          timestamp: 10,
+        );
+
+        final result = processEvent(conversation, streaming, event);
+
+        expect(result.conversation.activities, hasLength(1));
+        expect(result.conversation.activities.first.activityType, 'plan');
+      });
+
+      test('replace:true overwrites record with same messageId in place', () {
+        const first = ActivitySnapshotEvent(
+          messageId: 'rag:call_1',
+          activityType: 'skill_tool_call',
+          content: {'tool_name': 'ask'},
+          timestamp: 1,
+        );
+        const second = ActivitySnapshotEvent(
+          messageId: 'rag:call_1',
+          activityType: 'skill_tool_call',
+          content: {'tool_name': 'ask', 'status': 'done'},
+          timestamp: 2,
+        );
+
+        final afterFirst = processEvent(conversation, streaming, first);
+        final afterSecond = processEvent(
+          afterFirst.conversation,
+          afterFirst.streaming,
+          second,
+        );
+
+        expect(afterSecond.conversation.activities, hasLength(1));
+        final record = afterSecond.conversation.activities.first;
+        expect(record.timestamp, 2);
+        expect(record.content['status'], 'done');
+      });
+
+      test('replace:false ignored when messageId already exists', () {
+        const first = ActivitySnapshotEvent(
+          messageId: 'rag:call_1',
+          activityType: 'skill_tool_call',
+          content: {'tool_name': 'ask'},
+          timestamp: 1,
+        );
+        const second = ActivitySnapshotEvent(
+          messageId: 'rag:call_1',
+          activityType: 'skill_tool_call',
+          content: {'tool_name': 'search'},
+          replace: false,
+          timestamp: 2,
+        );
+
+        final afterFirst = processEvent(conversation, streaming, first);
+        final afterSecond = processEvent(
+          afterFirst.conversation,
+          afterFirst.streaming,
+          second,
+        );
+
+        expect(afterSecond.conversation.activities, hasLength(1));
+        final record = afterSecond.conversation.activities.first;
+        expect(record.content['tool_name'], 'ask');
+        expect(record.timestamp, 1);
+      });
+
+      test('replace:false appends when messageId is new', () {
+        const event = ActivitySnapshotEvent(
+          messageId: 'rag:call_2',
+          activityType: 'skill_tool_call',
+          content: {'tool_name': 'ask'},
+          replace: false,
+          timestamp: 5,
+        );
+
+        final result = processEvent(conversation, streaming, event);
+
+        expect(result.conversation.activities, hasLength(1));
+        expect(result.conversation.activities.first.messageId, 'rag:call_2');
+      });
+
+      test('distinct messageIds accumulate in order received', () {
+        const e1 = ActivitySnapshotEvent(
+          messageId: 'a',
+          activityType: 'skill_tool_call',
+          content: {'tool_name': 'ask'},
+          timestamp: 1,
+        );
+        const e2 = ActivitySnapshotEvent(
+          messageId: 'b',
+          activityType: 'skill_tool_call',
+          content: {'tool_name': 'search'},
+          timestamp: 2,
+        );
+
+        var r = processEvent(conversation, streaming, e1);
+        r = processEvent(r.conversation, r.streaming, e2);
+
+        expect(
+          r.conversation.activities.map((a) => a.messageId).toList(),
+          equals(['a', 'b']),
+        );
+      });
+
+      test('persists even when skill_tool_call is missing tool_name', () {
+        const event = ActivitySnapshotEvent(
+          messageId: 'rag:call_x',
+          activityType: 'skill_tool_call',
+          content: <String, dynamic>{},
+          timestamp: 9,
+        );
+
+        final result = processEvent(conversation, streaming, event);
+
+        expect(result.conversation.activities, hasLength(1));
+        expect(result.conversation.activities.first.messageId, 'rag:call_x');
       });
     });
 
@@ -1118,33 +1258,30 @@ void main() {
         expect(awaitingText.isThinkingStreaming, isFalse);
       });
 
-      test(
-        'TextMessageEndEvent preserves reasoning-sourced thinkingText',
-        () {
-          const event = ReasoningMessageContentEvent(
-            messageId: 'reas-1',
-            delta: 'Inner reasoning',
-          );
-          final afterReasoning = processEvent(conversation, streaming, event);
+      test('TextMessageEndEvent preserves reasoning-sourced thinkingText', () {
+        const event = ReasoningMessageContentEvent(
+          messageId: 'reas-1',
+          delta: 'Inner reasoning',
+        );
+        final afterReasoning = processEvent(conversation, streaming, event);
 
-          const textStart = TextMessageStartEvent(messageId: 'msg-1');
-          final afterStart = processEvent(
-            afterReasoning.conversation,
-            afterReasoning.streaming,
-            textStart,
-          );
+        const textStart = TextMessageStartEvent(messageId: 'msg-1');
+        final afterStart = processEvent(
+          afterReasoning.conversation,
+          afterReasoning.streaming,
+          textStart,
+        );
 
-          const textEnd = TextMessageEndEvent(messageId: 'msg-1');
-          final result = processEvent(
-            afterStart.conversation,
-            afterStart.streaming,
-            textEnd,
-          );
+        const textEnd = TextMessageEndEvent(messageId: 'msg-1');
+        final result = processEvent(
+          afterStart.conversation,
+          afterStart.streaming,
+          textEnd,
+        );
 
-          final message = result.conversation.messages.first as TextMessage;
-          expect(message.thinkingText, equals('Inner reasoning'));
-        },
-      );
+        final message = result.conversation.messages.first as TextMessage;
+        expect(message.thinkingText, equals('Inner reasoning'));
+      });
     });
 
     group('state events', () {

--- a/packages/soliplex_client/test/domain/activity_record_test.dart
+++ b/packages/soliplex_client/test/domain/activity_record_test.dart
@@ -1,0 +1,70 @@
+import 'package:soliplex_client/soliplex_client.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('ActivityRecord', () {
+    test('fields are preserved on construction', () {
+      const record = ActivityRecord(
+        messageId: 'rag:call_1',
+        activityType: 'skill_tool_call',
+        content: {'tool_name': 'ask', 'args': '{"q":"hi"}'},
+        timestamp: 1234,
+      );
+      expect(record.messageId, 'rag:call_1');
+      expect(record.activityType, 'skill_tool_call');
+      expect(record.content['tool_name'], 'ask');
+      expect(record.timestamp, 1234);
+    });
+
+    test('equality based on all fields', () {
+      const a = ActivityRecord(
+        messageId: 'm1',
+        activityType: 'skill_tool_call',
+        content: {'tool_name': 'ask'},
+        timestamp: 1,
+      );
+      const b = ActivityRecord(
+        messageId: 'm1',
+        activityType: 'skill_tool_call',
+        content: {'tool_name': 'ask'},
+        timestamp: 1,
+      );
+      const c = ActivityRecord(
+        messageId: 'm1',
+        activityType: 'skill_tool_call',
+        content: {'tool_name': 'search'},
+        timestamp: 1,
+      );
+      expect(a, equals(b));
+      expect(a.hashCode, equals(b.hashCode));
+      expect(a, isNot(equals(c)));
+    });
+
+    test('copyWith replaces only the given fields', () {
+      const a = ActivityRecord(
+        messageId: 'm1',
+        activityType: 'skill_tool_call',
+        content: {'tool_name': 'ask'},
+        timestamp: 1,
+      );
+      final b = a.copyWith(timestamp: 2);
+      expect(b.messageId, a.messageId);
+      expect(b.activityType, a.activityType);
+      expect(b.content, a.content);
+      expect(b.timestamp, 2);
+    });
+
+    test('toString includes identifying fields', () {
+      const a = ActivityRecord(
+        messageId: 'rag:call_1',
+        activityType: 'skill_tool_call',
+        content: {},
+        timestamp: 7,
+      );
+      final s = a.toString();
+      expect(s, contains('rag:call_1'));
+      expect(s, contains('skill_tool_call'));
+      expect(s, contains('7'));
+    });
+  });
+}

--- a/packages/soliplex_client/test/domain/conversation_test.dart
+++ b/packages/soliplex_client/test/domain/conversation_test.dart
@@ -67,8 +67,9 @@ void main() {
         const toolCall1 = ToolCallInfo(id: 'tool-1', name: 'search');
         const toolCall2 = ToolCallInfo(id: 'tool-2', name: 'read');
 
-        final updated =
-            conversation.withToolCall(toolCall1).withToolCall(toolCall2);
+        final updated = conversation
+            .withToolCall(toolCall1)
+            .withToolCall(toolCall2);
 
         expect(updated.toolCalls, hasLength(2));
       });
@@ -204,6 +205,21 @@ void main() {
         final conv2 = conv1.withMessageState(
           'user-1',
           MessageState(userMessageId: 'user-1', sourceReferences: const []),
+        );
+        expect(conv1, isNot(equals(conv2)));
+      });
+
+      test('conversations with different activities are not equal', () {
+        final conv1 = Conversation.empty(threadId: 'thread-1');
+        final conv2 = conv1.copyWith(
+          activities: const [
+            ActivityRecord(
+              messageId: 'm1',
+              activityType: 'skill_tool_call',
+              content: {'tool_name': 'ask'},
+              timestamp: 1,
+            ),
+          ],
         );
         expect(conv1, isNot(equals(conv2)));
       });


### PR DESCRIPTION
## Summary

First slice of the **activity-persistence stack** — plumbing only, no UI consumer yet.

- Adds `ActivityRecord` domain model (`messageId`, `activityType`, raw `content: Map<String, dynamic>`, `timestamp`).
- Extends `Conversation` with an `activities: List<ActivityRecord>` surface.
- Wires `agui_event_processor` to upsert records on `ActivitySnapshotEvent`, honoring the AG-UI spec:
  - `replace: true` overwrites the record with the same `messageId`
  - `replace: false` is ignored if the `messageId` already exists
- Existing `skill_tool_call` streaming behavior (`streaming.currentActivity`) is preserved — this PR only adds the persisted surface alongside it.

## Stack

This is **S0** of a two-slice stack. **S1** (`s1/typed-canary-tool`, stacked on this branch) adds a typed reader view and an end-to-end pipeline canary that validates the persisted data is UI-consumable. Future slices will build StatePanel / ActivityLog UI on top.

## Notes

- No UI consumer yet; purely domain + processor changes.
- The formatter reflowed `agui_event_processor.dart` call-site arguments (trailing-comma style change); included here because it touches the same file.
- Stays on upstream SDK `^3.6.0` — deliberately **not** rebased onto `chore/bump-sdk-3.7`.

## Test plan

- [x] `flutter analyze` (packages/soliplex_client): clean
- [x] `flutter test --exclude-tags integration`: 1288 tests pass
  - New: `test/domain/activity_record_test.dart`, `test/domain/conversation_test.dart` (extended), `test/application/agui_event_processor_test.dart` (extended — snapshot persistence, replace semantics)
- [ ] Integration-tagged tests skipped (require live backend; unrelated to this change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
