### PR TITLE
feat(room): SessionSpawner extracts spawn state machine

### DIFF
--- a/lib/src/modules/room/room_state.dart
+++ b/lib/src/modules/room/room_state.dart
@@ -1,11 +1,11 @@
 import 'dart:async' show unawaited;
-import 'dart:developer' as dev;
 
 import 'package:soliplex_agent/soliplex_agent.dart';
 
 import '../auth/server_entry.dart';
 import 'agent_runtime_manager.dart';
 import 'run_registry.dart';
+import 'session_spawner.dart';
 import 'thread_list_state.dart';
 import 'thread_view_state.dart';
 import 'upload_tracker.dart';
@@ -64,15 +64,15 @@ class RoomState {
   final UploadTracker uploadTracker;
   ThreadViewState? _activeThreadView;
   CancelToken? _roomFetchToken;
-  Future<AgentSession>? _pendingSpawn;
   bool _isDisposed = false;
+
+  final SessionSpawner _spawner = SessionSpawner();
 
   final Signal<RoomStatus> _room = Signal<RoomStatus>(RoomLoading());
   ReadonlySignal<RoomStatus> get room => _room;
 
-  // Lifecycle: null → spawning (sendToNewThread) → null (on completion,
-  //            error, or cancelSpawn). Doubles as a concurrency guard and
-  //            the UI signal for ChatInput's cancel button.
+  /// Tracks the spawn lifecycle: null → spawning → null.
+  /// Non-null while a new-thread spawn is in progress.
   final Signal<AgentSessionState?> _sessionState =
       Signal<AgentSessionState?>(null);
   ReadonlySignal<AgentSessionState?> get sessionState => _sessionState;
@@ -167,79 +167,59 @@ class RoomState {
     return null;
   }
 
+  /// Cancels a pending new-thread spawn. No-op if nothing is in progress.
+  void cancelSpawn() {
+    if (_spawner.cancel()) _sessionState.value = null;
+  }
+
   /// Implicit thread creation (send message with no thread selected).
   ///
   /// Spawns a session which creates the thread server-side, then creates a
   /// [ThreadViewState] and attaches the session to it.
-  void cancelSpawn() {
-    final pending = _pendingSpawn;
-    if (pending == null) return;
-    _pendingSpawn = null;
-    _sessionState.value = null;
-    unawaited(pending.then((s) {
-      s.cancel();
-      s.dispose();
-    }).catchError((Object e, StackTrace st) {
-      dev.log(
-        'Cancelled spawn cleanup failed',
-        error: e,
-        stackTrace: st,
-        name: 'RoomState',
-        level: 1000,
-      );
-    }));
-  }
-
   Future<void> sendToNewThread(
     String prompt, {
     Map<String, dynamic>? stateOverlay,
-  }) async {
-    if (_sessionState.value != null) return;
-    _lastError.value = null;
-    _sessionState.value = AgentSessionState.spawning;
-    Future<AgentSession>? spawnFuture;
-    try {
-      spawnFuture = runtime.spawn(
-        roomId: _roomId,
+  }) =>
+      _spawner.spawn(
+        spawnFn: () => runtime.spawn(
+          roomId: _roomId,
+          prompt: prompt,
+          stateOverlay: stateOverlay,
+        ),
+        errorSignal: _lastError,
         prompt: prompt,
-        stateOverlay: stateOverlay,
+        isDisposed: () => _isDisposed,
+        onSpawned: (session) {
+          // Clear room-level spawn state — the thread view takes over.
+          _sessionState.value = null;
+          final key = session.threadKey;
+          _registry.register(key, session);
+          if (_isDisposed) return;
+          // Spawn only exposes a threadKey — no ThreadInfo. Insert a stub so
+          // the sidebar reflects the new thread immediately. The backend
+          // generates the thread's name lazily after the run finishes; the
+          // sidebar picks that up on the next natural refresh (room change,
+          // pull-to-refresh, re-entry).
+          threadList.noteSpawnedThread(ThreadInfo(
+            id: key.threadId,
+            roomId: _roomId,
+            createdAt: DateTime.now(),
+          ));
+          selectThread(key.threadId);
+          _activeThreadView!.attachSession(session);
+          onNavigateToThread?.call(key.threadId);
+        },
+        onStateTransition: (state) {
+          if (_isDisposed) return;
+          _sessionState.value = state;
+        },
       );
-      _pendingSpawn = spawnFuture;
-      final session = await spawnFuture;
-      if (_pendingSpawn != spawnFuture) return;
-      _pendingSpawn = null;
-      _sessionState.value = null;
-      final key = session.threadKey;
-      _registry.register(key, session);
-      if (_isDisposed) return;
-      // Spawn only exposes a threadKey — no ThreadInfo. Insert a stub so
-      // the sidebar reflects the new thread immediately. The backend
-      // generates the thread's name lazily after the run finishes; the
-      // sidebar picks that up on the next natural refresh (room change,
-      // pull-to-refresh, re-entry).
-      threadList.noteSpawnedThread(ThreadInfo(
-        id: key.threadId,
-        roomId: _roomId,
-        createdAt: DateTime.now(),
-      ));
-      selectThread(key.threadId);
-      _activeThreadView!.attachSession(session);
-      onNavigateToThread?.call(key.threadId);
-    } on Object catch (error) {
-      if (_isDisposed || _sessionState.value == null) return;
-      _lastError.value = SendError(error, unsentText: prompt);
-    } finally {
-      if (_pendingSpawn == spawnFuture) {
-        _pendingSpawn = null;
-        _sessionState.value = null;
-      }
-    }
-  }
 
   void dispose() {
     _isDisposed = true;
     _roomFetchToken?.cancel('disposed');
     threadList.dispose();
     _activeThreadView?.dispose();
+    _sessionState.dispose();
   }
 }

