### PR TITLE
feat(soliplex_client): typed SkillToolCallActivity view + pipeline canary (S1)

### DIFF
--- a/packages/soliplex_client/lib/src/domain/domain.dart
+++ b/packages/soliplex_client/lib/src/domain/domain.dart
@@ -16,6 +16,7 @@ export 'room_agent.dart';
 export 'room_skill.dart';
 export 'room_tool.dart';
 export 'run_info.dart';
+export 'skill_tool_call_activity.dart';
 export 'source_reference.dart';
 export 'thread_history.dart';
 export 'thread_info.dart';

--- a/packages/soliplex_client/lib/src/domain/skill_tool_call_activity.dart
+++ b/packages/soliplex_client/lib/src/domain/skill_tool_call_activity.dart
@@ -1,0 +1,172 @@
+import 'dart:convert';
+import 'dart:developer' as developer;
+
+import 'package:collection/collection.dart';
+import 'package:meta/meta.dart';
+
+import 'package:soliplex_client/src/domain/activity_record.dart';
+import 'package:soliplex_client/src/domain/conversation.dart';
+
+/// Typed view of a `skill_tool_call` activity record.
+///
+/// Decodes the raw [ActivityRecord.content] bag for the
+/// `skill_tool_call` [ActivityRecord.activityType]. The `args` field in
+/// the raw content is a double-encoded JSON string per the backend
+/// contract; this class decodes it into a plain map.
+///
+/// Construct via [SkillToolCallActivity.fromRecord], which returns
+/// `null` when the record is not a well-formed skill_tool_call. The
+/// underlying [ActivityRecord] stays authoritative — this is a read
+/// view for UI consumers, not a replacement.
+@immutable
+class SkillToolCallActivity {
+  /// Creates a [SkillToolCallActivity]. Prefer [fromRecord].
+  const SkillToolCallActivity({
+    required this.messageId,
+    required this.toolName,
+    required this.args,
+    required this.status,
+    required this.timestamp,
+  });
+
+  /// Attempts to decode [record] as a [SkillToolCallActivity].
+  ///
+  /// Returns `null` when:
+  /// - [ActivityRecord.activityType] is not `"skill_tool_call"`
+  /// - `content['tool_name']` is missing or not a [String]
+  /// - `content['args']` is present but not decodable as a JSON object
+  ///
+  /// Missing `args` yields an empty map; missing `status` yields `null`.
+  /// Schema drift is logged (warning) rather than thrown, matching the
+  /// processor's posture in `_processActivitySnapshot`.
+  static SkillToolCallActivity? fromRecord(ActivityRecord record) {
+    if (record.activityType != 'skill_tool_call') {
+      return null;
+    }
+    final toolName = record.content['tool_name'];
+    if (toolName is! String) {
+      developer.log(
+        'SkillToolCallActivity.fromRecord: missing or invalid tool_name '
+        '(runtimeType=${toolName.runtimeType}) for messageId '
+        '${record.messageId}',
+        name: 'soliplex_client.skill_tool_call_activity',
+        level: 900,
+      );
+      return null;
+    }
+
+    final rawArgs = record.content['args'];
+    final Map<String, dynamic> decodedArgs;
+    switch (rawArgs) {
+      case null:
+        decodedArgs = const {};
+      case final String s when s.isEmpty:
+        decodedArgs = const {};
+      case final String s:
+        final parsed = _tryDecodeJsonObject(s, record.messageId);
+        if (parsed == null) {
+          return null;
+        }
+        decodedArgs = parsed;
+      case final Map<String, dynamic> m:
+        decodedArgs = m;
+      default:
+        developer.log(
+          'SkillToolCallActivity.fromRecord: unexpected args '
+          'runtimeType=${rawArgs.runtimeType} for messageId '
+          '${record.messageId}',
+          name: 'soliplex_client.skill_tool_call_activity',
+          level: 900,
+        );
+        return null;
+    }
+
+    final rawStatus = record.content['status'];
+    final status = rawStatus is String ? rawStatus : null;
+
+    return SkillToolCallActivity(
+      messageId: record.messageId,
+      toolName: toolName,
+      args: decodedArgs,
+      status: status,
+      timestamp: record.timestamp,
+    );
+  }
+
+  /// Identifier for the target `ActivityMessage`.
+  final String messageId;
+
+  /// Tool being invoked (e.g. `"ask"`).
+  final String toolName;
+
+  /// Decoded arguments for the tool call. Empty when absent.
+  final Map<String, dynamic> args;
+
+  /// Optional status token (e.g. `"in_progress"`, `"done"`).
+  final String? status;
+
+  /// Event timestamp for the underlying snapshot.
+  final int timestamp;
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    if (other is! SkillToolCallActivity) return false;
+    const mapEquals = DeepCollectionEquality();
+    return messageId == other.messageId &&
+        toolName == other.toolName &&
+        status == other.status &&
+        timestamp == other.timestamp &&
+        mapEquals.equals(args, other.args);
+  }
+
+  @override
+  int get hashCode => Object.hash(
+    messageId,
+    toolName,
+    status,
+    timestamp,
+    const DeepCollectionEquality().hash(args),
+  );
+
+  @override
+  String toString() =>
+      'SkillToolCallActivity(messageId: $messageId, '
+      'toolName: $toolName, status: $status, timestamp: $timestamp)';
+}
+
+Map<String, dynamic>? _tryDecodeJsonObject(String raw, String messageId) {
+  try {
+    final decoded = jsonDecode(raw);
+    if (decoded is Map<String, dynamic>) {
+      return decoded;
+    }
+    developer.log(
+      'SkillToolCallActivity.fromRecord: args decoded to '
+      '${decoded.runtimeType}, not a JSON object, for messageId '
+      '$messageId',
+      name: 'soliplex_client.skill_tool_call_activity',
+      level: 900,
+    );
+    return null;
+  } on FormatException catch (e) {
+    developer.log(
+      'SkillToolCallActivity.fromRecord: args JSON parse failed for '
+      'messageId $messageId: $e',
+      name: 'soliplex_client.skill_tool_call_activity',
+      level: 900,
+    );
+    return null;
+  }
+}
+
+/// Typed accessors for [Conversation.activities].
+extension ConversationSkillToolCalls on Conversation {
+  /// All `skill_tool_call` activities in [activities], decoded to the
+  /// typed view. Malformed records are skipped (see
+  /// [SkillToolCallActivity.fromRecord]).
+  List<SkillToolCallActivity> get skillToolCalls => [
+    for (final record in activities)
+      if (SkillToolCallActivity.fromRecord(record) case final call?) call,
+  ];
+}

