### PR TITLE
M4: feat(core): AppModule lifecycle, deprecate ModuleContribution

### DIFF
--- a/lib/soliplex_frontend.dart
+++ b/lib/soliplex_frontend.dart
@@ -1,6 +1,8 @@
 /// Modular Flutter frontend framework for Soliplex.
 library;
 
+export 'src/core/app_module.dart'
+    show AppModule, AppModuleContext, ModuleRoutes;
 export 'src/core/shell.dart' show runSoliplexShell;
 export 'src/core/shell_config.dart' show ModuleContribution, ShellConfig;
 export 'src/interfaces/auth_state.dart'

--- a/lib/src/core/app_module.dart
+++ b/lib/src/core/app_module.dart
@@ -1,0 +1,53 @@
+import 'package:flutter_riverpod/misc.dart';
+import 'package:go_router/go_router.dart';
+
+/// Routes and Riverpod overrides contributed by an [AppModule].
+///
+/// Replaces the deprecated [ModuleContribution].
+class ModuleRoutes {
+  const ModuleRoutes({
+    this.routes = const [],
+    this.overrides = const [],
+    this.redirect,
+  });
+
+  final List<RouteBase> routes;
+  final List<Override> overrides;
+  final GoRouterRedirect? redirect;
+}
+
+/// Context passed to [AppModule.build] and [AppModule.onAttach].
+///
+/// Enables cross-module discovery without hard coupling between modules.
+/// Context passed to [AppModule.build] and [AppModule.onAttach].
+///
+/// Enables cross-module discovery without hard coupling between modules.
+abstract interface class AppModuleContext {
+  T? module<T extends AppModule>();
+}
+
+/// Lifecycle unit for a feature module.
+///
+/// Subclass and pass instances to [ShellConfig.fromModules] instead of using
+/// the deprecated [ModuleContribution] function pattern. Modules declare
+/// routes and overrides via [build] and release owned resources in
+/// [onDispose].
+abstract class AppModule {
+  String get namespace;
+  int get priority => 0;
+
+  /// Declares the routes and overrides this module contributes.
+  ///
+  /// Called once during [ShellConfig.fromModules] initialisation, before
+  /// [onAttach]. Use [ctx] to look up sibling modules if needed.
+  ModuleRoutes build(AppModuleContext ctx);
+
+  /// Called after all modules have been built, in descending [priority] order.
+  Future<void> onAttach(AppModuleContext ctx) async {}
+
+  /// Called when the shell is disposed, in reverse registration order.
+  ///
+  /// Release any resources owned by this module (HTTP clients, stream
+  /// subscriptions, state objects, etc.).
+  Future<void> onDispose() async {}
+}

--- a/lib/src/core/shell_config.dart
+++ b/lib/src/core/shell_config.dart
@@ -1,9 +1,22 @@
+import 'dart:async' show unawaited;
+
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/misc.dart';
 import 'package:go_router/go_router.dart';
 
+import 'app_module.dart';
 import 'router.dart';
 
+/// A static bag of routes, overrides, and an optional redirect contributed
+/// by a module.
+///
+/// Deprecated. Implement [AppModule] and use [ShellConfig.fromModules]
+/// instead. [ModuleContribution] will be removed once all consumers have
+/// migrated.
+@Deprecated(
+  'Implement AppModule and use ShellConfig.fromModules instead. '
+  'ModuleContribution will be removed once all consumers have migrated.',
+)
 class ModuleContribution {
   final List<RouteBase> routes;
   final List<Override> overrides;
@@ -22,29 +35,140 @@ class ShellConfig {
   final Widget? logo;
   final ThemeData theme;
   final String initialRoute;
-  final List<ModuleContribution> modules;
   final Listenable? refreshListenable;
   final VoidCallback? onDispose;
 
+  final List<RouteBase> _routes;
+  final List<Override> _overrides;
+  final List<GoRouterRedirect> _redirects;
+
+  /// Deprecated. Use [ShellConfig.fromModules] with [AppModule] classes
+  /// instead. This constructor will be removed once all consumers have
+  /// migrated.
+  // ignore: deprecated_member_use_from_same_package
+  @Deprecated(
+    'Use ShellConfig.fromModules with AppModule classes instead. '
+    'This constructor will be removed once all consumers have migrated.',
+  )
+  // ignore: deprecated_member_use_from_same_package
   ShellConfig({
     required this.appName,
     this.logo,
     required this.theme,
     this.initialRoute = '/',
+    // ignore: deprecated_member_use_from_same_package
     List<ModuleContribution> modules = const [],
     this.refreshListenable,
     this.onDispose,
-  }) : modules = List.unmodifiable(modules);
+    // ignore: deprecated_member_use_from_same_package
+  })  : _routes = modules.expand((m) => m.routes).toList(),
+        // ignore: deprecated_member_use_from_same_package
+        _overrides = modules.expand((m) => m.overrides).toList(),
+        // ignore: deprecated_member_use_from_same_package
+        _redirects = modules.map((m) => m.redirect).nonNulls.toList();
 
-  List<RouteBase> get routes => modules.expand((m) => m.routes).toList();
+  ShellConfig._internal({
+    required this.appName,
+    this.logo,
+    required this.theme,
+    this.initialRoute = '/',
+    required List<RouteBase> routes,
+    required List<Override> overrides,
+    required List<GoRouterRedirect> redirects,
+    this.refreshListenable,
+    this.onDispose,
+  })  : _routes = routes,
+        _overrides = overrides,
+        _redirects = redirects;
 
