### PR TITLE
feat(flavor): expose extraExtensions hook in standard(); wire monty via it

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -63,6 +63,56 @@ Flavors are functions that construct `AppModule` instances and call
 `ShellConfig.fromModules(...)`. Modules are included/excluded by presence in the
 flavor — no enum or toggle framework.
 
+### Adding custom client-side session extensions
+
+`standard()` takes an optional `extraExtensions: SessionExtensionFactory?`
+parameter. The factory is invoked once per `AgentSession` and its output is
+appended after the framework's built-in extensions (execution tracker, tool
+calls, human approval). Use this to register custom `SessionExtension`s —
+including ones that expose `ClientTool`s — without forking the flavor.
+
+Example — a consumer adding a `get_current_time` tool:
+
+```dart
+class ClockExtension extends SessionExtension {
+  @override
+  String get namespace => 'clock';
+
+  @override
+  Future<void> onAttach(AgentSession session) async {}
+
+  @override
+  void onDispose() {}
+
+  @override
+  List<ClientTool> get tools => [
+        ClientTool.simple(
+          name: 'get_current_time',
+          description: 'Returns the current device time as ISO 8601.',
+          executor: (_, __) async => DateTime.now().toIso8601String(),
+        ),
+      ];
+}
+
+// In main.dart:
+runSoliplexShell(
+  await standard(
+    extraExtensions: () async => [ClockExtension()],
+  ),
+);
+```
+
+The framework's own `main.dart` uses the same hook to gate the on-device
+Python runtime (`MontyRuntimeExtension` from `soliplex_agent_monty`) behind
+the compile-time `MONTY_ENABLED` flag:
+
+```sh
+flutter build macos --dart-define=MONTY_ENABLED=true
+```
+
+The flag is a tree-shake boundary — with `MONTY_ENABLED=false` (default)
+the `dart_monty` bytes do not reach the release binary.
+
 ## Modules
 
 Five feature modules composed in the standard flavor:
@@ -75,9 +125,10 @@ Five feature modules composed in the standard flavor:
 
 ## Workspace Packages
 
-Four internal packages under `packages/`:
+Internal packages under `packages/`:
 
 - `soliplex_agent` — Agent orchestration (runtime, sessions, tool registry, execution events)
+- `soliplex_agent_monty` — Bridge that wraps `dart_monty`'s Python sandbox in a `SessionExtension` and exposes the `run_python_on_device` `ClientTool`. Optional; enabled via `--dart-define=MONTY_ENABLED=true`.
 - `soliplex_client` — Backend HTTP/AG-UI API client, domain models, citation extraction
 - `soliplex_client_native` — Native HTTP client (iOS/macOS via cupertino_http)
 - `soliplex_logging` — Structured logging with memory, console, disk, and backend sinks

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,11 +1,36 @@
 import 'package:flutter/widgets.dart';
 
-import 'package:soliplex_frontend/soliplex_frontend.dart';
+import 'package:soliplex_agent_monty/soliplex_agent_monty.dart';
 import 'package:soliplex_frontend/flavors.dart';
+import 'package:soliplex_frontend/soliplex_frontend.dart';
+
+/// Compile-time flag gating the on-device Python runtime.
+///
+/// Build the monty-enabled variant with:
+///
+/// ```sh
+/// flutter build macos --dart-define=MONTY_ENABLED=true
+/// ```
+///
+/// When `false` (default), `MontyRuntimeExtension` is never constructed
+/// and the `dart_monty` bytes tree-shake out of the release binary.
+const _montyEnabled = bool.fromEnvironment(
+  'MONTY_ENABLED',
+  // ignore: avoid_redundant_argument_values
+  defaultValue: false,
+);
 
 Future<void> main() async {
   WidgetsFlutterBinding.ensureInitialized();
   final callbackParams = CallbackParamsCapture.captureNow();
   clearCallbackUrl();
-  runSoliplexShell(await standard(callbackParams: callbackParams));
+  runSoliplexShell(
+    await standard(
+      callbackParams: callbackParams,
+      extraExtensions: () async => [
+        if (_montyEnabled)
+          MontyRuntimeExtension(extensions: MontyExtensionSet.standard()),
+      ],
+    ),
+  );
 }

