### PR TITLE
M11: test(m11): comprehensive tests for M1–M10 extension/coordinator work

### DIFF
--- a/packages/soliplex_agent/test/runtime/session_coordinator_test.dart
+++ b/packages/soliplex_agent/test/runtime/session_coordinator_test.dart
@@ -1,0 +1,348 @@
+import 'package:soliplex_agent/soliplex_agent.dart';
+import 'package:soliplex_agent/src/runtime/session_coordinator.dart';
+import 'package:soliplex_agent/src/runtime/stateful_session_extension.dart';
+import 'package:test/test.dart';
+
+// ---------------------------------------------------------------------------
+// Test doubles
+// ---------------------------------------------------------------------------
+
+class _FakeExtension extends SessionExtension {
+  _FakeExtension({String ns = '', int pri = 0, List<ClientTool> t = const []})
+      : _ns = ns,
+        _pri = pri,
+        _tools = t;
+
+  final String _ns;
+  final int _pri;
+  final List<ClientTool> _tools;
+
+  int attachCount = 0;
+  int disposeCount = 0;
+  AgentSession? attachedSession;
+
+  @override
+  String get namespace => _ns;
+
+  @override
+  int get priority => _pri;
+
+  @override
+  Future<void> onAttach(AgentSession session) async {
+    attachCount++;
+    attachedSession = session;
+  }
+
+  @override
+  List<ClientTool> get tools => _tools;
+
+  @override
+  void onDispose() => disposeCount++;
+}
+
+class _StatefulExtension extends SessionExtension
+    with StatefulSessionExtension<int> {
+  _StatefulExtension(int initial, {String ns = 'stateful', int pri = 0}) {
+    setInitialState(initial);
+    _ns = ns;
+    _pri = pri;
+  }
+
+  late final String _ns;
+  late final int _pri;
+
+  @override
+  String get namespace => _ns;
+
+  @override
+  int get priority => _pri;
+
+  @override
+  Future<void> onAttach(AgentSession session) async {}
+
+  @override
+  List<ClientTool> get tools => const [];
+
+  @override
+  void onDispose() => super.onDispose();
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+void main() {
+  group('SessionCoordinator', () {
+    group('namespace validation', () {
+      test('accepts empty list', () {
+        expect(() => SessionCoordinator(const []), returnsNormally);
+      });
+
+      test('accepts unique namespaces', () {
+        final a = _FakeExtension(ns: 'a');
+        final b = _FakeExtension(ns: 'b');
+        expect(() => SessionCoordinator([a, b]), returnsNormally);
+      });
+
+      test('accepts multiple extensions with empty namespace', () {
+        final a = _FakeExtension(ns: '');
+        final b = _FakeExtension(ns: '');
+        expect(() => SessionCoordinator([a, b]), returnsNormally);
+      });
+
+      test('throws ArgumentError for duplicate non-empty namespace', () {
+        final a = _FakeExtension(ns: 'dup');
+        final b = _FakeExtension(ns: 'dup');
+        expect(
+          () => SessionCoordinator([a, b]),
+          throwsA(isA<ArgumentError>()),
+        );
+      });
+    });
+
+    group('attachAll', () {
+      test('calls onAttach on all extensions', () async {
+        final a = _FakeExtension(ns: 'a');
+        final b = _FakeExtension(ns: 'b');
+        final coordinator = SessionCoordinator([a, b]);
+
+        // We can't easily pass a real AgentSession here, so we verify that
+        // attachCount increments (onAttach was called).
+        // Use a fake that satisfies the type requirement via noSuchMethod.
+        final fakeSession = _FakeAgentSessionStub();
+        await coordinator.attachAll(fakeSession);
+
+        expect(a.attachCount, 1);
+        expect(b.attachCount, 1);
+      });
+
+      test('attaches in descending priority order', () async {
+        final order = <int>[];
+        final low = _OrderRecordingExtension(ns: 'low', pri: 1, order: order);
+        final high = _OrderRecordingExtension(ns: 'high', pri: 10, order: order);
+        final mid = _OrderRecordingExtension(ns: 'mid', pri: 5, order: order);
+
+        final coordinator = SessionCoordinator([low, high, mid]);
+        await coordinator.attachAll(_FakeAgentSessionStub());
+
+        expect(order, [10, 5, 1]);
+      });
+    });
+
+    group('disposeAll', () {
+      test('calls onDispose on all extensions', () async {
+        final a = _FakeExtension(ns: 'a');
+        final b = _FakeExtension(ns: 'b');
+        final coordinator = SessionCoordinator([a, b]);
+
+        await coordinator.attachAll(_FakeAgentSessionStub());
+        coordinator.disposeAll();
+
+        expect(a.disposeCount, 1);
+        expect(b.disposeCount, 1);
+      });
+
+      test('disposes in reverse attach order', () async {
+        final order = <int>[];
+        final low = _DisposeOrderExtension(ns: 'low', pri: 1, order: order);
+        final high = _DisposeOrderExtension(ns: 'high', pri: 10, order: order);
+        final mid = _DisposeOrderExtension(ns: 'mid', pri: 5, order: order);
+
+        final coordinator = SessionCoordinator([low, high, mid]);
+        await coordinator.attachAll(_FakeAgentSessionStub());
+        coordinator.disposeAll();
+
+        // Attach order was [high(10), mid(5), low(1)]; dispose reverses it.
+        expect(order, [1, 5, 10]);
+      });
+
+      test('is idempotent — calling twice does not double-dispose', () async {
+        final ext = _FakeExtension(ns: 'x');
+        final coordinator = SessionCoordinator([ext]);
+        await coordinator.attachAll(_FakeAgentSessionStub());
+
+        coordinator.disposeAll();
+        coordinator.disposeAll();
+
+        expect(ext.disposeCount, 1);
+      });
+
+      test('disposes without prior attachAll (uses registration order)', () {
+        final a = _FakeExtension(ns: 'a');
+        final b = _FakeExtension(ns: 'b');
+        final coordinator = SessionCoordinator([a, b]);
+
+        expect(() => coordinator.disposeAll(), returnsNormally);
+        expect(a.disposeCount, 1);
+        expect(b.disposeCount, 1);
+      });
+    });
+
+    group('getExtension', () {
+      test('returns matching extension by type', () {
+        final ext = _FakeExtension(ns: 'a');
+        final coordinator = SessionCoordinator([ext]);
+
+        expect(coordinator.getExtension<_FakeExtension>(), same(ext));
+      });
+
+      test('returns null when type not registered', () {
+        final coordinator = SessionCoordinator(const []);
+
+        expect(coordinator.getExtension<_FakeExtension>(), isNull);
+      });
+
+      test('returns first matching extension when multiple present', () {
+        final first = _FakeExtension(ns: 'first');
+        final second = _FakeExtension(ns: 'second');
+        final coordinator = SessionCoordinator([first, second]);
+
+        expect(coordinator.getExtension<_FakeExtension>(), same(first));
+      });
+    });
+
+    group('statefulObservations', () {
+      test('yields nothing for empty coordinator', () {
+        final coordinator = SessionCoordinator(const []);
+        expect(coordinator.statefulObservations(), isEmpty);
+      });
+
+      test('yields nothing for non-stateful extensions', () {
+        final ext = _FakeExtension(ns: 'plain');
+        final coordinator = SessionCoordinator([ext]);
+        expect(coordinator.statefulObservations(), isEmpty);
+      });
+
+      test('skips stateful extension with empty namespace', () {
+        final ext = _StatefulExtension(0, ns: '');
+        final coordinator = SessionCoordinator([ext]);
+        expect(coordinator.statefulObservations(), isEmpty);
+      });
+
+      test('yields (namespace, signal) for stateful extension', () {
+        final ext = _StatefulExtension(42, ns: 'my_ext');
+        final coordinator = SessionCoordinator([ext]);
+
+        final obs = coordinator.statefulObservations().toList();
+
+        expect(obs, hasLength(1));
+        expect(obs.first.$1, 'my_ext');
+        expect(obs.first.$2.value, 42);
+      });
+
+      test('signal in observation reflects state changes', () {
+        final ext = _StatefulExtension(0, ns: 'counter');
+        final coordinator = SessionCoordinator([ext]);
+
+        final obs = coordinator.statefulObservations().first;
+        expect(obs.$2.value, 0);
+
+        ext.state = 99;
+        expect(obs.$2.value, 99);
+      });
+
+      test('yields one entry per stateful extension with namespace', () {
+        final a = _StatefulExtension(1, ns: 'a');
+        final b = _StatefulExtension(2, ns: 'b');
+        final plain = _FakeExtension(ns: 'plain');
+        final coordinator = SessionCoordinator([a, plain, b]);
+
+        final obs = coordinator.statefulObservations().toList();
+
+        expect(obs, hasLength(2));
+        expect(obs.map((e) => e.$1), containsAll(['a', 'b']));
+      });
+    });
+
+    group('tools', () {
+      test('returns empty list when no tools contributed', () {
+        final coordinator = SessionCoordinator([_FakeExtension()]);
+        expect(coordinator.tools, isEmpty);
+      });
+
+      test('flattens tools from all extensions', () {
+        final tool1 = ClientTool(
+          definition: const Tool(name: 'tool_a', description: 'A'),
+          executor: (_, __) async => '',
+        );
+        final tool2 = ClientTool(
+          definition: const Tool(name: 'tool_b', description: 'B'),
+          executor: (_, __) async => '',
+        );
+        final a = _FakeExtension(ns: 'a', t: [tool1]);
+        final b = _FakeExtension(ns: 'b', t: [tool2]);
+        final coordinator = SessionCoordinator([a, b]);
+
+        expect(
+          coordinator.tools.map((t) => t.definition.name),
+          containsAll(['tool_a', 'tool_b']),
+        );
+      });
+    });
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Additional test doubles
+// ---------------------------------------------------------------------------
+
+class _FakeAgentSessionStub implements AgentSession {
+  @override
+  dynamic noSuchMethod(Invocation i) => null;
+}
+
+class _OrderRecordingExtension extends SessionExtension {
+  _OrderRecordingExtension({
+    required String ns,
+    required int pri,
+    required this.order,
+  })  : _ns = ns,
+        _pri = pri;
+
+  final String _ns;
+  final int _pri;
+  final List<int> order;
+
+  @override
+  String get namespace => _ns;
+
+  @override
+  int get priority => _pri;
+
+  @override
+  Future<void> onAttach(AgentSession session) async => order.add(_pri);
+
+  @override
+  List<ClientTool> get tools => const [];
+
+  @override
+  void onDispose() {}
+}
+
+class _DisposeOrderExtension extends SessionExtension {
+  _DisposeOrderExtension({
+    required String ns,
+    required int pri,
+    required this.order,
+  })  : _ns = ns,
+        _pri = pri;
+
+  final String _ns;
+  final int _pri;
+  final List<int> order;
+
+  @override
+  String get namespace => _ns;
+
+  @override
+  int get priority => _pri;
+
+  @override
+  Future<void> onAttach(AgentSession session) async {}
+
+  @override
+  List<ClientTool> get tools => const [];
+
+  @override
+  void onDispose() => order.add(_pri);
+}

--- a/packages/soliplex_agent/test/runtime/stateful_session_extension_test.dart
+++ b/packages/soliplex_agent/test/runtime/stateful_session_extension_test.dart
@@ -1,0 +1,134 @@
+import 'package:soliplex_agent/soliplex_agent.dart';
+import 'package:soliplex_agent/src/runtime/stateful_session_extension.dart';
+import 'package:test/test.dart';
+
+// ---------------------------------------------------------------------------
+// Concrete implementation under test
+// ---------------------------------------------------------------------------
+
+class _CounterExtension extends SessionExtension
+    with StatefulSessionExtension<int> {
+  _CounterExtension([int initial = 0]) {
+    setInitialState(initial);
+  }
+
+  @override
+  String get namespace => 'counter';
+
+  @override
+  Future<void> onAttach(AgentSession session) async {}
+
+  @override
+  List<ClientTool> get tools => const [];
+
+  @override
+  void onDispose() => super.onDispose();
+}
+
+class _NullableExtension extends SessionExtension
+    with StatefulSessionExtension<String?> {
+  _NullableExtension() {
+    setInitialState(null);
+  }
+
+  @override
+  String get namespace => 'nullable';
+
+  @override
+  Future<void> onAttach(AgentSession session) async {}
+
+  @override
+  List<ClientTool> get tools => const [];
+
+  @override
+  void onDispose() => super.onDispose();
+}
+
+void main() {
+  group('StatefulSessionExtension', () {
+    group('initial state', () {
+      test('stateSignal reflects initial value', () {
+        final ext = _CounterExtension(7);
+        expect(ext.stateSignal.value, 7);
+      });
+
+      test('state getter returns initial value', () {
+        final ext = _CounterExtension(42);
+        expect(ext.state, 42);
+      });
+
+      test('initial state can be null for nullable type', () {
+        final ext = _NullableExtension();
+        expect(ext.state, isNull);
+      });
+    });
+
+    group('state read/write', () {
+      test('state setter updates value', () {
+        final ext = _CounterExtension(0);
+        ext.state = 5;
+        expect(ext.state, 5);
+      });
+
+      test('stateSignal reflects state setter update', () {
+        final ext = _CounterExtension(0);
+        ext.state = 99;
+        expect(ext.stateSignal.value, 99);
+      });
+
+      test('state setter notifies subscribers', () {
+        final ext = _CounterExtension(0);
+        final received = <int>[];
+        ext.stateSignal.subscribe((v) => received.add(v));
+
+        ext.state = 1;
+        ext.state = 2;
+
+        expect(received, containsAll([1, 2]));
+      });
+    });
+
+    group('stateSignalAsObject', () {
+      test('returns type-erased signal reflecting current state', () {
+        final ext = _CounterExtension(10);
+        expect(ext.stateSignalAsObject.value, 10);
+      });
+
+      test('type-erased signal tracks state changes', () {
+        final ext = _CounterExtension(0);
+        final objectSig = ext.stateSignalAsObject;
+
+        ext.state = 77;
+
+        expect(objectSig.value, 77);
+      });
+
+      test('returns same instance on repeated calls', () {
+        final ext = _CounterExtension(0);
+        final sig1 = ext.stateSignalAsObject;
+        final sig2 = ext.stateSignalAsObject;
+        expect(identical(sig1, sig2), isTrue);
+      });
+    });
+
+    group('onDispose', () {
+      test('cleans up without error', () {
+        final ext = _CounterExtension(0);
+        expect(() => ext.onDispose(), returnsNormally);
+      });
+
+      test('calling onDispose twice does not throw', () {
+        final ext = _CounterExtension(0);
+        ext.onDispose();
+        expect(() => ext.onDispose(), returnsNormally);
+      });
+    });
+
+    group('implements HasStatefulObservation', () {
+      test('extension satisfies HasStatefulObservation', () {
+        final ext = _CounterExtension(0);
+        expect(ext, isA<HasStatefulObservation>());
+      });
+    });
+  });
+}

--- a/test/core/app_module_test.dart
+++ b/test/core/app_module_test.dart
@@ -1,0 +1,305 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:soliplex_frontend/src/core/app_module.dart';
+import 'package:soliplex_frontend/src/core/shell_config.dart';
+
+// ---------------------------------------------------------------------------
+// Test doubles
+// ---------------------------------------------------------------------------
+
+class _FakeModule extends AppModule {
+  _FakeModule({
+    required String ns,
+    int pri = 0,
+    ModuleRoutes? routes,
+  })  : _ns = ns,
+        _pri = pri,
+        _routes = routes ?? const ModuleRoutes();
+
+  final String _ns;
+  final int _pri;
+  final ModuleRoutes _routes;
+
+  int attachCount = 0;
+  int disposeCount = 0;
+  AppModuleContext? attachedCtx;
+
+  @override
+  String get namespace => _ns;
+
+  @override
+  int get priority => _pri;
+
+  @override
+  ModuleRoutes build(AppModuleContext ctx) => _routes;
+
+  @override
+  Future<void> onAttach(AppModuleContext ctx) async {
+    attachCount++;
+    attachedCtx = ctx;
+  }
+
+  @override
+  Future<void> onDispose() async => disposeCount++;
+}
+
+class _OrderRecordingModule extends AppModule {
+  _OrderRecordingModule({required String ns, required int pri, required this.order})
+      : _ns = ns,
+        _pri = pri;
+
+  final String _ns;
+  final int _pri;
+  final List<int> order;
+
+  @override
+  String get namespace => _ns;
+
+  @override
+  int get priority => _pri;
+
+  @override
+  ModuleRoutes build(AppModuleContext ctx) => const ModuleRoutes();
+
+  @override
+  Future<void> onAttach(AppModuleContext ctx) async => order.add(_pri);
+}
+
+class _DisposeOrderModule extends AppModule {
+  _DisposeOrderModule({required String ns, required int pri, required this.order})
+      : _ns = ns,
+        _pri = pri;
+
+  final String _ns;
+  final int _pri;
+  final List<int> order;
+
+  @override
+  String get namespace => _ns;
+
+  @override
+  int get priority => _pri;
+
+  @override
+  ModuleRoutes build(AppModuleContext ctx) => const ModuleRoutes();
+
+  @override
+  Future<void> onDispose() async => order.add(_pri);
+}
+
+ThemeData _theme() => ThemeData.light();
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+void main() {
+  group('ShellConfig.fromModules — namespace validation', () {
+    test('accepts empty module list', () async {
+      await expectLater(
+        ShellConfig.fromModules(
+          modules: const [],
+          appName: 'test',
+          theme: _theme(),
+        ),
+        completes,
+      );
+    });
+
+    test('accepts modules with unique namespaces', () async {
+      final a = _FakeModule(ns: 'a');
+      final b = _FakeModule(ns: 'b');
+
+      await expectLater(
+        ShellConfig.fromModules(modules: [a, b], appName: 'test', theme: _theme()),
+        completes,
+      );
+    });
+
+    test('allows multiple modules with empty namespace', () async {
+      final a = _FakeModule(ns: '');
+      final b = _FakeModule(ns: '');
+
+      await expectLater(
+        ShellConfig.fromModules(modules: [a, b], appName: 'test', theme: _theme()),
+        completes,
+      );
+    });
+
+    test('throws StateError for duplicate non-empty namespace', () async {
+      final a = _FakeModule(ns: 'dup');
+      final b = _FakeModule(ns: 'dup');
+
+      await expectLater(
+        ShellConfig.fromModules(modules: [a, b], appName: 'test', theme: _theme()),
+        throwsA(isA<StateError>()),
+      );
+    });
+  });
+
+  group('ShellConfig.fromModules — lifecycle', () {
+    test('calls onAttach on all modules', () async {
+      final a = _FakeModule(ns: 'a');
+      final b = _FakeModule(ns: 'b');
+
+      await ShellConfig.fromModules(
+        modules: [a, b],
+        appName: 'test',
+        theme: _theme(),
+      );
+
+      expect(a.attachCount, 1);
+      expect(b.attachCount, 1);
+    });
+
+    test('attaches in descending priority order', () async {
+      final order = <int>[];
+      final low = _OrderRecordingModule(ns: 'low', pri: 1, order: order);
+      final high = _OrderRecordingModule(ns: 'high', pri: 10, order: order);
+      final mid = _OrderRecordingModule(ns: 'mid', pri: 5, order: order);
+
+      await ShellConfig.fromModules(
+        modules: [low, high, mid],
+        appName: 'test',
+        theme: _theme(),
+      );
+
+      expect(order, [10, 5, 1]);
+    });
+
+    test('onDispose called in reverse registration order', () async {
+      final order = <int>[];
+      // Register high→mid→low so reversed = low→mid→high.
+      final high = _DisposeOrderModule(ns: 'high', pri: 10, order: order);
+      final mid = _DisposeOrderModule(ns: 'mid', pri: 5, order: order);
+      final low = _DisposeOrderModule(ns: 'low', pri: 1, order: order);
+
+      final config = await ShellConfig.fromModules(
+        modules: [high, mid, low],
+        appName: 'test',
+        theme: _theme(),
+      );
+
+      config.onDispose?.call();
+      await Future<void>.delayed(Duration.zero);
+
+      expect(order, [1, 5, 10]);
+    });
+  });
+
+  group('AppModuleContext.module<T>()', () {
+    test('returns matching module by type', () async {
+      final a = _FakeModule(ns: 'a');
+      _FakeModule? discovered;
+
+      final b = _DiscoveryModule(
+        ns: 'b',
+        attachCallback: (ctx) => discovered = ctx.module<_FakeModule>(),
+      );
+
+      await ShellConfig.fromModules(
+        modules: [a, b],
+        appName: 'test',
+        theme: _theme(),
+      );
+
+      expect(discovered, same(a));
+    });
+
+    test('returns null when type not registered', () async {
+      _FakeModule? discovered;
+
+      final b = _DiscoveryModule(
+        ns: 'b',
+        attachCallback: (ctx) => discovered = ctx.module<_FakeModule>(),
+      );
+
+      await ShellConfig.fromModules(
+        modules: [b],
+        appName: 'test',
+        theme: _theme(),
+      );
+
+      expect(discovered, isNull);
+    });
+  });
+
+  group('ShellConfig.fromModules — routes & overrides', () {
+    test('flattens routes from all modules', () async {
+      // ModuleRoutes with empty routes still produces a valid config.
+      final config = await ShellConfig.fromModules(
+        modules: [_FakeModule(ns: 'a'), _FakeModule(ns: 'b')],
+        appName: 'test',
+        theme: _theme(),
+      );
+
+      expect(config.routes, isA<List>());
+    });
+
+    test('config carries appName and theme', () async {
+      final theme = _theme();
+      final config = await ShellConfig.fromModules(
+        modules: const [],
+        appName: 'MyApp',
+        theme: theme,
+      );
+
+      expect(config.appName, 'MyApp');
+      expect(config.theme, same(theme));
+    });
+  });
+
+  group('AppModule defaults', () {
+    test('default priority is 0', () {
+      expect(_FakeModule(ns: 'x').priority, 0);
+    });
+
+    test('default onAttach is a no-op', () async {
+      final m = _NoLifecycleModule();
+      expect(
+        () async => m.onAttach(_StubContext()),
+        returnsNormally,
+      );
+    });
+
+    test('default onDispose is a no-op', () async {
+      final m = _NoLifecycleModule();
+      expect(() async => m.onDispose(), returnsNormally);
+    });
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Additional test doubles
+// ---------------------------------------------------------------------------
+
+class _DiscoveryModule extends AppModule {
+  _DiscoveryModule({required String ns, required this.attachCallback})
+      : _ns = ns;
+
+  final String _ns;
+  final void Function(AppModuleContext) attachCallback;
+
+  @override
+  String get namespace => _ns;
+
+  @override
+  ModuleRoutes build(AppModuleContext ctx) => const ModuleRoutes();
+
+  @override
+  Future<void> onAttach(AppModuleContext ctx) async => attachCallback(ctx);
+}
+
+class _NoLifecycleModule extends AppModule {
+  @override
+  String get namespace => 'no-lifecycle';
+
+  @override
+  ModuleRoutes build(AppModuleContext ctx) => const ModuleRoutes();
+}
+
+class _StubContext implements AppModuleContext {
+  @override
+  T? module<T extends AppModule>() => null;
+}

--- a/test/modules/room/conversation_state_extension_test.dart
+++ b/test/modules/room/conversation_state_extension_test.dart
@@ -1,0 +1,139 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:signals_core/signals_core.dart';
+import 'package:soliplex_agent/soliplex_agent.dart';
+import 'package:soliplex_client/soliplex_client.dart';
+
+import 'package:soliplex_frontend/src/modules/room/conversation_state_extension.dart';
+
+// ---------------------------------------------------------------------------
+// Fake session exposing just the signals the extension needs
+// ---------------------------------------------------------------------------
+
+class _FakeSession implements AgentSession {
+  final Signal<RunState> _runState = Signal(const IdleState());
+
+  @override
+  ReadonlySignal<RunState> get runState => _runState;
+
+  void emit(RunState state) => _runState.value = state;
+
+  @override
+  dynamic noSuchMethod(Invocation i) => null;
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const _threadKey = (serverId: 'srv', roomId: 'room', threadId: 'thread');
+
+Conversation _conversation({Map<String, dynamic> aguiState = const {}}) =>
+    Conversation(threadId: 'thread', aguiState: aguiState);
+
+RunningState _running(Conversation conv) => RunningState(
+      threadKey: _threadKey,
+      runId: 'r1',
+      conversation: conv,
+      streaming: const AwaitingText(),
+    );
+
+CompletedState _completed(Conversation conv) => CompletedState(
+      threadKey: _threadKey,
+      runId: 'r1',
+      conversation: conv,
+    );
+
+FailedState _failed(Conversation conv) => FailedState(
+      threadKey: _threadKey,
+      reason: FailureReason.internalError,
+      error: 'fail',
+      conversation: conv,
+    );
+
+void main() {
+  group('ConversationStateExtension', () {
+    late ConversationStateExtension ext;
+    late _FakeSession session;
+
+    setUp(() async {
+      ext = ConversationStateExtension();
+      session = _FakeSession();
+      await ext.onAttach(session);
+    });
+
+    tearDown(() => ext.onDispose());
+
+    test('initial state is empty map', () {
+      expect(ext.state, isEmpty);
+      expect(ext.stateSignal.value, isEmpty);
+    });
+
+    test('updates state from RunningState conversation aguiState', () {
+      session.emit(_running(_conversation(aguiState: {'key': 'value'})));
+
+      expect(ext.state, {'key': 'value'});
+    });
+
+    test('updates state from CompletedState conversation aguiState', () {
+      session.emit(_completed(_conversation(aguiState: {'done': true})));
+
+      expect(ext.state, {'done': true});
+    });
+
+    test('updates state from FailedState when conversation is present', () {
+      session.emit(_failed(_conversation(aguiState: {'err': 1})));
+
+      expect(ext.state, {'err': 1});
+    });
+
+    test('does not update state for IdleState', () {
+      session.emit(_running(_conversation(aguiState: {'step': 1})));
+      session.emit(const IdleState());
+
+      expect(ext.state, {'step': 1});
+    });
+
+    test('does not update state when aguiState is unchanged', () {
+      final aguiState = {'x': 1};
+      session.emit(_running(_conversation(aguiState: aguiState)));
+
+      final snapshot = ext.state;
+      session.emit(_running(_conversation(aguiState: aguiState)));
+
+      expect(identical(ext.state, snapshot), isTrue);
+    });
+
+    test('stateSignal notifies on change', () {
+      final received = <Map<String, dynamic>>[];
+      ext.stateSignal.subscribe((v) {
+        if (v.isNotEmpty) received.add(v);
+      });
+
+      session.emit(_running(_conversation(aguiState: {'a': 1})));
+      session.emit(_running(_conversation(aguiState: {'b': 2})));
+
+      expect(received.length, 2);
+    });
+
+    test('namespace is conversation_state', () {
+      expect(ext.namespace, 'conversation_state');
+    });
+
+    test('priority is 20', () {
+      expect(ext.priority, 20);
+    });
+
+    test('tools is empty', () {
+      expect(ext.tools, isEmpty);
+    });
+
+    test('onDispose unsubscribes from runState', () {
+      ext.onDispose();
+
+      expect(
+        () => session.emit(_running(_conversation(aguiState: {'post': 'dispose'}))),
+        returnsNormally,
+      );
+    });
+  });
+}

--- a/test/modules/room/execution_tracker_extension_test.dart
+++ b/test/modules/room/execution_tracker_extension_test.dart
@@ -1,0 +1,192 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:signals_core/signals_core.dart';
+import 'package:soliplex_agent/soliplex_agent.dart';
+import 'package:soliplex_client/soliplex_client.dart';
+
+import 'package:soliplex_frontend/src/modules/room/execution_tracker.dart';
+import 'package:soliplex_frontend/src/modules/room/execution_tracker_extension.dart';
+
+// ---------------------------------------------------------------------------
+// Fake session exposing the two signals the extension subscribes to
+// ---------------------------------------------------------------------------
+
+class _FakeSession implements AgentSession {
+  final Signal<RunState> _runState = Signal(const IdleState());
+  final Signal<ExecutionEvent?> _event = Signal(null);
+
+  @override
+  ReadonlySignal<RunState> get runState => _runState;
+
+  @override
+  ReadonlySignal<ExecutionEvent?> get lastExecutionEvent => _event;
+
+  void emitRun(RunState state) => _runState.value = state;
+
+  @override
+  dynamic noSuchMethod(Invocation i) => null;
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const _threadKey = (serverId: 'srv', roomId: 'room', threadId: 'thread');
+
+RunningState _running(StreamingState streaming) => RunningState(
+      threadKey: _threadKey,
+      runId: 'r1',
+      conversation: const Conversation(threadId: 'thread'),
+      streaming: streaming,
+    );
+
+CompletedState _completed() => const CompletedState(
+      threadKey: _threadKey,
+      runId: 'r1',
+      conversation: Conversation(threadId: 'thread'),
+    );
+
+FailedState _failed() => const FailedState(
+      threadKey: _threadKey,
+      reason: FailureReason.internalError,
+      error: 'fail',
+    );
+
+CancelledState _cancelled() => const CancelledState(threadKey: _threadKey);
+
+void main() {
+  group('ExecutionTrackerExtension', () {
+    late ExecutionTrackerExtension ext;
+    late _FakeSession session;
+
+    setUp(() async {
+      ext = ExecutionTrackerExtension();
+      session = _FakeSession();
+      await ext.onAttach(session);
+    });
+
+    tearDown(() => ext.onDispose());
+
+    test('initial state is empty map', () {
+      expect(ext.state, isEmpty);
+      expect(ext.trackers, isEmpty);
+    });
+
+    test('RunningState with AwaitingText creates a tracker entry', () {
+      session.emitRun(_running(const AwaitingText()));
+
+      expect(ext.state, isNotEmpty);
+      expect(ext.trackers, isNotEmpty);
+    });
+
+    test('tracker created for AwaitingText uses awaiting sentinel key', () {
+      session.emitRun(_running(const AwaitingText()));
+
+      expect(ext.trackers.containsKey('_awaiting'), isTrue);
+    });
+
+    test('tracker created for TextStreaming uses messageId as key', () {
+      session.emitRun(
+        _running(
+          const TextStreaming(
+            messageId: 'msg-1',
+            user: ChatUser.assistant,
+            text: 'hello',
+          ),
+        ),
+      );
+
+      expect(ext.trackers.containsKey('msg-1'), isTrue);
+    });
+
+    test('tracker entry is an ExecutionTracker', () {
+      session.emitRun(_running(const AwaitingText()));
+
+      expect(ext.trackers.values.first, isA<ExecutionTracker>());
+    });
+
+    test('CompletedState freezes the active tracker', () {
+      session.emitRun(_running(const AwaitingText()));
+      final tracker = ext.trackers.values.first;
+
+      session.emitRun(_completed());
+
+      expect(tracker.isFrozen, isTrue);
+    });
+
+    test('FailedState freezes the active tracker', () {
+      session.emitRun(_running(const AwaitingText()));
+      final tracker = ext.trackers.values.first;
+
+      session.emitRun(_failed());
+
+      expect(tracker.isFrozen, isTrue);
+    });
+
+    test('CancelledState freezes the active tracker', () {
+      session.emitRun(_running(const AwaitingText()));
+      final tracker = ext.trackers.values.first;
+
+      session.emitRun(_cancelled());
+
+      expect(tracker.isFrozen, isTrue);
+    });
+
+    test('IdleState does not create or freeze trackers', () {
+      session.emitRun(const IdleState());
+
+      expect(ext.state, isEmpty);
+    });
+
+    test('ToolYieldingState does not create or freeze trackers', () {
+      session.emitRun(
+        ToolYieldingState(
+          threadKey: _threadKey,
+          runId: 'r1',
+          conversation: const Conversation(threadId: 'thread'),
+          pendingToolCalls: const [],
+          toolDepth: 0,
+        ),
+      );
+
+      expect(ext.state, isEmpty);
+    });
+
+    test('stateSignal notifies when tracker map changes', () {
+      final counts = <int>[];
+      ext.stateSignal.subscribe((v) => counts.add(v.length));
+
+      session.emitRun(_running(const AwaitingText()));
+
+      expect(counts, contains(1));
+    });
+
+    test('state reflects tracker map after terminal state', () {
+      session.emitRun(_running(const AwaitingText()));
+      session.emitRun(_completed());
+
+      expect(ext.state, isNotEmpty);
+      expect(ext.state.values.first.isFrozen, isTrue);
+    });
+
+    test('namespace is execution_tracker', () {
+      expect(ext.namespace, 'execution_tracker');
+    });
+
+    test('priority is 10', () {
+      expect(ext.priority, 10);
+    });
+
+    test('tools is empty', () {
+      expect(ext.tools, isEmpty);
+    });
+
+    test('onDispose unsubscribes — emitting after dispose does not throw', () {
+      ext.onDispose();
+
+      expect(
+        () => session.emitRun(_running(const AwaitingText())),
+        returnsNormally,
+      );
+    });
+  });
+}

--- a/test/modules/room/human_approval_extension_test.dart
+++ b/test/modules/room/human_approval_extension_test.dart
@@ -1,0 +1,211 @@
+import 'dart:async';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:soliplex_agent/soliplex_agent.dart';
+
+import 'package:soliplex_frontend/src/modules/room/human_approval_extension.dart';
+
+class _FakeSession implements AgentSession {
+  @override
+  dynamic noSuchMethod(Invocation i) => null;
+}
+
+void main() {
+  group('HumanApprovalExtension', () {
+    late HumanApprovalExtension ext;
+
+    setUp(() async {
+      ext = HumanApprovalExtension();
+      await ext.onAttach(_FakeSession());
+    });
+
+    tearDown(() => ext.onDispose());
+
+    test('initial state is null', () {
+      expect(ext.state, isNull);
+    });
+
+    test('requestApproval sets state to ApprovalRequest', () async {
+      unawaited(ext.requestApproval(
+        toolCallId: 'tc-1',
+        toolName: 'my_tool',
+        arguments: {'x': 1},
+        rationale: 'doing stuff',
+      ));
+
+      expect(ext.state, isNotNull);
+      expect(ext.state!.toolCallId, 'tc-1');
+      expect(ext.state!.toolName, 'my_tool');
+      expect(ext.state!.rationale, 'doing stuff');
+    });
+
+    test('respond(true) resolves future with true', () async {
+      final future = ext.requestApproval(
+        toolCallId: 'tc-1',
+        toolName: 'my_tool',
+        arguments: {},
+        rationale: 'reason',
+      );
+
+      ext.respond(true);
+
+      expect(await future, isTrue);
+    });
+
+    test('respond(false) resolves future with false', () async {
+      final future = ext.requestApproval(
+        toolCallId: 'tc-1',
+        toolName: 'my_tool',
+        arguments: {},
+        rationale: 'reason',
+      );
+
+      ext.respond(false);
+
+      expect(await future, isFalse);
+    });
+
+    test('respond clears state to null', () async {
+      unawaited(ext.requestApproval(
+        toolCallId: 'tc-1',
+        toolName: 'my_tool',
+        arguments: {},
+        rationale: 'reason',
+      ));
+
+      ext.respond(true);
+
+      expect(ext.state, isNull);
+    });
+
+    test('new requestApproval denies stale pending with false', () async {
+      final first = ext.requestApproval(
+        toolCallId: 'tc-1',
+        toolName: 'tool_a',
+        arguments: {},
+        rationale: 'first',
+      );
+
+      unawaited(ext.requestApproval(
+        toolCallId: 'tc-2',
+        toolName: 'tool_b',
+        arguments: {},
+        rationale: 'second',
+      ));
+
+      expect(await first, isFalse);
+    });
+
+    test('new requestApproval updates state to new request', () async {
+      unawaited(ext.requestApproval(
+        toolCallId: 'tc-1',
+        toolName: 'tool_a',
+        arguments: {},
+        rationale: 'first',
+      ));
+      unawaited(ext.requestApproval(
+        toolCallId: 'tc-2',
+        toolName: 'tool_b',
+        arguments: {},
+        rationale: 'second',
+      ));
+
+      expect(ext.state!.toolCallId, 'tc-2');
+    });
+
+    test('onDispose auto-denies pending request with false', () async {
+      final future = ext.requestApproval(
+        toolCallId: 'tc-1',
+        toolName: 'my_tool',
+        arguments: {},
+        rationale: 'reason',
+      );
+
+      ext.onDispose();
+
+      expect(await future, isFalse);
+    });
+
+    test('respond when no pending is a no-op', () {
+      expect(() => ext.respond(true), returnsNormally);
+    });
+
+    test('stateSignal notifies when request arrives', () {
+      final received = <ApprovalRequest?>[];
+      ext.stateSignal.subscribe((v) => received.add(v));
+
+      unawaited(ext.requestApproval(
+        toolCallId: 'tc-1',
+        toolName: 'my_tool',
+        arguments: {},
+        rationale: 'r',
+      ));
+
+      expect(received.where((v) => v != null), isNotEmpty);
+    });
+
+    test('stateSignal notifies null after respond', () async {
+      final nullCount = <int>[];
+      ext.stateSignal.subscribe((v) {
+        if (v == null) nullCount.add(1);
+      });
+
+      final future = ext.requestApproval(
+        toolCallId: 'tc-1',
+        toolName: 'my_tool',
+        arguments: {},
+        rationale: 'r',
+      );
+      ext.respond(true);
+      await future;
+
+      expect(nullCount, isNotEmpty);
+    });
+
+    test('namespace is human_approval', () => expect(ext.namespace, 'human_approval'));
+    test('priority is 30', () => expect(ext.priority, 30));
+    test('tools is empty', () => expect(ext.tools, isEmpty));
+
+    test('onAttach is a no-op (does not throw)', () async {
+      final ext2 = HumanApprovalExtension();
+      expect(() async => ext2.onAttach(_FakeSession()), returnsNormally);
+      ext2.onDispose();
+    });
+  });
+
+  group('ApprovalRequest', () {
+    const r = ApprovalRequest(
+      toolCallId: 'tc-1',
+      toolName: 'my_tool',
+      arguments: {'x': 1},
+      rationale: 'reason',
+    );
+
+    test('equality considers toolCallId, toolName, rationale', () {
+      const same = ApprovalRequest(
+        toolCallId: 'tc-1',
+        toolName: 'my_tool',
+        arguments: {'y': 2},
+        rationale: 'reason',
+      );
+      const different = ApprovalRequest(
+        toolCallId: 'tc-2',
+        toolName: 'my_tool',
+        arguments: {},
+        rationale: 'reason',
+      );
+      expect(r, equals(same));
+      expect(r, isNot(equals(different)));
+    });
+
+    test('hashCode consistent with equality', () {
+      const same = ApprovalRequest(
+        toolCallId: 'tc-1',
+        toolName: 'my_tool',
+        arguments: {},
+        rationale: 'reason',
+      );
+      expect(r.hashCode, same.hashCode);
+    });
+  });
+}

--- a/test/modules/room/session_spawner_test.dart
+++ b/test/modules/room/session_spawner_test.dart
@@ -1,0 +1,271 @@
+import 'dart:async';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:signals_core/signals_core.dart';
+import 'package:soliplex_agent/soliplex_agent.dart';
+
+import 'package:soliplex_frontend/src/modules/room/send_error.dart';
+import 'package:soliplex_frontend/src/modules/room/session_spawner.dart';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+class _FakeSession implements AgentSession {
+  bool cancelCalled = false;
+  bool disposeCalled = false;
+
+  @override
+  void cancel() => cancelCalled = true;
+
+  @override
+  void dispose() => disposeCalled = true;
+
+  @override
+  dynamic noSuchMethod(Invocation i) => null;
+}
+
+void main() {
+  group('SessionSpawner', () {
+    late SessionSpawner spawner;
+    late Signal<SendError?> errorSignal;
+
+    setUp(() {
+      spawner = SessionSpawner();
+      errorSignal = Signal(null);
+    });
+
+    tearDown(() {
+      spawner.dispose();
+      errorSignal.dispose();
+    });
+
+    test('initial sessionState is null', () {
+      expect(spawner.sessionState.value, isNull);
+    });
+
+    test('spawn sets state to spawning immediately', () async {
+      final completer = Completer<AgentSession>();
+
+      unawaited(
+        spawner.spawn(
+          spawnFn: () => completer.future,
+          errorSignal: errorSignal,
+          prompt: 'test',
+          isDisposed: () => false,
+          onSpawned: (_) {},
+        ),
+      );
+
+      expect(spawner.sessionState.value, AgentSessionState.spawning);
+      completer.complete(_FakeSession());
+      await Future<void>.delayed(Duration.zero);
+    });
+
+    test('spawn calls onSpawned with the session', () async {
+      final session = _FakeSession();
+      AgentSession? received;
+
+      await spawner.spawn(
+        spawnFn: () async => session,
+        errorSignal: errorSignal,
+        prompt: 'test',
+        isDisposed: () => false,
+        onSpawned: (s) => received = s,
+      );
+
+      expect(received, same(session));
+    });
+
+    test('spawn leaves sessionState as spawning after success', () async {
+      // The spawner does NOT auto-reset after a successful spawn.
+      // Callers update state via updateState() inside onSpawned.
+      await spawner.spawn(
+        spawnFn: () async => _FakeSession(),
+        errorSignal: errorSignal,
+        prompt: 'test',
+        isDisposed: () => false,
+        onSpawned: (_) {},
+      );
+
+      expect(spawner.sessionState.value, AgentSessionState.spawning);
+    });
+
+    test('onSpawned can clear sessionState via updateState', () async {
+      await spawner.spawn(
+        spawnFn: () async => _FakeSession(),
+        errorSignal: errorSignal,
+        prompt: 'test',
+        isDisposed: () => false,
+        onSpawned: (_) => spawner.updateState(null),
+      );
+
+      expect(spawner.sessionState.value, isNull);
+    });
+
+    test('spawn clears error signal before starting', () async {
+      errorSignal.value = SendError(Exception('old'));
+
+      await spawner.spawn(
+        spawnFn: () async => _FakeSession(),
+        errorSignal: errorSignal,
+        prompt: 'test',
+        isDisposed: () => false,
+        onSpawned: (_) {},
+      );
+
+      expect(errorSignal.value, isNull);
+    });
+
+    test('concurrent spawn is a no-op when sessionState is non-null', () async {
+      final firstCompleter = Completer<AgentSession>();
+      var spawnCount = 0;
+
+      unawaited(
+        spawner.spawn(
+          spawnFn: () {
+            spawnCount++;
+            return firstCompleter.future;
+          },
+          errorSignal: errorSignal,
+          prompt: 'first',
+          isDisposed: () => false,
+          onSpawned: (_) {},
+        ),
+      );
+
+      // Second spawn while first is pending — should be ignored.
+      await spawner.spawn(
+        spawnFn: () {
+          spawnCount++;
+          return Future.value(_FakeSession());
+        },
+        errorSignal: errorSignal,
+        prompt: 'second',
+        isDisposed: () => false,
+        onSpawned: (_) {},
+      );
+
+      expect(spawnCount, 1);
+      firstCompleter.complete(_FakeSession());
+      await Future<void>.delayed(Duration.zero);
+    });
+
+    test('spawn on error sets errorSignal when not disposed', () async {
+      final error = Exception('spawn failed');
+
+      await spawner.spawn(
+        spawnFn: () async => throw error,
+        errorSignal: errorSignal,
+        prompt: 'my prompt',
+        isDisposed: () => false,
+        onSpawned: (_) {},
+      );
+
+      expect(errorSignal.value, isNotNull);
+      expect(errorSignal.value!.unsentText, 'my prompt');
+    });
+
+    test('spawn on error suppressed when isDisposed returns true', () async {
+      await spawner.spawn(
+        spawnFn: () async => throw Exception('boom'),
+        errorSignal: errorSignal,
+        prompt: 'test',
+        isDisposed: () => true,
+        onSpawned: (_) {},
+      );
+
+      expect(errorSignal.value, isNull);
+    });
+
+    test('spawn resets sessionState to null on error', () async {
+      await spawner.spawn(
+        spawnFn: () async => throw Exception('boom'),
+        errorSignal: errorSignal,
+        prompt: 'test',
+        isDisposed: () => false,
+        onSpawned: (_) {},
+      );
+
+      expect(spawner.sessionState.value, isNull);
+    });
+
+    group('cancel', () {
+      test('returns false when nothing is pending', () {
+        expect(spawner.cancel(), isFalse);
+      });
+
+      test('returns true when a spawn is pending', () async {
+        final completer = Completer<AgentSession>();
+
+        unawaited(
+          spawner.spawn(
+            spawnFn: () => completer.future,
+            errorSignal: errorSignal,
+            prompt: 'test',
+            isDisposed: () => false,
+            onSpawned: (_) {},
+          ),
+        );
+
+        expect(spawner.cancel(), isTrue);
+        completer.complete(_FakeSession());
+        await Future<void>.delayed(Duration.zero);
+      });
+
+      test('resets sessionState to null on cancel', () async {
+        final completer = Completer<AgentSession>();
+
+        unawaited(
+          spawner.spawn(
+            spawnFn: () => completer.future,
+            errorSignal: errorSignal,
+            prompt: 'test',
+            isDisposed: () => false,
+            onSpawned: (_) {},
+          ),
+        );
+
+        spawner.cancel();
+
+        expect(spawner.sessionState.value, isNull);
+        completer.complete(_FakeSession());
+        await Future<void>.delayed(Duration.zero);
+      });
+
+      test('cancelled spawn does not call onSpawned', () async {
+        final completer = Completer<AgentSession>();
+        var spawnedCalled = false;
+
+        unawaited(
+          spawner.spawn(
+            spawnFn: () => completer.future,
+            errorSignal: errorSignal,
+            prompt: 'test',
+            isDisposed: () => false,
+            onSpawned: (_) => spawnedCalled = true,
+          ),
+        );
+
+        spawner.cancel();
+        completer.complete(_FakeSession());
+        await Future<void>.delayed(Duration.zero);
+
+        expect(spawnedCalled, isFalse);
+      });
+    });
+
+    group('updateState', () {
+      test('directly sets sessionState', () {
+        spawner.updateState(AgentSessionState.running);
+        expect(spawner.sessionState.value, AgentSessionState.running);
+      });
+
+      test('can clear sessionState to null', () {
+        spawner.updateState(AgentSessionState.running);
+        spawner.updateState(null);
+        expect(spawner.sessionState.value, isNull);
+      });
+    });
+  });
+}

--- a/test/modules/room/tool_calls_extension_test.dart
+++ b/test/modules/room/tool_calls_extension_test.dart
@@ -1,0 +1,210 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:signals_core/signals_core.dart';
+import 'package:soliplex_agent/soliplex_agent.dart';
+import 'package:soliplex_client/soliplex_client.dart' show ToolCallStatus;
+
+import 'package:soliplex_frontend/src/modules/room/tool_calls_extension.dart';
+
+// ---------------------------------------------------------------------------
+// Fake session
+// ---------------------------------------------------------------------------
+
+class _FakeSession implements AgentSession {
+  final Signal<ExecutionEvent?> _event = Signal(null);
+
+  @override
+  ReadonlySignal<ExecutionEvent?> get lastExecutionEvent => _event;
+
+  void emit(ExecutionEvent event) => _event.value = event;
+
+  @override
+  dynamic noSuchMethod(Invocation i) => null;
+}
+
+void main() {
+  group('ToolCallsExtension', () {
+    late ToolCallsExtension ext;
+    late _FakeSession session;
+
+    setUp(() async {
+      ext = ToolCallsExtension();
+      session = _FakeSession();
+      await ext.onAttach(session);
+    });
+
+    tearDown(() => ext.onDispose());
+
+    test('initial state is empty list', () {
+      expect(ext.state, isEmpty);
+    });
+
+    test('ClientToolExecuting adds executing entry (client-side)', () {
+      session.emit(const ClientToolExecuting(
+        toolCallId: 'tc-1',
+        toolName: 'my_tool',
+      ));
+
+      expect(ext.state, hasLength(1));
+      expect(ext.state.first.toolCallId, 'tc-1');
+      expect(ext.state.first.toolName, 'my_tool');
+      expect(ext.state.first.status, ToolCallStatus.executing);
+      expect(ext.state.first.isClientSide, isTrue);
+    });
+
+    test('ServerToolCallStarted adds executing entry (server-side)', () {
+      session.emit(const ServerToolCallStarted(
+        toolCallId: 'tc-s1',
+        toolName: 'server_tool',
+      ));
+
+      expect(ext.state, hasLength(1));
+      expect(ext.state.first.isClientSide, isFalse);
+      expect(ext.state.first.status, ToolCallStatus.executing);
+    });
+
+    test('ClientToolCompleted updates status on existing entry', () {
+      session.emit(const ClientToolExecuting(
+        toolCallId: 'tc-1',
+        toolName: 'my_tool',
+      ));
+      session.emit(const ClientToolCompleted(
+        toolCallId: 'tc-1',
+        status: ToolCallStatus.completed,
+        result: 'result',
+      ));
+
+      expect(ext.state.first.status, ToolCallStatus.completed);
+    });
+
+    test('ServerToolCallCompleted marks entry completed', () {
+      session.emit(const ServerToolCallStarted(
+        toolCallId: 'tc-s1',
+        toolName: 'server_tool',
+      ));
+      session.emit(const ServerToolCallCompleted(
+        toolCallId: 'tc-s1',
+        result: 'done',
+      ));
+
+      expect(ext.state.first.status, ToolCallStatus.completed);
+    });
+
+    test('multiple tool calls tracked independently', () {
+      session.emit(const ClientToolExecuting(
+        toolCallId: 'tc-1',
+        toolName: 'tool_a',
+      ));
+      session.emit(const ServerToolCallStarted(
+        toolCallId: 'tc-2',
+        toolName: 'tool_b',
+      ));
+
+      expect(ext.state, hasLength(2));
+      expect(ext.state.map((e) => e.toolCallId), containsAll(['tc-1', 'tc-2']));
+    });
+
+    test('completion of unknown id is a no-op', () {
+      session.emit(const ServerToolCallCompleted(
+        toolCallId: 'unknown',
+        result: 'x',
+      ));
+      expect(ext.state, isEmpty);
+    });
+
+    test('upsert on existing id updates status rather than appending', () {
+      session.emit(const ClientToolExecuting(
+        toolCallId: 'tc-1',
+        toolName: 'my_tool',
+      ));
+      session.emit(const ClientToolExecuting(
+        toolCallId: 'tc-1',
+        toolName: 'my_tool',
+      ));
+
+      expect(ext.state, hasLength(1));
+    });
+
+    test('preserves insertion order', () {
+      for (var i = 1; i <= 3; i++) {
+        session.emit(ServerToolCallStarted(
+          toolCallId: 'tc-$i',
+          toolName: 'tool_$i',
+        ));
+      }
+
+      expect(
+        ext.state.map((e) => e.toolCallId).toList(),
+        ['tc-1', 'tc-2', 'tc-3'],
+      );
+    });
+
+    test('stateSignal notifies on change', () {
+      final counts = <int>[];
+      ext.stateSignal.subscribe((v) => counts.add(v.length));
+
+      session.emit(const ServerToolCallStarted(
+        toolCallId: 'tc-1',
+        toolName: 't',
+      ));
+      session.emit(const ServerToolCallCompleted(
+        toolCallId: 'tc-1',
+        result: 'done',
+      ));
+
+      expect(counts, contains(1));
+    });
+
+    test('namespace is tool_calls', () => expect(ext.namespace, 'tool_calls'));
+    test('priority is 5', () => expect(ext.priority, 5));
+    test('tools is empty', () => expect(ext.tools, isEmpty));
+
+    test('onDispose unsubscribes — emitting after dispose does not throw', () {
+      ext.onDispose();
+      expect(
+        () => session.emit(const ServerToolCallStarted(
+          toolCallId: 'post',
+          toolName: 't',
+        )),
+        returnsNormally,
+      );
+    });
+  });
+
+  group('ToolCallEntry', () {
+    const entry = ToolCallEntry(
+      toolCallId: 'tc-1',
+      toolName: 'my_tool',
+      status: ToolCallStatus.executing,
+      isClientSide: true,
+    );
+
+    test('copyWith updates status', () {
+      final updated = entry.copyWith(status: ToolCallStatus.completed);
+      expect(updated.status, ToolCallStatus.completed);
+      expect(updated.toolCallId, entry.toolCallId);
+      expect(updated.isClientSide, entry.isClientSide);
+    });
+
+    test('copyWith without args returns equivalent entry', () {
+      final copy = entry.copyWith();
+      expect(copy, equals(entry));
+    });
+
+    test('equality considers all fields', () {
+      const same = ToolCallEntry(
+        toolCallId: 'tc-1',
+        toolName: 'my_tool',
+        status: ToolCallStatus.executing,
+        isClientSide: true,
+      );
+      const different = ToolCallEntry(
+        toolCallId: 'tc-1',
+        toolName: 'my_tool',
+        status: ToolCallStatus.completed,
+        isClientSide: true,
+      );
+      expect(entry, equals(same));
+      expect(entry, isNot(equals(different)));
+    });
+  });
+}

--- a/test/modules/room/ui/extension_state_panel_test.dart
+++ b/test/modules/room/ui/extension_state_panel_test.dart
@@ -1,0 +1,182 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:signals_core/signals_core.dart';
+import 'package:soliplex_agent/soliplex_agent.dart';
+
+import 'package:soliplex_frontend/src/modules/room/thread_view_state.dart';
+import 'package:soliplex_frontend/src/modules/room/ui/extension_state_panel.dart';
+
+class _MockThreadViewState extends Mock implements ThreadViewState {}
+
+Widget _frame(ThreadViewState view) {
+  return MaterialApp(
+    home: Scaffold(body: ExtensionStatePanel(threadView: view)),
+  );
+}
+
+void main() {
+  late _MockThreadViewState view;
+  late Signal<AgentSessionState?> sessionStateSignal;
+
+  setUp(() {
+    view = _MockThreadViewState();
+    sessionStateSignal = Signal<AgentSessionState?>(null);
+    when(() => view.sessionState).thenReturn(sessionStateSignal.readonly());
+    when(() => view.statefulObservations)
+        .thenReturn(const <(String, ReadonlySignal<Object?>)>[]);
+  });
+
+  tearDown(() {
+    sessionStateSignal.dispose();
+    reset(view);
+  });
+
+  group('ExtensionStatePanel', () {
+    testWidgets('renders nothing when observations is empty', (tester) async {
+      await tester.pumpWidget(_frame(view));
+
+      expect(find.byType(ExtensionStatePanel), findsOneWidget);
+      expect(find.text('EXTENSIONS'), findsNothing);
+    });
+
+    testWidgets('renders header when there are observations', (tester) async {
+      final sig = Signal<Object?>({'step': 1});
+      when(() => view.statefulObservations)
+          .thenReturn([(('my_ext', sig.readonly()))]);
+
+      await tester.pumpWidget(_frame(view));
+
+      expect(find.text('EXTENSIONS'), findsOneWidget);
+      sig.dispose();
+    });
+
+    testWidgets('badge shows correct extension count', (tester) async {
+      final s1 = Signal<Object?>(1);
+      final s2 = Signal<Object?>(2);
+      when(() => view.statefulObservations).thenReturn([
+        ('ext_a', s1.readonly()),
+        ('ext_b', s2.readonly()),
+      ]);
+
+      await tester.pumpWidget(_frame(view));
+
+      expect(find.text('2'), findsOneWidget);
+      s1.dispose();
+      s2.dispose();
+    });
+
+    testWidgets('panel is collapsed by default (rows not visible)',
+        (tester) async {
+      final sig = Signal<Object?>({'x': 1});
+      when(() => view.statefulObservations)
+          .thenReturn([('my_ext', sig.readonly())]);
+
+      await tester.pumpWidget(_frame(view));
+
+      expect(find.text('my_ext'), findsNothing);
+      sig.dispose();
+    });
+
+    testWidgets('tapping header expands the panel', (tester) async {
+      final sig = Signal<Object?>({'x': 1});
+      when(() => view.statefulObservations)
+          .thenReturn([('my_ext', sig.readonly())]);
+
+      await tester.pumpWidget(_frame(view));
+
+      await tester.tap(find.text('EXTENSIONS'));
+      await tester.pump();
+
+      expect(find.text('my_ext'), findsOneWidget);
+      sig.dispose();
+    });
+
+    testWidgets('tapping header again collapses the panel', (tester) async {
+      final sig = Signal<Object?>({'x': 1});
+      when(() => view.statefulObservations)
+          .thenReturn([('my_ext', sig.readonly())]);
+
+      await tester.pumpWidget(_frame(view));
+
+      await tester.tap(find.text('EXTENSIONS'));
+      await tester.pump();
+      expect(find.text('my_ext'), findsOneWidget);
+
+      await tester.tap(find.text('EXTENSIONS'));
+      await tester.pump();
+      expect(find.text('my_ext'), findsNothing);
+      sig.dispose();
+    });
+
+    testWidgets('expanded panel renders namespace label for each extension',
+        (tester) async {
+      final s1 = Signal<Object?>(1);
+      final s2 = Signal<Object?>('hello');
+      when(() => view.statefulObservations).thenReturn([
+        ('counter', s1.readonly()),
+        ('greeter', s2.readonly()),
+      ]);
+
+      await tester.pumpWidget(_frame(view));
+      await tester.tap(find.text('EXTENSIONS'));
+      await tester.pump();
+
+      expect(find.text('counter'), findsOneWidget);
+      expect(find.text('greeter'), findsOneWidget);
+      s1.dispose();
+      s2.dispose();
+    });
+
+    testWidgets('expanded panel JSON-encodes signal value', (tester) async {
+      final sig = Signal<Object?>(42);
+      when(() => view.statefulObservations)
+          .thenReturn([('my_ext', sig.readonly())]);
+
+      await tester.pumpWidget(_frame(view));
+      await tester.tap(find.text('EXTENSIONS'));
+      await tester.pump();
+
+      expect(find.text('42'), findsOneWidget);
+      sig.dispose();
+    });
+
+    testWidgets('panel refreshes observations when sessionState changes',
+        (tester) async {
+      when(() => view.statefulObservations)
+          .thenReturn(const <(String, ReadonlySignal<Object?>)>[]);
+
+      await tester.pumpWidget(_frame(view));
+      expect(find.text('EXTENSIONS'), findsNothing);
+
+      final sig = Signal<Object?>(1);
+      when(() => view.statefulObservations)
+          .thenReturn([('new_ext', sig.readonly())]);
+
+      sessionStateSignal.value = AgentSessionState.running;
+      await tester.pump();
+
+      expect(find.text('EXTENSIONS'), findsOneWidget);
+      sig.dispose();
+    });
+
+    testWidgets('rebinds when threadView changes', (tester) async {
+      final view2 = _MockThreadViewState();
+      final sessionStateSignal2 = Signal<AgentSessionState?>(null);
+      final sig = Signal<Object?>(99);
+      when(() => view2.sessionState).thenReturn(sessionStateSignal2.readonly());
+      when(() => view2.statefulObservations)
+          .thenReturn([('ext_v2', sig.readonly())]);
+
+      await tester.pumpWidget(_frame(view));
+      expect(find.text('EXTENSIONS'), findsNothing);
+
+      await tester.pumpWidget(_frame(view2));
+      await tester.pump();
+      expect(find.text('EXTENSIONS'), findsOneWidget);
+
+      sig.dispose();
+      sessionStateSignal2.dispose();
+    });
+  });
+}


### PR DESCRIPTION
## Summary

- 9 new test files, ~2 000 lines covering all behaviour introduced in M1–M10
- `packages/soliplex_agent/test/runtime/` — `StatefulSessionExtension<T>` and `SessionCoordinator` (pure Dart)
- `test/modules/room/` — `SessionSpawner`, `ConversationStateExtension`, `ToolCallsExtension`, `HumanApprovalExtension`, `ExecutionTrackerExtension`
- `test/core/` — `AppModule` / `ShellConfig.fromModules` lifecycle, namespace validation, priority ordering, cross-module discovery
- `test/modules/room/ui/` — `ExtensionStatePanel` widget (expand/collapse, badge count, signal value rendering, sessionState-driven refresh)

## Test plan

- [ ] `flutter test packages/soliplex_agent/test/runtime/` — all pass
- [ ] `flutter test test/` — all pass
- [ ] `flutter analyze` zero warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)