--- a/lib/src/modules/room/session_spawner.dart
+++ b/lib/src/modules/room/session_spawner.dart
@@ -1,0 +1,90 @@
+import 'dart:async' show unawaited;
+
+import 'package:flutter/foundation.dart' show debugPrint;
+import 'package:soliplex_agent/soliplex_agent.dart';
+
+import 'send_error.dart';
+
+/// Owns the pending-spawn state machine shared by [ThreadViewState] and
+/// [RoomState].
+///
+/// Encapsulates:
+/// - The concurrency guard — [spawn] is a no-op while another spawn is
+///   in-flight.
+/// - Pending-future tracking and race detection via [cancel].
+/// - Cleanup of a spawn future that was abandoned by [cancel].
+///
+/// The lifecycle [Signal<AgentSessionState?>] is NOT owned by the spawner;
+/// callers pass an `onStateTransition` callback and own the signal they
+/// update from it. This keeps the spawner scoped to spawn-phase logic and
+/// leaves session-level state (running, detached, etc.) to the caller.
+class SessionSpawner {
+  Future<AgentSession>? _pendingSpawn;
+  bool _cancelled = false;
+
+  bool get isSpawning => _pendingSpawn != null;
+
+  /// Runs the spawn state machine.
+  ///
+  /// - Guards against concurrent spawns (no-op if already spawning).
+  /// - Clears [errorSignal] and emits
+  ///   [AgentSessionState.spawning] via [onStateTransition].
+  /// - Awaits the future returned by [spawnFn] with race detection.
+  /// - On success, calls [onSpawned]; the callback is responsible for
+  ///   checking whether the owner is disposed before attaching.
+  /// - On error, surfaces via [errorSignal] unless cancelled or the owner
+  ///   is disposed.
+  /// - Emits `null` via [onStateTransition] when the spawn completes
+  ///   without success (e.g. error path), so callers can clear their
+  ///   lifecycle signal without duplicating bookkeeping.
+  Future<void> spawn({
+    required Future<AgentSession> Function() spawnFn,
+    required Signal<SendError?> errorSignal,
+    required String prompt,
+    required bool Function() isDisposed,
+    required void Function(AgentSession) onSpawned,
+    required void Function(AgentSessionState?) onStateTransition,
+  }) async {
+    if (_pendingSpawn != null) return;
+    _cancelled = false;
+    errorSignal.value = null;
+    onStateTransition(AgentSessionState.spawning);
+    Future<AgentSession>? future;
+    try {
+      future = spawnFn();
+      _pendingSpawn = future;
+      final session = await future;
+      if (_cancelled) return;
+      _pendingSpawn = null;
+      onSpawned(session); // Callback owns the dispose/attach decision.
+    } on Object catch (error) {
+      if (_cancelled || isDisposed()) return;
+      errorSignal.value = SendError(error, unsentText: prompt);
+    } finally {
+      if (!_cancelled && _pendingSpawn == future) {
+        _pendingSpawn = null;
+        onStateTransition(null);
+      }
+    }
+  }
+
+  /// Cancels the pending spawn, if any. Returns `true` if a spawn was
+  /// cancelled, `false` if there was nothing pending. Callers are
+  /// responsible for clearing their lifecycle signal — the spawner does
+  /// not call back into `onStateTransition` from here.
+  bool cancel() {
+    final pending = _pendingSpawn;
+    if (pending == null) return false;
+    _pendingSpawn = null;
+    _cancelled = true;
+    unawaited(
+      pending.then((s) {
+        s.cancel();
+        s.dispose();
+      }).catchError((Object e) {
+        debugPrint('SessionSpawner: cancelled spawn cleanup failed: $e');
+      }),
+    );
+    return true;
+  }
+}

