### PR TITLE
M10: feat(room): ExtensionStatePanel via statefulObservations()

### DIFF
--- a/lib/src/modules/room/human_approval_extension.dart
+++ b/lib/src/modules/room/human_approval_extension.dart
@@ -1,6 +1,6 @@
 import 'dart:async';
 
-import 'package:meta/meta.dart';
+import 'package:flutter/foundation.dart' show immutable;
 import 'package:soliplex_agent/soliplex_agent.dart';
 
 /// An in-flight tool approval request waiting for a user decision.

--- a/lib/src/modules/room/thread_view_state.dart
+++ b/lib/src/modules/room/thread_view_state.dart
@@ -137,6 +137,14 @@ class ThreadViewState {
   HumanApprovalExtension? get approvalExtension =>
       _activeSession?.getExtension<HumanApprovalExtension>();
 
+  /// Returns `(namespace, signal)` pairs for every stateful extension on the
+  /// active session, or an empty iterable if no session is attached.
+  ///
+  /// Re-evaluate whenever [sessionState] changes.
+  Iterable<(String, ReadonlySignal<Object?>)> get statefulObservations =>
+      _activeSession?.statefulObservations() ??
+      const <(String, ReadonlySignal<Object?>)>[];
+
   void submitFeedback(String runId, FeedbackType feedback, String? reason) {
     unawaited(
       _connection.api

--- a/lib/src/modules/room/tool_calls_extension.dart
+++ b/lib/src/modules/room/tool_calls_extension.dart
@@ -1,6 +1,5 @@
-import 'package:meta/meta.dart';
+import 'package:flutter/foundation.dart' show immutable;
 import 'package:soliplex_agent/soliplex_agent.dart';
-import 'package:soliplex_client/soliplex_client.dart' show ToolCallStatus;
 
 /// A tool call's current status during a session.
 @immutable

--- a/lib/src/modules/room/ui/extension_state_panel.dart
+++ b/lib/src/modules/room/ui/extension_state_panel.dart
@@ -1,0 +1,190 @@
+import 'dart:convert';
+
+import 'package:flutter/material.dart';
+import 'package:signals_core/signals_core.dart' show ReadonlySignal;
+import 'package:signals_flutter/signals_flutter.dart';
+
+import '../thread_view_state.dart';
+
+/// Collapsible debug panel that renders live reactive state for every
+/// [StatefulSessionExtension] in the active [AgentSession].
+///
+/// Iterates [ThreadViewState.statefulObservations] to obtain
+/// `(namespace, signal)` pairs, then renders a row per extension that
+/// rebuilds independently as each signal changes. The panel itself rebuilds
+/// when [ThreadViewState.sessionState] changes (session attached/detached).
+class ExtensionStatePanel extends StatefulWidget {
+  const ExtensionStatePanel({super.key, required this.threadView});
+  final ThreadViewState threadView;
+
+  @override
+  State<ExtensionStatePanel> createState() => _ExtensionStatePanelState();
+}
+
+class _ExtensionStatePanelState extends State<ExtensionStatePanel> {
+  void Function()? _unsub;
+  List<(String, ReadonlySignal<Object?>)> _observations = const [];
+  bool _isExpanded = false;
+
+  @override
+  void initState() {
+    super.initState();
+    _subscribe(widget.threadView);
+  }
+
+  @override
+  void didUpdateWidget(ExtensionStatePanel oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (oldWidget.threadView != widget.threadView) {
+      _unsub?.call();
+      _subscribe(widget.threadView);
+    }
+  }
+
+  void _subscribe(ThreadViewState view) {
+    setState(() {
+      _observations = view.statefulObservations.toList();
+    });
+    _unsub = view.sessionState.subscribe((_) {
+      if (!mounted) return;
+      setState(() {
+        _observations = view.statefulObservations.toList();
+      });
+    });
+  }
+
+  @override
+  void dispose() {
+    _unsub?.call();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    if (_observations.isEmpty) return const SizedBox.shrink();
+
+    final theme = Theme.of(context);
+    return Container(
+      decoration: BoxDecoration(
+        color: theme.colorScheme.surfaceContainerHigh,
+        border: Border(
+          top: BorderSide(color: theme.colorScheme.outlineVariant),
+        ),
+      ),
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          InkWell(
+            onTap: () => setState(() => _isExpanded = !_isExpanded),
+            child: Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+              child: Row(
+                children: [
+                  Icon(
+                    Icons.extension,
+                    size: 16,
+                    color: theme.colorScheme.secondary,
+                  ),
+                  const SizedBox(width: 8),
+                  Text(
+                    'EXTENSIONS',
+                    style: theme.textTheme.labelSmall?.copyWith(
+                      letterSpacing: 1.1,
+                      fontWeight: FontWeight.bold,
+                    ),
+                  ),
+                  const SizedBox(width: 8),
+                  Container(
+                    padding: const EdgeInsets.symmetric(
+                      horizontal: 6,
+                      vertical: 2,
+                    ),
+                    decoration: BoxDecoration(
+                      color: theme.colorScheme.secondaryContainer,
+                      borderRadius: BorderRadius.circular(10),
+                    ),
+                    child: Text(
+                      '${_observations.length}',
+                      style: theme.textTheme.labelSmall?.copyWith(
+                        color: theme.colorScheme.onSecondaryContainer,
+                      ),
+                    ),
+                  ),
+                  const Spacer(),
+                  Icon(
+                    _isExpanded
+                        ? Icons.keyboard_arrow_down
+                        : Icons.keyboard_arrow_up,
+                    size: 18,
+                  ),
+                ],
+              ),
+            ),
+          ),
+          if (_isExpanded)
+            ConstrainedBox(
+              constraints: const BoxConstraints(maxHeight: 320),
+              child: SingleChildScrollView(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.stretch,
+                  children: [
+                    for (final (namespace, signal) in _observations)
+                      _ExtensionRow(namespace: namespace, signal: signal),
+                  ],
+                ),
+              ),
+            ),
+        ],
+      ),
+    );
+  }
+}
+
+class _ExtensionRow extends StatelessWidget {
+  const _ExtensionRow({required this.namespace, required this.signal});
+  final String namespace;
+  final ReadonlySignal<Object?> signal;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final value = signal.watch(context);
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(16, 6, 16, 0),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            namespace,
+            style: theme.textTheme.labelSmall?.copyWith(
+              color: theme.colorScheme.secondary,
+              fontWeight: FontWeight.bold,
+              letterSpacing: 0.5,
+            ),
+          ),
+          const SizedBox(height: 2),
+          Text(
+            _encode(value),
+            style: theme.textTheme.bodySmall?.copyWith(
+              fontFamily: 'monospace',
+              fontSize: 10,
+              color: theme.colorScheme.onSurfaceVariant,
+            ),
+            maxLines: 6,
+            overflow: TextOverflow.ellipsis,
+          ),
+          const Divider(height: 12),
+        ],
+      ),
+    );
+  }
+
+  static String _encode(Object? value) {
+    try {
+      return const JsonEncoder.withIndent('  ').convert(value);
+    } catch (_) {
+      return value.toString();
+    }
+  }
+}

