### PR TITLE
M2: feat(room): ExecutionTrackerExtension (first reactor)

### DIFF
--- a/lib/src/flavors/standard.dart
+++ b/lib/src/flavors/standard.dart
@@ -22,6 +22,7 @@ import '../modules/diagnostics/network_inspector.dart';
 import '../modules/lobby/lobby_module.dart';
 import '../modules/quiz/quiz_module.dart';
 import '../modules/room/agent_runtime_manager.dart';
+import '../modules/room/execution_tracker_extension.dart';
 import '../modules/room/room_module.dart';
 import '../modules/room/run_registry.dart';
 import '../modules/room/ui/markdown/markdown_theme_extension.dart';
@@ -134,6 +135,7 @@ Future<ShellConfig> standard({
         : const NativePlatformConstraints(),
     toolRegistryResolver: (_) async => const ToolRegistry(),
     logger: LogManager.instance.getLogger('room'),
+    extensionFactory: () async => [ExecutionTrackerExtension()],
   );
 
   final registry = RunRegistry();

--- a/lib/src/modules/room/execution_tracker_extension.dart
+++ b/lib/src/modules/room/execution_tracker_extension.dart
@@ -1,0 +1,69 @@
+import 'package:soliplex_agent/soliplex_agent.dart';
+
+import 'execution_tracker.dart';
+import 'tracker_registry.dart';
+
+/// A [SessionExtension] that reacts to [AgentSession] run-state changes and
+/// drives an internal [TrackerRegistry].
+///
+/// Subscribes to `session.runState` in [onAttach] and routes
+/// [RunningState]/terminal states into the registry. The resulting
+/// [Map<String, ExecutionTracker>] is exposed via the [stateSignal] and the
+/// convenience [trackers] getter.
+///
+/// [ThreadViewState] absorbs the live trackers into its own historical
+/// registry on detach, so execution data persists after the session ends.
+class ExecutionTrackerExtension extends SessionExtension
+    with StatefulSessionExtension<Map<String, ExecutionTracker>> {
+  ExecutionTrackerExtension() : _registry = TrackerRegistry() {
+    setInitialState(const <String, ExecutionTracker>{});
+  }
+
+  final TrackerRegistry _registry;
+  void Function()? _runStateUnsub;
+  AgentSession? _session;
+
+  @override
+  String get namespace => 'execution_tracker';
+
+  @override
+  int get priority => 10;
+
+  @override
+  List<ClientTool> get tools => const [];
+
+  /// Current tracker map (historical + live for this session).
+  Map<String, ExecutionTracker> get trackers => _registry.trackers;
+
+  @override
+  Future<void> onAttach(AgentSession session) async {
+    _session = session;
+    _runStateUnsub = session.runState.subscribe(_onRunState);
+  }
+
+  @override
+  void onDispose() {
+    _runStateUnsub?.call();
+    _runStateUnsub = null;
+    _session = null;
+    _registry.dispose();
+    super.onDispose();
+  }
+
+  void _onRunState(RunState runState) {
+    final session = _session;
+    if (session == null) return;
+    switch (runState) {
+      case RunningState(:final streaming):
+        _registry.onStreaming(streaming, session.lastExecutionEvent);
+        _sync();
+      case CompletedState() || FailedState() || CancelledState():
+        _registry.onRunTerminated();
+        _sync();
+      case IdleState() || ToolYieldingState():
+        break;
+    }
+  }
+
+  void _sync() => state = _registry.trackers;
+}

--- a/lib/src/modules/room/thread_view_state.dart
+++ b/lib/src/modules/room/thread_view_state.dart
@@ -4,6 +4,7 @@ import 'package:flutter/foundation.dart' show debugPrint;
 import 'package:soliplex_agent/soliplex_agent.dart';
 
 import 'execution_tracker.dart';
+import 'execution_tracker_extension.dart';
 import 'historical_replay.dart';
 import 'run_registry.dart';
 import 'send_error.dart';
@@ -102,9 +103,17 @@ class ThreadViewState {
   final Signal<SendError?> _lastSendError = Signal<SendError?>(null);
   ReadonlySignal<SendError?> get lastSendError => _lastSendError;
 
+  // Persists historical trackers from loaded thread history and from
+  // completed sessions (absorbed in _detachSession).
   final TrackerRegistry _trackerRegistry = TrackerRegistry();
-  Map<String, ExecutionTracker> get executionTrackers =>
-      _trackerRegistry.trackers;
+
+  /// Returns all execution trackers for this thread: historical (from loaded
+  /// thread history) merged with any live trackers from the active session.
+  Map<String, ExecutionTracker> get executionTrackers {
+    final ext = _activeSession?.getExtension<ExecutionTrackerExtension>();
+    if (ext == null) return _trackerRegistry.trackers;
+    return {..._trackerRegistry.trackers, ...ext.trackers};
+  }
 
   void submitFeedback(String runId, FeedbackType feedback, String? reason) {
     unawaited(
@@ -189,8 +198,6 @@ class ThreadViewState {
   }
 
   void _onRunState(RunState runState) {
-    final session = _activeSession;
-    if (session == null) return;
     switch (runState) {
       case RunningState(:final conversation, :final streaming):
         final current = _messages.value;
@@ -200,23 +207,16 @@ class ThreadViewState {
         }
         _streamingState.value = streaming;
         _sessionState.value = AgentSessionState.running;
-        _trackerRegistry.onStreaming(
-          streaming,
-          session.lastExecutionEvent,
-        );
       case CompletedState(:final conversation):
-        _trackerRegistry.onRunTerminated();
         _detachSession();
         _messages.value = _messagesLoaded(conversation);
       case FailedState(:final conversation, :final error):
-        _trackerRegistry.onRunTerminated();
         _detachSession();
         _lastSendError.value = SendError(error);
         if (conversation != null) {
           _messages.value = _messagesLoaded(conversation);
         }
       case CancelledState(:final conversation):
-        _trackerRegistry.onRunTerminated();
         _detachSession();
         if (conversation != null) {
           _messages.value = _messagesLoaded(conversation);
@@ -240,6 +240,12 @@ class ThreadViewState {
   }
 
   void _detachSession() {
+    // Absorb live trackers from the extension before clearing the session
+    // reference, so historical data persists after the session ends.
+    final ext = _activeSession?.getExtension<ExecutionTrackerExtension>();
+    if (ext != null) {
+      _trackerRegistry.seedHistorical(ext.trackers);
+    }
     _runStateUnsub?.call();
     _runStateUnsub = null;
     _activeSession = null;

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -70,10 +70,10 @@ packages:
     dependency: transitive
     description:
       name: characters
-      sha256: f71061c654a3380576a52b451dd5532377954cf9dbd272a78fc8479606670803
+      sha256: faf38497bda5ead2a8c7615f4f7939df04333478bf32e4173fcb06d428b5716b
       url: "https://pub.dev"
     source: hosted
-    version: "1.4.0"
+    version: "1.4.1"
   checked_yaml:
     dependency: transitive
     description:
@@ -481,14 +481,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.0.1"
-  js:
-    dependency: transitive
-    description:
-      name: js
-      sha256: "53385261521cc4a0c4658fd0ad07a7d14591cf8fc33abbceae306ddb974888dc"
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.7.2"
   json_annotation:
     dependency: transitive
     description:
@@ -549,18 +541,18 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: dc58c723c3c24bf8d3e2d3ad3f2f9d7bd9cf43ec6feaa64181775e60190153f2
+      sha256: dc0b7dc7651697ea4ff3e69ef44b0407ea32c487a39fff6a4004fa585e901861
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.17"
+    version: "0.12.19"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: f7142bb1154231d7ea5f96bc7bde4bda2a0945d2806bb11670e30b850d56bdec
+      sha256: "9c337007e82b1889149c82ed242ed1cb24a66044e30979c44912381e9be4c48b"
       url: "https://pub.dev"
     source: hosted
-    version: "0.11.1"
+    version: "0.13.0"
   meta:
     dependency: transitive
     description:
@@ -938,26 +930,26 @@ packages:
     dependency: transitive
     description:
       name: test
-      sha256: "75906bf273541b676716d1ca7627a17e4c4070a3a16272b7a3dc7da3b9f3f6b7"
+      sha256: "280d6d890011ca966ad08df7e8a4ddfab0fb3aa49f96ed6de56e3521347a9ae7"
       url: "https://pub.dev"
     source: hosted
-    version: "1.26.3"
+    version: "1.30.0"
   test_api:
     dependency: transitive
     description:
       name: test_api
-      sha256: ab2726c1a94d3176a45960b6234466ec367179b87dd74f1611adb1f3b5fb9d55
+      sha256: "8161c84903fd860b26bfdefb7963b3f0b68fee7adea0f59ef805ecca346f0c7a"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.7"
+    version: "0.7.10"
   test_core:
     dependency: transitive
     description:
       name: test_core
-      sha256: "0cc24b5ff94b38d2ae73e1eb43cc302b77964fbf67abad1e296025b78deb53d0"
+      sha256: "0381bd1585d1a924763c308100f2138205252fb90c9d4eeaf28489ee65ccde51"
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.12"
+    version: "0.6.16"
   tuple:
     dependency: transitive
     description:


### PR DESCRIPTION
## Summary

- `ExecutionTrackerExtension` — first concrete reactor: attaches to `AgentSession.runState`, drives `TrackerRegistry`, exposes `Map<String, ExecutionTracker>` via `stateSignal`
- `ThreadViewState` absorbs live trackers from the extension rather than owning `TrackerRegistry` directly
- Wires `extensionFactory` in `standard.dart`

## Test plan

- [ ] `flutter test test/modules/room/execution_tracker_extension_test.dart`
- [ ] `flutter analyze` zero warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)