### PR TITLE
feat(soliplex_agent): SessionCoordinator and StatefulSessionExtension

### DIFF
--- a/lib/src/modules/room/agent_runtime_manager.dart
+++ b/lib/src/modules/room/agent_runtime_manager.dart
@@ -9,12 +9,15 @@ class AgentRuntimeManager {
     required PlatformConstraints platform,
     required Future<ToolRegistry> Function(String roomId) toolRegistryResolver,
     required Logger logger,
+    SessionExtensionFactory? extensionFactory,
   })  : _platform = platform,
         _toolRegistryResolver = toolRegistryResolver,
+        _extensionFactory = extensionFactory,
         _logger = logger;
 
   final PlatformConstraints _platform;
   final Future<ToolRegistry> Function(String roomId) _toolRegistryResolver;
+  final SessionExtensionFactory? _extensionFactory;
   final Logger _logger;
   final Map<String, ({ServerConnection connection, AgentRuntime runtime})>
       _cache = {};
@@ -49,6 +52,7 @@ class AgentRuntimeManager {
       connection: connection,
       toolRegistryResolver: _toolRegistryResolver,
       platform: _platform,
+      extensionFactory: _extensionFactory,
       logger: _logger,
     );
   }

--- a/packages/soliplex_agent/lib/soliplex_agent.dart
+++ b/packages/soliplex_agent/lib/soliplex_agent.dart
@@ -62,7 +62,9 @@ export 'src/runtime/agent_ui_delegate.dart';
 export 'src/runtime/multi_server_runtime.dart';
 export 'src/runtime/server_connection.dart';
 export 'src/runtime/server_registry.dart';
+export 'src/runtime/session_coordinator.dart';
 export 'src/runtime/session_extension.dart';
+export 'src/runtime/stateful_session_extension.dart';
 // ── Scripting ──
 export 'src/scripting/script_environment.dart';
 // ── Tools ──

--- a/packages/soliplex_agent/lib/src/runtime/agent_runtime.dart
+++ b/packages/soliplex_agent/lib/src/runtime/agent_runtime.dart
@@ -12,6 +12,7 @@ import 'package:soliplex_agent/src/runtime/agent_session.dart';
 import 'package:soliplex_agent/src/runtime/agent_session_state.dart';
 import 'package:soliplex_agent/src/runtime/agent_ui_delegate.dart';
 import 'package:soliplex_agent/src/runtime/server_connection.dart';
+import 'package:soliplex_agent/src/runtime/session_coordinator.dart';
 import 'package:soliplex_agent/src/runtime/session_extension.dart';
 import 'package:soliplex_agent/src/tools/tool_registry_resolver.dart';
 import 'package:soliplex_client/soliplex_client.dart' show ThreadHistory;