--- a/lib/src/modules/room/ui/extension_state_panel.dart
+++ b/lib/src/modules/room/ui/extension_state_panel.dart
@@ -1,7 +1,6 @@
 import 'dart:convert';
 
 import 'package:flutter/material.dart';
-import 'package:signals_core/signals_core.dart' show ReadonlySignal;
 import 'package:signals_flutter/signals_flutter.dart';
 
 import '../thread_view_state.dart';

--- a/lib/src/modules/room/ui/room_screen.dart
+++ b/lib/src/modules/room/ui/room_screen.dart
@@ -29,6 +29,7 @@ import 'message_timeline.dart';
 import 'async_action_dialog.dart';
 import 'room_welcome.dart';
 import 'thread_sidebar.dart';
+import 'extension_state_panel.dart';
 import 'state_panel.dart';
 import 'upload_event_banner.dart';
 import '../human_approval_extension.dart';
@@ -916,6 +917,7 @@ class _RoomScreenState extends State<RoomScreen> {
                 onToggle: () =>
                     setState(() => _statePanelExpanded = !_statePanelExpanded),
               ),
+            ExtensionStatePanel(threadView: threadView),
             ChatInput(
               onSend: (text) => threadView.sendMessage(
                 text,

--- a/packages/soliplex_agent/lib/src/runtime/tool_approval_extension.dart
+++ b/packages/soliplex_agent/lib/src/runtime/tool_approval_extension.dart
@@ -3,11 +3,11 @@ import 'package:soliplex_agent/src/runtime/session_extension.dart';
 /// An extension that can respond to tool approval requests.
 ///
 /// Subclass this in the application layer (e.g. `HumanApprovalExtension`) to
-/// intercept calls to [AgentSession.requestApproval] and surface them as
+/// intercept calls to `AgentSession.requestApproval` and surface them as
 /// reactive state that the UI can observe and respond to.
 ///
 /// When an instance of this extension is registered with a session,
-/// [AgentSession.requestApproval] delegates to [requestApproval] instead of
+/// `AgentSession.requestApproval` delegates to [requestApproval] instead of
 /// falling back to `AgentUiDelegate`. Only one `ToolApprovalExtension` may be
 /// registered per session (enforced by the namespace uniqueness check in
 /// `SessionCoordinator`).
@@ -15,7 +15,7 @@ abstract class ToolApprovalExtension extends SessionExtension {
   /// Requests user consent for the given tool call.
   ///
   /// Returns `true` to proceed with execution, `false` to deny.
-  /// The [AgentSession] races this future against its [CancelToken] —
+  /// The session races this future against its cancel token —
   /// cancellation automatically produces `false`.
   Future<bool> requestApproval({
     required String toolCallId,

--- a/packages/soliplex_agent/test/helpers/fake_tool_execution_context.dart
+++ b/packages/soliplex_agent/test/helpers/fake_tool_execution_context.dart
@@ -1,5 +1,4 @@
 import 'package:soliplex_agent/soliplex_agent.dart';
-import 'package:soliplex_agent/src/tools/tool_execution_context.dart';
 
 /// Test double for [ToolExecutionContext].
 ///

--- a/packages/soliplex_agent/test/tools/tool_registry_test.dart
+++ b/packages/soliplex_agent/test/tools/tool_registry_test.dart
@@ -1,5 +1,4 @@
 import 'package:soliplex_agent/soliplex_agent.dart';
-import 'package:soliplex_agent/src/tools/tool_execution_context.dart';
 import 'package:test/test.dart';
 
 import '../helpers/fake_tool_execution_context.dart';


### PR DESCRIPTION
## Summary

- `ExtensionStatePanel` — collapsible debug widget that iterates `ThreadViewState.statefulObservations` to show live reactive state for every `StatefulSessionExtension` in the active session
- Each row rebuilds independently as its signal changes; panel header shows extension count badge
- Subscribes to `sessionState` signal to refresh observation list when session is attached/detached

## Test plan

- [ ] `flutter test test/modules/room/ui/extension_state_panel_test.dart`
- [ ] Visual: open a room with an active session, verify panel shows extension state rows
- [ ] `flutter analyze` zero warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)