--- a/packages/soliplex_client/test/canary/activity_pipeline_canary_test.dart
+++ b/packages/soliplex_client/test/canary/activity_pipeline_canary_test.dart
@@ -1,0 +1,244 @@
+/// End-to-end pipeline canary for the activity-persistence feature.
+///
+/// Drives realistic `ActivitySnapshotEvent` sequences through the
+/// production `processEvent` function and reads the result back through
+/// the typed `Conversation.skillToolCalls` accessor, the same surface a
+/// future StatePanel / ActivityLog UI will consume.
+///
+/// If this test ever fails, the UI cannot trust `conversation.activities`
+/// to reflect what the backend emitted — the contract is broken
+/// somewhere between the AG-UI processor and the typed view.
+library;
+
+import 'package:soliplex_client/soliplex_client.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('activity pipeline canary', () {
+    late Conversation conversation;
+    late StreamingState streaming;
+
+    setUp(() {
+      conversation = Conversation.empty(threadId: 'thread-1');
+      streaming = const AwaitingText();
+    });
+
+    test(
+      'single skill_tool_call snapshot → typed view exposes toolName, '
+      'decoded args, and status',
+      () {
+        const event = ActivitySnapshotEvent(
+          messageId: 'rag:call_1',
+          activityType: 'skill_tool_call',
+          content: {
+            'tool_name': 'ask',
+            'args': '{"q":"what is AG-UI?","top_k":3}',
+            'status': 'in_progress',
+          },
+          timestamp: 100,
+        );
+
+        final result = processEvent(conversation, streaming, event);
+        final calls = result.conversation.skillToolCalls;
+
+        expect(calls, hasLength(1));
+        expect(calls.single.messageId, 'rag:call_1');
+        expect(calls.single.toolName, 'ask');
+        expect(calls.single.args, {'q': 'what is AG-UI?', 'top_k': 3});
+        expect(calls.single.status, 'in_progress');
+        expect(calls.single.timestamp, 100);
+      },
+    );
+
+    test(
+      'replace:true upgrade from in_progress → done is visible through the '
+      'typed accessor (status flips, messageId stable)',
+      () {
+        const start = ActivitySnapshotEvent(
+          messageId: 'rag:call_1',
+          activityType: 'skill_tool_call',
+          content: {
+            'tool_name': 'ask',
+            'args': '{"q":"hi"}',
+            'status': 'in_progress',
+          },
+          timestamp: 1,
+        );
+        const finish = ActivitySnapshotEvent(
+          messageId: 'rag:call_1',
+          activityType: 'skill_tool_call',
+          content: {
+            'tool_name': 'ask',
+            'args': '{"q":"hi"}',
+            'status': 'done',
+          },
+          timestamp: 2,
+        );
+
+        final afterStart = processEvent(conversation, streaming, start);
+        final afterFinish = processEvent(
+          afterStart.conversation,
+          afterStart.streaming,
+          finish,
+        );
+
+        final calls = afterFinish.conversation.skillToolCalls;
+        expect(calls, hasLength(1));
+        expect(calls.single.messageId, 'rag:call_1');
+        expect(calls.single.status, 'done');
+        expect(calls.single.timestamp, 2);
+      },
+    );
+
+    test(
+      'two concurrent skill_tool_call message IDs stay independent in the '
+      'typed view',
+      () {
+        const askEvent = ActivitySnapshotEvent(
+          messageId: 'rag:call_ask',
+          activityType: 'skill_tool_call',
+          content: {
+            'tool_name': 'ask',
+            'args': '{"q":"what"}',
+            'status': 'in_progress',
+          },
+          timestamp: 1,
+        );
+        const searchEvent = ActivitySnapshotEvent(
+          messageId: 'rag:call_search',
+          activityType: 'skill_tool_call',
+          content: {
+            'tool_name': 'search',
+            'args': '{"q":"where"}',
+            'status': 'in_progress',
+          },
+          timestamp: 2,
+        );
+
+        final afterAsk = processEvent(conversation, streaming, askEvent);
+        final afterSearch = processEvent(
+          afterAsk.conversation,
+          afterAsk.streaming,
+          searchEvent,
+        );
+
+        final calls = afterSearch.conversation.skillToolCalls;
+        expect(calls, hasLength(2));
+        final byId = {for (final c in calls) c.messageId: c};
+        expect(byId['rag:call_ask']!.toolName, 'ask');
+        expect(byId['rag:call_search']!.toolName, 'search');
+      },
+    );
+
+    test(
+      'non-skill_tool_call activities are persisted but filtered out of '
+      'the typed accessor',
+      () {
+        const planEvent = ActivitySnapshotEvent(
+          messageId: 'plan:1',
+          activityType: 'plan',
+          content: {'steps': 3},
+          timestamp: 1,
+        );
+        const toolEvent = ActivitySnapshotEvent(
+          messageId: 'rag:call_1',
+          activityType: 'skill_tool_call',
+          content: {
+            'tool_name': 'ask',
+            'args': '{"q":"hi"}',
+            'status': 'in_progress',
+          },
+          timestamp: 2,
+        );
+
+        final afterPlan = processEvent(conversation, streaming, planEvent);
+        final afterTool = processEvent(
+          afterPlan.conversation,
+          afterPlan.streaming,
+          toolEvent,
+        );
+
+        expect(afterTool.conversation.activities, hasLength(2));
+        final calls = afterTool.conversation.skillToolCalls;
+        expect(calls, hasLength(1));
+        expect(calls.single.messageId, 'rag:call_1');
+      },
+    );
+
+    test(
+      'replace:false on an existing messageId is ignored — typed view still '
+      'reflects the first snapshot',
+      () {
+        const first = ActivitySnapshotEvent(
+          messageId: 'rag:call_1',
+          activityType: 'skill_tool_call',
+          content: {
+            'tool_name': 'ask',
+            'args': '{"q":"first"}',
+            'status': 'in_progress',
+          },
+          timestamp: 1,
+        );
+        const shadow = ActivitySnapshotEvent(
+          messageId: 'rag:call_1',
+          activityType: 'skill_tool_call',
+          content: {
+            'tool_name': 'search',
+            'args': '{"q":"second"}',
+            'status': 'done',
+          },
+          replace: false,
+          timestamp: 2,
+        );
+
+        final afterFirst = processEvent(conversation, streaming, first);
+        final afterShadow = processEvent(
+          afterFirst.conversation,
+          afterFirst.streaming,
+          shadow,
+        );
+
+        final calls = afterShadow.conversation.skillToolCalls;
+        expect(calls, hasLength(1));
+        expect(calls.single.toolName, 'ask');
+        expect(calls.single.status, 'in_progress');
+        expect(calls.single.args, {'q': 'first'});
+      },
+    );
+
+    test(
+      'malformed skill_tool_call is persisted raw but dropped from the '
+      'typed accessor — keeps the list usable for UI consumers',
+      () {
+        const goodEvent = ActivitySnapshotEvent(
+          messageId: 'rag:call_1',
+          activityType: 'skill_tool_call',
+          content: {
+            'tool_name': 'ask',
+            'args': '{"q":"ok"}',
+            'status': 'done',
+          },
+          timestamp: 1,
+        );
+        const badEvent = ActivitySnapshotEvent(
+          messageId: 'rag:call_2',
+          activityType: 'skill_tool_call',
+          content: {'tool_name': 'search', 'args': 'not json {'},
+          timestamp: 2,
+        );
+
+        final afterGood = processEvent(conversation, streaming, goodEvent);
+        final afterBad = processEvent(
+          afterGood.conversation,
+          afterGood.streaming,
+          badEvent,
+        );
+
+        expect(afterBad.conversation.activities, hasLength(2));
+        final calls = afterBad.conversation.skillToolCalls;
+        expect(calls, hasLength(1));
+        expect(calls.single.messageId, 'rag:call_1');
+      },
+    );
+  });
+}

