### PR TITLE
M9: feat(room): HumanApprovalExtension + ToolApprovalExtension

### DIFF
--- a/lib/src/flavors/standard.dart
+++ b/lib/src/flavors/standard.dart
@@ -23,6 +23,7 @@ import '../modules/quiz/quiz_module.dart';
 import '../modules/room/agent_runtime_manager.dart';
 import '../modules/room/conversation_state_extension.dart';
 import '../modules/room/execution_tracker_extension.dart';
+import '../modules/room/human_approval_extension.dart';
 import '../modules/room/tool_calls_extension.dart';
 import '../modules/room/room_module.dart';
 import '../modules/room/run_registry.dart';
@@ -139,6 +140,7 @@ Future<ShellConfig> standard({
       ExecutionTrackerExtension(),
       ConversationStateExtension(),
       ToolCallsExtension(),
+      HumanApprovalExtension(),
     ],
   );
 

--- a/lib/src/modules/room/human_approval_extension.dart
+++ b/lib/src/modules/room/human_approval_extension.dart
@@ -1,0 +1,98 @@
+import 'dart:async';
+
+import 'package:meta/meta.dart';
+import 'package:soliplex_agent/soliplex_agent.dart';
+
+/// An in-flight tool approval request waiting for a user decision.
+@immutable
+class ApprovalRequest {
+  const ApprovalRequest({
+    required this.toolCallId,
+    required this.toolName,
+    required this.arguments,
+    required this.rationale,
+  });
+
+  final String toolCallId;
+  final String toolName;
+  final Map<String, dynamic> arguments;
+  final String rationale;
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is ApprovalRequest &&
+          toolCallId == other.toolCallId &&
+          toolName == other.toolName &&
+          rationale == other.rationale;
+
+  @override
+  int get hashCode => Object.hash(toolCallId, toolName, rationale);
+}
+
+/// A [ToolApprovalExtension] that surfaces tool approval requests as reactive
+/// state so the UI can respond without an [AgentUiDelegate].
+///
+/// When [AgentSession.requestApproval] fires, [stateSignal] is set to the
+/// pending [ApprovalRequest]. The UI watches the signal, shows an approval
+/// dialog, then calls [respond] with the user's decision. Calling [respond]
+/// clears the signal back to `null` and resolves the session's future.
+///
+/// If the session is cancelled or the extension is disposed while an approval
+/// is pending, the request is automatically denied.
+class HumanApprovalExtension extends ToolApprovalExtension
+    with StatefulSessionExtension<ApprovalRequest?> {
+  HumanApprovalExtension() {
+    setInitialState(null);
+  }
+
+  Completer<bool>? _pending;
+
+  @override
+  String get namespace => 'human_approval';
+
+  @override
+  int get priority => 30;
+
+  @override
+  List<ClientTool> get tools => const [];
+
+  @override
+  Future<void> onAttach(AgentSession session) async {}
+
+  @override
+  void onDispose() {
+    _pending?.complete(false);
+    _pending = null;
+    super.onDispose();
+  }
+
+  @override
+  Future<bool> requestApproval({
+    required String toolCallId,
+    required String toolName,
+    required Map<String, dynamic> arguments,
+    required String rationale,
+  }) {
+    // Deny any stale pending request before starting a new one.
+    _pending?.complete(false);
+    final completer = Completer<bool>();
+    _pending = completer;
+    state = ApprovalRequest(
+      toolCallId: toolCallId,
+      toolName: toolName,
+      arguments: arguments,
+      rationale: rationale,
+    );
+    return completer.future;
+  }
+
+  /// Resolves the pending approval request with [approved].
+  ///
+  /// No-op if there is no pending request.
+  void respond(bool approved) {
+    _pending?.complete(approved);
+    _pending = null;
+    state = null;
+  }
+}

--- a/lib/src/modules/room/human_approval_extension.dart
+++ b/lib/src/modules/room/human_approval_extension.dart
@@ -1,6 +1,6 @@
 import 'dart:async';
 
