### PR TITLE
feat(soliplex_agent): per-thread ThreadState + ThreadKey keying on AgentRuntime

### DIFF
--- a/docs/agent-runtime-thread-state.md
+++ b/docs/agent-runtime-thread-state.md
@@ -1,0 +1,181 @@
+# `AgentRuntime` per-thread state — `ThreadState` and `ThreadKey` keying
+
+Replaces the old `_threadHistories: Map<String, ThreadHistory>` cache
+with `_threadStates: Map<ThreadKey, ThreadState>` and introduces
+`ThreadState` as the per-thread bundle holder.
+
+## What problem this solves
+
+Two issues with the prior cache:
+
+1. **Latent bug**: `_threadHistories` was keyed by bare `threadId`
+   (a `String`). In a multi-room runtime, two rooms could in
+   principle issue the same `threadId` and the cache wouldn't catch
+   the collision. Today `AgentRuntime` is per-server so the bug is
+   masked, but the typing didn't enforce uniqueness.
+2. **No place for a per-thread `StateBus`**: the redesign needs each
+   thread to own a `StateBus` that survives session boundaries. The
+   plain `ThreadHistory` cache had no slot for it.
+
+This commit fixes both: keying moves from `String` to the full
+`ThreadKey` triple `(serverId, roomId, threadId)`, and the cache's
+value type becomes `ThreadState(StateBus bus, ThreadHistory? history)`
+— a slot for both.
+
+## Data flow
+
+```mermaid
+flowchart LR
+    subgraph CALLERS["External callers"]
+        UI["UI 'new thread' button"]
+        History["Thread history fetch"]
+        Session["spawn() / _captureThreadHistory()"]
+    end
+
+    subgraph RUNTIME["AgentRuntime"]
+        States[("_threadStates<br/>Map of ThreadKey to ThreadState")]
+        Seed["seedThreadState(key, ...)<br/>seedThreadHistory(key, ...)"]
+    end
+
+    subgraph TS["ThreadState (per thread)"]
+        Bus["StateBus bus<br/>(survives session boundary)"]
+        Hist["ThreadHistory? history<br/>(messages + aguiState)"]
+    end
+
+    UI -- "seedThreadState(key, agui)" --> Seed
+    History -- "seedThreadHistory(key, hist)" --> Seed
+    Session -- "_threadStates[key]?.history" --> States
+    Session -. "captureThreadHistory" .-> States
+
+    Seed --> States
+    States --> Bus
+    States --> Hist
+```
+
+The bus survives across session attach / detach within a thread's
+lifetime. The history field carries the cached messages + aguiState
+that prior sessions left behind.
+
+## Why ThreadKey, not bare threadId
+
+```dart
+// Before — bare String key
+final Map<String, ThreadHistory> _threadHistories = {};
+
+void seedThreadState(String threadId, Map<String, dynamic> aguiState) {
+  // ... two rooms with the same threadId would collide silently
+}
+
+// After — full ThreadKey record
+final Map<ThreadKey, ThreadState> _threadStates = {};
+
+void seedThreadState(ThreadKey key, Map<String, dynamic> aguiState) {
+  // ThreadKey value-equality enforces uniqueness across the triple
+}
+```
+
+`ThreadKey` is the existing typedef record
+`(String serverId, String roomId, String threadId)` — Dart's record
+value-equality makes it a valid `Map` key out of the box.
+
+## Why a `ThreadState` class instead of just `Map<ThreadKey, StateBus>`
+
+Two reasons:
+
+1. **Composite slot**: a thread needs both a `StateBus` (for live
+   reactive state) and a `ThreadHistory?` (for cached messages +
+   aguiState used during resume). Wrapping both into one
+   per-thread bundle keeps the runtime's spawn-path simple.
+2. **Lifecycle**: `ThreadState.dispose()` disposes the bus
+   idempotently. The runtime's `dispose()` calls
+   `state.dispose()` on every entry, ensuring every per-thread bus
+   is released.
+
+```dart
+@immutable
+class ThreadState {
+  ThreadState({StateBus? bus, this.history}) : bus = bus ?? StateBus();
+
+  final StateBus bus;
+  final ThreadHistory? history;
+
+  ThreadState withHistory(ThreadHistory? next) =>
+      ThreadState(bus: bus, history: next);
+
+  void dispose() => bus.dispose();
+}
+```
+
+`withHistory` returns a copy with a different `history` while
+preserving the same `bus` (so live signal subscriptions keep
+working). The class is `@immutable` for the same reason `Conversation`
+is — value-typed updates make reasoning about state transitions
+easier.
+
+## What this PR ships
+
+- **New file**: `packages/soliplex_agent/lib/src/runtime/thread_state.dart`
+  (~50 LOC) — the `ThreadState` class.
+- **Modified**: `packages/soliplex_agent/lib/src/runtime/agent_runtime.dart`
+  - `_threadHistories: Map<String, ThreadHistory>` →
+    `_threadStates: Map<ThreadKey, ThreadState>`.
+  - `seedThreadState(threadId, ...)` → `seedThreadState(key, ...)`.
+  - `seedThreadHistory(threadId, ...)` → `seedThreadHistory(key, ...)`.
+  - Both seed methods now also seed the `bus` from `aguiState`, so
+    the bus is populated when a session is later spawned.
+  - `_captureThreadHistory` writes via `withHistory` (immutable
+    update preserving the bus).
+  - `dispose` disposes all per-thread buses.
+- **Modified**: `packages/soliplex_agent/lib/soliplex_agent.dart` —
+  re-exports `thread_state.dart`.
+- **Modified callers**:
+  - `lib/src/modules/room/room_state.dart` — passes full `ThreadKey`
+    to `seedThreadState`/`seedThreadHistory` (constructed from
+    `(_connection.serverId, _roomId, threadId)`).
+  - `packages/soliplex_agent/test/runtime/agent_runtime_test.dart` —
+    same, in the test fixtures.
+
+## Breaking change
+
+`AgentRuntime.seedThreadState` and `AgentRuntime.seedThreadHistory`
+change their first parameter type from `String` to `ThreadKey`.
+
+| Call site | Before | After |
+| --- | --- | --- |
+| `lib/src/modules/room/room_state.dart` | `runtime.seedThreadHistory(id, history)` | `runtime.seedThreadHistory((serverId: ..., roomId: ..., threadId: id), history)` |
+| `packages/soliplex_agent/test/runtime/agent_runtime_test.dart` | `runtime.seedThreadState(_threadId, initialState)` | `runtime.seedThreadState((serverId: 'default', roomId: _roomId, threadId: _threadId), initialState)` |
+
+Two callers in the monorepo. Both updated in this PR.
+
+## Test plan
+
+- [x] `flutter analyze` — 0 issues
+- [x] `flutter test packages/soliplex_agent/test/runtime/agent_runtime_test.dart` —
+  46/46 pass (existing tests unaffected by the keying change since
+  they just construct ThreadKey records inline now)
+- [x] `dart format` — clean
+- [x] `markdownlint-cli2 docs/agent-runtime-thread-state.md` — clean
+
+## Stack position
+
+Base: `feat/agent-state-signal` (PR #190 — `AgentSession.agentState`
+reactive signal). Depends on the `StateBus` type from PR #189
+indirectly (already present via the parent stack).
+
+This is the structural prerequisite for follow-up PRs that route
+AG-UI events through the bus — once `_threadStates` is keyed by
+`ThreadKey` and each entry owns a bus, the next PR (`AgentSession`
+forwards state changes into `bus.setAgentState(...)`) has a natural
+target.
+
+## What this PR explicitly does NOT ship
+
+- No bus-write integration in `AgentSession._onStateChange` — the
+  bus is constructed and seeded but no AG-UI events route through
+  it yet. That's the next stacked PR.
+- No `AgentSession.bus` getter — the runtime has the buses but
+  sessions don't expose them yet.
+- No `Conversation` per-thread scope move. `Conversation` is still
+  per-session; `ThreadHistory` is the carry-forward field.
+- No projection registrations or surface wiring — those are
+  consumer concerns in plugin packages, not runtime concerns.

