### PR TITLE
M5: feat: show spinner on thread tile when agent run is active

### DIFF
--- a/lib/src/modules/room/room_state.dart
+++ b/lib/src/modules/room/room_state.dart
@@ -71,6 +71,15 @@ class RoomState {
   final Signal<RoomStatus> _room = Signal<RoomStatus>(RoomLoading());
   ReadonlySignal<RoomStatus> get room => _room;
 
+  /// Reactive set of thread IDs that currently have an active run in this room.
+  late final ReadonlySignal<Set<String>> runningThreadIds =
+      computed<Set<String>>(
+    () => _registry.activeKeys.value
+        .where((k) => k.serverId == _connection.serverId && k.roomId == _roomId)
+        .map((k) => k.threadId)
+        .toSet(),
+  );
+
   /// Tracks the spawn lifecycle: null → spawning → null.
   /// Non-null while a new-thread spawn is in progress.
   ReadonlySignal<AgentSessionState?> get sessionState => _spawner.sessionState;
@@ -213,5 +222,6 @@ class RoomState {
     threadList.dispose();
     _activeThreadView?.dispose();
     _spawner.dispose();
+    runningThreadIds.dispose();
   }
 }

--- a/lib/src/modules/room/run_registry.dart
+++ b/lib/src/modules/room/run_registry.dart
@@ -35,7 +35,11 @@ class CancelledRun extends RunOutcome {
 /// session to reattach to or a completed outcome to display.
 class RunRegistry {
   final Map<ThreadKey, _TrackedRun> _runs = {};
+  final Signal<Set<ThreadKey>> _activeKeys = Signal({});
   bool _isDisposed = false;
+
+  /// Reactive set of keys that currently have an active (non-terminal) session.
+  ReadonlySignal<Set<ThreadKey>> get activeKeys => _activeKeys.readonly();
 
   /// Register a session for the given thread.
   ///
@@ -49,12 +53,14 @@ class RunRegistry {
     }
     final run = _TrackedRun(session: session);
     _runs[key] = run;
+    _activeKeys.value = {..._activeKeys.value, key};
 
     unawaited(session.result.then((result) {
       if (_isDisposed) return;
       final terminalState = session.runState.value;
       run.outcome = _outcomeFrom(terminalState, result);
       run.session = null;
+      _activeKeys.value = _activeKeys.value.difference({key});
     }));
   }
 
@@ -77,6 +83,8 @@ class RunRegistry {
       run.session?.cancel();
     }
     _runs.clear();
+    // Do not update _activeKeys here — downstream computeds may already be
+    // disposed and the update would log spurious "read after disposed" warnings.
   }
 
   static RunOutcome _outcomeFrom(RunState state, AgentResult result) {

--- a/lib/src/modules/room/ui/room_screen.dart
+++ b/lib/src/modules/room/ui/room_screen.dart
@@ -359,6 +359,7 @@ class _RoomScreenState extends State<RoomScreen> {
             onQuizTapped: _onQuizTapped,
             onRenameThread: _showRenameDialog,
             onDeleteThread: _showDeleteDialog,
+            runningThreadIds: _state.runningThreadIds,
           );
           final content = _buildContent(room);
 

--- a/lib/src/modules/room/ui/thread_sidebar.dart
+++ b/lib/src/modules/room/ui/thread_sidebar.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:signals_flutter/signals_flutter.dart';
 
 import '../thread_list_state.dart';
 import 'error_retry_panel.dart';
@@ -20,6 +21,7 @@ class ThreadSidebar extends StatelessWidget {
     this.onQuizTapped,
     this.onRenameThread,
     this.onDeleteThread,
+    this.runningThreadIds,
   });
 
   final ThreadListStatus threadListStatus;
@@ -35,6 +37,7 @@ class ThreadSidebar extends StatelessWidget {
   final void Function(String quizId)? onQuizTapped;
   final void Function(String threadId, String currentName)? onRenameThread;
   final void Function(String threadId)? onDeleteThread;
+  final ReadonlySignal<Set<String>>? runningThreadIds;
 
   @override
   Widget build(BuildContext context) {
@@ -125,9 +128,12 @@ class ThreadSidebar extends StatelessWidget {
                   itemCount: threads.length,
                   itemBuilder: (context, index) {
                     final thread = threads[index];
+                    final running =
+                        runningThreadIds?.watch(context) ?? const <String>{};
                     return ThreadTile(
                       thread: thread,
                       isSelected: thread.id == selectedThreadId,
+                      isRunning: running.contains(thread.id),
                       onTap: () => onThreadSelected(thread.id),
                       onRename: () =>
                           onRenameThread?.call(thread.id, thread.name),

--- a/lib/src/modules/room/ui/thread_tile.dart
+++ b/lib/src/modules/room/ui/thread_tile.dart
@@ -13,6 +13,7 @@ class ThreadTile extends StatefulWidget {
     required this.onTap,
     required this.onRename,
     required this.onDelete,
+    this.isRunning = false,
   });
 
   final ThreadInfo thread;
@@ -20,6 +21,7 @@ class ThreadTile extends StatefulWidget {
   final VoidCallback onTap;
   final VoidCallback onRename;
   final VoidCallback onDelete;
+  final bool isRunning;
 
   @override
   State<ThreadTile> createState() => _ThreadTileState();
@@ -60,7 +62,18 @@ class _ThreadTileState extends State<ThreadTile> {
         ),
         dense: true,
         onTap: widget.onTap,
-        trailing: showMenu ? _buildMenu(theme) : null,
+        trailing: showMenu ? _buildMenu(theme) : _buildTrailing(theme),
+      ),
+    );
+  }
+
+  Widget? _buildTrailing(ThemeData theme) {
+    if (!widget.isRunning) return null;
+    return SizedBox.square(
+      dimension: 18,
+      child: CircularProgressIndicator(
+        strokeWidth: 2,
+        color: theme.colorScheme.primary,
       ),
     );
   }


### PR DESCRIPTION
## Summary

- `RunRegistry` gains `Signal<Set<ThreadKey>> _activeKeys` — updated on session register and on completion; skipped on dispose to avoid downstream computed-read-after-disposed warnings
- `RoomState.runningThreadIds` — `late final computed<Set<String>>` filtered to the current server+room, disposed in `RoomState.dispose()`
- `ThreadSidebar` watches the signal per tile via `signal.watch(context)`
- `ThreadTile` renders an 18×18 `CircularProgressIndicator` in the trailing slot when `isRunning` is true; hidden when the context menu is visible (menu takes priority)
- `RoomScreen` passes `_state.runningThreadIds` to the sidebar

Stacked on M4.

## Test plan

- [ ] Send a message — target thread tile shows spinner while agent runs
- [ ] Navigate to another thread — spinner remains on background thread tile
- [ ] Open context menu on running thread — spinner hides, menu shows
- [ ] Run completes — spinner disappears reactively
- [ ] `flutter test --reporter failures-only` — all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)