-import 'package:meta/meta.dart';
+import 'package:flutter/foundation.dart' show immutable;
 import 'package:soliplex_agent/soliplex_agent.dart';
 
 /// An in-flight tool approval request waiting for a user decision.

--- a/lib/src/modules/room/thread_view_state.dart
+++ b/lib/src/modules/room/thread_view_state.dart
@@ -7,6 +7,7 @@ import 'conversation_state_extension.dart';
 import 'execution_tracker.dart';
 import 'execution_tracker_extension.dart';
 import 'historical_replay.dart';
+import 'human_approval_extension.dart';
 import 'tool_calls_extension.dart';
 import 'run_registry.dart';
 import 'send_error.dart';
@@ -125,6 +126,16 @@ class ThreadViewState {
   /// is attached.
   ReadonlySignal<List<ToolCallEntry>>? get toolCalls =>
       _activeSession?.getExtension<ToolCallsExtension>()?.stateSignal;
+
+  /// Pending approval request from the active session, or null if no session
+  /// is attached or no approval is pending.
+  ReadonlySignal<ApprovalRequest?>? get pendingApproval =>
+      _activeSession?.getExtension<HumanApprovalExtension>()?.stateSignal;
+
+  /// The [HumanApprovalExtension] attached to the active session, or null.
+  /// Use [respond] to resolve a pending request shown via [pendingApproval].
+  HumanApprovalExtension? get approvalExtension =>
+      _activeSession?.getExtension<HumanApprovalExtension>();
 
   void submitFeedback(String runId, FeedbackType feedback, String? reason) {
     unawaited(

--- a/lib/src/modules/room/tool_calls_extension.dart
+++ b/lib/src/modules/room/tool_calls_extension.dart
@@ -1,6 +1,5 @@
-import 'package:meta/meta.dart';
+import 'package:flutter/foundation.dart' show immutable;
 import 'package:soliplex_agent/soliplex_agent.dart';
-import 'package:soliplex_client/soliplex_client.dart' show ToolCallStatus;
 
 /// A tool call's current status during a session.
 @immutable

--- a/lib/src/modules/room/ui/room_screen.dart
+++ b/lib/src/modules/room/ui/room_screen.dart
@@ -31,6 +31,7 @@ import 'room_welcome.dart';
 import 'thread_sidebar.dart';
 import 'state_panel.dart';
 import 'upload_event_banner.dart';
+import '../human_approval_extension.dart';
 import '../upload_tracker.dart';
 import '../upload_tracker_registry.dart';
 
@@ -835,103 +836,109 @@ class _RoomScreenState extends State<RoomScreen> {
 
     _restoreUnsentText(sendError?.unsentText);
 
-    return Column(
+    return Stack(
       children: [
-        Expanded(
-          child: switch (status) {
-            MessagesLoading() => const Center(
-                child: CircularProgressIndicator(),
-              ),
-            MessagesFailed(:final error) => ErrorRetryPanel(
-                title: 'Failed to load messages',
-                error: error,
-                onRetry: threadView.refresh,
-              ),
-            MessagesLoaded(:final messages, :final messageStates) =>
-              computeDisplayMessages(messages, streaming).isEmpty
-                  ? RoomWelcome(
-                      room: room,
-                      onSuggestionTapped: (suggestion) =>
-                          threadView.sendMessage(
-                        suggestion,
-                        _state.runtime,
-                        stateOverlay: _buildStateOverlay(),
-                      ),
-                      onQuizTapped: _onQuizTapped,
-                      fallback: _threadEmptyFallback(context),
-                    )
-                  : MessageTimeline(
-                      key: ValueKey(threadView.threadId),
-                      messages: messages,
-                      messageStates: messageStates,
-                      streamingState: streaming,
-                      executionTrackers: threadView.executionTrackers,
-                      onFeedbackSubmit: threadView.submitFeedback,
-                      onInspect: (runId) {
-                        final inspector = ProviderScope.containerOf(context)
-                            .read(networkInspectorProvider);
-                        final filtered = filterEventsByRunId(
-                          inspector.events,
-                          runId,
-                        );
-                        final groups = groupHttpEvents(filtered);
-                        Navigator.of(context).push(
-                          MaterialPageRoute<void>(
-                            builder: (_) => RunHttpDetailPage(groups: groups),
+        _ApprovalHandler(threadView: threadView),
+        Column(
+          children: [
+            Expanded(
+              child: switch (status) {
+                MessagesLoading() => const Center(
+                    child: CircularProgressIndicator(),
+                  ),
+                MessagesFailed(:final error) => ErrorRetryPanel(
+                    title: 'Failed to load messages',
+                    error: error,
+                    onRetry: threadView.refresh,
+                  ),
+                MessagesLoaded(:final messages, :final messageStates) =>
+                  computeDisplayMessages(messages, streaming).isEmpty
+                      ? RoomWelcome(
+                          room: room,
+                          onSuggestionTapped: (suggestion) =>
+                              threadView.sendMessage(
+                            suggestion,
+                            _state.runtime,
+                            stateOverlay: _buildStateOverlay(),
                           ),
-                        );
-                      },
-                      onShowChunkVisualization: (ref) =>
-                          ChunkVisualizationPage.show(
-                        context: context,
-                        api: widget.serverEntry.connection.api,
-                        roomId: widget.roomId,
-                        chunkId: ref.chunkId,
-                        documentTitle: ref.displayTitle,
-                        pageNumbers: ref.pageNumbers,
-                      ),
-                    ),
-          },
-        ),
-        if (sendError != null)
-          _SendErrorBanner(
-            error: sendError,
-            onDismiss: () => threadView.clearSendError(),
-          ),
-        if (attachEnabled)
-          UploadEventBanner(
-            tracker: _state.uploadTracker,
-            roomId: widget.roomId,
-            threadId: threadView.threadId,
-          ),
-        if (threadView.conversationState case final stateSignal?)
-          StatePanel(
-            stateSignal: stateSignal,
-            isExpanded: _statePanelExpanded,
-            onToggle: () =>
-                setState(() => _statePanelExpanded = !_statePanelExpanded),
-          ),
-        ChatInput(
-          onSend: (text) => threadView.sendMessage(
-            text,
-            _state.runtime,
-            stateOverlay: _buildStateOverlay(),
-          ),
-          onCancel: threadView.cancelRun,
-          sessionState: threadView.sessionState,
-          controller: _chatController,
-          focusNode: _chatFocusNode,
-          enabled: status is MessagesLoaded,
-          selectedDocuments: _selectedDocuments,
-          onFilterTap: _filterEnabled ? _openDocumentPicker : null,
-          onDocumentRemoved: _filterEnabled
-              ? (doc) => _updateSelection(
-                    Set.of(_selectedDocuments)..remove(doc),
-                  )
-              : null,
-          onAttachFile: attachEnabled
-              ? () => _pickAndUploadToThread(threadView.threadId)
-              : null,
+                          onQuizTapped: _onQuizTapped,
+                          fallback: _threadEmptyFallback(context),
+                        )
+                      : MessageTimeline(
+                          key: ValueKey(threadView.threadId),
+                          messages: messages,
+                          messageStates: messageStates,
+                          streamingState: streaming,
+                          executionTrackers: threadView.executionTrackers,
+                          onFeedbackSubmit: threadView.submitFeedback,
+                          onInspect: (runId) {
+                            final inspector = ProviderScope.containerOf(context)
+                                .read(networkInspectorProvider);
+                            final filtered = filterEventsByRunId(
+                              inspector.events,
+                              runId,
+                            );
+                            final groups = groupHttpEvents(filtered);
+                            Navigator.of(context).push(
+                              MaterialPageRoute<void>(
+                                builder: (_) =>
+                                    RunHttpDetailPage(groups: groups),
+                              ),
+                            );
+                          },
+                          onShowChunkVisualization: (ref) =>
+                              ChunkVisualizationPage.show(
+                            context: context,
+                            api: widget.serverEntry.connection.api,
+                            roomId: widget.roomId,
+                            chunkId: ref.chunkId,
+                            documentTitle: ref.displayTitle,
+                            pageNumbers: ref.pageNumbers,
+                          ),
+                        ),
+              },
+            ),
+            if (sendError != null)
+              _SendErrorBanner(
+                error: sendError,
+                onDismiss: () => threadView.clearSendError(),
+              ),
+            if (attachEnabled)
+              UploadEventBanner(
+                tracker: _state.uploadTracker,
+                roomId: widget.roomId,
+                threadId: threadView.threadId,
+              ),
+            if (threadView.conversationState case final stateSignal?)
+              StatePanel(
+                stateSignal: stateSignal,
+                isExpanded: _statePanelExpanded,
+                onToggle: () =>
+                    setState(() => _statePanelExpanded = !_statePanelExpanded),
+              ),
+            ChatInput(
+              onSend: (text) => threadView.sendMessage(
+                text,
+                _state.runtime,
+                stateOverlay: _buildStateOverlay(),
+              ),
+              onCancel: threadView.cancelRun,
+              sessionState: threadView.sessionState,
+              controller: _chatController,
+              focusNode: _chatFocusNode,
+              enabled: status is MessagesLoaded,
+              selectedDocuments: _selectedDocuments,
+              onFilterTap: _filterEnabled ? _openDocumentPicker : null,
+              onDocumentRemoved: _filterEnabled
+                  ? (doc) => _updateSelection(
+                        Set.of(_selectedDocuments)..remove(doc),
+                      )
+                  : null,
+              onAttachFile: attachEnabled
+                  ? () => _pickAndUploadToThread(threadView.threadId)
+                  : null,
+            ),
+          ],
         ),
       ],
     );
@@ -994,6 +1001,119 @@ class _SendErrorBanner extends StatelessWidget {
           ),
         ],
       ),
+    );
+  }
+}
+
+/// Zero-size widget that subscribes to [ThreadViewState.pendingApproval] and
+/// shows an approval dialog when a tool requests user consent.
+///
+/// Placed inside a [Stack] so it has no effect on layout.
+class _ApprovalHandler extends StatefulWidget {
+  const _ApprovalHandler({required this.threadView});
+  final ThreadViewState threadView;
+
+  @override
+  State<_ApprovalHandler> createState() => _ApprovalHandlerState();
+}
+
+class _ApprovalHandlerState extends State<_ApprovalHandler> {
+  void Function()? _unsub;
+  String? _activeToolCallId;
+
+  @override
+  void initState() {
+    super.initState();
+    _subscribe(widget.threadView);
+  }
+
+  @override
+  void didUpdateWidget(_ApprovalHandler oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (oldWidget.threadView != widget.threadView) {
+      _unsub?.call();
+      _activeToolCallId = null;
+      _subscribe(widget.threadView);
+    }
+  }
+
+  void _subscribe(ThreadViewState view) {
+    final signal = view.pendingApproval;
+    if (signal == null) return;
+    _unsub = signal.subscribe((request) {
+      if (request == null || request.toolCallId == _activeToolCallId) return;
+      _activeToolCallId = request.toolCallId;
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        if (!mounted) return;
+        _showDialog(request, view);
+      });
+    });
+  }
+
+  Future<void> _showDialog(
+    ApprovalRequest request,
+    ThreadViewState view,
+  ) async {
+    final ext = view.approvalExtension;
+    if (ext == null || !mounted) return;
+
+    final approved = await showDialog<bool>(
+      context: context,
+      barrierDismissible: false,
+      builder: (_) => _ApprovalDialog(request: request),
+    );
+    ext.respond(approved ?? false);
+    _activeToolCallId = null;
+  }
+
+  @override
+  void dispose() {
+    _unsub?.call();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) => const SizedBox.shrink();
+}
+
+class _ApprovalDialog extends StatelessWidget {
+  const _ApprovalDialog({required this.request});
+  final ApprovalRequest request;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return AlertDialog(
+      title: Row(
+        children: [
+          Icon(Icons.security, color: theme.colorScheme.primary, size: 20),
+          const SizedBox(width: 8),
+          const Text('Tool Approval Required'),
+        ],
+      ),
+      content: Column(
+        mainAxisSize: MainAxisSize.min,
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            request.toolName,
+            style: theme.textTheme.titleSmall
+                ?.copyWith(fontWeight: FontWeight.bold),
+          ),
+          const SizedBox(height: 8),
+          Text(request.rationale, style: theme.textTheme.bodyMedium),
+        ],
+      ),
+      actions: [
+        TextButton(
+          onPressed: () => Navigator.of(context).pop(false),
+          child: const Text('Deny'),
+        ),
+        FilledButton(
+          onPressed: () => Navigator.of(context).pop(true),
+          child: const Text('Allow'),
+        ),
+      ],
     );
   }
 }

