### PR TITLE
M1: feat(soliplex_agent): SessionCoordinator + StatefulSessionExtension

### DIFF
--- a/lib/src/modules/room/agent_runtime_manager.dart
+++ b/lib/src/modules/room/agent_runtime_manager.dart
@@ -9,12 +9,15 @@ class AgentRuntimeManager {
     required PlatformConstraints platform,
     required Future<ToolRegistry> Function(String roomId) toolRegistryResolver,
     required Logger logger,
+    SessionExtensionFactory? extensionFactory,
   })  : _platform = platform,
         _toolRegistryResolver = toolRegistryResolver,
+        _extensionFactory = extensionFactory,
         _logger = logger;
 
   final PlatformConstraints _platform;
   final Future<ToolRegistry> Function(String roomId) _toolRegistryResolver;
+  final SessionExtensionFactory? _extensionFactory;
   final Logger _logger;
   final Map<String, ({ServerConnection connection, AgentRuntime runtime})>
       _cache = {};
@@ -49,6 +52,7 @@ class AgentRuntimeManager {
       connection: connection,
       toolRegistryResolver: _toolRegistryResolver,
       platform: _platform,
+      extensionFactory: _extensionFactory,
       logger: _logger,
     );
   }

--- a/packages/soliplex_agent/lib/soliplex_agent.dart
+++ b/packages/soliplex_agent/lib/soliplex_agent.dart
@@ -62,7 +62,9 @@ export 'src/runtime/agent_ui_delegate.dart';
 export 'src/runtime/multi_server_runtime.dart';
 export 'src/runtime/server_connection.dart';
 export 'src/runtime/server_registry.dart';
+export 'src/runtime/session_coordinator.dart';
 export 'src/runtime/session_extension.dart';
+export 'src/runtime/stateful_session_extension.dart';
 // ── Scripting ──
 export 'src/scripting/script_environment.dart';
 // ── Tools ──

--- a/packages/soliplex_agent/lib/src/runtime/agent_runtime.dart
+++ b/packages/soliplex_agent/lib/src/runtime/agent_runtime.dart
@@ -12,6 +12,7 @@ import 'package:soliplex_agent/src/runtime/agent_session.dart';
 import 'package:soliplex_agent/src/runtime/agent_session_state.dart';
 import 'package:soliplex_agent/src/runtime/agent_ui_delegate.dart';
 import 'package:soliplex_agent/src/runtime/server_connection.dart';
+import 'package:soliplex_agent/src/runtime/session_coordinator.dart';
 import 'package:soliplex_agent/src/runtime/session_extension.dart';
 import 'package:soliplex_agent/src/tools/tool_registry_resolver.dart';
 import 'package:soliplex_client/soliplex_client.dart' show ThreadHistory;
