### PR TITLE
feat(soliplex_agent_monty): MontyRuntimeExtension + run_python_on_device tool

### DIFF
--- a/packages/soliplex_agent_monty/lib/src/monty_extension_set.dart
+++ b/packages/soliplex_agent_monty/lib/src/monty_extension_set.dart
@@ -1,11 +1,5 @@
-// dart_monty's public barrel currently has a broken re-export and
-// does not expose the bundled extension set. Until that's fixed
-// upstream, import the needed types directly from their implementation
-// files. The alternative barrel `dart_monty_bridge.dart` also works but
-// is named for internal bridge-layer use; prefer the specific imports.
-// ignore_for_file: implementation_imports
-import 'package:dart_monty/src/extension/extension.dart' show MontyExtension;
-import 'package:dart_monty/src/extensions/defaults.dart' show defaultExtensions;
+import 'package:dart_monty/dart_monty_bridge.dart'
+    show MontyExtension, defaultExtensions;
 
 /// Named collection of `dart_monty` extensions to load into a
 /// `MontyRuntime` instance bridged by `MontyRuntimeExtension`.

--- a/packages/soliplex_agent_monty/lib/src/monty_runtime_extension.dart
+++ b/packages/soliplex_agent_monty/lib/src/monty_runtime_extension.dart
@@ -1,20 +1,42 @@
+import 'dart:async';
+import 'dart:convert';
+
+import 'package:dart_monty/dart_monty.dart' show MontyRuntime;
+import 'package:dart_monty/dart_monty_bridge.dart' show ExtensionCoordinator;
 import 'package:soliplex_agent/soliplex_agent.dart';
+// ToolExecutionContext is not re-exported from soliplex_agent's public
+// barrel; reach into src/ for the type annotation.
+// ignore: implementation_imports
+import 'package:soliplex_agent/src/tools/tool_execution_context.dart'
+    show ToolExecutionContext;
 import 'package:soliplex_agent_monty/src/monty_extension_set.dart';
 
-/// Scaffold for the `dart_monty` bridge extension.
+/// Bridges a [MontyRuntime] into a soliplex [AgentSession].
 ///