--- a/lib/src/modules/room/room_state.dart
+++ b/lib/src/modules/room/room_state.dart
@@ -117,7 +117,14 @@ class RoomState {
       threadId: threadId,
       registry: _registry,
       onHistoryLoaded: (id, history) {
-        runtime.seedThreadHistory(id, history);
+        runtime.seedThreadHistory(
+          (
+            serverId: _connection.serverId,
+            roomId: _roomId,
+            threadId: id,
+          ),
+          history,
+        );
       },
     );
     // Thread switch → force a refresh for the same reasons as room
@@ -134,7 +141,14 @@ class RoomState {
       if (result == null) return null; // disposed
       final (threadInfo, aguiState) = result;
       if (_isDisposed) return threadInfo.id;
-      runtime.seedThreadState(threadInfo.id, aguiState);
+      runtime.seedThreadState(
+        (
+          serverId: _connection.serverId,
+          roomId: _roomId,
+          threadId: threadInfo.id,
+        ),
+        aguiState,
+      );
       selectThread(threadInfo.id);
       onNavigateToThread?.call(threadInfo.id);
       return threadInfo.id;

--- a/packages/soliplex_agent/lib/soliplex_agent.dart
+++ b/packages/soliplex_agent/lib/soliplex_agent.dart
@@ -64,6 +64,7 @@ export 'src/runtime/server_registry.dart';
 export 'src/runtime/session_coordinator.dart';
 export 'src/runtime/session_extension.dart';
 export 'src/runtime/stateful_session_extension.dart';
+export 'src/runtime/thread_state.dart';
 export 'src/runtime/tool_approval_extension.dart';
 // ── Scripting ──
 export 'src/scripting/script_environment.dart';

--- a/packages/soliplex_agent/lib/src/runtime/agent_runtime.dart
+++ b/packages/soliplex_agent/lib/src/runtime/agent_runtime.dart
@@ -13,6 +13,7 @@ import 'package:soliplex_agent/src/runtime/agent_session_state.dart';
 import 'package:soliplex_agent/src/runtime/server_connection.dart';
 import 'package:soliplex_agent/src/runtime/session_coordinator.dart';
 import 'package:soliplex_agent/src/runtime/session_extension.dart';
+import 'package:soliplex_agent/src/runtime/thread_state.dart';
 import 'package:soliplex_agent/src/tools/tool_registry_resolver.dart';
 import 'package:soliplex_client/soliplex_client.dart' show ThreadHistory;
 import 'package:soliplex_logging/soliplex_logging.dart';
@@ -89,7 +90,14 @@ class AgentRuntime {
   final Map<String, AgentSession> _sessions = {};
   final Map<String, Timer> _rootTimeoutTimers = {};
   final Set<String> _deletedThreadIds = {};
-  final Map<String, ThreadHistory> _threadHistories = {};
+
+  /// Per-thread state, keyed by full [ThreadKey].
+  ///
+  /// Replaces the prior `_threadHistories: Map<String, ThreadHistory>`
+  /// cache (Phase 1 step 3a). Each entry owns a `StateBus` that survives
+  /// session boundaries within the thread's lifetime, plus the cached
+  /// `ThreadHistory` used to seed resume paths.
+  final Map<ThreadKey, ThreadState> _threadStates = {};
   final _spawnQueue = <Completer<void>>[];
   final StreamController<List<AgentSession>> _sessionController =
       StreamController<List<AgentSession>>.broadcast();
@@ -122,15 +130,18 @@ class AgentRuntime {
   ///
   /// Call this when a thread is created outside of [spawn] (e.g. via
   /// a UI "new thread" button) so that the backend-provided initial
-  /// state is available when [spawn] is later called with that threadId.
+  /// state is available when [spawn] is later called for that thread.
+  ///
+  /// Phase 1 step 3a — keyed by full [ThreadKey] (was bare `threadId`).
   void seedThreadState(
-    String threadId,
+    ThreadKey key,
     Map<String, dynamic> aguiState,
   ) {
     if (aguiState.isEmpty) return;
-    _threadHistories[threadId] = ThreadHistory(
-      messages: const [],
-      aguiState: aguiState,
+    final state = _threadStateFor(key);
+    state.bus.setAgentState(aguiState);
+    _threadStates[key] = state.withHistory(
+      ThreadHistory(messages: const [], aguiState: aguiState),
     );
   }
 
@@ -138,10 +149,22 @@ class AgentRuntime {
   ///
   /// Call this when thread history is fetched (e.g. when selecting an
   /// existing thread) so that messages and AG-UI state are available
-  /// when [spawn] is later called with that threadId.
-  void seedThreadHistory(String threadId, ThreadHistory history) {
-    _threadHistories[threadId] = history;
+  /// when [spawn] is later called for that thread.
+  ///
+  /// Phase 1 step 3a — keyed by full [ThreadKey] (was bare `threadId`).
+  void seedThreadHistory(ThreadKey key, ThreadHistory history) {
+    final state = _threadStateFor(key);
+    if (history.aguiState.isNotEmpty) {
+      state.bus.setAgentState(history.aguiState);
+    }
+    _threadStates[key] = state.withHistory(history);
   }
+
+  /// Returns the per-thread state for [key], creating a fresh
+  /// [ThreadState] if none has been registered yet. Internal helper —
+  /// callers outside the runtime should use the seed APIs above.
+  ThreadState _threadStateFor(ThreadKey key) =>
+      _threadStates[key] ??= ThreadState();
 
   /// Spawns a new agent session.
   ///
@@ -167,7 +190,7 @@ class AgentRuntime {
     _guardSpawnDepth(parent);
     final depth = parent == null ? 0 : parent.depth + 1;
     final (key, existingRunId) = await _resolveThread(roomId, threadId);
-    final history = _threadHistories[key.threadId];
+    final history = _threadStates[key]?.history;
     final session = await _buildSession(
       key: key,
       roomId: roomId,
@@ -241,6 +264,10 @@ class AgentRuntime {
       session.dispose();
     }
     _sessions.clear();
+    for (final state in _threadStates.values) {
+      state.dispose();
+    }
+    _threadStates.clear();
     _sessionsSignal.dispose();
     unawaited(_sessionController.close());
   }
@@ -298,10 +325,7 @@ class AgentRuntime {
         await _connection.api.createThread(roomId);
     final key = (serverId: serverId, roomId: roomId, threadId: threadInfo.id);
     if (initialAguiState.isNotEmpty) {
-      _threadHistories[key.threadId] = ThreadHistory(
-        messages: const [],
-        aguiState: initialAguiState,
-      );
+      seedThreadState(key, initialAguiState);
     }
     final existingRunId =
         threadInfo.hasInitialRun ? threadInfo.initialRunId : null;
@@ -448,7 +472,9 @@ class AgentRuntime {
       _ => null,
     };
     if (history == null) return;
-    _threadHistories[session.threadKey.threadId] = history;
+    final key = session.threadKey;
+    final threadState = _threadStateFor(key);
+    _threadStates[key] = threadState.withHistory(history);
   }
 
   // ---------------------------------------------------------------------------

--- a/packages/soliplex_agent/lib/src/runtime/thread_state.dart
+++ b/packages/soliplex_agent/lib/src/runtime/thread_state.dart
@@ -1,0 +1,53 @@
+import 'package:meta/meta.dart';
+import 'package:soliplex_client/soliplex_client.dart'
+    show StateBus, ThreadHistory;
+
+/// Per-thread state owned by `AgentRuntime` and keyed by `ThreadKey`.
+///
+/// Replaces the old `_threadHistories: Map<String, ThreadHistory>`
+/// cache with a richer per-thread bundle that survives session
+/// boundaries.
+///
+/// Phase 1 step 3a introduces this type. Subsequent steps evolve its
+/// fields:
+///
+/// - 3a (this commit): introduces `bus` and keeps `history` so the
+///   existing resume-from-prior-session pathway keeps working.
+/// - 3c–3d: `bus` becomes the canonical writer/reader for AG-UI
+///   state events.
+/// - 3e–3f: `Conversation` (currently transient on the session) moves
+///   here, so `history` is replaced by a per-thread `Conversation`
+///   reference.
+///
+/// Plan reference: `docs/plans/reactive-bus-redesign.md` (Phase 1 step 3).
+@immutable
+class ThreadState {
+  /// Constructs a per-thread bundle with a fresh [bus] and no history.
+  ///
+  /// The [bus] is owned by the [ThreadState]; disposing the state
+  /// disposes the bus.
+  ThreadState({StateBus? bus, this.history}) : bus = bus ?? StateBus();
+
+  /// Per-thread reactive document. AG-UI events feed in via
+  /// [StateBus.setAgentState] and [StateBus.update]; surfaces read
+  /// via [StateBus.project].
+  final StateBus bus;
+
+  /// Cached AG-UI state + messages from a prior session on this
+  /// thread, used to seed a new session's resume path. Step 3e
+  /// removes the `aguiState` field (the bus is canonical); step 3f
+  /// folds the remaining fields into a per-thread `Conversation`.
+  final ThreadHistory? history;
+
+  /// Returns a copy with a different [history]. The underlying [bus]
+  /// is preserved across mutations because it carries the live
+  /// signal subscriptions.
+  ThreadState withHistory(ThreadHistory? next) =>
+      ThreadState(bus: bus, history: next);
+
+  /// Tear down. Disposes the underlying [bus]. Idempotent — the bus's
+  /// own [StateBus.dispose] guards against double-dispose internally.
+  void dispose() {
+    bus.dispose();
+  }
+}

--- a/packages/soliplex_agent/test/runtime/agent_runtime_test.dart
+++ b/packages/soliplex_agent/test/runtime/agent_runtime_test.dart
@@ -269,7 +269,10 @@ void main() {
           'citations': <dynamic>[],
         },
       };
-      runtime.seedThreadState(_threadId, initialState);
+      runtime.seedThreadState(
+        (serverId: 'default', roomId: _roomId, threadId: _threadId),
+        initialState,
+      );
 
       stubCreateRun();
       stubDeleteThread();


### PR DESCRIPTION
## Summary

Replaces `AgentRuntime._threadHistories: Map<String, ThreadHistory>`
with `_threadStates: Map<ThreadKey, ThreadState>`, where `ThreadState`
is a new per-thread bundle wrapping `(StateBus bus, ThreadHistory? history)`.

Closes a latent bug — bare `threadId` keying meant two rooms could in
principle share a `threadId` and the cache wouldn't catch the
collision — and gives each thread a slot for a per-thread `StateBus`
that survives session boundaries within the thread's lifetime.

## Stack position

**Base: `feat/agent-state-signal`** (PR #190 — `AgentSession.agentState`
reactive signal). Depends indirectly on the `StateBus` type from
PR #189 (`Surface` / `StateProjection` / `StateBus` foundation).

```
main
  └── feat/genui-state-bus-types         (PR #189)
       └── feat/agent-state-signal       (PR #190)
            └── feat/agent-runtime-threadkey  (this PR)
```

## What lands

- `packages/soliplex_agent/lib/src/runtime/thread_state.dart` (new) —
  the `ThreadState` class. ~50 LOC. `@immutable`; `withHistory` returns
  a copy preserving the same bus; `dispose` releases the bus.
- `packages/soliplex_agent/lib/src/runtime/agent_runtime.dart`:
  - `_threadHistories: Map<String, ThreadHistory>` →
    `_threadStates: Map<ThreadKey, ThreadState>`.
  - `seedThreadState(threadId, ...)` → `seedThreadState(key, ...)`.
  - `seedThreadHistory(threadId, ...)` → `seedThreadHistory(key, ...)`.
  - Both seed methods now also seed the `bus` from `aguiState`, so
    the bus is populated when a session is later spawned.
  - `_captureThreadHistory` writes via `withHistory` (immutable update
    preserving the bus across spawn / capture cycles).
  - `dispose` disposes all per-thread buses idempotently.
- `packages/soliplex_agent/lib/soliplex_agent.dart` — re-exports
  `thread_state.dart`.
- `docs/agent-runtime-thread-state.md` — architectural doc with
  data-flow mermaid diagram, motivation, before/after API examples.

## Breaking change

`seedThreadState` and `seedThreadHistory` change their first parameter
from `String threadId` to `ThreadKey key`. Two callers migrated:

- `lib/src/modules/room/room_state.dart` — passes the full triple
  via `(serverId: _connection.serverId, roomId: _roomId, threadId: id)`.
- `packages/soliplex_agent/test/runtime/agent_runtime_test.dart` —
  same in test fixtures.

## What this PR explicitly does NOT ship

- No bus-write integration in `AgentSession._onStateChange` — buses
  are constructed and seeded but no AG-UI events route through them
  yet. Next stacked PR.
- No `AgentSession.bus` getter — runtime owns the buses but sessions
  don't expose them yet. Next stacked PR.
- No `Conversation` per-thread scope move — `Conversation` is still
  per-session; `ThreadHistory` is the carry-forward field.
- No projection registrations or surface wiring — those are consumer
  concerns in plugin packages.

## Test plan

- [x] `flutter analyze` — 0 issues
- [x] `flutter test packages/soliplex_agent/test/runtime/agent_runtime_test.dart` — 46/46 pass (existing tests unaffected, just construct ThreadKey records inline now)
- [x] `dart format` — clean
- [x] `markdownlint-cli2 docs/agent-runtime-thread-state.md` — clean

## Reviewer focus

- `ThreadState` shape — `@immutable`, `withHistory` preserving the bus, idempotent `dispose`.
- The migration of `_captureThreadHistory` — uses `_threadStateFor(key)` to ensure the entry exists, then `withHistory` to update.
- The seed methods now populating the bus from `aguiState` — see if that's the right place vs. doing it lazily in `spawn()`.
- `docs/agent-runtime-thread-state.md` for the architectural why.

🤖 Generated with [Claude Code](https://claude.com/claude-code)