--- a/packages/soliplex_client/test/domain/skill_tool_call_activity_test.dart
+++ b/packages/soliplex_client/test/domain/skill_tool_call_activity_test.dart
@@ -1,0 +1,216 @@
+import 'package:soliplex_client/soliplex_client.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('SkillToolCallActivity.fromRecord', () {
+    test('decodes a well-formed skill_tool_call', () {
+      const record = ActivityRecord(
+        messageId: 'rag:call_1',
+        activityType: 'skill_tool_call',
+        content: {
+          'tool_name': 'ask',
+          'args': '{"q":"hello","top_k":3}',
+          'status': 'in_progress',
+        },
+        timestamp: 1234,
+      );
+
+      final call = SkillToolCallActivity.fromRecord(record);
+
+      expect(call, isNotNull);
+      expect(call!.messageId, 'rag:call_1');
+      expect(call.toolName, 'ask');
+      expect(call.status, 'in_progress');
+      expect(call.timestamp, 1234);
+      expect(call.args, {'q': 'hello', 'top_k': 3});
+    });
+
+    test('missing args decodes to an empty map', () {
+      const record = ActivityRecord(
+        messageId: 'rag:call_2',
+        activityType: 'skill_tool_call',
+        content: {'tool_name': 'ask'},
+        timestamp: 10,
+      );
+
+      final call = SkillToolCallActivity.fromRecord(record);
+
+      expect(call, isNotNull);
+      expect(call!.args, isEmpty);
+      expect(call.status, isNull);
+    });
+
+    test('empty args string decodes to an empty map', () {
+      const record = ActivityRecord(
+        messageId: 'rag:call_3',
+        activityType: 'skill_tool_call',
+        content: {'tool_name': 'ask', 'args': ''},
+        timestamp: 11,
+      );
+
+      final call = SkillToolCallActivity.fromRecord(record);
+
+      expect(call, isNotNull);
+      expect(call!.args, isEmpty);
+    });
+
+    test('args already as a Map passes through', () {
+      const record = ActivityRecord(
+        messageId: 'rag:call_4',
+        activityType: 'skill_tool_call',
+        content: {
+          'tool_name': 'ask',
+          'args': {'q': 'hi'},
+        },
+        timestamp: 12,
+      );
+
+      final call = SkillToolCallActivity.fromRecord(record);
+
+      expect(call, isNotNull);
+      expect(call!.args, {'q': 'hi'});
+    });
+
+    test('non-skill_tool_call activityType returns null', () {
+      const record = ActivityRecord(
+        messageId: 'plan:1',
+        activityType: 'plan',
+        content: {'steps': 3},
+        timestamp: 1,
+      );
+
+      expect(SkillToolCallActivity.fromRecord(record), isNull);
+    });
+
+    test('missing tool_name returns null', () {
+      const record = ActivityRecord(
+        messageId: 'rag:bad_1',
+        activityType: 'skill_tool_call',
+        content: {'args': '{}'},
+        timestamp: 1,
+      );
+
+      expect(SkillToolCallActivity.fromRecord(record), isNull);
+    });
+
+    test('non-string tool_name returns null', () {
+      const record = ActivityRecord(
+        messageId: 'rag:bad_2',
+        activityType: 'skill_tool_call',
+        content: {'tool_name': 42, 'args': '{}'},
+        timestamp: 1,
+      );
+
+      expect(SkillToolCallActivity.fromRecord(record), isNull);
+    });
+
+    test('malformed args JSON returns null', () {
+      const record = ActivityRecord(
+        messageId: 'rag:bad_3',
+        activityType: 'skill_tool_call',
+        content: {'tool_name': 'ask', 'args': 'not json {'},
+        timestamp: 1,
+      );
+
+      expect(SkillToolCallActivity.fromRecord(record), isNull);
+    });
+
+    test('args JSON that is not an object returns null', () {
+      const record = ActivityRecord(
+        messageId: 'rag:bad_4',
+        activityType: 'skill_tool_call',
+        content: {'tool_name': 'ask', 'args': '[1,2,3]'},
+        timestamp: 1,
+      );
+
+      expect(SkillToolCallActivity.fromRecord(record), isNull);
+    });
+
+    test('args with unexpected runtimeType returns null', () {
+      const record = ActivityRecord(
+        messageId: 'rag:bad_5',
+        activityType: 'skill_tool_call',
+        content: {'tool_name': 'ask', 'args': 42},
+        timestamp: 1,
+      );
+
+      expect(SkillToolCallActivity.fromRecord(record), isNull);
+    });
+
+    test('non-string status is coerced to null', () {
+      const record = ActivityRecord(
+        messageId: 'rag:call_5',
+        activityType: 'skill_tool_call',
+        content: {'tool_name': 'ask', 'args': '{}', 'status': 1},
+        timestamp: 1,
+      );
+
+      final call = SkillToolCallActivity.fromRecord(record);
+
+      expect(call, isNotNull);
+      expect(call!.status, isNull);
+    });
+  });
+
+  group('SkillToolCallActivity equality', () {
+    test('equal when fields match, including nested args', () {
+      const a = SkillToolCallActivity(
+        messageId: 'm1',
+        toolName: 'ask',
+        args: {
+          'q': 'hi',
+          'top_k': 3,
+        },
+        status: 'done',
+        timestamp: 1,
+      );
+      const b = SkillToolCallActivity(
+        messageId: 'm1',
+        toolName: 'ask',
+        args: {
+          'q': 'hi',
+          'top_k': 3,
+        },
+        status: 'done',
+        timestamp: 1,
+      );
+
+      expect(a, equals(b));
+      expect(a.hashCode, equals(b.hashCode));
+    });
+
+    test('not equal when args differ', () {
+      const a = SkillToolCallActivity(
+        messageId: 'm1',
+        toolName: 'ask',
+        args: {'q': 'hi'},
+        status: null,
+        timestamp: 1,
+      );
+      const b = SkillToolCallActivity(
+        messageId: 'm1',
+        toolName: 'ask',
+        args: {'q': 'bye'},
+        status: null,
+        timestamp: 1,
+      );
+
+      expect(a, isNot(equals(b)));
+    });
+
+    test('toString includes identifying fields', () {
+      const a = SkillToolCallActivity(
+        messageId: 'rag:call_1',
+        toolName: 'ask',
+        args: {},
+        status: 'done',
+        timestamp: 7,
+      );
+      final s = a.toString();
+      expect(s, contains('rag:call_1'));
+      expect(s, contains('ask'));
+      expect(s, contains('done'));
+      expect(s, contains('7'));
+    });
+  });
+}


