### PR TITLE
feat(room): ExecutionTrackerExtension — first session reactor

### DIFF
--- a/lib/src/flavors/standard.dart
+++ b/lib/src/flavors/standard.dart
@@ -21,6 +21,7 @@ import '../modules/diagnostics/network_inspector.dart';
 import '../modules/lobby/lobby_module.dart';
 import '../modules/quiz/quiz_module.dart';
 import '../modules/room/agent_runtime_manager.dart';
+import '../modules/room/execution_tracker_extension.dart';
 import '../modules/room/room_module.dart';
 import '../modules/room/run_registry.dart';
 import '../modules/room/ui/markdown/markdown_theme_extension.dart';
@@ -132,6 +133,7 @@ Future<ShellConfig> standard({
         : const NativePlatformConstraints(),
     toolRegistryResolver: (_) async => const ToolRegistry(),
     logger: LogManager.instance.getLogger('room'),
+    extensionFactory: () async => [ExecutionTrackerExtension()],
   );
 
   final registry = RunRegistry();

--- a/lib/src/modules/room/execution_tracker_extension.dart
+++ b/lib/src/modules/room/execution_tracker_extension.dart
@@ -1,0 +1,69 @@
+import 'package:soliplex_agent/soliplex_agent.dart';
+
+import 'execution_tracker.dart';
+import 'tracker_registry.dart';
+
+/// A [SessionExtension] that reacts to [AgentSession] run-state changes and
+/// drives an internal [TrackerRegistry].
+///
+/// Subscribes to `session.runState` in [onAttach] and routes
+/// [RunningState]/terminal states into the registry. The resulting
+/// [Map<String, ExecutionTracker>] is exposed via the [stateSignal] and the
+/// convenience [trackers] getter.
+///
+/// [ThreadViewState] absorbs the live trackers into its own historical
+/// registry on detach, so execution data persists after the session ends.
+class ExecutionTrackerExtension extends SessionExtension
+    with StatefulSessionExtension<Map<String, ExecutionTracker>> {
+  ExecutionTrackerExtension() : _registry = TrackerRegistry() {
+    setInitialState(const <String, ExecutionTracker>{});
+  }
+
+  final TrackerRegistry _registry;
+  void Function()? _runStateUnsub;
+  AgentSession? _session;
+
+  @override
+  String get namespace => 'execution_tracker';
+
+  @override
+  int get priority => 10;
+
+  @override
+  List<ClientTool> get tools => const [];
+
+  /// Current tracker map (historical + live for this session).
+  Map<String, ExecutionTracker> get trackers => _registry.trackers;
+
+  @override
+  Future<void> onAttach(AgentSession session) async {
+    _session = session;
+    _runStateUnsub = session.runState.subscribe(_onRunState);
+  }
+
+  @override
+  void onDispose() {
+    _runStateUnsub?.call();
+    _runStateUnsub = null;
+    _session = null;
+    _registry.dispose();
+    super.onDispose();
+  }
+
+  void _onRunState(RunState runState) {
+    final session = _session;
+    if (session == null) return;
+    switch (runState) {
+      case RunningState(:final streaming):
+        _registry.onStreaming(streaming, session.lastExecutionEvent);
+        _sync();
+      case CompletedState() || FailedState() || CancelledState():
+        _registry.onRunTerminated();
+        _sync();
+      case IdleState() || ToolYieldingState():
+        break;
+    }
+  }
+
+  void _sync() => state = _registry.trackers;
+}

--- a/lib/src/modules/room/execution_tracker_extension.dart
+++ b/lib/src/modules/room/execution_tracker_extension.dart
@@ -43,6 +43,8 @@ class ExecutionTrackerExtension extends SessionExtension
 
   @override
   void onDispose() {
+    // Order is load-bearing: unsubscribe must precede clearing _session, so
+    // _onRunState can rely on _session being non-null while subscribed.
     _runStateUnsub?.call();
     _runStateUnsub = null;
     _session = null;
@@ -51,8 +53,7 @@ class ExecutionTrackerExtension extends SessionExtension
   }
 
   void _onRunState(RunState runState) {
-    final session = _session;
-    if (session == null) return;
+    final session = _session!;
     switch (runState) {
       case RunningState(:final streaming):
         _registry.onStreaming(streaming, session.lastExecutionEvent);

--- a/lib/src/modules/room/thread_view_state.dart
+++ b/lib/src/modules/room/thread_view_state.dart
@@ -247,7 +247,7 @@ class ThreadViewState {
     if (ext != null) {
       // Live tracker wins over any historical entry with the same key.
       for (final entry in ext.trackers.entries) {
-        _historicalTrackers.putIfAbsent(entry.key, () => entry.value);
+        _historicalTrackers[entry.key] = entry.value;
       }
     }
     _runStateUnsub?.call();
@@ -302,6 +302,9 @@ class ThreadViewState {
         .then((history) {
       if (token.isCancelled) return;
       _cancelToken = null;
+      // putIfAbsent (not []=) on refresh: server replay must not overwrite a
+      // tracker already absorbed from a live session (`_detachSession`), which
+      // captured the full client-side event stream.
       for (final entry in replayToTrackers(history.runs).entries) {
         _historicalTrackers.putIfAbsent(entry.key, () => entry.value);
       }

--- a/lib/src/modules/room/thread_view_state.dart
+++ b/lib/src/modules/room/thread_view_state.dart
@@ -4,10 +4,10 @@ import 'package:flutter/foundation.dart' show debugPrint;
 import 'package:soliplex_agent/soliplex_agent.dart';
 
 import 'execution_tracker.dart';
+import 'execution_tracker_extension.dart';
 import 'historical_replay.dart';
 import 'run_registry.dart';
 import 'send_error.dart';
-import 'tracker_registry.dart';
 
 export 'send_error.dart';
 
@@ -102,9 +102,19 @@ class ThreadViewState {
   final Signal<SendError?> _lastSendError = Signal<SendError?>(null);
   ReadonlySignal<SendError?> get lastSendError => _lastSendError;
 
-  final TrackerRegistry _trackerRegistry = TrackerRegistry();
-  Map<String, ExecutionTracker> get executionTrackers =>
-      _trackerRegistry.trackers;
+  // Persists historical trackers from loaded thread history and from
+  // completed sessions (absorbed in _detachSession). Plain map — the live
+  // registry lives inside ExecutionTrackerExtension, which outlives the
+  // view when the session runs in the background.
+  final Map<String, ExecutionTracker> _historicalTrackers = {};
+
+  /// Returns all execution trackers for this thread: historical (from loaded
+  /// thread history) merged with any live trackers from the active session.
+  Map<String, ExecutionTracker> get executionTrackers {
+    final ext = _activeSession?.getExtension<ExecutionTrackerExtension>();
+    if (ext == null) return Map.unmodifiable(_historicalTrackers);
+    return {..._historicalTrackers, ...ext.trackers};
+  }
 
   void submitFeedback(String runId, FeedbackType feedback, String? reason) {
     unawaited(
@@ -189,8 +199,6 @@ class ThreadViewState {
   }
 
   void _onRunState(RunState runState) {
-    final session = _activeSession;
-    if (session == null) return;
     switch (runState) {
       case RunningState(:final conversation, :final streaming):
         final current = _messages.value;
@@ -200,23 +208,16 @@ class ThreadViewState {
         }
         _streamingState.value = streaming;
         _sessionState.value = AgentSessionState.running;
-        _trackerRegistry.onStreaming(
-          streaming,
-          session.lastExecutionEvent,
-        );
       case CompletedState(:final conversation):
-        _trackerRegistry.onRunTerminated();
         _detachSession();
         _messages.value = _messagesLoaded(conversation);
       case FailedState(:final conversation, :final error):
-        _trackerRegistry.onRunTerminated();
         _detachSession();
         _lastSendError.value = SendError(error);
         if (conversation != null) {
           _messages.value = _messagesLoaded(conversation);
         }
       case CancelledState(:final conversation):
-        _trackerRegistry.onRunTerminated();
         _detachSession();
         if (conversation != null) {
           _messages.value = _messagesLoaded(conversation);
@@ -240,6 +241,15 @@ class ThreadViewState {
   }
 
   void _detachSession() {
+    // Absorb live trackers from the extension before clearing the session
+    // reference, so historical data persists after the session ends.
+    final ext = _activeSession?.getExtension<ExecutionTrackerExtension>();
+    if (ext != null) {
+      // Live tracker wins over any historical entry with the same key.
+      for (final entry in ext.trackers.entries) {
+        _historicalTrackers.putIfAbsent(entry.key, () => entry.value);
+      }
+    }
     _runStateUnsub?.call();
     _runStateUnsub = null;
     _activeSession = null;
@@ -292,7 +302,9 @@ class ThreadViewState {
         .then((history) {
       if (token.isCancelled) return;
       _cancelToken = null;
-      _trackerRegistry.seedHistorical(replayToTrackers(history.runs));
+      for (final entry in replayToTrackers(history.runs).entries) {
+        _historicalTrackers.putIfAbsent(entry.key, () => entry.value);
+      }
       _messages.value = MessagesLoaded(
         messages: history.messages,
         messageStates: history.messageStates,
@@ -311,6 +323,5 @@ class ThreadViewState {
     _isDisposed = true;
     _cancelToken?.cancel('disposed');
     _detachSession();
-    _trackerRegistry.dispose();
   }
 }

--- a/test/modules/room/thread_view_state_test.dart
+++ b/test/modules/room/thread_view_state_test.dart
@@ -4,6 +4,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:soliplex_agent/soliplex_agent.dart';
 
 import 'package:soliplex_frontend/src/modules/room/agent_runtime_manager.dart';
+import 'package:soliplex_frontend/src/modules/room/execution_tracker_extension.dart';
 import 'package:soliplex_frontend/src/modules/room/run_registry.dart';
 import 'package:soliplex_frontend/src/modules/room/thread_view_state.dart';
 
@@ -17,13 +18,15 @@ ServerConnection _fakeConnection(FakeSoliplexApi api) => ServerConnection(
 
 /// Minimal session fake for testing [ThreadViewState] signal behavior.
 class _FakeAgentSession implements AgentSession {
-  _FakeAgentSession()
+  _FakeAgentSession({List<SessionExtension> extensions = const []})
       : _runState = Signal<RunState>(const IdleState()),
-        _lastExecutionEvent = Signal<ExecutionEvent?>(null);
+        _lastExecutionEvent = Signal<ExecutionEvent?>(null),
+        _extensions = extensions;
 
   final Signal<RunState> _runState;
   final Signal<ExecutionEvent?> _lastExecutionEvent;
   final Completer<AgentResult> _resultCompleter = Completer<AgentResult>();
+  final List<SessionExtension> _extensions;
   bool cancelCalled = false;
 
   @override
@@ -40,6 +43,14 @@ class _FakeAgentSession implements AgentSession {
 
   @override
   void cancel() => cancelCalled = true;
+
+  @override
+  T? getExtension<T extends SessionExtension>() {
+    for (final ext in _extensions) {
+      if (ext is T) return ext;
+    }
+    return null;
+  }
 
   void emit(RunState state) => _runState.value = state;
 
@@ -648,10 +659,81 @@ void main() {
         conversation: conversation,
       ));
 
-      // No crash — the null-check in _onRunState handles cleanup safely.
+      // CompletedState triggers _detachSession, which clears sessionState.
       expect(state.sessionState.value, isNull);
 
       state.dispose();
+    });
+
+    test('live tracker wins over historical on detach absorb', () async {
+      const threadKey = (
+        serverId: 'test-server',
+        roomId: 'room-1',
+        threadId: 'thread-1',
+      );
+
+      // Seed history so _fetch installs a historical tracker for 'asst-1'.
+      api.nextThreadHistory = ThreadHistory(
+        messages: const [],
+        runs: [
+          RunEventBundle(
+            runId: 'run-prior',
+            events: const [
+              TextMessageStartEvent(messageId: 'asst-1'),
+              TextMessageContentEvent(messageId: 'asst-1', delta: 'historical'),
+              TextMessageEndEvent(messageId: 'asst-1'),
+            ],
+          ),
+        ],
+      );
+
+      final state = ThreadViewState(
+        connection: connection,
+        roomId: 'room-1',
+        threadId: 'thread-1',
+        registry: registry,
+      );
+      await Future<void>.delayed(Duration.zero);
+
+      final historicalTracker = state.executionTrackers['asst-1'];
+      expect(historicalTracker, isNotNull,
+          reason: 'replayToTrackers must seed a tracker for asst-1');
+
+      // Attach a session whose extension will produce a live tracker under
+      // the same message id.
+      final ext = ExecutionTrackerExtension();
+      final fakeSession = _FakeAgentSession(extensions: [ext]);
+      await ext.onAttach(fakeSession);
+      state.attachSession(fakeSession);
+
+      final conversation = Conversation(threadId: 'thread-1');
+      fakeSession.emit(RunningState(
+        threadKey: threadKey,
+        runId: 'run-live',
+        conversation: conversation,
+        streaming: const TextStreaming(
+          messageId: 'asst-1',
+          user: ChatUser.assistant,
+          text: '',
+        ),
+      ));
+
+      final liveTracker = ext.trackers['asst-1'];
+      expect(liveTracker, isNotNull);
+      expect(identical(liveTracker, historicalTracker), isFalse);
+
+      // Terminal state drives _detachSession → absorb.
+      fakeSession.emit(CompletedState(
+        threadKey: threadKey,
+        runId: 'run-live',
+        conversation: conversation,
+      ));
+
+      expect(identical(state.executionTrackers['asst-1'], liveTracker), isTrue,
+          reason: 'live tracker must overwrite historical on key collision');
+
+      state.dispose();
+      ext.onDispose();
     });
 
     test('executionTrackers are cleaned up on dispose', () async {


### PR DESCRIPTION
First concrete reactor riding the `SessionCoordinator` seam.

- `ExecutionTrackerExtension` subscribes to `session.runState` in `onAttach`, routes `RunningState` + terminal states into an internal `TrackerRegistry`, and exposes the resulting `Map<String, ExecutionTracker>` as reactive state via `StatefulSessionExtension`.
- Wired into the standard flavor via `AgentRuntimeManager.extensionFactory`.

`ThreadViewState` reads live trackers directly from the extension and absorbs them into a plain `Map<String, ExecutionTracker> _historicalTrackers` on detach. The view does not keep its own `TrackerRegistry` — live lifecycle belongs to the extension (which outlives the view when a session runs in the background), and the view only needs bulk-insert + read-through.

## Stack

PR 3 of 11. Base: feat/session-coordinator.

Supersedes #161 (legacy M2, trim applied inline).

## Test plan

- [x] `flutter analyze` — 0 issues
- [x] `flutter test` — 1091 pass
