### PR TITLE
feat(soliplex_agent_monty): package scaffold for dart_monty bridge

### DIFF
--- a/packages/soliplex_agent_monty/analysis_options.yaml
+++ b/packages/soliplex_agent_monty/analysis_options.yaml
@@ -1,0 +1,6 @@
+include:
+  - package:very_good_analysis/analysis_options.yaml
+
+linter:
+  rules:
+    public_member_api_docs: false

--- a/packages/soliplex_agent_monty/lib/soliplex_agent_monty.dart
+++ b/packages/soliplex_agent_monty/lib/soliplex_agent_monty.dart
@@ -1,0 +1,10 @@
+/// Bridge between `soliplex_agent` and `dart_monty`.
+///
+/// Wraps a `MontyRuntime` in a `SessionExtension` so Python scripts
+/// running in the on-device sandbox integrate with the same session
+/// lifecycle and observation surface as the rest of the agent's
+/// extensions.
+library;
+
+export 'src/monty_extension_set.dart';
+export 'src/monty_runtime_extension.dart';

--- a/packages/soliplex_agent_monty/lib/src/monty_extension_set.dart
+++ b/packages/soliplex_agent_monty/lib/src/monty_extension_set.dart
@@ -1,0 +1,28 @@
+// dart_monty's public barrel currently has a broken re-export and
+// does not expose the bundled extension set. Until that's fixed
+// upstream, import the needed types directly from their implementation
+// files. The alternative barrel `dart_monty_bridge.dart` also works but
+// is named for internal bridge-layer use; prefer the specific imports.
+// ignore_for_file: implementation_imports
+import 'package:dart_monty/src/extension/extension.dart' show MontyExtension;
+import 'package:dart_monty/src/extensions/defaults.dart' show defaultExtensions;
+
+/// Named collection of `dart_monty` extensions to load into a
+/// `MontyRuntime` instance bridged by `MontyRuntimeExtension`.
+///
+/// Exists as a typed wrapper (rather than a bare `List<MontyExtension>`)
+/// so future tiers — `.withSandbox`, `.withDatabase`, etc. — slot in
+/// without changing the bridge API.
+class MontyExtensionSet {
+  const MontyExtensionSet(this.all);
+
+  /// Config-free, cross-backend default set from `dart_monty`'s
+  /// `defaultExtensions()`: Jinja templating, message bus, and event
+  /// loop. No filesystem, no subprocesses, no platform-specific
+  /// extensions.
+  factory MontyExtensionSet.standard() =>
+      MontyExtensionSet(defaultExtensions());
+
+  /// The extensions to pass to `MontyRuntime`'s `extensions` parameter.
+  final List<MontyExtension> all;
+}

--- a/packages/soliplex_agent_monty/lib/src/monty_runtime_extension.dart
+++ b/packages/soliplex_agent_monty/lib/src/monty_runtime_extension.dart
@@ -1,0 +1,33 @@
+import 'package:soliplex_agent/soliplex_agent.dart';
+import 'package:soliplex_agent_monty/src/monty_extension_set.dart';
+
+/// Scaffold for the `dart_monty` bridge extension.
+///
+/// The full implementation (lifecycle, observation fan-out, the
+/// `run_python_on_device` [ClientTool]) lands in the follow-up PR. This
+/// scaffold exists so the package is self-contained and the wiring PR
+/// can start importing the type.
+class MontyRuntimeExtension extends SessionExtension {
+  MontyRuntimeExtension({required MontyExtensionSet extensions})
+      : _extensions = extensions;
+
+  // Preserved for the implementation PR — suppresses unused-field lint
+  // without code-gen noise.
+  // ignore: unused_field
+  final MontyExtensionSet _extensions;
+
+  @override
+  String get namespace => 'monty';
+
+  @override
+  int get priority => 0;
+
+  @override
+  List<ClientTool> get tools => const [];
+
+  @override
+  Future<void> onAttach(AgentSession session) async {}
+
+  @override
+  void onDispose() {}
+}

