### PR TITLE
feat(room): ActivityLog widget — first visible slice of activity-persistence (S3)

### DIFF
--- a/lib/src/modules/room/ui/execution/activity_log.dart
+++ b/lib/src/modules/room/ui/execution/activity_log.dart
@@ -1,0 +1,127 @@
+import 'package:flutter/material.dart';
+import 'package:signals_flutter/signals_flutter.dart';
+
+import '../../execution_tracker.dart';
+
+/// Collapsible log of `skill_tool_call` activities for the current
+/// execution. Watches [ExecutionTracker.skillToolCalls] — one row per
+/// decoded activity, keyed by `messageId`. Hides itself when empty.
+class ActivityLog extends StatefulWidget {
+  const ActivityLog({super.key, required this.tracker});
+  final ExecutionTracker tracker;
+
+  @override
+  State<ActivityLog> createState() => _ActivityLogState();
+}
+
+class _ActivityLogState extends State<ActivityLog> {
+  bool _expanded = false;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final activities = widget.tracker.skillToolCalls.watch(context);
+    if (activities.isEmpty) return const SizedBox.shrink();
+
+    return Padding(
+      padding: const EdgeInsets.only(bottom: 8),
+      child: GestureDetector(
+        onTap: () => setState(() => _expanded = !_expanded),
+        child: Container(
+          padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
+          decoration: BoxDecoration(
+            color: theme.colorScheme.surfaceContainerLow,
+            borderRadius: BorderRadius.circular(6),
+          ),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Row(
+                children: [
+                  Icon(
+                    _expanded ? Icons.expand_more : Icons.chevron_right,
+                    size: 16,
+                    color: theme.colorScheme.onSurfaceVariant,
+                  ),
+                  const SizedBox(width: 4),
+                  Text(
+                    '${activities.length} '
+                    'activit${activities.length == 1 ? 'y' : 'ies'}',
+                    style: theme.textTheme.bodySmall?.copyWith(
+                      color: theme.colorScheme.onSurfaceVariant,
+                    ),
+                  ),
+                ],
+              ),
+              if (_expanded) ...[
+                const SizedBox(height: 4),
+                for (final activity in activities)
+                  Padding(
+                    padding: const EdgeInsets.symmetric(vertical: 2),
+                    child: Row(
+                      children: [
+                        _statusIcon(activity.status, theme),
+                        const SizedBox(width: 8),
+                        Expanded(
+                          child: Text(
+                            activity.toolName,
+                            style: theme.textTheme.bodySmall?.copyWith(
+                              color: theme.colorScheme.onSurfaceVariant,
+                            ),
+                          ),
+                        ),
+                        if (activity.status != null)
+                          Text(
+                            activity.status!,
+                            style: theme.textTheme.bodySmall?.copyWith(
+                              color: theme.colorScheme.outline,
+                              fontSize: 11,
+                            ),
+                          ),
+                      ],
+                    ),
+                  ),
+              ],
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+
+  Widget _statusIcon(String? status, ThemeData theme) {
+    switch (status) {
+      case 'in_progress':
+      case 'running':
+        return SizedBox(
+          width: 12,
+          height: 12,
+          child: CircularProgressIndicator(
+            strokeWidth: 1.5,
+            color: theme.colorScheme.primary,
+          ),
+        );
+      case 'failed':
+      case 'error':
+        return Icon(
+          Icons.error,
+          size: 12,
+          color: theme.colorScheme.error,
+        );
+      case 'done':
+      case 'completed':
+      case 'success':
+        return Icon(
+          Icons.check_circle,
+          size: 12,
+          color: theme.colorScheme.primary,
+        );
+      default:
+        return Icon(
+          Icons.circle_outlined,
+          size: 12,
+          color: theme.colorScheme.outline,
+        );
+    }
+  }
+}

--- a/lib/src/modules/room/ui/loading_message_tile.dart
+++ b/lib/src/modules/room/ui/loading_message_tile.dart
@@ -3,6 +3,7 @@ import 'package:soliplex_agent/soliplex_agent.dart' hide State;
 
 import '../execution_tracker.dart';
 import 'execution/activity_indicator.dart';
+import 'execution/activity_log.dart';
 import 'execution/step_log.dart';
 import 'execution/thinking_block.dart';
 
@@ -25,6 +26,7 @@ class LoadingMessageTile extends StatelessWidget {
           if (streamingActivity != null)
             ActivityIndicator(activity: streamingActivity!),
           StepLog(tracker: executionTracker!),
+          ActivityLog(tracker: executionTracker!),
           ExecutionThinkingBlock(tracker: executionTracker!),
         ],
       );

--- a/lib/src/modules/room/ui/text_message_tile.dart
+++ b/lib/src/modules/room/ui/text_message_tile.dart
@@ -4,6 +4,7 @@ import 'package:soliplex_agent/soliplex_agent.dart';
 import '../execution_tracker.dart';
 import 'citations_section.dart';
 import 'execution/activity_indicator.dart';
+import 'execution/activity_log.dart';
 import 'execution/step_log.dart';
 import 'execution/thinking_block.dart';
 import 'copy_button.dart';
@@ -45,6 +46,7 @@ class TextMessageTile extends StatelessWidget {
         if (streamingActivity != null)
           ActivityIndicator(activity: streamingActivity!),
         if (hasTracker) StepLog(tracker: executionTracker!),
+        if (hasTracker) ActivityLog(tracker: executionTracker!),
         if (hasTracker)
           ExecutionThinkingBlock(tracker: executionTracker!)
         else if (!isUser && message.hasThinkingText)

--- a/test/modules/room/ui/execution/activity_log_test.dart
+++ b/test/modules/room/ui/execution/activity_log_test.dart
@@ -1,0 +1,205 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:soliplex_agent/soliplex_agent.dart';
+
+import 'package:soliplex_frontend/src/modules/room/execution_tracker.dart';
+import 'package:soliplex_frontend/src/modules/room/ui/execution/activity_log.dart';
+
+Widget wrap(Widget child) => MaterialApp(home: Scaffold(body: child));
+
+void main() {
+  late Signal<ExecutionEvent?> events;
+  late ExecutionTracker tracker;
+
+  setUp(() {
+    events = Signal<ExecutionEvent?>(null);
+    tracker = ExecutionTracker(executionEvents: events);
+  });
+
+  tearDown(() => tracker.dispose());
+
+  testWidgets('returns empty widget when no activities', (tester) async {
+    await tester.pumpWidget(wrap(ActivityLog(tracker: tracker)));
+    await tester.pump();
+
+    expect(find.byType(GestureDetector), findsNothing);
+  });
+
+  testWidgets('shows singular "activity" for one call', (tester) async {
+    events.value = const ActivitySnapshot(
+      messageId: 'rag:call_1',
+      activityType: 'skill_tool_call',
+      content: {'tool_name': 'ask', 'args': '{}'},
+      timestamp: 1,
+    );
+
+    await tester.pumpWidget(wrap(ActivityLog(tracker: tracker)));
+    await tester.pump();
+
+    expect(find.text('1 activity'), findsOneWidget);
+  });
+
+  testWidgets('shows plural "activities" for multiple calls', (tester) async {
+    events.value = const ActivitySnapshot(
+      messageId: 'rag:call_1',
+      activityType: 'skill_tool_call',
+      content: {'tool_name': 'ask', 'args': '{}'},
+      timestamp: 1,
+    );
+    events.value = const ActivitySnapshot(
+      messageId: 'rag:call_2',
+      activityType: 'skill_tool_call',
+      content: {'tool_name': 'search', 'args': '{}'},
+      timestamp: 2,
+    );
+
+    await tester.pumpWidget(wrap(ActivityLog(tracker: tracker)));
+    await tester.pump();
+
+    expect(find.text('2 activities'), findsOneWidget);
+  });
+
+  testWidgets('tap expands to show tool names', (tester) async {
+    events.value = const ActivitySnapshot(
+      messageId: 'rag:call_1',
+      activityType: 'skill_tool_call',
+      content: {'tool_name': 'ask', 'args': '{}', 'status': 'in_progress'},
+      timestamp: 1,
+    );
+
+    await tester.pumpWidget(wrap(ActivityLog(tracker: tracker)));
+    await tester.pump();
+
+    expect(find.text('ask'), findsNothing);
+
+    await tester.tap(find.byType(GestureDetector));
+    await tester.pump();
+
+    expect(find.text('ask'), findsOneWidget);
+  });
+
+  testWidgets('expanded row shows status label when present', (tester) async {
+    events.value = const ActivitySnapshot(
+      messageId: 'rag:call_1',
+      activityType: 'skill_tool_call',
+      content: {'tool_name': 'ask', 'args': '{}', 'status': 'done'},
+      timestamp: 1,
+    );
+
+    await tester.pumpWidget(wrap(ActivityLog(tracker: tracker)));
+    await tester.pump();
+    await tester.tap(find.byType(GestureDetector));
+    await tester.pump();
+
+    expect(find.text('done'), findsOneWidget);
+  });
+
+  testWidgets('shows spinner icon for in_progress status', (tester) async {
+    events.value = const ActivitySnapshot(
+      messageId: 'rag:call_1',
+      activityType: 'skill_tool_call',
+      content: {'tool_name': 'ask', 'args': '{}', 'status': 'in_progress'},
+      timestamp: 1,
+    );
+
+    await tester.pumpWidget(wrap(ActivityLog(tracker: tracker)));
+    await tester.pump();
+    await tester.tap(find.byType(GestureDetector));
+    await tester.pump();
+
+    expect(find.byType(CircularProgressIndicator), findsOneWidget);
+  });
+
+  testWidgets('shows check icon for done status', (tester) async {
+    events.value = const ActivitySnapshot(
+      messageId: 'rag:call_1',
+      activityType: 'skill_tool_call',
+      content: {'tool_name': 'ask', 'args': '{}', 'status': 'done'},
+      timestamp: 1,
+    );
+
+    await tester.pumpWidget(wrap(ActivityLog(tracker: tracker)));
+    await tester.pump();
+    await tester.tap(find.byType(GestureDetector));
+    await tester.pump();
+
+    expect(find.byIcon(Icons.check_circle), findsOneWidget);
+  });
+
+  testWidgets('shows error icon for failed status', (tester) async {
+    events.value = const ActivitySnapshot(
+      messageId: 'rag:call_1',
+      activityType: 'skill_tool_call',
+      content: {'tool_name': 'ask', 'args': '{}', 'status': 'failed'},
+      timestamp: 1,
+    );
+
+    await tester.pumpWidget(wrap(ActivityLog(tracker: tracker)));
+    await tester.pump();
+    await tester.tap(find.byType(GestureDetector));
+    await tester.pump();
+
+    expect(find.byIcon(Icons.error), findsOneWidget);
+  });
+
+  testWidgets('non-skill_tool_call activities are ignored', (tester) async {
+    events.value = const ActivitySnapshot(
+      messageId: 'plan:1',
+      activityType: 'plan',
+      content: {'steps': 3},
+      timestamp: 1,
+    );
+
+    await tester.pumpWidget(wrap(ActivityLog(tracker: tracker)));
+    await tester.pump();
+
+    expect(find.byType(GestureDetector), findsNothing);
+  });
+
+  testWidgets('replace:true updates the existing row in place', (
+    tester,
+  ) async {
+    events.value = const ActivitySnapshot(
+      messageId: 'rag:call_1',
+      activityType: 'skill_tool_call',
+      content: {'tool_name': 'ask', 'args': '{}', 'status': 'in_progress'},
+      timestamp: 1,
+    );
+    events.value = const ActivitySnapshot(
+      messageId: 'rag:call_1',
+      activityType: 'skill_tool_call',
+      content: {'tool_name': 'ask', 'args': '{}', 'status': 'done'},
+      timestamp: 2,
+    );
+
+    await tester.pumpWidget(wrap(ActivityLog(tracker: tracker)));
+    await tester.pump();
+    await tester.tap(find.byType(GestureDetector));
+    await tester.pump();
+
+    expect(find.text('1 activity'), findsOneWidget);
+    expect(find.text('done'), findsOneWidget);
+    expect(find.text('in_progress'), findsNothing);
+  });
+
+  testWidgets('tap again collapses the rows', (tester) async {
+    events.value = const ActivitySnapshot(
+      messageId: 'rag:call_1',
+      activityType: 'skill_tool_call',
+      content: {'tool_name': 'ask', 'args': '{}'},
+      timestamp: 1,
+    );
+
+    await tester.pumpWidget(wrap(ActivityLog(tracker: tracker)));
+    await tester.pump();
+    await tester.tap(find.byType(GestureDetector));
+    await tester.pump();
+
+    expect(find.text('ask'), findsOneWidget);
+
+    await tester.tap(find.byType(GestureDetector));
+    await tester.pump();
+
+    expect(find.text('ask'), findsNothing);
+  });
+}


### PR DESCRIPTION
## Summary

**Fourth slice of the activity-persistence stack — and the first visible one.**

Adds a collapsible \`ActivityLog\` widget rendering \`ExecutionTracker.skillToolCalls\` (the reactive signal added in **#24**). Header shows the count of decoded activities; tapping expands to rows of \`[status icon] [tool name] [status label]\`. Hides itself when empty.

Status icons follow existing execution-surface conventions:

- \`in_progress\` / \`running\` → spinner
- \`done\` / \`completed\` / \`success\` → \`check_circle\`
- \`failed\` / \`error\` → \`error\`
- anything else → \`circle_outlined\` (row still renders)

Mounted next to \`StepLog\` in both \`LoadingMessageTile\` and \`TextMessageTile\`, so activities are visible during streaming runs and after completion.

## Deliberately out of scope

- **Args display / copy button** — the first visible slice stays tight. A later slice can add per-row args expansion when there's a concrete need.
- **StatePanel** (aguiState \`(i)\` chiclet) — separate domain, separate slice.

## Stack

Stacked on **#24 (S2)** → **#23 (S1)** → **#22 (S0)**. Merge in order; GitHub auto-retargets as each lands.

## Verification

- [x] \`flutter analyze\` (workspace): clean
- [x] \`flutter test --exclude-tags integration\` on the app: 1014 pass (was 1003 in S2; +11 \`ActivityLog\` widget tests)
- [x] Widget tests cover: empty, singular/plural header, tap expand/collapse, in_progress/done/failed icon routing, \`replace:true\` in-place update rendering, non-skill_tool_call filtering
- [ ] **Live-backend smoke test** — not run in this PR. Requires an AG-UI server emitting \`ACTIVITY_SNAPSHOT\` events against a real room. The canary in **#23** is the pure-Dart equivalent — it proves the decode pipeline is sound. To manually verify the widget lights up, run the app against a room that emits skill_tool_call activities.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
