### PR TITLE
feat(core): AppModule lifecycle replaces ModuleContribution

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## What This Is
 
-Soliplex Flutter frontend — both a **runnable app** and an **importable library**. Uses a modular shell architecture where each module is a function returning a `ModuleContribution` (routes, Riverpod overrides, and an optional redirect). See `docs/plans/0001-app-shell/proposal.md` for the full design proposal.
+Soliplex Flutter frontend — both a **runnable app** and an **importable library**. Uses a modular shell architecture where each module is an `AppModule` subclass that contributes routes, Riverpod overrides, and lifecycle hooks.
 
 ## Commands
 
@@ -33,19 +33,35 @@ Prefer Dart MCP tools over shell commands. All tools take `root` as `file:///abs
 
 Entry point: `runSoliplexShell(ShellConfig)` boots the app from a `ShellConfig`.
 
-Each module is a function that takes dependencies via constructor injection and returns a `ModuleContribution` (routes, Riverpod overrides, and an optional redirect). No base class, no registry. The compiler enforces dependency ordering. Flavor functions create concrete instances, inject them into module functions, and compose `ModuleContribution` values into a `ShellConfig`. The shell flattens modules and collects overrides into a single root `ProviderScope`.
+Each module subclasses `AppModule` and implements:
+
+- `String get namespace` — unique identifier (validated at startup)
+- `ModuleRoutes build()` — returns routes, Riverpod overrides, and an optional
+  redirect
+- `Future<void> onDispose()` — resource cleanup (optional)
+
+Flavor functions construct concrete `AppModule` instances and pass them to
+`ShellConfig.fromModules(...)`. Modules are built in registration order and
+disposed in reverse. The shell flattens routes and collects overrides into a
+single root `ProviderScope`.
 
 ### State Management
 
-Riverpod is **DI/service locator only** — no AsyncNotifier or FutureProvider chains. Reactive state comes from `signals` (via `soliplex_agent`). The `signals` package bridges signal reactivity to Flutter widget rebuilds.
+Riverpod is **DI/service locator only** — no AsyncNotifier or FutureProvider chains.
+Reactive state comes from `signals` (via `soliplex_agent`). The `signals` package
+bridges signal reactivity to Flutter widget rebuilds.
 
 ### Theming
 
-`ShellConfig` takes `ThemeData` directly — Flutter's standard abstraction. Each flavor provides its own `ThemeData`. Custom palette abstractions deferred until multiple flavors need them.
+`ShellConfig` takes `ThemeData` directly — Flutter's standard abstraction. Each flavor
+provides its own `ThemeData`. Custom palette abstractions deferred until multiple
+flavors need them.
 
 ### Flavors
 
-Flavors are functions that compose module functions into a `ShellConfig`. Modules are included/excluded by presence in the flavor — no enum or toggle framework.
+Flavors are functions that construct `AppModule` instances and call
+`ShellConfig.fromModules(...)`. Modules are included/excluded by presence in the
+flavor — no enum or toggle framework.
 
 ## Modules
 

--- a/lib/soliplex_frontend.dart
+++ b/lib/soliplex_frontend.dart
@@ -1,8 +1,9 @@
 /// Modular Flutter frontend framework for Soliplex.
 library;
 
+export 'src/core/app_module.dart' show AppModule, ModuleRoutes;
 export 'src/core/shell.dart' show runSoliplexShell;
-export 'src/core/shell_config.dart' show ModuleContribution, ShellConfig;
+export 'src/core/shell_config.dart' show ShellConfig;
 export 'src/interfaces/auth_state.dart'
     show AuthState, Authenticated, Unauthenticated;
 export 'src/modules/auth/auth_providers.dart' show serverManagerProvider;

--- a/lib/src/core/app_module.dart
+++ b/lib/src/core/app_module.dart
@@ -1,0 +1,30 @@
+import 'package:flutter_riverpod/misc.dart';
+import 'package:go_router/go_router.dart';
+
+/// Routes and Riverpod overrides contributed by an [AppModule].
+class ModuleRoutes {
+  const ModuleRoutes({
+    this.routes = const [],
+    this.overrides = const [],
+    this.redirect,
+  });
+
+  final List<RouteBase> routes;
+  final List<Override> overrides;
+  final GoRouterRedirect? redirect;
+}
+
+/// Lifecycle unit for a feature module.
+///
+/// Subclass and pass instances to [ShellConfig.fromModules]. Modules
+/// declare routes and overrides via [build] and release owned resources
+/// in [onDispose].
+abstract class AppModule {
+  String get namespace;
+
+  /// Declares the routes and overrides this module contributes.
+  ModuleRoutes build();
+
+  /// Called when the shell is disposed, in reverse registration order.
+  Future<void> onDispose() async {}
+}

--- a/lib/src/core/shell.dart
+++ b/lib/src/core/shell.dart
@@ -47,7 +47,6 @@ class _SoliplexShellState extends State<SoliplexShell> {
   @override
   void dispose() {
     _router.dispose();
-    widget.config.onDispose?.call();
     super.dispose();
   }
 }

--- a/lib/src/core/shell_config.dart
+++ b/lib/src/core/shell_config.dart
@@ -1,50 +1,104 @@
+import 'dart:async' show unawaited;
+
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/misc.dart';
 import 'package:go_router/go_router.dart';
 
+import 'app_module.dart';
 import 'router.dart';
-
-class ModuleContribution {
-  final List<RouteBase> routes;
-  final List<Override> overrides;
-  final GoRouterRedirect? redirect;
-
-  ModuleContribution({
-    List<RouteBase> routes = const [],
-    List<Override> overrides = const [],
-    this.redirect,
-  })  : routes = List.unmodifiable(routes),
-        overrides = List.unmodifiable(overrides);
-}
 
 class ShellConfig {
   final String appName;
   final Widget? logo;
   final ThemeData theme;
   final String initialRoute;
-  final List<ModuleContribution> modules;
   final Listenable? refreshListenable;
   final VoidCallback? onDispose;
 
-  ShellConfig({
+  final List<RouteBase> _routes;
+  final List<Override> _overrides;
+  final List<GoRouterRedirect> _redirects;
+
+  ShellConfig._internal({
     required this.appName,
     this.logo,
     required this.theme,
     this.initialRoute = '/',
-    List<ModuleContribution> modules = const [],
+    required List<RouteBase> routes,
+    required List<Override> overrides,
+    required List<GoRouterRedirect> redirects,
     this.refreshListenable,
     this.onDispose,
-  }) : modules = List.unmodifiable(modules);
+  })  : _routes = routes,
+        _overrides = overrides,
+        _redirects = redirects;
 
-  List<RouteBase> get routes => modules.expand((m) => m.routes).toList();
-
-  List<Override> get overrides => modules.expand((m) => m.overrides).toList();
-
-  List<GoRouterRedirect> get redirects =>
-      modules.map((m) => m.redirect).nonNulls.toList();
+  List<RouteBase> get routes => _routes;
+  List<Override> get overrides => _overrides;
+  List<GoRouterRedirect> get redirects => _redirects;
 
   List<String> validate() => validateRoutes(
         routes: routes,
         initialRoute: initialRoute,
       );
+
+  /// Creates a [ShellConfig] from a list of [AppModule] instances.
+  ///
+  /// Calls [AppModule.build] on each module in registration order to
+  /// collect routes and overrides. When the shell is disposed, calls
+  /// [AppModule.onDispose] in reverse registration order.
+  static Future<ShellConfig> fromModules({
+    required List<AppModule> modules,
+    required String appName,
+    Widget? logo,
+    required ThemeData theme,
+    String initialRoute = '/',
+    Listenable? refreshListenable,
+  }) async {
+    final coordinator = _AppModuleCoordinator(modules);
+    return ShellConfig._internal(
+      appName: appName,
+      logo: logo,
+      theme: theme,
+      initialRoute: initialRoute,
+      routes: coordinator.routes,
+      overrides: coordinator.overrides,
+      redirects: coordinator.redirects,
+      refreshListenable: refreshListenable,
+      onDispose: () => unawaited(coordinator.disposeAll()),
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Internal coordinator — not part of the public API.
+// ---------------------------------------------------------------------------
+
+class _AppModuleCoordinator {
+  _AppModuleCoordinator(List<AppModule> modules) {
+    final seen = <String>{};
+    for (final m in modules) {
+      if (m.namespace.isNotEmpty && !seen.add(m.namespace)) {
+        throw StateError('Duplicate AppModule namespace: "${m.namespace}"');
+      }
+    }
+    _modules = List.unmodifiable(modules);
+    _built = _modules.map((m) => m.build()).toList(growable: false);
+  }
+
+  late final List<AppModule> _modules;
+  late final List<ModuleRoutes> _built;
+
+  Future<void> disposeAll() async {
+    for (final m in _modules.reversed) {
+      await m.onDispose();
+    }
+  }
+
+  List<RouteBase> get routes => _built.expand((r) => r.routes).toList();
+
+  List<Override> get overrides => _built.expand((r) => r.overrides).toList();
+
+  List<GoRouterRedirect> get redirects =>
+      _built.map((r) => r.redirect).nonNulls.toList();
 }

--- a/lib/src/core/shell_config.dart
+++ b/lib/src/core/shell_config.dart
@@ -1,5 +1,3 @@
-import 'dart:async' show unawaited;
-
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/misc.dart';
 import 'package:go_router/go_router.dart';
@@ -13,7 +11,16 @@ class ShellConfig {
   final ThemeData theme;
   final String initialRoute;
   final Listenable? refreshListenable;
-  final VoidCallback? onDispose;
+
+  /// Tears down every module's `onDispose` in reverse registration order.
+  ///
+  /// **Caller responsibility.** The shell widget does not invoke this —
+  /// it owns neither the config nor the modules. Callers that need
+  /// deterministic teardown (tests, embedded library consumers, future
+  /// lifecycle-owner wrappers) must `await shellConfig.dispose?.call()`
+  /// themselves. Standalone apps (`runSoliplexShell` + process exit)
+  /// rely on OS reclamation.
+  final Future<void> Function()? dispose;
 
   final List<RouteBase> _routes;
   final List<Override> _overrides;
@@ -28,7 +35,7 @@ class ShellConfig {
     required List<Override> overrides,
     required List<GoRouterRedirect> redirects,
     this.refreshListenable,
-    this.onDispose,
+    this.dispose,
   })  : _routes = routes,
         _overrides = overrides,
         _redirects = redirects;
@@ -65,7 +72,7 @@ class ShellConfig {
       overrides: coordinator.overrides,
       redirects: coordinator.redirects,
       refreshListenable: refreshListenable,
-      onDispose: () => unawaited(coordinator.disposeAll()),
+      dispose: coordinator.disposeAll,
     );
   }
 }

--- a/lib/src/flavors/standard.dart
+++ b/lib/src/flavors/standard.dart
@@ -6,8 +6,7 @@ import 'package:soliplex_logging/soliplex_logging.dart' show LoggerFactory;
 
 import '../design/design.dart';
 import '../core/shell_config.dart';
-import '../core/signal_listenable.dart';
-import '../interfaces/auth_state.dart';
+import '../interfaces/auth_state.dart' show Authenticated;
 import '../modules/auth/auth_module.dart';
 import '../modules/auth/default_backend_url.dart';
 import '../modules/auth/auth_session.dart';
@@ -125,7 +124,6 @@ Future<ShellConfig> standard({
         webOrigin: kIsWeb ? Uri.base : null,
       );
 
-  final authListenable = SignalListenable(serverManager.authState);
   final authFlow = createAuthFlow(redirectScheme: redirectScheme);
 
   final runtimeManager = AgentRuntimeManager(
@@ -138,42 +136,36 @@ Future<ShellConfig> standard({
 
   final registry = RunRegistry();
 
-  return ShellConfig(
+  final authMod = AuthAppModule(
+    serverManager: serverManager,
+    probeClient: plainClient,
+    authFlow: authFlow,
+    appName: appName,
+    callbackParams: callbackParams is! NoCallbackParams ? callbackParams : null,
+    consentNotice: consentNotice,
+    logo: logo,
+    defaultBackendUrl: resolvedUrl,
+  );
+
+  return ShellConfig.fromModules(
     appName: appName,
     logo: logo,
     theme: theme ?? _defaultTheme(),
     initialRoute: callbackParams is! NoCallbackParams
         ? '/auth/callback'
         : (serverManager.authState.value is Authenticated ? '/lobby' : '/'),
-    refreshListenable: authListenable,
-    onDispose: () {
-      authListenable.dispose();
-      serverManager.dispose();
-      plainClient.close();
-      runtimeManager.dispose();
-      registry.dispose();
-      inspector.dispose();
-    },
+    refreshListenable: authMod.refreshListenable,
     modules: [
-      diagnosticsModule(inspector: inspector),
-      lobbyModule(serverManager: serverManager),
-      roomModule(
+      DiagnosticsAppModule(inspector: inspector),
+      authMod,
+      LobbyAppModule(serverManager: serverManager),
+      RoomAppModule(
         serverManager: serverManager,
         runtimeManager: runtimeManager,
         registry: registry,
         enableDocumentFilter: true,
       ),
-      quizModule(serverManager: serverManager),
-      authModule(
-        serverManager: serverManager,
-        authFlow: authFlow,
-        probeClient: plainClient,
-        appName: appName,
-        callbackParams: callbackParams,
-        consentNotice: consentNotice,
-        logo: logo,
-        defaultBackendUrl: resolvedUrl,
-      ),
+      QuizAppModule(serverManager: serverManager),
     ],
   );
 }

--- a/lib/src/modules/auth/auth_module.dart
+++ b/lib/src/modules/auth/auth_module.dart
@@ -2,7 +2,8 @@ import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
 import 'package:soliplex_agent/soliplex_agent.dart' hide AuthException;
 
-import '../../core/shell_config.dart';
+import '../../core/app_module.dart';
+import '../../core/signal_listenable.dart';
 import '../../interfaces/auth_state.dart';
 import 'auth_providers.dart';
 import 'consent_notice.dart';
@@ -13,65 +14,99 @@ import 'ui/auth_callback_screen.dart';
 import 'ui/home_screen.dart';
 import 'ui/server_list_screen.dart';
 
-/// Public routes that don't require authentication.
 const _publicPaths = {'/', '/servers', '/auth/callback'};
 
-ModuleContribution authModule({
-  required ServerManager serverManager,
-  required AuthFlow authFlow,
-  required SoliplexHttpClient probeClient,
-  required String appName,
-  CallbackParams? callbackParams,
-  ConsentNotice? consentNotice,
-  Widget? logo,
-  String? defaultBackendUrl,
-}) {
-  return ModuleContribution(
-    overrides: [
-      serverManagerProvider.overrideWithValue(serverManager),
-      authFlowProvider.overrideWithValue(authFlow),
-      probeClientProvider.overrideWithValue(probeClient),
-      if (callbackParams != null)
-        callbackParamsProvider.overrideWithValue(callbackParams),
-      if (consentNotice != null)
-        consentNoticeProvider.overrideWithValue(consentNotice),
-    ],
-    routes: [
-      GoRoute(
-        path: '/',
-        pageBuilder: (_, state) {
-          final autoConnectUrl = state.uri.queryParameters['url'];
-          return NoTransitionPage(
-            key: autoConnectUrl != null ? UniqueKey() : state.pageKey,
-            child: HomeScreen(
-              serverManager: serverManager,
-              appName: appName,
-              logo: logo,
-              defaultBackendUrl: defaultBackendUrl,
-              autoConnectUrl: autoConnectUrl,
-            ),
-          );
-        },
-      ),
-      GoRoute(
-        path: '/servers',
-        pageBuilder: (_, __) => NoTransitionPage(
-          child: ServerListScreen(serverManager: serverManager),
-        ),
-      ),
-      GoRoute(
-        path: '/auth/callback',
-        pageBuilder: (_, __) => NoTransitionPage(
-          child: AuthCallbackScreen(serverManager: serverManager),
-        ),
-      ),
-    ],
-    redirect: (_, state) {
-      final isAuthenticated = serverManager.authState.value is Authenticated;
-      final isPublic = _publicPaths.contains(state.matchedLocation);
+class AuthAppModule extends AppModule {
+  AuthAppModule({
+    required ServerManager serverManager,
+    required SoliplexHttpClient probeClient,
+    required AuthFlow authFlow,
+    required String appName,
+    CallbackParams? callbackParams,
+    ConsentNotice? consentNotice,
+    Widget? logo,
+    String? defaultBackendUrl,
+  })  : _serverManager = serverManager,
+        _probeClient = probeClient,
+        _authFlow = authFlow,
+        _appName = appName,
+        _callbackParams = callbackParams,
+        _consentNotice = consentNotice,
+        _logo = logo,
+        _defaultBackendUrl = defaultBackendUrl,
+        _refreshListenable = SignalListenable(serverManager.authState);
 
-      if (!isAuthenticated && !isPublic) return '/';
-      return null;
-    },
-  );
+  final ServerManager _serverManager;
+  final SoliplexHttpClient _probeClient;
+  final AuthFlow _authFlow;
+  final String _appName;
+  final CallbackParams? _callbackParams;
+  final ConsentNotice? _consentNotice;
+  final Widget? _logo;
+  final String? _defaultBackendUrl;
+  final SignalListenable _refreshListenable;
+
+  /// The [Listenable] that notifies [GoRouter] when auth state changes.
+  /// Pass this to [ShellConfig.fromModules] as [refreshListenable].
+  Listenable get refreshListenable => _refreshListenable;
+
+  @override
+  String get namespace => 'auth';
+
+  @override
+  ModuleRoutes build() => ModuleRoutes(
+        overrides: [
+          serverManagerProvider.overrideWithValue(_serverManager),
+          authFlowProvider.overrideWithValue(_authFlow),
+          probeClientProvider.overrideWithValue(_probeClient),
+          if (_callbackParams != null)
+            callbackParamsProvider.overrideWithValue(_callbackParams),
+          if (_consentNotice != null)
+            consentNoticeProvider.overrideWithValue(_consentNotice),
+        ],
+        routes: [
+          GoRoute(
+            path: '/',
+            pageBuilder: (_, state) {
+              final autoConnectUrl = state.uri.queryParameters['url'];
+              return NoTransitionPage(
+                key: autoConnectUrl != null ? UniqueKey() : state.pageKey,
+                child: HomeScreen(
+                  serverManager: _serverManager,
+                  appName: _appName,
+                  logo: _logo,
+                  defaultBackendUrl: _defaultBackendUrl,
+                  autoConnectUrl: autoConnectUrl,
+                ),
+              );
+            },
+          ),
+          GoRoute(
+            path: '/servers',
+            pageBuilder: (_, __) => NoTransitionPage(
+              child: ServerListScreen(serverManager: _serverManager),
+            ),
+          ),
+          GoRoute(
+            path: '/auth/callback',
+            pageBuilder: (_, __) => NoTransitionPage(
+              child: AuthCallbackScreen(serverManager: _serverManager),
+            ),
+          ),
+        ],
+        redirect: (_, state) {
+          final isAuthenticated =
+              _serverManager.authState.value is Authenticated;
+          final isPublic = _publicPaths.contains(state.matchedLocation);
+          if (!isAuthenticated && !isPublic) return '/';
+          return null;
+        },
+      );
+
+  @override
+  Future<void> onDispose() async {
+    _refreshListenable.dispose();
+    _serverManager.dispose();
+    _probeClient.close();
+  }
 }

--- a/lib/src/modules/diagnostics/diagnostics_module.dart
+++ b/lib/src/modules/diagnostics/diagnostics_module.dart
@@ -1,22 +1,32 @@
 import 'package:go_router/go_router.dart';
 
-import '../../core/shell_config.dart';
+import '../../core/app_module.dart';
 import 'diagnostics_providers.dart';
 import 'network_inspector.dart';
 import 'ui/network_inspector_screen.dart';
 
-ModuleContribution diagnosticsModule({required NetworkInspector inspector}) {
-  return ModuleContribution(
-    overrides: [
-      networkInspectorProvider.overrideWithValue(inspector),
-    ],
-    routes: [
-      GoRoute(
-        path: '/diagnostics/network',
-        builder: (context, state) => NetworkInspectorScreen(
-          inspector: inspector,
-        ),
-      ),
-    ],
-  );
+class DiagnosticsAppModule extends AppModule {
+  DiagnosticsAppModule({required this.inspector});
+
+  final NetworkInspector inspector;
+
+  @override
+  String get namespace => 'diagnostics';
+
+  @override
+  ModuleRoutes build() => ModuleRoutes(
+        overrides: [
+          networkInspectorProvider.overrideWithValue(inspector),
+        ],
+        routes: [
+          GoRoute(
+            path: '/diagnostics/network',
+            builder: (context, state) =>
+                NetworkInspectorScreen(inspector: inspector),
+          ),
+        ],
+      );
+
+  @override
+  Future<void> onDispose() async => inspector.dispose();
 }

--- a/lib/src/modules/lobby/lobby_module.dart
+++ b/lib/src/modules/lobby/lobby_module.dart
@@ -1,20 +1,26 @@
 import 'package:go_router/go_router.dart';
 
-import '../../core/shell_config.dart';
+import '../../core/app_module.dart';
 import '../auth/server_manager.dart';
 import 'ui/lobby_screen.dart';
 
-ModuleContribution lobbyModule({
-  required ServerManager serverManager,
-}) {
-  return ModuleContribution(
-    routes: [
-      GoRoute(
-        path: '/lobby',
-        pageBuilder: (_, __) => NoTransitionPage(
-          child: LobbyScreen(serverManager: serverManager),
-        ),
-      ),
-    ],
-  );
+class LobbyAppModule extends AppModule {
+  LobbyAppModule({required this.serverManager});
+
+  final ServerManager serverManager;
+
+  @override
+  String get namespace => 'lobby';
+
+  @override
+  ModuleRoutes build() => ModuleRoutes(
+        routes: [
+          GoRoute(
+            path: '/lobby',
+            pageBuilder: (_, __) => NoTransitionPage(
+              child: LobbyScreen(serverManager: serverManager),
+            ),
+          ),
+        ],
+      );
 }

--- a/lib/src/modules/quiz/quiz_module.dart
+++ b/lib/src/modules/quiz/quiz_module.dart
@@ -1,40 +1,44 @@
 import 'package:flutter/widgets.dart';
 import 'package:go_router/go_router.dart';
 
-import '../../core/shell_config.dart';
+import '../../core/app_module.dart';
 import '../auth/require_connected_server.dart';
 import '../auth/server_manager.dart';
 import 'ui/quiz_screen.dart';
 
-ModuleContribution quizModule({
-  required ServerManager serverManager,
-}) {
-  return ModuleContribution(
-    routes: [
-      GoRoute(
-        path: '/room/:serverAlias/:roomId/quiz/:quizId',
-        redirect: (context, state) => requireConnectedServer(
-          serverManager,
-          state.pathParameters['serverAlias'],
-        ),
-        pageBuilder: (context, state) {
-          final alias = state.pathParameters['serverAlias']!;
-          final entry = serverManager.entryByAlias(alias);
-          if (entry == null || !entry.isConnected) {
-            return const NoTransitionPage(
-              child: SizedBox.shrink(),
-            );
-          }
-          return NoTransitionPage(
-            child: QuizScreen(
-              serverEntry: entry,
-              roomId: state.pathParameters['roomId']!,
-              quizId: state.pathParameters['quizId']!,
-              returnRoute: state.uri.queryParameters['from'],
+class QuizAppModule extends AppModule {
+  QuizAppModule({required this.serverManager});
+
+  final ServerManager serverManager;
+
+  @override
+  String get namespace => 'quiz';
+
+  @override
+  ModuleRoutes build() => ModuleRoutes(
+        routes: [
+          GoRoute(
+            path: '/room/:serverAlias/:roomId/quiz/:quizId',
+            redirect: (context, state) => requireConnectedServer(
+              serverManager,
+              state.pathParameters['serverAlias'],
             ),
-          );
-        },
-      ),
-    ],
-  );
+            pageBuilder: (context, state) {
+              final alias = state.pathParameters['serverAlias']!;
+              final entry = serverManager.entryByAlias(alias);
+              if (entry == null || !entry.isConnected) {
+                return const NoTransitionPage(child: SizedBox.shrink());
+              }
+              return NoTransitionPage(
+                child: QuizScreen(
+                  serverEntry: entry,
+                  roomId: state.pathParameters['roomId']!,
+                  quizId: state.pathParameters['quizId']!,
+                  returnRoute: state.uri.queryParameters['from'],
+                ),
+              );
+            },
+          ),
+        ],
+      );
 }

--- a/lib/src/modules/room/room_module.dart
+++ b/lib/src/modules/room/room_module.dart
@@ -1,6 +1,6 @@
 import 'package:go_router/go_router.dart';
 
-import '../../core/shell_config.dart';
+import '../../core/app_module.dart';
 import '../auth/require_connected_server.dart';
 import '../auth/server_manager.dart';
 import 'agent_runtime_manager.dart';
@@ -12,91 +12,88 @@ import 'ui/room_info_screen.dart';
 import 'ui/room_screen.dart';
 import 'upload_tracker_registry.dart';
 
-ModuleContribution roomModule({
-  required ServerManager serverManager,
-  required AgentRuntimeManager runtimeManager,
-  required RunRegistry registry,
-  bool enableDocumentFilter = false,
-}) {
-  final documentSelections = DocumentSelections();
-  final uploadRegistry = UploadTrackerRegistry(servers: serverManager.servers);
-  final messageExpansions = MessageExpansions();
-  return ModuleContribution(
-    overrides: [
-      messageExpansionsProvider.overrideWithValue(messageExpansions),
-    ],
-    routes: [
-      GoRoute(
-        path: '/room/:serverAlias/:roomId/info',
-        redirect: (context, state) => requireConnectedServer(
-          serverManager,
-          state.pathParameters['serverAlias'],
-        ),
-        pageBuilder: (context, state) {
-          final alias = state.pathParameters['serverAlias']!;
-          final entry = serverManager.entryByAlias(alias)!;
-          return NoTransitionPage(
-            child: RoomInfoScreen(
-              serverEntry: entry,
-              roomId: state.pathParameters['roomId']!,
-              toolRegistryResolver: runtimeManager.toolRegistryResolver,
-              uploadRegistry: uploadRegistry,
-            ),
-          );
-        },
-      ),
-      _buildRoute(
-        '/room/:serverAlias/:roomId',
-        serverManager,
-        runtimeManager,
-        registry,
-        uploadRegistry,
-        enableDocumentFilter,
-        documentSelections,
-      ),
-      _buildRoute(
-        '/room/:serverAlias/:roomId/thread/:threadId',
-        serverManager,
-        runtimeManager,
-        registry,
-        uploadRegistry,
-        enableDocumentFilter,
-        documentSelections,
-      ),
-    ],
-  );
-}
+class RoomAppModule extends AppModule {
+  RoomAppModule({
+    required this.serverManager,
+    required this.runtimeManager,
+    required this.registry,
+    this.enableDocumentFilter = false,
+  })  : _documentSelections = DocumentSelections(),
+        _messageExpansions = MessageExpansions(),
+        _uploadRegistry = UploadTrackerRegistry(servers: serverManager.servers);
 
-GoRoute _buildRoute(
-  String path,
-  ServerManager serverManager,
-  AgentRuntimeManager runtimeManager,
-  RunRegistry registry,
-  UploadTrackerRegistry uploadRegistry,
-  bool enableDocumentFilter,
-  DocumentSelections documentSelections,
-) {
-  return GoRoute(
-    path: path,
-    redirect: (context, state) => requireConnectedServer(
-      serverManager,
-      state.pathParameters['serverAlias'],
-    ),
-    pageBuilder: (context, state) {
-      final alias = state.pathParameters['serverAlias']!;
-      final entry = serverManager.entryByAlias(alias)!;
-      return NoTransitionPage(
-        child: RoomScreen(
-          serverEntry: entry,
-          roomId: state.pathParameters['roomId']!,
-          threadId: state.pathParameters['threadId'],
-          runtimeManager: runtimeManager,
-          registry: registry,
-          uploadRegistry: uploadRegistry,
-          enableDocumentFilter: enableDocumentFilter,
-          documentSelections: documentSelections,
-        ),
+  final ServerManager serverManager;
+  final AgentRuntimeManager runtimeManager;
+  final RunRegistry registry;
+  final bool enableDocumentFilter;
+
+  final DocumentSelections _documentSelections;
+  final MessageExpansions _messageExpansions;
+  final UploadTrackerRegistry _uploadRegistry;
+
+  @override
+  String get namespace => 'room';
+
+  @override
+  ModuleRoutes build() => ModuleRoutes(
+        overrides: [
+          messageExpansionsProvider.overrideWithValue(_messageExpansions),
+        ],
+        routes: [
+          GoRoute(
+            path: '/room/:serverAlias/:roomId/info',
+            redirect: (context, state) => requireConnectedServer(
+              serverManager,
+              state.pathParameters['serverAlias'],
+            ),
+            pageBuilder: (context, state) {
+              final alias = state.pathParameters['serverAlias']!;
+              final entry = serverManager.entryByAlias(alias)!;
+              return NoTransitionPage(
+                child: RoomInfoScreen(
+                  serverEntry: entry,
+                  roomId: state.pathParameters['roomId']!,
+                  toolRegistryResolver: runtimeManager.toolRegistryResolver,
+                  uploadRegistry: _uploadRegistry,
+                ),
+              );
+            },
+          ),
+          _buildRoute('/room/:serverAlias/:roomId'),
+          _buildRoute('/room/:serverAlias/:roomId/thread/:threadId'),
+        ],
       );
-    },
-  );
+
+  GoRoute _buildRoute(String path) {
+    return GoRoute(
+      path: path,
+      redirect: (context, state) => requireConnectedServer(
+        serverManager,
+        state.pathParameters['serverAlias'],
+      ),
+      pageBuilder: (context, state) {
+        final alias = state.pathParameters['serverAlias']!;
+        final entry = serverManager.entryByAlias(alias)!;
+        return NoTransitionPage(
+          child: RoomScreen(
+            serverEntry: entry,
+            roomId: state.pathParameters['roomId']!,
+            threadId: state.pathParameters['threadId'],
+            runtimeManager: runtimeManager,
+            registry: registry,
+            uploadRegistry: _uploadRegistry,
+            enableDocumentFilter: enableDocumentFilter,
+            documentSelections: _documentSelections,
+          ),
+        );
+      },
+    );
+  }
+
+  @override
+  Future<void> onDispose() async {
+    await runtimeManager.dispose();
+    registry.dispose();
+    _uploadRegistry.dispose();
+  }
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -70,10 +70,10 @@ packages:
     dependency: transitive
     description:
       name: characters
-      sha256: faf38497bda5ead2a8c7615f4f7939df04333478bf32e4173fcb06d428b5716b
+      sha256: f71061c654a3380576a52b451dd5532377954cf9dbd272a78fc8479606670803
       url: "https://pub.dev"
     source: hosted
-    version: "1.4.1"
+    version: "1.4.0"
   checked_yaml:
     dependency: transitive
     description:
@@ -481,6 +481,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.0.1"
+  js:
+    dependency: transitive
+    description:
+      name: js
+      sha256: "53385261521cc4a0c4658fd0ad07a7d14591cf8fc33abbceae306ddb974888dc"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.7.2"
   json_annotation:
     dependency: transitive
     description:
@@ -541,18 +549,18 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: dc0b7dc7651697ea4ff3e69ef44b0407ea32c487a39fff6a4004fa585e901861
+      sha256: dc58c723c3c24bf8d3e2d3ad3f2f9d7bd9cf43ec6feaa64181775e60190153f2
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.19"
+    version: "0.12.17"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: "9c337007e82b1889149c82ed242ed1cb24a66044e30979c44912381e9be4c48b"
+      sha256: f7142bb1154231d7ea5f96bc7bde4bda2a0945d2806bb11670e30b850d56bdec
       url: "https://pub.dev"
     source: hosted
-    version: "0.13.0"
+    version: "0.11.1"
   meta:
     dependency: transitive
     description:
@@ -930,26 +938,26 @@ packages:
     dependency: transitive
     description:
       name: test
-      sha256: "280d6d890011ca966ad08df7e8a4ddfab0fb3aa49f96ed6de56e3521347a9ae7"
+      sha256: "75906bf273541b676716d1ca7627a17e4c4070a3a16272b7a3dc7da3b9f3f6b7"
       url: "https://pub.dev"
     source: hosted
-    version: "1.30.0"
+    version: "1.26.3"
   test_api:
     dependency: transitive
     description:
       name: test_api
-      sha256: "8161c84903fd860b26bfdefb7963b3f0b68fee7adea0f59ef805ecca346f0c7a"
+      sha256: ab2726c1a94d3176a45960b6234466ec367179b87dd74f1611adb1f3b5fb9d55
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.10"
+    version: "0.7.7"
   test_core:
     dependency: transitive
     description:
       name: test_core
-      sha256: "0381bd1585d1a924763c308100f2138205252fb90c9d4eeaf28489ee65ccde51"
+      sha256: "0cc24b5ff94b38d2ae73e1eb43cc302b77964fbf67abad1e296025b78deb53d0"
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.16"
+    version: "0.6.12"
   tuple:
     dependency: transitive
     description:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -70,10 +70,10 @@ packages:
     dependency: transitive
     description:
       name: characters
-      sha256: f71061c654a3380576a52b451dd5532377954cf9dbd272a78fc8479606670803
+      sha256: faf38497bda5ead2a8c7615f4f7939df04333478bf32e4173fcb06d428b5716b
       url: "https://pub.dev"
     source: hosted
-    version: "1.4.0"
+    version: "1.4.1"
   checked_yaml:
     dependency: transitive
     description:
@@ -481,14 +481,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.0.1"
-  js:
-    dependency: transitive
-    description:
-      name: js
-      sha256: "53385261521cc4a0c4658fd0ad07a7d14591cf8fc33abbceae306ddb974888dc"
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.7.2"
   json_annotation:
     dependency: transitive
     description:
@@ -549,18 +541,18 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: dc58c723c3c24bf8d3e2d3ad3f2f9d7bd9cf43ec6feaa64181775e60190153f2
+      sha256: dc0b7dc7651697ea4ff3e69ef44b0407ea32c487a39fff6a4004fa585e901861
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.17"
+    version: "0.12.19"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: f7142bb1154231d7ea5f96bc7bde4bda2a0945d2806bb11670e30b850d56bdec
+      sha256: "9c337007e82b1889149c82ed242ed1cb24a66044e30979c44912381e9be4c48b"
       url: "https://pub.dev"
     source: hosted
-    version: "0.11.1"
+    version: "0.13.0"
   meta:
     dependency: transitive
     description:
@@ -938,26 +930,26 @@ packages:
     dependency: transitive
     description:
       name: test
-      sha256: "75906bf273541b676716d1ca7627a17e4c4070a3a16272b7a3dc7da3b9f3f6b7"
+      sha256: "280d6d890011ca966ad08df7e8a4ddfab0fb3aa49f96ed6de56e3521347a9ae7"
       url: "https://pub.dev"
     source: hosted
-    version: "1.26.3"
+    version: "1.30.0"
   test_api:
     dependency: transitive
     description:
       name: test_api
-      sha256: ab2726c1a94d3176a45960b6234466ec367179b87dd74f1611adb1f3b5fb9d55
+      sha256: "8161c84903fd860b26bfdefb7963b3f0b68fee7adea0f59ef805ecca346f0c7a"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.7"
+    version: "0.7.10"
   test_core:
     dependency: transitive
     description:
       name: test_core
-      sha256: "0cc24b5ff94b38d2ae73e1eb43cc302b77964fbf67abad1e296025b78deb53d0"
+      sha256: "0381bd1585d1a924763c308100f2138205252fb90c9d4eeaf28489ee65ccde51"
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.12"
+    version: "0.6.16"
   tuple:
     dependency: transitive
     description:

--- a/test/core/shell_test.dart
+++ b/test/core/shell_test.dart
@@ -171,10 +171,39 @@ void main() {
         ],
       );
 
-      config.onDispose?.call();
-      await Future<void>.delayed(Duration.zero); // let async dispose flush
+      await config.dispose?.call();
       expect(log, ['dispose:b', 'dispose:a']);
     });
+
+    testWidgets(
+      'widget unmount does not trigger module onDispose',
+      (tester) async {
+        final log = <String>[];
+
+        final config = await ShellConfig.fromModules(
+          appName: 'Test',
+          theme: ThemeData(),
+          modules: [_LifecycleModule('x', log)],
+        );
+
+        await tester.pumpWidget(SoliplexShell(config: config));
+        await tester.pumpWidget(const SizedBox());
+        await tester.pumpAndSettle();
+
+        expect(
+          log,
+          isEmpty,
+          reason: 'widget unmount must not dispose modules',
+        );
+
+        await config.dispose?.call();
+        expect(
+          log,
+          ['dispose:x'],
+          reason: 'explicit caller dispose must fire onDispose',
+        );
+      },
+    );
   });
 }
 

--- a/test/core/shell_test.dart
+++ b/test/core/shell_test.dart
@@ -1,16 +1,46 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_riverpod/misc.dart' show Override;
 import 'package:flutter_test/flutter_test.dart';
 import 'package:go_router/go_router.dart';
+import 'package:soliplex_frontend/src/core/app_module.dart';
 import 'package:soliplex_frontend/src/core/shell.dart';
 import 'package:soliplex_frontend/src/core/shell_config.dart';
 
+// ---------------------------------------------------------------------------
+// Test helpers
+// ---------------------------------------------------------------------------
+
+class _TestModule extends AppModule {
+  _TestModule({
+    this.routes = const [],
+    this.overrides = const [],
+    this.redirect,
+    this.namespace = '',
+  });
+
+  @override
+  final String namespace;
+  final List<RouteBase> routes;
+  final List<Override> overrides;
+  final GoRouterRedirect? redirect;
+
+  @override
+  ModuleRoutes build() =>
+      ModuleRoutes(routes: routes, overrides: overrides, redirect: redirect);
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
 void main() {
   group('runSoliplexShell', () {
-    test('throws ArgumentError on invalid config', () {
-      final config = ShellConfig(
+    test('throws ArgumentError on invalid config', () async {
+      final config = await ShellConfig.fromModules(
         appName: 'Test',
         theme: ThemeData(),
+        modules: [],
       );
 
       expect(() => runSoliplexShell(config), throwsArgumentError);
@@ -22,15 +52,15 @@ void main() {
       final greeting = Provider<String>((_) => 'default greeting');
       final farewell = Provider<String>((_) => 'default farewell');
 
-      final config = ShellConfig(
+      final config = await ShellConfig.fromModules(
         appName: 'Test',
         theme: ThemeData(),
         initialRoute: '/check',
         modules: [
-          ModuleContribution(
+          _TestModule(
             overrides: [greeting.overrideWithValue('hello')],
           ),
-          ModuleContribution(
+          _TestModule(
             overrides: [farewell.overrideWithValue('goodbye')],
             routes: [
               GoRoute(
@@ -59,20 +89,20 @@ void main() {
 
   group('redirect composition', () {
     testWidgets('first non-null redirect wins', (tester) async {
-      final config = ShellConfig(
+      final config = await ShellConfig.fromModules(
         appName: 'Test',
         theme: ThemeData(),
         initialRoute: '/a',
         modules: [
-          ModuleContribution(
+          _TestModule(
             redirect: (context, state) =>
                 state.matchedLocation == '/a' ? '/b' : null,
           ),
-          ModuleContribution(
+          _TestModule(
             redirect: (context, state) =>
                 state.matchedLocation == '/a' ? '/c' : null,
           ),
-          ModuleContribution(
+          _TestModule(
             routes: [
               GoRoute(
                 path: '/a',
@@ -97,4 +127,69 @@ void main() {
       expect(find.text('Page B'), findsOneWidget);
     });
   });
+
+  group('AppModuleCoordinator', () {
+    test('duplicate namespace throws StateError', () async {
+      expect(
+        () => ShellConfig.fromModules(
+          appName: 'Test',
+          theme: ThemeData(),
+          modules: [
+            _TestModule(namespace: 'same'),
+            _TestModule(namespace: 'same'),
+          ],
+        ),
+        throwsStateError,
+      );
+    });
+
+    test('empty namespace skips uniqueness check', () async {
+      // Should not throw even though both modules have empty namespace.
+      await ShellConfig.fromModules(
+        appName: 'Test',
+        theme: ThemeData(),
+        modules: [
+          _TestModule(
+            routes: [
+              GoRoute(path: '/', builder: (_, __) => const SizedBox()),
+            ],
+          ),
+          _TestModule(),
+        ],
+      );
+    });
+
+    test('onDispose is called in reverse registration order', () async {
+      final log = <String>[];
+
+      final config = await ShellConfig.fromModules(
+        appName: 'Test',
+        theme: ThemeData(),
+        modules: [
+          _LifecycleModule('a', log),
+          _LifecycleModule('b', log),
+        ],
+      );
+
+      config.onDispose?.call();
+      await Future<void>.delayed(Duration.zero); // let async dispose flush
+      expect(log, ['dispose:b', 'dispose:a']);
+    });
+  });
+}
+
+class _LifecycleModule extends AppModule {
+  _LifecycleModule(this._name, this._log);
+
+  final String _name;
+  final List<String> _log;
+
+  @override
+  String get namespace => _name;
+
+  @override
+  ModuleRoutes build() => const ModuleRoutes();
+
+  @override
+  Future<void> onDispose() async => _log.add('dispose:$_name');
 }

--- a/test/main_test.dart
+++ b/test/main_test.dart
@@ -4,18 +4,24 @@ import 'package:go_router/go_router.dart';
 
 import 'package:soliplex_frontend/soliplex_frontend.dart';
 
+class _HomeModule extends AppModule {
+  @override
+  String get namespace => 'home';
+
+  @override
+  ModuleRoutes build() => ModuleRoutes(
+        routes: [
+          GoRoute(path: '/', builder: (_, __) => const Text('Soliplex')),
+        ],
+      );
+}
+
 void main() {
   testWidgets('app boots and renders home screen', (tester) async {
-    final config = ShellConfig(
+    final config = await ShellConfig.fromModules(
       appName: 'Soliplex',
       theme: ThemeData(),
-      modules: [
-        ModuleContribution(
-          routes: [
-            GoRoute(path: '/', builder: (_, __) => const Text('Soliplex')),
-          ],
-        ),
-      ],
+      modules: [_HomeModule()],
     );
     runSoliplexShell(config);
     await tester.pumpAndSettle();

--- a/test/modules/auth/auth_module_test.dart
+++ b/test/modules/auth/auth_module_test.dart
@@ -17,43 +17,29 @@ ServerManager _createServerManager() => ServerManager(
       storage: InMemoryServerStorage(),
     );
 
-void main() {
-  group('authModule', () {
-    test('contributes routes for /, /servers, /auth/callback', () {
-      final serverManager = _createServerManager();
-      final contribution = authModule(
-        serverManager: serverManager,
-        authFlow: FakeAuthFlow(),
-        probeClient: FakeHttpClient(),
-        appName: 'Soliplex',
-      );
+AuthAppModule _createModule({ServerManager? serverManager}) => AuthAppModule(
+      serverManager: serverManager ?? _createServerManager(),
+      probeClient: FakeHttpClient(),
+      authFlow: FakeAuthFlow(),
+      appName: 'Soliplex',
+    );
 
+void main() {
+  group('AuthAppModule', () {
+    test('contributes routes for /, /servers, /auth/callback', () {
+      final contribution = _createModule().build();
       final paths =
           contribution.routes.whereType<GoRoute>().map((r) => r.path).toList();
       expect(paths, containsAll(['/', '/servers', '/auth/callback']));
     });
 
     test('contributes a redirect', () {
-      final serverManager = _createServerManager();
-      final contribution = authModule(
-        serverManager: serverManager,
-        authFlow: FakeAuthFlow(),
-        probeClient: FakeHttpClient(),
-        appName: 'Soliplex',
-      );
-
+      final contribution = _createModule().build();
       expect(contribution.redirect, isNotNull);
     });
 
     test('contributes overrides for required providers', () {
-      final serverManager = _createServerManager();
-      final contribution = authModule(
-        serverManager: serverManager,
-        authFlow: FakeAuthFlow(),
-        probeClient: FakeHttpClient(),
-        appName: 'Soliplex',
-      );
-
+      final contribution = _createModule().build();
       // At minimum: serverManager, authFlow, probeClient.
       // Optional overrides only added when non-null.
       expect(contribution.overrides, isNotEmpty);
@@ -62,16 +48,11 @@ void main() {
 
   group('auth redirect', () {
     late ServerManager serverManager;
+    late AuthAppModule module;
     late GoRouter router;
 
     Widget buildApp() {
-      final contribution = authModule(
-        serverManager: serverManager,
-        authFlow: FakeAuthFlow(),
-        probeClient: FakeHttpClient(),
-        appName: 'Soliplex',
-      );
-
+      final contribution = module.build();
       router = GoRouter(
         initialLocation: '/',
         routes: [
@@ -83,7 +64,6 @@ void main() {
         ],
         redirect: contribution.redirect,
       );
-
       return ProviderScope(
         overrides: contribution.overrides,
         child: MaterialApp.router(routerConfig: router),
@@ -92,7 +72,10 @@ void main() {
 
     setUp(() {
       serverManager = _createServerManager();
+      module = _createModule(serverManager: serverManager);
     });
+
+    tearDown(() async => module.onDispose());
 
     testWidgets('stays on / when unauthenticated', (tester) async {
       await tester.pumpWidget(buildApp());
@@ -113,13 +96,7 @@ void main() {
     });
 
     testWidgets('allows /auth/callback when unauthenticated', (tester) async {
-      final contribution = authModule(
-        serverManager: serverManager,
-        authFlow: FakeAuthFlow(),
-        probeClient: FakeHttpClient(),
-        appName: 'Soliplex',
-      );
-
+      final contribution = module.build();
       router = GoRouter(
         initialLocation: '/auth/callback',
         routes: contribution.routes,

--- a/test/modules/lobby/lobby_module_test.dart
+++ b/test/modules/lobby/lobby_module_test.dart
@@ -13,18 +13,18 @@ ServerManager _createManager() => ServerManager(
     );
 
 void main() {
-  group('lobbyModule', () {
+  group('LobbyAppModule', () {
     test('contributes /lobby route', () {
-      final contribution = lobbyModule(serverManager: _createManager());
-
+      final contribution =
+          LobbyAppModule(serverManager: _createManager()).build();
       final paths =
           contribution.routes.whereType<GoRoute>().map((r) => r.path).toList();
       expect(paths, contains('/lobby'));
     });
 
     test('does not contribute a redirect', () {
-      final contribution = lobbyModule(serverManager: _createManager());
-
+      final contribution =
+          LobbyAppModule(serverManager: _createManager()).build();
       expect(contribution.redirect, isNull);
     });
   });

--- a/test/modules/room/room_module_test.dart
+++ b/test/modules/room/room_module_test.dart
@@ -21,6 +21,7 @@ ServerManager _createManager() => ServerManager(
 void main() {
   late AgentRuntimeManager runtimeManager;
   late RunRegistry registry;
+  late RoomAppModule module;
 
   setUp(() {
     runtimeManager = AgentRuntimeManager(
@@ -29,20 +30,19 @@ void main() {
       logger: testLogger(),
     );
     registry = RunRegistry();
-  });
-
-  tearDown(() async {
-    await runtimeManager.dispose();
-    registry.dispose();
-  });
-
-  test('contributes room routes', () {
-    final manager = _createManager();
-    final contribution = roomModule(
-      serverManager: manager,
+    module = RoomAppModule(
+      serverManager: _createManager(),
       runtimeManager: runtimeManager,
       registry: registry,
     );
+  });
+
+  tearDown(() async {
+    await module.onDispose();
+  });
+
+  test('contributes room routes', () {
+    final contribution = module.build();
     final paths =
         contribution.routes.whereType<GoRoute>().map((r) => r.path).toList();
     expect(paths, contains('/room/:serverAlias/:roomId'));
@@ -50,12 +50,7 @@ void main() {
   });
 
   test('contributes room info route before thread route', () {
-    final manager = _createManager();
-    final contribution = roomModule(
-      serverManager: manager,
-      runtimeManager: runtimeManager,
-      registry: registry,
-    );
+    final contribution = module.build();
     final paths =
         contribution.routes.whereType<GoRoute>().map((r) => r.path).toList();
     expect(paths, contains('/room/:serverAlias/:roomId/info'));
@@ -69,12 +64,7 @@ void main() {
   });
 
   test('overrides messageExpansionsProvider so reads succeed', () {
-    final manager = _createManager();
-    final contribution = roomModule(
-      serverManager: manager,
-      runtimeManager: runtimeManager,
-      registry: registry,
-    );
+    final contribution = module.build();
 
     // Resolving the provider through the module's overrides must not
     // throw — the default provider throws StateError.


### PR DESCRIPTION
Replaces the function-per-module + `ModuleContribution` pattern with an `AppModule` subclass API. Final design — no deprecation layer, no unused surface.

- `AppModule` — subclass to declare a namespace, `build()` returning `ModuleRoutes` (routes + overrides + redirect), and an optional `onDispose()`.
- `ShellConfig.fromModules(...)` — validates unique namespaces, builds modules in registration order, runs `onDispose` in reverse when the shell tears down.
- Five modules ported: `AuthAppModule`, `LobbyAppModule`, `DiagnosticsAppModule`, `RoomAppModule`, `QuizAppModule`.
- `RoomAppModule.onDispose` awaits `runtimeManager.dispose()` so shell teardown does not return while cached runtimes are still shutting down.
- Old `ModuleContribution` class and `ShellConfig(modules:)` constructor deleted; `AppModuleContext` discovery surface not introduced.
- CLAUDE.md Module System section matches the API.

## Stack

PR 1 of 11. Base: `main`. The rest of the stack layers feature-by-feature on top.

Supersedes #163 (legacy M4, since-merged trim applied inline).

## Test plan

- [x] `flutter analyze` — 0 issues
- [x] `flutter test` — 1091 pass
