### PR TITLE
M3: feat(room): SessionSpawner

### DIFF
--- a/lib/src/modules/room/room_state.dart
+++ b/lib/src/modules/room/room_state.dart
@@ -1,11 +1,11 @@
 import 'dart:async' show unawaited;
-import 'dart:developer' as dev;
 
 import 'package:soliplex_agent/soliplex_agent.dart';
 
 import '../auth/server_entry.dart';
 import 'agent_runtime_manager.dart';
 import 'run_registry.dart';
+import 'session_spawner.dart';
 import 'thread_list_state.dart';
 import 'thread_view_state.dart';
 import 'upload_tracker.dart';
@@ -64,18 +64,16 @@ class RoomState {
   final UploadTracker uploadTracker;
   ThreadViewState? _activeThreadView;
   CancelToken? _roomFetchToken;
-  Future<AgentSession>? _pendingSpawn;
   bool _isDisposed = false;
+
+  final SessionSpawner _spawner = SessionSpawner();
 
   final Signal<RoomStatus> _room = Signal<RoomStatus>(RoomLoading());
   ReadonlySignal<RoomStatus> get room => _room;
 
-  // Lifecycle: null → spawning (sendToNewThread) → null (on completion,
-  //            error, or cancelSpawn). Doubles as a concurrency guard and
-  //            the UI signal for ChatInput's cancel button.
-  final Signal<AgentSessionState?> _sessionState =
-      Signal<AgentSessionState?>(null);
-  ReadonlySignal<AgentSessionState?> get sessionState => _sessionState;
+  /// Tracks the spawn lifecycle: null → spawning → null.
+  /// Non-null while a new-thread spawn is in progress.
+  ReadonlySignal<AgentSessionState?> get sessionState => _spawner.sessionState;
 
   final Signal<SendError?> _lastError = Signal<SendError?>(null);
   ReadonlySignal<SendError?> get lastError => _lastError;
@@ -167,79 +165,53 @@ class RoomState {
     return null;
   }
 
+  /// Cancels a pending new-thread spawn. No-op if nothing is in progress.
+  void cancelSpawn() => _spawner.cancel();
+
   /// Implicit thread creation (send message with no thread selected).
   ///
   /// Spawns a session which creates the thread server-side, then creates a
   /// [ThreadViewState] and attaches the session to it.
-  void cancelSpawn() {
-    final pending = _pendingSpawn;
-    if (pending == null) return;
-    _pendingSpawn = null;
-    _sessionState.value = null;
-    unawaited(pending.then((s) {
-      s.cancel();
-      s.dispose();
-    }).catchError((Object e, StackTrace st) {
-      dev.log(
-        'Cancelled spawn cleanup failed',
-        error: e,
-        stackTrace: st,
-        name: 'RoomState',
-        level: 1000,
-      );
-    }));
-  }
-
   Future<void> sendToNewThread(
     String prompt, {
     Map<String, dynamic>? stateOverlay,
-  }) async {
-    if (_sessionState.value != null) return;
-    _lastError.value = null;
-    _sessionState.value = AgentSessionState.spawning;
-    Future<AgentSession>? spawnFuture;
-    try {
-      spawnFuture = runtime.spawn(
-        roomId: _roomId,
+  }) =>
+      _spawner.spawn(
+        spawnFn: () => runtime.spawn(
+          roomId: _roomId,
+          prompt: prompt,
+          stateOverlay: stateOverlay,
+        ),
+        errorSignal: _lastError,
         prompt: prompt,
-        stateOverlay: stateOverlay,
+        isDisposed: () => _isDisposed,
+        onSpawned: (session) {
+          // Clear room-level spawn state — the thread view takes over.
+          _spawner.updateState(null);
+          final key = session.threadKey;
+          _registry.register(key, session);
+          if (_isDisposed) return;
+          // Spawn only exposes a threadKey — no ThreadInfo. Insert a stub so
+          // the sidebar reflects the new thread immediately. The backend
+          // generates the thread's name lazily after the run finishes; the
+          // sidebar picks that up on the next natural refresh (room change,
+          // pull-to-refresh, re-entry).
+          threadList.noteSpawnedThread(ThreadInfo(
+            id: key.threadId,
+            roomId: _roomId,
+            createdAt: DateTime.now(),
+          ));
+          selectThread(key.threadId);
+          _activeThreadView!.attachSession(session);
+          onNavigateToThread?.call(key.threadId);
+        },
       );
-      _pendingSpawn = spawnFuture;
-      final session = await spawnFuture;
-      if (_pendingSpawn != spawnFuture) return;
-      _pendingSpawn = null;
-      _sessionState.value = null;
-      final key = session.threadKey;
-      _registry.register(key, session);
-      if (_isDisposed) return;
-      // Spawn only exposes a threadKey — no ThreadInfo. Insert a stub so
-      // the sidebar reflects the new thread immediately. The backend
-      // generates the thread's name lazily after the run finishes; the
-      // sidebar picks that up on the next natural refresh (room change,
-      // pull-to-refresh, re-entry).
-      threadList.noteSpawnedThread(ThreadInfo(
-        id: key.threadId,
-        roomId: _roomId,
-        createdAt: DateTime.now(),
-      ));
-      selectThread(key.threadId);
-      _activeThreadView!.attachSession(session);
-      onNavigateToThread?.call(key.threadId);
-    } on Object catch (error) {
-      if (_isDisposed || _sessionState.value == null) return;
-      _lastError.value = SendError(error, unsentText: prompt);
-    } finally {
-      if (_pendingSpawn == spawnFuture) {
-        _pendingSpawn = null;
-        _sessionState.value = null;
-      }
-    }
-  }
 
   void dispose() {
     _isDisposed = true;
     _roomFetchToken?.cancel('disposed');
     threadList.dispose();
     _activeThreadView?.dispose();
+    _spawner.dispose();
   }
 }

