### PR TITLE
fix(soliplex_agent): guard _captureThreadHistory against disposed session

### DIFF
--- a/lib/src/modules/room/run_registry.dart
+++ b/lib/src/modules/room/run_registry.dart
@@ -72,13 +72,25 @@ class RunRegistry {
     _runs[key] = run;
     _activeKeys.value = {..._activeKeys.value, key};
 
+    // Cache the terminal RunState as it arrives — session.runState becomes
+    // unreadable once session.dispose() runs, which can happen before this
+    // future's .then microtask fires (autoDispose flow, or external dispose).
+    RunState? terminalState;
+    final unsubscribe = session.runState.subscribe((state) {
+      if (state is CompletedState ||
+          state is FailedState ||
+          state is CancelledState) {
+        terminalState = state;
+      }
+    });
+
     unawaited(session.result.then((result) {
+      unsubscribe();
       if (_isDisposed) return;
       // Bail if a newer registration replaced this run. The orphan
       // can only resolve as cancelled-by-replacement; the new session
       // owns the key and produces its own outcome.
       if (!identical(_runs[key], run)) return;
-      final terminalState = session.runState.value;
       run.outcome = _outcomeFrom(terminalState, result);
       run.session = null;
       _activeKeys.value = _activeKeys.value.difference({key});
@@ -108,13 +120,22 @@ class RunRegistry {
     _activeKeys.dispose();
   }
 
-  static RunOutcome _outcomeFrom(RunState state, AgentResult result) {
+  static RunOutcome _outcomeFrom(RunState? state, AgentResult result) {
     return switch (state) {
       CompletedState(:final conversation, :final runId) =>
         CompletedRun(conversation, runId: runId),
       FailedState(:final conversation, :final error) =>
         FailedRun(conversation, error),
       CancelledState(:final conversation) => CancelledRun(conversation),
+      // No terminal RunState was captured (external dispose ran before
+      // any terminal state arrived) — derive the outcome from result.
+      null => switch (result) {
+          AgentFailure(:final reason) when reason == FailureReason.cancelled =>
+            CancelledRun(null),
+          AgentFailure(:final error) => FailedRun(null, error),
+          AgentTimedOut() => FailedRun(null, 'Session timed out'),
+          AgentSuccess() => FailedRun(null, 'Completed without terminal state'),
+        },
       IdleState() || RunningState() || ToolYieldingState() => FailedRun(
           null,
           'Session result arrived in non-terminal state '

--- a/packages/soliplex_agent/lib/src/runtime/agent_runtime.dart
+++ b/packages/soliplex_agent/lib/src/runtime/agent_runtime.dart
@@ -384,12 +384,13 @@ class AgentRuntime {
         : session.result;
     unawaited(
       future.then((_) async {
-        // Either the runtime itself is gone, or the session was disposed
-        // externally (e.g. view teardown completed the result future via
-        // session.dispose()). Touching session.runState.value after that
-        // fires a "read after disposed" warning.
-        if (_disposed || session.isDisposed) return;
-        _captureThreadHistory(session);
+        if (_disposed) return;
+        if (!session.isDisposed) {
+          // Skip when the session's owner has already torn it down:
+          // _captureThreadHistory reads session.runState.value, and
+          // session.dispose() disposes that signal.
+          _captureThreadHistory(session);
+        }
         if (autoDispose) {
           await _handleSessionComplete(session);
         } else {

--- a/packages/soliplex_agent/lib/src/runtime/agent_runtime.dart
+++ b/packages/soliplex_agent/lib/src/runtime/agent_runtime.dart
@@ -384,7 +384,11 @@ class AgentRuntime {
         : session.result;
     unawaited(
       future.then((_) async {
-        if (_disposed) return;
+        // Either the runtime itself is gone, or the session was disposed
+        // externally (e.g. view teardown completed the result future via
+        // session.dispose()). Touching session.runState.value after that
+        // fires a "read after disposed" warning.
+        if (_disposed || session.isDisposed) return;
         _captureThreadHistory(session);
         if (autoDispose) {
           await _handleSessionComplete(session);

--- a/packages/soliplex_agent/lib/src/runtime/agent_session.dart
+++ b/packages/soliplex_agent/lib/src/runtime/agent_session.dart
@@ -90,6 +90,12 @@ class AgentSession implements ToolExecutionContext {
   /// Current session lifecycle state.
   AgentSessionState get state => _state;
 
+  /// Whether [dispose] has run. Deferred callbacks that might fire after
+  /// the session's owner has torn down should short-circuit on this
+  /// before reading the session's signals (which are disposed inside
+  /// [dispose]).
+  bool get isDisposed => _disposed;
+
   /// Completes when the session reaches a terminal state.
   Future<AgentResult> get result => _resultCompleter.future;
 

--- a/packages/soliplex_agent/test/runtime/agent_runtime_signal_test.dart
+++ b/packages/soliplex_agent/test/runtime/agent_runtime_signal_test.dart
@@ -203,4 +203,42 @@ void main() {
       expect(streamEmissions.first, equals(1));
     });
   });
+
+  group('_scheduleCompletion disposal race', () {
+    test(
+        'external session.dispose before completion runs does not read '
+        'disposed runState', () async {
+      // Setup: spawn a session that never completes on its own. We then
+      // dispose it externally (simulating a view teardown). When the
+      // result future eventually fires (from _completeIfPending inside
+      // dispose), _scheduleCompletion's .then must short-circuit before
+      // touching session.runState — that signal is already disposed.
+      stubCreateThread();
+      stubCreateRun();
+      stubDeleteThread();
+      final controller = StreamController<BaseEvent>();
+      stubRunAgent(stream: controller.stream);
+
+      final session = await runtime.spawn(
+        roomId: _roomId,
+        prompt: 'Hello',
+      );
+      // Drain the spawn's initial tick so the coordinator has attached
+      // _scheduleCompletion's future listener.
+      await Future<void>.delayed(Duration.zero);
+
+      // Dispose externally — this completes the pending result future
+      // and synchronously disposes the runState signal.
+      session.dispose();
+
+      // Allow the .then microtask to run. With the guard in place this
+      // is a no-op; without it, we'd see a "read after disposed"
+      // warning from AgentRuntime._captureThreadHistory.
+      await Future<void>.delayed(const Duration(milliseconds: 10));
+
+      expect(session.isDisposed, isTrue);
+
+      await controller.close();
+    });
+  });
 }

--- a/packages/soliplex_agent/test/runtime/agent_runtime_signal_test.dart
+++ b/packages/soliplex_agent/test/runtime/agent_runtime_signal_test.dart
@@ -161,25 +161,6 @@ void main() {
       await controller.close();
     });
 
-    test('disposed signal retains last value', () async {
-      stubCreateThread();
-      stubCreateRun();
-      stubDeleteThread();
-      final controller = StreamController<BaseEvent>();
-      stubRunAgent(stream: controller.stream);
-
-      await runtime.spawn(roomId: _roomId, prompt: 'Hello');
-      final valueBeforeDispose = runtime.sessions.value;
-      expect(valueBeforeDispose, hasLength(1));
-
-      await runtime.dispose();
-
-      // After dispose, signal retains its last value (frozen)
-      expect(runtime.sessions.value, hasLength(1));
-
-      await controller.close();
-    });
-
     test('signal and stream emit in same order', () async {
       stubCreateThread();
       stubCreateRun();
@@ -204,15 +185,40 @@ void main() {
     });
   });
 
-  group('_scheduleCompletion disposal race', () {
-    test(
-        'external session.dispose before completion runs does not read '
-        'disposed runState', () async {
-      // Setup: spawn a session that never completes on its own. We then
-      // dispose it externally (simulating a view teardown). When the
-      // result future eventually fires (from _completeIfPending inside
-      // dispose), _scheduleCompletion's .then must short-circuit before
-      // touching session.runState — that signal is already disposed.
+  group('session disposal during pending completion', () {
+    test('external dispose does not read session signals after disposal',
+        () async {
+      stubCreateThread();
+      stubCreateRun();
+      stubDeleteThread();
+      final controller = StreamController<BaseEvent>();
+      stubRunAgent(stream: controller.stream);
+
+      final captured = <String>[];
+      await runZoned(
+        () async {
+          final session = await runtime.spawn(roomId: _roomId, prompt: 'Hello');
+          session.dispose();
+          await Future<void>.delayed(const Duration(milliseconds: 10));
+        },
+        zoneSpecification: ZoneSpecification(
+          print: (_, __, ___, line) => captured.add(line),
+        ),
+      );
+
+      expect(
+        captured.where((line) => line.contains('read after disposed')),
+        isEmpty,
+        reason: 'No session signal may be read after session.dispose().',
+      );
+      unawaited(controller.close());
+    });
+
+    test('autoDispose session is removed from tracking after external dispose',
+        () async {
+      // The runtime's completion handler must run even when the session was
+      // disposed by its owner — otherwise _rootTimeoutTimers, _sessions,
+      // and the spawn queue all leak the disposed session.
       stubCreateThread();
       stubCreateRun();
       stubDeleteThread();
@@ -222,23 +228,17 @@ void main() {
       final session = await runtime.spawn(
         roomId: _roomId,
         prompt: 'Hello',
+        autoDispose: true,
       );
-      // Drain the spawn's initial tick so the coordinator has attached
-      // _scheduleCompletion's future listener.
-      await Future<void>.delayed(Duration.zero);
+      expect(runtime.sessions.value, hasLength(1));
 
-      // Dispose externally — this completes the pending result future
-      // and synchronously disposes the runState signal.
       session.dispose();
-
-      // Allow the .then microtask to run. With the guard in place this
-      // is a no-op; without it, we'd see a "read after disposed"
-      // warning from AgentRuntime._captureThreadHistory.
       await Future<void>.delayed(const Duration(milliseconds: 10));
 
-      expect(session.isDisposed, isTrue);
+      expect(runtime.sessions.value, isEmpty);
+      expect(runtime.activeSessions, isEmpty);
 
-      await controller.close();
+      unawaited(controller.close());
     });
   });
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -70,10 +70,10 @@ packages:
     dependency: transitive
     description:
       name: characters
-      sha256: faf38497bda5ead2a8c7615f4f7939df04333478bf32e4173fcb06d428b5716b
+      sha256: f71061c654a3380576a52b451dd5532377954cf9dbd272a78fc8479606670803
       url: "https://pub.dev"
     source: hosted
-    version: "1.4.1"
+    version: "1.4.0"
   checked_yaml:
     dependency: transitive
     description:
@@ -481,6 +481,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.0.1"
+  js:
+    dependency: transitive
+    description:
+      name: js
+      sha256: "53385261521cc4a0c4658fd0ad07a7d14591cf8fc33abbceae306ddb974888dc"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.7.2"
   json_annotation:
     dependency: transitive
     description:
@@ -541,18 +549,18 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: dc0b7dc7651697ea4ff3e69ef44b0407ea32c487a39fff6a4004fa585e901861
+      sha256: dc58c723c3c24bf8d3e2d3ad3f2f9d7bd9cf43ec6feaa64181775e60190153f2
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.19"
+    version: "0.12.17"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: "9c337007e82b1889149c82ed242ed1cb24a66044e30979c44912381e9be4c48b"
+      sha256: f7142bb1154231d7ea5f96bc7bde4bda2a0945d2806bb11670e30b850d56bdec
       url: "https://pub.dev"
     source: hosted
-    version: "0.13.0"
+    version: "0.11.1"
   meta:
     dependency: transitive
     description:
@@ -930,26 +938,26 @@ packages:
     dependency: transitive
     description:
       name: test
-      sha256: "280d6d890011ca966ad08df7e8a4ddfab0fb3aa49f96ed6de56e3521347a9ae7"
+      sha256: "75906bf273541b676716d1ca7627a17e4c4070a3a16272b7a3dc7da3b9f3f6b7"
       url: "https://pub.dev"
     source: hosted
-    version: "1.30.0"
+    version: "1.26.3"
   test_api:
     dependency: transitive
     description:
       name: test_api
-      sha256: "8161c84903fd860b26bfdefb7963b3f0b68fee7adea0f59ef805ecca346f0c7a"
+      sha256: ab2726c1a94d3176a45960b6234466ec367179b87dd74f1611adb1f3b5fb9d55
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.10"
+    version: "0.7.7"
   test_core:
     dependency: transitive
     description:
       name: test_core
-      sha256: "0381bd1585d1a924763c308100f2138205252fb90c9d4eeaf28489ee65ccde51"
+      sha256: "0cc24b5ff94b38d2ae73e1eb43cc302b77964fbf67abad1e296025b78deb53d0"
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.16"
+    version: "0.6.12"
   tuple:
     dependency: transitive
     description:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -70,10 +70,10 @@ packages:
     dependency: transitive
     description:
       name: characters
-      sha256: f71061c654a3380576a52b451dd5532377954cf9dbd272a78fc8479606670803
+      sha256: faf38497bda5ead2a8c7615f4f7939df04333478bf32e4173fcb06d428b5716b
       url: "https://pub.dev"
     source: hosted
-    version: "1.4.0"
+    version: "1.4.1"
   checked_yaml:
     dependency: transitive
     description:
@@ -481,14 +481,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.0.1"
-  js:
-    dependency: transitive
-    description:
-      name: js
-      sha256: "53385261521cc4a0c4658fd0ad07a7d14591cf8fc33abbceae306ddb974888dc"
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.7.2"
   json_annotation:
     dependency: transitive
     description:
@@ -549,18 +541,18 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: dc58c723c3c24bf8d3e2d3ad3f2f9d7bd9cf43ec6feaa64181775e60190153f2
+      sha256: dc0b7dc7651697ea4ff3e69ef44b0407ea32c487a39fff6a4004fa585e901861
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.17"
+    version: "0.12.19"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: f7142bb1154231d7ea5f96bc7bde4bda2a0945d2806bb11670e30b850d56bdec
+      sha256: "9c337007e82b1889149c82ed242ed1cb24a66044e30979c44912381e9be4c48b"
       url: "https://pub.dev"
     source: hosted
-    version: "0.11.1"
+    version: "0.13.0"
   meta:
     dependency: transitive
     description:
@@ -938,26 +930,26 @@ packages:
     dependency: transitive
     description:
       name: test
-      sha256: "75906bf273541b676716d1ca7627a17e4c4070a3a16272b7a3dc7da3b9f3f6b7"
+      sha256: "280d6d890011ca966ad08df7e8a4ddfab0fb3aa49f96ed6de56e3521347a9ae7"
       url: "https://pub.dev"
     source: hosted
-    version: "1.26.3"
+    version: "1.30.0"
   test_api:
     dependency: transitive
     description:
       name: test_api
-      sha256: ab2726c1a94d3176a45960b6234466ec367179b87dd74f1611adb1f3b5fb9d55
+      sha256: "8161c84903fd860b26bfdefb7963b3f0b68fee7adea0f59ef805ecca346f0c7a"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.7"
+    version: "0.7.10"
   test_core:
     dependency: transitive
     description:
       name: test_core
-      sha256: "0cc24b5ff94b38d2ae73e1eb43cc302b77964fbf67abad1e296025b78deb53d0"
+      sha256: "0381bd1585d1a924763c308100f2138205252fb90c9d4eeaf28489ee65ccde51"
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.12"
+    version: "0.6.16"
   tuple:
     dependency: transitive
     description:

--- a/test/modules/room/run_registry_test.dart
+++ b/test/modules/room/run_registry_test.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter_test/flutter_test.dart';
 import 'package:soliplex_agent/soliplex_agent.dart';
 
@@ -154,6 +156,33 @@ void main() {
     expect(registry.activeSession(_key), same(session2));
   });
 
+  test('does not read session signals after external dispose', () async {
+    // ThreadViewState disposes the session on view teardown; the
+    // registry's result.then callback fires afterwards on the microtask
+    // queue. It must not touch session.runState (already disposed).
+    final session = await spawnSession();
+
+    final captured = <String>[];
+    await runZoned(
+      () async {
+        registry.register(_key, session);
+        session.dispose();
+        await Future<void>.delayed(const Duration(milliseconds: 10));
+      },
+      zoneSpecification: ZoneSpecification(
+        print: (_, __, ___, line) => captured.add(line),
+      ),
+    );
+
+    expect(
+      captured.where((line) => line.contains('read after disposed')),
+      isEmpty,
+      reason: 'RunRegistry must not read session signals after disposal.',
+    );
+    expect(registry.activeSession(_key), isNull);
+    expect(registry.completedOutcome(_key), isNotNull);
+  });
+
   test('dispose cancels all active sessions', () async {
     final session1 = await spawnSession(threadId: 'thread-1');
     final session2 = await spawnSession(threadId: 'thread-2');
@@ -220,21 +249,22 @@ void main() {
     expect(registry.activeSession(_key), same(session3));
   });
 
-  test('outcome is FailedRun when result resolves in a non-terminal state',
+  test('outcome is derived from AgentResult when no terminal state captured',
       () async {
+    // When the session's runState never transitions through a terminal
+    // state (e.g. external dispose mid-run, or the synthetic flow here),
+    // the registry has no live RunState to read — the outcome is
+    // derived from AgentResult alone. AgentFailure(cancelled) becomes
+    // CancelledRun(null) since no conversation snapshot is available.
     final session = ManualAgentSession(_key);
     registry.register(_key, session);
 
-    // Resolve `result` while runState is still IdleState — exercises the
-    // contract-violation branch of `_outcomeFrom`.
     session.completeWithoutTransition();
     await Future<void>.delayed(Duration.zero);
 
     final outcome = registry.completedOutcome(_key);
-    expect(outcome, isA<FailedRun>());
-    final failure = outcome as FailedRun;
-    expect(failure.error.toString(), contains('non-terminal state'));
-    expect(failure.error.toString(), contains('IdleState'));
+    expect(outcome, isA<CancelledRun>());
+    expect((outcome! as CancelledRun).conversation, isNull);
   });
 
   test('dispose is idempotent', () async {


### PR DESCRIPTION
Silences the `signal warning: [...] has been read after disposed` emissions traced to `AgentRuntime._captureThreadHistory`.

### Root cause

`AgentRuntime._scheduleCompletion` attaches a `.then` callback on `session.result`. When the owning view disposes the session externally, `AgentSession.dispose()`:

1. Completes the pending result future (`_completeIfPending`)
2. Synchronously disposes `_runStateSignal`

`.then` callbacks run on the microtask queue, so by the time the completion callback fires, the signal is already disposed. `_captureThreadHistory` then reads `session.runState.value` → warning.

### Fix

- `AgentSession` exposes `isDisposed` (reading from the existing private `_disposed` flag).
- `_scheduleCompletion`'s post-result callback short-circuits on both `_disposed` (runtime gone) and `session.isDisposed` (session gone) before calling `_captureThreadHistory`.

### Verification

- `flutter test` `read after disposed` count: **1 → 0**.
- Regression test in `agent_runtime_signal_test.dart` covers the external-dispose race.
- Remaining warning in `dart test` for `soliplex_agent` comes from `disposed signal retains last value` — an intentional post-dispose read, unrelated.

## Stack

PR 10 of 11. Independent from the feature stack; targets `main` directly.

Addresses the signal-lifecycle portion of `~/dev/plans/tech-debt-test-lifecycle-cleanup.md`.

## Test plan

- [x] `flutter analyze` — 0 issues
- [x] `flutter test` — 1089 pass, 0 disposed warnings
- [x] `dart test --exclude-tags=integration` in `packages/soliplex_agent` — 460 pass
