### PR TITLE
feat(execution-tracker): reactive skillToolCalls signal from activity snapshots (S2)

### DIFF
--- a/lib/src/modules/room/execution_tracker.dart
+++ b/lib/src/modules/room/execution_tracker.dart
@@ -25,6 +25,16 @@ class ExecutionTracker {
   final Signal<bool> _isThinkingStreaming = Signal<bool>(false);
   ReadonlySignal<bool> get isThinkingStreaming => _isThinkingStreaming;
 
+  /// Decoded `skill_tool_call` activities in arrival order, keyed by
+  /// `messageId`. Records that fail to decode as a skill_tool_call are
+  /// dropped from this signal (but their raw form is still emitted on
+  /// [executionEvents]). Mirrors the upsert semantics of
+  /// `Conversation.activities` in soliplex_client.
+  final Signal<List<SkillToolCallActivity>> _skillToolCalls =
+      Signal<List<SkillToolCallActivity>>(const []);
+  ReadonlySignal<List<SkillToolCallActivity>> get skillToolCalls =>
+      _skillToolCalls;
+
   void freeze() {
     _unsub?.call();
     _unsub = null;
@@ -67,13 +77,58 @@ class ExecutionTracker {
       case RunFailed() || RunCancelled():
         _completeAllSteps(StepStatus.failed);
         _isThinkingStreaming.value = false;
+      case ActivitySnapshot(
+        :final messageId,
+        :final activityType,
+        :final content,
+        :final timestamp,
+        :final replace,
+      ):
+        _upsertSkillToolCall(
+          messageId: messageId,
+          activityType: activityType,
+          content: content,
+          timestamp: timestamp,
+          replace: replace,
+        );
       case TextDelta() ||
             StateUpdated() ||
             StepProgress() ||
             AwaitingApproval() ||
-            ActivitySnapshot() ||
             CustomExecutionEvent():
         break;
+    }
+  }
+
+  void _upsertSkillToolCall({
+    required String messageId,
+    required String activityType,
+    required Map<String, dynamic> content,
+    required int? timestamp,
+    required bool replace,
+  }) {
+    final current = _skillToolCalls.value;
+    final existingIndex = current.indexWhere((a) => a.messageId == messageId);
+
+    if (existingIndex >= 0 && !replace) {
+      return;
+    }
+
+    final record = ActivityRecord(
+      messageId: messageId,
+      activityType: activityType,
+      content: content,
+      timestamp: timestamp ?? DateTime.now().millisecondsSinceEpoch,
+    );
+    final decoded = SkillToolCallActivity.fromRecord(record);
+    if (decoded == null) {
+      return;
+    }
+
+    if (existingIndex >= 0) {
+      _skillToolCalls.value = [...current]..[existingIndex] = decoded;
+    } else {
+      _skillToolCalls.value = [...current, decoded];
     }
   }
 

--- a/packages/soliplex_agent/lib/src/orchestration/execution_event.dart
+++ b/packages/soliplex_agent/lib/src/orchestration/execution_event.dart
@@ -245,9 +245,16 @@ class AwaitingApproval extends ExecutionEvent {
 /// A sub-agent activity snapshot from the backend.
 class ActivitySnapshot extends ExecutionEvent {
   const ActivitySnapshot({
+    required this.messageId,
     required this.activityType,
     required this.content,
+    this.timestamp,
+    this.replace = true,
   });
+
+  /// Identifier for the target `ActivityMessage`. Snapshots with the
+  /// same [messageId] update the same tracker entry.
+  final String messageId;
 
   /// The kind of activity (e.g. `'skill_tool_call'`).
   final String activityType;
@@ -255,15 +262,33 @@ class ActivitySnapshot extends ExecutionEvent {
   /// Payload from the backend (e.g. `{'tool_name': 'search'}`).
   final Map<String, dynamic> content;
 
+  /// Event timestamp in ms since epoch, or `null` if the backend did
+  /// not supply one.
+  final int? timestamp;
+
+  /// AG-UI upsert semantic: `true` overwrites the record with the same
+  /// [messageId]; `false` is ignored when that [messageId] already
+  /// exists. Defaults to `true` per the AG-UI spec.
+  final bool replace;
+
   @override
   bool operator ==(Object other) =>
       identical(this, other) ||
       other is ActivitySnapshot &&
+          messageId == other.messageId &&
           activityType == other.activityType &&
+          timestamp == other.timestamp &&
+          replace == other.replace &&
           _deepEq.equals(content, other.content);
 
   @override
-  int get hashCode => Object.hash(activityType, _deepEq.hash(content));
+  int get hashCode => Object.hash(
+    messageId,
+    activityType,
+    timestamp,
+    replace,
+    _deepEq.hash(content),
+  );
 }
 
 /// Extension point for third-party plugins to emit custom events.

--- a/packages/soliplex_agent/lib/src/runtime/agent_session.dart
+++ b/packages/soliplex_agent/lib/src/runtime/agent_session.dart
@@ -493,8 +493,20 @@ ExecutionEvent? bridgeBaseEvent(BaseEvent event) {
       ServerToolCallCompleted(toolCallId: toolCallId, result: content),
     RunFinishedEvent() => const RunCompleted(),
     RunErrorEvent(:final message) => RunFailed(error: message),
-    ActivitySnapshotEvent(:final activityType, :final content) =>
-      ActivitySnapshot(activityType: activityType, content: content),
+    ActivitySnapshotEvent(
+      :final messageId,
+      :final activityType,
+      :final content,
+      :final timestamp,
+      :final replace,
+    ) =>
+      ActivitySnapshot(
+        messageId: messageId,
+        activityType: activityType,
+        content: content,
+        timestamp: timestamp,
+        replace: replace,
+      ),
     StepStartedEvent(:final stepName) => StepProgress(stepName: stepName),
 
     // Events that don't need ExecutionEvent bridging.

--- a/packages/soliplex_agent/test/orchestration/execution_event_test.dart
+++ b/packages/soliplex_agent/test/orchestration/execution_event_test.dart
@@ -176,21 +176,30 @@ void main() {
 
       test('ActivitySnapshot equality', () {
         const a = ActivitySnapshot(
+          messageId: 'rag:call_1',
           activityType: 'skill_tool_call',
           content: {'tool_name': 'search'},
         );
         const b = ActivitySnapshot(
+          messageId: 'rag:call_1',
           activityType: 'skill_tool_call',
           content: {'tool_name': 'search'},
         );
         const c = ActivitySnapshot(
+          messageId: 'rag:call_1',
           activityType: 'skill_tool_call',
           content: {'tool_name': 'ask'},
+        );
+        const d = ActivitySnapshot(
+          messageId: 'rag:call_2',
+          activityType: 'skill_tool_call',
+          content: {'tool_name': 'search'},
         );
 
         expect(a, equals(b));
         expect(a.hashCode, equals(b.hashCode));
         expect(a, isNot(equals(c)));
+        expect(a, isNot(equals(d)));
       });
 
       test('CustomExecutionEvent deep equality with nested payload', () {
@@ -242,7 +251,7 @@ void main() {
           const StateUpdated(aguiState: {}),
           const StepProgress(stepName: ''),
           const CustomExecutionEvent(type: '', payload: {}),
-          const ActivitySnapshot(activityType: '', content: {}),
+          const ActivitySnapshot(messageId: '', activityType: '', content: {}),
         ];
 
         expect(events, hasLength(14));

--- a/test/modules/room/execution_tracker_test.dart
+++ b/test/modules/room/execution_tracker_test.dart
@@ -162,6 +162,7 @@ void main() {
   test('ActivitySnapshot does not affect steps or thinking', () {
     events.value = const ThinkingStarted();
     events.value = const ActivitySnapshot(
+      messageId: 'rag:call_1',
       activityType: 'skill_tool_call',
       content: {'tool_name': 'search'},
     );
@@ -176,5 +177,148 @@ void main() {
     tracker.dispose();
     events.value = const ThinkingStarted();
     expect(tracker.steps.value, isEmpty);
+  });
+
+  group('skillToolCalls signal', () {
+    test('starts empty', () {
+      expect(tracker.skillToolCalls.value, isEmpty);
+    });
+
+    test('decodes a single skill_tool_call snapshot', () {
+      events.value = const ActivitySnapshot(
+        messageId: 'rag:call_1',
+        activityType: 'skill_tool_call',
+        content: {
+          'tool_name': 'ask',
+          'args': '{"q":"hi"}',
+          'status': 'in_progress',
+        },
+        timestamp: 100,
+      );
+
+      final calls = tracker.skillToolCalls.value;
+      expect(calls, hasLength(1));
+      expect(calls.single.messageId, 'rag:call_1');
+      expect(calls.single.toolName, 'ask');
+      expect(calls.single.args, {'q': 'hi'});
+      expect(calls.single.status, 'in_progress');
+      expect(calls.single.timestamp, 100);
+    });
+
+    test('replace:true overwrites record with same messageId in place', () {
+      events.value = const ActivitySnapshot(
+        messageId: 'rag:call_1',
+        activityType: 'skill_tool_call',
+        content: {
+          'tool_name': 'ask',
+          'args': '{"q":"hi"}',
+          'status': 'in_progress',
+        },
+        timestamp: 1,
+      );
+      events.value = const ActivitySnapshot(
+        messageId: 'rag:call_1',
+        activityType: 'skill_tool_call',
+        content: {
+          'tool_name': 'ask',
+          'args': '{"q":"hi"}',
+          'status': 'done',
+        },
+        timestamp: 2,
+      );
+
+      final calls = tracker.skillToolCalls.value;
+      expect(calls, hasLength(1));
+      expect(calls.single.status, 'done');
+      expect(calls.single.timestamp, 2);
+    });
+
+    test('replace:false on existing messageId is ignored', () {
+      events.value = const ActivitySnapshot(
+        messageId: 'rag:call_1',
+        activityType: 'skill_tool_call',
+        content: {
+          'tool_name': 'ask',
+          'args': '{"q":"first"}',
+          'status': 'in_progress',
+        },
+        timestamp: 1,
+      );
+      events.value = const ActivitySnapshot(
+        messageId: 'rag:call_1',
+        activityType: 'skill_tool_call',
+        content: {
+          'tool_name': 'search',
+          'args': '{"q":"second"}',
+          'status': 'done',
+        },
+        replace: false,
+        timestamp: 2,
+      );
+
+      final calls = tracker.skillToolCalls.value;
+      expect(calls, hasLength(1));
+      expect(calls.single.toolName, 'ask');
+      expect(calls.single.args, {'q': 'first'});
+    });
+
+    test('two concurrent messageIds stay independent', () {
+      events.value = const ActivitySnapshot(
+        messageId: 'rag:call_a',
+        activityType: 'skill_tool_call',
+        content: {'tool_name': 'ask', 'args': '{"q":"a"}'},
+        timestamp: 1,
+      );
+      events.value = const ActivitySnapshot(
+        messageId: 'rag:call_b',
+        activityType: 'skill_tool_call',
+        content: {'tool_name': 'search', 'args': '{"q":"b"}'},
+        timestamp: 2,
+      );
+
+      final calls = tracker.skillToolCalls.value;
+      expect(calls, hasLength(2));
+      final byId = {for (final c in calls) c.messageId: c};
+      expect(byId['rag:call_a']!.toolName, 'ask');
+      expect(byId['rag:call_b']!.toolName, 'search');
+    });
+
+    test('non-skill_tool_call activityType is dropped', () {
+      events.value = const ActivitySnapshot(
+        messageId: 'plan:1',
+        activityType: 'plan',
+        content: {'steps': 3},
+        timestamp: 1,
+      );
+
+      expect(tracker.skillToolCalls.value, isEmpty);
+    });
+
+    test('malformed skill_tool_call is dropped', () {
+      events.value = const ActivitySnapshot(
+        messageId: 'rag:bad',
+        activityType: 'skill_tool_call',
+        content: {'tool_name': 'ask', 'args': 'not json {'},
+        timestamp: 1,
+      );
+
+      expect(tracker.skillToolCalls.value, isEmpty);
+    });
+
+    test(
+      'missing timestamp is filled with wall-clock (non-zero) so the '
+      'decoded activity still appears',
+      () {
+        events.value = const ActivitySnapshot(
+          messageId: 'rag:call_1',
+          activityType: 'skill_tool_call',
+          content: {'tool_name': 'ask', 'args': '{}'},
+        );
+
+        final calls = tracker.skillToolCalls.value;
+        expect(calls, hasLength(1));
+        expect(calls.single.timestamp, greaterThan(0));
+      },
+    );
   });
 }

--- a/test/modules/room/ui/execution/step_log_test.dart
+++ b/test/modules/room/ui/execution/step_log_test.dart
@@ -161,6 +161,10 @@ class _FakeTracker implements ExecutionTracker {
   ReadonlySignal<bool> get isThinkingStreaming => Signal<bool>(false);
 
   @override
+  ReadonlySignal<List<SkillToolCallActivity>> get skillToolCalls =>
+      Signal<List<SkillToolCallActivity>>(const []);
+
+  @override
   bool get isFrozen => false;
 
   @override


### PR DESCRIPTION
## Summary

Third slice of the **activity-persistence stack** — the signals bridge between the AG-UI event stream and a UI-ready reactive surface. Still no widget, but this is the last plumbing slice: S3 will wire a widget against the signal this PR adds.

## soliplex_agent

- **\`ActivitySnapshot\` ExecutionEvent** now carries \`messageId\`, \`timestamp\`, and \`replace\` — previously dropped during the \`BaseEvent → ExecutionEvent\` bridge, which made downstream dedup / upsert impossible.
- **\`agent_session.bridgeBaseEvent\`** pass-through updated accordingly.

## soliplex-frontend

- **\`ExecutionTracker.skillToolCalls: ReadonlySignal<List<SkillToolCallActivity>>\`** driven by \`ActivitySnapshot\` events.
  - Upsert semantics mirror \`Conversation.activities\` on the client side: \`replace:true\` overwrites by \`messageId\`; \`replace:false\` is ignored when the \`messageId\` already exists.
  - Malformed records drop out (same posture as S1's \`SkillToolCallActivity.fromRecord\`).
  - Wall-clock fallback when the backend omits \`timestamp\`.

## Stack

Stacked on **#23 (S1)** which is stacked on **#22 (S0)**. Merge #22 → #23 → this PR.

## Test plan

- [x] \`flutter analyze\` (workspace): clean
- [x] \`flutter test --exclude-tags integration\` — all green:
  - \`soliplex_client\`: 1308 ✓
  - \`soliplex_agent\`: 459 ✓
  - \`soliplex-frontend\`: 1003 ✓ (includes 8 new \`ExecutionTracker.skillToolCalls\` tests)
- [ ] Integration-tagged tests skipped (require live backend; unrelated)

## Next

**S3** will add the \`ActivityLog\` widget consuming this signal — the first visible slice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
