### PR TITLE
S5b: hydrate ExecutionTrackers from historical runs

### DIFF
--- a/lib/src/modules/room/execution_tracker.dart
+++ b/lib/src/modules/room/execution_tracker.dart
@@ -11,6 +11,22 @@ class ExecutionTracker {
     _unsub = executionEvents.subscribe(_onEvent);
   }
 
+  /// Builds a frozen tracker seeded from a list of already-emitted
+  /// execution events — used on the reload path to reconstruct the
+  /// timeline for a completed run.
+  ///
+  /// The tracker opens no subscription; callers should not pass the
+  /// returned instance to any signal. It is immutable from construction
+  /// ([isFrozen] returns `true`).
+  ExecutionTracker.historical({required List<ExecutionEvent> events}) {
+    _stopwatch.start();
+    for (final event in events) {
+      _onEvent(event);
+    }
+    _stopwatch.stop();
+    _isFrozen = true;
+  }
+
   final Stopwatch _stopwatch = Stopwatch();
   void Function()? _unsub;
   bool _isFrozen = false;
@@ -87,12 +103,12 @@ class ExecutionTracker {
         _completeAllSteps(StepStatus.failed);
         _isThinkingStreaming.value = false;
       case ActivitySnapshot(
-        :final messageId,
-        :final activityType,
-        :final content,
-        :final timestamp,
-        :final replace,
-      ):
+          :final messageId,
+          :final activityType,
+          :final content,
+          :final timestamp,
+          :final replace,
+        ):
         _upsertSkillToolCall(
           messageId: messageId,
           activityType: activityType,
@@ -209,17 +225,16 @@ class ExecutionTracker {
         }
       } else if (entry is TimelineOrphanActivity &&
           entry.activity.messageId == decoded.messageId) {
-        _timeline.value = [...current]
-          ..[i] = TimelineOrphanActivity(activity: decoded);
+        _timeline.value = [...current]..[i] =
+            TimelineOrphanActivity(activity: decoded);
         return;
       }
     }
     if (current.isNotEmpty && current.last is TimelineStep) {
       final lastStep = current.last as TimelineStep;
       if (lastStep.step.status == StepStatus.active) {
-        _timeline.value = [...current]
-          ..[current.length - 1] =
-              lastStep.withActivities([...lastStep.activities, decoded]);
+        _timeline.value = [...current]..[current.length - 1] =
+            lastStep.withActivities([...lastStep.activities, decoded]);
         return;
       }
     }

--- a/lib/src/modules/room/historical_replay.dart
+++ b/lib/src/modules/room/historical_replay.dart
@@ -1,0 +1,52 @@
+import 'package:soliplex_agent/soliplex_agent.dart';
+
+import 'execution_tracker.dart';
+
+/// Replays stored AG-UI event bundles into one frozen [ExecutionTracker]
+/// per assistant message, keyed by that message's id.
+///
+/// Events that land in the run before the first assistant
+/// `TEXT_MESSAGE_START` are buffered and attached to the next assistant
+/// message encountered. Events between two assistant messages (e.g.
+/// tool-use round-trips) attach to the preceding message — matching the
+/// live path, where the active tracker at tool dispatch captures the
+/// tool call.
+///
+/// Bundles whose run never produces an assistant message yield no
+/// tracker; their events are dropped rather than grafted onto an
+/// unrelated bucket.
+Map<String, ExecutionTracker> replayToTrackers(List<RunEventBundle> runs) {
+  final buckets = <String, List<ExecutionEvent>>{};
+
+  for (final bundle in runs) {
+    String? currentMessageId;
+    final pending = <ExecutionEvent>[];
+
+    for (final raw in bundle.events) {
+      if (raw is TextMessageStartEvent &&
+          raw.role == TextMessageRole.assistant) {
+        final messageId = raw.messageId;
+        currentMessageId = messageId;
+        final bucket = buckets.putIfAbsent(messageId, () => []);
+        if (pending.isNotEmpty) {
+          bucket.addAll(pending);
+          pending.clear();
+        }
+      }
+
+      final execEvent = bridgeBaseEvent(raw);
+      if (execEvent == null) continue;
+
+      if (currentMessageId != null) {
+        buckets.putIfAbsent(currentMessageId, () => []).add(execEvent);
+      } else {
+        pending.add(execEvent);
+      }
+    }
+  }
+
+  return {
+    for (final entry in buckets.entries)
+      entry.key: ExecutionTracker.historical(events: entry.value),
+  };
+}

--- a/lib/src/modules/room/thread_view_state.dart
+++ b/lib/src/modules/room/thread_view_state.dart
@@ -4,6 +4,7 @@ import 'package:flutter/foundation.dart' show debugPrint;
 import 'package:soliplex_agent/soliplex_agent.dart';
 
 import 'execution_tracker.dart';