@@ -323,10 +324,9 @@ class AgentRuntime {
   }) async {
     var toolRegistry = await _toolRegistryResolver(roomId);
     final extensions = await _createExtensions();
-    for (final ext in extensions) {
-      for (final tool in ext.tools) {
-        toolRegistry = toolRegistry.register(tool);
-      }
+    final coordinator = SessionCoordinator(extensions);
+    for (final tool in coordinator.tools) {
+      toolRegistry = toolRegistry.register(tool);
     }
     final orchestrator = RunOrchestrator(
       llmProvider: _llmProvider,
@@ -340,7 +340,7 @@ class AgentRuntime {
       runtime: this,
       orchestrator: orchestrator,
       toolRegistry: toolRegistry,
-      extensions: extensions,
+      coordinator: coordinator,
       uiDelegate: _uiDelegate,
       logger: _logger,
     );

--- a/packages/soliplex_agent/lib/src/runtime/agent_runtime.dart
+++ b/packages/soliplex_agent/lib/src/runtime/agent_runtime.dart
@@ -324,7 +324,7 @@ class AgentRuntime {
   }) async {
     var toolRegistry = await _toolRegistryResolver(roomId);
     final extensions = await _createExtensions();
-    final coordinator = SessionCoordinator(extensions);
+    final coordinator = SessionCoordinator(extensions, logger: _logger);
     for (final tool in coordinator.tools) {
       toolRegistry = toolRegistry.register(tool);
     }

--- a/packages/soliplex_agent/lib/src/runtime/agent_session.dart
+++ b/packages/soliplex_agent/lib/src/runtime/agent_session.dart
@@ -216,8 +216,7 @@ class AgentSession implements ToolExecutionContext {
   T? getExtension<T extends SessionExtension>() =>
       _coordinator.getExtension<T>();
 
-  /// Yields `(namespace, signal)` for every stateful extension with a
-  /// non-empty namespace registered in this session.
+  /// See [SessionCoordinator.statefulObservations].
   Iterable<(String, ReadonlySignal<Object?>)> statefulObservations() =>
       _coordinator.statefulObservations();
 
@@ -280,7 +279,16 @@ class AgentSession implements ToolExecutionContext {
     if (_disposed) return;
     _disposed = true;
     for (final child in _children.toList()) {
-      child.dispose();
+      try {
+        child.dispose();
+      } on Object catch (e, st) {
+        _logger.error(
+          'Child AgentSession dispose threw (parent=$id, '
+          'thread=${threadKey.threadId}, child=${child.id})',
+          error: e,
+          stackTrace: st,
+        );
+      }
     }
     _children.clear();
     _disposeExtensions();
@@ -288,7 +296,16 @@ class AgentSession implements ToolExecutionContext {
     _subscription = null;
     unawaited(_baseEventSubscription?.cancel());
     _baseEventSubscription = null;
-    _orchestrator.dispose();
+    try {
+      _orchestrator.dispose();
+    } on Object catch (e, st) {
+      _logger.error(
+        'Orchestrator dispose threw (session=$id, '
+        'thread=${threadKey.threadId})',
+        error: e,
+        stackTrace: st,
+      );
+    }
     _completeIfPending();
     _runStateSignal.dispose();
     _sessionStateSignal.dispose();

--- a/packages/soliplex_agent/lib/src/runtime/agent_session.dart
+++ b/packages/soliplex_agent/lib/src/runtime/agent_session.dart
@@ -11,6 +11,7 @@ import 'package:soliplex_agent/src/orchestration/run_state.dart';
 import 'package:soliplex_agent/src/runtime/agent_runtime.dart';
 import 'package:soliplex_agent/src/runtime/agent_session_state.dart';
 import 'package:soliplex_agent/src/runtime/agent_ui_delegate.dart';
+import 'package:soliplex_agent/src/runtime/session_coordinator.dart';
 import 'package:soliplex_agent/src/runtime/session_extension.dart';
 import 'package:soliplex_agent/src/tools/tool_execution_context.dart';
 import 'package:soliplex_agent/src/tools/tool_registry.dart';
@@ -42,12 +43,12 @@ class AgentSession implements ToolExecutionContext {
     required RunOrchestrator orchestrator,
     required ToolRegistry toolRegistry,
     required Logger logger,
-    List<SessionExtension> extensions = const [],
+    required SessionCoordinator coordinator,
     AgentUiDelegate? uiDelegate,
   })  : _runtime = runtime,
         _orchestrator = orchestrator,
         _toolRegistry = toolRegistry,
-        _extensions = extensions,
+        _coordinator = coordinator,
         _uiDelegate = uiDelegate,
         _logger = logger,
         id = '${threadKey.threadId}-'
@@ -68,7 +69,7 @@ class AgentSession implements ToolExecutionContext {
   final AgentRuntime _runtime;
   final RunOrchestrator _orchestrator;
   final ToolRegistry _toolRegistry;
-  final List<SessionExtension> _extensions;
+  final SessionCoordinator _coordinator;
   final AgentUiDelegate? _uiDelegate;
   final Logger _logger;
 
@@ -212,12 +213,13 @@ class AgentSession implements ToolExecutionContext {
   }
 
   @override
-  T? getExtension<T extends SessionExtension>() {
-    for (final ext in _extensions) {
-      if (ext is T) return ext;
-    }
-    return null;
-  }
+  T? getExtension<T extends SessionExtension>() =>
+      _coordinator.getExtension<T>();
+
+  /// Yields `(namespace, signal)` for every stateful extension with a
+  /// non-empty namespace registered in this session.
+  Iterable<(String, ReadonlySignal<Object?>)> statefulObservations() =>
+      _coordinator.statefulObservations();
 
   // ---------------------------------------------------------------------------
   // Child management
@@ -297,17 +299,9 @@ class AgentSession implements ToolExecutionContext {
   // Extension lifecycle
   // ---------------------------------------------------------------------------
 
-  Future<void> _attachExtensions() async {
-    for (final ext in _extensions) {
-      await ext.onAttach(this);
-    }
-  }
+  Future<void> _attachExtensions() => _coordinator.attachAll(this);
 
-  void _disposeExtensions() {
-    for (final ext in _extensions) {
-      ext.onDispose();
-    }
-  }
+  void _disposeExtensions() => _coordinator.disposeAll();
 
   // ---------------------------------------------------------------------------
   // State listener

--- a/packages/soliplex_agent/lib/src/runtime/session_coordinator.dart
+++ b/packages/soliplex_agent/lib/src/runtime/session_coordinator.dart
@@ -3,34 +3,36 @@ import 'package:soliplex_agent/src/runtime/agent_session.dart';
 import 'package:soliplex_agent/src/runtime/session_extension.dart';
 import 'package:soliplex_agent/src/runtime/stateful_session_extension.dart';
 import 'package:soliplex_agent/src/tools/tool_registry.dart';
+import 'package:soliplex_logging/soliplex_logging.dart';
 
-/// Manages the lifecycle of a set of [SessionExtension]s for one
-/// [AgentSession].
-///
-/// Responsibilities:
-/// - **Namespace validation** — rejects duplicate non-empty namespaces.
-/// - **Priority-ordered attach** — [attachAll] sorts by descending priority.
-/// - **Reverse-order dispose** — [disposeAll] tears down in reverse attach
-///   order.
-/// - **Type-based lookup** — [getExtension] mirrors
-///   [AgentSession.getExtension].
-/// - **Stateful observations** — [statefulObservations] enumerates stateful
-///   extensions, yielding `(namespace, signal)` pairs for reactive state
-///   consumers that don't need to know the concrete extension types.
+/// Owns the lifecycle of a set of [SessionExtension]s for one
+/// [AgentSession]: validates namespaces at construction, attaches and
+/// disposes in order, and exposes lookup plus reactive-state enumeration
+/// to consumers that don't know the concrete extension types.
 class SessionCoordinator {
-  SessionCoordinator(List<SessionExtension> extensions)
-      : _extensions = List.of(extensions) {
+  /// Throws [ArgumentError] if any two extensions share a non-empty
+  /// namespace.
+  SessionCoordinator(
+    List<SessionExtension> extensions, {
+    required Logger logger,
+  })  : _extensions = List.of(extensions),
+        _logger = logger {
     _validateNamespaces();
   }
 
   final List<SessionExtension> _extensions;
+  final Logger _logger;
   List<SessionExtension>? _attachOrder;
   bool _disposed = false;
 
-  /// All tools contributed by all extensions.
   List<ClientTool> get tools => _extensions.expand((e) => e.tools).toList();
 
   /// Attaches all extensions to [session] in descending priority order.
+  ///
+  /// On exception, partially-attached extensions are not auto-disposed
+  /// here; the caller is responsible for invoking [disposeAll] (in
+  /// production this happens via [AgentSession.dispose] from the
+  /// spawn-path's cleanup in `AgentRuntime.spawn`).
   Future<void> attachAll(AgentSession session) async {
     final ordered = List.of(_extensions)
       ..sort((a, b) => b.priority.compareTo(a.priority));
@@ -40,17 +42,35 @@ class SessionCoordinator {
     }
   }
 
-  /// Disposes all extensions in reverse attach order. Idempotent.
+  /// Disposes all extensions in reverse of [attachAll]'s priority order,
+  /// or in reverse registration order if [attachAll] never ran.
+  /// Idempotent and terminal: a throwing `onDispose` is logged per
+  /// extension and does not propagate — every registered extension gets
+  /// its dispose call.
   void disposeAll() {
     if (_disposed) return;
     _disposed = true;
     final order = _attachOrder ?? _extensions;
     for (final ext in order.reversed) {
-      ext.onDispose();
+      try {
+        ext.onDispose();
+      } on Object catch (e, st) {
+        _logger.error(
+          'SessionExtension "${ext.namespace}" onDispose threw',
+          error: e,
+          stackTrace: st,
+        );
+      }
     }
   }
 
-  /// Returns the first extension of type [T], or `null` if none is registered.
+  /// Returns the first extension of type [T] in registration order, or
+  /// `null` if none is registered.
+  ///
+  /// Uniqueness is enforced by namespace, not by type: two extensions of
+  /// the same type with different namespaces are both legal, and this
+  /// lookup returns the first-registered one. Prefer namespace-based
+  /// discovery when unambiguous lookup matters.
   T? getExtension<T extends SessionExtension>() {
     for (final ext in _extensions) {
       if (ext is T) return ext;
@@ -67,9 +87,8 @@ class SessionCoordinator {
     for (final ext in _extensions) {
       final ns = ext.namespace;
       if (ns.isEmpty) continue;
-      switch (ext) {
-        case final HasStatefulObservation stateful:
-          yield (ns, stateful.stateSignalAsObject);
+      if (ext case final HasStatefulObservation stateful) {
+        yield (ns, stateful.stateSignalAsObject);
       }
     }
   }

--- a/packages/soliplex_agent/lib/src/runtime/session_coordinator.dart
+++ b/packages/soliplex_agent/lib/src/runtime/session_coordinator.dart
@@ -1,0 +1,90 @@
+import 'package:signals_core/signals_core.dart';
+import 'package:soliplex_agent/src/runtime/agent_session.dart';
+import 'package:soliplex_agent/src/runtime/session_extension.dart';
+import 'package:soliplex_agent/src/runtime/stateful_session_extension.dart';
+import 'package:soliplex_agent/src/tools/tool_registry.dart';
+
+/// Manages the lifecycle of a set of [SessionExtension]s for one
+/// [AgentSession].
+///
+/// Responsibilities:
+/// - **Namespace validation** — rejects duplicate non-empty namespaces.
+/// - **Priority-ordered attach** — [attachAll] sorts by descending priority.
+/// - **Reverse-order dispose** — [disposeAll] tears down in reverse attach
+///   order.
+/// - **Type-based lookup** — [getExtension] mirrors
+///   [AgentSession.getExtension].
+/// - **Stateful observations** — [statefulObservations] enumerates stateful
+///   extensions, yielding `(namespace, signal)` pairs for reactive state
+///   consumers that don't need to know the concrete extension types.
+class SessionCoordinator {
+  SessionCoordinator(List<SessionExtension> extensions)
+      : _extensions = List.of(extensions) {
+    _validateNamespaces();
+  }
+
+  final List<SessionExtension> _extensions;
+  List<SessionExtension>? _attachOrder;
+  bool _disposed = false;
+
+  /// All tools contributed by all extensions.
+  List<ClientTool> get tools => _extensions.expand((e) => e.tools).toList();
+
+  /// Attaches all extensions to [session] in descending priority order.
+  Future<void> attachAll(AgentSession session) async {
+    final ordered = List.of(_extensions)
+      ..sort((a, b) => b.priority.compareTo(a.priority));
+    _attachOrder = ordered;
+    for (final ext in ordered) {
+      await ext.onAttach(session);
+    }
+  }
+
+  /// Disposes all extensions in reverse attach order. Idempotent.
+  void disposeAll() {
+    if (_disposed) return;
+    _disposed = true;
+    final order = _attachOrder ?? _extensions;
+    for (final ext in order.reversed) {
+      ext.onDispose();
+    }
+  }
+
+  /// Returns the first extension of type [T], or `null` if none is registered.
+  T? getExtension<T extends SessionExtension>() {
+    for (final ext in _extensions) {
+      if (ext is T) return ext;
+    }
+    return null;
+  }
+
+  /// Yields `(namespace, signal)` for every [StatefulSessionExtension] with a
+  /// non-empty namespace, in registration order.
+  ///
+  /// Consumers can iterate this to observe all reactive extension state
+  /// without importing concrete extension types.
+  Iterable<(String, ReadonlySignal<Object?>)> statefulObservations() sync* {
+    for (final ext in _extensions) {
+      final ns = ext.namespace;
+      if (ns.isEmpty) continue;
+      switch (ext) {
+        case final HasStatefulObservation stateful:
+          yield (ns, stateful.stateSignalAsObject);
+      }
+    }
+  }
+
+  void _validateNamespaces() {
+    final seen = <String>{};
+    for (final ext in _extensions) {
+      final ns = ext.namespace;
+      if (ns.isEmpty) continue;
+      if (!seen.add(ns)) {
+        throw ArgumentError(
+          'Duplicate SessionExtension namespace "$ns". '
+          'Each named extension must have a unique namespace.',
+        );
+      }
+    }
+  }
+}

--- a/packages/soliplex_agent/lib/src/runtime/session_extension.dart
+++ b/packages/soliplex_agent/lib/src/runtime/session_extension.dart
@@ -4,9 +4,22 @@ import 'package:soliplex_agent/src/tools/tool_registry.dart';
 /// A capability bound to the lifecycle of an [AgentSession].
 ///
 /// Extensions provide tools and resources that are created when the
-/// session starts and disposed when the session ends. The session
-/// cascades dispose to all extensions.
-abstract interface class SessionExtension {
+/// session starts and disposed when the session ends.
+///
+/// Subclass via `extends SessionExtension` to inherit the default
+/// [namespace] and [priority]. Mix in `StatefulSessionExtension` to
+/// add a typed reactive-state signal.
+abstract class SessionExtension {
+  /// Unique identifier for this extension type.
+  ///
+  /// The coordinator validates uniqueness across all extensions in a session
+  /// when the namespace is non-empty. Use the default empty string for
+  /// extensions that do not need cross-extension discovery.
+  String get namespace => '';
+
+  /// Attach priority. Higher values attach first and dispose last.
+  int get priority => 0;
+
   /// Called after session creation, before the run starts.
   ///
   /// Receives the [session] for context access (e.g. spawning children,

--- a/packages/soliplex_agent/lib/src/runtime/session_extension.dart
+++ b/packages/soliplex_agent/lib/src/runtime/session_extension.dart
@@ -33,6 +33,10 @@ abstract class SessionExtension {
   List<ClientTool> get tools;
 
   /// Called when the session is disposed. Must be idempotent.
+  ///
+  /// May be invoked even if [onAttach] did not complete (e.g. a sibling
+  /// extension threw mid-attach). Implementations must tolerate being
+  /// called from any partially-initialized state.
   void onDispose();
 }
 

--- a/packages/soliplex_agent/lib/src/runtime/stateful_session_extension.dart
+++ b/packages/soliplex_agent/lib/src/runtime/stateful_session_extension.dart
@@ -1,0 +1,80 @@
+import 'package:signals_core/signals_core.dart';
+import 'package:soliplex_agent/src/runtime/session_extension.dart';
+
+/// Marker interface for extensions that expose a type-erased reactive state
+/// signal. Used by `SessionCoordinator.statefulObservations` to enumerate
+/// stateful extensions without knowing concrete type parameters.
+abstract interface class HasStatefulObservation {
+  ReadonlySignal<Object?> get stateSignalAsObject;
+}
+
+/// Adds a single typed reactive-state signal to a [SessionExtension].
+///
+/// Call [setInitialState] in the constructor before [onAttach] runs.
+/// Read [state] / write [state] to drive the signal. Dispose is handled
+/// automatically — override [onDispose] and call `super.onDispose()` to
+/// chain cleanup.
+///
+/// ```dart
+/// class MyExtension extends SessionExtension
+///     with StatefulSessionExtension<MySnapshot> {
+///   MyExtension() {
+///     setInitialState(const MySnapshot());
+///   }
+///
+///   @override
+///   String get namespace => 'my_extension';
+///
+///   @override
+///   Future<void> onAttach(AgentSession session) async {
+///     // subscribe to session signals here
+///   }
+///
+///   @override
+///   List<ClientTool> get tools => const [];
+///
+///   @override
+///   void onDispose() {
+///     // clean up subscriptions
+///     super.onDispose(); // disposes the state signal
+///   }
+/// }
+/// ```
+mixin StatefulSessionExtension<T> on SessionExtension
+    implements HasStatefulObservation {
+  Signal<T>? _stateSignal;
+  ReadonlySignal<Object?>? _objectSignal;
+
+  /// Initialises the backing signal. Must be called in the constructor.
+  void setInitialState(T initial) {
+    _stateSignal = signal(initial);
+  }
+
+  /// Typed read-only view of the state signal.
+  ReadonlySignal<T> get stateSignal {
+    assert(_stateSignal != null, 'Call setInitialState() in the constructor');
+    return _stateSignal!.readonly();
+  }
+
+  /// Current state value.
+  T get state => _stateSignal!.value;
+
+  /// Replaces the current state, notifying all subscribers.
+  set state(T value) => _stateSignal!.value = value;
+
+  /// Type-erased view of [stateSignal] for use by `SessionCoordinator`.
+  ///
+  /// Backed by a `computed` signal to avoid unsafe generic casts at runtime.
+  @override
+  ReadonlySignal<Object?> get stateSignalAsObject {
+    return _objectSignal ??= computed<Object?>(() => _stateSignal!.value);
+  }
+
+  @override
+  void onDispose() {
+    _objectSignal?.dispose();
+    _objectSignal = null;
+    _stateSignal?.dispose();
+    _stateSignal = null;
+  }
+}

--- a/packages/soliplex_agent/lib/src/runtime/stateful_session_extension.dart
+++ b/packages/soliplex_agent/lib/src/runtime/stateful_session_extension.dart
@@ -1,3 +1,4 @@
+import 'package:meta/meta.dart';
 import 'package:signals_core/signals_core.dart';
 import 'package:soliplex_agent/src/runtime/session_extension.dart';
 
@@ -45,8 +46,11 @@ mixin StatefulSessionExtension<T> on SessionExtension
   Signal<T>? _stateSignal;
   ReadonlySignal<Object?>? _objectSignal;
 
-  /// Initialises the backing signal. Must be called in the constructor.
+  /// Initialises the backing signal. Must be called exactly once, in the
+  /// constructor, before [onAttach] runs.
+  @protected
   void setInitialState(T initial) {
+    assert(_stateSignal == null, 'setInitialState() called more than once');
     _stateSignal = signal(initial);
   }
 
@@ -57,16 +61,23 @@ mixin StatefulSessionExtension<T> on SessionExtension
   }
 
   /// Current state value.
-  T get state => _stateSignal!.value;
+  T get state {
+    assert(_stateSignal != null, 'Call setInitialState() in the constructor');
+    return _stateSignal!.value;
+  }
 
   /// Replaces the current state, notifying all subscribers.
-  set state(T value) => _stateSignal!.value = value;
+  set state(T value) {
+    assert(_stateSignal != null, 'Call setInitialState() in the constructor');
+    _stateSignal!.value = value;
+  }
 
   /// Type-erased view of [stateSignal] for use by `SessionCoordinator`.
   ///
   /// Backed by a `computed` signal to avoid unsafe generic casts at runtime.
   @override
   ReadonlySignal<Object?> get stateSignalAsObject {
+    assert(_stateSignal != null, 'Call setInitialState() in the constructor');
     return _objectSignal ??= computed<Object?>(() => _stateSignal!.value);
   }
 

--- a/packages/soliplex_agent/lib/src/scripting/script_environment.dart
+++ b/packages/soliplex_agent/lib/src/scripting/script_environment.dart
@@ -30,7 +30,7 @@ typedef ScriptEnvironmentFactory = Future<ScriptEnvironment> Function();
 ///
 /// Bridges existing [ScriptEnvironmentFactory] callers to the new
 /// extension-based lifecycle without breaking downstream code.
-class ScriptEnvironmentExtension implements SessionExtension {
+class ScriptEnvironmentExtension extends SessionExtension {
   /// Creates an extension that wraps the given [ScriptEnvironment].
   ScriptEnvironmentExtension(this._environment);
 

--- a/packages/soliplex_agent/lib/src/scripting/script_environment.dart
+++ b/packages/soliplex_agent/lib/src/scripting/script_environment.dart
@@ -26,10 +26,8 @@ abstract interface class ScriptEnvironment {
 /// MontyLimits, etc.) so callers only need to invoke it.
 typedef ScriptEnvironmentFactory = Future<ScriptEnvironment> Function();
 
-/// Adapter that wraps a [ScriptEnvironment] as a [SessionExtension].
-///
-/// Bridges existing [ScriptEnvironmentFactory] callers to the new
-/// extension-based lifecycle without breaking downstream code.
+/// Exposes a [ScriptEnvironment] as a [SessionExtension] so its tools
+/// and dispose hook participate in normal session lifecycle.
 class ScriptEnvironmentExtension extends SessionExtension {
   /// Creates an extension that wraps the given [ScriptEnvironment].
   ScriptEnvironmentExtension(this._environment);

--- a/packages/soliplex_agent/test/runtime/agent_runtime_test.dart
+++ b/packages/soliplex_agent/test/runtime/agent_runtime_test.dart
@@ -25,7 +25,7 @@ class _FakeCancelToken extends Fake implements CancelToken {}
 // Test doubles
 // ---------------------------------------------------------------------------
 
-class _TestExtension implements SessionExtension {
+class _TestExtension extends SessionExtension {
   _TestExtension({this.toolList = const []});
 
   final List<ClientTool> toolList;
@@ -42,7 +42,7 @@ class _TestExtension implements SessionExtension {
   void onDispose() => disposeCount++;
 }
 
-class _ThrowingExtension implements SessionExtension {
+class _ThrowingExtension extends SessionExtension {
   @override
   Future<void> onAttach(AgentSession session) async =>
       throw StateError('onAttach boom');

--- a/packages/soliplex_agent/test/runtime/agent_session_signal_test.dart
+++ b/packages/soliplex_agent/test/runtime/agent_session_signal_test.dart
@@ -70,6 +70,7 @@ AgentSession createSession({
     runtime: runtime ?? MockAgentRuntime(),
     orchestrator: orchestrator,
     toolRegistry: registry,
+    coordinator: SessionCoordinator(const []),
     logger: logger,
   );
 }

--- a/packages/soliplex_agent/test/runtime/agent_session_signal_test.dart
+++ b/packages/soliplex_agent/test/runtime/agent_session_signal_test.dart
@@ -70,7 +70,7 @@ AgentSession createSession({
     runtime: runtime ?? MockAgentRuntime(),
     orchestrator: orchestrator,
     toolRegistry: registry,
-    coordinator: SessionCoordinator(const []),
+    coordinator: SessionCoordinator(const [], logger: logger),
     logger: logger,
   );
 }

--- a/packages/soliplex_agent/test/runtime/agent_session_test.dart
+++ b/packages/soliplex_agent/test/runtime/agent_session_test.dart
@@ -88,7 +88,7 @@ class _TestScriptEnvironment implements ScriptEnvironment {
   void dispose() => disposeCount++;
 }
 
-class _TestExtension implements SessionExtension {
+class _TestExtension extends SessionExtension {
   int attachCount = 0;
   int disposeCount = 0;
   AgentSession? attachedSession;
@@ -106,7 +106,7 @@ class _TestExtension implements SessionExtension {
   void onDispose() => disposeCount++;
 }
 
-class _TestExtensionWithTool implements SessionExtension {
+class _TestExtensionWithTool extends SessionExtension {
   _TestExtensionWithTool(this._tool);
 
   final ClientTool _tool;
@@ -150,7 +150,7 @@ AgentSession createSession({
     runtime: runtime ?? MockAgentRuntime(),
     orchestrator: orchestrator,
     toolRegistry: registry,
-    extensions: extensions,
+    coordinator: SessionCoordinator(extensions),
     logger: logger,
   );
 }

--- a/packages/soliplex_agent/test/runtime/agent_session_test.dart
+++ b/packages/soliplex_agent/test/runtime/agent_session_test.dart
@@ -150,7 +150,7 @@ AgentSession createSession({
     runtime: runtime ?? MockAgentRuntime(),
     orchestrator: orchestrator,
     toolRegistry: registry,
-    coordinator: SessionCoordinator(extensions),
+    coordinator: SessionCoordinator(extensions, logger: logger),
     logger: logger,
   );
 }


### PR DESCRIPTION
Introduces the session-level plugin seam that feature extensions (execution trackers, tool call status, human approval) attach through.

- `SessionCoordinator` — ordered list of `SessionExtension`s, keyed by unique namespace. Manages `attachAll` / reverse `disposeAll`, surfaces per-extension state via `statefulObservations()`.
- `SessionExtension` — base type. Provides a namespace, optional `ClientTool` contributions, and `onAttach` / `onDispose` hooks.
- `StatefulSessionExtension<T>` mixin + `HasStatefulObservation` interface — plug a typed reactive signal onto an extension so the coordinator can fan observations out to debug tooling.

Pure addition to `soliplex_agent`; no existing consumers change shape in this PR (those follow).

## Stack

PR 2 of 11. Base: feat/app-module-lifecycle.

Supersedes #160 (legacy M1).

## Test plan

- [x] `flutter analyze` — 0 issues
- [x] `flutter test` — 1091 pass
- [x] `dart test --exclude-tags=integration` in `packages/soliplex_agent` — 459 pass
