### PR TITLE
feat(room): ToolCallsExtension — status-only tool call tracking

### DIFF
--- a/lib/src/flavors/standard.dart
+++ b/lib/src/flavors/standard.dart
@@ -22,9 +22,9 @@ import '../modules/lobby/lobby_module.dart';
 import '../modules/quiz/quiz_module.dart';
 import '../modules/room/agent_runtime_manager.dart';
 import '../modules/room/execution_tracker_extension.dart';
-import '../modules/room/tool_calls_extension.dart';
 import '../modules/room/room_module.dart';
 import '../modules/room/run_registry.dart';
+import '../modules/room/tool_calls_extension.dart';
 import '../modules/room/ui/markdown/markdown_theme_extension.dart';
 
 const _defaultLogoAsset = 'assets/branding/soliplex/logo_1024.png';

--- a/lib/src/flavors/standard.dart
+++ b/lib/src/flavors/standard.dart
@@ -22,6 +22,7 @@ import '../modules/lobby/lobby_module.dart';
 import '../modules/quiz/quiz_module.dart';
 import '../modules/room/agent_runtime_manager.dart';
 import '../modules/room/execution_tracker_extension.dart';
+import '../modules/room/tool_calls_extension.dart';
 import '../modules/room/room_module.dart';
 import '../modules/room/run_registry.dart';
 import '../modules/room/ui/markdown/markdown_theme_extension.dart';
