### PR TITLE
feat(room): show spinner on thread tile when agent run is active

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -57,7 +57,7 @@ interchangeable — pick by rebuild scope:
 - **`signal.watch(context)`** — extension method. Subscribes the calling element;
   the whole widget's `build()` re-runs on every change. Use at the top of a
   screen-level `build()` when most of the tree depends on the signal anyway.
-  Auto-unsubscribes via GC.
+  Auto-unsubscribes when the element is unmounted.
 - **`Watch((context) => ...)`** — wrapper widget. Subscribes only the closure's
   subtree. Use for surgical reactivity inside an otherwise-static widget (e.g.,
   a spinner inside a list tile). Auto-unsubscribes deterministically on

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -51,6 +51,21 @@ Riverpod is **DI/service locator only** — no AsyncNotifier or FutureProvider c
 Reactive state comes from `signals` (via `soliplex_agent`). The `signals` package
 bridges signal reactivity to Flutter widget rebuilds.
 
+`signals_flutter` offers two ways to subscribe a widget to a signal. They are not
+interchangeable — pick by rebuild scope:
+
+- **`signal.watch(context)`** — extension method. Subscribes the calling element;
+  the whole widget's `build()` re-runs on every change. Use at the top of a
+  screen-level `build()` when most of the tree depends on the signal anyway.
+  Auto-unsubscribes via GC.
+- **`Watch((context) => ...)`** — wrapper widget. Subscribes only the closure's
+  subtree. Use for surgical reactivity inside an otherwise-static widget (e.g.,
+  a spinner inside a list tile). Auto-unsubscribes deterministically on
+  element unmount. Prefer this when most of the surrounding widget does not
+  depend on the signal.
+
+Mental model: `Watch` is to signals what `StreamBuilder` is to streams.
+
 ### Theming
 
 `ShellConfig` takes `ThemeData` directly — Flutter's standard abstraction. Each flavor