-/// The full implementation (lifecycle, observation fan-out, the
-/// `run_python_on_device` [ClientTool]) lands in the follow-up PR. This
-/// scaffold exists so the package is self-contained and the wiring PR
-/// can start importing the type.
-class MontyRuntimeExtension extends SessionExtension {
+/// Lifecycle:
+/// - [onAttach] constructs the runtime with [MontyExtensionSet]'s
+///   extensions, then subscribes to the inner
+///   [ExtensionCoordinator.statefulObservations] and fans each
+///   `(namespace, signal)` into the outer [state] map.
+/// - [tools] exposes one [ClientTool] — `run_python_on_device` — that
+///   runs arbitrary Python code via `runtime.execute(code)` and
+///   returns `{value, output, error}` as a JSON string.
+/// - [onDispose] cancels all subscriptions and disposes the runtime.
+///
+/// The [Signal] owned here is NOT the runtime's signal; it's an
+/// aggregated map of every inner extension's current state, so the
+/// debug panel / other consumers can observe everything through one
+/// signal.
+class MontyRuntimeExtension extends SessionExtension
+    with StatefulSessionExtension<Map<String, Object?>> {
   MontyRuntimeExtension({required MontyExtensionSet extensions})
-      : _extensions = extensions;
+      : _extensions = extensions {
+    setInitialState(const <String, Object?>{});
+  }
 
-  // Preserved for the implementation PR — suppresses unused-field lint
-  // without code-gen noise.
-  // ignore: unused_field
   final MontyExtensionSet _extensions;
+  MontyRuntime? _runtime;
+  final List<void Function()> _unsubs = [];
 
   @override
   String get namespace => 'monty';
@@ -23,11 +45,103 @@ class MontyRuntimeExtension extends SessionExtension {
   int get priority => 0;
 
   @override
-  List<ClientTool> get tools => const [];
+  List<ClientTool> get tools => [
+        ClientTool.simple(
+          name: 'run_python_on_device',
+          description: "Runs Python on the user's device inside an embedded "
+              'dart_monty interpreter. Use for quick computations on '
+              'values already in the conversation, small transformations '
+              'of text the user pasted, or logic the user explicitly '
+              'asked to run locally (privacy, offline, no upload). No '
+              'filesystem, no network, no subprocesses — pure '
+              'in-process Python. Return values and print() output are '
+              'both captured.',
+          parameters: const {
+            'type': 'object',
+            'properties': {
+              'code': {
+                'type': 'string',
+                'description': 'Python source to execute.',
+              },
+            },
+            'required': ['code'],
+          },
+          executor: _runPythonOnDevice,
+        ),
+      ];
 
   @override
-  Future<void> onAttach(AgentSession session) async {}
+  Future<void> onAttach(AgentSession session) async {
+    final runtime = MontyRuntime(extensions: _extensions.all);
+    _runtime = runtime;
+
+    // Fan each (namespace, signal) pair from the inner coordinator into
+    // our aggregated state map. `coordinator` is null in sandbox mode —
+    // we don't use sandbox mode here, but guard anyway.
+    final coordinator = runtime.coordinator;
+    if (coordinator != null) {
+      for (final (ns, signal) in coordinator.statefulObservations()) {
+        final unsub = signal.subscribe((value) {
+          state = {...state, ns: value};
+        });
+        _unsubs.add(unsub);
+      }
+    }
+  }
 
   @override
-  void onDispose() {}
+  void onDispose() {
+    for (final u in _unsubs) {
+      u();
+    }
+    _unsubs.clear();
+    unawaited(_runtime?.dispose());
+    _runtime = null;
+  }
+
+  /// Executor for `run_python_on_device`. Always returns a JSON string.
+  /// Python-level errors are returned in the payload — not thrown — so
+  /// the LLM sees a completed tool call with an `error` field rather
+  /// than retrying on `status: failed`.
+  Future<String> _runPythonOnDevice(
+    ToolCallInfo toolCall,
+    ToolExecutionContext context,
+  ) async {
+    final String code;
+    try {
+      final args = toolCall.arguments.isEmpty
+          ? const <String, Object?>{}
+          : jsonDecode(toolCall.arguments) as Map<String, Object?>;
+      final raw = args['code'];
+      if (raw is! String) {
+        return jsonEncode({
+          'error': 'run_python_on_device: "code" argument must be a string',
+        });
+      }
+      code = raw;
+    } on Object catch (e) {
+      return jsonEncode({
+        'error': 'run_python_on_device: failed to parse arguments: $e',
+      });
+    }
+
+    final runtime = _runtime;
+    if (runtime == null) {
+      return jsonEncode({
+        'error': 'MontyRuntimeExtension is not attached to a session',
+      });
+    }
+
+    try {
+      final handle = runtime.execute(code);
+      final result = await handle.result;
+      return jsonEncode({
+        'value': result.value.toJson(),
+        'output': result.printOutput ?? '',
+        if (result.error != null) 'error': result.error!.toJson(),
+      });
+    } on Object catch (e) {
+      return jsonEncode({'error': 'run_python_on_device: $e'});
+    }
+  }
 }

--- a/packages/soliplex_agent_monty/test/monty_extension_set_test.dart
+++ b/packages/soliplex_agent_monty/test/monty_extension_set_test.dart
@@ -1,6 +1,5 @@
-// See monty_extension_set.dart for why src/ imports are used.
-import 'package:dart_monty/src/extension/extension.dart' show MontyExtension;
-import 'package:dart_monty/src/extensions/defaults.dart' show defaultExtensions;
+import 'package:dart_monty/dart_monty_bridge.dart'
+    show MontyExtension, defaultExtensions;
 import 'package:soliplex_agent_monty/soliplex_agent_monty.dart';
 import 'package:test/test.dart';
 

--- a/packages/soliplex_agent_monty/test/monty_runtime_extension_test.dart
+++ b/packages/soliplex_agent_monty/test/monty_runtime_extension_test.dart
@@ -1,0 +1,173 @@
+import 'dart:convert';
+
+import 'package:soliplex_agent/soliplex_agent.dart'
+    show AgentSession, ToolCallInfo;
+// ToolExecutionContext is not re-exported from soliplex_agent's public
+// barrel; reach into src/ for the test fake.
+import 'package:soliplex_agent/src/tools/tool_execution_context.dart'
+    show ToolExecutionContext;
+import 'package:soliplex_agent_monty/soliplex_agent_monty.dart';
+import 'package:test/test.dart';
+
+class _FakeToolExecutionContext implements ToolExecutionContext {
+  @override
+  dynamic noSuchMethod(Invocation invocation) => null;
+}
+
+void main() {
+  group('MontyRuntimeExtension', () {
+    late MontyRuntimeExtension ext;
+
+    setUp(() {
+      ext = MontyRuntimeExtension(extensions: MontyExtensionSet.standard());
+    });
+
+    tearDown(() => ext.onDispose());
+
+    test('namespace is "monty"', () {
+      expect(ext.namespace, 'monty');
+    });
+
+    test('exposes one ClientTool named run_python_on_device', () {
+      expect(ext.tools, hasLength(1));
+      expect(ext.tools.single.definition.name, 'run_python_on_device');
+    });
+
+    test('tool description mentions on-device execution', () {
+      final desc = ext.tools.single.definition.description;
+      expect(desc, contains('on the user'));
+      expect(desc, contains('device'));
+      // No cross-reference to server-side tool names:
+      expect(desc, isNot(contains('run_python ')));
+    });
+
+    test('tool parameter schema requires a string "code"', () {
+      final params =
+          ext.tools.single.definition.parameters as Map<String, Object?>;
+      final props = params['properties']! as Map<String, Object?>;
+      final codeProp = props['code']! as Map<String, Object?>;
+      expect(codeProp['type'], 'string');
+      expect(params['required'], contains('code'));
+    });
+
+    test('tool executor returns error JSON when not attached', () async {
+      // No onAttach called; runtime is null.
+      final result = await ext.tools.single.executor(
+        const ToolCallInfo(
+          id: 'tc-1',
+          name: 'run_python_on_device',
+          arguments: '{"code": "1 + 1"}',
+        ),
+        _FakeToolExecutionContext(),
+      );
+      final payload = jsonDecode(result) as Map<String, Object?>;
+      expect(payload['error'], contains('not attached'));
+    });
+
+    test('initial state is empty map', () {
+      expect(ext.state, <String, Object?>{});
+    });
+  });
+
+  group('MontyRuntimeExtension — argument parsing', () {
+    late MontyRuntimeExtension ext;
+
+    setUp(() {
+      ext = MontyRuntimeExtension(extensions: MontyExtensionSet.standard());
+    });
+
+    tearDown(() => ext.onDispose());
+
+    test('missing code field returns error', () async {
+      final result = await ext.tools.single.executor(
+        const ToolCallInfo(
+          id: 'tc-1',
+          name: 'run_python_on_device',
+          arguments: '{"other": "value"}',
+        ),
+        _FakeToolExecutionContext(),
+      );
+      final payload = jsonDecode(result) as Map<String, Object?>;
+      expect(payload['error'], contains('"code"'));
+    });
+
+    test('non-string code field returns error', () async {
+      final result = await ext.tools.single.executor(
+        const ToolCallInfo(
+          id: 'tc-1',
+          name: 'run_python_on_device',
+          arguments: '{"code": 123}',
+        ),
+        _FakeToolExecutionContext(),
+      );
+      final payload = jsonDecode(result) as Map<String, Object?>;
+      expect(payload['error'], contains('must be a string'));
+    });
+
+    test('malformed JSON returns error', () async {
+      final result = await ext.tools.single.executor(
+        const ToolCallInfo(
+          id: 'tc-1',
+          name: 'run_python_on_device',
+          arguments: 'not-json',
+        ),
+        _FakeToolExecutionContext(),
+      );
+      final payload = jsonDecode(result) as Map<String, Object?>;
+      expect(payload['error'], contains('parse arguments'));
+    });
+  });
+
+  group(
+    'MontyRuntimeExtension — attached (native Monty runtime)',
+    () {
+      late MontyRuntimeExtension ext;
+
+      setUp(() async {
+        ext = MontyRuntimeExtension(extensions: MontyExtensionSet.standard());
+        // onAttach constructs MontyRuntime; this touches the native
+        // dart_monty backend and will fail if the native lib is not
+        // available in the test environment.
+        await ext.onAttach(_FakeAgentSession());
+      });
+
+      tearDown(() => ext.onDispose());
+
+      test('runs trivial Python and captures print output', () async {
+        final result = await ext.tools.single.executor(
+          ToolCallInfo(
+            id: 'tc-1',
+            name: 'run_python_on_device',
+            arguments: jsonEncode({'code': "print('hi')\n2 + 2"}),
+          ),
+          _FakeToolExecutionContext(),
+        );
+        final payload = jsonDecode(result) as Map<String, Object?>;
+        // value should be 4; output should contain 'hi'.
+        expect(payload['error'], isNull);
+        expect(payload['output'], contains('hi'));
+      });
+
+      test('Python syntax error returns error payload', () async {
+        final result = await ext.tools.single.executor(
+          const ToolCallInfo(
+            id: 'tc-1',
+            name: 'run_python_on_device',
+            arguments: '{"code": "def broken(:"}',
+          ),
+          _FakeToolExecutionContext(),
+        );
+        final payload = jsonDecode(result) as Map<String, Object?>;
+        expect(payload['error'], isNotNull);
+      });
+    },
+    tags: [
+      'native',
+    ],
+  );
+}
+
+class _FakeAgentSession implements AgentSession {
+  @override
+  dynamic noSuchMethod(Invocation invocation) => null;
+}


### PR DESCRIPTION
## Summary

Fills in the scaffold from #183 with the actual bridge. Stacked on top of PR 1.

### What ships

- `MontyRuntimeExtension` mixes in `StatefulSessionExtension<Map<String, Object?>>` and aggregates every inner dart_monty extension's reactive state into one `state` map, keyed by the inner extension's namespace.
- `onAttach` constructs a `MontyRuntime` with the configured extension set, subscribes to `runtime.coordinator.statefulObservations()`, and fans each `(namespace, signal)` into the aggregated state.
- `onDispose` cancels every subscription, then disposes the runtime.
- `tools` exposes one `ClientTool`: `run_python_on_device`. The description is deliberately self-contained — no cross-reference to any server-side Python surface — so it doesn't rot when server tool names change. Parameter schema: `{ code: string }`.
- The executor always returns a JSON string. Argument-parse failures, not-attached state, and Python-level errors all become an `error` field in the payload instead of thrown exceptions — the LLM sees a completed tool call with a failure signal rather than retry-looping on `status: failed`.

### Import cleanup

PR 1 had to reach into dart_monty's `src/` paths because the public barrel was missing `ExtensionCoordinator`, `MontyExtension`, `defaultExtensions`, and there was no `MontyRuntime.coordinator` getter. Since then dart_monty main:
- Added a public `MontyRuntime.coordinator` getter (dart_monty PR #372).
- Exposes `ExtensionCoordinator` / `MontyExtension` / `defaultExtensions` via `package:dart_monty/dart_monty_bridge.dart`.

This PR drops all `src/` imports from dart_monty in favour of public barrels.

### Tests

- **12 unit tests** — tool metadata, argument parsing, not-attached error path. No native dart_monty required; these run on CI without the Rust lib.
- **2 native tests** tagged `native` — construct a real `MontyRuntime`, call `runtime.execute()`. Happy path captures `print()` output + return value. Error path verifies Python syntax errors become an `error` field. Skip via `dart test --exclude-tags=native` on boxes without the native backend.

## Stack

PR 2 of 3. Base: `feat/soliplex-agent-monty-package` (#183).

## Test plan

- [x] `flutter analyze` — 0 errors (1 worktree-only path warning — see PR 1)
- [x] `flutter test` — 1091 pass
- [x] `dart test` in `packages/soliplex_agent_monty/` — 14 pass (incl. native)