### PR DESCRIPTION
## Summary

Second slice of the **activity-persistence stack** — typed reader + canary.

- Adds `SkillToolCallActivity` immutable typed view over `skill_tool_call` records:
  - Decodes `content['args']` (the backend sends it as a **double-encoded JSON string**) into a plain map
  - Surfaces `toolName`, `args`, `status`, `messageId`, `timestamp`
- Adds `Conversation.skillToolCalls` extension getter so UI consumers can read a typed list without walking raw `content` maps.
- Schema-drift posture matches the AG-UI processor: malformed records log a warning and drop out of the typed accessor, while the raw `conversation.activities` list stays authoritative.

## Canary

Adds `test/canary/activity_pipeline_canary_test.dart` — six end-to-end tests that drive real `ActivitySnapshotEvent` sequences through `processEvent` and read them back through `conversation.skillToolCalls`. Covers:

- single snapshot round-trip with decoded args
- in-progress → done via `replace: true`
- two concurrent tool calls staying independent
- non-`skill_tool_call` activities filtered from the typed accessor
- `replace: false` ignore semantics through the typed view
- malformed records retained raw but dropped from the typed view

**If this canary ever fails, the UI cannot trust `conversation.activities` to reflect what the backend emitted.**

## Stack

Stacked on **#22 (S0)**. Merge S0 first; GitHub will retarget this PR to `main` automatically.

## Test plan

- [x] `flutter analyze` (packages/soliplex_client): clean
- [x] `flutter test --exclude-tags integration`: 1308 tests pass (S0: 1288 + 20 new: 14 unit + 6 canary)
- [ ] Integration-tagged tests skipped (require live backend; unrelated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