--- a/packages/soliplex_agent_monty/pubspec.yaml
+++ b/packages/soliplex_agent_monty/pubspec.yaml
@@ -1,0 +1,21 @@
+name: soliplex_agent_monty
+description: dart_monty bridge for the soliplex_agent session coordinator.
+version: 0.1.0
+publish_to: none
+resolution: workspace
+
+environment:
+  sdk: ^3.6.0
+
+dependencies:
+  # NOTE: Local path dep during development. Swap to a pinned git ref
+  # (commit SHA) before the feature flag ships to users.
+  dart_monty:
+    path: ../../../dart_monty
+  signals_core: ^6.2.0
+  soliplex_agent:
+    path: ../soliplex_agent
+
+dev_dependencies:
+  test: ^1.24.0
+  very_good_analysis: ^10.0.0

--- a/packages/soliplex_agent_monty/test/monty_extension_set_test.dart
+++ b/packages/soliplex_agent_monty/test/monty_extension_set_test.dart
@@ -1,0 +1,36 @@
+// See monty_extension_set.dart for why src/ imports are used.
+import 'package:dart_monty/src/extension/extension.dart' show MontyExtension;
+import 'package:dart_monty/src/extensions/defaults.dart' show defaultExtensions;
+import 'package:soliplex_agent_monty/soliplex_agent_monty.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('MontyExtensionSet', () {
+    test('standard returns dart_monty defaultExtensions', () {
+      final set = MontyExtensionSet.standard();
+
+      expect(set.all, isNotEmpty);
+      // defaultExtensions is: JinjaTemplateExtension, MessageBusExtension,
+      // EventLoopExtension (3 entries as of dart_monty 0.20.0).
+      expect(set.all.length, 3);
+      expect(set.all, everyElement(isA<MontyExtension>()));
+    });
+
+    test('standard returns a fresh list each call', () {
+      // Mutating one list must not leak into the next.
+      final a = MontyExtensionSet.standard();
+      expect(a.all, isNotEmpty);
+      final b = MontyExtensionSet.standard();
+      expect(identical(a.all, b.all), isFalse);
+    });
+
+    test('direct constructor preserves ordering', () {
+      final exts = <MontyExtension>[
+        ...defaultExtensions(),
+      ];
+      final set = MontyExtensionSet(exts);
+
+      expect(set.all, same(exts));
+    });
+  });
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -11,6 +11,7 @@ environment:
 
 workspace:
   - packages/soliplex_agent
+  - packages/soliplex_agent_monty
   - packages/soliplex_client
   - packages/soliplex_client_native
   - packages/soliplex_logging


### PR DESCRIPTION
## Summary

Creates `packages/soliplex_agent_monty/` — a new workspace package that will host the `soliplex_agent` ↔ `dart_monty` bridge. **Scaffold only**; the `MontyRuntimeExtension` implementation and the `run_python_on_device` ClientTool land in follow-up PRs per `~/dev/plans/monty-client-bridge.md`.

### What ships here

- `MontyExtensionSet` — typed wrapper around `List<MontyExtension>` with a `.standard()` factory that delegates to dart_monty's `defaultExtensions()` (Jinja templating, message bus, event loop).
- `MontyRuntimeExtension` — empty scaffold extending `SessionExtension`. All hooks are no-ops; the implementation arrives in PR 2.
- Unit tests for `MontyExtensionSet` (composition, freshness, ordering).

### Notes for reviewers

- **dart_monty dep** uses a local path (`../../../dart_monty`). Plan is to pin a git ref (commit SHA) before the feature ships behind a flag. Fine as-is for now.
- **Two dart_monty types imported via `src/` paths** (`MontyExtension`, `defaultExtensions`). dart_monty's public `lib/dart_monty.dart` barrel currently has a stale broken export (`src/bridge/bridge/monty_plugin.dart` — file doesn't exist after the plugin→extension rename) and does not re-export the bundled extension set. Both issues will be resolved in dart_monty's public API; the `src/` imports are an explicit, short-lived workaround with a code comment pointing to the fix.
- **Worktree-only warning**: `flutter analyze` on a nested worktree reports `path '../../../dart_monty' doesn't exist`. The canonical checkout layout resolves correctly — this warning is artifact of the `.claude/worktrees/` nesting.

### Stack position

PR 1 of 3 in the monty stack. Base: `feat/hide-extension-state-panel` (feature stack tip — gives post-feature-merge `SessionExtension` shape, which is `abstract class` not `abstract interface class`).

### Test plan

- [x] `flutter analyze` — 0 errors (1 worktree-only path warning as above)
- [x] `flutter test` — 1091 pass (no regressions)
- [x] `dart test` in `packages/soliplex_agent_monty/` — 3 pass