-  List<Override> get overrides => modules.expand((m) => m.overrides).toList();
-
-  List<GoRouterRedirect> get redirects =>
-      modules.map((m) => m.redirect).nonNulls.toList();
+  List<RouteBase> get routes => _routes;
+  List<Override> get overrides => _overrides;
+  List<GoRouterRedirect> get redirects => _redirects;
 
   List<String> validate() => validateRoutes(
         routes: routes,
         initialRoute: initialRoute,
       );
+
+  /// Creates a [ShellConfig] from a list of [AppModule] instances.
+  ///
+  /// Calls [AppModule.build] on each module to collect routes and overrides,
+  /// then calls [AppModule.onAttach] in descending [AppModule.priority] order.
+  /// When the shell is disposed, calls [AppModule.onDispose] in reverse
+  /// registration order.
+  static Future<ShellConfig> fromModules({
+    required List<AppModule> modules,
+    required String appName,
+    Widget? logo,
+    required ThemeData theme,
+    String initialRoute = '/',
+    Listenable? refreshListenable,
+  }) async {
+    final coordinator = _AppModuleCoordinator(modules);
+    await coordinator.attachAll();
+    return ShellConfig._internal(
+      appName: appName,
+      logo: logo,
+      theme: theme,
+      initialRoute: initialRoute,
+      routes: coordinator.routes,
+      overrides: coordinator.overrides,
+      redirects: coordinator.redirects,
+      refreshListenable: refreshListenable,
+      onDispose: () => unawaited(coordinator.disposeAll()),
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Internal coordinator — not part of the public API.
+// ---------------------------------------------------------------------------
+
+class _AppModuleCoordinator implements AppModuleContext {
+  _AppModuleCoordinator(List<AppModule> modules) {
+    final seen = <String>{};
+    for (final m in modules) {
+      if (m.namespace.isNotEmpty && !seen.add(m.namespace)) {
+        throw StateError('Duplicate AppModule namespace: "${m.namespace}"');
+      }
+    }
+    _modules = List.unmodifiable(modules);
+  }
+
+  late final List<AppModule> _modules;
+  List<ModuleRoutes>? _built;
+
+  List<ModuleRoutes> get _builtModules =>
+      _built ??= _modules.map((m) => m.build(this)).toList();
+
+  @override
+  T? module<T extends AppModule>() {
+    for (final m in _modules) {
+      if (m is T) return m;
+    }
+    return null;
+  }
+
+  Future<void> attachAll() async {
+    _built = _modules.map((m) => m.build(this)).toList();
+    final sorted = [..._modules]
+      ..sort((a, b) => b.priority.compareTo(a.priority));
+    for (final m in sorted) {
+      await m.onAttach(this);
+    }
+  }
+
+  Future<void> disposeAll() async {
+    for (final m in _modules.reversed) {
+      await m.onDispose();
+    }
+  }
+
+  List<RouteBase> get routes => _builtModules.expand((r) => r.routes).toList();
+
+  List<Override> get overrides =>
+      _builtModules.expand((r) => r.overrides).toList();
+
+  List<GoRouterRedirect> get redirects =>
+      _builtModules.map((r) => r.redirect).nonNulls.toList();
 }

--- a/lib/src/flavors/standard.dart
+++ b/lib/src/flavors/standard.dart
@@ -6,8 +6,7 @@ import 'package:soliplex_logging/soliplex_logging.dart' show LoggerFactory;
 
 import '../design/design.dart';
 import '../core/shell_config.dart';
-import '../core/signal_listenable.dart';
-import '../interfaces/auth_state.dart';
+import '../interfaces/auth_state.dart' show Authenticated;
 import '../modules/auth/auth_module.dart';
 import '../modules/auth/default_backend_url.dart';
 import '../modules/auth/auth_session.dart';
@@ -126,7 +125,6 @@ Future<ShellConfig> standard({
         webOrigin: kIsWeb ? Uri.base : null,
       );
 
-  final authListenable = SignalListenable(serverManager.authState);
   final authFlow = createAuthFlow(redirectScheme: redirectScheme);
 
   final runtimeManager = AgentRuntimeManager(
@@ -140,42 +138,36 @@ Future<ShellConfig> standard({
 
   final registry = RunRegistry();
 
-  return ShellConfig(
+  final authMod = AuthAppModule(
+    serverManager: serverManager,
+    probeClient: plainClient,
+    authFlow: authFlow,
+    appName: appName,
+    callbackParams: callbackParams is! NoCallbackParams ? callbackParams : null,
+    consentNotice: consentNotice,
+    logo: logo,
+    defaultBackendUrl: resolvedUrl,
+  );
+
+  return ShellConfig.fromModules(
     appName: appName,
     logo: logo,
     theme: theme ?? _defaultTheme(),
     initialRoute: callbackParams is! NoCallbackParams
         ? '/auth/callback'
         : (serverManager.authState.value is Authenticated ? '/lobby' : '/'),
-    refreshListenable: authListenable,
-    onDispose: () {
-      authListenable.dispose();
-      serverManager.dispose();
-      plainClient.close();
-      runtimeManager.dispose();
-      registry.dispose();
-      inspector.dispose();
-    },
+    refreshListenable: authMod.refreshListenable,
     modules: [
-      diagnosticsModule(inspector: inspector),
-      lobbyModule(serverManager: serverManager),
-      roomModule(
+      DiagnosticsAppModule(inspector: inspector),
+      authMod,
+      LobbyAppModule(serverManager: serverManager),
+      RoomAppModule(
         serverManager: serverManager,
         runtimeManager: runtimeManager,
         registry: registry,
         enableDocumentFilter: true,
       ),
-      quizModule(serverManager: serverManager),
-      authModule(
-        serverManager: serverManager,
-        authFlow: authFlow,
-        probeClient: plainClient,
-        appName: appName,
-        callbackParams: callbackParams,
-        consentNotice: consentNotice,
-        logo: logo,
-        defaultBackendUrl: resolvedUrl,
-      ),
+      QuizAppModule(serverManager: serverManager),
     ],
   );
 }

--- a/lib/src/modules/auth/auth_module.dart
+++ b/lib/src/modules/auth/auth_module.dart
@@ -2,7 +2,8 @@ import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
 import 'package:soliplex_agent/soliplex_agent.dart' hide AuthException;
 
-import '../../core/shell_config.dart';
+import '../../core/app_module.dart';
+import '../../core/signal_listenable.dart';
 import '../../interfaces/auth_state.dart';
 import 'auth_providers.dart';
 import 'consent_notice.dart';
@@ -13,65 +14,99 @@ import 'ui/auth_callback_screen.dart';
 import 'ui/home_screen.dart';
 import 'ui/server_list_screen.dart';
 
-/// Public routes that don't require authentication.
 const _publicPaths = {'/', '/servers', '/auth/callback'};
 
-ModuleContribution authModule({
-  required ServerManager serverManager,
-  required AuthFlow authFlow,
-  required SoliplexHttpClient probeClient,
-  required String appName,
-  CallbackParams? callbackParams,
-  ConsentNotice? consentNotice,
-  Widget? logo,
-  String? defaultBackendUrl,
-}) {
-  return ModuleContribution(
-    overrides: [
-      serverManagerProvider.overrideWithValue(serverManager),
-      authFlowProvider.overrideWithValue(authFlow),
-      probeClientProvider.overrideWithValue(probeClient),
-      if (callbackParams != null)
-        callbackParamsProvider.overrideWithValue(callbackParams),
-      if (consentNotice != null)
-        consentNoticeProvider.overrideWithValue(consentNotice),
-    ],
-    routes: [
-      GoRoute(
-        path: '/',
-        pageBuilder: (_, state) {
-          final autoConnectUrl = state.uri.queryParameters['url'];
-          return NoTransitionPage(
-            key: autoConnectUrl != null ? UniqueKey() : state.pageKey,
-            child: HomeScreen(
-              serverManager: serverManager,
-              appName: appName,
-              logo: logo,
-              defaultBackendUrl: defaultBackendUrl,
-              autoConnectUrl: autoConnectUrl,
-            ),
-          );
-        },
-      ),
-      GoRoute(
-        path: '/servers',
-        pageBuilder: (_, __) => NoTransitionPage(
-          child: ServerListScreen(serverManager: serverManager),
-        ),
-      ),
-      GoRoute(
-        path: '/auth/callback',
-        pageBuilder: (_, __) => NoTransitionPage(
-          child: AuthCallbackScreen(serverManager: serverManager),
-        ),
-      ),
-    ],
-    redirect: (_, state) {
-      final isAuthenticated = serverManager.authState.value is Authenticated;
-      final isPublic = _publicPaths.contains(state.matchedLocation);
+class AuthAppModule extends AppModule {
+  AuthAppModule({
+    required ServerManager serverManager,
+    required SoliplexHttpClient probeClient,
+    required AuthFlow authFlow,
+    required String appName,
+    CallbackParams? callbackParams,
+    ConsentNotice? consentNotice,
+    Widget? logo,
+    String? defaultBackendUrl,
+  })  : _serverManager = serverManager,
+        _probeClient = probeClient,
+        _authFlow = authFlow,
+        _appName = appName,
+        _callbackParams = callbackParams,
+        _consentNotice = consentNotice,
+        _logo = logo,
+        _defaultBackendUrl = defaultBackendUrl,
+        _refreshListenable = SignalListenable(serverManager.authState);
 
-      if (!isAuthenticated && !isPublic) return '/';
-      return null;
-    },
-  );
+  final ServerManager _serverManager;
+  final SoliplexHttpClient _probeClient;
+  final AuthFlow _authFlow;
+  final String _appName;
+  final CallbackParams? _callbackParams;
+  final ConsentNotice? _consentNotice;
+  final Widget? _logo;
+  final String? _defaultBackendUrl;
+  final SignalListenable _refreshListenable;
+
+  /// The [Listenable] that notifies [GoRouter] when auth state changes.
+  /// Pass this to [ShellConfig.fromModules] as [refreshListenable].
+  Listenable get refreshListenable => _refreshListenable;
+
+  @override
+  String get namespace => 'auth';
+
+  @override
+  ModuleRoutes build(AppModuleContext ctx) => ModuleRoutes(
+        overrides: [
+          serverManagerProvider.overrideWithValue(_serverManager),
+          authFlowProvider.overrideWithValue(_authFlow),
+          probeClientProvider.overrideWithValue(_probeClient),
+          if (_callbackParams != null)
+            callbackParamsProvider.overrideWithValue(_callbackParams),
+          if (_consentNotice != null)
+            consentNoticeProvider.overrideWithValue(_consentNotice),
+        ],
+        routes: [
+          GoRoute(
+            path: '/',
+            pageBuilder: (_, state) {
+              final autoConnectUrl = state.uri.queryParameters['url'];
+              return NoTransitionPage(
+                key: autoConnectUrl != null ? UniqueKey() : state.pageKey,
+                child: HomeScreen(
+                  serverManager: _serverManager,
+                  appName: _appName,
+                  logo: _logo,
+                  defaultBackendUrl: _defaultBackendUrl,
+                  autoConnectUrl: autoConnectUrl,
+                ),
+              );
+            },
+          ),
+          GoRoute(
+            path: '/servers',
+            pageBuilder: (_, __) => NoTransitionPage(
+              child: ServerListScreen(serverManager: _serverManager),
+            ),
+          ),
+          GoRoute(
+            path: '/auth/callback',
+            pageBuilder: (_, __) => NoTransitionPage(
+              child: AuthCallbackScreen(serverManager: _serverManager),
+            ),
+          ),
+        ],
+        redirect: (_, state) {
+          final isAuthenticated =
+              _serverManager.authState.value is Authenticated;
+          final isPublic = _publicPaths.contains(state.matchedLocation);
+          if (!isAuthenticated && !isPublic) return '/';
+          return null;
+        },
+      );
+
+  @override
+  Future<void> onDispose() async {
+    _refreshListenable.dispose();
+    _serverManager.dispose();
+    _probeClient.close();
+  }
 }

--- a/lib/src/modules/diagnostics/diagnostics_module.dart
+++ b/lib/src/modules/diagnostics/diagnostics_module.dart
@@ -1,22 +1,32 @@
 import 'package:go_router/go_router.dart';
 
-import '../../core/shell_config.dart';
+import '../../core/app_module.dart';
 import 'diagnostics_providers.dart';
 import 'network_inspector.dart';
 import 'ui/network_inspector_screen.dart';
 
-ModuleContribution diagnosticsModule({required NetworkInspector inspector}) {
-  return ModuleContribution(
-    overrides: [
-      networkInspectorProvider.overrideWithValue(inspector),
-    ],
-    routes: [
-      GoRoute(
-        path: '/diagnostics/network',
-        builder: (context, state) => NetworkInspectorScreen(
-          inspector: inspector,
-        ),
-      ),
-    ],
-  );
+class DiagnosticsAppModule extends AppModule {
+  DiagnosticsAppModule({required this.inspector});
+
+  final NetworkInspector inspector;
+
+  @override
+  String get namespace => 'diagnostics';
+
+  @override
+  ModuleRoutes build(AppModuleContext ctx) => ModuleRoutes(
+        overrides: [
+          networkInspectorProvider.overrideWithValue(inspector),
+        ],
+        routes: [
+          GoRoute(
+            path: '/diagnostics/network',
+            builder: (context, state) =>
+                NetworkInspectorScreen(inspector: inspector),
+          ),
+        ],
+      );
+
+  @override
+  Future<void> onDispose() async => inspector.dispose();
 }

--- a/lib/src/modules/lobby/lobby_module.dart
+++ b/lib/src/modules/lobby/lobby_module.dart
@@ -1,20 +1,26 @@
 import 'package:go_router/go_router.dart';
 
-import '../../core/shell_config.dart';
+import '../../core/app_module.dart';
 import '../auth/server_manager.dart';
 import 'ui/lobby_screen.dart';
 
-ModuleContribution lobbyModule({
-  required ServerManager serverManager,
-}) {
-  return ModuleContribution(
-    routes: [
-      GoRoute(
-        path: '/lobby',
-        pageBuilder: (_, __) => NoTransitionPage(
-          child: LobbyScreen(serverManager: serverManager),
-        ),
-      ),
-    ],
-  );
+class LobbyAppModule extends AppModule {
+  LobbyAppModule({required this.serverManager});
+
+  final ServerManager serverManager;
+
+  @override
+  String get namespace => 'lobby';
+
+  @override
+  ModuleRoutes build(AppModuleContext ctx) => ModuleRoutes(
+        routes: [
+          GoRoute(
+            path: '/lobby',
+            pageBuilder: (_, __) => NoTransitionPage(
+              child: LobbyScreen(serverManager: serverManager),
+            ),
+          ),
+        ],
+      );
 }

--- a/lib/src/modules/quiz/quiz_module.dart
+++ b/lib/src/modules/quiz/quiz_module.dart
@@ -1,40 +1,44 @@
 import 'package:flutter/widgets.dart';
 import 'package:go_router/go_router.dart';
 
-import '../../core/shell_config.dart';
+import '../../core/app_module.dart';
 import '../auth/require_connected_server.dart';
 import '../auth/server_manager.dart';
 import 'ui/quiz_screen.dart';
 
-ModuleContribution quizModule({
-  required ServerManager serverManager,
-}) {
-  return ModuleContribution(
-    routes: [
-      GoRoute(
-        path: '/room/:serverAlias/:roomId/quiz/:quizId',
-        redirect: (context, state) => requireConnectedServer(
-          serverManager,
-          state.pathParameters['serverAlias'],
-        ),
-        pageBuilder: (context, state) {
-          final alias = state.pathParameters['serverAlias']!;
-          final entry = serverManager.entryByAlias(alias);
-          if (entry == null || !entry.isConnected) {
-            return const NoTransitionPage(
-              child: SizedBox.shrink(),
-            );
-          }
-          return NoTransitionPage(
-            child: QuizScreen(
-              serverEntry: entry,
-              roomId: state.pathParameters['roomId']!,
-              quizId: state.pathParameters['quizId']!,
-              returnRoute: state.uri.queryParameters['from'],
+class QuizAppModule extends AppModule {
+  QuizAppModule({required this.serverManager});
+
+  final ServerManager serverManager;
+
+  @override
+  String get namespace => 'quiz';
+
+  @override
+  ModuleRoutes build(AppModuleContext ctx) => ModuleRoutes(
+        routes: [
+          GoRoute(
+            path: '/room/:serverAlias/:roomId/quiz/:quizId',
+            redirect: (context, state) => requireConnectedServer(
+              serverManager,
+              state.pathParameters['serverAlias'],
             ),
-          );
-        },
-      ),
-    ],
-  );
+            pageBuilder: (context, state) {
+              final alias = state.pathParameters['serverAlias']!;
+              final entry = serverManager.entryByAlias(alias);
+              if (entry == null || !entry.isConnected) {
+                return const NoTransitionPage(child: SizedBox.shrink());
+              }
+              return NoTransitionPage(
+                child: QuizScreen(
+                  serverEntry: entry,
+                  roomId: state.pathParameters['roomId']!,
+                  quizId: state.pathParameters['quizId']!,
+                  returnRoute: state.uri.queryParameters['from'],
+                ),
+              );
+            },
+          ),
+        ],
+      );
 }

--- a/lib/src/modules/room/room_module.dart
+++ b/lib/src/modules/room/room_module.dart
@@ -1,6 +1,6 @@
 import 'package:go_router/go_router.dart';
 
-import '../../core/shell_config.dart';
+import '../../core/app_module.dart';
 import '../auth/require_connected_server.dart';
 import '../auth/server_manager.dart';
 import 'agent_runtime_manager.dart';
@@ -10,87 +10,83 @@ import 'ui/room_info_screen.dart';
 import 'ui/room_screen.dart';
 import 'upload_tracker_registry.dart';
 
-ModuleContribution roomModule({
-  required ServerManager serverManager,
-  required AgentRuntimeManager runtimeManager,
-  required RunRegistry registry,
-  bool enableDocumentFilter = false,
-}) {
-  final documentSelections = DocumentSelections();
-  final uploadRegistry = UploadTrackerRegistry(servers: serverManager.servers);
-  return ModuleContribution(
-    routes: [
-      GoRoute(
-        path: '/room/:serverAlias/:roomId/info',
-        redirect: (context, state) => requireConnectedServer(
-          serverManager,
-          state.pathParameters['serverAlias'],
-        ),
-        pageBuilder: (context, state) {
-          final alias = state.pathParameters['serverAlias']!;
-          final entry = serverManager.entryByAlias(alias)!;
-          return NoTransitionPage(
-            child: RoomInfoScreen(
-              serverEntry: entry,
-              roomId: state.pathParameters['roomId']!,
-              toolRegistryResolver: runtimeManager.toolRegistryResolver,
-              uploadRegistry: uploadRegistry,
-            ),
-          );
-        },
-      ),
-      _buildRoute(
-        '/room/:serverAlias/:roomId',
-        serverManager,
-        runtimeManager,
-        registry,
-        uploadRegistry,
-        enableDocumentFilter,
-        documentSelections,
-      ),
-      _buildRoute(
-        '/room/:serverAlias/:roomId/thread/:threadId',
-        serverManager,
-        runtimeManager,
-        registry,
-        uploadRegistry,
-        enableDocumentFilter,
-        documentSelections,
-      ),
-    ],
-  );
-}
+class RoomAppModule extends AppModule {
+  RoomAppModule({
+    required this.serverManager,
+    required this.runtimeManager,
+    required this.registry,
+    this.enableDocumentFilter = false,
+  })  : _documentSelections = DocumentSelections(),
+        _uploadRegistry = UploadTrackerRegistry(servers: serverManager.servers);
 
-GoRoute _buildRoute(
-  String path,
-  ServerManager serverManager,
-  AgentRuntimeManager runtimeManager,
-  RunRegistry registry,
-  UploadTrackerRegistry uploadRegistry,
-  bool enableDocumentFilter,
-  DocumentSelections documentSelections,
-) {
-  return GoRoute(
-    path: path,
-    redirect: (context, state) => requireConnectedServer(
-      serverManager,
-      state.pathParameters['serverAlias'],
-    ),
-    pageBuilder: (context, state) {
-      final alias = state.pathParameters['serverAlias']!;
-      final entry = serverManager.entryByAlias(alias)!;
-      return NoTransitionPage(
-        child: RoomScreen(
-          serverEntry: entry,
-          roomId: state.pathParameters['roomId']!,
-          threadId: state.pathParameters['threadId'],
-          runtimeManager: runtimeManager,
-          registry: registry,
-          uploadRegistry: uploadRegistry,
-          enableDocumentFilter: enableDocumentFilter,
-          documentSelections: documentSelections,
-        ),
+  final ServerManager serverManager;
+  final AgentRuntimeManager runtimeManager;
+  final RunRegistry registry;
+  final bool enableDocumentFilter;
+
+  final DocumentSelections _documentSelections;
+  final UploadTrackerRegistry _uploadRegistry;
+
+  @override
+  String get namespace => 'room';
+
+  @override
+  ModuleRoutes build(AppModuleContext ctx) => ModuleRoutes(
+        routes: [
+          GoRoute(
+            path: '/room/:serverAlias/:roomId/info',
+            redirect: (context, state) => requireConnectedServer(
+              serverManager,
+              state.pathParameters['serverAlias'],
+            ),
+            pageBuilder: (context, state) {
+              final alias = state.pathParameters['serverAlias']!;
+              final entry = serverManager.entryByAlias(alias)!;
+              return NoTransitionPage(
+                child: RoomInfoScreen(
+                  serverEntry: entry,
+                  roomId: state.pathParameters['roomId']!,
+                  toolRegistryResolver: runtimeManager.toolRegistryResolver,
+                  uploadRegistry: _uploadRegistry,
+                ),
+              );
+            },
+          ),
+          _buildRoute('/room/:serverAlias/:roomId'),
+          _buildRoute('/room/:serverAlias/:roomId/thread/:threadId'),
+        ],
       );
-    },
-  );
+
+  GoRoute _buildRoute(String path) {
+    return GoRoute(
+      path: path,
+      redirect: (context, state) => requireConnectedServer(
+        serverManager,
+        state.pathParameters['serverAlias'],
+      ),
+      pageBuilder: (context, state) {
+        final alias = state.pathParameters['serverAlias']!;
+        final entry = serverManager.entryByAlias(alias)!;
+        return NoTransitionPage(
+          child: RoomScreen(
+            serverEntry: entry,
+            roomId: state.pathParameters['roomId']!,
+            threadId: state.pathParameters['threadId'],
+            runtimeManager: runtimeManager,
+            registry: registry,
+            uploadRegistry: _uploadRegistry,
+            enableDocumentFilter: enableDocumentFilter,
+            documentSelections: _documentSelections,
+          ),
+        );
+      },
+    );
+  }
+
+  @override
+  Future<void> onDispose() async {
+    runtimeManager.dispose();
+    registry.dispose();
+    _uploadRegistry.dispose();
+  }
 }

--- a/test/core/shell_test.dart
+++ b/test/core/shell_test.dart
@@ -1,16 +1,46 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_riverpod/misc.dart' show Override;
 import 'package:flutter_test/flutter_test.dart';
 import 'package:go_router/go_router.dart';
+import 'package:soliplex_frontend/src/core/app_module.dart';
 import 'package:soliplex_frontend/src/core/shell.dart';
 import 'package:soliplex_frontend/src/core/shell_config.dart';
 
+// ---------------------------------------------------------------------------
+// Test helpers
+// ---------------------------------------------------------------------------
+
+class _TestModule extends AppModule {
+  _TestModule({
+    this.routes = const [],
+    this.overrides = const [],
+    this.redirect,
+    this.namespace = '',
+  });
+
+  @override
+  final String namespace;
+  final List<RouteBase> routes;
+  final List<Override> overrides;
+  final GoRouterRedirect? redirect;
+
+  @override
+  ModuleRoutes build(AppModuleContext ctx) =>
+      ModuleRoutes(routes: routes, overrides: overrides, redirect: redirect);
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
 void main() {
   group('runSoliplexShell', () {
-    test('throws ArgumentError on invalid config', () {
-      final config = ShellConfig(
+    test('throws ArgumentError on invalid config', () async {
+      final config = await ShellConfig.fromModules(
         appName: 'Test',
         theme: ThemeData(),
+        modules: [],
       );
 
       expect(() => runSoliplexShell(config), throwsArgumentError);
@@ -22,15 +52,15 @@ void main() {
       final greeting = Provider<String>((_) => 'default greeting');
       final farewell = Provider<String>((_) => 'default farewell');
 
-      final config = ShellConfig(
+      final config = await ShellConfig.fromModules(
         appName: 'Test',
         theme: ThemeData(),
         initialRoute: '/check',
         modules: [
-          ModuleContribution(
+          _TestModule(
             overrides: [greeting.overrideWithValue('hello')],
           ),
-          ModuleContribution(
+          _TestModule(
             overrides: [farewell.overrideWithValue('goodbye')],
             routes: [
               GoRoute(
@@ -59,20 +89,20 @@ void main() {
 
   group('redirect composition', () {
     testWidgets('first non-null redirect wins', (tester) async {
-      final config = ShellConfig(
+      final config = await ShellConfig.fromModules(
         appName: 'Test',
         theme: ThemeData(),
         initialRoute: '/a',
         modules: [
-          ModuleContribution(
+          _TestModule(
             redirect: (context, state) =>
                 state.matchedLocation == '/a' ? '/b' : null,
           ),
-          ModuleContribution(
+          _TestModule(
             redirect: (context, state) =>
                 state.matchedLocation == '/a' ? '/c' : null,
           ),
-          ModuleContribution(
+          _TestModule(
             routes: [
               GoRoute(
                 path: '/a',
@@ -97,4 +127,70 @@ void main() {
       expect(find.text('Page B'), findsOneWidget);
     });
   });
+
+  group('AppModuleCoordinator', () {
+    test('duplicate namespace throws StateError', () async {
+      expect(
+        () => ShellConfig.fromModules(
+          appName: 'Test',
+          theme: ThemeData(),
+          modules: [
+            _TestModule(namespace: 'same'),
+            _TestModule(namespace: 'same'),
+          ],
+        ),
+        throwsStateError,
+      );
+    });
+
+    test('empty namespace skips uniqueness check', () async {
+      // Should not throw even though both modules have empty namespace.
+      await ShellConfig.fromModules(
+        appName: 'Test',
+        theme: ThemeData(),
+        modules: [
+          _TestModule(
+            routes: [
+              GoRoute(path: '/', builder: (_, __) => const SizedBox()),
+            ],
+          ),
+          _TestModule(),
+        ],
+      );
+    });
+
+    test('onAttach and onDispose are called', () async {
+      final log = <String>[];
+
+      final module = _LifecycleModule(log);
+      final config = await ShellConfig.fromModules(
+        appName: 'Test',
+        theme: ThemeData(),
+        modules: [module],
+      );
+
+      expect(log, ['attach']);
+      config.onDispose?.call();
+      await Future<void>.delayed(Duration.zero); // let async dispose flush
+      expect(log, ['attach', 'dispose']);
+    });
+  });
+}
+
+class _LifecycleModule extends AppModule {
+  _LifecycleModule(this._log);
+
+  final List<String> _log;
+
+  @override
+  String get namespace => 'lifecycle';
+
+  @override
+  ModuleRoutes build(AppModuleContext ctx) => const ModuleRoutes();
+
+  @override
+  Future<void> onAttach(AppModuleContext ctx) async => _log.add('attach');
+
+  @override
+  Future<void> onDispose() async => _log.add('dispose');
 }

--- a/test/main_test.dart
+++ b/test/main_test.dart
@@ -4,18 +4,24 @@ import 'package:go_router/go_router.dart';
 
 import 'package:soliplex_frontend/soliplex_frontend.dart';
 
+class _HomeModule extends AppModule {
+  @override
+  String get namespace => 'home';
+
+  @override
+  ModuleRoutes build(AppModuleContext ctx) => ModuleRoutes(
+        routes: [
+          GoRoute(path: '/', builder: (_, __) => const Text('Soliplex')),
+        ],
+      );
+}
+
 void main() {
   testWidgets('app boots and renders home screen', (tester) async {
-    final config = ShellConfig(
+    final config = await ShellConfig.fromModules(
       appName: 'Soliplex',
       theme: ThemeData(),
-      modules: [
-        ModuleContribution(
-          routes: [
-            GoRoute(path: '/', builder: (_, __) => const Text('Soliplex')),
-          ],
-        ),
-      ],
+      modules: [_HomeModule()],
     );
     runSoliplexShell(config);
     await tester.pumpAndSettle();

--- a/test/modules/auth/auth_module_test.dart
+++ b/test/modules/auth/auth_module_test.dart
@@ -2,12 +2,20 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:go_router/go_router.dart';
+import 'package:soliplex_frontend/src/core/app_module.dart';
 import 'package:soliplex_frontend/src/modules/auth/auth_module.dart';
 import 'package:soliplex_frontend/src/modules/auth/auth_session.dart';
 import 'package:soliplex_frontend/src/modules/auth/auth_tokens.dart';
 import 'package:soliplex_frontend/src/modules/auth/server_manager.dart';
 
 import '../../helpers/fakes.dart';
+
+class _NullContext implements AppModuleContext {
+  @override
+  T? module<T extends AppModule>() => null;
+}
+
+final _ctx = _NullContext();
 
 ServerManager _createServerManager() => ServerManager(
       authFactory: () => AuthSession(
@@ -17,43 +25,29 @@ ServerManager _createServerManager() => ServerManager(
       storage: InMemoryServerStorage(),
     );
 
-void main() {
-  group('authModule', () {
-    test('contributes routes for /, /servers, /auth/callback', () {
-      final serverManager = _createServerManager();
-      final contribution = authModule(
-        serverManager: serverManager,
-        authFlow: FakeAuthFlow(),
-        probeClient: FakeHttpClient(),
-        appName: 'Soliplex',
-      );
+AuthAppModule _createModule({ServerManager? serverManager}) => AuthAppModule(
+      serverManager: serverManager ?? _createServerManager(),
+      probeClient: FakeHttpClient(),
+      authFlow: FakeAuthFlow(),
+      appName: 'Soliplex',
+    );
 
+void main() {
+  group('AuthAppModule', () {
+    test('contributes routes for /, /servers, /auth/callback', () {
+      final contribution = _createModule().build(_ctx);
       final paths =
           contribution.routes.whereType<GoRoute>().map((r) => r.path).toList();
       expect(paths, containsAll(['/', '/servers', '/auth/callback']));
     });
 
     test('contributes a redirect', () {
-      final serverManager = _createServerManager();
-      final contribution = authModule(
-        serverManager: serverManager,
-        authFlow: FakeAuthFlow(),
-        probeClient: FakeHttpClient(),
-        appName: 'Soliplex',
-      );
-
+      final contribution = _createModule().build(_ctx);
       expect(contribution.redirect, isNotNull);
     });
 
     test('contributes overrides for required providers', () {
-      final serverManager = _createServerManager();
-      final contribution = authModule(
-        serverManager: serverManager,
-        authFlow: FakeAuthFlow(),
-        probeClient: FakeHttpClient(),
-        appName: 'Soliplex',
-      );
-
+      final contribution = _createModule().build(_ctx);
       // At minimum: serverManager, authFlow, probeClient.
       // Optional overrides only added when non-null.
       expect(contribution.overrides, isNotEmpty);
@@ -62,16 +56,11 @@ void main() {
 
   group('auth redirect', () {
     late ServerManager serverManager;
+    late AuthAppModule module;
     late GoRouter router;
 
     Widget buildApp() {
-      final contribution = authModule(
-        serverManager: serverManager,
-        authFlow: FakeAuthFlow(),
-        probeClient: FakeHttpClient(),
-        appName: 'Soliplex',
-      );
-
+      final contribution = module.build(_ctx);
       router = GoRouter(
         initialLocation: '/',
         routes: [
@@ -83,7 +72,6 @@ void main() {
         ],
         redirect: contribution.redirect,
       );
-
       return ProviderScope(
         overrides: contribution.overrides,
         child: MaterialApp.router(routerConfig: router),
@@ -92,7 +80,10 @@ void main() {
 
     setUp(() {
       serverManager = _createServerManager();
+      module = _createModule(serverManager: serverManager);
     });
+
+    tearDown(() async => module.onDispose());
 
     testWidgets('stays on / when unauthenticated', (tester) async {
       await tester.pumpWidget(buildApp());
@@ -113,13 +104,7 @@ void main() {
     });
 
     testWidgets('allows /auth/callback when unauthenticated', (tester) async {
-      final contribution = authModule(
-        serverManager: serverManager,
-        authFlow: FakeAuthFlow(),
-        probeClient: FakeHttpClient(),
-        appName: 'Soliplex',
-      );
-
+      final contribution = module.build(_ctx);
       router = GoRouter(
         initialLocation: '/auth/callback',
         routes: contribution.routes,

--- a/test/modules/lobby/lobby_module_test.dart
+++ b/test/modules/lobby/lobby_module_test.dart
@@ -1,10 +1,18 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:go_router/go_router.dart';
+import 'package:soliplex_frontend/src/core/app_module.dart';
 import 'package:soliplex_frontend/src/modules/auth/auth_session.dart';
 import 'package:soliplex_frontend/src/modules/auth/server_manager.dart';
 import 'package:soliplex_frontend/src/modules/lobby/lobby_module.dart';
 
 import '../../helpers/fakes.dart';
+
+class _NullContext implements AppModuleContext {
+  @override
+  T? module<T extends AppModule>() => null;
+}
+
+final _ctx = _NullContext();
 
 ServerManager _createManager() => ServerManager(
       authFactory: () => AuthSession(refreshService: FakeTokenRefreshService()),
@@ -13,18 +21,18 @@ ServerManager _createManager() => ServerManager(
     );
 
 void main() {
-  group('lobbyModule', () {
+  group('LobbyAppModule', () {
     test('contributes /lobby route', () {
-      final contribution = lobbyModule(serverManager: _createManager());
-
+      final contribution =
+          LobbyAppModule(serverManager: _createManager()).build(_ctx);
       final paths =
           contribution.routes.whereType<GoRoute>().map((r) => r.path).toList();
       expect(paths, contains('/lobby'));
     });
 
     test('does not contribute a redirect', () {
-      final contribution = lobbyModule(serverManager: _createManager());
-
+      final contribution =
+          LobbyAppModule(serverManager: _createManager()).build(_ctx);
       expect(contribution.redirect, isNull);
     });
   });

--- a/test/modules/room/room_module_test.dart
+++ b/test/modules/room/room_module_test.dart
@@ -1,6 +1,7 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:go_router/go_router.dart';
 import 'package:soliplex_agent/soliplex_agent.dart';
+import 'package:soliplex_frontend/src/core/app_module.dart';
 import 'package:soliplex_frontend/src/modules/auth/auth_session.dart';
 import 'package:soliplex_frontend/src/modules/auth/server_manager.dart';
 import 'package:soliplex_frontend/src/modules/room/agent_runtime_manager.dart';
@@ -8,6 +9,13 @@ import 'package:soliplex_frontend/src/modules/room/room_module.dart';
 import 'package:soliplex_frontend/src/modules/room/run_registry.dart';
 
 import '../../helpers/fakes.dart';
+
+class _NullContext implements AppModuleContext {
+  @override
+  T? module<T extends AppModule>() => null;
+}
+
+final _ctx = _NullContext();
 
 ServerManager _createManager() => ServerManager(
       authFactory: () => AuthSession(refreshService: FakeTokenRefreshService()),
@@ -18,6 +26,7 @@ ServerManager _createManager() => ServerManager(
 void main() {
   late AgentRuntimeManager runtimeManager;
   late RunRegistry registry;
+  late RoomAppModule module;
 
   setUp(() {
     runtimeManager = AgentRuntimeManager(
@@ -26,20 +35,19 @@ void main() {
       logger: testLogger(),
     );
     registry = RunRegistry();
-  });
-
-  tearDown(() async {
-    await runtimeManager.dispose();
-    registry.dispose();
-  });
-
-  test('contributes room routes', () {
-    final manager = _createManager();
-    final contribution = roomModule(
-      serverManager: manager,
+    module = RoomAppModule(
+      serverManager: _createManager(),
       runtimeManager: runtimeManager,
       registry: registry,
     );
+  });
+
+  tearDown(() async {
+    await module.onDispose();
+  });
+
+  test('contributes room routes', () {
+    final contribution = module.build(_ctx);
     final paths =
         contribution.routes.whereType<GoRoute>().map((r) => r.path).toList();
     expect(paths, contains('/room/:serverAlias/:roomId'));
@@ -47,12 +55,7 @@ void main() {
   });
 
   test('contributes room info route before thread route', () {
-    final manager = _createManager();
-    final contribution = roomModule(
-      serverManager: manager,
-      runtimeManager: runtimeManager,
-      registry: registry,
-    );
+    final contribution = module.build(_ctx);
     final paths =
         contribution.routes.whereType<GoRoute>().map((r) => r.path).toList();
     expect(paths, contains('/room/:serverAlias/:roomId/info'));
@@ -65,13 +68,8 @@ void main() {
             '/info must precede /:threadId to avoid eager parameter matching');
   });
 
-  test('contributes no overrides in Slice A', () {
-    final manager = _createManager();
-    final contribution = roomModule(
-      serverManager: manager,
-      runtimeManager: runtimeManager,
-      registry: registry,
-    );
+  test('contributes no overrides', () {
+    final contribution = module.build(_ctx);
     expect(contribution.overrides, isEmpty);
   });
 }


### PR DESCRIPTION
## Summary

- Adds `AppModule` / `AppModuleContext` / `ModuleRoutes` — lifecycle-aware module API replacing the old function-per-module pattern
- `AppModule.build()` → routes + overrides; `onAttach()` / `onDispose()` for initialization and cleanup; `priority` for ordered attach (descending) and dispose (reverse)
- Adds `ShellConfig.fromModules()` async factory + private `_AppModuleCoordinator` with namespace uniqueness validation
- Converts all 5 modules to `AppModule` subclasses: `AuthAppModule`, `DiagnosticsAppModule`, `LobbyAppModule`, `RoomAppModule`, `QuizAppModule`
- `ModuleContribution` and old `ShellConfig(modules: [...])` constructor marked `@Deprecated` — kept for backward compatibility, not deleted
- `RoomAppModule` fixes a pre-existing `UploadTrackerRegistry` leak (was never disposed)

Stacked on M3.

## Test plan

- [ ] `flutter test --reporter failures-only` — all pass
- [ ] `flutter analyze` — zero warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)