### PR TITLE
refactor(soliplex_client): extract _onActiveTextStream guard helper

### DIFF
--- a/packages/soliplex_client/lib/src/application/agui_event_processor.dart
+++ b/packages/soliplex_client/lib/src/application/agui_event_processor.dart
@@ -296,64 +296,77 @@ EventProcessingResult _processTextStart(
   );
 }
 
-// TODO(cleanup): Extract streaming guard pattern if a third streaming event
-// type is added. Both _processTextContent and _processTextEnd share the
-// "check if streaming matches messageId, else return unchanged" pattern.
+/// Runs [onMatch] only when [streaming] is an active [TextStreaming] for
+/// [messageId]. Otherwise returns [conversation] and [streaming] unchanged —
+/// events for a stale or already-closed stream are ignored.
+EventProcessingResult _onActiveTextStream(
+  Conversation conversation,
+  StreamingState streaming,
+  String messageId,
+  EventProcessingResult Function(TextStreaming active) onMatch,
+) {
+  if (streaming is TextStreaming && streaming.messageId == messageId) {
+    return onMatch(streaming);
+  }
+  return EventProcessingResult(
+    conversation: conversation,
+    streaming: streaming,
+  );
+}
+
 EventProcessingResult _processTextContent(
   Conversation conversation,
   StreamingState streaming,
   String messageId,
   String delta,
-) {
-  if (streaming is TextStreaming && streaming.messageId == messageId) {
-    return EventProcessingResult(
-      conversation: conversation,
-      streaming: streaming.appendDelta(delta),
+) =>
+    _onActiveTextStream(
+      conversation,
+      streaming,
+      messageId,
+      (active) => EventProcessingResult(
+        conversation: conversation,
+        streaming: active.appendDelta(delta),
+      ),
     );
-  }
-  return EventProcessingResult(
-    conversation: conversation,
-    streaming: streaming,
-  );
-}
 
 EventProcessingResult _processTextEnd(
   Conversation conversation,
   StreamingState streaming,
   String messageId,
-) {
-  if (streaming is TextStreaming && streaming.messageId == messageId) {
-    // Skip if a message with this ID already exists — idempotency guard
-    // against duplicate events (e.g. from history replay).
-    if (conversation.messages.any((m) => m.id == messageId)) {
-      developer.log(
-        'Skipped duplicate message ID: $messageId',
-        name: 'soliplex_client.event_processor',
-        level: 800,
-      );
-      return EventProcessingResult(
-        conversation: conversation,
-        streaming: const AwaitingText(),
-      );
-    }
+) =>
+    _onActiveTextStream(
+      conversation,
+      streaming,
+      messageId,
+      (active) {
+        // Skip if a message with this ID already exists — idempotency guard
+        // against duplicate events (e.g. from history replay).
+        if (conversation.messages.any((m) => m.id == messageId)) {
+          developer.log(
+            'Skipped duplicate message ID: $messageId',
+            name: 'soliplex_client.event_processor',
+            level: 800,
+          );
+          return EventProcessingResult(
+            conversation: conversation,
+            streaming: const AwaitingText(),
+          );
+        }
 
-    final newMessage = TextMessage.create(
-      id: messageId,
-      user: streaming.user,
-      text: streaming.text,
-      thinkingText: streaming.thinkingText,
-    );
+        final newMessage = TextMessage.create(
+          id: messageId,
+          user: active.user,
+          text: active.text,
+          thinkingText: active.thinkingText,
+        );
 
-    return EventProcessingResult(
-      conversation: conversation.withAppendedMessage(newMessage),
-      streaming: const AwaitingText(),
+        return EventProcessingResult(
+          conversation: conversation.withAppendedMessage(newMessage),
+          streaming: const AwaitingText(),
+        );
+      },
     );
-  }
-  return EventProcessingResult(
-    conversation: conversation,
-    streaming: streaming,
-  );
-}
 
 /// Maps AG-UI TextMessageRole to domain ChatUser.
 ChatUser _mapRoleToChatUser(TextMessageRole role) {

--- a/packages/soliplex_client/lib/src/application/agui_event_processor.dart
+++ b/packages/soliplex_client/lib/src/application/agui_event_processor.dart
@@ -296,9 +296,7 @@ EventProcessingResult _processTextStart(
   );
 }
 
-/// Runs [onMatch] only when [streaming] is an active [TextStreaming] for
-/// [messageId]. Otherwise returns [conversation] and [streaming] unchanged —
-/// events for a stale or already-closed stream are ignored.
+/// Events for a stale or already-closed stream are ignored.
 EventProcessingResult _onActiveTextStream(
   Conversation conversation,
   StreamingState streaming,


### PR DESCRIPTION
Resolves the `TODO(cleanup)` in `agui_event_processor.dart` noting that `_processTextContent` and `_processTextEnd` duplicated the same "streaming is `TextStreaming` for this `messageId`, else return unchanged" guard.

Extracts the guard into `_onActiveTextStream(conversation, streaming, messageId, onMatch)`:
- If the streaming state matches, the closure is invoked with the active `TextStreaming` (typed, no cast needed at the callsite).
- Otherwise the unchanged result is returned — late events for a stale/closed stream fall through cleanly.

Both processors now delegate to the helper. Adding a third streaming event type (e.g., a dedicated thinking-delta processor) won't require re-deriving the guard each time.

Pure refactor; behavior is unchanged.

## Stack

PR 11 of 11. Base: fix/capture-thread-history-disposed.

Addresses `~/dev/plans/fix-streaming-guard-extraction.md`.

## Test plan

- [x] `flutter analyze` — 0 issues
- [x] `flutter test` — 1088 pass
- [x] `dart test --exclude-tags=integration` in `packages/soliplex_client` — 1373 pass
