### PR TITLE
refactor(soliplex_agent): agentState is now a view of bus.agentState

### DIFF
--- a/docs/agent-state-as-bus-view.md
+++ b/docs/agent-state-as-bus-view.md
@@ -1,0 +1,111 @@
+# `AgentSession.agentState` as a view of the bus
+
+Cleanup PR. Eliminates the parallel-compute path for the `agentState`
+signal now that the per-thread bus is the canonical source of truth
+for agent state.
+
+## Before
+
+```dart
+late final ReadonlySignal<Map<String, dynamic>> agentState = computed(() {
+  final state = _runStateSignal.value;
+  return _aguiStateOf(state) ?? const <String, dynamic>{};
+});
+```
+
+`agentState` was a `computed()` derivation off `_runStateSignal`. It
+extracted the conversation's `aguiState` via the exhaustive
+`_aguiStateOf` switch, which was the original P1 plumbing.
+
+## After
+
+```dart
+late final ReadonlySignal<Map<String, dynamic>> agentState = bus.agentState;
+```
+
+A direct view of `bus.agentState`. Same value, single source of truth.
+
+## Why this is now safe
+
+After PR #192 (`feat/session-bus-route`), `_onStateChange` writes the
+bus on every `RunState` transition. So `bus.agentState.value` is
+guaranteed to reflect the same snapshot the prior `computed()` would
+have produced — they were both reading the same conversation by
+different paths.
+
+Removing the `computed()` wrapper:
+
+- **One signal subscription chain**, not two.
+- **No risk of a future RunState variant accidentally being missing
+  from the `_aguiStateOf` switch** while the bus path keeps working
+  (or vice versa).
+- **One source of truth for projections and direct watchers.** A
+  widget that does `session.agentState.watch(context)` and a
+  projection that does `bus.project(...)` see the exact same data,
+  through the exact same signal.
+
+## Data flow after this PR
+
+```mermaid
+flowchart LR
+    Snap["StateSnapshotEvent / StateDeltaEvent"]
+    Proc["processEvent()"]
+    Conv["Conversation.aguiState"]
+    Run["_runStateSignal"]
+    OnChange["_onStateChange"]
+    Bus[("bus.agentState<br/>signal of Map")]
+    AgentState[".agentState getter<br/>= bus.agentState"]
+    Watch["widget.watch(...)"]
+    Project["bus.project(...)"]
+
+    Snap --> Proc --> Conv --> Run --> OnChange
+    OnChange -- "bus.setAgentState(next)" --> Bus
+    Bus --> AgentState
+    AgentState --> Watch
+    Bus --> Project
+```
+
+The `_aguiStateOf` switch lives on inside `_onStateChange` (it still
+extracts the conversation's `aguiState` to pass into
+`bus.setAgentState`). It just no longer powers a parallel
+`computed()`.
+
+## What this PR ships
+
+- `packages/soliplex_agent/lib/src/runtime/agent_session.dart` —
+  collapses `agentState` from `computed()` to `bus.agentState`. Net
+  diff: ~5 LOC.
+- `docs/agent-state-as-bus-view.md` — this doc.
+
+## What this PR explicitly does NOT ship
+
+- No removal of `_aguiStateOf` — it still does useful work in
+  `_onStateChange` (extracting the conversation's aguiState to
+  forward to the bus).
+- No `Conversation.aguiState` removal — the field stays as the
+  underlying source. This PR just stops *reading* it twice.
+- No projection registrations or surface wiring.
+
+## Stack position
+
+```text
+main
+  └── feat/genui-state-bus-types       (PR #189)
+       └── feat/agent-state-signal     (PR #190)
+            └── feat/agent-runtime-threadkey  (PR #191)
+                 └── feat/session-bus-route  (PR #192)
+                      └── feat/agent-state-view-of-bus  (this PR)
+```
+
+## Test plan
+
+- [x] `flutter analyze` — 0 issues
+- [x] `flutter test` (agent_session_test.dart + agent_session_signal_test.dart) — 44/44 pass
+- [x] `dart format` — clean
+- [x] `dcm analyze` — no issues
+- [x] `markdownlint-cli2` — clean
+
+The existing `agent_session_signal_test.dart` cases covering
+`agentState` for Idle / StateSnapshotEvent / StateDeltaEvent
+continue to pass — they exercise the same data flow, now through
+one signal instead of two.