--- a/packages/soliplex_agent/lib/soliplex_agent.dart
+++ b/packages/soliplex_agent/lib/soliplex_agent.dart
@@ -65,6 +65,7 @@ export 'src/runtime/server_registry.dart';
 export 'src/runtime/session_coordinator.dart';
 export 'src/runtime/session_extension.dart';
 export 'src/runtime/stateful_session_extension.dart';
+export 'src/runtime/tool_approval_extension.dart';
 // ── Scripting ──
 export 'src/scripting/script_environment.dart';
 // ── Tools ──

--- a/packages/soliplex_agent/lib/src/runtime/agent_session.dart
+++ b/packages/soliplex_agent/lib/src/runtime/agent_session.dart
@@ -13,6 +13,7 @@ import 'package:soliplex_agent/src/runtime/agent_session_state.dart';
 import 'package:soliplex_agent/src/runtime/agent_ui_delegate.dart';
 import 'package:soliplex_agent/src/runtime/session_coordinator.dart';
 import 'package:soliplex_agent/src/runtime/session_extension.dart';
+import 'package:soliplex_agent/src/runtime/tool_approval_extension.dart';
 import 'package:soliplex_agent/src/tools/tool_execution_context.dart';
 import 'package:soliplex_agent/src/tools/tool_registry.dart';
 import 'package:soliplex_client/soliplex_client.dart';