@@ -323,10 +324,9 @@ class AgentRuntime {
   }) async {
     var toolRegistry = await _toolRegistryResolver(roomId);
     final extensions = await _createExtensions();
-    for (final ext in extensions) {
-      for (final tool in ext.tools) {
-        toolRegistry = toolRegistry.register(tool);
-      }
+    final coordinator = SessionCoordinator(extensions);
+    for (final tool in coordinator.tools) {
+      toolRegistry = toolRegistry.register(tool);
     }
     final orchestrator = RunOrchestrator(
       llmProvider: _llmProvider,
@@ -340,7 +340,7 @@ class AgentRuntime {
       runtime: this,
       orchestrator: orchestrator,
       toolRegistry: toolRegistry,
-      extensions: extensions,
+      coordinator: coordinator,
       uiDelegate: _uiDelegate,
       logger: _logger,
     );

--- a/packages/soliplex_agent/lib/src/runtime/agent_session.dart
+++ b/packages/soliplex_agent/lib/src/runtime/agent_session.dart
@@ -11,6 +11,7 @@ import 'package:soliplex_agent/src/orchestration/run_state.dart';
 import 'package:soliplex_agent/src/runtime/agent_runtime.dart';
 import 'package:soliplex_agent/src/runtime/agent_session_state.dart';
 import 'package:soliplex_agent/src/runtime/agent_ui_delegate.dart';
+import 'package:soliplex_agent/src/runtime/session_coordinator.dart';
 import 'package:soliplex_agent/src/runtime/session_extension.dart';
 import 'package:soliplex_agent/src/tools/tool_execution_context.dart';
 import 'package:soliplex_agent/src/tools/tool_registry.dart';
@@ -42,12 +43,12 @@ class AgentSession implements ToolExecutionContext {
     required RunOrchestrator orchestrator,
     required ToolRegistry toolRegistry,
     required Logger logger,
-    List<SessionExtension> extensions = const [],
+    required SessionCoordinator coordinator,
     AgentUiDelegate? uiDelegate,
   })  : _runtime = runtime,
         _orchestrator = orchestrator,
         _toolRegistry = toolRegistry,
-        _extensions = extensions,
+        _coordinator = coordinator,
         _uiDelegate = uiDelegate,
         _logger = logger,
         id = '${threadKey.threadId}-'
@@ -68,7 +69,7 @@ class AgentSession implements ToolExecutionContext {
   final AgentRuntime _runtime;
   final RunOrchestrator _orchestrator;
   final ToolRegistry _toolRegistry;
-  final List<SessionExtension> _extensions;
+  final SessionCoordinator _coordinator;
   final AgentUiDelegate? _uiDelegate;
   final Logger _logger;
 
@@ -212,12 +213,13 @@ class AgentSession implements ToolExecutionContext {
   }
 
   @override
-  T? getExtension<T extends SessionExtension>() {
-    for (final ext in _extensions) {
-      if (ext is T) return ext;
-    }
-    return null;
-  }
+  T? getExtension<T extends SessionExtension>() =>
+      _coordinator.getExtension<T>();
+
+  /// Yields `(namespace, signal)` for every stateful extension with a
+  /// non-empty namespace registered in this session.
+  Iterable<(String, ReadonlySignal<Object?>)> statefulObservations() =>
+      _coordinator.statefulObservations();
 
   // ---------------------------------------------------------------------------
   // Child management
@@ -297,17 +299,9 @@ class AgentSession implements ToolExecutionContext {
   // Extension lifecycle
   // ---------------------------------------------------------------------------
 
-  Future<void> _attachExtensions() async {
-    for (final ext in _extensions) {
-      await ext.onAttach(this);
-    }
-  }
+  Future<void> _attachExtensions() => _coordinator.attachAll(this);
 
-  void _disposeExtensions() {
-    for (final ext in _extensions) {
-      ext.onDispose();
-    }
-  }
+  void _disposeExtensions() => _coordinator.disposeAll();
 
   // ---------------------------------------------------------------------------
   // State listener

--- a/packages/soliplex_agent/lib/src/runtime/session_coordinator.dart
+++ b/packages/soliplex_agent/lib/src/runtime/session_coordinator.dart
@@ -28,8 +28,7 @@ class SessionCoordinator {
   bool _disposed = false;
 
   /// All tools contributed by all extensions.
-  List<ClientTool> get tools =>
-      _extensions.expand((e) => e.tools).toList();
+  List<ClientTool> get tools => _extensions.expand((e) => e.tools).toList();
 
   /// Attaches all extensions to [session] in descending priority order.
   Future<void> attachAll(AgentSession session) async {

--- a/packages/soliplex_agent/lib/src/runtime/session_coordinator.dart
+++ b/packages/soliplex_agent/lib/src/runtime/session_coordinator.dart
@@ -1,0 +1,91 @@
+import 'package:signals_core/signals_core.dart';
+import 'package:soliplex_agent/src/runtime/agent_session.dart';
+import 'package:soliplex_agent/src/runtime/session_extension.dart';
+import 'package:soliplex_agent/src/runtime/stateful_session_extension.dart';
+import 'package:soliplex_agent/src/tools/tool_registry.dart';
+
+/// Manages the lifecycle of a set of [SessionExtension]s for one
+/// [AgentSession].
+///
+/// Responsibilities:
+/// - **Namespace validation** — rejects duplicate non-empty namespaces.
+/// - **Priority-ordered attach** — [attachAll] sorts by descending priority.
+/// - **Reverse-order dispose** — [disposeAll] tears down in reverse attach
+///   order.
+/// - **Type-based lookup** — [getExtension] mirrors
+///   [AgentSession.getExtension].
+/// - **Stateful observations** — [statefulObservations] enumerates stateful
+///   extensions, yielding `(namespace, signal)` pairs for reactive state
+///   consumers that don't need to know the concrete extension types.
+class SessionCoordinator {
+  SessionCoordinator(List<SessionExtension> extensions)
+      : _extensions = List.of(extensions) {
+    _validateNamespaces();
+  }
+
+  final List<SessionExtension> _extensions;
+  List<SessionExtension>? _attachOrder;
+  bool _disposed = false;
+
+  /// All tools contributed by all extensions.
+  List<ClientTool> get tools =>
+      _extensions.expand((e) => e.tools).toList();
+
+  /// Attaches all extensions to [session] in descending priority order.
+  Future<void> attachAll(AgentSession session) async {
+    final ordered = List.of(_extensions)
+      ..sort((a, b) => b.priority.compareTo(a.priority));
+    _attachOrder = ordered;
+    for (final ext in ordered) {
+      await ext.onAttach(session);
+    }
+  }
+
+  /// Disposes all extensions in reverse attach order. Idempotent.
+  void disposeAll() {
+    if (_disposed) return;
+    _disposed = true;
+    final order = _attachOrder ?? _extensions;
+    for (final ext in order.reversed) {
+      ext.onDispose();
+    }
+  }
+
+  /// Returns the first extension of type [T], or `null` if none is registered.
+  T? getExtension<T extends SessionExtension>() {
+    for (final ext in _extensions) {
+      if (ext is T) return ext;
+    }
+    return null;
+  }
+
+  /// Yields `(namespace, signal)` for every [StatefulSessionExtension] with a
+  /// non-empty namespace, in registration order.
+  ///
+  /// Consumers can iterate this to observe all reactive extension state
+  /// without importing concrete extension types.
+  Iterable<(String, ReadonlySignal<Object?>)> statefulObservations() sync* {
+    for (final ext in _extensions) {
+      final ns = ext.namespace;
+      if (ns.isEmpty) continue;
+      switch (ext) {
+        case final HasStatefulObservation stateful:
+          yield (ns, stateful.stateSignalAsObject);
+      }
+    }
+  }
+
+  void _validateNamespaces() {
+    final seen = <String>{};
+    for (final ext in _extensions) {
+      final ns = ext.namespace;
+      if (ns.isEmpty) continue;
+      if (!seen.add(ns)) {
+        throw ArgumentError(
+          'Duplicate SessionExtension namespace "$ns". '
+          'Each named extension must have a unique namespace.',
+        );
+      }
+    }
+  }
+}

--- a/packages/soliplex_agent/lib/src/runtime/session_extension.dart
+++ b/packages/soliplex_agent/lib/src/runtime/session_extension.dart
@@ -4,9 +4,22 @@ import 'package:soliplex_agent/src/tools/tool_registry.dart';
 /// A capability bound to the lifecycle of an [AgentSession].
 ///
 /// Extensions provide tools and resources that are created when the
-/// session starts and disposed when the session ends. The session
-/// cascades dispose to all extensions.
-abstract interface class SessionExtension {
+/// session starts and disposed when the session ends.
+///
+/// Subclass via `extends SessionExtension` to inherit the default
+/// [namespace] and [priority]. Mix in `StatefulSessionExtension` to
+/// add a typed reactive-state signal.
+abstract class SessionExtension {
+  /// Unique identifier for this extension type.
+  ///
+  /// The coordinator validates uniqueness across all extensions in a session
+  /// when the namespace is non-empty. Use the default empty string for
+  /// extensions that do not need cross-extension discovery.
+  String get namespace => '';
+
+  /// Attach priority. Higher values attach first and dispose last.
+  int get priority => 0;
+
   /// Called after session creation, before the run starts.
   ///
   /// Receives the [session] for context access (e.g. spawning children,

--- a/packages/soliplex_agent/lib/src/runtime/stateful_session_extension.dart
+++ b/packages/soliplex_agent/lib/src/runtime/stateful_session_extension.dart
@@ -1,0 +1,80 @@
+import 'package:signals_core/signals_core.dart';
+import 'package:soliplex_agent/src/runtime/session_extension.dart';
+
+/// Marker interface for extensions that expose a type-erased reactive state
+/// signal. Used by `SessionCoordinator.statefulObservations` to enumerate
+/// stateful extensions without knowing concrete type parameters.
+abstract interface class HasStatefulObservation {
+  ReadonlySignal<Object?> get stateSignalAsObject;
+}
+
+/// Adds a single typed reactive-state signal to a [SessionExtension].
+///
+/// Call [setInitialState] in the constructor before [onAttach] runs.
+/// Read [state] / write [state] to drive the signal. Dispose is handled
+/// automatically — override [onDispose] and call `super.onDispose()` to
+/// chain cleanup.
+///
+/// ```dart
+/// class MyExtension extends SessionExtension
+///     with StatefulSessionExtension<MySnapshot> {
+///   MyExtension() {
+///     setInitialState(const MySnapshot());
+///   }
+///
+///   @override
+///   String get namespace => 'my_extension';
+///
+///   @override
+///   Future<void> onAttach(AgentSession session) async {
+///     // subscribe to session signals here
+///   }
+///
+///   @override
+///   List<ClientTool> get tools => const [];
+///
+///   @override
+///   void onDispose() {
+///     // clean up subscriptions
+///     super.onDispose(); // disposes the state signal
+///   }
+/// }
+/// ```
+mixin StatefulSessionExtension<T> on SessionExtension
+    implements HasStatefulObservation {
+  Signal<T>? _stateSignal;
+  ReadonlySignal<Object?>? _objectSignal;
+
+  /// Initialises the backing signal. Must be called in the constructor.
+  void setInitialState(T initial) {
+    _stateSignal = signal(initial);
+  }
+
+  /// Typed read-only view of the state signal.
+  ReadonlySignal<T> get stateSignal {
+    assert(_stateSignal != null, 'Call setInitialState() in the constructor');
+    return _stateSignal!.readonly();
+  }
+
+  /// Current state value.
+  T get state => _stateSignal!.value;
+
+  /// Replaces the current state, notifying all subscribers.
+  set state(T value) => _stateSignal!.value = value;
+
+  /// Type-erased view of [stateSignal] for use by `SessionCoordinator`.
+  ///
+  /// Backed by a `computed` signal to avoid unsafe generic casts at runtime.
+  @override
+  ReadonlySignal<Object?> get stateSignalAsObject {
+    return _objectSignal ??= computed<Object?>(() => _stateSignal!.value);
+  }
+
+  @override
+  void onDispose() {
+    _objectSignal?.dispose();
+    _objectSignal = null;
+    _stateSignal?.dispose();
+    _stateSignal = null;
+  }
+}

--- a/packages/soliplex_agent/lib/src/scripting/script_environment.dart
+++ b/packages/soliplex_agent/lib/src/scripting/script_environment.dart
@@ -30,7 +30,7 @@ typedef ScriptEnvironmentFactory = Future<ScriptEnvironment> Function();
 ///
 /// Bridges existing [ScriptEnvironmentFactory] callers to the new
 /// extension-based lifecycle without breaking downstream code.
-class ScriptEnvironmentExtension implements SessionExtension {
+class ScriptEnvironmentExtension extends SessionExtension {
   /// Creates an extension that wraps the given [ScriptEnvironment].
   ScriptEnvironmentExtension(this._environment);
 

--- a/packages/soliplex_agent/test/runtime/agent_runtime_test.dart
+++ b/packages/soliplex_agent/test/runtime/agent_runtime_test.dart
@@ -25,7 +25,7 @@ class _FakeCancelToken extends Fake implements CancelToken {}
 // Test doubles
 // ---------------------------------------------------------------------------
 
-class _TestExtension implements SessionExtension {
+class _TestExtension extends SessionExtension {
   _TestExtension({this.toolList = const []});
 
   final List<ClientTool> toolList;
@@ -42,7 +42,7 @@ class _TestExtension implements SessionExtension {
   void onDispose() => disposeCount++;
 }
 
-class _ThrowingExtension implements SessionExtension {
+class _ThrowingExtension extends SessionExtension {
   @override
   Future<void> onAttach(AgentSession session) async =>
       throw StateError('onAttach boom');

--- a/packages/soliplex_agent/test/runtime/agent_session_signal_test.dart
+++ b/packages/soliplex_agent/test/runtime/agent_session_signal_test.dart
@@ -70,6 +70,7 @@ AgentSession createSession({
     runtime: runtime ?? MockAgentRuntime(),
     orchestrator: orchestrator,
     toolRegistry: registry,
+    coordinator: SessionCoordinator(const []),
     logger: logger,
   );
 }

--- a/packages/soliplex_agent/test/runtime/agent_session_test.dart
+++ b/packages/soliplex_agent/test/runtime/agent_session_test.dart
@@ -88,7 +88,7 @@ class _TestScriptEnvironment implements ScriptEnvironment {
   void dispose() => disposeCount++;
 }
 
-class _TestExtension implements SessionExtension {
+class _TestExtension extends SessionExtension {
   int attachCount = 0;
   int disposeCount = 0;
   AgentSession? attachedSession;
@@ -106,7 +106,7 @@ class _TestExtension implements SessionExtension {
   void onDispose() => disposeCount++;
 }
 
-class _TestExtensionWithTool implements SessionExtension {
+class _TestExtensionWithTool extends SessionExtension {
   _TestExtensionWithTool(this._tool);
 
   final ClientTool _tool;
@@ -150,7 +150,7 @@ AgentSession createSession({
     runtime: runtime ?? MockAgentRuntime(),
     orchestrator: orchestrator,
     toolRegistry: registry,
-    extensions: extensions,
+    coordinator: SessionCoordinator(extensions),
     logger: logger,
   );
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -70,10 +70,10 @@ packages:
     dependency: transitive
     description:
       name: characters
-      sha256: f71061c654a3380576a52b451dd5532377954cf9dbd272a78fc8479606670803
+      sha256: faf38497bda5ead2a8c7615f4f7939df04333478bf32e4173fcb06d428b5716b
       url: "https://pub.dev"
     source: hosted
-    version: "1.4.0"
+    version: "1.4.1"
   checked_yaml:
     dependency: transitive
     description:
@@ -481,14 +481,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.0.1"
-  js:
-    dependency: transitive
-    description:
-      name: js
-      sha256: "53385261521cc4a0c4658fd0ad07a7d14591cf8fc33abbceae306ddb974888dc"
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.7.2"
   json_annotation:
     dependency: transitive
     description:
@@ -549,18 +541,18 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: dc58c723c3c24bf8d3e2d3ad3f2f9d7bd9cf43ec6feaa64181775e60190153f2
+      sha256: dc0b7dc7651697ea4ff3e69ef44b0407ea32c487a39fff6a4004fa585e901861
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.17"
+    version: "0.12.19"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: f7142bb1154231d7ea5f96bc7bde4bda2a0945d2806bb11670e30b850d56bdec
+      sha256: "9c337007e82b1889149c82ed242ed1cb24a66044e30979c44912381e9be4c48b"
       url: "https://pub.dev"
     source: hosted
-    version: "0.11.1"
+    version: "0.13.0"
   meta:
     dependency: transitive
     description:
@@ -938,26 +930,26 @@ packages:
     dependency: transitive
     description:
       name: test
-      sha256: "75906bf273541b676716d1ca7627a17e4c4070a3a16272b7a3dc7da3b9f3f6b7"
+      sha256: "280d6d890011ca966ad08df7e8a4ddfab0fb3aa49f96ed6de56e3521347a9ae7"
       url: "https://pub.dev"
     source: hosted
-    version: "1.26.3"
+    version: "1.30.0"
   test_api:
     dependency: transitive
     description:
       name: test_api
-      sha256: ab2726c1a94d3176a45960b6234466ec367179b87dd74f1611adb1f3b5fb9d55
+      sha256: "8161c84903fd860b26bfdefb7963b3f0b68fee7adea0f59ef805ecca346f0c7a"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.7"
+    version: "0.7.10"
   test_core:
     dependency: transitive
     description:
       name: test_core
-      sha256: "0cc24b5ff94b38d2ae73e1eb43cc302b77964fbf67abad1e296025b78deb53d0"
+      sha256: "0381bd1585d1a924763c308100f2138205252fb90c9d4eeaf28489ee65ccde51"
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.12"
+    version: "0.6.16"
   tuple:
     dependency: transitive
     description:


### PR DESCRIPTION
## Summary

- Adds `StatefulSessionExtension<T>` mixin — lifecycle unit that owns a typed `Signal<T>`, exposes `stateSignal`, `state` R/W, and auto-disposes
- Adds `SessionCoordinator` — priority-sorted attach/dispose, namespace uniqueness validation, `getExtension<T>()`, `statefulObservations()` iterator
- Adds `HasStatefulObservation` marker interface
- Wires coordinator into `AgentSession` and `AgentRuntime`

## Test plan

- [ ] `dart test packages/soliplex_agent/test/runtime/session_coordinator_test.dart`
- [ ] `dart test packages/soliplex_agent/test/runtime/stateful_session_extension_test.dart`
- [ ] `flutter analyze` zero warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)