--- a/lib/src/modules/room/session_spawner.dart
+++ b/lib/src/modules/room/session_spawner.dart
@@ -1,0 +1,98 @@
+import 'dart:async' show unawaited;
+
+import 'package:flutter/foundation.dart' show debugPrint;
+import 'package:soliplex_agent/soliplex_agent.dart';
+
+import 'send_error.dart';
+
+/// Owns the pending-spawn state machine shared by [ThreadViewState] and
+/// [RoomState].
+///
+/// Encapsulates:
+/// - The concurrency guard (`sessionState` is non-null while a spawn or
+///   active session is in progress).
+/// - Pending-future tracking and race detection via [cancel].
+/// - Cleanup of a spawn future that was abandoned by [cancel].
+///
+/// Callers drive non-spawn lifecycle updates via [updateState].
+///
+/// **Dispose vs cancel semantics**: [dispose] only marks the spawner as
+/// disposed; it does NOT cancel in-flight spawns. This preserves the
+/// invariant that a session is always registered in the registry even if
+/// the owning view is disposed before the spawn resolves. Use [cancel]
+/// (via `cancelRun`/`cancelSpawn`) to explicitly abort a pending spawn.
+class SessionSpawner {
+  final Signal<AgentSessionState?> _sessionState = Signal(null);
+  Future<AgentSession>? _pendingSpawn;
+
+  ReadonlySignal<AgentSessionState?> get sessionState =>
+      _sessionState.readonly();
+
+  /// Updates the session state from outside the spawn lifecycle —
+  /// e.g. running, completed, or cleared after detach.
+  void updateState(AgentSessionState? state) => _sessionState.value = state;
+
+  /// Runs the spawn state machine.
+  ///
+  /// - Guards against concurrent spawns (no-op if [sessionState] is
+  ///   non-null).
+  /// - Clears [errorSignal] and sets state to [AgentSessionState.spawning].
+  /// - Awaits the future returned by [spawnFn] with race detection.
+  /// - On success, calls [onSpawned]; the callback is responsible for
+  ///   checking whether the owner is disposed before attaching.
+  /// - On error, calls [isDisposed] (or checks `_sessionState == null`
+  ///   for cancellation) before surfacing the error in [errorSignal].
+  /// - Always cleans up pending state in the `finally` block.
+  Future<void> spawn({
+    required Future<AgentSession> Function() spawnFn,
+    required Signal<SendError?> errorSignal,
+    required String prompt,
+    required bool Function() isDisposed,
+    required void Function(AgentSession) onSpawned,
+  }) async {
+    if (_sessionState.value != null) return;
+    errorSignal.value = null;
+    _sessionState.value = AgentSessionState.spawning;
+    Future<AgentSession>? future;
+    try {
+      future = spawnFn();
+      _pendingSpawn = future;
+      final session = await future;
+      if (_pendingSpawn != future) return; // Cancelled via cancel().
+      _pendingSpawn = null;
+      onSpawned(session); // Callback owns the dispose/attach decision.
+    } on Object catch (error) {
+      // Suppress errors when cancelled (_sessionState cleared by cancel())
+      // or when the owning view is disposed.
+      if (isDisposed() || _sessionState.value == null) return;
+      errorSignal.value = SendError(error, unsentText: prompt);
+    } finally {
+      if (_pendingSpawn == future) {
+        _pendingSpawn = null;
+        _sessionState.value = null;
+      }
+    }
+  }
+
+  /// Cancels the pending spawn, if any. Returns `true` if a spawn was
+  /// cancelled, `false` if there was nothing pending.
+  bool cancel() {
+    final pending = _pendingSpawn;
+    if (pending == null) return false;
+    _pendingSpawn = null;
+    _sessionState.value = null;
+    unawaited(
+      pending.then((s) {
+        s.cancel();
+        s.dispose();
+      }).catchError((Object e) {
+        debugPrint('SessionSpawner: cancelled spawn cleanup failed: $e');
+      }),
+    );
+    return true;
+  }
+
+  /// No-op. In-flight spawns complete normally so sessions are always
+  /// registered. Use [cancel] to explicitly abort a pending spawn.
+  void dispose() {}
+}