@@ -172,7 +173,6 @@ class AgentSession implements ToolExecutionContext {
     required Map<String, dynamic> arguments,
     required String rationale,
   }) async {
-    if (_uiDelegate == null) return false;
     emitEvent(
       AwaitingApproval(
         toolCallId: toolCallId,
@@ -180,6 +180,21 @@ class AgentSession implements ToolExecutionContext {
         rationale: rationale,
       ),
     );
+
+    final approvalExt = _coordinator.getExtension<ToolApprovalExtension>();
+    if (approvalExt != null) {
+      return Future.any([
+        approvalExt.requestApproval(
+          toolCallId: toolCallId,
+          toolName: toolName,
+          arguments: arguments,
+          rationale: rationale,
+        ),
+        cancelToken.whenCancelled.then((_) => false),
+      ]);
+    }
+
+    if (_uiDelegate == null) return false;
     return Future.any([
       _uiDelegate.requestToolApproval(
         session: this,

--- a/packages/soliplex_agent/lib/src/runtime/tool_approval_extension.dart
+++ b/packages/soliplex_agent/lib/src/runtime/tool_approval_extension.dart
@@ -3,11 +3,11 @@ import 'package:soliplex_agent/src/runtime/session_extension.dart';
 /// An extension that can respond to tool approval requests.
 ///
 /// Subclass this in the application layer (e.g. `HumanApprovalExtension`) to
-/// intercept calls to [AgentSession.requestApproval] and surface them as
+/// intercept calls to `AgentSession.requestApproval` and surface them as
 /// reactive state that the UI can observe and respond to.
 ///
 /// When an instance of this extension is registered with a session,
-/// [AgentSession.requestApproval] delegates to [requestApproval] instead of
+/// `AgentSession.requestApproval` delegates to [requestApproval] instead of
 /// falling back to `AgentUiDelegate`. Only one `ToolApprovalExtension` may be
 /// registered per session (enforced by the namespace uniqueness check in
 /// `SessionCoordinator`).
@@ -15,7 +15,7 @@ abstract class ToolApprovalExtension extends SessionExtension {
   /// Requests user consent for the given tool call.
   ///
   /// Returns `true` to proceed with execution, `false` to deny.
-  /// The [AgentSession] races this future against its [CancelToken] —
+  /// The session races this future against its cancel token —
   /// cancellation automatically produces `false`.
   Future<bool> requestApproval({
     required String toolCallId,

--- a/packages/soliplex_agent/lib/src/runtime/tool_approval_extension.dart
+++ b/packages/soliplex_agent/lib/src/runtime/tool_approval_extension.dart
@@ -1,0 +1,26 @@
+import 'package:soliplex_agent/src/runtime/session_extension.dart';
+
+/// An extension that can respond to tool approval requests.
+///
+/// Subclass this in the application layer (e.g. `HumanApprovalExtension`) to
+/// intercept calls to [AgentSession.requestApproval] and surface them as
+/// reactive state that the UI can observe and respond to.
+///
+/// When an instance of this extension is registered with a session,
+/// [AgentSession.requestApproval] delegates to [requestApproval] instead of
+/// falling back to `AgentUiDelegate`. Only one `ToolApprovalExtension` may be
+/// registered per session (enforced by the namespace uniqueness check in
+/// `SessionCoordinator`).
+abstract class ToolApprovalExtension extends SessionExtension {
+  /// Requests user consent for the given tool call.
+  ///
+  /// Returns `true` to proceed with execution, `false` to deny.
+  /// The [AgentSession] races this future against its [CancelToken] —
+  /// cancellation automatically produces `false`.
+  Future<bool> requestApproval({
+    required String toolCallId,
+    required String toolName,
+    required Map<String, dynamic> arguments,
+    required String rationale,
+  });
+}

--- a/packages/soliplex_agent/test/helpers/fake_tool_execution_context.dart
+++ b/packages/soliplex_agent/test/helpers/fake_tool_execution_context.dart
@@ -1,5 +1,4 @@
 import 'package:soliplex_agent/soliplex_agent.dart';
-import 'package:soliplex_agent/src/tools/tool_execution_context.dart';
 
 /// Test double for [ToolExecutionContext].
 ///

--- a/packages/soliplex_agent/test/tools/tool_registry_test.dart
+++ b/packages/soliplex_agent/test/tools/tool_registry_test.dart
@@ -1,5 +1,4 @@
 import 'package:soliplex_agent/soliplex_agent.dart';
-import 'package:soliplex_agent/src/tools/tool_execution_context.dart';
 import 'package:test/test.dart';
 
 import '../helpers/fake_tool_execution_context.dart';


### PR DESCRIPTION
## Summary

- Adds `ToolApprovalExtension` abstract class in `soliplex_agent` — allows the `SessionCoordinator` to route `requestApproval` calls to a registered extension before falling back to `AgentUiDelegate`
- Implements `HumanApprovalExtension` in the app layer: a `StatefulSessionExtension<ApprovalRequest?>` that parks the approval future on a `Completer` and exposes the pending request as reactive state
- UI: `_ApprovalHandler` widget subscribes to `ThreadViewState.pendingApproval` and shows `_ApprovalDialog` when a request is pending; approve/deny calls `approvalExtension.respond(bool)`
- Stacks on M8

## Test plan

- [ ] `flutter analyze` zero warnings
- [ ] `flutter test` all unit tests pass
- [ ] `dart format` no changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)