--- a/lib/src/modules/room/room_state.dart
+++ b/lib/src/modules/room/room_state.dart
@@ -71,7 +71,6 @@ class RoomState {
   final Signal<RoomStatus> _room = Signal<RoomStatus>(RoomLoading());
   ReadonlySignal<RoomStatus> get room => _room;
 
-  /// Reactive set of thread IDs that currently have an active run in this room.
   late final ReadonlySignal<Set<String>> runningThreadIds =
       computed<Set<String>>(
     () => _registry.activeKeys.value

--- a/lib/src/modules/room/room_state.dart
+++ b/lib/src/modules/room/room_state.dart
@@ -71,6 +71,15 @@ class RoomState {
   final Signal<RoomStatus> _room = Signal<RoomStatus>(RoomLoading());
   ReadonlySignal<RoomStatus> get room => _room;
 
+  /// Reactive set of thread IDs that currently have an active run in this room.
+  late final ReadonlySignal<Set<String>> runningThreadIds =
+      computed<Set<String>>(
+    () => _registry.activeKeys.value
+        .where((k) => k.serverId == _connection.serverId && k.roomId == _roomId)
+        .map((k) => k.threadId)
+        .toSet(),
+  );
+
   /// Tracks the spawn lifecycle: null → spawning → null.
   /// Non-null while a new-thread spawn is in progress.
   final Signal<AgentSessionState?> _sessionState =
@@ -221,5 +230,6 @@ class RoomState {
     threadList.dispose();
     _activeThreadView?.dispose();
     _sessionState.dispose();
+    runningThreadIds.dispose();
   }
 }

--- a/lib/src/modules/room/run_registry.dart
+++ b/lib/src/modules/room/run_registry.dart
@@ -35,7 +35,11 @@ class CancelledRun extends RunOutcome {
 /// session to reattach to or a completed outcome to display.
 class RunRegistry {
   final Map<ThreadKey, _TrackedRun> _runs = {};
+  final Signal<Set<ThreadKey>> _activeKeys = Signal({});
   bool _isDisposed = false;
+
+  /// Reactive set of keys that currently have an active (non-terminal) session.
+  ReadonlySignal<Set<ThreadKey>> get activeKeys => _activeKeys.readonly();
 
   /// Register a session for the given thread.
   ///
@@ -49,12 +53,14 @@ class RunRegistry {
     }
     final run = _TrackedRun(session: session);
     _runs[key] = run;
+    _activeKeys.value = {..._activeKeys.value, key};
 
     unawaited(session.result.then((result) {
       if (_isDisposed) return;
       final terminalState = session.runState.value;
       run.outcome = _outcomeFrom(terminalState, result);
       run.session = null;
+      _activeKeys.value = _activeKeys.value.difference({key});
     }));
   }
 
@@ -77,6 +83,8 @@ class RunRegistry {
       run.session?.cancel();
     }
     _runs.clear();
+    // Do not update _activeKeys here — downstream computeds may already be
+    // disposed and the update would log spurious "read after disposed" warnings.
   }
 
   static RunOutcome _outcomeFrom(RunState state, AgentResult result) {

--- a/lib/src/modules/room/run_registry.dart
+++ b/lib/src/modules/room/run_registry.dart
@@ -46,6 +46,9 @@ class RunRegistry {
   ///
   /// If there is an existing active session for this key, it is
   /// cancelled first (at most one run per thread).
+  ///
+  /// If the registry has been disposed, the session is cancelled and
+  /// the call asserts in debug / no-ops in release.
   void register(ThreadKey key, AgentSession session) {
     if (_isDisposed) {
       // Caller bug: a disposed registry can no longer manage the
@@ -71,9 +74,9 @@ class RunRegistry {
 
     unawaited(session.result.then((result) {
       if (_isDisposed) return;
-      // Bail if a newer registration replaced this run. Removing the
-      // key here would clear it while the new session is still active,
-      // and the orphan's outcome is intentionally discarded.
+      // Bail if a newer registration replaced this run. The orphan
+      // can only resolve as cancelled-by-replacement; the new session
+      // owns the key and produces its own outcome.
       if (!identical(_runs[key], run)) return;
       final terminalState = session.runState.value;
       run.outcome = _outcomeFrom(terminalState, result);

--- a/lib/src/modules/room/run_registry.dart
+++ b/lib/src/modules/room/run_registry.dart
@@ -1,4 +1,5 @@
 import 'dart:async' show unawaited;
+import 'dart:developer' as dev;
 
 import 'package:soliplex_agent/soliplex_agent.dart';
 
@@ -47,9 +48,17 @@ class RunRegistry {
   /// cancelled first (at most one run per thread).
   void register(ThreadKey key, AgentSession session) {
     if (_isDisposed) {
-      // Cancel rather than leak the session — the registry can no
-      // longer manage it and would otherwise drop it silently.
+      // Caller bug: a disposed registry can no longer manage the
+      // session. Cancel first so the session is never leaked even
+      // if the assert fires, log so the bug is observable in
+      // release, then assert so it's loud in debug.
       session.cancel();
+      dev.log(
+        'register called on disposed RunRegistry; cancelling session',
+        name: 'RunRegistry',
+        level: 1000,
+      );
+      assert(false, 'register called on disposed RunRegistry for $key');
       return;
     }
     final existing = _runs[key];
@@ -103,7 +112,11 @@ class RunRegistry {
       FailedState(:final conversation, :final error) =>
         FailedRun(conversation, error),
       CancelledState(:final conversation) => CancelledRun(conversation),
-      _ => FailedRun(null, 'Unexpected terminal state: ${state.runtimeType}'),
+      IdleState() || RunningState() || ToolYieldingState() => FailedRun(
+          null,
+          'Session result arrived in non-terminal state '
+          '${state.runtimeType}: $result',
+        ),
     };
   }
 }

--- a/lib/src/modules/room/run_registry.dart
+++ b/lib/src/modules/room/run_registry.dart
@@ -46,7 +46,12 @@ class RunRegistry {
   /// If there is an existing active session for this key, it is
   /// cancelled first (at most one run per thread).
   void register(ThreadKey key, AgentSession session) {
-    assert(!_isDisposed, 'Cannot register on a disposed RunRegistry');
+    if (_isDisposed) {
+      // Cancel rather than leak the session — the registry can no
+      // longer manage it and would otherwise drop it silently.
+      session.cancel();
+      return;
+    }
     final existing = _runs[key];
     if (existing != null && existing.session != null) {
       existing.session!.cancel();
@@ -57,6 +62,10 @@ class RunRegistry {
 
     unawaited(session.result.then((result) {
       if (_isDisposed) return;
+      // Bail if a newer registration replaced this run. Removing the
+      // key here would clear it while the new session is still active,
+      // and the orphan's outcome is intentionally discarded.
+      if (!identical(_runs[key], run)) return;
       final terminalState = session.runState.value;
       run.outcome = _outcomeFrom(terminalState, result);
       run.session = null;
@@ -76,15 +85,15 @@ class RunRegistry {
     return _runs[key]?.outcome;
   }
 
-  /// Cancels all active sessions and releases resources.
+  /// Cancels all active sessions and releases resources. Idempotent.
   void dispose() {
+    if (_isDisposed) return;
     _isDisposed = true;
     for (final run in _runs.values) {
       run.session?.cancel();
     }
     _runs.clear();
-    // Do not update _activeKeys here — downstream computeds may already be
-    // disposed and the update would log spurious "read after disposed" warnings.
+    _activeKeys.dispose();
   }
 
   static RunOutcome _outcomeFrom(RunState state, AgentResult result) {

--- a/lib/src/modules/room/ui/room_screen.dart
+++ b/lib/src/modules/room/ui/room_screen.dart
@@ -411,6 +411,7 @@ class _RoomScreenState extends State<RoomScreen> {
                       _onRoomInfo();
                     },
                     roomName: roomName,
+                    runningThreadIds: _state.runningThreadIds,
                     onRetryThreads: () => _state.threadList.refresh(),
                     quizzes: room?.quizzes ?? const {},
                     onQuizTapped: _onQuizTapped,

--- a/lib/src/modules/room/ui/room_screen.dart
+++ b/lib/src/modules/room/ui/room_screen.dart
@@ -361,6 +361,7 @@ class _RoomScreenState extends State<RoomScreen> {
             onQuizTapped: _onQuizTapped,
             onRenameThread: _showRenameDialog,
             onDeleteThread: _showDeleteDialog,
+            runningThreadIds: _state.runningThreadIds,
           );
           final content = _buildContent(room);
 

--- a/lib/src/modules/room/ui/thread_sidebar.dart
+++ b/lib/src/modules/room/ui/thread_sidebar.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:signals_flutter/signals_flutter.dart';
 
 import '../thread_list_state.dart';
 import 'error_retry_panel.dart';
@@ -20,6 +21,7 @@ class ThreadSidebar extends StatelessWidget {
     this.onQuizTapped,
     this.onRenameThread,
     this.onDeleteThread,
+    this.runningThreadIds,
   });
 
   final ThreadListStatus threadListStatus;
@@ -35,6 +37,7 @@ class ThreadSidebar extends StatelessWidget {
   final void Function(String quizId)? onQuizTapped;
   final void Function(String threadId, String currentName)? onRenameThread;
   final void Function(String threadId)? onDeleteThread;
+  final ReadonlySignal<Set<String>>? runningThreadIds;
 
   @override
   Widget build(BuildContext context) {
@@ -125,9 +128,12 @@ class ThreadSidebar extends StatelessWidget {
                   itemCount: threads.length,
                   itemBuilder: (context, index) {
                     final thread = threads[index];
+                    final running =
+                        runningThreadIds?.watch(context) ?? const <String>{};
                     return ThreadTile(
                       thread: thread,
                       isSelected: thread.id == selectedThreadId,
+                      isRunning: running.contains(thread.id),
                       onTap: () => onThreadSelected(thread.id),
                       onRename: () =>
                           onRenameThread?.call(thread.id, thread.name),

--- a/lib/src/modules/room/ui/thread_sidebar.dart
+++ b/lib/src/modules/room/ui/thread_sidebar.dart
@@ -16,12 +16,12 @@ class ThreadSidebar extends StatelessWidget {
     required this.onNetworkInspector,
     required this.onRoomInfo,
     required this.roomName,
+    required this.runningThreadIds,
     this.onRetryThreads,
     this.quizzes = const {},
     this.onQuizTapped,
     this.onRenameThread,
     this.onDeleteThread,
-    this.runningThreadIds,
   });
 
   final ThreadListStatus threadListStatus;
@@ -37,7 +37,7 @@ class ThreadSidebar extends StatelessWidget {
   final void Function(String quizId)? onQuizTapped;
   final void Function(String threadId, String currentName)? onRenameThread;
   final void Function(String threadId)? onDeleteThread;
-  final ReadonlySignal<Set<String>>? runningThreadIds;
+  final ReadonlySignal<Set<String>> runningThreadIds;
 
   @override
   Widget build(BuildContext context) {
@@ -124,23 +124,24 @@ class ThreadSidebar extends StatelessWidget {
                     )),
                   ],
                 )
-              : ListView.builder(
-                  itemCount: threads.length,
-                  itemBuilder: (context, index) {
-                    final thread = threads[index];
-                    final running =
-                        runningThreadIds?.watch(context) ?? const <String>{};
-                    return ThreadTile(
-                      thread: thread,
-                      isSelected: thread.id == selectedThreadId,
-                      isRunning: running.contains(thread.id),
-                      onTap: () => onThreadSelected(thread.id),
-                      onRename: () =>
-                          onRenameThread?.call(thread.id, thread.name),
-                      onDelete: () => onDeleteThread?.call(thread.id),
-                    );
-                  },
-                ),
+              : Watch((context) {
+                  final running = runningThreadIds.value;
+                  return ListView.builder(
+                    itemCount: threads.length,
+                    itemBuilder: (context, index) {
+                      final thread = threads[index];
+                      return ThreadTile(
+                        thread: thread,
+                        isSelected: thread.id == selectedThreadId,
+                        isRunning: running.contains(thread.id),
+                        onTap: () => onThreadSelected(thread.id),
+                        onRename: () =>
+                            onRenameThread?.call(thread.id, thread.name),
+                        onDelete: () => onDeleteThread?.call(thread.id),
+                      );
+                    },
+                  );
+                }),
         ),
     };
   }

--- a/lib/src/modules/room/ui/thread_tile.dart
+++ b/lib/src/modules/room/ui/thread_tile.dart
@@ -13,6 +13,7 @@ class ThreadTile extends StatefulWidget {
     required this.onTap,
     required this.onRename,
     required this.onDelete,
+    this.isRunning = false,
   });
 
   final ThreadInfo thread;
@@ -20,6 +21,7 @@ class ThreadTile extends StatefulWidget {
   final VoidCallback onTap;
   final VoidCallback onRename;
   final VoidCallback onDelete;
+  final bool isRunning;
 
   @override
   State<ThreadTile> createState() => _ThreadTileState();
@@ -60,7 +62,18 @@ class _ThreadTileState extends State<ThreadTile> {
         ),
         dense: true,
         onTap: widget.onTap,
-        trailing: showMenu ? _buildMenu(theme) : null,
+        trailing: showMenu ? _buildMenu(theme) : _buildTrailing(theme),
+      ),
+    );
+  }
+
+  Widget? _buildTrailing(ThemeData theme) {
+    if (!widget.isRunning) return null;
+    return SizedBox.square(
+      dimension: 18,
+      child: CircularProgressIndicator(
+        strokeWidth: 2,
+        color: theme.colorScheme.primary,
       ),
     );
   }

--- a/lib/src/modules/room/ui/thread_tile.dart
+++ b/lib/src/modules/room/ui/thread_tile.dart
@@ -68,15 +68,9 @@ class _ThreadTileState extends State<ThreadTile> {
   }
 
   Widget? _buildTrailing(ThemeData theme, {required bool showMenu}) {
-    if (!widget.isRunning && !showMenu) return null;
-    return Row(
-      mainAxisSize: MainAxisSize.min,
-      children: [
-        if (widget.isRunning) _buildSpinner(theme),
-        if (widget.isRunning && showMenu) const SizedBox(width: 4),
-        if (showMenu) _buildMenu(theme),
-      ],
-    );
+    if (widget.isRunning) return _buildSpinner(theme);
+    if (showMenu) return _buildMenu(theme);
+    return null;
   }
 
   Widget _buildSpinner(ThemeData theme) {

--- a/lib/src/modules/room/ui/thread_tile.dart
+++ b/lib/src/modules/room/ui/thread_tile.dart
@@ -62,13 +62,24 @@ class _ThreadTileState extends State<ThreadTile> {
         ),
         dense: true,
         onTap: widget.onTap,
-        trailing: showMenu ? _buildMenu(theme) : _buildTrailing(theme),
+        trailing: _buildTrailing(theme, showMenu: showMenu),
       ),
     );
   }
 
-  Widget? _buildTrailing(ThemeData theme) {
-    if (!widget.isRunning) return null;
+  Widget? _buildTrailing(ThemeData theme, {required bool showMenu}) {
+    if (!widget.isRunning && !showMenu) return null;
+    return Row(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        if (widget.isRunning) _buildSpinner(theme),
+        if (widget.isRunning && showMenu) const SizedBox(width: 4),
+        if (showMenu) _buildMenu(theme),
+      ],
+    );
+  }
+
+  Widget _buildSpinner(ThemeData theme) {
     return SizedBox.square(
       dimension: 18,
       child: CircularProgressIndicator(

--- a/test/helpers/fakes.dart
+++ b/test/helpers/fakes.dart
@@ -356,6 +356,54 @@ class FakeAgUiStreamClient extends AgUiStreamClient {
         );
 }
 
+/// AgentSession fake whose terminal state and result future are
+/// controlled by the test. Without [completeAsCancelled] /
+/// [completeWithoutTransition], the session never terminates — handy
+/// for asserting widget state while a session is "in flight".
+class ManualAgentSession implements AgentSession {
+  ManualAgentSession(this.threadKey);
+
+  @override
+  final ThreadKey threadKey;
+  final Completer<AgentResult> _resultCompleter = Completer<AgentResult>();
+  final Signal<RunState> _runState = Signal<RunState>(const IdleState());
+  bool cancelCalled = false;
+
+  @override
+  Future<AgentResult> get result => _resultCompleter.future;
+
+  @override
+  ReadonlySignal<RunState> get runState => _runState;
+
+  @override
+  void cancel() {
+    cancelCalled = true;
+  }
+
+  void completeAsCancelled() {
+    _runState.value = CancelledState(threadKey: threadKey);
+    _resultCompleter.complete(AgentFailure(
+      threadKey: threadKey,
+      reason: FailureReason.cancelled,
+      error: 'cancelled',
+    ));
+  }
+
+  /// Resolves [result] without driving [runState] into a terminal
+  /// subtype. Used to exercise the contract-violation branch of
+  /// `RunRegistry._outcomeFrom`.
+  void completeWithoutTransition() {
+    _resultCompleter.complete(AgentFailure(
+      threadKey: threadKey,
+      reason: FailureReason.cancelled,
+      error: 'no transition',
+    ));
+  }
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
 /// Logger for tests. Uses soliplex_logging's LogManager.
 Logger testLogger() {
   return LogManager.instance.getLogger('test');

--- a/test/modules/room/room_state_test.dart
+++ b/test/modules/room/room_state_test.dart
@@ -337,6 +337,46 @@ void main() {
     state.dispose();
   });
 
+  test('runningThreadIds excludes runs from other rooms and other servers',
+      () async {
+    api.nextRoom = Room(id: 'room-1', name: 'Test');
+    api.nextThreads = [];
+    api.nextThreadHistory = ThreadHistory(messages: const []);
+
+    final state = RoomState(
+      serverEntry: serverEntry,
+      roomId: 'room-1',
+      runtimeManager: runtimeManager,
+      registry: registry,
+      uploadRegistry: uploadRegistry,
+    );
+
+    final runtime = runtimeManager.getRuntime(connection);
+    final session1 = await runtime.spawn(
+        roomId: 'room-1', prompt: 't', threadId: 'thread-A');
+    final session2 = await runtime.spawn(
+        roomId: 'room-2', prompt: 't', threadId: 'thread-B');
+    final session3 = await runtime.spawn(
+        roomId: 'room-1', prompt: 't', threadId: 'thread-C');
+
+    registry.register(
+      (serverId: 'test-server', roomId: 'room-1', threadId: 'thread-A'),
+      session1,
+    );
+    registry.register(
+      (serverId: 'test-server', roomId: 'room-2', threadId: 'thread-B'),
+      session2,
+    );
+    registry.register(
+      (serverId: 'other-server', roomId: 'room-1', threadId: 'thread-C'),
+      session3,
+    );
+
+    expect(state.runningThreadIds.value, {'thread-A'});
+
+    state.dispose();
+  });
+
   group('deleteThread', () {
     test('navigates to next thread after deletion', () async {
       final threads = [

--- a/test/modules/room/room_state_test.dart
+++ b/test/modules/room/room_state_test.dart
@@ -337,6 +337,38 @@ void main() {
     state.dispose();
   });
 
+  test('runningThreadIds clears when the underlying session terminates',
+      () async {
+    api.nextRoom = Room(id: 'room-1', name: 'Test');
+    api.nextThreads = [];
+    api.nextThreadHistory = ThreadHistory(messages: const []);
+
+    final state = RoomState(
+      serverEntry: serverEntry,
+      roomId: 'room-1',
+      runtimeManager: runtimeManager,
+      registry: registry,
+      uploadRegistry: uploadRegistry,
+    );
+
+    final key = (
+      serverId: 'test-server',
+      roomId: 'room-1',
+      threadId: 'thread-A',
+    );
+    final session = ManualAgentSession(key);
+    registry.register(key, session);
+
+    expect(state.runningThreadIds.value, {'thread-A'});
+
+    session.completeAsCancelled();
+    await Future<void>.delayed(Duration.zero);
+
+    expect(state.runningThreadIds.value, isEmpty);
+
+    state.dispose();
+  });
+
   test('runningThreadIds excludes runs from other rooms and other servers',
       () async {
     api.nextRoom = Room(id: 'room-1', name: 'Test');

--- a/test/modules/room/run_registry_test.dart
+++ b/test/modules/room/run_registry_test.dart
@@ -1,5 +1,3 @@
-import 'dart:async';
-
 import 'package:flutter_test/flutter_test.dart';
 import 'package:soliplex_agent/soliplex_agent.dart';
 
@@ -7,41 +5,6 @@ import 'package:soliplex_frontend/src/modules/room/agent_runtime_manager.dart';
 import 'package:soliplex_frontend/src/modules/room/run_registry.dart';
 
 import '../../helpers/fakes.dart';
-
-/// Session fake whose result future is controlled by the test, so the
-/// terminal callback can be triggered at a chosen point.
-class _ManualSession implements AgentSession {
-  _ManualSession(this.threadKey);
-
-  @override
-  final ThreadKey threadKey;
-  final Completer<AgentResult> _resultCompleter = Completer<AgentResult>();
-  final Signal<RunState> _runState = Signal<RunState>(const IdleState());
-  bool cancelCalled = false;
-
-  @override
-  Future<AgentResult> get result => _resultCompleter.future;
-
-  @override
-  ReadonlySignal<RunState> get runState => _runState;
-
-  @override
-  void cancel() {
-    cancelCalled = true;
-  }
-
-  void completeAsCancelled() {
-    _runState.value = CancelledState(threadKey: threadKey);
-    _resultCompleter.complete(AgentFailure(
-      threadKey: threadKey,
-      reason: FailureReason.cancelled,
-      error: 'cancelled',
-    ));
-  }
-
-  @override
-  dynamic noSuchMethod(Invocation invocation) => null;
-}
 
 ServerConnection _fakeConnection(FakeSoliplexApi api) => ServerConnection(
       serverId: 'test-server',
@@ -223,9 +186,8 @@ void main() {
 
   test('activeKeys keeps key when prior session terminates after replacement',
       () async {
-    // Use manual sessions so we can control when each terminates.
-    final session1 = _ManualSession(_key);
-    final session2 = _ManualSession(_key);
+    final session1 = ManualAgentSession(_key);
+    final session2 = ManualAgentSession(_key);
 
     registry.register(_key, session1);
     registry.register(_key, session2);
@@ -237,6 +199,42 @@ void main() {
 
     expect(registry.activeKeys.value, contains(_key));
     expect(registry.activeSession(_key), same(session2));
+  });
+
+  test('orphan guard works for any superseded run, not only the first',
+      () async {
+    final session1 = ManualAgentSession(_key);
+    final session2 = ManualAgentSession(_key);
+    final session3 = ManualAgentSession(_key);
+
+    registry.register(_key, session1);
+    registry.register(_key, session2);
+    registry.register(_key, session3);
+
+    // Terminate the middle session: it's orphaned (replaced by session3)
+    // and the guard must protect session3's slot.
+    session2.completeAsCancelled();
+    await Future<void>.delayed(Duration.zero);
+
+    expect(registry.activeKeys.value, contains(_key));
+    expect(registry.activeSession(_key), same(session3));
+  });
+
+  test('outcome is FailedRun when result resolves in a non-terminal state',
+      () async {
+    final session = ManualAgentSession(_key);
+    registry.register(_key, session);
+
+    // Resolve `result` while runState is still IdleState — exercises the
+    // contract-violation branch of `_outcomeFrom`.
+    session.completeWithoutTransition();
+    await Future<void>.delayed(Duration.zero);
+
+    final outcome = registry.completedOutcome(_key);
+    expect(outcome, isA<FailedRun>());
+    final failure = outcome as FailedRun;
+    expect(failure.error.toString(), contains('non-terminal state'));
+    expect(failure.error.toString(), contains('IdleState'));
   });
 
   test('dispose is idempotent', () async {
@@ -254,10 +252,7 @@ void main() {
       () async {
     registry.dispose();
 
-    final session = _ManualSession(_key);
-    // The assert is the loud signal that a structural bug occurred.
-    // Cancellation must still happen first so the session's underlying
-    // stream is not leaked even when the assert fires.
+    final session = ManualAgentSession(_key);
     expect(
       () => registry.register(_key, session),
       throwsA(isA<AssertionError>()),

--- a/test/modules/room/run_registry_test.dart
+++ b/test/modules/room/run_registry_test.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter_test/flutter_test.dart';
 import 'package:soliplex_agent/soliplex_agent.dart';
 
@@ -5,6 +7,41 @@ import 'package:soliplex_frontend/src/modules/room/agent_runtime_manager.dart';
 import 'package:soliplex_frontend/src/modules/room/run_registry.dart';
 
 import '../../helpers/fakes.dart';
+
+/// Session fake whose result future is controlled by the test, so the
+/// terminal callback can be triggered at a chosen point.
+class _ManualSession implements AgentSession {
+  _ManualSession(this.threadKey);
+
+  @override
+  final ThreadKey threadKey;
+  final Completer<AgentResult> _resultCompleter = Completer<AgentResult>();
+  final Signal<RunState> _runState = Signal<RunState>(const IdleState());
+  bool cancelCalled = false;
+
+  @override
+  Future<AgentResult> get result => _resultCompleter.future;
+
+  @override
+  ReadonlySignal<RunState> get runState => _runState;
+
+  @override
+  void cancel() {
+    cancelCalled = true;
+  }
+
+  void completeAsCancelled() {
+    _runState.value = CancelledState(threadKey: threadKey);
+    _resultCompleter.complete(AgentFailure(
+      threadKey: threadKey,
+      reason: FailureReason.cancelled,
+      error: 'cancelled',
+    ));
+  }
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => null;
+}
 
 ServerConnection _fakeConnection(FakeSoliplexApi api) => ServerConnection(
       serverId: 'test-server',
@@ -165,5 +202,63 @@ void main() {
 
     expect(registry.activeSession(_key), isNull);
     expect(registry.activeSession(_key2), isNull);
+  });
+
+  test('activeKeys adds on register and removes on terminal completion',
+      () async {
+    expect(registry.activeKeys.value, isEmpty);
+
+    final session = await spawnSession();
+    registry.register(_key, session);
+
+    expect(registry.activeKeys.value, contains(_key));
+
+    try {
+      await session.result;
+    } on Object catch (_) {}
+    await Future<void>.delayed(Duration.zero);
+
+    expect(registry.activeKeys.value, isNot(contains(_key)));
+  });
+
+  test('activeKeys keeps key when prior session terminates after replacement',
+      () async {
+    // Use manual sessions so we can control when each terminates.
+    final session1 = _ManualSession(_key);
+    final session2 = _ManualSession(_key);
+
+    registry.register(_key, session1);
+    registry.register(_key, session2);
+
+    // session2 stays active. Trigger session1's terminal callback —
+    // it must NOT remove the key.
+    session1.completeAsCancelled();
+    await Future<void>.delayed(Duration.zero);
+
+    expect(registry.activeKeys.value, contains(_key));
+    expect(registry.activeSession(_key), same(session2));
+  });
+
+  test('dispose is idempotent', () async {
+    final session = await spawnSession();
+    registry.register(_key, session);
+
+    registry.dispose();
+    registry.dispose();
+    // tearDown will dispose a third time.
+
+    expect(registry.activeSession(_key), isNull);
+  });
+
+  test('register after dispose cancels the session and is a no-op', () async {
+    registry.dispose();
+
+    final session = _ManualSession(_key);
+    registry.register(_key, session);
+
+    expect(registry.activeSession(_key), isNull);
+    // The session must be cancelled — otherwise its underlying stream
+    // stays open and is leaked.
+    expect(session.cancelCalled, isTrue);
   });
 }

--- a/test/modules/room/run_registry_test.dart
+++ b/test/modules/room/run_registry_test.dart
@@ -250,15 +250,19 @@ void main() {
     expect(registry.activeSession(_key), isNull);
   });
 
-  test('register after dispose cancels the session and is a no-op', () async {
+  test('register after dispose cancels the session and asserts in debug',
+      () async {
     registry.dispose();
 
     final session = _ManualSession(_key);
-    registry.register(_key, session);
-
-    expect(registry.activeSession(_key), isNull);
-    // The session must be cancelled — otherwise its underlying stream
-    // stays open and is leaked.
+    // The assert is the loud signal that a structural bug occurred.
+    // Cancellation must still happen first so the session's underlying
+    // stream is not leaked even when the assert fires.
+    expect(
+      () => registry.register(_key, session),
+      throwsA(isA<AssertionError>()),
+    );
     expect(session.cancelCalled, isTrue);
+    expect(registry.activeSession(_key), isNull);
   });
 }

--- a/test/modules/room/ui/room_screen_test.dart
+++ b/test/modules/room/ui/room_screen_test.dart
@@ -16,28 +16,6 @@ import 'package:soliplex_frontend/src/modules/auth/server_entry.dart';
 import '../../../helpers/fakes.dart';
 import '../../../helpers/test_server_entry.dart';
 
-/// Session fake whose result future never completes — useful for
-/// asserting widget state while a session is "in flight".
-class _NeverCompletingSession implements AgentSession {
-  _NeverCompletingSession(this.threadKey);
-
-  @override
-  final ThreadKey threadKey;
-  final Signal<RunState> _runState = Signal<RunState>(const IdleState());
-
-  @override
-  Future<AgentResult> get result => Completer<AgentResult>().future;
-
-  @override
-  ReadonlySignal<RunState> get runState => _runState;
-
-  @override
-  void cancel() {}
-
-  @override
-  dynamic noSuchMethod(Invocation invocation) => null;
-}
-
 class _BlockingThreadsApi extends FakeSoliplexApi {
   final _completer = Completer<List<ThreadInfo>>();
 
@@ -212,11 +190,8 @@ void main() {
     );
   });
 
-  testWidgets('narrow layout: drawer thread tile shows running spinner',
+  testWidgets('narrow layout: drawer thread tile spinner appears and clears',
       (tester) async {
-    // Defends the wiring of `runningThreadIds` into the drawer
-    // ThreadSidebar — a regression here would silently degrade the
-    // mobile/touch running indicator.
     tester.view.physicalSize = const Size(400, 800);
     tester.view.devicePixelRatio = 1.0;
     addTearDown(tester.view.resetPhysicalSize);
@@ -242,23 +217,25 @@ void main() {
       roomId: 'room-1',
       threadId: 'thread-1',
     );
-    registry.register(key, _NeverCompletingSession(key));
+    final session = ManualAgentSession(key);
+    registry.register(key, session);
     await tester.pump();
 
-    expect(
-      find.descendant(
-        of: find.byType(Drawer),
-        matching: find.byType(CircularProgressIndicator),
-      ),
-      findsOneWidget,
+    final spinnerInDrawer = find.descendant(
+      of: find.byType(Drawer),
+      matching: find.byType(CircularProgressIndicator),
     );
+    expect(spinnerInDrawer, findsOneWidget);
+
+    session.completeAsCancelled();
+    await tester.pump();
+    await tester.pump();
+
+    expect(spinnerInDrawer, findsNothing);
   });
 
-  testWidgets('wide layout: sidebar thread tile shows running spinner',
+  testWidgets('wide layout: sidebar thread tile spinner appears and clears',
       (tester) async {
-    // Mirrors the narrow-layout drawer test: defends the wiring of
-    // `runningThreadIds` into the wide-layout ThreadSidebar so a
-    // copy-paste regression in `_buildContent` is caught.
     tester.view.physicalSize = const Size(1200, 800);
     tester.view.devicePixelRatio = 1.0;
     addTearDown(tester.view.resetPhysicalSize);
@@ -281,16 +258,21 @@ void main() {
       roomId: 'room-1',
       threadId: 'thread-1',
     );
-    registry.register(key, _NeverCompletingSession(key));
+    final session = ManualAgentSession(key);
+    registry.register(key, session);
     await tester.pump();
 
-    expect(
-      find.descendant(
-        of: find.byType(ThreadSidebar),
-        matching: find.byType(CircularProgressIndicator),
-      ),
-      findsOneWidget,
+    final spinnerInSidebar = find.descendant(
+      of: find.byType(ThreadSidebar),
+      matching: find.byType(CircularProgressIndicator),
     );
+    expect(spinnerInSidebar, findsOneWidget);
+
+    session.completeAsCancelled();
+    await tester.pump();
+    await tester.pump();
+
+    expect(spinnerInSidebar, findsNothing);
   });
 
   testWidgets('shows RoomWelcome fallback when no thread selected',

--- a/test/modules/room/ui/room_screen_test.dart
+++ b/test/modules/room/ui/room_screen_test.dart
@@ -9,6 +9,7 @@ import 'package:soliplex_frontend/src/modules/room/agent_runtime_manager.dart';
 import 'package:soliplex_frontend/src/modules/room/document_selections.dart';
 import 'package:soliplex_frontend/src/modules/room/run_registry.dart';
 import 'package:soliplex_frontend/src/modules/room/ui/room_screen.dart';
+import 'package:soliplex_frontend/src/modules/room/ui/thread_sidebar.dart';
 import 'package:soliplex_frontend/src/modules/room/upload_tracker_registry.dart';
 import 'package:soliplex_frontend/src/modules/auth/server_entry.dart';
 
@@ -247,6 +248,45 @@ void main() {
     expect(
       find.descendant(
         of: find.byType(Drawer),
+        matching: find.byType(CircularProgressIndicator),
+      ),
+      findsOneWidget,
+    );
+  });
+
+  testWidgets('wide layout: sidebar thread tile shows running spinner',
+      (tester) async {
+    // Mirrors the narrow-layout drawer test: defends the wiring of
+    // `runningThreadIds` into the wide-layout ThreadSidebar so a
+    // copy-paste regression in `_buildContent` is caught.
+    tester.view.physicalSize = const Size(1200, 800);
+    tester.view.devicePixelRatio = 1.0;
+    addTearDown(tester.view.resetPhysicalSize);
+
+    await tester.pumpWidget(MaterialApp(
+      home: RoomScreen(
+        serverEntry: entry,
+        roomId: 'room-1',
+        threadId: null,
+        runtimeManager: runtimeManager,
+        registry: registry,
+        uploadRegistry: uploadRegistry,
+        documentSelections: DocumentSelections(),
+      ),
+    ));
+    await tester.pumpAndSettle();
+
+    final key = (
+      serverId: entry.serverId,
+      roomId: 'room-1',
+      threadId: 'thread-1',
+    );
+    registry.register(key, _NeverCompletingSession(key));
+    await tester.pump();
+
+    expect(
+      find.descendant(
+        of: find.byType(ThreadSidebar),
         matching: find.byType(CircularProgressIndicator),
       ),
       findsOneWidget,

--- a/test/modules/room/ui/room_screen_test.dart
+++ b/test/modules/room/ui/room_screen_test.dart
@@ -15,6 +15,28 @@ import 'package:soliplex_frontend/src/modules/auth/server_entry.dart';
 import '../../../helpers/fakes.dart';
 import '../../../helpers/test_server_entry.dart';
 
+/// Session fake whose result future never completes — useful for
+/// asserting widget state while a session is "in flight".
+class _NeverCompletingSession implements AgentSession {
+  _NeverCompletingSession(this.threadKey);
+
+  @override
+  final ThreadKey threadKey;
+  final Signal<RunState> _runState = Signal<RunState>(const IdleState());
+
+  @override
+  Future<AgentResult> get result => Completer<AgentResult>().future;
+
+  @override
+  ReadonlySignal<RunState> get runState => _runState;
+
+  @override
+  void cancel() {}
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => null;
+}
+
 class _BlockingThreadsApi extends FakeSoliplexApi {
   final _completer = Completer<List<ThreadInfo>>();
 
@@ -184,6 +206,48 @@ void main() {
       find.descendant(
         of: find.byType(Drawer),
         matching: find.text('Test thread'),
+      ),
+      findsOneWidget,
+    );
+  });
+
+  testWidgets('narrow layout: drawer thread tile shows running spinner',
+      (tester) async {
+    // Defends the wiring of `runningThreadIds` into the drawer
+    // ThreadSidebar — a regression here would silently degrade the
+    // mobile/touch running indicator.
+    tester.view.physicalSize = const Size(400, 800);
+    tester.view.devicePixelRatio = 1.0;
+    addTearDown(tester.view.resetPhysicalSize);
+
+    await tester.pumpWidget(MaterialApp(
+      home: RoomScreen(
+        serverEntry: entry,
+        roomId: 'room-1',
+        threadId: null,
+        runtimeManager: runtimeManager,
+        registry: registry,
+        uploadRegistry: uploadRegistry,
+        documentSelections: DocumentSelections(),
+      ),
+    ));
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.byIcon(Icons.menu));
+    await tester.pumpAndSettle();
+
+    final key = (
+      serverId: entry.serverId,
+      roomId: 'room-1',
+      threadId: 'thread-1',
+    );
+    registry.register(key, _NeverCompletingSession(key));
+    await tester.pump();
+
+    expect(
+      find.descendant(
+        of: find.byType(Drawer),
+        matching: find.byType(CircularProgressIndicator),
       ),
       findsOneWidget,
     );

--- a/test/modules/room/ui/thread_sidebar_quiz_row_test.dart
+++ b/test/modules/room/ui/thread_sidebar_quiz_row_test.dart
@@ -1,10 +1,13 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:soliplex_agent/soliplex_agent.dart';
 
 import 'package:soliplex_frontend/src/modules/room/thread_list_state.dart';
 import 'package:soliplex_frontend/src/modules/room/ui/thread_sidebar.dart';
 
 void main() {
+  final emptyRunning = Signal(<String>{}).readonly();
+
   Widget buildSidebar({
     Map<String, String> quizzes = const {},
     void Function(String)? onQuizTapped,
@@ -20,6 +23,7 @@ void main() {
           onNetworkInspector: () {},
           onRoomInfo: () {},
           roomName: 'Test Room',
+          runningThreadIds: emptyRunning,
           quizzes: quizzes,
           onQuizTapped: onQuizTapped,
         ),

--- a/test/modules/room/ui/thread_sidebar_test.dart
+++ b/test/modules/room/ui/thread_sidebar_test.dart
@@ -260,6 +260,92 @@ void main() {
     expect(renamedId, 't-1');
   });
 
+  testWidgets('spinner appears and disappears as runningThreadIds changes',
+      (tester) async {
+    final running = Signal(<String>{});
+    final threads = [
+      ThreadInfo(
+        id: 't-1',
+        roomId: 'room-1',
+        name: 'Thread',
+        createdAt: DateTime(2026, 3, 1),
+      ),
+    ];
+
+    await tester.pumpWidget(MaterialApp(
+      home: Scaffold(
+        body: ThreadSidebar(
+          threadListStatus: ThreadsLoaded(threads),
+          selectedThreadId: null,
+          onThreadSelected: (_) {},
+          onBackToLobby: () {},
+          onCreateThread: () {},
+          onNetworkInspector: () {},
+          onRoomInfo: () {},
+          roomName: 'Test Room',
+          runningThreadIds: running.readonly(),
+        ),
+      ),
+    ));
+
+    expect(find.byType(CircularProgressIndicator), findsNothing);
+
+    running.value = {'t-1'};
+    await tester.pump();
+    expect(find.byType(CircularProgressIndicator), findsOneWidget);
+
+    running.value = {};
+    await tester.pump();
+    expect(find.byType(CircularProgressIndicator), findsNothing);
+  });
+
+  testWidgets('spinner shows only on the running tile, not the selected one',
+      (tester) async {
+    final running = Signal(<String>{'t-2'});
+    final threads = [
+      ThreadInfo(
+        id: 't-1',
+        roomId: 'room-1',
+        name: 'Selected',
+        createdAt: DateTime(2026, 3, 1),
+      ),
+      ThreadInfo(
+        id: 't-2',
+        roomId: 'room-1',
+        name: 'Running',
+        createdAt: DateTime(2026, 3, 2),
+      ),
+    ];
+
+    await tester.pumpWidget(MaterialApp(
+      home: Scaffold(
+        body: ThreadSidebar(
+          threadListStatus: ThreadsLoaded(threads),
+          selectedThreadId: 't-1',
+          onThreadSelected: (_) {},
+          onBackToLobby: () {},
+          onCreateThread: () {},
+          onNetworkInspector: () {},
+          onRoomInfo: () {},
+          roomName: 'Test Room',
+          runningThreadIds: running.readonly(),
+        ),
+      ),
+    ));
+
+    expect(find.byType(CircularProgressIndicator), findsOneWidget);
+    expect(
+      find.descendant(
+        of: find.ancestor(
+          of: find.text('Running'),
+          matching: find.byType(ListTile),
+        ),
+        matching: find.byType(CircularProgressIndicator),
+      ),
+      findsOneWidget,
+    );
+  });
+
   testWidgets('delete callback propagates from ThreadTile', (tester) async {
     String? deletedId;
     final threads = [

--- a/test/modules/room/ui/thread_sidebar_test.dart
+++ b/test/modules/room/ui/thread_sidebar_test.dart
@@ -5,6 +5,8 @@ import 'package:soliplex_agent/soliplex_agent.dart';
 import 'package:soliplex_frontend/src/modules/room/thread_list_state.dart';
 import 'package:soliplex_frontend/src/modules/room/ui/thread_sidebar.dart';
 
+final _emptyRunning = Signal(<String>{}).readonly();
+
 void main() {
   testWidgets('shows loading indicator when loading', (tester) async {
     await tester.pumpWidget(MaterialApp(
@@ -18,6 +20,7 @@ void main() {
           onNetworkInspector: () {},
           onRoomInfo: () {},
           roomName: 'Test Room',
+          runningThreadIds: _emptyRunning,
           onRetryThreads: () async {},
         ),
       ),
@@ -52,6 +55,7 @@ void main() {
           onNetworkInspector: () {},
           onRoomInfo: () {},
           roomName: 'Test Room',
+          runningThreadIds: _emptyRunning,
           onRetryThreads: () async {},
         ),
       ),
@@ -83,6 +87,7 @@ void main() {
           onNetworkInspector: () {},
           onRoomInfo: () {},
           roomName: 'Test Room',
+          runningThreadIds: _emptyRunning,
           onRetryThreads: () async {},
         ),
       ),
@@ -106,6 +111,7 @@ void main() {
           onNetworkInspector: () {},
           onRoomInfo: () {},
           roomName: 'Test Room',
+          runningThreadIds: _emptyRunning,
           onRetryThreads: () async {},
         ),
       ),
@@ -130,6 +136,7 @@ void main() {
           onNetworkInspector: () => inspectorCalled = true,
           onRoomInfo: () {},
           roomName: 'Test Room',
+          runningThreadIds: _emptyRunning,
           onRetryThreads: () async {},
         ),
       ),
@@ -153,6 +160,7 @@ void main() {
           onNetworkInspector: () {},
           onRoomInfo: () => infoCalled = true,
           roomName: 'My Room',
+          runningThreadIds: _emptyRunning,
           onRetryThreads: () async {},
         ),
       ),
@@ -184,6 +192,7 @@ void main() {
           onNetworkInspector: () {},
           onRoomInfo: () {},
           roomName: 'Test Room',
+          runningThreadIds: _emptyRunning,
           onRetryThreads: () async {},
         ),
       ),
@@ -205,6 +214,7 @@ void main() {
           onNetworkInspector: () {},
           onRoomInfo: () {},
           roomName: 'Test Room',
+          runningThreadIds: _emptyRunning,
         ),
       ),
     ));
@@ -234,6 +244,7 @@ void main() {
           onNetworkInspector: () {},
           onRoomInfo: () {},
           roomName: 'Test Room',
+          runningThreadIds: _emptyRunning,
           onRetryThreads: () async {},
           onRenameThread: (id, name) => renamedId = id,
           onDeleteThread: (_) {},
@@ -271,6 +282,7 @@ void main() {
           onNetworkInspector: () {},
           onRoomInfo: () {},
           roomName: 'Test Room',
+          runningThreadIds: _emptyRunning,
           onRetryThreads: () async {},
           onRenameThread: (_, __) {},
           onDeleteThread: (id) => deletedId = id,

--- a/test/modules/room/ui/thread_tile_test.dart
+++ b/test/modules/room/ui/thread_tile_test.dart
@@ -195,8 +195,7 @@ void main() {
     debugDefaultTargetPlatformOverride = null;
   });
 
-  testWidgets('renders spinner when isRunning is true on mobile',
-      (tester) async {
+  testWidgets('mobile: spinner replaces menu when isRunning', (tester) async {
     debugDefaultTargetPlatformOverride = TargetPlatform.iOS;
     await tester.pumpWidget(MaterialApp(
       home: Scaffold(
@@ -212,12 +211,12 @@ void main() {
     ));
 
     expect(find.byType(CircularProgressIndicator), findsOneWidget);
+    expect(find.byIcon(Icons.more_vert), findsNothing);
     debugDefaultTargetPlatformOverride = null;
   });
 
-  testWidgets(
-      'shows both spinner and menu when isRunning is true and tile is hovered '
-      '(desktop)', (tester) async {
+  testWidgets('desktop hover: spinner replaces menu when isRunning',
+      (tester) async {
     debugDefaultTargetPlatformOverride = TargetPlatform.macOS;
     await tester.pumpWidget(MaterialApp(
       home: Scaffold(
@@ -246,7 +245,7 @@ void main() {
     await tester.pump();
 
     expect(find.byType(CircularProgressIndicator), findsOneWidget);
-    expect(find.byIcon(Icons.more_vert), findsOneWidget);
+    expect(find.byIcon(Icons.more_vert), findsNothing);
 
     debugDefaultTargetPlatformOverride = null;
   });

--- a/test/modules/room/ui/thread_tile_test.dart
+++ b/test/modules/room/ui/thread_tile_test.dart
@@ -195,6 +195,83 @@ void main() {
     debugDefaultTargetPlatformOverride = null;
   });
 
+  testWidgets('renders spinner when isRunning is true on mobile',
+      (tester) async {
+    debugDefaultTargetPlatformOverride = TargetPlatform.iOS;
+    await tester.pumpWidget(MaterialApp(
+      home: Scaffold(
+        body: ThreadTile(
+          thread: thread,
+          isSelected: false,
+          isRunning: true,
+          onTap: () {},
+          onRename: () {},
+          onDelete: () {},
+        ),
+      ),
+    ));
+
+    expect(find.byType(CircularProgressIndicator), findsOneWidget);
+    debugDefaultTargetPlatformOverride = null;
+  });
+
+  testWidgets(
+      'shows both spinner and menu when isRunning is true and tile is hovered '
+      '(desktop)', (tester) async {
+    debugDefaultTargetPlatformOverride = TargetPlatform.macOS;
+    await tester.pumpWidget(MaterialApp(
+      home: Scaffold(
+        body: Align(
+          alignment: Alignment.topLeft,
+          child: SizedBox(
+            width: 300,
+            child: ThreadTile(
+              thread: thread,
+              isSelected: false,
+              isRunning: true,
+              onTap: () {},
+              onRename: () {},
+              onDelete: () {},
+            ),
+          ),
+        ),
+      ),
+    ));
+
+    final gesture = await tester.createGesture(kind: PointerDeviceKind.mouse);
+    addTearDown(gesture.removePointer);
+    await gesture.addPointer(location: Offset.zero);
+    await gesture.moveTo(tester.getCenter(find.byType(ThreadTile)));
+    // Spinner animates indefinitely; pump a frame instead of settling.
+    await tester.pump();
+
+    expect(find.byType(CircularProgressIndicator), findsOneWidget);
+    expect(find.byIcon(Icons.more_vert), findsOneWidget);
+
+    debugDefaultTargetPlatformOverride = null;
+  });
+
+  testWidgets(
+      'renders no trailing widget when not running and not selected/hovered '
+      '(desktop)', (tester) async {
+    debugDefaultTargetPlatformOverride = TargetPlatform.macOS;
+    await tester.pumpWidget(MaterialApp(
+      home: Scaffold(
+        body: ThreadTile(
+          thread: thread,
+          isSelected: false,
+          onTap: () {},
+          onRename: () {},
+          onDelete: () {},
+        ),
+      ),
+    ));
+
+    expect(find.byType(CircularProgressIndicator), findsNothing);
+    expect(find.byIcon(Icons.more_vert), findsNothing);
+    debugDefaultTargetPlatformOverride = null;
+  });
+
   testWidgets('Delete menu item uses error color', (tester) async {
     await tester.pumpWidget(MaterialApp(
       home: Scaffold(


### PR DESCRIPTION
Adds a per-thread running indicator: `RoomState` exposes a computed `runningThreadIds` signal derived from the `RunRegistry`'s active keys filtered to the current room. `ThreadSidebar` tiles render a progress indicator when the thread is present in that set, so a user can see which threads in the sidebar currently have an active agent run.

## Stack

PR 5 of 11. Base: feat/session-spawner.

Supersedes #164 (legacy `feat/thread-busy-indicator`).

## Test plan

- [x] `flutter analyze` — 0 issues
- [x] `flutter test` — 1091 pass