--- a/lib/src/flavors/standard.dart
+++ b/lib/src/flavors/standard.dart
@@ -79,6 +79,7 @@ Future<ShellConfig> standard({
   CallbackParams callbackParams = const NoCallbackParams(),
   ConsentNotice? consentNotice,
   Widget? logo,
+  SessionExtensionFactory? extraExtensions,
 }) async {
   logo ??= Image.asset(_defaultLogoAsset, width: _logoSize, height: _logoSize);
   final inspector = NetworkInspector();
@@ -139,6 +140,7 @@ Future<ShellConfig> standard({
       ExecutionTrackerExtension(),
       ToolCallsExtension(),
       HumanApprovalExtension(),
+      ...?(await extraExtensions?.call()),
     ],
   );
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -36,6 +36,8 @@ dependencies:
   web: ^1.1.1
   soliplex_agent:
     path: packages/soliplex_agent
+  soliplex_agent_monty:
+    path: packages/soliplex_agent_monty
   soliplex_client:
     path: packages/soliplex_client
   soliplex_client_native:

--- a/test/flavors/standard_extra_extensions_test.dart
+++ b/test/flavors/standard_extra_extensions_test.dart
@@ -1,0 +1,80 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:soliplex_agent/soliplex_agent.dart';
+
+/// Covers the composition pattern `standard()` uses for the
+/// `extraExtensions` hook: `[...builtIns, ...await extras?.call() ?? []]`.
+///
+/// `standard()` itself wires real HTTP, storage, and auth layers, so it
+/// is exercised via the running app rather than a widget test. This
+/// test locks in the composition contract that `standard()` relies on —
+/// if it drifts (e.g., extras are prepended instead of appended, or a
+/// `null` factory raises), the pattern is wrong and `standard()` will
+/// misbehave in the same way.
+///
+/// Keep the composition shape in `lib/src/flavors/standard.dart` in
+/// sync with [composeExtensions].
+Future<List<SessionExtension>> composeExtensions(
+  List<SessionExtension> builtIns,
+  SessionExtensionFactory? extras,
+) async {
+  return [
+    ...builtIns,
+    ...?(await extras?.call()),
+  ];
+}
+
+class _FakeExtension implements SessionExtension {
+  _FakeExtension(this.name);
+  final String name;
+  @override
+  dynamic noSuchMethod(Invocation invocation) => null;
+}
+
+void main() {
+  group('standard() extraExtensions composition', () {
+    test('null extras returns the built-in list unchanged', () async {
+      final builtIns = <SessionExtension>[_FakeExtension('a')];
+      final composed = await composeExtensions(builtIns, null);
+      expect(composed, hasLength(1));
+      expect((composed.single as _FakeExtension).name, 'a');
+    });
+
+    test('extras append after built-ins', () async {
+      final builtIns = <SessionExtension>[
+        _FakeExtension('a'),
+        _FakeExtension('b'),
+      ];
+      final composed = await composeExtensions(
+        builtIns,
+        () async => [_FakeExtension('c')],
+      );
+      expect(
+        composed.map((e) => (e as _FakeExtension).name).toList(),
+        ['a', 'b', 'c'],
+      );
+    });
+
+    test('empty extras list preserves built-ins', () async {
+      final builtIns = <SessionExtension>[_FakeExtension('a')];
+      final composed = await composeExtensions(
+        builtIns,
+        () async => <SessionExtension>[],
+      );
+      expect(composed, hasLength(1));
+    });
+
+    test('factory is awaited fresh on each call', () async {
+      var callCount = 0;
+      Future<List<SessionExtension>> factory() async {
+        callCount++;
+        return [_FakeExtension('n$callCount')];
+      }
+
+      final first = await composeExtensions(const [], factory);
+      final second = await composeExtensions(const [], factory);
+      expect((first.single as _FakeExtension).name, 'n1');
+      expect((second.single as _FakeExtension).name, 'n2');
+      expect(callCount, 2);
+    });
+  });
+}


### PR DESCRIPTION
## Summary

Replaces the closed-off extension list in `standard()` with a public `SessionExtensionFactory? extraExtensions` parameter. The factory is invoked once per `AgentSession` and its output is appended after the framework's built-in extensions. Consumers add custom session extensions — including ones that contribute `ClientTool`s — **without forking the flavor**.

The framework's own `lib/main.dart` uses the new hook for monty:

```dart
runSoliplexShell(
  await standard(
    callbackParams: callbackParams,
    extraExtensions: () async => [
      if (_montyEnabled)
        MontyRuntimeExtension(extensions: MontyExtensionSet.standard()),
    ],
  ),
);
```

`_montyEnabled` is `bool.fromEnvironment('MONTY_ENABLED')` — a compile-time constant. With the flag off (default), `dart_monty` bytes tree-shake out of the release binary entirely. Build the monty-enabled variant with:

```sh
flutter build macos --dart-define=MONTY_ENABLED=true
```

**`standard()` itself does NOT import `soliplex_agent_monty`** — the framework stays monty-agnostic, and monty is one consumer of the public extension hook rather than a framework special case. A downstream consumer adding a `get_current_time` tool follows the same path `main.dart` uses for monty.

### Architectural payoff

This is the win hidden inside the monty feature: the `extraExtensions` hook retires the "fork `standard()` to add anything" pattern. Future capabilities (weather tools, on-device RAG, domain panels) plug in the same way. See `CLAUDE.md` "Adding custom client-side session extensions" for the consumer-facing docs.

### What's in this PR

- `standard()` gains `extraExtensions: SessionExtensionFactory?` parameter; composition is `[...builtIns, ...?(await extras?.call())]`.
- `lib/main.dart` imports `soliplex_agent_monty` and wires monty through the new hook behind `_montyEnabled`.
- Workspace root `pubspec.yaml` adds `soliplex_agent_monty` as a path dep.
- `CLAUDE.md` gains an "Adding custom client-side session extensions" section with a `ClockExtension` example.
- Unit tests for the composition contract: null extras, appending order, empty extras, factory-called-fresh-per-session.

### What's NOT in this PR

- Widget-level coverage of `standard()` itself — it wires real HTTP/storage/auth/network inspector layers, so a direct test is mostly mocking ceremony. The composition logic is what can regress and that is covered.
- `AgentRuntimeManager` signature change — it already accepts `SessionExtensionFactory`. The composition happens inside `standard()`.
- Per-room gating of extensions — out of scope; could follow.

## Stack

PR 3 of 3. Base: `feat/monty-runtime-extension` (#184).

## Related

Opened #185 for a small pre-existing naming nit in `main.dart` (`callbackParams` → `oauthCallback`) — deliberately kept out of this PR.

## Test plan

- [x] `flutter analyze` — 0 errors (1 worktree-only path warning — see PR 1 notes)
- [x] `flutter test` — 1095 pass (includes 4 new composition tests)
- [x] `markdownlint-cli2 CLAUDE.md` — 0 errors
- [x] `flutter build macos --dart-define=MONTY_ENABLED=true` — builds (local)