--- a/lib/src/modules/room/session_spawner.dart
+++ b/lib/src/modules/room/session_spawner.dart
@@ -18,6 +18,17 @@ import 'send_error.dart';
 /// callers pass an `onStateTransition` callback and own the signal they
 /// update from it. This keeps the spawner scoped to spawn-phase logic and
 /// leaves session-level state (running, detached, etc.) to the caller.
+///
+/// Callback asymmetry: [spawn] notifies `onStateTransition` with
+/// `spawning` on entry, and with `null` from its `finally` block on
+/// any non-success path (spawn future failed, owner disposed, or
+/// `onSpawned` threw). On success the spawner does not emit again —
+/// the caller's `onSpawned` is expected to drive the next transition.
+/// [cancel] deliberately does NOT call back into `onStateTransition`
+/// — callers are responsible for clearing their lifecycle signal when
+/// they invoke [cancel]. This asymmetry is intentional: the caller
+/// already knows a cancel is happening and may want to bundle other
+/// side-effects with the signal clear.
 class SessionSpawner {
   Future<AgentSession>? _pendingSpawn;
   bool _cancelled = false;
@@ -49,20 +60,20 @@ class SessionSpawner {
     _cancelled = false;
     errorSignal.value = null;
     onStateTransition(AgentSessionState.spawning);
-    Future<AgentSession>? future;
+    var succeeded = false;
     try {
-      future = spawnFn();
+      final future = spawnFn();
       _pendingSpawn = future;
       final session = await future;
       if (_cancelled) return;
-      _pendingSpawn = null;
       onSpawned(session); // Callback owns the dispose/attach decision.
+      succeeded = true;
     } on Object catch (error) {
       if (_cancelled || isDisposed()) return;
       errorSignal.value = SendError(error, unsentText: prompt);
     } finally {
-      if (!_cancelled && _pendingSpawn == future) {
-        _pendingSpawn = null;
+      _pendingSpawn = null;
+      if (!_cancelled && !succeeded) {
         onStateTransition(null);
       }
     }

--- a/lib/src/modules/room/thread_view_state.dart
+++ b/lib/src/modules/room/thread_view_state.dart
@@ -8,6 +8,7 @@ import 'execution_tracker_extension.dart';
 import 'historical_replay.dart';
 import 'run_registry.dart';
 import 'send_error.dart';
+import 'session_spawner.dart';
 
 export 'send_error.dart';
 
@@ -80,9 +81,10 @@ class ThreadViewState {
 
   CancelToken? _cancelToken;
   AgentSession? _activeSession;
-  Future<AgentSession>? _pendingSpawn;
   void Function()? _runStateUnsub;
   bool _isDisposed = false;
+
+  final SessionSpawner _spawner = SessionSpawner();
 
   final Signal<ThreadViewStatus> _messages =
       Signal<ThreadViewStatus>(MessagesLoading());
@@ -91,10 +93,9 @@ class ThreadViewState {
   final Signal<StreamingState?> _streamingState = Signal<StreamingState?>(null);
   ReadonlySignal<StreamingState?> get streamingState => _streamingState;
 
-  // Lifecycle: null → spawning (sendMessage) → running (_onRunState)
-  //            → null (_detachSession on terminal state, or cancelRun).
-  //            Doubles as a concurrency guard (sendMessage rejects if non-null)
-  //            and the UI signal for ChatInput's cancel button.
+  /// Tracks the session lifecycle: null → spawning → running → null.
+  /// Driven by [_spawner] during spawn (via its state-transition callback)
+  /// and updated directly here for attach, running, and detach transitions.
   final Signal<AgentSessionState?> _sessionState =
       Signal<AgentSessionState?>(null);
   ReadonlySignal<AgentSessionState?> get sessionState => _sessionState;
@@ -134,34 +135,31 @@ class ThreadViewState {
     String prompt,
     AgentRuntime runtime, {
     Map<String, dynamic>? stateOverlay,
-  }) async {
-    if (_sessionState.value != null) return;
-    _lastSendError.value = null;
-    _sessionState.value = AgentSessionState.spawning;
-    Future<AgentSession>? spawnFuture;
-    try {
-      spawnFuture = runtime.spawn(
+  }) {
+    // Guard against sends while a session is already spawning/running.
+    // The spawner's own re-entrancy guard only covers in-flight spawns;
+    // this blocks overlapping sends when a prior session is attached.
+    if (_sessionState.value != null) return Future<void>.value();
+    return _spawner.spawn(
+      spawnFn: () => runtime.spawn(
         roomId: _roomId,
         prompt: prompt,
         threadId: threadId,
         stateOverlay: stateOverlay,
-      );
-      _pendingSpawn = spawnFuture;
-      final session = await spawnFuture;
-      if (_pendingSpawn != spawnFuture) return;
-      _pendingSpawn = null;
-      _registry.register(threadKey, session);
-      if (_isDisposed) return;
-      _attachSession(session);
-    } on Object catch (error) {
-      if (_isDisposed || _sessionState.value == null) return;
-      _lastSendError.value = SendError(error, unsentText: prompt);
-    } finally {
-      if (_pendingSpawn == spawnFuture) {
-        _pendingSpawn = null;
-        _sessionState.value = null;
-      }
-    }
+      ),
+      errorSignal: _lastSendError,
+      prompt: prompt,
+      isDisposed: () => _isDisposed,
+      onSpawned: (session) {
+        _registry.register(threadKey, session);
+        if (_isDisposed) return;
+        _attachSession(session);
+      },
+      onStateTransition: (state) {
+        if (_isDisposed) return;
+        _sessionState.value = state;
+      },
+    );
   }
 
   void attachSession(AgentSession session) {
@@ -169,24 +167,11 @@ class ThreadViewState {
   }
 
   void cancelRun() {
-    if (_cancelPendingSpawn()) return;
+    if (_spawner.cancel()) {
+      _sessionState.value = null;
+      return;
+    }
     _activeSession?.cancel();
-  }
-
-  /// Cancels a pending spawn if one exists. Returns true if a spawn was
-  /// cancelled, false if there was nothing pending.
-  bool _cancelPendingSpawn() {
-    final pending = _pendingSpawn;
-    if (pending == null) return false;
-    _pendingSpawn = null;
-    _sessionState.value = null;
-    unawaited(pending.then((s) {
-      s.cancel();
-      s.dispose();
-    }).catchError((Object e) {
-      debugPrint('Cancelled spawn cleanup failed: $e');
-    }));
-    return true;
   }
 
   void _attachSession(AgentSession session) {
@@ -326,5 +311,6 @@ class ThreadViewState {
     _isDisposed = true;
     _cancelToken?.cancel('disposed');
     _detachSession();
+    _sessionState.dispose();
   }
 }

--- a/lib/src/modules/room/ui/room_screen.dart
+++ b/lib/src/modules/room/ui/room_screen.dart
@@ -458,12 +458,18 @@ class _RoomScreenState extends State<RoomScreen> {
 
     return Column(
       children: [
-        _buildRoomHeader(room, roomStatus, threadStatus),
-        if (_filesExpanded) _buildFilePanel(roomStatus, threadStatus),
         Expanded(
-          child: threadView == null
-              ? _buildNoThreadBody(room)
-              : _buildThreadBody(threadView, room),
+          child: Column(
+            children: [
+              _buildRoomHeader(room, roomStatus, threadStatus),
+              if (_filesExpanded) _buildFilePanel(roomStatus, threadStatus),
+              Expanded(
+                child: threadView == null
+                    ? _buildNoThreadBody(room)
+                    : _buildThreadBody(threadView, room),
+              ),
+            ],
+          ),
         ),
       ],
     );

--- a/lib/src/modules/room/ui/room_screen.dart
+++ b/lib/src/modules/room/ui/room_screen.dart
@@ -458,18 +458,12 @@ class _RoomScreenState extends State<RoomScreen> {
 
     return Column(
       children: [
+        _buildRoomHeader(room, roomStatus, threadStatus),
+        if (_filesExpanded) _buildFilePanel(roomStatus, threadStatus),
         Expanded(
-          child: Column(
-            children: [
-              _buildRoomHeader(room, roomStatus, threadStatus),
-              if (_filesExpanded) _buildFilePanel(roomStatus, threadStatus),
-              Expanded(
-                child: threadView == null
-                    ? _buildNoThreadBody(room)
-                    : _buildThreadBody(threadView, room),
-              ),
-            ],
-          ),
+          child: threadView == null
+              ? _buildNoThreadBody(room)
+              : _buildThreadBody(threadView, room),
         ),
       ],
     );

--- a/test/modules/room/session_spawner_test.dart
+++ b/test/modules/room/session_spawner_test.dart
@@ -1,0 +1,225 @@
+import 'dart:async';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:soliplex_agent/soliplex_agent.dart';
+
+import 'package:soliplex_frontend/src/modules/room/send_error.dart';
+import 'package:soliplex_frontend/src/modules/room/session_spawner.dart';
+
+class _StubAgentSession implements AgentSession {
+  bool cancelCalled = false;
+  bool disposed = false;
+
+  @override
+  void cancel() => cancelCalled = true;
+
+  @override
+  void dispose() => disposed = true;
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => null;
+}
+
+void main() {
+  group('SessionSpawner', () {
+    test('emits spawning on entry and nothing else on success', () async {
+      final session = _StubAgentSession();
+      final transitions = <AgentSessionState?>[];
+      final errorSignal = Signal<SendError?>(null);
+      AgentSession? received;
+
+      await SessionSpawner().spawn(
+        spawnFn: () async => session,
+        errorSignal: errorSignal,
+        prompt: 'hi',
+        isDisposed: () => false,
+        onSpawned: (s) => received = s,
+        onStateTransition: transitions.add,
+      );
+
+      expect(transitions, [AgentSessionState.spawning]);
+      expect(received, same(session));
+      expect(errorSignal.value, isNull);
+    });
+
+    test('emits null and surfaces error when spawn future fails', () async {
+      final transitions = <AgentSessionState?>[];
+      final errorSignal = Signal<SendError?>(null);
+
+      await SessionSpawner().spawn(
+        spawnFn: () async => throw StateError('boom'),
+        errorSignal: errorSignal,
+        prompt: 'hi',
+        isDisposed: () => false,
+        onSpawned: (_) {},
+        onStateTransition: transitions.add,
+      );
+
+      expect(transitions, [AgentSessionState.spawning, isNull]);
+      expect(errorSignal.value, isNotNull);
+      expect(errorSignal.value!.unsentText, 'hi');
+    });
+
+    test('emits null and surfaces error when onSpawned throws', () async {
+      final transitions = <AgentSessionState?>[];
+      final errorSignal = Signal<SendError?>(null);
+
+      await SessionSpawner().spawn(
+        spawnFn: () async => _StubAgentSession(),
+        errorSignal: errorSignal,
+        prompt: 'hi',
+        isDisposed: () => false,
+        onSpawned: (_) => throw StateError('attach failed'),
+        onStateTransition: transitions.add,
+      );
+
+      expect(transitions, [AgentSessionState.spawning, isNull]);
+      expect(errorSignal.value, isNotNull);
+      expect(errorSignal.value!.unsentText, 'hi');
+    });
+
+    test(
+        'disposed-during-spawn does not surface error but still '
+        'emits null transition', () async {
+      final transitions = <AgentSessionState?>[];
+      final errorSignal = Signal<SendError?>(null);
+
+      await SessionSpawner().spawn(
+        spawnFn: () async => throw StateError('boom'),
+        errorSignal: errorSignal,
+        prompt: 'hi',
+        isDisposed: () => true,
+        onSpawned: (_) {},
+        onStateTransition: transitions.add,
+      );
+
+      expect(transitions, [AgentSessionState.spawning, isNull]);
+      expect(errorSignal.value, isNull);
+    });
+
+    test(
+        'cancel during spawn suppresses transition and error, '
+        'and disposes the orphaned session', () async {
+      final spawner = SessionSpawner();
+      final transitions = <AgentSessionState?>[];
+      final errorSignal = Signal<SendError?>(null);
+      final completer = Completer<AgentSession>();
+      var onSpawnedCalled = false;
+
+      final spawnFuture = spawner.spawn(
+        spawnFn: () => completer.future,
+        errorSignal: errorSignal,
+        prompt: 'hi',
+        isDisposed: () => false,
+        onSpawned: (_) => onSpawnedCalled = true,
+        onStateTransition: transitions.add,
+      );
+      expect(transitions, [AgentSessionState.spawning]);
+
+      expect(spawner.cancel(), isTrue);
+
+      final session = _StubAgentSession();
+      completer.complete(session);
+      await spawnFuture;
+      for (var i = 0; i < 5; i++) {
+        await Future<void>.delayed(Duration.zero);
+      }
+
+      expect(transitions, [AgentSessionState.spawning]);
+      expect(errorSignal.value, isNull);
+      expect(onSpawnedCalled, isFalse);
+      expect(session.cancelCalled, isTrue);
+      expect(session.disposed, isTrue);
+    });
+
+    test('re-entrant spawn is a no-op while another is in-flight', () async {
+      final spawner = SessionSpawner();
+      final transitions = <AgentSessionState?>[];
+      final errorSignal = Signal<SendError?>(null);
+      final firstCompleter = Completer<AgentSession>();
+      final firstSession = _StubAgentSession();
+      final secondSession = _StubAgentSession();
+      AgentSession? firstReceived;
+      var secondOnSpawnedCalled = false;
+      var secondSpawnFnCalled = false;
+
+      final firstSpawn = spawner.spawn(
+        spawnFn: () => firstCompleter.future,
+        errorSignal: errorSignal,
+        prompt: 'first',
+        isDisposed: () => false,
+        onSpawned: (s) => firstReceived = s,
+        onStateTransition: transitions.add,
+      );
+      expect(transitions, [AgentSessionState.spawning]);
+      expect(spawner.isSpawning, isTrue);
+
+      // Re-entrant call while first is in flight.
+      await spawner.spawn(
+        spawnFn: () async {
+          secondSpawnFnCalled = true;
+          return secondSession;
+        },
+        errorSignal: errorSignal,
+        prompt: 'second',
+        isDisposed: () => false,
+        onSpawned: (_) => secondOnSpawnedCalled = true,
+        onStateTransition: transitions.add,
+      );
+
+      expect(secondSpawnFnCalled, isFalse);
+      expect(secondOnSpawnedCalled, isFalse);
+      expect(transitions, [AgentSessionState.spawning]);
+
+      // Let the first spawn complete cleanly.
+      firstCompleter.complete(firstSession);
+      await firstSpawn;
+      expect(firstReceived, same(firstSession));
+    });
+
+    test('cancel returns false when nothing is pending', () {
+      final spawner = SessionSpawner();
+      expect(spawner.cancel(), isFalse);
+    });
+
+    test('emits null and surfaces error when spawnFn throws synchronously',
+        () async {
+      final transitions = <AgentSessionState?>[];
+      final errorSignal = Signal<SendError?>(null);
+
+      await SessionSpawner().spawn(
+        spawnFn: () => throw StateError('sync boom'),
+        errorSignal: errorSignal,
+        prompt: 'hi',
+        isDisposed: () => false,
+        onSpawned: (_) {},
+        onStateTransition: transitions.add,
+      );
+
+      expect(transitions, [AgentSessionState.spawning, isNull]);
+      expect(errorSignal.value, isNotNull);
+      expect(errorSignal.value!.unsentText, 'hi');
+    });
+
+    test(
+        'cancel after successful spawn returns false and leaves '
+        'the session untouched', () async {
+      final spawner = SessionSpawner();
+      final session = _StubAgentSession();
+
+      await spawner.spawn(
+        spawnFn: () async => session,
+        errorSignal: Signal<SendError?>(null),
+        prompt: 'hi',
+        isDisposed: () => false,
+        onSpawned: (_) {},
+        onStateTransition: (_) {},
+      );
+
+      expect(spawner.isSpawning, isFalse);
+      expect(spawner.cancel(), isFalse);
+      expect(session.cancelCalled, isFalse);
+      expect(session.disposed, isFalse);
+    });
+  });
+}


### PR DESCRIPTION
Extracts the pending-spawn state machine from `ThreadViewState` and `RoomState` into a shared `SessionSpawner`. Both callers previously duplicated concurrency guards, race detection, and error/cancel handling around the same spawn primitive.

`SessionSpawner` owns only spawn-phase state:
- Re-entrancy guard — `spawn()` is a no-op while another spawn is in-flight.
- Pending-future tracking with race detection via `cancel()`.
- Cleanup of a spawn future abandoned by `cancel()`.

The lifecycle `Signal<AgentSessionState?>` stays with the caller. Spawner emits spawning/null transitions via an `onStateTransition` callback; callers update their own signal from it and keep full control of running/detached transitions. A separate `_cancelled` flag disambiguates cancel vs. completion so that `onSpawned` throwing after a successful spawn still surfaces the error, matching the original semantics.

`ThreadViewState.sendMessage` guards on its own `_sessionState != null` before calling the spawner, replacing the old implicit block on active sessions. Both callers guard the `onStateTransition` callback with `_isDisposed` so a spawn that finishes after dispose cannot write to a disposed signal.

## Stack

PR 4 of 11. Base: feat/execution-tracker-extension.

Supersedes #162 (legacy M3, trim applied inline).

## Test plan

- [x] `flutter analyze` — 0 issues
- [x] `flutter test` — 1091 pass