+import 'historical_replay.dart';
 import 'run_registry.dart';
 import 'send_error.dart';
 import 'tracker_registry.dart';
@@ -291,6 +292,7 @@ class ThreadViewState {
         .then((history) {
       if (token.isCancelled) return;
       _cancelToken = null;
+      _trackerRegistry.seedHistorical(replayToTrackers(history.runs));
       _messages.value = MessagesLoaded(
         messages: history.messages,
         messageStates: history.messageStates,

--- a/lib/src/modules/room/tracker_registry.dart
+++ b/lib/src/modules/room/tracker_registry.dart
@@ -51,6 +51,15 @@ class TrackerRegistry {
     _freezeActive();
   }
 
+  /// Bulk-inserts already-frozen trackers produced from a loaded thread's
+  /// history. Existing entries with the same key are not overwritten —
+  /// a live tracker always wins over a historical one.
+  void seedHistorical(Map<String, ExecutionTracker> historical) {
+    for (final entry in historical.entries) {
+      _trackers.putIfAbsent(entry.key, () => entry.value);
+    }
+  }
+
   void _freezeActive() {
     if (_activeId != null) {
       _trackers[_activeId!]?.freeze();

--- a/packages/soliplex_agent/lib/src/runtime/agent_session.dart
+++ b/packages/soliplex_agent/lib/src/runtime/agent_session.dart
@@ -475,9 +475,9 @@ class AgentSession implements ToolExecutionContext {
 /// consumers of [AgentSession.lastExecutionEvent] should observe, or
 /// `null` when the event does not map to an execution-event emission.
 ///
-/// Exposed for testing the translation table independently of the
-/// [AgentSession] fixture overhead.
-@visibleForTesting
+/// Used on the live path by [AgentSession] and on the historical replay
+/// path by the app layer when hydrating execution-tracker state from a
+/// loaded `ThreadHistory`.
 ExecutionEvent? bridgeBaseEvent(BaseEvent event) {
   return switch (event) {
     TextMessageContentEvent(:final delta) => TextDelta(delta: delta),

--- a/test/modules/room/execution_tracker_test.dart
+++ b/test/modules/room/execution_tracker_test.dart
@@ -477,4 +477,60 @@ void main() {
       expect(step.step.status, StepStatus.completed);
     });
   });
+
+  group('ExecutionTracker.historical', () {
+    test('returns frozen tracker', () {
+      final tracker = ExecutionTracker.historical(events: const []);
+      expect(tracker.isFrozen, isTrue);
+      tracker.dispose();
+    });
+
+    test('seeds steps from events', () {
+      final tracker = ExecutionTracker.historical(
+        events: const [
+          ThinkingStarted(),
+          ThinkingContent(delta: 'hello'),
+          ServerToolCallStarted(toolName: 'search', toolCallId: 'tc-1'),
+          ServerToolCallCompleted(toolCallId: 'tc-1', result: 'ok'),
+          RunCompleted(),
+        ],
+      );
+
+      expect(tracker.steps.value.map((s) => s.label), ['Thinking', 'search']);
+      expect(tracker.steps.value.every((s) => s.status.isTerminal), isTrue);
+      expect(tracker.thinkingBlocks.value, ['hello']);
+      tracker.dispose();
+    });
+
+    test('seeds activities under active step when present', () {
+      final tracker = ExecutionTracker.historical(
+        events: const [
+          ClientToolExecuting(toolName: 'execute_skill', toolCallId: 'tc-1'),
+          ActivitySnapshot(
+            messageId: 'bwrap:call_1',
+            activityType: 'skill_tool_call',
+            content: {'tool_name': 'execute_script', 'args': '{}'},
+            timestamp: 100,
+          ),
+        ],
+      );
+
+      final step = tracker.timeline.value.single as TimelineStep;
+      expect(step.activities, hasLength(1));
+      expect(step.activities.single.toolName, 'execute_script');
+      tracker.dispose();
+    });
+
+    test('empty events list yields empty timeline', () {
+      final tracker = ExecutionTracker.historical(events: const []);
+      expect(tracker.steps.value, isEmpty);
+      expect(tracker.timeline.value, isEmpty);
+      tracker.dispose();
+    });
+  });
+}
+
+extension on StepStatus {
+  bool get isTerminal =>
+      this == StepStatus.completed || this == StepStatus.failed;
 }

--- a/test/modules/room/historical_replay_test.dart
+++ b/test/modules/room/historical_replay_test.dart
@@ -1,0 +1,170 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:soliplex_agent/soliplex_agent.dart';
+
+import 'package:soliplex_frontend/src/modules/room/historical_replay.dart';
+import 'package:soliplex_frontend/src/modules/room/ui/execution/timeline_entry.dart';
+
+void main() {
+  group('replayToTrackers', () {
+    test('returns empty map for empty runs', () {
+      expect(replayToTrackers(const []), isEmpty);
+    });
+
+    test('builds one tracker per assistant message', () {
+      final runs = [
+        RunEventBundle(
+          runId: 'run-1',
+          events: const [
+            RunStartedEvent(threadId: 't-1', runId: 'run-1'),
+            TextMessageStartEvent(messageId: 'msg-1'),
+            TextMessageContentEvent(messageId: 'msg-1', delta: 'hi'),
+            TextMessageEndEvent(messageId: 'msg-1'),
+            RunFinishedEvent(threadId: 't-1', runId: 'run-1'),
+          ],
+        ),
+      ];
+
+      final trackers = replayToTrackers(runs);
+
+      expect(trackers.keys, ['msg-1']);
+      expect(trackers['msg-1']!.isFrozen, isTrue);
+    });
+
+    test('thinking events before TEXT_MESSAGE_START attach to that message',
+        () {
+      final runs = [
+        RunEventBundle(
+          runId: 'run-1',
+          events: const [
+            ReasoningMessageStartEvent(messageId: 'reason-1'),
+            ReasoningMessageContentEvent(
+              messageId: 'reason-1',
+              delta: 'thinking...',
+            ),
+            TextMessageStartEvent(messageId: 'msg-1'),
+            TextMessageEndEvent(messageId: 'msg-1'),
+          ],
+        ),
+      ];
+
+      final trackers = replayToTrackers(runs);
+      final tracker = trackers['msg-1']!;
+
+      expect(tracker.steps.value, hasLength(1));
+      expect(tracker.steps.value.first.label, 'Thinking');
+      expect(tracker.thinkingBlocks.value, ['thinking...']);
+    });
+
+    test('tool calls between two assistant messages attach to the first', () {
+      final runs = [
+        RunEventBundle(
+          runId: 'run-1',
+          events: const [
+            TextMessageStartEvent(messageId: 'msg-1'),
+            TextMessageEndEvent(messageId: 'msg-1'),
+            ToolCallStartEvent(
+              toolCallId: 'tc-1',
+              toolCallName: 'search',
+            ),
+            ToolCallResultEvent(
+              messageId: 'result-1',
+              toolCallId: 'tc-1',
+              content: 'ok',
+            ),
+            TextMessageStartEvent(messageId: 'msg-2'),
+            TextMessageEndEvent(messageId: 'msg-2'),
+          ],
+        ),
+      ];
+
+      final trackers = replayToTrackers(runs);
+
+      expect(trackers.keys, containsAll(['msg-1', 'msg-2']));
+      final first = trackers['msg-1']!;
+      expect(first.steps.value.map((s) => s.label), ['search']);
+      final second = trackers['msg-2']!;
+      expect(second.steps.value, isEmpty);
+    });
+
+    test('activity nests under its surrounding tool-call step', () {
+      final runs = [
+        RunEventBundle(
+          runId: 'run-1',
+          events: const [
+            TextMessageStartEvent(messageId: 'msg-1'),
+            TextMessageEndEvent(messageId: 'msg-1'),
+            ToolCallStartEvent(
+              toolCallId: 'tc-1',
+              toolCallName: 'execute_skill',
+            ),
+            ActivitySnapshotEvent(
+              messageId: 'bwrap:call_1',
+              activityType: 'skill_tool_call',
+              content: {
+                'tool_name': 'execute_script',
+                'args': '{"script":"print(1)"}',
+              },
+              timestamp: 100,
+            ),
+            ToolCallResultEvent(
+              messageId: 'result-1',
+              toolCallId: 'tc-1',
+              content: 'ok',
+            ),
+          ],
+        ),
+      ];
+
+      final trackers = replayToTrackers(runs);
+      final tracker = trackers['msg-1']!;
+      final entries = tracker.timeline.value;
+
+      expect(entries, hasLength(1));
+      final step = entries.single as TimelineStep;
+      expect(step.step.label, 'execute_skill');
+      expect(step.activities, hasLength(1));
+      expect(step.activities.single.toolName, 'execute_script');
+    });
+
+    test('runs with no assistant message produce no tracker', () {
+      final runs = [
+        RunEventBundle(
+          runId: 'run-1',
+          events: const [
+            TextMessageStartEvent(messageId: 'user-1', role: TextMessageRole.user),
+            TextMessageEndEvent(messageId: 'user-1'),
+          ],
+        ),
+      ];
+
+      expect(replayToTrackers(runs), isEmpty);
+    });
+
+    test('multi-run thread yields one tracker per assistant message', () {
+      final runs = [
+        RunEventBundle(
+          runId: 'run-1',
+          events: const [
+            TextMessageStartEvent(messageId: 'asst-1'),
+            TextMessageEndEvent(messageId: 'asst-1'),
+          ],
+        ),
+        RunEventBundle(
+          runId: 'run-2',
+          events: const [
+            ReasoningMessageStartEvent(messageId: 'r-1'),
+            ReasoningMessageContentEvent(messageId: 'r-1', delta: 'go'),
+            TextMessageStartEvent(messageId: 'asst-2'),
+            TextMessageEndEvent(messageId: 'asst-2'),
+          ],
+        ),
+      ];
+
+      final trackers = replayToTrackers(runs);
+
+      expect(trackers.keys, ['asst-1', 'asst-2']);
+      expect(trackers['asst-1']!.steps.value, isEmpty);
+      expect(trackers['asst-2']!.steps.value, hasLength(1));
+    });
+  });
+}

--- a/test/modules/room/tracker_registry_test.dart
+++ b/test/modules/room/tracker_registry_test.dart
@@ -1,6 +1,7 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:soliplex_agent/soliplex_agent.dart';
 
+import 'package:soliplex_frontend/src/modules/room/execution_tracker.dart';
 import 'package:soliplex_frontend/src/modules/room/tracker_registry.dart';
 
 void main() {
@@ -159,6 +160,39 @@ void main() {
 
     registry.dispose();
     expect(registry.trackers, isEmpty);
+  });
+
+  group('seedHistorical', () {
+    test('adds frozen trackers under their message ids', () {
+      final historical = {
+        'asst-1': ExecutionTracker.historical(events: const []),
+        'asst-2': ExecutionTracker.historical(events: const []),
+      };
+
+      registry.seedHistorical(historical);
+
+      expect(registry.trackers.keys, containsAll(['asst-1', 'asst-2']));
+      expect(registry.trackers['asst-1']!.isFrozen, isTrue);
+    });
+
+    test('does not overwrite an existing live tracker', () {
+      registry.onStreaming(
+        const TextStreaming(
+          messageId: 'asst-1',
+          user: ChatUser.assistant,
+          text: '',
+        ),
+        events,
+      );
+      final live = registry.trackers['asst-1'];
+
+      final historical = {
+        'asst-1': ExecutionTracker.historical(events: const []),
+      };
+      registry.seedHistorical(historical);
+
+      expect(registry.trackers['asst-1'], same(live));
+    });
   });
 
   test('ignores AwaitingText when tracker already active', () {


### PR DESCRIPTION
## Summary

- Reconstruct per-message `ExecutionTracker`s when a thread is re-entered, closing the gap where reloaded rooms showed no execution timeline.
- Replay decoded `RunEventBundle`s (surfaced in S5a / #27) into frozen trackers and seed them into `TrackerRegistry` before `MessagesLoaded` fires.
- Share the single AG-UI → `ExecutionEvent` decode path (`bridgeBaseEvent`) between the live and historical replay code paths.

## Stack

Stacked on #27 (S5a). Merge after S5a.

## Design

- `ExecutionTracker.historical({required List<ExecutionEvent> events})` — seeds via the same `_onEvent` path the live tracker uses, then freezes. No subscription, no active timers.
- `replayToTrackers(List<RunEventBundle>) → Map<String, ExecutionTracker>`:
  - Assistant `TEXT_MESSAGE_START` sets the current bucket.
  - Events before the first assistant message in a run are buffered and attached to the next assistant message (matches how the live path attaches pre-stream thinking/tool events).
  - Events between two assistant messages attach to the preceding one — the live path keeps the previous tracker active when tool calls interleave.
  - Bundles with no assistant message produce no tracker (events dropped rather than grafted onto an unrelated bucket).
- `TrackerRegistry.seedHistorical(Map)` uses `putIfAbsent` — live trackers always win if a race somehow occurs.
- `ThreadViewState._fetch` hydrates the registry before `_messages.value = MessagesLoaded(...)`, so the first signal-driven rebuild sees a populated trackers map.
- `bridgeBaseEvent` promoted from `@visibleForTesting` to a documented public export so the app-layer replay path can reuse it.

## Test plan

- [x] `flutter test test/modules/room/execution_tracker_test.dart` — 4 new tests for the `historical` factory (frozen on return, seeds steps, activities nest under active step, empty events)
- [x] `flutter test test/modules/room/historical_replay_test.dart` — 7 tests covering empty runs, one tracker per assistant message, thinking-before-text attaches, tool calls between two assistant messages attach to the first, activity nests under tool-call step, runs with no assistant message produce no tracker, multi-run threads yield one tracker per message
- [x] `flutter test test/modules/room/tracker_registry_test.dart` — added `seedHistorical` group (adds frozen trackers under message ids, does not overwrite existing live tracker)
- [x] Full app suite: 1024/1024 passing
- [x] `flutter test packages/soliplex_agent/test --exclude-tags integration` — 459/459 passing
- [x] `dart format` clean
- [x] `flutter analyze` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