--- a/lib/src/modules/room/thread_view_state.dart
+++ b/lib/src/modules/room/thread_view_state.dart
@@ -8,6 +8,7 @@ import 'execution_tracker_extension.dart';
 import 'historical_replay.dart';
 import 'run_registry.dart';
 import 'send_error.dart';
+import 'session_spawner.dart';
 import 'tracker_registry.dart';
 
 export 'send_error.dart';
@@ -81,9 +82,10 @@ class ThreadViewState {
 
   CancelToken? _cancelToken;
   AgentSession? _activeSession;
-  Future<AgentSession>? _pendingSpawn;
   void Function()? _runStateUnsub;
   bool _isDisposed = false;
+
+  final SessionSpawner _spawner = SessionSpawner();
 
   final Signal<ThreadViewStatus> _messages =
       Signal<ThreadViewStatus>(MessagesLoading());
@@ -92,13 +94,10 @@ class ThreadViewState {
   final Signal<StreamingState?> _streamingState = Signal<StreamingState?>(null);
   ReadonlySignal<StreamingState?> get streamingState => _streamingState;
 
-  // Lifecycle: null → spawning (sendMessage) → running (_onRunState)
-  //            → null (_detachSession on terminal state, or cancelRun).
-  //            Doubles as a concurrency guard (sendMessage rejects if non-null)
-  //            and the UI signal for ChatInput's cancel button.
-  final Signal<AgentSessionState?> _sessionState =
-      Signal<AgentSessionState?>(null);
-  ReadonlySignal<AgentSessionState?> get sessionState => _sessionState;
+  /// Tracks the session lifecycle: null → spawning → running → null.
+  /// Managed by [_spawner] during spawn; updated via [_spawner.updateState]
+  /// for running and detach transitions.
+  ReadonlySignal<AgentSessionState?> get sessionState => _spawner.sessionState;
 
   final Signal<SendError?> _lastSendError = Signal<SendError?>(null);
   ReadonlySignal<SendError?> get lastSendError => _lastSendError;
@@ -133,59 +132,31 @@ class ThreadViewState {
     String prompt,
     AgentRuntime runtime, {
     Map<String, dynamic>? stateOverlay,
-  }) async {
-    if (_sessionState.value != null) return;
-    _lastSendError.value = null;
-    _sessionState.value = AgentSessionState.spawning;
-    Future<AgentSession>? spawnFuture;
-    try {
-      spawnFuture = runtime.spawn(
-        roomId: _roomId,
+  }) =>
+      _spawner.spawn(
+        spawnFn: () => runtime.spawn(
+          roomId: _roomId,
+          prompt: prompt,
+          threadId: threadId,
+          stateOverlay: stateOverlay,
+        ),
+        errorSignal: _lastSendError,
         prompt: prompt,
-        threadId: threadId,
-        stateOverlay: stateOverlay,
+        isDisposed: () => _isDisposed,
+        onSpawned: (session) {
+          _registry.register(threadKey, session);
+          if (_isDisposed) return;
+          _attachSession(session);
+        },
       );
-      _pendingSpawn = spawnFuture;
-      final session = await spawnFuture;
-      if (_pendingSpawn != spawnFuture) return;
-      _pendingSpawn = null;
-      _registry.register(threadKey, session);
-      if (_isDisposed) return;
-      _attachSession(session);
-    } on Object catch (error) {
-      if (_isDisposed || _sessionState.value == null) return;
-      _lastSendError.value = SendError(error, unsentText: prompt);
-    } finally {
-      if (_pendingSpawn == spawnFuture) {
-        _pendingSpawn = null;
-        _sessionState.value = null;
-      }
-    }
-  }
 
   void attachSession(AgentSession session) {
     _attachSession(session);
   }
 
   void cancelRun() {
-    if (_cancelPendingSpawn()) return;
+    if (_spawner.cancel()) return;
     _activeSession?.cancel();
-  }
-
-  /// Cancels a pending spawn if one exists. Returns true if a spawn was
-  /// cancelled, false if there was nothing pending.
-  bool _cancelPendingSpawn() {
-    final pending = _pendingSpawn;
-    if (pending == null) return false;
-    _pendingSpawn = null;
-    _sessionState.value = null;
-    unawaited(pending.then((s) {
-      s.cancel();
-      s.dispose();
-    }).catchError((Object e) {
-      debugPrint('Cancelled spawn cleanup failed: $e');
-    }));
-    return true;
   }
 
   void _attachSession(AgentSession session) {
@@ -193,7 +164,7 @@ class ThreadViewState {
     _detachSession();
     _cancelToken?.cancel('session attached');
     _activeSession = session;
-    _sessionState.value = session.state;
+    _spawner.updateState(session.state);
     _runStateUnsub = session.runState.subscribe(_onRunState);
   }
 
@@ -206,7 +177,7 @@ class ThreadViewState {
           _messages.value = _messagesLoaded(conversation);
         }
         _streamingState.value = streaming;
-        _sessionState.value = AgentSessionState.running;
+        _spawner.updateState(AgentSessionState.running);
       case CompletedState(:final conversation):
         _detachSession();
         _messages.value = _messagesLoaded(conversation);
@@ -250,7 +221,7 @@ class ThreadViewState {
     _runStateUnsub = null;
     _activeSession = null;
     _streamingState.value = null;
-    _sessionState.value = null;
+    _spawner.updateState(null);
   }
 
   bool _restoreFromRegistry() {
@@ -318,5 +289,6 @@ class ThreadViewState {
     _cancelToken?.cancel('disposed');
     _detachSession();
     _trackerRegistry.dispose();
+    _spawner.dispose();
   }
 }

--- a/lib/src/modules/room/ui/room_screen.dart
+++ b/lib/src/modules/room/ui/room_screen.dart
@@ -456,12 +456,18 @@ class _RoomScreenState extends State<RoomScreen> {
 
     return Column(
       children: [
-        _buildRoomHeader(room, roomStatus, threadStatus),
-        if (_filesExpanded) _buildFilePanel(roomStatus, threadStatus),
         Expanded(
-          child: threadView == null
-              ? _buildNoThreadBody(room)
-              : _buildThreadBody(threadView, room),
+          child: Column(
+            children: [
+              _buildRoomHeader(room, roomStatus, threadStatus),
+              if (_filesExpanded) _buildFilePanel(roomStatus, threadStatus),
+              Expanded(
+                child: threadView == null
+                    ? _buildNoThreadBody(room)
+                    : _buildThreadBody(threadView, room),
+              ),
+            ],
+          ),
         ),
       ],
     );

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -70,10 +70,10 @@ packages:
     dependency: transitive
     description:
       name: characters
-      sha256: f71061c654a3380576a52b451dd5532377954cf9dbd272a78fc8479606670803
+      sha256: faf38497bda5ead2a8c7615f4f7939df04333478bf32e4173fcb06d428b5716b
       url: "https://pub.dev"
     source: hosted
-    version: "1.4.0"
+    version: "1.4.1"
   checked_yaml:
     dependency: transitive
     description:
@@ -481,14 +481,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.0.1"
-  js:
-    dependency: transitive
-    description:
-      name: js
-      sha256: "53385261521cc4a0c4658fd0ad07a7d14591cf8fc33abbceae306ddb974888dc"
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.7.2"
   json_annotation:
     dependency: transitive
     description:
@@ -549,18 +541,18 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: dc58c723c3c24bf8d3e2d3ad3f2f9d7bd9cf43ec6feaa64181775e60190153f2
+      sha256: dc0b7dc7651697ea4ff3e69ef44b0407ea32c487a39fff6a4004fa585e901861
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.17"
+    version: "0.12.19"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: f7142bb1154231d7ea5f96bc7bde4bda2a0945d2806bb11670e30b850d56bdec
+      sha256: "9c337007e82b1889149c82ed242ed1cb24a66044e30979c44912381e9be4c48b"
       url: "https://pub.dev"
     source: hosted
-    version: "0.11.1"
+    version: "0.13.0"
   meta:
     dependency: transitive
     description:
@@ -938,26 +930,26 @@ packages:
     dependency: transitive
     description:
       name: test
-      sha256: "75906bf273541b676716d1ca7627a17e4c4070a3a16272b7a3dc7da3b9f3f6b7"
+      sha256: "280d6d890011ca966ad08df7e8a4ddfab0fb3aa49f96ed6de56e3521347a9ae7"
       url: "https://pub.dev"
     source: hosted
-    version: "1.26.3"
+    version: "1.30.0"
   test_api:
     dependency: transitive
     description:
       name: test_api
-      sha256: ab2726c1a94d3176a45960b6234466ec367179b87dd74f1611adb1f3b5fb9d55
+      sha256: "8161c84903fd860b26bfdefb7963b3f0b68fee7adea0f59ef805ecca346f0c7a"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.7"
+    version: "0.7.10"
   test_core:
     dependency: transitive
     description:
       name: test_core
-      sha256: "0cc24b5ff94b38d2ae73e1eb43cc302b77964fbf67abad1e296025b78deb53d0"
+      sha256: "0381bd1585d1a924763c308100f2138205252fb90c9d4eeaf28489ee65ccde51"
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.12"
+    version: "0.6.16"
   tuple:
     dependency: transitive
     description:


### PR DESCRIPTION
## Summary

- Extracts `SessionSpawner` — owns the pending-spawn state machine shared by `ThreadViewState` and `RoomState`
- Encapsulates: concurrency guard, race detection via `cancel()`, error surfacing into `SendError` signal
- Eliminates ~30 lines of duplicated spawn/cancel logic from each state class

## Test plan

- [ ] `flutter test test/modules/room/session_spawner_test.dart`
- [ ] `flutter analyze` zero warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)