@@ -133,7 +134,10 @@ Future<ShellConfig> standard({
         : const NativePlatformConstraints(),
     toolRegistryResolver: (_) async => const ToolRegistry(),
     logger: LogManager.instance.getLogger('room'),
-    extensionFactory: () async => [ExecutionTrackerExtension()],
+    extensionFactory: () async => [
+      ExecutionTrackerExtension(),
+      ToolCallsExtension(),
+    ],
   );
 
   final registry = RunRegistry();

--- a/lib/src/modules/room/thread_view_state.dart
+++ b/lib/src/modules/room/thread_view_state.dart
@@ -6,10 +6,10 @@ import 'package:soliplex_agent/soliplex_agent.dart';
 import 'execution_tracker.dart';
 import 'execution_tracker_extension.dart';
 import 'historical_replay.dart';
-import 'tool_calls_extension.dart';
 import 'run_registry.dart';
 import 'send_error.dart';
 import 'session_spawner.dart';
+import 'tool_calls_extension.dart';
 
 export 'send_error.dart';
 
@@ -119,7 +119,11 @@ class ThreadViewState {
   }
 
   /// Live tool call statuses from the active session, or null if no session
-  /// is attached.
+  /// is attached or the active session has no [ToolCallsExtension].
+  ///
+  /// Status is intentionally not persisted past the session's lifetime: this
+  /// signal returns null the moment the session detaches, even if its list
+  /// had populated entries.
   ReadonlySignal<List<ToolCallEntry>>? get toolCalls =>
       _activeSession?.getExtension<ToolCallsExtension>()?.stateSignal;
 

--- a/lib/src/modules/room/thread_view_state.dart
+++ b/lib/src/modules/room/thread_view_state.dart
@@ -6,6 +6,7 @@ import 'package:soliplex_agent/soliplex_agent.dart';
 import 'execution_tracker.dart';
 import 'execution_tracker_extension.dart';
 import 'historical_replay.dart';
+import 'tool_calls_extension.dart';
 import 'run_registry.dart';
 import 'send_error.dart';
 import 'session_spawner.dart';
@@ -116,6 +117,11 @@ class ThreadViewState {
     if (ext == null) return Map.unmodifiable(_historicalTrackers);
     return {..._historicalTrackers, ...ext.trackers};
   }
+
+  /// Live tool call statuses from the active session, or null if no session
+  /// is attached.
+  ReadonlySignal<List<ToolCallEntry>>? get toolCalls =>
+      _activeSession?.getExtension<ToolCallsExtension>()?.stateSignal;
 
   void submitFeedback(String runId, FeedbackType feedback, String? reason) {
     unawaited(

--- a/lib/src/modules/room/tool_calls_extension.dart
+++ b/lib/src/modules/room/tool_calls_extension.dart
@@ -15,7 +15,8 @@ class ToolCallEntry {
   final String toolName;
   final ToolCallStatus status;
 
-  /// True for client-side tool calls (executed locally), false for server-side.
+  /// True when this client executes the tool; false when the agent
+  /// backend executes it.
   final bool isClientSide;
 
   ToolCallEntry copyWith({ToolCallStatus? status}) => ToolCallEntry(
@@ -42,11 +43,15 @@ class ToolCallEntry {
 ///
 /// Subscribes to [AgentSession.lastExecutionEvent] in [onAttach] and maintains
 /// an ordered list of [ToolCallEntry] values. Each entry records the call's
-/// name, ID, whether it is client-side or server-side, and current status
-/// (executing / completed / failed).
+/// name, ID, whether it is client-side or server-side, and current status.
+/// Client-side calls surface [ToolCallStatus.completed] or
+/// [ToolCallStatus.failed] via [ClientToolCompleted.status]; server-side
+/// calls only ever surface [ToolCallStatus.completed] because the upstream
+/// event stream has no server-tool failure variant.
 ///
-/// Resets to an empty list at the start of each new run via [RunCompleted]
-/// and [RunFailed] terminal events clearing on the next session attach.
+/// State accumulates across all runs within a session. The runtime's
+/// `extensionFactory` constructs a fresh instance per session, so the list
+/// always starts empty on session attach.
 class ToolCallsExtension extends SessionExtension
     with StatefulSessionExtension<List<ToolCallEntry>> {
   ToolCallsExtension() {

--- a/lib/src/modules/room/tool_calls_extension.dart
+++ b/lib/src/modules/room/tool_calls_extension.dart
@@ -1,0 +1,150 @@
+import 'package:flutter/foundation.dart' show immutable;
+import 'package:soliplex_agent/soliplex_agent.dart';
+
+/// A tool call's current status during a session.
+@immutable
+class ToolCallEntry {
+  const ToolCallEntry({
+    required this.toolCallId,
+    required this.toolName,
+    required this.status,
+    required this.isClientSide,
+  });
+
+  final String toolCallId;
+  final String toolName;
+  final ToolCallStatus status;
+
+  /// True for client-side tool calls (executed locally), false for server-side.
+  final bool isClientSide;
+
+  ToolCallEntry copyWith({ToolCallStatus? status}) => ToolCallEntry(
+        toolCallId: toolCallId,
+        toolName: toolName,
+        status: status ?? this.status,
+        isClientSide: isClientSide,
+      );
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is ToolCallEntry &&
+          toolCallId == other.toolCallId &&
+          toolName == other.toolName &&
+          status == other.status &&
+          isClientSide == other.isClientSide;
+
+  @override
+  int get hashCode => Object.hash(toolCallId, toolName, status, isClientSide);
+}
+
+/// A [SessionExtension] that tracks tool call statuses reactively.
+///
+/// Subscribes to [AgentSession.lastExecutionEvent] in [onAttach] and maintains
+/// an ordered list of [ToolCallEntry] values. Each entry records the call's
+/// name, ID, whether it is client-side or server-side, and current status
+/// (executing / completed / failed).
+///
+/// Resets to an empty list at the start of each new run via [RunCompleted]
+/// and [RunFailed] terminal events clearing on the next session attach.
+class ToolCallsExtension extends SessionExtension
+    with StatefulSessionExtension<List<ToolCallEntry>> {
+  ToolCallsExtension() {
+    setInitialState(const []);
+  }
+
+  void Function()? _unsub;
+
+  @override
+  String get namespace => 'tool_calls';
+
+  @override
+  int get priority => 5;
+
+  @override
+  List<ClientTool> get tools => const [];
+
+  @override
+  Future<void> onAttach(AgentSession session) async {
+    _unsub = session.lastExecutionEvent.subscribe(_onEvent);
+  }
+
+  @override
+  void onDispose() {
+    _unsub?.call();
+    _unsub = null;
+    super.onDispose();
+  }
+
+  void _onEvent(ExecutionEvent? event) {
+    if (event == null) return;
+    final next = _reduce(state, event);
+    if (!identical(next, state)) state = next;
+  }
+
+  static List<ToolCallEntry> _reduce(
+    List<ToolCallEntry> entries,
+    ExecutionEvent event,
+  ) =>
+      switch (event) {
+        ClientToolExecuting(:final toolCallId, :final toolName) => _upsert(
+            entries,
+            toolCallId,
+            toolName,
+            ToolCallStatus.executing,
+            isClientSide: true,
+          ),
+        ClientToolCompleted(:final toolCallId, :final status) =>
+          _updateStatus(entries, toolCallId, status),
+        ServerToolCallStarted(:final toolCallId, :final toolName) => _upsert(
+            entries,
+            toolCallId,
+            toolName,
+            ToolCallStatus.executing,
+            isClientSide: false,
+          ),
+        ServerToolCallCompleted(:final toolCallId) =>
+          _updateStatus(entries, toolCallId, ToolCallStatus.completed),
+        _ => entries,
+      };
+
+  static List<ToolCallEntry> _upsert(
+    List<ToolCallEntry> entries,
+    String toolCallId,
+    String toolName,
+    ToolCallStatus status, {
+    required bool isClientSide,
+  }) {
+    final idx = entries.indexWhere((e) => e.toolCallId == toolCallId);
+    if (idx >= 0) {
+      return [
+        ...entries.sublist(0, idx),
+        entries[idx].copyWith(status: status),
+        ...entries.sublist(idx + 1),
+      ];
+    }
+    return [
+      ...entries,
+      ToolCallEntry(
+        toolCallId: toolCallId,
+        toolName: toolName,
+        status: status,
+        isClientSide: isClientSide,
+      ),
+    ];
+  }
+
+  static List<ToolCallEntry> _updateStatus(
+    List<ToolCallEntry> entries,
+    String toolCallId,
+    ToolCallStatus status,
+  ) {
+    final idx = entries.indexWhere((e) => e.toolCallId == toolCallId);
+    if (idx < 0) return entries;
+    return [
+      ...entries.sublist(0, idx),
+      entries[idx].copyWith(status: status),
+      ...entries.sublist(idx + 1),
+    ];
+  }
+}

--- a/test/modules/room/tool_calls_extension_test.dart
+++ b/test/modules/room/tool_calls_extension_test.dart
@@ -1,0 +1,236 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:soliplex_agent/soliplex_agent.dart';
+import 'package:soliplex_frontend/src/modules/room/tool_calls_extension.dart';
+
+/// Minimal AgentSession fake that only exposes [lastExecutionEvent].
+class _FakeSession implements AgentSession {
+  final Signal<ExecutionEvent?> events = Signal<ExecutionEvent?>(null);
+
+  @override
+  ReadonlySignal<ExecutionEvent?> get lastExecutionEvent => events;
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => null;
+}
+
+void main() {
+  late _FakeSession session;
+  late ToolCallsExtension ext;
+
+  setUp(() async {
+    session = _FakeSession();
+    ext = ToolCallsExtension();
+    await ext.onAttach(session);
+  });
+
+  tearDown(() => ext.onDispose());
+
+  test('starts empty after onAttach', () {
+    expect(ext.state, isEmpty);
+  });
+
+  test('ClientToolExecuting appends an executing client-side entry', () {
+    session.events.value = const ClientToolExecuting(
+      toolCallId: 'tc-1',
+      toolName: 'lookup',
+    );
+
+    expect(ext.state, [
+      const ToolCallEntry(
+        toolCallId: 'tc-1',
+        toolName: 'lookup',
+        status: ToolCallStatus.executing,
+        isClientSide: true,
+      ),
+    ]);
+  });
+
+  test('ServerToolCallStarted appends an executing server-side entry', () {
+    session.events.value = const ServerToolCallStarted(
+      toolCallId: 'tc-2',
+      toolName: 'search',
+    );
+
+    expect(ext.state, [
+      const ToolCallEntry(
+        toolCallId: 'tc-2',
+        toolName: 'search',
+        status: ToolCallStatus.executing,
+        isClientSide: false,
+      ),
+    ]);
+  });
+
+  test('ClientToolCompleted propagates the event status (completed)', () {
+    session.events.value = const ClientToolExecuting(
+      toolCallId: 'tc-1',
+      toolName: 'lookup',
+    );
+    session.events.value = const ClientToolCompleted(
+      toolCallId: 'tc-1',
+      result: 'ok',
+      status: ToolCallStatus.completed,
+    );
+
+    expect(ext.state.single.status, ToolCallStatus.completed);
+  });
+
+  test('ClientToolCompleted propagates the event status (failed)', () {
+    session.events.value = const ClientToolExecuting(
+      toolCallId: 'tc-1',
+      toolName: 'lookup',
+    );
+    session.events.value = const ClientToolCompleted(
+      toolCallId: 'tc-1',
+      result: 'boom',
+      status: ToolCallStatus.failed,
+    );
+
+    expect(ext.state.single.status, ToolCallStatus.failed);
+  });
+
+  test('ServerToolCallCompleted marks the matching entry completed', () {
+    session.events.value = const ServerToolCallStarted(
+      toolCallId: 'tc-2',
+      toolName: 'search',
+    );
+    session.events.value = const ServerToolCallCompleted(
+      toolCallId: 'tc-2',
+      result: 'done',
+    );
+
+    expect(ext.state.single.status, ToolCallStatus.completed);
+  });
+
+  test('re-entry of the same toolCallId updates in place', () {
+    session.events.value = const ClientToolExecuting(
+      toolCallId: 'tc-1',
+      toolName: 'lookup',
+    );
+    // A second ClientToolExecuting for the same call must not append a
+    // duplicate; `_upsert` should mutate the existing entry while
+    // preserving `toolName` and `side`.
+    session.events.value = const ClientToolExecuting(
+      toolCallId: 'tc-1',
+      toolName: 'lookup',
+    );
+
+    expect(ext.state.length, 1);
+    expect(ext.state.single.toolName, 'lookup');
+    expect(ext.state.single.isClientSide, isTrue);
+  });
+
+  test('completion for unknown toolCallId is a no-op', () {
+    session.events.value = const ServerToolCallCompleted(
+      toolCallId: 'unknown',
+      result: 'done',
+    );
+
+    expect(ext.state, isEmpty);
+  });
+
+  test('unrelated ExecutionEvent variants leave state unchanged', () {
+    session.events.value = const ClientToolExecuting(
+      toolCallId: 'tc-1',
+      toolName: 'lookup',
+    );
+    final before = ext.state;
+
+    session.events.value = const ThinkingStarted();
+    session.events.value = const ThinkingContent(delta: 'hmm');
+
+    expect(identical(ext.state, before), isTrue);
+  });
+
+  test('no-op event does not emit a new signal value', () {
+    session.events.value = const ClientToolExecuting(
+      toolCallId: 'tc-1',
+      toolName: 'lookup',
+    );
+    var emissions = 0;
+    final dispose = ext.stateSignal.subscribe((_) => emissions++);
+    // The subscription fires once on register with the current value;
+    // a subsequent unrelated event must not trigger a second emission.
+    expect(emissions, 1);
+
+    session.events.value = const ThinkingStarted();
+
+    expect(emissions, 1);
+    dispose();
+  });
+
+  test('preserves order across distinct tool calls', () {
+    session.events.value = const ClientToolExecuting(
+      toolCallId: 'a',
+      toolName: 'first',
+    );
+    session.events.value = const ServerToolCallStarted(
+      toolCallId: 'b',
+      toolName: 'second',
+    );
+    session.events.value = const ClientToolExecuting(
+      toolCallId: 'c',
+      toolName: 'third',
+    );
+
+    expect(
+      ext.state.map((e) => e.toolCallId).toList(),
+      ['a', 'b', 'c'],
+    );
+  });
+
+  test('onDispose stops applying further events', () {
+    ext.onDispose();
+
+    // If the subscription weren't torn down, the next event would fire
+    // `_onEvent`, which reads the now-disposed `state` and throws an
+    // assertion. Completing normally confirms the unsubscribe happened.
+    expect(
+      () => session.events.value = const ClientToolExecuting(
+        toolCallId: 'tc-1',
+        toolName: 'lookup',
+      ),
+      returnsNormally,
+    );
+  });
+
+  test('onDispose is idempotent', () {
+    ext.onDispose();
+    expect(ext.onDispose, returnsNormally);
+  });
+
+  group('ToolCallEntry value semantics', () {
+    const entry = ToolCallEntry(
+      toolCallId: 'tc-1',
+      toolName: 'lookup',
+      status: ToolCallStatus.executing,
+      isClientSide: true,
+    );
+
+    test('equal values are ==', () {
+      const other = ToolCallEntry(
+        toolCallId: 'tc-1',
+        toolName: 'lookup',
+        status: ToolCallStatus.executing,
+        isClientSide: true,
+      );
+
+      expect(entry, other);
+      expect(entry.hashCode, other.hashCode);
+    });
+
+    test('differing status breaks equality', () {
+      final completed = entry.copyWith(status: ToolCallStatus.completed);
+
+      expect(entry, isNot(completed));
+    });
+
+    test('copyWith preserves identity fields', () {
+      final completed = entry.copyWith(status: ToolCallStatus.completed);
+
+      expect(completed.toolCallId, entry.toolCallId);
+      expect(completed.toolName, entry.toolName);
+      expect(completed.isClientSide, entry.isClientSide);
+    });
+  });
+}

--- a/test/modules/room/tool_calls_extension_test.dart
+++ b/test/modules/room/tool_calls_extension_test.dart
@@ -142,23 +142,6 @@ void main() {
     expect(identical(ext.state, before), isTrue);
   });
 
-  test('no-op event does not emit a new signal value', () {
-    session.events.value = const ClientToolExecuting(
-      toolCallId: 'tc-1',
-      toolName: 'lookup',
-    );
-    var emissions = 0;
-    final dispose = ext.stateSignal.subscribe((_) => emissions++);
-    // The subscription fires once on register with the current value;
-    // a subsequent unrelated event must not trigger a second emission.
-    expect(emissions, 1);
-
-    session.events.value = const ThinkingStarted();
-
-    expect(emissions, 1);
-    dispose();
-  });
-
   test('preserves order across distinct tool calls', () {
     session.events.value = const ClientToolExecuting(
       toolCallId: 'a',
@@ -199,7 +182,7 @@ void main() {
     expect(ext.onDispose, returnsNormally);
   });
 
-  group('ToolCallEntry value semantics', () {
+  test('ToolCallEntry.copyWith preserves identity fields', () {
     const entry = ToolCallEntry(
       toolCallId: 'tc-1',
       toolName: 'lookup',
@@ -207,30 +190,10 @@ void main() {
       isClientSide: true,
     );
 
-    test('equal values are ==', () {
-      const other = ToolCallEntry(
-        toolCallId: 'tc-1',
-        toolName: 'lookup',
-        status: ToolCallStatus.executing,
-        isClientSide: true,
-      );
+    final completed = entry.copyWith(status: ToolCallStatus.completed);
 
-      expect(entry, other);
-      expect(entry.hashCode, other.hashCode);
-    });
-
-    test('differing status breaks equality', () {
-      final completed = entry.copyWith(status: ToolCallStatus.completed);
-
-      expect(entry, isNot(completed));
-    });
-
-    test('copyWith preserves identity fields', () {
-      final completed = entry.copyWith(status: ToolCallStatus.completed);
-
-      expect(completed.toolCallId, entry.toolCallId);
-      expect(completed.toolName, entry.toolName);
-      expect(completed.isClientSide, entry.isClientSide);
-    });
+    expect(completed.toolCallId, entry.toolCallId);
+    expect(completed.toolName, entry.toolName);
+    expect(completed.isClientSide, entry.isClientSide);
   });
 }


### PR DESCRIPTION
Adds a minimal `ToolCallsExtension` riding the `SessionCoordinator` seam. Listens to the session's `lastExecutionEvent` and accumulates an ordered `List<ToolCallEntry>` keyed by `toolCallId`, with a status field mirroring the execution events (executing → completed/failed, client- and server-side).

No arguments, results, durations, or error payloads on the entries — those live on the underlying execution events and will be shaped later when a concrete consumer lands. Kept intentionally tiny: the value here is having a single reactive surface the UI can watch to see which tool calls are live in the current session.

Wired into the standard flavor alongside `ExecutionTrackerExtension`.

## Stack

PR 6 of 11. Base: feat/thread-tile-spinner.

Supersedes #167 (legacy M8).

## Test plan

- [x] `flutter analyze` — 0 issues
- [x] `flutter test` — 1091 pass