--- a/packages/soliplex_agent/lib/src/runtime/agent_session.dart
+++ b/packages/soliplex_agent/lib/src/runtime/agent_session.dart
@@ -124,19 +124,17 @@ class AgentSession implements ToolExecutionContext {
   /// Reactive signal tracking the agent's `aguiState` map across the
   /// session lifetime.
   ///
-  /// Sourced from the conversation's `aguiState` on every [RunState]
-  /// change. Empty when no conversation has accumulated yet (Idle
-  /// state, or a Failed/Cancelled state with no conversation).
+  /// View of the per-thread [bus]'s `agentState` signal. The bus is
+  /// fed by `_onStateChange` on every [RunState] transition, so
+  /// `session.agentState` and `bus.agentState` see the same snapshot
+  /// at all times — no parallel compute path.
   ///
-  /// This is the seam between the AG-UI streaming pipeline (which
-  /// already applies `StateSnapshotEvent` / `StateDeltaEvent` into
-  /// `Conversation.aguiState`) and the GenUI surface layer in
-  /// `soliplex_client`'s `StateBus`. Hosts pass the most recent
-  /// value here into `StateBus.setAgentState(...)`.
-  late final ReadonlySignal<Map<String, dynamic>> agentState = computed(() {
-    final state = _runStateSignal.value;
-    return _aguiStateOf(state) ?? const <String, dynamic>{};
-  });
+  /// Hosts that previously subscribed to this signal and forwarded
+  /// values into a separate `StateBus` no longer need to: the bus is
+  /// already the source. Subscribe to `bus.agentState` directly when
+  /// reaching the bus is more natural (e.g. inside `bus.project(...)`
+  /// projections).
+  late final ReadonlySignal<Map<String, dynamic>> agentState = bus.agentState;
 
   /// The per-thread reactive bus this session writes into. Owned by
   /// the runtime; survives session boundaries within the thread's

--- a/packages/soliplex_agent/lib/src/runtime/agent_session.dart
+++ b/packages/soliplex_agent/lib/src/runtime/agent_session.dart
@@ -134,7 +134,7 @@ class AgentSession implements ToolExecutionContext {
   /// already the source. Subscribe to `bus.agentState` directly when
   /// reaching the bus is more natural (e.g. inside `bus.project(...)`
   /// projections).
-  late final ReadonlySignal<Map<String, dynamic>> agentState = bus.agentState;
+  ReadonlySignal<Map<String, dynamic>> get agentState => bus.agentState;
 
   /// The per-thread reactive bus this session writes into. Owned by
   /// the runtime; survives session boundaries within the thread's


### PR DESCRIPTION
## Summary

Cleanup PR. Eliminates the parallel-compute path for
`AgentSession.agentState` now that the per-thread bus is the
canonical source of truth.

```dart
// Before
late final agentState = computed(() {
  final state = _runStateSignal.value;
  return _aguiStateOf(state) ?? const <String, dynamic>{};
});

// After
late final agentState = bus.agentState;
```

## Why this is now safe

After PR #192 (`feat/session-bus-route`), `_onStateChange` writes
the bus on every `RunState` transition. So `bus.agentState.value`
reflects the same snapshot the prior `computed()` would have
produced — they were both reading the same conversation by
different paths.

Net diff: ~5 LOC (plus doc).

## Stack position

```
main
  └── feat/genui-state-bus-types      (PR #189)
       └── feat/agent-state-signal    (PR #190)
            └── feat/agent-runtime-threadkey  (PR #191)
                 └── feat/session-bus-route  (PR #192)
                      └── feat/agent-state-view-of-bus  (this PR)
```

## What this PR keeps

- `_aguiStateOf` still does useful work in `_onStateChange`
  (extracting the conversation's `aguiState` to forward to the
  bus). Just no longer powers a parallel `computed`.
- `Conversation.aguiState` stays as the underlying source. This PR
  just stops reading it twice.

## Test plan

- [x] `flutter analyze` — 0 issues
- [x] `flutter test packages/soliplex_agent/test/runtime/agent_session_test.dart packages/soliplex_agent/test/runtime/agent_session_signal_test.dart` — 44/44 pass
- [x] `dart format` — clean
- [x] `dcm analyze` — no issues
- [x] `markdownlint-cli2 docs/agent-state-as-bus-view.md` — clean

The existing tests covering `agentState` for Idle / StateSnapshotEvent
/ StateDeltaEvent continue to pass — they exercise the same data
flow, now through one signal instead of two.

## Reviewer focus

- Verify single-source-of-truth: every consumer reading
  `session.agentState` and every consumer reading `bus.agentState`
  see the same value at the same time. After this PR the two are
  literally the same signal.
- `docs/agent-state-as-bus-view.md` for the architectural why.

🤖 Generated with [Claude Code](https://claude.com/claude-code)