### PR TITLE
feat(room): persist per-message expansion state across rebuilds

### DIFF
--- a/lib/src/modules/room/compute_display_messages.dart
+++ b/lib/src/modules/room/compute_display_messages.dart
@@ -1,5 +1,11 @@
 import 'package:soliplex_agent/soliplex_agent.dart';
 
+/// Sentinel id for the placeholder [LoadingMessage] appended during
+/// [AwaitingText]. It is reused across runs, so it must never be used
+/// as a persistence key — state written under it would leak into the
+/// next response.
+const loadingMessageId = '_loading';
+
 /// Merges streaming state into the message list for unified rendering.
 ///
 /// During [TextStreaming], the historical message with the same ID (if
@@ -12,7 +18,10 @@ List<ChatMessage> computeDisplayMessages(
 ) {
   if (streaming == null) return messages;
   return switch (streaming) {
-    AwaitingText() => [...messages, LoadingMessage.create(id: '_loading')],
+    AwaitingText() => [
+        ...messages,
+        LoadingMessage.create(id: loadingMessageId)
+      ],
     TextStreaming(
       :final messageId,
       :final user,

--- a/lib/src/modules/room/message_expansions.dart
+++ b/lib/src/modules/room/message_expansions.dart
@@ -1,0 +1,72 @@
+import 'compute_display_messages.dart' show loadingMessageId;
+
+/// Per-message UI expansion state for assistant responses — whether each
+/// message's execution timeline, thinking block, and activity source rows
+/// are open. Owned by `roomModule()`; outlives widget rebuilds, thread
+/// switches, and room navigations within the room module.
+///
+/// Identity is `(roomId, messageId)`. [loadingMessageId] is rejected,
+/// because it is reused across runs and state written under it would
+/// leak into the next response.
+///
+/// All access goes through a [MessageExpansion] handle obtained via
+/// [forMessage]; the internal storage is private.
+class MessageExpansions {
+  final Map<(String, String), _Expansion> _state = {};
+
+  /// Returns a handle bound to one message so callers pass `(roomId,
+  /// messageId)` exactly once. Both are same-typed strings, so passing
+  /// them in the wrong order at every access site is easy to get wrong.
+  MessageExpansion forMessage(String roomId, String messageId) {
+    assert(
+      messageId != loadingMessageId,
+      'MessageExpansions must not be keyed by loadingMessageId',
+    );
+    return MessageExpansion._(this, (roomId, messageId));
+  }
+
+  /// Test-only probe: returns whether any state has been written under
+  /// the given key. Intended for verifying that [loadingMessageId] (which
+  /// [forMessage] rejects) has not leaked in via some other path.
+  bool hasStateFor(String roomId, String messageId) =>
+      _state.containsKey((roomId, messageId));
+}
+
+class _Expansion {
+  bool timeline = false;
+  bool thinking = false;
+  final Set<String> sources = {};
+}
+
+/// A view of [MessageExpansions] bound to a single `(roomId, messageId)`.
+/// Obtain via [MessageExpansions.forMessage].
+class MessageExpansion {
+  MessageExpansion._(this._owner, this._key);
+
+  final MessageExpansions _owner;
+  final (String, String) _key;
+
+  _Expansion? get _entry => _owner._state[_key];
+  _Expansion _ensureEntry() =>
+      _owner._state.putIfAbsent(_key, () => _Expansion());
+
+  bool get timelineExpanded => _entry?.timeline ?? false;
+  set timelineExpanded(bool value) => _ensureEntry().timeline = value;
+
+  bool get thinkingExpanded => _entry?.thinking ?? false;
+  set thinkingExpanded(bool value) => _ensureEntry().thinking = value;
+
+  bool isSourceExpanded(String activityId) =>
+      _entry?.sources.contains(activityId) ?? false;
+
+  void setSourceExpanded(String activityId, bool value) {
+    if (value) {
+      _ensureEntry().sources.add(activityId);
+      return;
+    }
+    _entry?.sources.remove(activityId);
+  }
+
+  void toggleSource(String activityId) =>
+      setSourceExpanded(activityId, !isSourceExpanded(activityId));
+}

--- a/lib/src/modules/room/message_expansions.dart
+++ b/lib/src/modules/room/message_expansions.dart
@@ -9,9 +9,17 @@ import 'compute_display_messages.dart' show loadingMessageId;
 /// because it is reused across runs and state written under it would
 /// leak into the next response.
 ///
+/// Retention is capped at [maxEntries]; once reached, the oldest-inserted
+/// entry is evicted when a new one is created.
+///
 /// All access goes through a [MessageExpansion] handle obtained via
 /// [forMessage]; the internal storage is private.
 class MessageExpansions {
+  /// Upper bound on entries retained. Eviction is FIFO (oldest-inserted).
+  /// Chosen to comfortably exceed realistic session sizes (~50 typical,
+  /// ~100-200 heavy use) so the cap almost never trips in practice.
+  static const int maxEntries = 200;
+
   final Map<(String, String), _Expansion> _state = {};
 
   /// Returns a handle bound to one message so callers pass `(roomId,
@@ -25,10 +33,10 @@ class MessageExpansions {
     return MessageExpansion._(this, (roomId, messageId));
   }
 
-  /// Test-only probe: returns whether any state has been written under
-  /// the given key. Intended for verifying that [loadingMessageId] (which
-  /// [forMessage] rejects) has not leaked in via some other path.
-  bool hasStateFor(String roomId, String messageId) =>
+  /// Debug/test probe: returns whether any state has been written under
+  /// `(roomId, messageId)`. Exposed by convention for tests — not enforced;
+  /// production code has no reason to introspect the store directly.
+  bool debugHasStateFor(String roomId, String messageId) =>
       _state.containsKey((roomId, messageId));
 }
 
@@ -47,8 +55,15 @@ class MessageExpansion {
   final (String, String) _key;
 
   _Expansion? get _entry => _owner._state[_key];
-  _Expansion _ensureEntry() =>
-      _owner._state.putIfAbsent(_key, () => _Expansion());
+  _Expansion _ensureEntry() {
+    final map = _owner._state;
+    final existing = map[_key];
+    if (existing != null) return existing;
+    if (map.length >= MessageExpansions.maxEntries) {
+      map.remove(map.keys.first);
+    }
+    return map[_key] = _Expansion();
+  }
 
   bool get timelineExpanded => _entry?.timeline ?? false;
   set timelineExpanded(bool value) => _ensureEntry().timeline = value;

--- a/lib/src/modules/room/room_module.dart
+++ b/lib/src/modules/room/room_module.dart
@@ -5,6 +5,8 @@ import '../auth/require_connected_server.dart';
 import '../auth/server_manager.dart';
 import 'agent_runtime_manager.dart';
 import 'document_selections.dart';
+import 'message_expansions.dart';
+import 'room_providers.dart';
 import 'run_registry.dart';
 import 'ui/room_info_screen.dart';
 import 'ui/room_screen.dart';
@@ -18,7 +20,11 @@ ModuleContribution roomModule({
 }) {
   final documentSelections = DocumentSelections();
   final uploadRegistry = UploadTrackerRegistry(servers: serverManager.servers);
+  final messageExpansions = MessageExpansions();
   return ModuleContribution(
+    overrides: [
+      messageExpansionsProvider.overrideWithValue(messageExpansions),
+    ],
     routes: [
       GoRoute(
         path: '/room/:serverAlias/:roomId/info',

--- a/lib/src/modules/room/room_providers.dart
+++ b/lib/src/modules/room/room_providers.dart
@@ -1,0 +1,13 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import 'message_expansions.dart';
+
+final messageExpansionsProvider = Provider<MessageExpansions>(
+  name: 'messageExpansionsProvider',
+  (_) => throw StateError(
+    'messageExpansionsProvider was read without an override. '
+    'In production this is wired by roomModule(); in tests, wrap the '
+    'widget in `ProviderScope(overrides: [messageExpansionsProvider'
+    '.overrideWithValue(MessageExpansions())])`.',
+  ),
+);

--- a/lib/src/modules/room/ui/execution/execution_timeline.dart
+++ b/lib/src/modules/room/ui/execution/execution_timeline.dart
@@ -1,11 +1,15 @@
 import 'dart:convert';
 
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:signals_flutter/signals_flutter.dart';
 import 'package:soliplex_agent/soliplex_agent.dart' hide State;
 
+import '../../compute_display_messages.dart' show loadingMessageId;
 import '../../execution_step.dart';
 import '../../execution_tracker.dart';
+import '../../message_expansions.dart';
+import '../../room_providers.dart';
 import '../copy_button.dart';
 import 'timeline_entry.dart';
 
@@ -13,17 +17,75 @@ import 'timeline_entry.dart';
 /// under their owning step. Activity rows with source (script/code/query
 /// args, or any args map) can expand to a monospace preview with a copy
 /// button.
-class ExecutionTimeline extends StatefulWidget {
-  const ExecutionTimeline({super.key, required this.tracker});
+class ExecutionTimeline extends ConsumerStatefulWidget {
+  const ExecutionTimeline({
+    super.key,
+    required this.roomId,
+    required this.messageId,
+    required this.tracker,
+  });
+
+  final String roomId;
+  final String messageId;
   final ExecutionTracker tracker;
 
   @override
-  State<ExecutionTimeline> createState() => _ExecutionTimelineState();
+  ConsumerState<ExecutionTimeline> createState() => _ExecutionTimelineState();
 }
 
-class _ExecutionTimelineState extends State<ExecutionTimeline> {
-  bool _expanded = false;
-  final Set<String> _expandedSources = <String>{};
+class _ExecutionTimelineState extends ConsumerState<ExecutionTimeline> {
+  // Sentinel-only fallbacks used while [_expansion] is null (the
+  // AwaitingText phase). Once a real messageId exists, state lives in
+  // the store and these are never read or written again.
+  bool _loadingPhaseTimeline = false;
+  final Set<String> _loadingPhaseSources = <String>{};
+
+  // Persistence handle — null during the AwaitingText phase, because
+  // loadingMessageId is reused across runs and persisting under it would
+  // leak state into the next response. Captured once in initState; the
+  // AwaitingText → TextStreaming transition remounts this widget under
+  // a real messageId (see MessageTimeline's per-id ValueKey), at which
+  // point [_expansion] becomes non-null for the rest of its life.
+  MessageExpansion? _expansion;
+
+  @override
+  void initState() {
+    super.initState();
+    if (widget.messageId == loadingMessageId) return;
+    _expansion = ref
+        .read(messageExpansionsProvider)
+        .forMessage(widget.roomId, widget.messageId);
+  }
+
+  bool get _expanded => _expansion?.timelineExpanded ?? _loadingPhaseTimeline;
+
+  void _toggleExpanded() {
+    setState(() {
+      final next = !_expanded;
+      if (_expansion != null) {
+        _expansion!.timelineExpanded = next;
+      } else {
+        _loadingPhaseTimeline = next;
+      }
+    });
+  }
+
+  void _toggleSource(String activityId) {
+    setState(() {
+      final expansion = _expansion;
+      if (expansion != null) {
+        expansion.toggleSource(activityId);
+        return;
+      }
+      if (!_loadingPhaseSources.remove(activityId)) {
+        _loadingPhaseSources.add(activityId);
+      }
+    });
+  }
+
+  bool _isSourceExpanded(String activityId) =>
+      _expansion?.isSourceExpanded(activityId) ??
+      _loadingPhaseSources.contains(activityId);
 
   @override
   Widget build(BuildContext context) {
@@ -48,7 +110,7 @@ class _ExecutionTimelineState extends State<ExecutionTimeline> {
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
             GestureDetector(
-              onTap: () => setState(() => _expanded = !_expanded),
+              onTap: _toggleExpanded,
               behavior: HitTestBehavior.opaque,
               child: Row(
                 children: [
@@ -127,7 +189,7 @@ class _ExecutionTimelineState extends State<ExecutionTimeline> {
   }) {
     final source = _pickSource(activity);
     final hasSource = source != null;
-    final isExpanded = _expandedSources.contains(activity.messageId);
+    final isExpanded = _isSourceExpanded(activity.messageId);
 
     return Padding(
       padding: EdgeInsets.only(left: indent, top: 2, bottom: 2),
@@ -135,15 +197,7 @@ class _ExecutionTimelineState extends State<ExecutionTimeline> {
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
           GestureDetector(
-            onTap: hasSource
-                ? () => setState(() {
-                      if (isExpanded) {
-                        _expandedSources.remove(activity.messageId);
-                      } else {
-                        _expandedSources.add(activity.messageId);
-                      }
-                    })
-                : null,
+            onTap: hasSource ? () => _toggleSource(activity.messageId) : null,
             behavior: HitTestBehavior.opaque,
             child: Row(
               children: [

--- a/lib/src/modules/room/ui/execution/execution_timeline.dart
+++ b/lib/src/modules/room/ui/execution/execution_timeline.dart
@@ -34,9 +34,10 @@ class ExecutionTimeline extends ConsumerStatefulWidget {
 }
 
 class _ExecutionTimelineState extends ConsumerState<ExecutionTimeline> {
-  // Sentinel-only fallbacks used while [_expansion] is null (the
-  // AwaitingText phase). Once a real messageId exists, state lives in
-  // the store and these are never read or written again.
+  // Expansion state while messageId == loadingMessageId. Kept local
+  // (not in the store) because the sentinel is reused across runs —
+  // persisting under it would leak open/closed state into the next
+  // response.
   bool _loadingPhaseTimeline = false;
   final Set<String> _loadingPhaseSources = <String>{};
 

--- a/lib/src/modules/room/ui/execution/thinking_block.dart
+++ b/lib/src/modules/room/ui/execution/thinking_block.dart
@@ -27,9 +27,10 @@ class ExecutionThinkingBlock extends ConsumerStatefulWidget {
 
 class _ExecutionThinkingBlockState
     extends ConsumerState<ExecutionThinkingBlock> {
-  // Sentinel-only fallback used while [_expansion] is null (the
-  // AwaitingText phase). Once a real messageId exists, state lives in
-  // the store and this is never read or written again.
+  // Thinking-block expansion while messageId == loadingMessageId. Kept
+  // local (not in the store) because the sentinel is reused across runs —
+  // persisting under it would leak open/closed state into the next
+  // response.
   bool _loadingPhaseThinking = false;
 
   // Null during the AwaitingText sentinel phase, because loadingMessageId

--- a/lib/src/modules/room/ui/execution/thinking_block.dart
+++ b/lib/src/modules/room/ui/execution/thinking_block.dart
@@ -1,19 +1,66 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:signals_flutter/signals_flutter.dart';
 
+import '../../compute_display_messages.dart' show loadingMessageId;
 import '../../execution_tracker.dart';
+import '../../message_expansions.dart' show MessageExpansion;
+import '../../room_providers.dart';
 import '../copy_button.dart';
 
-class ExecutionThinkingBlock extends StatefulWidget {
-  const ExecutionThinkingBlock({super.key, required this.tracker});
+class ExecutionThinkingBlock extends ConsumerStatefulWidget {
+  const ExecutionThinkingBlock({
+    super.key,
+    required this.roomId,
+    required this.messageId,
+    required this.tracker,
+  });
+
+  final String roomId;
+  final String messageId;
   final ExecutionTracker tracker;
 
   @override
-  State<ExecutionThinkingBlock> createState() => _ExecutionThinkingBlockState();
+  ConsumerState<ExecutionThinkingBlock> createState() =>
+      _ExecutionThinkingBlockState();
 }
 
-class _ExecutionThinkingBlockState extends State<ExecutionThinkingBlock> {
-  bool _expanded = false;
+class _ExecutionThinkingBlockState
+    extends ConsumerState<ExecutionThinkingBlock> {
+  // Sentinel-only fallback used while [_expansion] is null (the
+  // AwaitingText phase). Once a real messageId exists, state lives in
+  // the store and this is never read or written again.
+  bool _loadingPhaseThinking = false;
+
+  // Null during the AwaitingText sentinel phase, because loadingMessageId
+  // is reused across runs and persisting under it would leak state into
+  // the next response. Captured once in initState; the AwaitingText →
+  // TextStreaming transition remounts this widget under a real messageId
+  // (see MessageTimeline's per-id ValueKey), at which point [_expansion]
+  // becomes non-null for the rest of its life.
+  MessageExpansion? _expansion;
+
+  @override
+  void initState() {
+    super.initState();
+    if (widget.messageId == loadingMessageId) return;
+    _expansion = ref
+        .read(messageExpansionsProvider)
+        .forMessage(widget.roomId, widget.messageId);
+  }
+
+  bool get _expanded => _expansion?.thinkingExpanded ?? _loadingPhaseThinking;
+
+  void _toggle() {
+    setState(() {
+      final next = !_expanded;
+      if (_expansion != null) {
+        _expansion!.thinkingExpanded = next;
+      } else {
+        _loadingPhaseThinking = next;
+      }
+    });
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -25,7 +72,7 @@ class _ExecutionThinkingBlockState extends State<ExecutionThinkingBlock> {
     return Padding(
       padding: const EdgeInsets.only(bottom: 8),
       child: GestureDetector(
-        onTap: () => setState(() => _expanded = !_expanded),
+        onTap: _toggle,
         child: Container(
           padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
           decoration: BoxDecoration(

--- a/lib/src/modules/room/ui/loading_message_tile.dart
+++ b/lib/src/modules/room/ui/loading_message_tile.dart
@@ -9,10 +9,14 @@ import 'execution/thinking_block.dart';
 class LoadingMessageTile extends StatelessWidget {
   const LoadingMessageTile({
     super.key,
+    required this.roomId,
+    required this.messageId,
     this.executionTracker,
     this.streamingActivity,
   });
 
+  final String roomId;
+  final String messageId;
   final ExecutionTracker? executionTracker;
   final ActivityType? streamingActivity;
 
@@ -24,8 +28,16 @@ class LoadingMessageTile extends StatelessWidget {
         children: [
           if (streamingActivity != null)
             ActivityIndicator(activity: streamingActivity!),
-          ExecutionTimeline(tracker: executionTracker!),
-          ExecutionThinkingBlock(tracker: executionTracker!),
+          ExecutionTimeline(
+            roomId: roomId,
+            messageId: messageId,
+            tracker: executionTracker!,
+          ),
+          ExecutionThinkingBlock(
+            roomId: roomId,
+            messageId: messageId,
+            tracker: executionTracker!,
+          ),
         ],
       );
     }

--- a/lib/src/modules/room/ui/message_tile.dart
+++ b/lib/src/modules/room/ui/message_tile.dart
@@ -11,6 +11,7 @@ import 'tool_call_tile.dart';
 class MessageTile extends StatelessWidget {
   const MessageTile({
     super.key,
+    required this.roomId,
     required this.message,
     this.runId,
     this.sourceReferences,
@@ -21,6 +22,7 @@ class MessageTile extends StatelessWidget {
     this.streamingActivity,
   });
 
+  final String roomId;
   final ChatMessage message;
   final String? runId;
   final List<SourceReference>? sourceReferences;
@@ -37,6 +39,7 @@ class MessageTile extends StatelessWidget {
       padding: const EdgeInsets.symmetric(vertical: 2),
       child: switch (message) {
         final TextMessage m => TextMessageTile(
+            roomId: roomId,
             message: m,
             runId: runId,
             sourceReferences: sourceReferences,
@@ -54,7 +57,9 @@ class MessageTile extends StatelessWidget {
         final ToolCallMessage m => ToolCallTile(message: m),
         final ErrorMessage m => ErrorMessageTile(message: m),
         final GenUiMessage m => GenUiTile(message: m),
-        LoadingMessage() => LoadingMessageTile(
+        final LoadingMessage m => LoadingMessageTile(
+            roomId: roomId,
+            messageId: m.id,
             executionTracker: executionTracker,
             streamingActivity: streamingActivity,
           ),

--- a/lib/src/modules/room/ui/message_timeline.dart
+++ b/lib/src/modules/room/ui/message_timeline.dart
@@ -14,6 +14,7 @@ import 'scroll/scroll_to_bottom.dart';
 class MessageTimeline extends StatefulWidget {
   const MessageTimeline({
     super.key,
+    required this.roomId,
     required this.messages,
     required this.messageStates,
     this.streamingState,
@@ -23,6 +24,7 @@ class MessageTimeline extends StatefulWidget {
     this.onShowChunkVisualization,
   });
 
+  final String roomId;
   final List<ChatMessage> messages;
   final Map<String, MessageState> messageStates;
   final StreamingState? streamingState;
@@ -186,12 +188,18 @@ class _MessageTimelineState extends State<MessageTimeline> {
                 itemBuilder: (context, index) {
                   final message = displayMessages[index];
                   final isLastItem = index == displayMessages.length - 1;
+                  // A distinct key for the loading sentinel is load-bearing:
+                  // it forces a remount at the AwaitingText → TextStreaming
+                  // transition so execution/thinking child widgets can
+                  // re-bind their MessageExpansion handle under the real
+                  // messageId. Unifying these keys would break persistence.
                   return Padding(
                     key: message is LoadingMessage
                         ? const ValueKey('loading')
                         : _keyFor(message.id),
                     padding: const EdgeInsets.only(bottom: 16),
                     child: MessageTile(
+                      roomId: widget.roomId,
                       message: message,
                       runId: _runIdMap[message.id] ??
                           (message is TextMessage &&

--- a/lib/src/modules/room/ui/message_timeline.dart
+++ b/lib/src/modules/room/ui/message_timeline.dart
@@ -188,11 +188,12 @@ class _MessageTimelineState extends State<MessageTimeline> {
                 itemBuilder: (context, index) {
                   final message = displayMessages[index];
                   final isLastItem = index == displayMessages.length - 1;
-                  // A distinct key for the loading sentinel is load-bearing:
-                  // it forces a remount at the AwaitingText → TextStreaming
-                  // transition so execution/thinking child widgets can
-                  // re-bind their MessageExpansion handle under the real
-                  // messageId. Unifying these keys would break persistence.
+                  // A distinct key for the loading sentinel forces a
+                  // remount at the AwaitingText → TextStreaming transition.
+                  // Children capture their MessageExpansion handle once in
+                  // initState; without the remount they would stay bound to
+                  // loadingMessageId (which forMessage rejects) and never
+                  // acquire a handle under the real messageId.
                   return Padding(
                     key: message is LoadingMessage
                         ? const ValueKey('loading')

--- a/lib/src/modules/room/ui/room_screen.dart
+++ b/lib/src/modules/room/ui/room_screen.dart
@@ -853,6 +853,7 @@ class _RoomScreenState extends State<RoomScreen> {
                     )
                   : MessageTimeline(
                       key: ValueKey(threadView.threadId),
+                      roomId: widget.roomId,
                       messages: messages,
                       messageStates: messageStates,
                       streamingState: streaming,

--- a/lib/src/modules/room/ui/text_message_tile.dart
+++ b/lib/src/modules/room/ui/text_message_tile.dart
@@ -143,11 +143,11 @@ class _ThinkingBlock extends ConsumerWidget {
     final theme = Theme.of(context);
     final expansion =
         ref.read(messageExpansionsProvider).forMessage(roomId, messageId);
-    // initiallyExpanded is read once on mount; the tile does not rebuild
-    // when the store changes. Safe because _ThinkingBlock and
-    // ExecutionThinkingBlock are mutually exclusive for a given (roomId,
-    // messageId) — selected by the `hasTracker` branch above — so only
-    // one widget writes the thinkingExpanded key.
+    // ExpansionTile reads initiallyExpanded once on mount and does not
+    // rebuild when the store changes. Safe because _ThinkingBlock and
+    // ExecutionThinkingBlock are selected by hasTracker and are therefore
+    // mutually exclusive for any given (roomId, messageId), so only one
+    // of them writes thinkingExpanded.
     return ExpansionTile(
       initiallyExpanded: expansion.thinkingExpanded,
       onExpansionChanged: (v) => expansion.thinkingExpanded = v,

--- a/lib/src/modules/room/ui/text_message_tile.dart
+++ b/lib/src/modules/room/ui/text_message_tile.dart
@@ -1,7 +1,9 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:soliplex_agent/soliplex_agent.dart';
 
 import '../execution_tracker.dart';
+import '../room_providers.dart';
 import 'citations_section.dart';
 import 'execution/activity_indicator.dart';
 import 'execution/execution_timeline.dart';
@@ -13,6 +15,7 @@ import 'markdown/flutter_markdown_plus_renderer.dart';
 class TextMessageTile extends StatelessWidget {
   const TextMessageTile({
     super.key,
+    required this.roomId,
     required this.message,
     this.runId,
     this.sourceReferences,
@@ -23,6 +26,7 @@ class TextMessageTile extends StatelessWidget {
     this.streamingActivity,
   });
 
+  final String roomId;
   final TextMessage message;
   final String? runId;
   final List<SourceReference>? sourceReferences;
@@ -44,11 +48,24 @@ class TextMessageTile extends StatelessWidget {
       children: [
         if (streamingActivity != null)
           ActivityIndicator(activity: streamingActivity!),
-        if (hasTracker) ExecutionTimeline(tracker: executionTracker!),
         if (hasTracker)
-          ExecutionThinkingBlock(tracker: executionTracker!)
+          ExecutionTimeline(
+            roomId: roomId,
+            messageId: message.id,
+            tracker: executionTracker!,
+          ),
+        if (hasTracker)
+          ExecutionThinkingBlock(
+            roomId: roomId,
+            messageId: message.id,
+            tracker: executionTracker!,
+          )
         else if (!isUser && message.hasThinkingText)
-          _ThinkingBlock(text: message.thinkingText),
+          _ThinkingBlock(
+            roomId: roomId,
+            messageId: message.id,
+            text: message.thinkingText,
+          ),
         Text(
           isUser ? 'You' : 'Assistant',
           style: theme.textTheme.labelSmall?.copyWith(
@@ -110,14 +127,30 @@ class TextMessageTile extends StatelessWidget {
   }
 }
 
-class _ThinkingBlock extends StatelessWidget {
-  const _ThinkingBlock({required this.text});
+class _ThinkingBlock extends ConsumerWidget {
+  const _ThinkingBlock({
+    required this.roomId,
+    required this.messageId,
+    required this.text,
+  });
+
+  final String roomId;
+  final String messageId;
   final String text;
 
   @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
     final theme = Theme.of(context);
+    final expansion =
+        ref.read(messageExpansionsProvider).forMessage(roomId, messageId);
+    // initiallyExpanded is read once on mount; the tile does not rebuild
+    // when the store changes. Safe because _ThinkingBlock and
+    // ExecutionThinkingBlock are mutually exclusive for a given (roomId,
+    // messageId) — selected by the `hasTracker` branch above — so only
+    // one widget writes the thinkingExpanded key.
     return ExpansionTile(
+      initiallyExpanded: expansion.thinkingExpanded,
+      onExpansionChanged: (v) => expansion.thinkingExpanded = v,
       title: Row(
         children: [
           Expanded(

--- a/test/modules/room/message_expansions_test.dart
+++ b/test/modules/room/message_expansions_test.dart
@@ -1,0 +1,81 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:soliplex_frontend/src/modules/room/message_expansions.dart';
+
+void main() {
+  group('MessageExpansions', () {
+    late MessageExpansions expansions;
+
+    setUp(() => expansions = MessageExpansions());
+
+    test('timeline default is false and round-trips', () {
+      final m = expansions.forMessage('r', 'm');
+      expect(m.timelineExpanded, isFalse);
+      m.timelineExpanded = true;
+      expect(m.timelineExpanded, isTrue);
+      m.timelineExpanded = false;
+      expect(m.timelineExpanded, isFalse);
+    });
+
+    test('thinking default is false and round-trips', () {
+      final m = expansions.forMessage('r', 'm');
+      expect(m.thinkingExpanded, isFalse);
+      m.thinkingExpanded = true;
+      expect(m.thinkingExpanded, isTrue);
+    });
+
+    test('source default is false; toggle adds then removes', () {
+      final m = expansions.forMessage('r', 'm');
+      expect(m.isSourceExpanded('a1'), isFalse);
+      m.toggleSource('a1');
+      expect(m.isSourceExpanded('a1'), isTrue);
+      m.toggleSource('a1');
+      expect(m.isSourceExpanded('a1'), isFalse);
+    });
+
+    test('handles keyed by (roomId, messageId) are independent', () {
+      expansions.forMessage('room-1', 'msg').timelineExpanded = true;
+      expect(expansions.forMessage('room-1', 'msg').timelineExpanded, isTrue);
+      expect(expansions.forMessage('room-2', 'msg').timelineExpanded, isFalse);
+      expect(
+          expansions.forMessage('room-1', 'other').timelineExpanded, isFalse);
+    });
+
+    test('the three state kinds do not cross-contaminate', () {
+      final m = expansions.forMessage('r', 'm');
+      m.timelineExpanded = true;
+      expect(m.thinkingExpanded, isFalse);
+      m.thinkingExpanded = true;
+      expect(m.isSourceExpanded('a1'), isFalse);
+      m.toggleSource('a1');
+      expect(m.timelineExpanded, isTrue);
+      expect(m.thinkingExpanded, isTrue);
+      expect(m.isSourceExpanded('a1'), isTrue);
+    });
+
+    test('multiple source activities tracked independently per message', () {
+      final m = expansions.forMessage('r', 'm');
+      m.toggleSource('a1');
+      m.toggleSource('a2');
+      expect(m.isSourceExpanded('a1'), isTrue);
+      expect(m.isSourceExpanded('a2'), isTrue);
+      m.toggleSource('a1');
+      expect(m.isSourceExpanded('a1'), isFalse);
+      expect(m.isSourceExpanded('a2'), isTrue);
+    });
+
+    test('setSourceExpanded(false) on unknown key is a no-op', () {
+      final m = expansions.forMessage('r', 'm');
+      m.setSourceExpanded('never-added', false);
+      expect(m.isSourceExpanded('never-added'), isFalse);
+    });
+
+    test('two handles to the same message share state', () {
+      final a = expansions.forMessage('r', 'm');
+      final b = expansions.forMessage('r', 'm');
+      a.timelineExpanded = true;
+      expect(b.timelineExpanded, isTrue);
+      b.toggleSource('a1');
+      expect(a.isSourceExpanded('a1'), isTrue);
+    });
+  });
+}

--- a/test/modules/room/message_expansions_test.dart
+++ b/test/modules/room/message_expansions_test.dart
@@ -77,5 +77,18 @@ void main() {
       b.toggleSource('a1');
       expect(a.isSourceExpanded('a1'), isTrue);
     });
+
+    test('entries beyond maxEntries evict oldest-inserted (FIFO)', () {
+      for (var i = 0; i < MessageExpansions.maxEntries; i++) {
+        expansions.forMessage('r', 'm$i').timelineExpanded = true;
+      }
+      expect(expansions.debugHasStateFor('r', 'm0'), isTrue);
+
+      // The next new entry evicts the oldest-inserted (m0).
+      expansions.forMessage('r', 'new').timelineExpanded = true;
+      expect(expansions.debugHasStateFor('r', 'm0'), isFalse);
+      expect(expansions.debugHasStateFor('r', 'new'), isTrue);
+      expect(expansions.debugHasStateFor('r', 'm1'), isTrue);
+    });
   });
 }

--- a/test/modules/room/room_module_test.dart
+++ b/test/modules/room/room_module_test.dart
@@ -1,10 +1,13 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:go_router/go_router.dart';
 import 'package:soliplex_agent/soliplex_agent.dart';
 import 'package:soliplex_frontend/src/modules/auth/auth_session.dart';
 import 'package:soliplex_frontend/src/modules/auth/server_manager.dart';
 import 'package:soliplex_frontend/src/modules/room/agent_runtime_manager.dart';
+import 'package:soliplex_frontend/src/modules/room/message_expansions.dart';
 import 'package:soliplex_frontend/src/modules/room/room_module.dart';
+import 'package:soliplex_frontend/src/modules/room/room_providers.dart';
 import 'package:soliplex_frontend/src/modules/room/run_registry.dart';
 
 import '../../helpers/fakes.dart';
@@ -65,13 +68,21 @@ void main() {
             '/info must precede /:threadId to avoid eager parameter matching');
   });
 
-  test('contributes no overrides in Slice A', () {
+  test('overrides messageExpansionsProvider so reads succeed', () {
     final manager = _createManager();
     final contribution = roomModule(
       serverManager: manager,
       runtimeManager: runtimeManager,
       registry: registry,
     );
-    expect(contribution.overrides, isEmpty);
+
+    // Resolving the provider through the module's overrides must not
+    // throw — the default provider throws StateError.
+    final container = ProviderContainer(overrides: contribution.overrides);
+    addTearDown(container.dispose);
+    expect(
+      container.read(messageExpansionsProvider),
+      isA<MessageExpansions>(),
+    );
   });
 }

--- a/test/modules/room/ui/execution/execution_timeline_test.dart
+++ b/test/modules/room/ui/execution/execution_timeline_test.dart
@@ -337,7 +337,7 @@ void main() {
       // Sentinel messageId must not leak into the store — it is reused
       // across runs and state written under it would leak to the next
       // response.
-      expect(store.hasStateFor(_roomId, loadingMessageId), isFalse);
+      expect(store.debugHasStateFor(_roomId, loadingMessageId), isFalse);
     });
 
     testWidgets('source toggle in loading phase uses local state only',
@@ -364,8 +364,15 @@ void main() {
       await tester.pump();
       expect(find.text('print(42)'), findsOneWidget);
 
-      // Same safety invariant for source rows.
-      expect(store.hasStateFor(_roomId, loadingMessageId), isFalse);
+      // Collapse pins the "remove from local set" branch. A regression
+      // that only adds and never removes would silently break the
+      // loading-phase collapse path.
+      await tester.tap(find.text('execute_script'));
+      await tester.pump();
+      expect(find.text('print(42)'), findsNothing);
+
+      // Safety invariant for source rows — no writes to the store.
+      expect(store.debugHasStateFor(_roomId, loadingMessageId), isFalse);
     });
   });
 }

--- a/test/modules/room/ui/execution/execution_timeline_test.dart
+++ b/test/modules/room/ui/execution/execution_timeline_test.dart
@@ -1,25 +1,52 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:soliplex_agent/soliplex_agent.dart';
 
 import 'package:soliplex_frontend/src/modules/room/execution_tracker.dart';
+import 'package:soliplex_frontend/src/modules/room/message_expansions.dart';
+import 'package:soliplex_frontend/src/modules/room/room_providers.dart';
 import 'package:soliplex_frontend/src/modules/room/ui/execution/execution_timeline.dart';
+import 'package:soliplex_frontend/src/modules/room/compute_display_messages.dart'
+    show loadingMessageId;
 
-Widget wrap(Widget child) => MaterialApp(home: Scaffold(body: child));
+const _roomId = 'r1';
+const _messageId = 'm1';
 
 void main() {
   late Signal<ExecutionEvent?> events;
   late ExecutionTracker tracker;
+  late MessageExpansions store;
 
   setUp(() {
     events = Signal<ExecutionEvent?>(null);
     tracker = ExecutionTracker(executionEvents: events);
+    store = MessageExpansions();
   });
 
   tearDown(() => tracker.dispose());
 
+  Widget wrap(Widget child, {MessageExpansions? storeOverride}) =>
+      ProviderScope(
+        overrides: [
+          messageExpansionsProvider.overrideWithValue(storeOverride ?? store),
+        ],
+        child: MaterialApp(home: Scaffold(body: child)),
+      );
+
+  ExecutionTimeline build({
+    String roomId = _roomId,
+    String messageId = _messageId,
+    ExecutionTracker? t,
+  }) =>
+      ExecutionTimeline(
+        roomId: roomId,
+        messageId: messageId,
+        tracker: t ?? tracker,
+      );
+
   testWidgets('renders nothing for empty timeline', (tester) async {
-    await tester.pumpWidget(wrap(ExecutionTimeline(tracker: tracker)));
+    await tester.pumpWidget(wrap(build()));
     await tester.pump();
 
     expect(find.byType(GestureDetector), findsNothing);
@@ -43,7 +70,7 @@ void main() {
       timestamp: 101,
     );
 
-    await tester.pumpWidget(wrap(ExecutionTimeline(tracker: tracker)));
+    await tester.pumpWidget(wrap(build()));
     await tester.pump();
 
     expect(find.text('3 events'), findsOneWidget);
@@ -52,7 +79,7 @@ void main() {
   testWidgets('singular label when only one event', (tester) async {
     events.value = const ThinkingStarted();
 
-    await tester.pumpWidget(wrap(ExecutionTimeline(tracker: tracker)));
+    await tester.pumpWidget(wrap(build()));
     await tester.pump();
 
     expect(find.text('1 event'), findsOneWidget);
@@ -70,7 +97,7 @@ void main() {
       timestamp: 100,
     );
 
-    await tester.pumpWidget(wrap(ExecutionTimeline(tracker: tracker)));
+    await tester.pumpWidget(wrap(build()));
     await tester.pump();
 
     expect(find.text('execute_skill'), findsNothing);
@@ -98,7 +125,7 @@ void main() {
       timestamp: 100,
     );
 
-    await tester.pumpWidget(wrap(ExecutionTimeline(tracker: tracker)));
+    await tester.pumpWidget(wrap(build()));
     await tester.pump();
     await tester.tap(find.text('2 events'));
     await tester.pump();
@@ -119,7 +146,7 @@ void main() {
       timestamp: 100,
     );
 
-    await tester.pumpWidget(wrap(ExecutionTimeline(tracker: tracker)));
+    await tester.pumpWidget(wrap(build()));
     await tester.pump();
     await tester.tap(find.text('1 event'));
     await tester.pump();
@@ -140,7 +167,7 @@ void main() {
       timestamp: 100,
     );
 
-    await tester.pumpWidget(wrap(ExecutionTimeline(tracker: tracker)));
+    await tester.pumpWidget(wrap(build()));
     await tester.pump();
     await tester.tap(find.text('1 event'));
     await tester.pump();
@@ -160,7 +187,7 @@ void main() {
       result: 'ok',
     );
 
-    await tester.pumpWidget(wrap(ExecutionTimeline(tracker: tracker)));
+    await tester.pumpWidget(wrap(build()));
     await tester.pump();
     await tester.tap(find.text('1 event'));
     await tester.pump();
@@ -179,11 +206,166 @@ void main() {
       timestamp: 100,
     );
 
-    await tester.pumpWidget(wrap(ExecutionTimeline(tracker: tracker)));
+    await tester.pumpWidget(wrap(build()));
     await tester.pump();
     await tester.tap(find.text('1 event'));
     await tester.pump();
 
     expect(find.text('execute_script'), findsOneWidget);
+  });
+
+  group('MessageExpansions persistence', () {
+    testWidgets('header expansion persists across parent-key swap',
+        (tester) async {
+      events.value = const ThinkingStarted();
+
+      Widget tree(Key parentKey) => wrap(
+            KeyedSubtree(key: parentKey, child: build()),
+          );
+
+      await tester.pumpWidget(tree(const ValueKey('A')));
+      await tester.pump();
+      await tester.tap(find.text('1 event'));
+      await tester.pump();
+      expect(find.text('Thinking'), findsOneWidget);
+
+      // Force State destruction by swapping the parent key; store is the
+      // same across pumps, so the re-mounted widget seeds _expanded=true.
+      await tester.pumpWidget(tree(const ValueKey('B')));
+      await tester.pump();
+      expect(find.text('Thinking'), findsOneWidget);
+    });
+
+    testWidgets('source expansion persists across parent-key swap',
+        (tester) async {
+      events.value = const ClientToolExecuting(
+        toolName: 'execute_skill',
+        toolCallId: 'tc-1',
+      );
+      events.value = const ActivitySnapshot(
+        messageId: 'bwrap:call_1',
+        activityType: 'skill_tool_call',
+        content: {
+          'tool_name': 'execute_script',
+          'args': '{"script":"print(42)"}',
+        },
+        timestamp: 100,
+      );
+
+      Widget tree(Key parentKey) => wrap(
+            KeyedSubtree(key: parentKey, child: build()),
+          );
+
+      await tester.pumpWidget(tree(const ValueKey('A')));
+      await tester.pump();
+      await tester.tap(find.text('2 events'));
+      await tester.pump();
+      await tester.tap(find.text('execute_script'));
+      await tester.pump();
+      expect(find.text('print(42)'), findsOneWidget);
+
+      await tester.pumpWidget(tree(const ValueKey('B')));
+      await tester.pump();
+      expect(find.text('print(42)'), findsOneWidget);
+    });
+
+    testWidgets('state is keyed by both roomId and messageId', (tester) async {
+      events.value = const ThinkingStarted();
+
+      final events2 = Signal<ExecutionEvent?>(null);
+      final tracker2 = ExecutionTracker(executionEvents: events2);
+      addTearDown(tracker2.dispose);
+      events2.value = const ThinkingStarted();
+
+      final events3 = Signal<ExecutionEvent?>(null);
+      final tracker3 = ExecutionTracker(executionEvents: events3);
+      addTearDown(tracker3.dispose);
+      events3.value = const ThinkingStarted();
+
+      // Three widgets: (r1, m1), (r1, other-msg), (other-room, m1).
+      // Tapping the first must not affect the other two.
+      await tester.pumpWidget(wrap(Column(
+        children: [
+          build(),
+          build(messageId: 'other-msg', t: tracker2),
+          build(roomId: 'other-room', t: tracker3),
+        ],
+      )));
+      await tester.pump();
+      expect(find.text('1 event'), findsNWidgets(3));
+
+      await tester.tap(find.text('1 event').first);
+      await tester.pump();
+
+      // Only the first expands; isolation holds across messageId AND roomId.
+      expect(find.text('Thinking'), findsOneWidget);
+    });
+
+    testWidgets('collapse persists across parent-key swap', (tester) async {
+      events.value = const ThinkingStarted();
+
+      Widget tree(Key parentKey) => wrap(
+            KeyedSubtree(key: parentKey, child: build()),
+          );
+
+      await tester.pumpWidget(tree(const ValueKey('A')));
+      await tester.pump();
+      // Expand, then collapse.
+      await tester.tap(find.text('1 event'));
+      await tester.pump();
+      await tester.tap(find.text('1 event'));
+      await tester.pump();
+      expect(find.text('Thinking'), findsNothing);
+
+      // Remount — the collapsed state must survive. This pins the decision
+      // to write every transition (not just expansion).
+      await tester.pumpWidget(tree(const ValueKey('B')));
+      await tester.pump();
+      expect(find.text('Thinking'), findsNothing);
+    });
+
+    testWidgets('header toggle in loading phase uses local state only',
+        (tester) async {
+      events.value = const ThinkingStarted();
+
+      await tester.pumpWidget(wrap(build(messageId: loadingMessageId)));
+      await tester.pump();
+      await tester.tap(find.text('1 event'));
+      await tester.pump();
+      expect(find.text('Thinking'), findsOneWidget);
+
+      // Sentinel messageId must not leak into the store — it is reused
+      // across runs and state written under it would leak to the next
+      // response.
+      expect(store.hasStateFor(_roomId, loadingMessageId), isFalse);
+    });
+
+    testWidgets('source toggle in loading phase uses local state only',
+        (tester) async {
+      events.value = const ClientToolExecuting(
+        toolName: 'execute_skill',
+        toolCallId: 'tc-1',
+      );
+      events.value = const ActivitySnapshot(
+        messageId: 'bwrap:call_1',
+        activityType: 'skill_tool_call',
+        content: {
+          'tool_name': 'execute_script',
+          'args': '{"script":"print(42)"}',
+        },
+        timestamp: 100,
+      );
+
+      await tester.pumpWidget(wrap(build(messageId: loadingMessageId)));
+      await tester.pump();
+      await tester.tap(find.text('2 events'));
+      await tester.pump();
+      await tester.tap(find.text('execute_script'));
+      await tester.pump();
+      expect(find.text('print(42)'), findsOneWidget);
+
+      // Same safety invariant for source rows.
+      expect(store.hasStateFor(_roomId, loadingMessageId), isFalse);
+    });
   });
 }

--- a/test/modules/room/ui/execution/thinking_block_test.dart
+++ b/test/modules/room/ui/execution/thinking_block_test.dart
@@ -219,7 +219,7 @@ void main() {
       expect(find.text('transient'), findsOneWidget);
 
       // Local state flipped, but nothing written to the store.
-      expect(store.hasStateFor(_roomId, loadingMessageId), isFalse);
+      expect(store.debugHasStateFor(_roomId, loadingMessageId), isFalse);
     });
   });
 }

--- a/test/modules/room/ui/execution/thinking_block_test.dart
+++ b/test/modules/room/ui/execution/thinking_block_test.dart
@@ -1,29 +1,54 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:soliplex_agent/soliplex_agent.dart';
 
+import 'package:soliplex_frontend/src/modules/room/compute_display_messages.dart'
+    show loadingMessageId;
 import 'package:soliplex_frontend/src/modules/room/execution_tracker.dart';
+import 'package:soliplex_frontend/src/modules/room/message_expansions.dart';
+import 'package:soliplex_frontend/src/modules/room/room_providers.dart';
 import 'package:soliplex_frontend/src/modules/room/ui/execution/thinking_block.dart';
 
-Widget wrap(Widget child) => MaterialApp(home: Scaffold(body: child));
+const _roomId = 'r1';
+const _messageId = 'm1';
 
 void main() {
   group('ExecutionThinkingBlock', () {
     late Signal<ExecutionEvent?> events;
     late ExecutionTracker tracker;
+    late MessageExpansions store;
 
     setUp(() {
       events = Signal<ExecutionEvent?>(null);
       tracker = ExecutionTracker(executionEvents: events);
+      store = MessageExpansions();
     });
 
     tearDown(() {
       tracker.dispose();
     });
 
+    Widget wrap(Widget child) => ProviderScope(
+          overrides: [
+            messageExpansionsProvider.overrideWithValue(store),
+          ],
+          child: MaterialApp(home: Scaffold(body: child)),
+        );
+
+    ExecutionThinkingBlock build({
+      String roomId = _roomId,
+      String messageId = _messageId,
+    }) =>
+        ExecutionThinkingBlock(
+          roomId: roomId,
+          messageId: messageId,
+          tracker: tracker,
+        );
+
     testWidgets('returns empty when no blocks and not streaming',
         (tester) async {
-      await tester.pumpWidget(wrap(ExecutionThinkingBlock(tracker: tracker)));
+      await tester.pumpWidget(wrap(build()));
 
       expect(find.byType(SizedBox), findsWidgets);
       expect(find.text('Thinking'), findsNothing);
@@ -34,7 +59,7 @@ void main() {
       events.value = const ThinkingStarted();
       events.value = const ThinkingContent(delta: 'Some thoughts');
 
-      await tester.pumpWidget(wrap(ExecutionThinkingBlock(tracker: tracker)));
+      await tester.pumpWidget(wrap(build()));
       await tester.pump();
 
       expect(find.text('Thinking'), findsOneWidget);
@@ -44,7 +69,7 @@ void main() {
         (tester) async {
       events.value = const ThinkingStarted();
 
-      await tester.pumpWidget(wrap(ExecutionThinkingBlock(tracker: tracker)));
+      await tester.pumpWidget(wrap(build()));
       await tester.pump();
 
       expect(find.byType(CircularProgressIndicator), findsOneWidget);
@@ -56,7 +81,7 @@ void main() {
       events.value = const ThinkingContent(delta: 'Some thoughts');
       events.value = const RunCompleted();
 
-      await tester.pumpWidget(wrap(ExecutionThinkingBlock(tracker: tracker)));
+      await tester.pumpWidget(wrap(build()));
       await tester.pump();
 
       expect(find.byType(CircularProgressIndicator), findsNothing);
@@ -66,7 +91,7 @@ void main() {
       events.value = const ThinkingStarted();
       events.value = const ThinkingContent(delta: 'Let me think about this');
 
-      await tester.pumpWidget(wrap(ExecutionThinkingBlock(tracker: tracker)));
+      await tester.pumpWidget(wrap(build()));
       await tester.pump();
 
       expect(find.text('Let me think about this'), findsNothing);
@@ -81,7 +106,7 @@ void main() {
       events.value = const ThinkingStarted();
       events.value = const ThinkingContent(delta: 'Let me think about this');
 
-      await tester.pumpWidget(wrap(ExecutionThinkingBlock(tracker: tracker)));
+      await tester.pumpWidget(wrap(build()));
       await tester.pump();
 
       await tester.tap(find.textContaining('Thinking'));
@@ -109,7 +134,7 @@ void main() {
       events.value = const ThinkingStarted();
       events.value = const ThinkingContent(delta: 'Second thought');
 
-      await tester.pumpWidget(wrap(ExecutionThinkingBlock(tracker: tracker)));
+      await tester.pumpWidget(wrap(build()));
       await tester.pump();
 
       expect(find.text('Thinking (2)'), findsOneWidget);
@@ -129,7 +154,7 @@ void main() {
       events.value = const ThinkingStarted();
       events.value = const ThinkingContent(delta: 'Second thought');
 
-      await tester.pumpWidget(wrap(ExecutionThinkingBlock(tracker: tracker)));
+      await tester.pumpWidget(wrap(build()));
       await tester.pump();
 
       await tester.tap(find.textContaining('Thinking'));
@@ -141,6 +166,60 @@ void main() {
       final textWidgets = tester.widgetList<Text>(find.byType(Text)).toList();
       // Header "Thinking (2)" + "Second thought" = 2 text widgets
       expect(textWidgets.length, 2);
+    });
+
+    testWidgets('expansion persists across parent-key swap', (tester) async {
+      events.value = const ThinkingStarted();
+      events.value = const ThinkingContent(delta: 'A deep thought');
+
+      Widget tree(Key parentKey) => wrap(
+            KeyedSubtree(key: parentKey, child: build()),
+          );
+
+      await tester.pumpWidget(tree(const ValueKey('A')));
+      await tester.pump();
+      await tester.tap(find.textContaining('Thinking'));
+      await tester.pump();
+      expect(find.text('A deep thought'), findsOneWidget);
+
+      await tester.pumpWidget(tree(const ValueKey('B')));
+      await tester.pump();
+      expect(find.text('A deep thought'), findsOneWidget);
+    });
+
+    testWidgets('collapse persists across parent-key swap', (tester) async {
+      events.value = const ThinkingStarted();
+      events.value = const ThinkingContent(delta: 'A deep thought');
+
+      Widget tree(Key parentKey) => wrap(
+            KeyedSubtree(key: parentKey, child: build()),
+          );
+
+      await tester.pumpWidget(tree(const ValueKey('A')));
+      await tester.pump();
+      await tester.tap(find.textContaining('Thinking'));
+      await tester.pump();
+      await tester.tap(find.textContaining('Thinking'));
+      await tester.pump();
+      expect(find.text('A deep thought'), findsNothing);
+
+      await tester.pumpWidget(tree(const ValueKey('B')));
+      await tester.pump();
+      expect(find.text('A deep thought'), findsNothing);
+    });
+
+    testWidgets('does not write to store during loading phase', (tester) async {
+      events.value = const ThinkingStarted();
+      events.value = const ThinkingContent(delta: 'transient');
+
+      await tester.pumpWidget(wrap(build(messageId: loadingMessageId)));
+      await tester.pump();
+      await tester.tap(find.textContaining('Thinking'));
+      await tester.pump();
+      expect(find.text('transient'), findsOneWidget);
+
+      // Local state flipped, but nothing written to the store.
+      expect(store.hasStateFor(_roomId, loadingMessageId), isFalse);
     });
   });
 }

--- a/test/modules/room/ui/execution_widgets_test.dart
+++ b/test/modules/room/ui/execution_widgets_test.dart
@@ -1,11 +1,21 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:soliplex_agent/soliplex_agent.dart';
 
 import 'package:soliplex_frontend/src/modules/room/execution_tracker.dart';
+import 'package:soliplex_frontend/src/modules/room/message_expansions.dart';
+import 'package:soliplex_frontend/src/modules/room/room_providers.dart';
 import 'package:soliplex_frontend/src/modules/room/ui/execution/activity_indicator.dart';
 import 'package:soliplex_frontend/src/modules/room/ui/execution/execution_timeline.dart';
 import 'package:soliplex_frontend/src/modules/room/ui/execution/thinking_block.dart';
+
+Widget _withStore(Widget child) => ProviderScope(
+      overrides: [
+        messageExpansionsProvider.overrideWithValue(MessageExpansions()),
+      ],
+      child: child,
+    );
 
 void main() {
   testWidgets('ActivityIndicator shows Processing label', (tester) async {
@@ -61,11 +71,15 @@ void main() {
       toolCallId: 'tc-1',
     );
 
-    await tester.pumpWidget(MaterialApp(
+    await tester.pumpWidget(_withStore(MaterialApp(
       home: Scaffold(
-        body: ExecutionTimeline(tracker: tracker),
+        body: ExecutionTimeline(
+          roomId: 'r',
+          messageId: 'm',
+          tracker: tracker,
+        ),
       ),
-    ));
+    )));
 
     expect(find.text('2 events'), findsOneWidget);
 
@@ -79,11 +93,15 @@ void main() {
     events.value = const ThinkingStarted();
     events.value = const ThinkingContent(delta: 'Let me think about this');
 
-    await tester.pumpWidget(MaterialApp(
+    await tester.pumpWidget(_withStore(MaterialApp(
       home: Scaffold(
-        body: ExecutionThinkingBlock(tracker: tracker),
+        body: ExecutionThinkingBlock(
+          roomId: 'r',
+          messageId: 'm',
+          tracker: tracker,
+        ),
       ),
-    ));
+    )));
 
     expect(find.text('Thinking'), findsOneWidget);
 

--- a/test/modules/room/ui/message_tile_test.dart
+++ b/test/modules/room/ui/message_tile_test.dart
@@ -1,14 +1,24 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:soliplex_agent/soliplex_agent.dart';
 
 import 'package:soliplex_frontend/src/modules/room/execution_tracker.dart';
+import 'package:soliplex_frontend/src/modules/room/message_expansions.dart';
+import 'package:soliplex_frontend/src/modules/room/room_providers.dart';
 import 'package:soliplex_frontend/src/modules/room/ui/execution/activity_indicator.dart';
 import 'package:soliplex_frontend/src/modules/room/ui/execution/execution_timeline.dart';
 import 'package:soliplex_frontend/src/modules/room/ui/execution/thinking_block.dart';
 import 'package:soliplex_frontend/src/modules/room/ui/loading_message_tile.dart';
 import 'package:soliplex_frontend/src/modules/room/ui/text_message_tile.dart';
 import 'package:soliplex_frontend/src/modules/room/ui/tool_call_tile.dart';
+
+Widget _wrap(Widget child) => ProviderScope(
+      overrides: [
+        messageExpansionsProvider.overrideWithValue(MessageExpansions()),
+      ],
+      child: MaterialApp(home: Scaffold(body: child)),
+    );
 
 void main() {
   group('TextMessageTile', () {
@@ -19,8 +29,8 @@ void main() {
         createdAt: DateTime(2026, 3, 1),
         text: 'Hello',
       );
-      await tester.pumpWidget(
-          MaterialApp(home: Scaffold(body: TextMessageTile(message: msg))));
+      await tester
+          .pumpWidget(_wrap(TextMessageTile(roomId: 'r', message: msg)));
       expect(find.text('You'), findsOneWidget);
       expect(find.text('Hello'), findsOneWidget);
     });
@@ -32,8 +42,8 @@ void main() {
         createdAt: DateTime(2026, 3, 1),
         text: 'Response',
       );
-      await tester.pumpWidget(
-          MaterialApp(home: Scaffold(body: TextMessageTile(message: msg))));
+      await tester
+          .pumpWidget(_wrap(TextMessageTile(roomId: 'r', message: msg)));
       expect(find.text('Assistant'), findsOneWidget);
     });
 
@@ -45,8 +55,8 @@ void main() {
         text: 'Response',
         thinkingText: 'Thinking about this...',
       );
-      await tester.pumpWidget(
-          MaterialApp(home: Scaffold(body: TextMessageTile(message: msg))));
+      await tester
+          .pumpWidget(_wrap(TextMessageTile(roomId: 'r', message: msg)));
       expect(find.text('Thinking...'), findsOneWidget);
     });
 
@@ -70,14 +80,11 @@ void main() {
         text: 'Response',
       );
 
-      await tester.pumpWidget(MaterialApp(
-        home: Scaffold(
-          body: TextMessageTile(
-            message: msg,
-            executionTracker: tracker,
-          ),
-        ),
-      ));
+      await tester.pumpWidget(_wrap(TextMessageTile(
+        roomId: 'r',
+        message: msg,
+        executionTracker: tracker,
+      )));
 
       expect(find.byType(ExecutionTimeline), findsOneWidget);
       expect(find.byType(ExecutionThinkingBlock), findsOneWidget);
@@ -94,14 +101,11 @@ void main() {
         text: 'Response',
       );
 
-      await tester.pumpWidget(MaterialApp(
-        home: Scaffold(
-          body: TextMessageTile(
-            message: msg,
-            streamingActivity: const RespondingActivity(),
-          ),
-        ),
-      ));
+      await tester.pumpWidget(_wrap(TextMessageTile(
+        roomId: 'r',
+        message: msg,
+        streamingActivity: const RespondingActivity(),
+      )));
 
       expect(find.byType(ActivityIndicator), findsOneWidget);
       expect(find.text('Responding...'), findsOneWidget);
@@ -115,9 +119,9 @@ void main() {
         text: '',
       );
 
-      await tester.pumpWidget(MaterialApp(
-        home: Scaffold(body: TextMessageTile(message: msg)),
-      ));
+      await tester.pumpWidget(
+        _wrap(TextMessageTile(roomId: 'r', message: msg)),
+      );
 
       expect(find.text('...'), findsOneWidget);
     });
@@ -138,14 +142,11 @@ void main() {
         thinkingText: 'persisted thinking',
       );
 
-      await tester.pumpWidget(MaterialApp(
-        home: Scaffold(
-          body: TextMessageTile(
-            message: msg,
-            executionTracker: tracker,
-          ),
-        ),
-      ));
+      await tester.pumpWidget(_wrap(TextMessageTile(
+        roomId: 'r',
+        message: msg,
+        executionTracker: tracker,
+      )));
 
       // ExecutionThinkingBlock is rendered, not the _ThinkingBlock
       expect(find.byType(ExecutionThinkingBlock), findsOneWidget);
@@ -158,9 +159,10 @@ void main() {
 
   group('LoadingMessageTile', () {
     testWidgets('renders spinner fallback without tracker', (tester) async {
-      await tester.pumpWidget(const MaterialApp(
-        home: Scaffold(body: LoadingMessageTile()),
-      ));
+      await tester.pumpWidget(_wrap(const LoadingMessageTile(
+        roomId: 'r',
+        messageId: '_loading',
+      )));
 
       expect(find.text('Thinking...'), findsOneWidget);
       expect(find.byType(CircularProgressIndicator), findsOneWidget);
@@ -173,14 +175,12 @@ void main() {
       events.value = const ThinkingStarted();
       events.value = const ThinkingContent(delta: 'working...');
 
-      await tester.pumpWidget(MaterialApp(
-        home: Scaffold(
-          body: LoadingMessageTile(
-            executionTracker: tracker,
-            streamingActivity: const ThinkingActivity(),
-          ),
-        ),
-      ));
+      await tester.pumpWidget(_wrap(LoadingMessageTile(
+        roomId: 'r',
+        messageId: '_loading',
+        executionTracker: tracker,
+        streamingActivity: const ThinkingActivity(),
+      )));
 
       expect(find.byType(ActivityIndicator), findsOneWidget);
       expect(find.byType(ExecutionTimeline), findsOneWidget);

--- a/test/modules/room/ui/message_timeline_test.dart
+++ b/test/modules/room/ui/message_timeline_test.dart
@@ -1,7 +1,10 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:soliplex_agent/soliplex_agent.dart';
 
+import 'package:soliplex_frontend/src/modules/room/message_expansions.dart';
+import 'package:soliplex_frontend/src/modules/room/room_providers.dart';
 import 'package:soliplex_frontend/src/modules/room/ui/message_timeline.dart';
 
 void main() {
@@ -13,11 +16,17 @@ void main() {
       text: 'Hello',
     );
 
-    await tester.pumpWidget(MaterialApp(
-      home: Scaffold(
-        body: MessageTimeline(
-          messages: [message],
-          messageStates: const {},
+    await tester.pumpWidget(ProviderScope(
+      overrides: [
+        messageExpansionsProvider.overrideWithValue(MessageExpansions()),
+      ],
+      child: MaterialApp(
+        home: Scaffold(
+          body: MessageTimeline(
+            roomId: 'r',
+            messages: [message],
+            messageStates: const {},
+          ),
         ),
       ),
     ));

--- a/test/modules/room/ui/text_message_tile_test.dart
+++ b/test/modules/room/ui/text_message_tile_test.dart
@@ -1,28 +1,36 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:soliplex_agent/soliplex_agent.dart';
 
+import 'package:soliplex_frontend/src/modules/room/message_expansions.dart';
+import 'package:soliplex_frontend/src/modules/room/room_providers.dart';
 import 'package:soliplex_frontend/src/modules/room/ui/copy_button.dart';
 import 'package:soliplex_frontend/src/modules/room/ui/feedback_buttons.dart';
 import 'package:soliplex_frontend/src/modules/room/ui/text_message_tile.dart';
 
+Widget _wrap(Widget child, {MessageExpansions? store}) => ProviderScope(
+      overrides: [
+        messageExpansionsProvider
+            .overrideWithValue(store ?? MessageExpansions()),
+      ],
+      child: MaterialApp(home: Scaffold(body: child)),
+    );
+
 void main() {
   testWidgets('user message shows copy button but no feedback buttons',
       (tester) async {
-    await tester.pumpWidget(
-      MaterialApp(
-        home: Scaffold(
-          body: TextMessageTile(
-            message: TextMessage(
-              id: '1',
-              user: ChatUser.user,
-              createdAt: DateTime(2026),
-              text: 'Hello',
-            ),
-          ),
+    await tester.pumpWidget(_wrap(
+      TextMessageTile(
+        roomId: 'r',
+        message: TextMessage(
+          id: '1',
+          user: ChatUser.user,
+          createdAt: DateTime(2026),
+          text: 'Hello',
         ),
       ),
-    );
+    ));
 
     expect(find.byType(CopyButton), findsOneWidget);
     expect(find.byType(FeedbackButtons), findsNothing);
@@ -30,22 +38,19 @@ void main() {
 
   testWidgets('assistant message shows copy button and feedback buttons',
       (tester) async {
-    await tester.pumpWidget(
-      MaterialApp(
-        home: Scaffold(
-          body: TextMessageTile(
-            message: TextMessage(
-              id: '2',
-              user: ChatUser.assistant,
-              createdAt: DateTime(2026),
-              text: 'Hi there',
-            ),
-            runId: 'run-1',
-            onFeedbackSubmit: (_, __) {},
-          ),
+    await tester.pumpWidget(_wrap(
+      TextMessageTile(
+        roomId: 'r',
+        message: TextMessage(
+          id: '2',
+          user: ChatUser.assistant,
+          createdAt: DateTime(2026),
+          text: 'Hi there',
         ),
+        runId: 'run-1',
+        onFeedbackSubmit: (_, __) {},
       ),
-    );
+    ));
 
     expect(find.byType(CopyButton), findsOneWidget);
     expect(find.byType(FeedbackButtons), findsOneWidget);
@@ -53,43 +58,107 @@ void main() {
 
   testWidgets('assistant message without feedback callback shows only copy',
       (tester) async {
-    await tester.pumpWidget(
-      MaterialApp(
-        home: Scaffold(
-          body: TextMessageTile(
-            message: TextMessage(
-              id: '3',
-              user: ChatUser.assistant,
-              createdAt: DateTime(2026),
-              text: 'Hi there',
-            ),
-          ),
+    await tester.pumpWidget(_wrap(
+      TextMessageTile(
+        roomId: 'r',
+        message: TextMessage(
+          id: '3',
+          user: ChatUser.assistant,
+          createdAt: DateTime(2026),
+          text: 'Hi there',
         ),
       ),
-    );
+    ));
 
     expect(find.byType(CopyButton), findsOneWidget);
     expect(find.byType(FeedbackButtons), findsNothing);
   });
 
   testWidgets('thinking block shows copy button', (tester) async {
-    await tester.pumpWidget(
-      MaterialApp(
-        home: Scaffold(
-          body: TextMessageTile(
-            message: TextMessage(
-              id: '4',
-              user: ChatUser.assistant,
-              createdAt: DateTime(2026),
-              text: 'Response',
-              thinkingText: 'Let me think about this...',
-            ),
-          ),
+    await tester.pumpWidget(_wrap(
+      TextMessageTile(
+        roomId: 'r',
+        message: TextMessage(
+          id: '4',
+          user: ChatUser.assistant,
+          createdAt: DateTime(2026),
+          text: 'Response',
+          thinkingText: 'Let me think about this...',
         ),
       ),
-    );
+    ));
 
     // One CopyButton for the message, one for the thinking block
     expect(find.byType(CopyButton), findsNWidgets(2));
+  });
+
+  testWidgets('fallback thinking block persists expansion across remount',
+      (tester) async {
+    // Fallback _ThinkingBlock wires ExpansionTile.initiallyExpanded +
+    // onExpansionChanged to the store. A remount (which destroys
+    // ExpansionTile's internal State) must re-seed from the store.
+    final store = MessageExpansions();
+    final msg = TextMessage(
+      id: 'msg-5',
+      user: ChatUser.assistant,
+      createdAt: DateTime(2026),
+      text: 'Response',
+      thinkingText: 'Deep thought',
+    );
+
+    Widget tree(Key parentKey) => _wrap(
+          KeyedSubtree(
+            key: parentKey,
+            child: TextMessageTile(roomId: 'r', message: msg),
+          ),
+          store: store,
+        );
+
+    await tester.pumpWidget(tree(const ValueKey('A')));
+    expect(find.text('Deep thought'), findsNothing);
+
+    await tester.tap(find.text('Thinking...'));
+    await tester.pumpAndSettle();
+    expect(find.text('Deep thought'), findsOneWidget);
+
+    await tester.pumpWidget(tree(const ValueKey('B')));
+    await tester.pumpAndSettle();
+    expect(find.text('Deep thought'), findsOneWidget);
+  });
+
+  testWidgets('fallback thinking block persists collapse across remount',
+      (tester) async {
+    // Mirror of the expand-persists test: collapse (false) must also be
+    // written to the store so a remount re-seeds as collapsed.
+    final store = MessageExpansions();
+    final msg = TextMessage(
+      id: 'msg-6',
+      user: ChatUser.assistant,
+      createdAt: DateTime(2026),
+      text: 'Response',
+      thinkingText: 'Deep thought',
+    );
+
+    Widget tree(Key parentKey) => _wrap(
+          KeyedSubtree(
+            key: parentKey,
+            child: TextMessageTile(roomId: 'r', message: msg),
+          ),
+          store: store,
+        );
+
+    await tester.pumpWidget(tree(const ValueKey('A')));
+    await tester.tap(find.text('Thinking...'));
+    await tester.pumpAndSettle();
+    expect(find.text('Deep thought'), findsOneWidget);
+
+    await tester.tap(find.text('Thinking...'));
+    await tester.pumpAndSettle();
+    expect(find.text('Deep thought'), findsNothing);
+    expect(store.forMessage('r', 'msg-6').thinkingExpanded, isFalse);
+
+    await tester.pumpWidget(tree(const ValueKey('B')));
+    await tester.pumpAndSettle();
+    expect(find.text('Deep thought'), findsNothing);
   });
 }


### PR DESCRIPTION
## Summary

- Introduces `MessageExpansions` — a room-module-scoped store that remembers which parts of each assistant message are expanded (execution timeline, thinking block, activity source rows). State survives widget rebuilds, thread switches, and room navigation within the module. Previously these bools lived in widget state and reset on every rebuild/scroll.
- Access goes through a `MessageExpansion` handle obtained via `forMessage(roomId, messageId)`; the underlying storage is private. Identity is `(roomId, messageId)`; the `loadingMessageId` sentinel is rejected so transient loading-phase state can't leak into the next response.
- Retention is capped at 200 entries (`MessageExpansions.maxEntries`) with FIFO eviction to bound long-session growth.

Commits on this branch:
- `46786be` — `style: dart format reflow` (pure formatter output, no semantic change)
- `530665d` — the feature
- `73265ab` — polish: size cap, `hasStateFor` → `debugHasStateFor`, sentinel-phase collapse-path test, comment clarifications

## Test plan

- [x] `flutter analyze` passes with zero warnings
- [x] `flutter test` — all 62 targeted tests pass (store unit + widget tests covering persistence across parent-key swap, sentinel-phase no-leak, expand/collapse persistence, cap eviction)
- [x] Manual: run the app, enter a room, expand a completed assistant message's timeline, switch threads and back, confirm timeline stays expanded
- [x] Manual: expand the thinking block on an assistant message, scroll off-screen and back, confirm it stays expanded
- [x] Manual: during a streaming response (loading sentinel), expand the timeline — confirm it behaves locally and does NOT persist after the message's real ID arrives