### PR TITLE
feat(tic-tac-toe): UI ↔ state binding round-trip via the StateBus

### DIFF
--- a/lib/src/flavors/standard.dart
+++ b/lib/src/flavors/standard.dart
@@ -27,6 +27,7 @@ import '../modules/room/room_module.dart';
 import '../modules/room/run_registry.dart';
 import '../modules/room/tool_calls_extension.dart';
 import '../modules/room/ui/markdown/markdown_theme_extension.dart';
+import '../modules/tic_tac_toe/tic_tac_toe_module.dart';
 
 const _defaultLogoAsset = 'assets/branding/soliplex/logo_1024.png';
 const _logoSize = 64.0;
@@ -174,6 +175,7 @@ Future<ShellConfig> standard({
         enableDocumentFilter: true,
       ),
       QuizAppModule(serverManager: serverManager),
+      TicTacToeAppModule(),
     ],
   );
 }

--- a/lib/src/modules/room/room_module.dart
+++ b/lib/src/modules/room/room_module.dart
@@ -38,6 +38,7 @@ class RoomAppModule extends AppModule {
   ModuleRoutes build() => ModuleRoutes(
         overrides: [
           messageExpansionsProvider.overrideWithValue(_messageExpansions),
+          runRegistryProvider.overrideWithValue(registry),
         ],
         routes: [
           GoRoute(

--- a/lib/src/modules/room/room_providers.dart
+++ b/lib/src/modules/room/room_providers.dart
@@ -40,6 +40,21 @@ final roomActiveThreadProvider =
   (_) => null,
 );
 
+/// Spawn a fresh thread in the active room with an optional state
+/// overlay. Returns a future that completes when the spawn has been
+/// initiated (the new thread becomes active). Null when no room is in
+/// scope. Surfaces (e.g., the tic-tac-toe toolbar button) use this to
+/// initiate a session from the no-thread state.
+typedef SpawnNewThread = Future<void> Function({
+  String prompt,
+  Map<String, dynamic>? stateOverlay,
+});
+
+final roomSpawnNewThreadProvider = Provider<SpawnNewThread?>(
+  name: 'roomSpawnNewThreadProvider',
+  (_) => null,
+);
+
 /// The room module's RunRegistry, exposed for cross-module observers
 /// (e.g., TicTacToeController watching for chat streaming events).
 /// Constructed and overridden by RoomAppModule.build().

--- a/lib/src/modules/room/room_providers.dart
+++ b/lib/src/modules/room/room_providers.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/widgets.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import 'message_expansions.dart';
@@ -10,4 +11,20 @@ final messageExpansionsProvider = Provider<MessageExpansions>(
     'widget in `ProviderScope(overrides: [messageExpansionsProvider'
     '.overrideWithValue(MessageExpansions())])`.',
   ),
+);
+
+/// Builders contributed by other modules to render between the message
+/// list and the chat input. Defaults to empty; modules override via
+/// ProviderScope to inject their widgets (e.g., the tic-tac-toe board).
+final roomAboveChatInputBuildersProvider = Provider<List<WidgetBuilder>>(
+  name: 'roomAboveChatInputBuildersProvider',
+  (_) => const [],
+);
+
+/// Builders contributed by other modules to render as extra icons in the
+/// chat input toolbar. Defaults to empty; modules override via
+/// ProviderScope.
+final roomChatInputToolbarBuildersProvider = Provider<List<WidgetBuilder>>(
+  name: 'roomChatInputToolbarBuildersProvider',
+  (_) => const [],
 );

--- a/lib/src/modules/room/room_providers.dart
+++ b/lib/src/modules/room/room_providers.dart
@@ -1,7 +1,9 @@
 import 'package:flutter/widgets.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:soliplex_agent/soliplex_agent.dart';
 
 import 'message_expansions.dart';
+import 'run_registry.dart';
 
 final messageExpansionsProvider = Provider<MessageExpansions>(
   name: 'messageExpansionsProvider',
@@ -27,4 +29,25 @@ final roomAboveChatInputBuildersProvider = Provider<List<WidgetBuilder>>(
 final roomChatInputToolbarBuildersProvider = Provider<List<WidgetBuilder>>(
   name: 'roomChatInputToolbarBuildersProvider',
   (_) => const [],
+);
+
+/// Currently-active thread in the room view. Null when no thread is
+/// selected. Set by the room screen as it switches threads. Other
+/// modules read this to attach per-thread controllers.
+final roomActiveThreadProvider =
+    Provider<({ThreadKey threadKey, AgentRuntime runtime})?>(
+  name: 'roomActiveThreadProvider',
+  (_) => null,
+);
+
+/// The room module's RunRegistry, exposed for cross-module observers
+/// (e.g., TicTacToeController watching for chat streaming events).
+/// Constructed and overridden by RoomAppModule.build().
+final runRegistryProvider = Provider<RunRegistry>(
+  name: 'runRegistryProvider',
+  (_) => throw StateError(
+    'runRegistryProvider was read without an override. '
+    'In production this is wired by RoomAppModule.build(); in tests, '
+    'override with the test registry.',
+  ),
 );

--- a/lib/src/modules/room/ui/chat_input.dart
+++ b/lib/src/modules/room/ui/chat_input.dart
@@ -18,6 +18,7 @@ class ChatInput extends StatefulWidget {
     this.onFilterTap,
     this.onDocumentRemoved,
     this.onAttachFile,
+    this.toolbarExtras = const [],
   });
 
   final void Function(String text) onSend;
@@ -30,6 +31,7 @@ class ChatInput extends StatefulWidget {
   final VoidCallback? onFilterTap;
   final void Function(RagDocument doc)? onDocumentRemoved;
   final VoidCallback? onAttachFile;
+  final List<WidgetBuilder> toolbarExtras;
 
   @override
   State<ChatInput> createState() => _ChatInputState();
@@ -234,6 +236,7 @@ class _ChatInputState extends State<ChatInput> {
                   tooltip: 'Upload file to thread',
                   onPressed: disabled ? null : widget.onAttachFile,
                 ),
+              ...widget.toolbarExtras.map((b) => b(context)),
               Expanded(
                 child: CallbackShortcuts(
                   bindings: {

--- a/lib/src/modules/room/ui/room_screen.dart
+++ b/lib/src/modules/room/ui/room_screen.dart
@@ -458,16 +458,32 @@ class _RoomScreenState extends State<RoomScreen> {
             .watch(context)
         : const UploadsLoaded(<DisplayUpload>[]);
 
-    return Column(
-      children: [
-        _buildRoomHeader(room, roomStatus, threadStatus),
-        if (_filesExpanded) _buildFilePanel(roomStatus, threadStatus),
-        Expanded(
-          child: threadView == null
-              ? _buildNoThreadBody(room)
-              : _buildThreadBody(threadView, room),
-        ),
+    final activeThread = threadView == null
+        ? null
+        : (
+            threadKey: (
+              serverId: widget.serverEntry.serverId,
+              roomId: widget.roomId,
+              threadId: threadView.threadId,
+            ),
+            runtime: _state.runtime,
+          );
+
+    return ProviderScope(
+      overrides: [
+        roomActiveThreadProvider.overrideWithValue(activeThread),
       ],
+      child: Column(
+        children: [
+          _buildRoomHeader(room, roomStatus, threadStatus),
+          if (_filesExpanded) _buildFilePanel(roomStatus, threadStatus),
+          Expanded(
+            child: threadView == null
+                ? _buildNoThreadBody(room)
+                : _buildThreadBody(threadView, room),
+          ),
+        ],
+      ),
     );
   }
 

--- a/lib/src/modules/room/ui/room_screen.dart
+++ b/lib/src/modules/room/ui/room_screen.dart
@@ -472,6 +472,10 @@ class _RoomScreenState extends State<RoomScreen> {
     return ProviderScope(
       overrides: [
         roomActiveThreadProvider.overrideWithValue(activeThread),
+        roomSpawnNewThreadProvider.overrideWithValue(
+          ({String prompt = '', Map<String, dynamic>? stateOverlay}) =>
+              _state.sendToNewThread(prompt, stateOverlay: stateOverlay),
+        ),
       ],
       child: Column(
         children: [

--- a/lib/src/modules/room/ui/room_screen.dart
+++ b/lib/src/modules/room/ui/room_screen.dart
@@ -16,6 +16,7 @@ import '../../diagnostics/models/http_event_grouper.dart';
 import '../../diagnostics/models/run_event_filter.dart';
 import '../../diagnostics/ui/run_http_detail_page.dart';
 import '../agent_runtime_manager.dart';
+import '../room_providers.dart';
 import '../room_state.dart';
 import '../run_registry.dart';
 import '../thread_list_state.dart';
@@ -786,6 +787,16 @@ class _RoomScreenState extends State<RoomScreen> {
             fallback: const Center(child: Text('Select a thread')),
           ),
         ),
+        Consumer(
+          builder: (context, ref, _) {
+            final aboveChat = ref.watch(roomAboveChatInputBuildersProvider);
+            if (aboveChat.isEmpty) return const SizedBox.shrink();
+            return Column(
+              mainAxisSize: MainAxisSize.min,
+              children: aboveChat.map((b) => b(context)).toList(),
+            );
+          },
+        ),
         if (roomError != null)
           _SendErrorBanner(
             error: roomError,
@@ -797,25 +808,32 @@ class _RoomScreenState extends State<RoomScreen> {
             roomId: widget.roomId,
             threadId: null,
           ),
-        ChatInput(
-          onSend: (text) => _state.sendToNewThread(
-            text,
-            stateOverlay: _buildStateOverlay(),
-          ),
-          onCancel: _state.cancelSpawn,
-          sessionState: _state.sessionState,
-          controller: _chatController,
-          focusNode: _chatFocusNode,
-          selectedDocuments: _selectedDocuments,
-          onFilterTap: _filterEnabled ? _openDocumentPicker : null,
-          onDocumentRemoved: _filterEnabled
-              ? (doc) => _updateSelection(
-                    Set.of(_selectedDocuments)..remove(doc),
-                  )
-              : null,
-          onAttachFile: (room?.enableAttachments ?? false)
-              ? _pickAndUploadToNewThread
-              : null,
+        Consumer(
+          builder: (context, ref, _) {
+            final toolbarExtras =
+                ref.watch(roomChatInputToolbarBuildersProvider);
+            return ChatInput(
+              onSend: (text) => _state.sendToNewThread(
+                text,
+                stateOverlay: _buildStateOverlay(),
+              ),
+              onCancel: _state.cancelSpawn,
+              sessionState: _state.sessionState,
+              controller: _chatController,
+              focusNode: _chatFocusNode,
+              selectedDocuments: _selectedDocuments,
+              onFilterTap: _filterEnabled ? _openDocumentPicker : null,
+              onDocumentRemoved: _filterEnabled
+                  ? (doc) => _updateSelection(
+                        Set.of(_selectedDocuments)..remove(doc),
+                      )
+                  : null,
+              onAttachFile: (room?.enableAttachments ?? false)
+                  ? _pickAndUploadToNewThread
+                  : null,
+              toolbarExtras: toolbarExtras,
+            );
+          },
         ),
       ],
     );
@@ -895,6 +913,16 @@ class _RoomScreenState extends State<RoomScreen> {
                         ),
               },
             ),
+            Consumer(
+              builder: (context, ref, _) {
+                final aboveChat = ref.watch(roomAboveChatInputBuildersProvider);
+                if (aboveChat.isEmpty) return const SizedBox.shrink();
+                return Column(
+                  mainAxisSize: MainAxisSize.min,
+                  children: aboveChat.map((b) => b(context)).toList(),
+                );
+              },
+            ),
             if (sendError != null)
               _SendErrorBanner(
                 error: sendError,
@@ -906,27 +934,34 @@ class _RoomScreenState extends State<RoomScreen> {
                 roomId: widget.roomId,
                 threadId: threadView.threadId,
               ),
-            ChatInput(
-              onSend: (text) => threadView.sendMessage(
-                text,
-                _state.runtime,
-                stateOverlay: _buildStateOverlay(),
-              ),
-              onCancel: threadView.cancelRun,
-              sessionState: threadView.sessionState,
-              controller: _chatController,
-              focusNode: _chatFocusNode,
-              enabled: status is MessagesLoaded,
-              selectedDocuments: _selectedDocuments,
-              onFilterTap: _filterEnabled ? _openDocumentPicker : null,
-              onDocumentRemoved: _filterEnabled
-                  ? (doc) => _updateSelection(
-                        Set.of(_selectedDocuments)..remove(doc),
-                      )
-                  : null,
-              onAttachFile: attachEnabled
-                  ? () => _pickAndUploadToThread(threadView.threadId)
-                  : null,
+            Consumer(
+              builder: (context, ref, _) {
+                final toolbarExtras =
+                    ref.watch(roomChatInputToolbarBuildersProvider);
+                return ChatInput(
+                  onSend: (text) => threadView.sendMessage(
+                    text,
+                    _state.runtime,
+                    stateOverlay: _buildStateOverlay(),
+                  ),
+                  onCancel: threadView.cancelRun,
+                  sessionState: threadView.sessionState,
+                  controller: _chatController,
+                  focusNode: _chatFocusNode,
+                  enabled: status is MessagesLoaded,
+                  selectedDocuments: _selectedDocuments,
+                  onFilterTap: _filterEnabled ? _openDocumentPicker : null,
+                  onDocumentRemoved: _filterEnabled
+                      ? (doc) => _updateSelection(
+                            Set.of(_selectedDocuments)..remove(doc),
+                          )
+                      : null,
+                  onAttachFile: attachEnabled
+                      ? () => _pickAndUploadToThread(threadView.threadId)
+                      : null,
+                  toolbarExtras: toolbarExtras,
+                );
+              },
             ),
           ],
         ),

--- a/lib/src/modules/tic_tac_toe/board_render_state.dart
+++ b/lib/src/modules/tic_tac_toe/board_render_state.dart
@@ -7,11 +7,20 @@ import 'tic_tac_toe_state.dart';
 class CellRender {
   const CellRender({
     required this.mark,
+    required this.serverMark,
     required this.isPending,
     required this.isWinning,
   });
 
+  /// What to display: server mark, OR the pending overlay's mark if
+  /// the cell is staged but not yet committed, OR null when empty.
   final String? mark;
+
+  /// What the server actually has at this cell, ignoring any pending
+  /// overlay. Used by the widget's enable rule so a pending cell stays
+  /// tappable (re-tap toggles the pending off, per the spec).
+  final String? serverMark;
+
   final bool isPending;
   final bool isWinning;
 
@@ -20,11 +29,12 @@ class CellRender {
       identical(this, other) ||
       other is CellRender &&
           mark == other.mark &&
+          serverMark == other.serverMark &&
           isPending == other.isPending &&
           isWinning == other.isWinning;
 
   @override
-  int get hashCode => Object.hash(mark, isPending, isWinning);
+  int get hashCode => Object.hash(mark, serverMark, isPending, isWinning);
 }
 
 @immutable
@@ -69,6 +79,7 @@ class BoardRenderState {
         final isPending = client.pending == Cell(r, c) && serverMark == null;
         return CellRender(
           mark: serverMark ?? (isPending ? _userMark : null),
+          serverMark: serverMark,
           isPending: isPending,
           isWinning: winning.contains(Cell(r, c)),
         );

--- a/lib/src/modules/tic_tac_toe/board_render_state.dart
+++ b/lib/src/modules/tic_tac_toe/board_render_state.dart
@@ -1,0 +1,97 @@
+import 'package:flutter/foundation.dart' show immutable;
+
+import 'tic_tac_toe_server_state.dart';
+import 'tic_tac_toe_state.dart';
+
+@immutable
+class CellRender {
+  const CellRender({
+    required this.mark,
+    required this.isPending,
+    required this.isWinning,
+  });
+
+  final String? mark;
+  final bool isPending;
+  final bool isWinning;
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is CellRender &&
+          mark == other.mark &&
+          isPending == other.isPending &&
+          isWinning == other.isWinning;
+
+  @override
+  int get hashCode => Object.hash(mark, isPending, isWinning);
+}
+
+@immutable
+class BoardRenderState {
+  const BoardRenderState({
+    required this.cells,
+    required this.turn,
+    required this.winner,
+    required this.winningLine,
+    required this.pending,
+    required this.canSend,
+    required this.canCancel,
+    required this.canUndo,
+    required this.canRedo,
+    required this.canNewGame,
+    required this.inFlight,
+  });
+
+  final List<List<CellRender>> cells;
+  final TicTacToePlayer turn;
+  final TicTacToeOutcome? winner;
+  final List<Cell>? winningLine;
+  final Cell? pending;
+  final bool canSend;
+  final bool canCancel;
+  final bool canUndo;
+  final bool canRedo;
+  final bool canNewGame;
+  final bool inFlight;
+
+  static const _userMark = 'X';
+
+  static BoardRenderState? compose({
+    required TicTacToeServerState? server,
+    required TicTacToeClientState client,
+  }) {
+    if (server == null) return null;
+    final winning = <Cell>{...?server.winningLine};
+    final cells = List.generate(3, (r) {
+      return List.generate(3, (c) {
+        final serverMark = server.board[r][c];
+        final isPending = client.pending == Cell(r, c) && serverMark == null;
+        return CellRender(
+          mark: serverMark ?? (isPending ? _userMark : null),
+          isPending: isPending,
+          isWinning: winning.contains(Cell(r, c)),
+        );
+      });
+    });
+    final movesEmpty = server.moves.isEmpty;
+    return BoardRenderState(
+      cells: cells,
+      turn: server.turn,
+      winner: server.winner,
+      winningLine: server.winningLine,
+      pending: client.pending,
+      canSend: !client.inFlight &&
+          client.pending != null &&
+          server.winner == null &&
+          server.turn == TicTacToePlayer.user,
+      canCancel: client.inFlight,
+      canUndo: !client.inFlight && (client.pending != null || !movesEmpty),
+      canRedo: !client.inFlight &&
+          client.pending == null &&
+          client.redoStack.isNotEmpty,
+      canNewGame: !client.inFlight,
+      inFlight: client.inFlight,
+    );
+  }
+}

--- a/lib/src/modules/tic_tac_toe/tic_tac_toe_controller.dart
+++ b/lib/src/modules/tic_tac_toe/tic_tac_toe_controller.dart
@@ -4,6 +4,7 @@ import 'package:meta/meta.dart';
 import 'package:signals_flutter/signals_flutter.dart';
 import 'package:soliplex_agent/soliplex_agent.dart' hide computed;
 
+import '../room/run_registry.dart';
 import 'board_render_state.dart';
 import 'tic_tac_toe_intent.dart';
 import 'tic_tac_toe_projection.dart';
@@ -16,7 +17,9 @@ class TicTacToeController {
   TicTacToeController({
     required this.threadKey,
     required AgentRuntime runtime,
-  }) : _runtime = runtime {
+    RunRegistry? runRegistry,
+  })  : _runtime = runtime,
+        _runRegistry = runRegistry {
     final bus = runtime.ensureThreadState(threadKey).bus;
     _serverSignal = bus.project(const TicTacToeProjection());
     _state = signal(const TicTacToeClientState());
@@ -27,15 +30,22 @@ class TicTacToeController {
       ),
     );
     _serverSubscription = _serverSignal.subscribe(_onServerState);
+    _activeKeysSubscription =
+        _runRegistry?.activeKeys.subscribe(_onActiveKeysChanged);
   }
 
   final ThreadKey threadKey;
   final AgentRuntime _runtime;
+  final RunRegistry? _runRegistry;
 
   late final ReadonlySignal<TicTacToeServerState?> _serverSignal;
   late final Signal<TicTacToeClientState> _state;
   late final ReadonlySignal<BoardRenderState?> _boardRender;
   void Function()? _serverSubscription;
+  void Function()? _activeKeysSubscription;
+  void Function()? _activeRunStateSub;
+  RunState? _lastRunState;
+  Timer? _bannerTimer;
   AgentSession? _activeSession;
   bool _disposed = false;
 
@@ -217,7 +227,58 @@ class TicTacToeController {
   }
 
   void setViewMode(TicTacToeViewMode mode) {
-    _state.value = _state.value.copyWith(viewMode: mode);
+    final s = _state.value;
+    final leavingFullscreen = s.viewMode == TicTacToeViewMode.fullscreen &&
+        mode != TicTacToeViewMode.fullscreen;
+    _state.value = s.copyWith(
+      viewMode: mode,
+      unreadChatWhileFullscreen:
+          leavingFullscreen ? 0 : s.unreadChatWhileFullscreen,
+      bannerVisible: leavingFullscreen ? false : s.bannerVisible,
+    );
+  }
+
+  void _onActiveKeysChanged(Set<ThreadKey> keys) {
+    _activeRunStateSub?.call();
+    _activeRunStateSub = null;
+    _lastRunState = null;
+    if (!keys.contains(threadKey)) return;
+    final session = _runRegistry?.activeSession(threadKey);
+    if (session == null) return;
+    _activeRunStateSub = session.runState.subscribe(_onAnyRunState);
+  }
+
+  void _onAnyRunState(RunState rs) {
+    final s = _state.value;
+    if (s.viewMode != TicTacToeViewMode.fullscreen) {
+      _lastRunState = rs;
+      return;
+    }
+    if (rs is RunningState && rs.streaming is TextStreaming) {
+      final last = _lastRunState;
+      final wasText = last is RunningState && last.streaming is TextStreaming;
+      if (!wasText) {
+        _state.value = s.copyWith(
+          unreadChatWhileFullscreen: s.unreadChatWhileFullscreen + 1,
+          bannerVisible: true,
+        );
+        _scheduleBannerAutoDismiss();
+      }
+    }
+    _lastRunState = rs;
+  }
+
+  void _scheduleBannerAutoDismiss() {
+    _bannerTimer?.cancel();
+    _bannerTimer = Timer(const Duration(seconds: 3), () {
+      if (_disposed) return;
+      _state.value = _state.value.copyWith(bannerVisible: false);
+    });
+  }
+
+  void dismissBanner() {
+    _bannerTimer?.cancel();
+    _state.value = _state.value.copyWith(bannerVisible: false);
   }
 
   void _onServerState(TicTacToeServerState? server) {
@@ -250,6 +311,9 @@ class TicTacToeController {
     _disposed = true;
     _activeSession?.cancel();
     _serverSubscription?.call();
+    _activeKeysSubscription?.call();
+    _activeRunStateSub?.call();
+    _bannerTimer?.cancel();
     _state.dispose();
   }
 }

--- a/lib/src/modules/tic_tac_toe/tic_tac_toe_controller.dart
+++ b/lib/src/modules/tic_tac_toe/tic_tac_toe_controller.dart
@@ -158,11 +158,12 @@ class TicTacToeController {
     if (server.winner != null) return;
     if (server.turn != TicTacToePlayer.user) return;
 
+    final pending = s.pending!;
     final overlay = <String, dynamic>{
       '_inbox': {
         TicTacToeIntent.surfaceKey: {
           TicTacToeIntent.intentKey: TicTacToeIntent.play,
-          'move': {'row': s.pending!.row, 'col': s.pending!.col},
+          'move': {'row': pending.row, 'col': pending.col},
         },
       },
     };
@@ -172,15 +173,23 @@ class TicTacToeController {
       redoStack: const [],
       clearLastError: true,
     );
-    unawaited(_runWithOverlay(overlay));
+    unawaited(
+      _runWithOverlay(
+        overlay,
+        prompt: 'Play (${pending.row}, ${pending.col}).',
+      ),
+    );
   }
 
-  Future<void> _runWithOverlay(Map<String, dynamic> overlay) async {
+  Future<void> _runWithOverlay(
+    Map<String, dynamic> overlay, {
+    required String prompt,
+  }) async {
     final (:roomId, :threadId, serverId: _) = threadKey;
     try {
       _activeSession = await _runtime.spawn(
         roomId: roomId,
-        prompt: '',
+        prompt: prompt,
         threadId: threadId,
         stateOverlay: overlay,
       );
@@ -219,7 +228,7 @@ class TicTacToeController {
       clearPending: true,
       clearLastError: true,
     );
-    unawaited(_runWithOverlay(overlay));
+    unawaited(_runWithOverlay(overlay, prompt: 'Start a new game.'));
   }
 
   void toggleAutoSend() {
@@ -304,7 +313,12 @@ class TicTacToeController {
       inFlight: true,
       clearLastError: true,
     );
-    unawaited(_runWithOverlay(overlay));
+    final prompt = switch (intent[TicTacToeIntent.intentKey]) {
+      TicTacToeIntent.undo => 'Undo.',
+      TicTacToeIntent.redo => 'Redo.',
+      _ => '',
+    };
+    unawaited(_runWithOverlay(overlay, prompt: prompt));
   }
 
   void dispose() {

--- a/lib/src/modules/tic_tac_toe/tic_tac_toe_controller.dart
+++ b/lib/src/modules/tic_tac_toe/tic_tac_toe_controller.dart
@@ -1,0 +1,255 @@
+import 'dart:async';
+
+import 'package:meta/meta.dart';
+import 'package:signals_flutter/signals_flutter.dart';
+import 'package:soliplex_agent/soliplex_agent.dart' hide computed;
+
+import 'board_render_state.dart';
+import 'tic_tac_toe_intent.dart';
+import 'tic_tac_toe_projection.dart';
+import 'tic_tac_toe_server_state.dart';
+import 'tic_tac_toe_state.dart';
+
+/// Per-thread tic-tac-toe controller. Held by [TicTacToeRegistry];
+/// constructed lazily by widgets through [TicTacToeRegistry.controllerFor].
+class TicTacToeController {
+  TicTacToeController({
+    required this.threadKey,
+    required AgentRuntime runtime,
+  }) : _runtime = runtime {
+    final bus = runtime.ensureThreadState(threadKey).bus;
+    _serverSignal = bus.project(const TicTacToeProjection());
+    _state = signal(const TicTacToeClientState());
+    _boardRender = computed(
+      () => BoardRenderState.compose(
+        server: _serverSignal.value,
+        client: _state.value,
+      ),
+    );
+    _serverSubscription = _serverSignal.subscribe(_onServerState);
+  }
+
+  final ThreadKey threadKey;
+  final AgentRuntime _runtime;
+
+  late final ReadonlySignal<TicTacToeServerState?> _serverSignal;
+  late final Signal<TicTacToeClientState> _state;
+  late final ReadonlySignal<BoardRenderState?> _boardRender;
+  void Function()? _serverSubscription;
+  AgentSession? _activeSession;
+  bool _disposed = false;
+
+  /// Visible to tests so we can assert dispatched intents without
+  /// actually spawning runs against a fake runtime.
+  @visibleForTesting
+  Map<String, dynamic>? lastDispatchedIntent;
+
+  ReadonlySignal<TicTacToeClientState> get state => _state.readonly();
+  ReadonlySignal<BoardRenderState?> get boardRender => _boardRender;
+
+  /// Stage / replace / toggle a pending move.
+  void clickCell(int row, int col) {
+    final s = _state.value;
+    if (s.inFlight) return;
+    final server = _serverSignal.value;
+    if (server == null) return;
+    if (server.winner != null) return;
+    if (server.board[row][col] != null) return;
+
+    final cell = Cell(row, col);
+    if (s.pending == cell) {
+      _state.value = s.copyWith(clearPending: true);
+      return;
+    }
+    _state.value = s.copyWith(pending: cell);
+
+    if (s.autoSend && _state.value.pending != null) {
+      send();
+    }
+  }
+
+  /// Undo: clears pending, OR sends an undo intent for committed history.
+  void clickUndo() {
+    final s = _state.value;
+    if (s.inFlight) return;
+    if (s.pending != null) {
+      _state.value = s.copyWith(clearPending: true);
+      return;
+    }
+    final server = _serverSignal.value;
+    if (server == null) return;
+    final moves = server.moves;
+    if (moves.isEmpty) return;
+
+    final lastIsAgent = moves.last.player == TicTacToePlayer.agent;
+    final pairCount = lastIsAgent ? 2 : 1;
+    final targetIndex = moves.length - pairCount;
+
+    final undoneUser = moves[moves.length - pairCount];
+    final undoneAgent = lastIsAgent ? moves.last : null;
+    final newRedoStack = [
+      ...s.redoStack,
+      TurnPair(
+        user: Cell(undoneUser.row, undoneUser.col),
+        agent:
+            undoneAgent == null ? null : Cell(undoneAgent.row, undoneAgent.col),
+      ),
+    ];
+    _state.value = s.copyWith(redoStack: newRedoStack);
+
+    _dispatch({
+      TicTacToeIntent.intentKey: TicTacToeIntent.undo,
+      'target_index': targetIndex,
+    });
+  }
+
+  void clickRedo() {
+    final s = _state.value;
+    if (s.inFlight) return;
+    if (s.pending != null) return;
+    if (s.redoStack.isEmpty) return;
+    final pair = s.redoStack.last;
+    final newStack = s.redoStack.sublist(0, s.redoStack.length - 1);
+    _state.value = s.copyWith(redoStack: newStack);
+
+    final movesPayload = <Map<String, dynamic>>[
+      {
+        'player': 'user',
+        'row': pair.user.row,
+        'col': pair.user.col,
+        'mark': 'X',
+      },
+      if (pair.agent != null)
+        {
+          'player': 'agent',
+          'row': pair.agent!.row,
+          'col': pair.agent!.col,
+          'mark': 'O',
+        },
+    ];
+    _dispatch({
+      TicTacToeIntent.intentKey: TicTacToeIntent.redo,
+      'moves': movesPayload,
+    });
+  }
+
+  /// Test-only seed for the client state.
+  @visibleForTesting
+  void applyTestSeed(TicTacToeClientState seed) {
+    _state.value = seed;
+  }
+
+  void send() {
+    final s = _state.value;
+    final server = _serverSignal.value;
+    if (s.inFlight) return;
+    if (s.pending == null) return;
+    if (server == null) return;
+    if (server.winner != null) return;
+    if (server.turn != TicTacToePlayer.user) return;
+
+    final overlay = <String, dynamic>{
+      '_inbox': {
+        TicTacToeIntent.surfaceKey: {
+          TicTacToeIntent.intentKey: TicTacToeIntent.play,
+          'move': {'row': s.pending!.row, 'col': s.pending!.col},
+        },
+      },
+    };
+
+    _state.value = s.copyWith(
+      inFlight: true,
+      redoStack: const [],
+      clearLastError: true,
+    );
+    unawaited(_runWithOverlay(overlay));
+  }
+
+  Future<void> _runWithOverlay(Map<String, dynamic> overlay) async {
+    final (:roomId, :threadId, serverId: _) = threadKey;
+    try {
+      _activeSession = await _runtime.spawn(
+        roomId: roomId,
+        prompt: '',
+        threadId: threadId,
+        stateOverlay: overlay,
+      );
+      await _activeSession!.awaitResult();
+    } on Object {
+      if (!_disposed) {
+        _state.value = _state.value.copyWith(
+          lastError: TicTacToeError.network,
+        );
+      }
+    } finally {
+      _activeSession = null;
+      if (!_disposed) {
+        _state.value = _state.value.copyWith(inFlight: false);
+      }
+    }
+  }
+
+  void cancel() {
+    _activeSession?.cancel();
+    _state.value = _state.value.copyWith(clearPending: true);
+  }
+
+  /// Dispatch a `new_game` intent to the agent.
+  void newGame() {
+    final overlay = <String, dynamic>{
+      '_inbox': {
+        TicTacToeIntent.surfaceKey: {
+          TicTacToeIntent.intentKey: TicTacToeIntent.newGame,
+        },
+      },
+    };
+    _state.value = _state.value.copyWith(
+      inFlight: true,
+      redoStack: const [],
+      clearPending: true,
+      clearLastError: true,
+    );
+    unawaited(_runWithOverlay(overlay));
+  }
+
+  void toggleAutoSend() {
+    _state.value = _state.value.copyWith(autoSend: !_state.value.autoSend);
+  }
+
+  void setViewMode(TicTacToeViewMode mode) {
+    _state.value = _state.value.copyWith(viewMode: mode);
+  }
+
+  void _onServerState(TicTacToeServerState? server) {
+    if (_disposed) return;
+    final s = _state.value;
+    if (server != null && s.viewMode == TicTacToeViewMode.hidden) {
+      _state.value = s.copyWith(viewMode: TicTacToeViewMode.inline);
+    }
+    if (server != null && s.pending != null) {
+      final p = s.pending!;
+      if (server.board[p.row][p.col] != null) {
+        _state.value = _state.value.copyWith(clearPending: true);
+      }
+    }
+  }
+
+  void _dispatch(Map<String, dynamic> intent) {
+    lastDispatchedIntent = intent;
+    final overlay = <String, dynamic>{
+      '_inbox': {TicTacToeIntent.surfaceKey: intent},
+    };
+    _state.value = _state.value.copyWith(
+      inFlight: true,
+      clearLastError: true,
+    );
+    unawaited(_runWithOverlay(overlay));
+  }
+
+  void dispose() {
+    _disposed = true;
+    _activeSession?.cancel();
+    _serverSubscription?.call();
+    _state.dispose();
+  }
+}

--- a/lib/src/modules/tic_tac_toe/tic_tac_toe_intent.dart
+++ b/lib/src/modules/tic_tac_toe/tic_tac_toe_intent.dart
@@ -1,0 +1,13 @@
+/// Wire keys for the `_inbox.tic_tac_toe` payload.
+class TicTacToeIntent {
+  const TicTacToeIntent._();
+
+  static const surfaceKey = 'tic_tac_toe';
+  static const intentKey = 'intent';
+
+  // Intent values
+  static const newGame = 'new_game';
+  static const play = 'play';
+  static const undo = 'undo';
+  static const redo = 'redo';
+}

--- a/lib/src/modules/tic_tac_toe/tic_tac_toe_module.dart
+++ b/lib/src/modules/tic_tac_toe/tic_tac_toe_module.dart
@@ -1,0 +1,37 @@
+import '../../core/app_module.dart';
+import '../room/room_providers.dart';
+import 'tic_tac_toe_providers.dart';
+import 'tic_tac_toe_registry.dart';
+import 'ui/tic_tac_toe_board.dart';
+import 'ui/tic_tac_toe_toolbar_button.dart';
+
+class TicTacToeAppModule extends AppModule {
+  TicTacToeAppModule();
+
+  TicTacToeRegistry? _registry;
+
+  @override
+  String get namespace => 'tic_tac_toe';
+
+  @override
+  ModuleRoutes build() {
+    final registry = TicTacToeRegistry();
+    _registry = registry;
+    return ModuleRoutes(
+      overrides: [
+        tictactoeRegistryProvider.overrideWithValue(registry),
+        roomAboveChatInputBuildersProvider.overrideWithValue(
+          [(_) => const TicTacToeBoard()],
+        ),
+        roomChatInputToolbarBuildersProvider.overrideWithValue(
+          [(_) => const TicTacToeToolbarButton()],
+        ),
+      ],
+    );
+  }
+
+  @override
+  Future<void> onDispose() async {
+    _registry?.disposeAll();
+  }
+}

--- a/lib/src/modules/tic_tac_toe/tic_tac_toe_projection.dart
+++ b/lib/src/modules/tic_tac_toe/tic_tac_toe_projection.dart
@@ -1,0 +1,75 @@
+import 'package:soliplex_client/soliplex_client.dart' show StateProjection;
+
+import 'tic_tac_toe_server_state.dart';
+import 'tic_tac_toe_state.dart';
+
+class TicTacToeProjection extends StateProjection<TicTacToeServerState?> {
+  const TicTacToeProjection();
+
+  @override
+  TicTacToeServerState? project(Map<String, dynamic> agentState) {
+    final game = agentState['game'];
+    if (game is! Map<String, dynamic>) return null;
+    try {
+      return TicTacToeServerState(
+        id: game['id'] as String,
+        board: _board(game['board']),
+        moves: _moves(game['moves']),
+        turn: _player(game['turn'] as String),
+        winner: _outcome(game['winner']),
+        winningLine: _winningLine(game['winning_line']),
+      );
+    } on Object {
+      // Tolerant per the StateProjection contract: malformed input
+      // produces null rather than throwing.
+      return null;
+    }
+  }
+
+  static List<List<String?>> _board(Object? raw) {
+    if (raw is! List) throw const FormatException('board not a list');
+    return raw
+        .cast<List>()
+        .map((row) => row.map((c) => c as String?).toList(growable: false))
+        .toList(growable: false);
+  }
+
+  static List<Move> _moves(Object? raw) {
+    if (raw is! List) return const [];
+    return raw
+        .cast<Map<String, dynamic>>()
+        .map(
+          (m) => Move(
+            player: _player(m['player'] as String),
+            row: (m['row'] as num).toInt(),
+            col: (m['col'] as num).toInt(),
+            mark: m['mark'] as String,
+          ),
+        )
+        .toList(growable: false);
+  }
+
+  static TicTacToePlayer _player(String s) => switch (s) {
+        'user' => TicTacToePlayer.user,
+        'agent' => TicTacToePlayer.agent,
+        _ => throw FormatException('unknown player $s'),
+      };
+
+  static TicTacToeOutcome? _outcome(Object? raw) {
+    if (raw == null) return null;
+    return switch (raw as String) {
+      'user' => TicTacToeOutcome.user,
+      'agent' => TicTacToeOutcome.agent,
+      'draw' => TicTacToeOutcome.draw,
+      _ => throw FormatException('unknown outcome $raw'),
+    };
+  }
+
+  static List<Cell>? _winningLine(Object? raw) {
+    if (raw == null) return null;
+    return (raw as List)
+        .cast<Map<String, dynamic>>()
+        .map((c) => Cell((c['row'] as num).toInt(), (c['col'] as num).toInt()))
+        .toList(growable: false);
+  }
+}

--- a/lib/src/modules/tic_tac_toe/tic_tac_toe_providers.dart
+++ b/lib/src/modules/tic_tac_toe/tic_tac_toe_providers.dart
@@ -1,0 +1,15 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import 'tic_tac_toe_registry.dart';
+
+/// Registry holding one TicTacToeController per active ThreadKey.
+/// Constructed and overridden by TicTacToeAppModule.build().
+final tictactoeRegistryProvider = Provider<TicTacToeRegistry>(
+  name: 'tictactoeRegistryProvider',
+  (_) => throw StateError(
+    'tictactoeRegistryProvider was read without an override. '
+    'In production this is wired by TicTacToeAppModule.build(); in '
+    'tests, wrap the widget in `ProviderScope(overrides: ['
+    'tictactoeRegistryProvider.overrideWithValue(...)])`.',
+  ),
+);

--- a/lib/src/modules/tic_tac_toe/tic_tac_toe_registry.dart
+++ b/lib/src/modules/tic_tac_toe/tic_tac_toe_registry.dart
@@ -1,0 +1,29 @@
+import 'package:soliplex_agent/soliplex_agent.dart';
+
+import 'tic_tac_toe_controller.dart';
+
+class TicTacToeRegistry {
+  final Map<ThreadKey, TicTacToeController> _controllers = {};
+  bool _disposed = false;
+
+  TicTacToeController controllerFor(
+    ThreadKey key,
+    TicTacToeController Function() factory,
+  ) {
+    assert(!_disposed, 'controllerFor on disposed TicTacToeRegistry');
+    return _controllers.putIfAbsent(key, factory);
+  }
+
+  void disposeFor(ThreadKey key) {
+    _controllers.remove(key)?.dispose();
+  }
+
+  void disposeAll() {
+    if (_disposed) return;
+    _disposed = true;
+    for (final c in _controllers.values) {
+      c.dispose();
+    }
+    _controllers.clear();
+  }
+}

--- a/lib/src/modules/tic_tac_toe/tic_tac_toe_server_state.dart
+++ b/lib/src/modules/tic_tac_toe/tic_tac_toe_server_state.dart
@@ -1,0 +1,85 @@
+import 'package:flutter/foundation.dart' show immutable, listEquals;
+
+import 'tic_tac_toe_state.dart';
+
+enum TicTacToePlayer { user, agent }
+
+enum TicTacToeOutcome { user, agent, draw }
+
+@immutable
+class Move {
+  const Move({
+    required this.player,
+    required this.row,
+    required this.col,
+    required this.mark,
+  });
+
+  final TicTacToePlayer player;
+  final int row;
+  final int col;
+  final String mark; // "X" or "O"
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is Move &&
+          player == other.player &&
+          row == other.row &&
+          col == other.col &&
+          mark == other.mark;
+
+  @override
+  int get hashCode => Object.hash(player, row, col, mark);
+}
+
+@immutable
+class TicTacToeServerState {
+  const TicTacToeServerState({
+    required this.id,
+    required this.board,
+    required this.moves,
+    required this.turn,
+    required this.winner,
+    required this.winningLine,
+  });
+
+  final String id;
+  final List<List<String?>> board;
+  final List<Move> moves;
+  final TicTacToePlayer turn;
+  final TicTacToeOutcome? winner;
+  final List<Cell>? winningLine;
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is TicTacToeServerState &&
+          id == other.id &&
+          _boardEquals(board, other.board) &&
+          listEquals(moves, other.moves) &&
+          turn == other.turn &&
+          winner == other.winner &&
+          listEquals(winningLine, other.winningLine);
+
+  @override
+  int get hashCode => Object.hash(
+        id,
+        _boardHash(board),
+        Object.hashAll(moves),
+        turn,
+        winner,
+        winningLine == null ? null : Object.hashAll(winningLine!),
+      );
+
+  static bool _boardEquals(List<List<String?>> a, List<List<String?>> b) {
+    if (a.length != b.length) return false;
+    for (var r = 0; r < a.length; r++) {
+      if (!listEquals(a[r], b[r])) return false;
+    }
+    return true;
+  }
+
+  static int _boardHash(List<List<String?>> b) =>
+      Object.hashAll(b.map(Object.hashAll));
+}

--- a/lib/src/modules/tic_tac_toe/tic_tac_toe_state.dart
+++ b/lib/src/modules/tic_tac_toe/tic_tac_toe_state.dart
@@ -1,0 +1,120 @@
+import 'package:flutter/foundation.dart' show immutable, listEquals;
+
+/// One cell on the 3x3 board.
+@immutable
+class Cell {
+  const Cell(this.row, this.col);
+
+  final int row;
+  final int col;
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is Cell && row == other.row && col == other.col;
+
+  @override
+  int get hashCode => Object.hash(row, col);
+
+  @override
+  String toString() => 'Cell($row, $col)';
+}
+
+/// One full turn — the user's move and the agent's response (if any).
+/// The agent's move is null when the user's move ended the game.
+@immutable
+class TurnPair {
+  const TurnPair({required this.user, this.agent});
+
+  final Cell user;
+  final Cell? agent;
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is TurnPair && user == other.user && agent == other.agent;
+
+  @override
+  int get hashCode => Object.hash(user, agent);
+}
+
+enum TicTacToeViewMode { hidden, inline, fullscreen }
+
+enum TicTacToeError { network, toolRejected }
+
+/// Client-only state held by [TicTacToeController].
+@immutable
+class TicTacToeClientState {
+  const TicTacToeClientState({
+    this.pending,
+    this.redoStack = const [],
+    this.viewMode = TicTacToeViewMode.hidden,
+    this.autoSend = false,
+    this.inFlight = false,
+    this.lastError,
+    this.unreadChatWhileFullscreen = 0,
+    this.bannerVisible = false,
+  });
+
+  final Cell? pending;
+  final List<TurnPair> redoStack;
+  final TicTacToeViewMode viewMode;
+  final bool autoSend;
+  final bool inFlight;
+  final TicTacToeError? lastError;
+  final int unreadChatWhileFullscreen;
+  final bool bannerVisible;
+
+  /// Copy with optional overrides. Use [clearPending] / [clearLastError]
+  /// to force the corresponding field to null (since named parameters
+  /// can't disambiguate "leave alone" vs "set null" otherwise).
+  TicTacToeClientState copyWith({
+    Cell? pending,
+    bool clearPending = false,
+    List<TurnPair>? redoStack,
+    TicTacToeViewMode? viewMode,
+    bool? autoSend,
+    bool? inFlight,
+    TicTacToeError? lastError,
+    bool clearLastError = false,
+    int? unreadChatWhileFullscreen,
+    bool? bannerVisible,
+  }) {
+    return TicTacToeClientState(
+      pending: clearPending ? null : (pending ?? this.pending),
+      redoStack: redoStack ?? this.redoStack,
+      viewMode: viewMode ?? this.viewMode,
+      autoSend: autoSend ?? this.autoSend,
+      inFlight: inFlight ?? this.inFlight,
+      lastError: clearLastError ? null : (lastError ?? this.lastError),
+      unreadChatWhileFullscreen:
+          unreadChatWhileFullscreen ?? this.unreadChatWhileFullscreen,
+      bannerVisible: bannerVisible ?? this.bannerVisible,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is TicTacToeClientState &&
+          pending == other.pending &&
+          listEquals(redoStack, other.redoStack) &&
+          viewMode == other.viewMode &&
+          autoSend == other.autoSend &&
+          inFlight == other.inFlight &&
+          lastError == other.lastError &&
+          unreadChatWhileFullscreen == other.unreadChatWhileFullscreen &&
+          bannerVisible == other.bannerVisible;
+
+  @override
+  int get hashCode => Object.hash(
+        pending,
+        Object.hashAll(redoStack),
+        viewMode,
+        autoSend,
+        inFlight,
+        lastError,
+        unreadChatWhileFullscreen,
+        bannerVisible,
+      );
+}

--- a/lib/src/modules/tic_tac_toe/ui/tic_tac_toe_board.dart
+++ b/lib/src/modules/tic_tac_toe/ui/tic_tac_toe_board.dart
@@ -1,7 +1,173 @@
-import 'package:flutter/widgets.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:signals_flutter/signals_flutter.dart';
 
-class TicTacToeBoard extends StatelessWidget {
+import '../../room/room_providers.dart';
+import '../board_render_state.dart';
+import '../tic_tac_toe_controller.dart';
+import '../tic_tac_toe_providers.dart';
+import '../tic_tac_toe_server_state.dart';
+import '../tic_tac_toe_state.dart';
+import 'tic_tac_toe_cell.dart';
+import 'tic_tac_toe_controls.dart';
+import 'tic_tac_toe_fullscreen_page.dart';
+
+class TicTacToeBoard extends ConsumerStatefulWidget {
   const TicTacToeBoard({super.key});
+
   @override
-  Widget build(BuildContext context) => const SizedBox.shrink();
+  ConsumerState<TicTacToeBoard> createState() => _TicTacToeBoardState();
+}
+
+class _TicTacToeBoardState extends ConsumerState<TicTacToeBoard> {
+  TicTacToeViewMode _lastSeenMode = TicTacToeViewMode.hidden;
+
+  @override
+  Widget build(BuildContext context) {
+    final active = ref.watch(roomActiveThreadProvider);
+    if (active == null) return const SizedBox.shrink();
+    final registry = ref.watch(tictactoeRegistryProvider);
+    final runRegistry = ref.watch(runRegistryProvider);
+    final controller = registry.controllerFor(
+      active.threadKey,
+      () => TicTacToeController(
+        threadKey: active.threadKey,
+        runtime: active.runtime,
+        runRegistry: runRegistry,
+      ),
+    );
+
+    return Watch((_) {
+      final render = controller.boardRender.value;
+      final s = controller.state.value;
+
+      if (s.viewMode != _lastSeenMode) {
+        WidgetsBinding.instance.addPostFrameCallback((_) {
+          _handleViewModeTransition(_lastSeenMode, s.viewMode, controller);
+          _lastSeenMode = s.viewMode;
+        });
+      }
+
+      if (render == null) return const SizedBox.shrink();
+      if (s.viewMode == TicTacToeViewMode.hidden ||
+          s.viewMode == TicTacToeViewMode.fullscreen) {
+        return const SizedBox.shrink();
+      }
+      return _BoardContent(
+        controller: controller,
+        render: render,
+        clientState: s,
+      );
+    });
+  }
+
+  void _handleViewModeTransition(
+    TicTacToeViewMode prev,
+    TicTacToeViewMode next,
+    TicTacToeController controller,
+  ) {
+    if (next == TicTacToeViewMode.fullscreen &&
+        prev != TicTacToeViewMode.fullscreen) {
+      Navigator.of(context)
+          .push(
+        MaterialPageRoute<void>(
+          builder: (_) => TicTacToeFullscreenPage(controller: controller),
+        ),
+      )
+          .then((_) {
+        if (controller.state.value.viewMode == TicTacToeViewMode.fullscreen) {
+          controller.setViewMode(TicTacToeViewMode.inline);
+        }
+      });
+    } else if (prev == TicTacToeViewMode.fullscreen &&
+        next != TicTacToeViewMode.fullscreen) {
+      if (Navigator.of(context).canPop()) Navigator.of(context).pop();
+    }
+  }
+}
+
+class _BoardContent extends StatelessWidget {
+  const _BoardContent({
+    required this.controller,
+    required this.render,
+    required this.clientState,
+  });
+
+  final TicTacToeController controller;
+  final BoardRenderState render;
+  final TicTacToeClientState clientState;
+
+  @override
+  Widget build(BuildContext context) {
+    return Card(
+      child: Padding(
+        padding: const EdgeInsets.all(8),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            if (render.winner != null) _ResultBanner(winner: render.winner!),
+            for (int r = 0; r < 3; r++)
+              Row(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  for (int c = 0; c < 3; c++)
+                    TicTacToeCell(
+                      key: Key('cell-$r-$c'),
+                      render: render.cells[r][c],
+                      enabled: !render.inFlight &&
+                          render.winner == null &&
+                          render.cells[r][c].mark == null,
+                      onTap: () => controller.clickCell(r, c),
+                    ),
+                ],
+              ),
+            if (render.winner != null)
+              Padding(
+                padding: const EdgeInsets.only(top: 8),
+                child: ElevatedButton(
+                  onPressed: render.canNewGame ? controller.newGame : null,
+                  child: const Text('Play again'),
+                ),
+              ),
+            const SizedBox(height: 8),
+            TicTacToeControls(
+              render: render,
+              autoSend: clientState.autoSend,
+              lastError: clientState.lastError,
+              onSend: controller.send,
+              onCancel: controller.cancel,
+              onUndo: controller.clickUndo,
+              onRedo: controller.clickRedo,
+              onToggleAutoSend: controller.toggleAutoSend,
+              onToggleFullscreen: () => controller.setViewMode(
+                clientState.viewMode == TicTacToeViewMode.fullscreen
+                    ? TicTacToeViewMode.inline
+                    : TicTacToeViewMode.fullscreen,
+              ),
+              onRetry: controller.send,
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _ResultBanner extends StatelessWidget {
+  const _ResultBanner({required this.winner});
+
+  final TicTacToeOutcome winner;
+
+  @override
+  Widget build(BuildContext context) {
+    final text = switch (winner) {
+      TicTacToeOutcome.user => 'You win!',
+      TicTacToeOutcome.agent => 'Agent wins.',
+      TicTacToeOutcome.draw => "It's a draw.",
+    };
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: 8),
+      child: Text(text, style: Theme.of(context).textTheme.titleLarge),
+    );
+  }
 }

--- a/lib/src/modules/tic_tac_toe/ui/tic_tac_toe_board.dart
+++ b/lib/src/modules/tic_tac_toe/ui/tic_tac_toe_board.dart
@@ -105,6 +105,17 @@ class _BoardContent extends StatelessWidget {
         child: Column(
           mainAxisSize: MainAxisSize.min,
           children: [
+            Align(
+              alignment: Alignment.centerRight,
+              child: IconButton(
+                tooltip: 'Hide board',
+                icon: const Icon(Icons.close),
+                iconSize: 18,
+                visualDensity: VisualDensity.compact,
+                onPressed: () =>
+                    controller.setViewMode(TicTacToeViewMode.hidden),
+              ),
+            ),
             if (render.winner != null) _ResultBanner(winner: render.winner!),
             for (int r = 0; r < 3; r++)
               Row(
@@ -116,7 +127,7 @@ class _BoardContent extends StatelessWidget {
                       render: render.cells[r][c],
                       enabled: !render.inFlight &&
                           render.winner == null &&
-                          render.cells[r][c].mark == null,
+                          render.cells[r][c].serverMark == null,
                       onTap: () => controller.clickCell(r, c),
                     ),
                 ],
@@ -134,16 +145,15 @@ class _BoardContent extends StatelessWidget {
               render: render,
               autoSend: clientState.autoSend,
               lastError: clientState.lastError,
+              isFullscreen: false,
+              unreadCount: 0,
               onSend: controller.send,
               onCancel: controller.cancel,
               onUndo: controller.clickUndo,
               onRedo: controller.clickRedo,
               onToggleAutoSend: controller.toggleAutoSend,
-              onToggleFullscreen: () => controller.setViewMode(
-                clientState.viewMode == TicTacToeViewMode.fullscreen
-                    ? TicTacToeViewMode.inline
-                    : TicTacToeViewMode.fullscreen,
-              ),
+              onToggleFullscreen: () =>
+                  controller.setViewMode(TicTacToeViewMode.fullscreen),
               onRetry: controller.send,
             ),
           ],

--- a/lib/src/modules/tic_tac_toe/ui/tic_tac_toe_board.dart
+++ b/lib/src/modules/tic_tac_toe/ui/tic_tac_toe_board.dart
@@ -1,0 +1,7 @@
+import 'package:flutter/widgets.dart';
+
+class TicTacToeBoard extends StatelessWidget {
+  const TicTacToeBoard({super.key});
+  @override
+  Widget build(BuildContext context) => const SizedBox.shrink();
+}

--- a/lib/src/modules/tic_tac_toe/ui/tic_tac_toe_board.dart
+++ b/lib/src/modules/tic_tac_toe/ui/tic_tac_toe_board.dart
@@ -105,15 +105,24 @@ class _BoardContent extends StatelessWidget {
         child: Column(
           mainAxisSize: MainAxisSize.min,
           children: [
-            Align(
-              alignment: Alignment.centerRight,
-              child: IconButton(
-                tooltip: 'Hide board',
-                icon: const Icon(Icons.close),
-                iconSize: 18,
-                visualDensity: VisualDensity.compact,
-                onPressed: () =>
-                    controller.setViewMode(TicTacToeViewMode.hidden),
+            GestureDetector(
+              behavior: HitTestBehavior.opaque,
+              onTap: () => controller.setViewMode(TicTacToeViewMode.hidden),
+              child: Row(
+                children: [
+                  const Spacer(),
+                  Text(
+                    'Hide',
+                    style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                          color: Theme.of(context).colorScheme.primary,
+                        ),
+                  ),
+                  Icon(
+                    Icons.expand_more,
+                    size: 16,
+                    color: Theme.of(context).colorScheme.primary,
+                  ),
+                ],
               ),
             ),
             if (render.winner != null) _ResultBanner(winner: render.winner!),

--- a/lib/src/modules/tic_tac_toe/ui/tic_tac_toe_cell.dart
+++ b/lib/src/modules/tic_tac_toe/ui/tic_tac_toe_cell.dart
@@ -27,11 +27,10 @@ class TicTacToeCell extends StatelessWidget {
           border: Border.all(color: Theme.of(context).colorScheme.outline),
           color: color?.withValues(alpha: 0.1),
         ),
-        child: Stack(
-          alignment: Alignment.center,
-          children: [
-            if (render.mark != null)
-              Text(
+        alignment: Alignment.center,
+        child: render.mark == null
+            ? null
+            : Text(
                 render.mark!,
                 style: Theme.of(context).textTheme.headlineLarge?.copyWith(
                       color: render.isPending
@@ -39,19 +38,6 @@ class TicTacToeCell extends StatelessWidget {
                           : color,
                     ),
               ),
-            if (render.isPending)
-              Positioned(
-                key: const Key('tictactoe-cell-pending'),
-                bottom: 4,
-                right: 4,
-                child: Icon(
-                  Icons.edit_outlined,
-                  size: 12,
-                  color: Theme.of(context).colorScheme.outline,
-                ),
-              ),
-          ],
-        ),
       ),
     );
   }

--- a/lib/src/modules/tic_tac_toe/ui/tic_tac_toe_cell.dart
+++ b/lib/src/modules/tic_tac_toe/ui/tic_tac_toe_cell.dart
@@ -1,0 +1,58 @@
+import 'package:flutter/material.dart';
+
+import '../board_render_state.dart';
+
+class TicTacToeCell extends StatelessWidget {
+  const TicTacToeCell({
+    required this.render,
+    required this.enabled,
+    required this.onTap,
+    super.key,
+  });
+
+  final CellRender render;
+  final bool enabled;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    final color =
+        render.isWinning ? Theme.of(context).colorScheme.primary : null;
+    return InkWell(
+      onTap: enabled ? onTap : null,
+      child: Container(
+        width: 64,
+        height: 64,
+        decoration: BoxDecoration(
+          border: Border.all(color: Theme.of(context).colorScheme.outline),
+          color: color?.withValues(alpha: 0.1),
+        ),
+        child: Stack(
+          alignment: Alignment.center,
+          children: [
+            if (render.mark != null)
+              Text(
+                render.mark!,
+                style: Theme.of(context).textTheme.headlineLarge?.copyWith(
+                      color: render.isPending
+                          ? Theme.of(context).colorScheme.outline
+                          : color,
+                    ),
+              ),
+            if (render.isPending)
+              Positioned(
+                key: const Key('tictactoe-cell-pending'),
+                bottom: 4,
+                right: 4,
+                child: Icon(
+                  Icons.edit_outlined,
+                  size: 12,
+                  color: Theme.of(context).colorScheme.outline,
+                ),
+              ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/src/modules/tic_tac_toe/ui/tic_tac_toe_controls.dart
+++ b/lib/src/modules/tic_tac_toe/ui/tic_tac_toe_controls.dart
@@ -1,0 +1,112 @@
+import 'package:flutter/material.dart';
+
+import '../board_render_state.dart';
+import '../tic_tac_toe_state.dart';
+
+class TicTacToeControls extends StatelessWidget {
+  const TicTacToeControls({
+    required this.render,
+    required this.autoSend,
+    required this.lastError,
+    required this.onSend,
+    required this.onCancel,
+    required this.onUndo,
+    required this.onRedo,
+    required this.onToggleAutoSend,
+    required this.onToggleFullscreen,
+    required this.onRetry,
+    super.key,
+  });
+
+  final BoardRenderState render;
+  final bool autoSend;
+  final TicTacToeError? lastError;
+  final VoidCallback onSend;
+  final VoidCallback onCancel;
+  final VoidCallback onUndo;
+  final VoidCallback onRedo;
+  final VoidCallback onToggleAutoSend;
+  final VoidCallback onToggleFullscreen;
+  final VoidCallback onRetry;
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        if (lastError != null) _ErrorChip(error: lastError!, onRetry: onRetry),
+        Row(
+          mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+          children: [
+            IconButton(
+              tooltip: 'Undo',
+              icon: const Icon(Icons.undo),
+              onPressed: render.canUndo ? onUndo : null,
+            ),
+            IconButton(
+              tooltip: 'Redo',
+              icon: const Icon(Icons.redo),
+              onPressed: render.canRedo ? onRedo : null,
+            ),
+            if (render.canCancel)
+              ElevatedButton(
+                onPressed: onCancel,
+                child: const Text('Cancel'),
+              )
+            else
+              ElevatedButton(
+                onPressed: render.canSend ? onSend : null,
+                child: const Text('Send'),
+              ),
+            Row(
+              children: [
+                const Text('Auto'),
+                Switch(value: autoSend, onChanged: (_) => onToggleAutoSend()),
+              ],
+            ),
+            IconButton(
+              tooltip: 'Fullscreen',
+              icon: const Icon(Icons.fullscreen),
+              onPressed: onToggleFullscreen,
+            ),
+          ],
+        ),
+      ],
+    );
+  }
+}
+
+class _ErrorChip extends StatelessWidget {
+  const _ErrorChip({required this.error, required this.onRetry});
+
+  final TicTacToeError error;
+  final VoidCallback onRetry;
+
+  @override
+  Widget build(BuildContext context) {
+    final text = switch (error) {
+      TicTacToeError.network => "Couldn't reach the server.",
+      TicTacToeError.toolRejected => 'Move was rejected.',
+    };
+    return Padding(
+      padding: const EdgeInsets.only(bottom: 4),
+      child: Row(
+        key: const Key('tictactoe-error-chip'),
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: [
+          Icon(
+            Icons.error_outline,
+            size: 16,
+            color: Theme.of(context).colorScheme.error,
+          ),
+          const SizedBox(width: 4),
+          Text(
+            text,
+            style: TextStyle(color: Theme.of(context).colorScheme.error),
+          ),
+          TextButton(onPressed: onRetry, child: const Text('Retry')),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/src/modules/tic_tac_toe/ui/tic_tac_toe_controls.dart
+++ b/lib/src/modules/tic_tac_toe/ui/tic_tac_toe_controls.dart
@@ -8,6 +8,8 @@ class TicTacToeControls extends StatelessWidget {
     required this.render,
     required this.autoSend,
     required this.lastError,
+    required this.isFullscreen,
+    required this.unreadCount,
     required this.onSend,
     required this.onCancel,
     required this.onUndo,
@@ -21,6 +23,15 @@ class TicTacToeControls extends StatelessWidget {
   final BoardRenderState render;
   final bool autoSend;
   final TicTacToeError? lastError;
+
+  /// True when the controls are rendered inside the fullscreen page.
+  /// Drives the toggle button's icon + tooltip + unread badge.
+  final bool isFullscreen;
+
+  /// Unread chat-message count accumulated while in fullscreen. The
+  /// badge is hidden when the count is zero.
+  final int unreadCount;
+
   final VoidCallback onSend;
   final VoidCallback onCancel;
   final VoidCallback onUndo;
@@ -64,10 +75,16 @@ class TicTacToeControls extends StatelessWidget {
                 Switch(value: autoSend, onChanged: (_) => onToggleAutoSend()),
               ],
             ),
-            IconButton(
-              tooltip: 'Fullscreen',
-              icon: const Icon(Icons.fullscreen),
-              onPressed: onToggleFullscreen,
+            Badge(
+              isLabelVisible: unreadCount > 0,
+              label: Text('$unreadCount'),
+              child: IconButton(
+                tooltip: isFullscreen ? 'Exit fullscreen' : 'Fullscreen',
+                icon: Icon(
+                  isFullscreen ? Icons.fullscreen_exit : Icons.fullscreen,
+                ),
+                onPressed: onToggleFullscreen,
+              ),
             ),
           ],
         ),

--- a/lib/src/modules/tic_tac_toe/ui/tic_tac_toe_fullscreen_page.dart
+++ b/lib/src/modules/tic_tac_toe/ui/tic_tac_toe_fullscreen_page.dart
@@ -1,0 +1,113 @@
+import 'package:flutter/material.dart';
+import 'package:signals_flutter/signals_flutter.dart';
+
+import '../tic_tac_toe_controller.dart';
+import '../tic_tac_toe_state.dart';
+import 'tic_tac_toe_cell.dart';
+import 'tic_tac_toe_controls.dart';
+
+class TicTacToeFullscreenPage extends StatelessWidget {
+  const TicTacToeFullscreenPage({required this.controller, super.key});
+
+  final TicTacToeController controller;
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      body: SafeArea(
+        child: Watch((_) {
+          final render = controller.boardRender.value;
+          final s = controller.state.value;
+          if (render == null) {
+            WidgetsBinding.instance.addPostFrameCallback((_) {
+              if (Navigator.of(context).canPop()) {
+                Navigator.of(context).pop();
+              }
+            });
+            return const SizedBox.shrink();
+          }
+          return Stack(
+            children: [
+              Center(
+                child: Column(
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    for (int r = 0; r < 3; r++)
+                      Row(
+                        mainAxisSize: MainAxisSize.min,
+                        children: [
+                          for (int c = 0; c < 3; c++)
+                            TicTacToeCell(
+                              key: Key('fs-cell-$r-$c'),
+                              render: render.cells[r][c],
+                              enabled: !render.inFlight &&
+                                  render.winner == null &&
+                                  render.cells[r][c].mark == null,
+                              onTap: () => controller.clickCell(r, c),
+                            ),
+                        ],
+                      ),
+                    const SizedBox(height: 16),
+                    TicTacToeControls(
+                      render: render,
+                      autoSend: s.autoSend,
+                      lastError: s.lastError,
+                      onSend: controller.send,
+                      onCancel: controller.cancel,
+                      onUndo: controller.clickUndo,
+                      onRedo: controller.clickRedo,
+                      onToggleAutoSend: controller.toggleAutoSend,
+                      onToggleFullscreen: () =>
+                          controller.setViewMode(TicTacToeViewMode.inline),
+                      onRetry: controller.send,
+                    ),
+                  ],
+                ),
+              ),
+              Positioned(
+                top: 8,
+                right: 8,
+                child: Badge(
+                  isLabelVisible: s.unreadChatWhileFullscreen > 0,
+                  label: Text('${s.unreadChatWhileFullscreen}'),
+                  child: IconButton(
+                    icon: const Icon(Icons.fullscreen_exit),
+                    onPressed: () =>
+                        controller.setViewMode(TicTacToeViewMode.inline),
+                  ),
+                ),
+              ),
+              if (s.bannerVisible)
+                Positioned(
+                  top: 0,
+                  left: 0,
+                  right: 0,
+                  child: Material(
+                    color: Theme.of(context).colorScheme.secondaryContainer,
+                    child: Padding(
+                      padding: const EdgeInsets.all(12),
+                      child: Row(
+                        children: [
+                          Expanded(
+                            child: Text(
+                              '${s.unreadChatWhileFullscreen} new chat '
+                              'message(s)',
+                              textAlign: TextAlign.center,
+                            ),
+                          ),
+                          IconButton(
+                            icon: const Icon(Icons.close),
+                            onPressed: controller.dismissBanner,
+                          ),
+                        ],
+                      ),
+                    ),
+                  ),
+                ),
+            ],
+          );
+        }),
+      ),
+    );
+  }
+}

--- a/lib/src/modules/tic_tac_toe/ui/tic_tac_toe_fullscreen_page.dart
+++ b/lib/src/modules/tic_tac_toe/ui/tic_tac_toe_fullscreen_page.dart
@@ -42,7 +42,7 @@ class TicTacToeFullscreenPage extends StatelessWidget {
                               render: render.cells[r][c],
                               enabled: !render.inFlight &&
                                   render.winner == null &&
-                                  render.cells[r][c].mark == null,
+                                  render.cells[r][c].serverMark == null,
                               onTap: () => controller.clickCell(r, c),
                             ),
                         ],
@@ -52,6 +52,8 @@ class TicTacToeFullscreenPage extends StatelessWidget {
                       render: render,
                       autoSend: s.autoSend,
                       lastError: s.lastError,
+                      isFullscreen: true,
+                      unreadCount: s.unreadChatWhileFullscreen,
                       onSend: controller.send,
                       onCancel: controller.cancel,
                       onUndo: controller.clickUndo,
@@ -62,19 +64,6 @@ class TicTacToeFullscreenPage extends StatelessWidget {
                       onRetry: controller.send,
                     ),
                   ],
-                ),
-              ),
-              Positioned(
-                top: 8,
-                right: 8,
-                child: Badge(
-                  isLabelVisible: s.unreadChatWhileFullscreen > 0,
-                  label: Text('${s.unreadChatWhileFullscreen}'),
-                  child: IconButton(
-                    icon: const Icon(Icons.fullscreen_exit),
-                    onPressed: () =>
-                        controller.setViewMode(TicTacToeViewMode.inline),
-                  ),
                 ),
               ),
               if (s.bannerVisible)

--- a/lib/src/modules/tic_tac_toe/ui/tic_tac_toe_toolbar_button.dart
+++ b/lib/src/modules/tic_tac_toe/ui/tic_tac_toe_toolbar_button.dart
@@ -1,7 +1,47 @@
-import 'package:flutter/widgets.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:signals_flutter/signals_flutter.dart';
 
-class TicTacToeToolbarButton extends StatelessWidget {
+import '../../room/room_providers.dart';
+import '../tic_tac_toe_controller.dart';
+import '../tic_tac_toe_providers.dart';
+import '../tic_tac_toe_state.dart';
+
+class TicTacToeToolbarButton extends ConsumerWidget {
   const TicTacToeToolbarButton({super.key});
+
   @override
-  Widget build(BuildContext context) => const SizedBox.shrink();
+  Widget build(BuildContext context, WidgetRef ref) {
+    final active = ref.watch(roomActiveThreadProvider);
+    if (active == null) return const SizedBox.shrink();
+    final registry = ref.watch(tictactoeRegistryProvider);
+    final runRegistry = ref.watch(runRegistryProvider);
+    final controller = registry.controllerFor(
+      active.threadKey,
+      () => TicTacToeController(
+        threadKey: active.threadKey,
+        runtime: active.runtime,
+        runRegistry: runRegistry,
+      ),
+    );
+    return Watch((_) {
+      final render = controller.boardRender.value;
+      return IconButton(
+        tooltip: render == null ? 'Play tic-tac-toe' : 'Toggle board',
+        icon: const Icon(Icons.grid_3x3),
+        onPressed: () {
+          if (render == null) {
+            controller.newGame();
+            return;
+          }
+          final s = controller.state.value;
+          controller.setViewMode(
+            s.viewMode == TicTacToeViewMode.hidden
+                ? TicTacToeViewMode.inline
+                : TicTacToeViewMode.hidden,
+          );
+        },
+      );
+    });
+  }
 }

--- a/lib/src/modules/tic_tac_toe/ui/tic_tac_toe_toolbar_button.dart
+++ b/lib/src/modules/tic_tac_toe/ui/tic_tac_toe_toolbar_button.dart
@@ -4,6 +4,7 @@ import 'package:signals_flutter/signals_flutter.dart';
 
 import '../../room/room_providers.dart';
 import '../tic_tac_toe_controller.dart';
+import '../tic_tac_toe_intent.dart';
 import '../tic_tac_toe_providers.dart';
 import '../tic_tac_toe_state.dart';
 
@@ -13,7 +14,24 @@ class TicTacToeToolbarButton extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final active = ref.watch(roomActiveThreadProvider);
-    if (active == null) return const SizedBox.shrink();
+    if (active == null) {
+      final spawn = ref.watch(roomSpawnNewThreadProvider);
+      if (spawn == null) return const SizedBox.shrink();
+      return IconButton(
+        tooltip: 'Play tic-tac-toe',
+        icon: const Icon(Icons.grid_3x3),
+        onPressed: () => spawn(
+          prompt: 'Start a new game.',
+          stateOverlay: {
+            '_inbox': {
+              TicTacToeIntent.surfaceKey: {
+                TicTacToeIntent.intentKey: TicTacToeIntent.newGame,
+              },
+            },
+          },
+        ),
+      );
+    }
     final registry = ref.watch(tictactoeRegistryProvider);
     final runRegistry = ref.watch(runRegistryProvider);
     final controller = registry.controllerFor(

--- a/lib/src/modules/tic_tac_toe/ui/tic_tac_toe_toolbar_button.dart
+++ b/lib/src/modules/tic_tac_toe/ui/tic_tac_toe_toolbar_button.dart
@@ -1,0 +1,7 @@
+import 'package:flutter/widgets.dart';
+
+class TicTacToeToolbarButton extends StatelessWidget {
+  const TicTacToeToolbarButton({super.key});
+  @override
+  Widget build(BuildContext context) => const SizedBox.shrink();
+}

--- a/packages/soliplex_agent/lib/src/orchestration/run_orchestrator.dart
+++ b/packages/soliplex_agent/lib/src/orchestration/run_orchestrator.dart
@@ -559,7 +559,18 @@ class RunOrchestrator {
       user: ChatUser.user,
       text: userMessage,
     );
-    final baseState = cachedHistory?.aguiState ?? const {};
+    // Strip wire-only keys from the cached state before replaying it.
+    // `_inbox` is the established convention for per-run intent payloads
+    // (e.g. tic-tac-toe surface); the server consumes it inside the
+    // run and never echoes it back via state deltas, so the bus never
+    // carries it. Replaying a stale `_inbox` from cachedHistory would
+    // re-issue the previous run's intent against the current state —
+    // e.g. "play (1,1)" on an already-finished game, which the agent
+    // rightly rejects. Treat it as transient.
+    final cachedAgui = cachedHistory?.aguiState ?? const <String, dynamic>{};
+    final baseState = cachedAgui.containsKey('_inbox')
+        ? (Map<String, dynamic>.of(cachedAgui)..remove('_inbox'))
+        : cachedAgui;
     final aguiState =
         stateOverlay == null ? baseState : _mergeState(baseState, stateOverlay);
     _preRunAguiState = aguiState;

--- a/packages/soliplex_agent/test/orchestration/run_orchestrator_test.dart
+++ b/packages/soliplex_agent/test/orchestration/run_orchestrator_test.dart
@@ -471,6 +471,43 @@ void main() {
       expect(completed.conversation.aguiState, containsPair('key', 'value'));
     });
 
+    test('strips wire-only `_inbox` key from cachedHistory before merge',
+        () async {
+      // `_inbox` is a per-run wire convention used by surfaces (e.g.
+      // tic-tac-toe) to signal intents to the agent. The server consumes
+      // it and never echoes it back via state deltas, so the bus never
+      // carries it. Replaying a stale `_inbox` from cachedHistory would
+      // re-issue the previous run's intent against the new state — a
+      // real bug that surfaced as "game already finished" when the user
+      // sent a chat message after the tic-tac-toe game ended.
+      stubCreateRun();
+      stubRunAgent(stream: Stream.fromIterable(_happyPathEvents()));
+
+      final history = ThreadHistory(
+        messages: const [],
+        aguiState: const {
+          '_inbox': {
+            'tic_tac_toe': {
+              'intent': 'play',
+              'move': {'row': 0, 'col': 0},
+            },
+          },
+          'game': {'winner': 'draw'},
+        },
+      );
+
+      await orchestrator.startRun(
+        key: _key,
+        userMessage: 'just chatting now',
+        cachedHistory: history,
+      );
+      await Future<void>.delayed(Duration.zero);
+
+      final completed = orchestrator.currentState as CompletedState;
+      expect(completed.conversation.aguiState.containsKey('_inbox'), isFalse);
+      expect(completed.conversation.aguiState, containsPair('game', anything));
+    });
+
     test('cachedHistory works with runToCompletion', () async {
       stubCreateRun();
       stubRunAgent(stream: Stream.fromIterable(_happyPathEvents()));

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -562,7 +562,7 @@ packages:
     source: hosted
     version: "0.11.1"
   meta:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: meta
       sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -28,6 +28,7 @@ dependencies:
   flutter_svg: ^2.0.17
   go_router: ^17.2.0
   markdown: ^7.0.0
+  meta: ^1.16.0
   shared_preferences: ^2.5.5
   signals_flutter: ^6.3.0
   file_picker: ^11.0.0

--- a/test/modules/room/room_providers_test.dart
+++ b/test/modules/room/room_providers_test.dart
@@ -1,0 +1,32 @@
+import 'package:flutter/widgets.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:soliplex_frontend/src/modules/room/room_providers.dart';
+
+void main() {
+  test('roomAboveChatInputBuildersProvider defaults to const empty', () {
+    final container = ProviderContainer();
+    addTearDown(container.dispose);
+    final builders = container.read(roomAboveChatInputBuildersProvider);
+    expect(builders, isEmpty);
+  });
+
+  test('roomChatInputToolbarBuildersProvider defaults to const empty', () {
+    final container = ProviderContainer();
+    addTearDown(container.dispose);
+    final builders = container.read(roomChatInputToolbarBuildersProvider);
+    expect(builders, isEmpty);
+  });
+
+  test('slot providers are overridable', () {
+    final container = ProviderContainer(
+      overrides: [
+        roomAboveChatInputBuildersProvider.overrideWithValue([
+          (_) => const SizedBox.shrink(),
+        ]),
+      ],
+    );
+    addTearDown(container.dispose);
+    expect(container.read(roomAboveChatInputBuildersProvider), hasLength(1));
+  });
+}

--- a/test/modules/room/ui/room_screen_test.dart
+++ b/test/modules/room/ui/room_screen_test.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:go_router/go_router.dart';
 import 'package:soliplex_agent/soliplex_agent.dart';
@@ -72,7 +73,9 @@ Widget _buildRouted({
       ),
     ],
   );
-  return MaterialApp.router(routerConfig: router);
+  return ProviderScope(
+    child: MaterialApp.router(routerConfig: router),
+  );
 }
 
 void main() {
@@ -117,7 +120,8 @@ void main() {
     tester.view.devicePixelRatio = 1.0;
     addTearDown(tester.view.resetPhysicalSize);
 
-    await tester.pumpWidget(MaterialApp(
+    await tester.pumpWidget(ProviderScope(
+        child: MaterialApp(
       home: RoomScreen(
         serverEntry: entry,
         roomId: 'room-1',
@@ -127,7 +131,7 @@ void main() {
         uploadRegistry: uploadRegistry,
         documentSelections: DocumentSelections(),
       ),
-    ));
+    )));
     await tester.pumpAndSettle();
 
     expect(find.text('Test thread'), findsOneWidget);
@@ -138,7 +142,8 @@ void main() {
     tester.view.devicePixelRatio = 1.0;
     addTearDown(tester.view.resetPhysicalSize);
 
-    await tester.pumpWidget(MaterialApp(
+    await tester.pumpWidget(ProviderScope(
+        child: MaterialApp(
       home: RoomScreen(
         serverEntry: entry,
         roomId: 'room-1',
@@ -148,7 +153,7 @@ void main() {
         uploadRegistry: uploadRegistry,
         documentSelections: DocumentSelections(),
       ),
-    ));
+    )));
     await tester.pump();
 
     expect(find.byType(AppBar), findsOneWidget);
@@ -162,7 +167,8 @@ void main() {
     tester.view.devicePixelRatio = 1.0;
     addTearDown(tester.view.resetPhysicalSize);
 
-    await tester.pumpWidget(MaterialApp(
+    await tester.pumpWidget(ProviderScope(
+        child: MaterialApp(
       home: RoomScreen(
         serverEntry: entry,
         roomId: 'room-1',
@@ -172,7 +178,7 @@ void main() {
         uploadRegistry: uploadRegistry,
         documentSelections: DocumentSelections(),
       ),
-    ));
+    )));
     await tester.pumpAndSettle();
 
     expect(find.byType(Drawer), findsNothing);
@@ -196,7 +202,8 @@ void main() {
     tester.view.devicePixelRatio = 1.0;
     addTearDown(tester.view.resetPhysicalSize);
 
-    await tester.pumpWidget(MaterialApp(
+    await tester.pumpWidget(ProviderScope(
+        child: MaterialApp(
       home: RoomScreen(
         serverEntry: entry,
         roomId: 'room-1',
@@ -206,7 +213,7 @@ void main() {
         uploadRegistry: uploadRegistry,
         documentSelections: DocumentSelections(),
       ),
-    ));
+    )));
     await tester.pumpAndSettle();
 
     await tester.tap(find.byIcon(Icons.menu));
@@ -240,7 +247,8 @@ void main() {
     tester.view.devicePixelRatio = 1.0;
     addTearDown(tester.view.resetPhysicalSize);
 
-    await tester.pumpWidget(MaterialApp(
+    await tester.pumpWidget(ProviderScope(
+        child: MaterialApp(
       home: RoomScreen(
         serverEntry: entry,
         roomId: 'room-1',
@@ -250,7 +258,7 @@ void main() {
         uploadRegistry: uploadRegistry,
         documentSelections: DocumentSelections(),
       ),
-    ));
+    )));
     await tester.pumpAndSettle();
 
     final key = (
@@ -281,7 +289,8 @@ void main() {
     api.nextThreads = const [];
     api.nextRoom = Room(id: 'room-1', name: 'My Room');
 
-    await tester.pumpWidget(MaterialApp(
+    await tester.pumpWidget(ProviderScope(
+        child: MaterialApp(
       home: RoomScreen(
         serverEntry: entry,
         roomId: 'room-1',
@@ -291,7 +300,7 @@ void main() {
         uploadRegistry: uploadRegistry,
         documentSelections: DocumentSelections(),
       ),
-    ));
+    )));
     await tester.pumpAndSettle();
 
     expect(find.text('Select a thread'), findsOneWidget);
@@ -305,7 +314,8 @@ void main() {
     api.nextThreads = const [];
     api.nextCreateThreadError = Exception('network error');
 
-    await tester.pumpWidget(MaterialApp(
+    await tester.pumpWidget(ProviderScope(
+        child: MaterialApp(
       home: RoomScreen(
         serverEntry: entry,
         roomId: 'room-1',
@@ -315,7 +325,7 @@ void main() {
         uploadRegistry: uploadRegistry,
         documentSelections: DocumentSelections(),
       ),
-    ));
+    )));
     await tester.pumpAndSettle();
 
     await tester.tap(find.text('New Thread'));
@@ -350,7 +360,8 @@ void main() {
     blockingApi.nextThreadHistory = ThreadHistory(messages: const []);
     final blockingEntry = createTestServerEntry(api: blockingApi);
 
-    await tester.pumpWidget(MaterialApp(
+    await tester.pumpWidget(ProviderScope(
+        child: MaterialApp(
       home: RoomScreen(
         serverEntry: blockingEntry,
         roomId: 'room-1',
@@ -360,7 +371,7 @@ void main() {
         uploadRegistry: uploadRegistry,
         documentSelections: DocumentSelections(),
       ),
-    ));
+    )));
     await tester.pump();
 
     expect(find.byType(CircularProgressIndicator), findsOneWidget);
@@ -383,7 +394,8 @@ void main() {
     // nextRoomUploads / nextThreadUploads default to empty → the chip
     // must not render when both scopes are Loaded([]).
 
-    await tester.pumpWidget(MaterialApp(
+    await tester.pumpWidget(ProviderScope(
+        child: MaterialApp(
       home: RoomScreen(
         serverEntry: entry,
         roomId: 'room-1',
@@ -393,7 +405,7 @@ void main() {
         uploadRegistry: uploadRegistry,
         documentSelections: DocumentSelections(),
       ),
-    ));
+    )));
     await tester.pumpAndSettle();
 
     // The chip always renders an expand_more/less icon; its absence
@@ -422,7 +434,8 @@ void main() {
       ),
     ];
 
-    await tester.pumpWidget(MaterialApp(
+    await tester.pumpWidget(ProviderScope(
+        child: MaterialApp(
       home: RoomScreen(
         serverEntry: entry,
         roomId: 'room-1',
@@ -432,7 +445,7 @@ void main() {
         uploadRegistry: uploadRegistry,
         documentSelections: DocumentSelections(),
       ),
-    ));
+    )));
     await tester.pumpAndSettle();
 
     // Tap the chip to expand the file panel.
@@ -463,7 +476,8 @@ void main() {
       ),
     ];
 
-    await tester.pumpWidget(MaterialApp(
+    await tester.pumpWidget(ProviderScope(
+        child: MaterialApp(
       home: RoomScreen(
         serverEntry: entry,
         roomId: 'room-1',
@@ -473,7 +487,7 @@ void main() {
         uploadRegistry: uploadRegistry,
         documentSelections: DocumentSelections(),
       ),
-    ));
+    )));
     await tester.pumpAndSettle();
 
     expect(find.byIcon(Icons.expand_more), findsOneWidget);
@@ -495,7 +509,8 @@ void main() {
     api.nextRoomUploadsError =
         const ApiException(statusCode: 500, message: 'boom');
 
-    await tester.pumpWidget(MaterialApp(
+    await tester.pumpWidget(ProviderScope(
+        child: MaterialApp(
       home: RoomScreen(
         serverEntry: entry,
         roomId: 'room-1',
@@ -505,7 +520,7 @@ void main() {
         uploadRegistry: uploadRegistry,
         documentSelections: DocumentSelections(),
       ),
-    ));
+    )));
     await tester.pumpAndSettle();
 
     // The chip leading icon should be error_outline (not the attach
@@ -526,7 +541,8 @@ void main() {
     ];
     final blockingEntry = createTestServerEntry(api: blockingApi);
 
-    await tester.pumpWidget(MaterialApp(
+    await tester.pumpWidget(ProviderScope(
+        child: MaterialApp(
       home: RoomScreen(
         serverEntry: blockingEntry,
         roomId: 'room-1',
@@ -536,7 +552,7 @@ void main() {
         uploadRegistry: uploadRegistry,
         documentSelections: DocumentSelections(),
       ),
-    ));
+    )));
     await tester.pump();
 
     final textField = tester.widget<TextField>(find.byType(TextField));

--- a/test/modules/tic_tac_toe/board_render_state_test.dart
+++ b/test/modules/tic_tac_toe/board_render_state_test.dart
@@ -1,0 +1,71 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:soliplex_frontend/src/modules/tic_tac_toe/board_render_state.dart';
+import 'package:soliplex_frontend/src/modules/tic_tac_toe/tic_tac_toe_server_state.dart';
+import 'package:soliplex_frontend/src/modules/tic_tac_toe/tic_tac_toe_state.dart';
+
+void main() {
+  TicTacToeServerState emptyServer({
+    TicTacToeOutcome? winner,
+    List<Cell>? winningLine,
+    TicTacToePlayer turn = TicTacToePlayer.user,
+  }) =>
+      TicTacToeServerState(
+        id: 'g1',
+        board: List.generate(3, (_) => List.filled(3, null)),
+        moves: const [],
+        turn: turn,
+        winner: winner,
+        winningLine: winningLine,
+      );
+
+  test('returns null when server state is null', () {
+    final r = BoardRenderState.compose(
+      server: null,
+      client: const TicTacToeClientState(),
+    );
+    expect(r, isNull);
+  });
+
+  test('compositing applies pending overlay', () {
+    final r = BoardRenderState.compose(
+      server: emptyServer(),
+      client: const TicTacToeClientState(pending: Cell(1, 1)),
+    )!;
+    expect(r.cells[1][1].mark, 'X');
+    expect(r.cells[1][1].isPending, isTrue);
+  });
+
+  test('canSend false when winner != null', () {
+    final r = BoardRenderState.compose(
+      server: emptyServer(winner: TicTacToeOutcome.user),
+      client: const TicTacToeClientState(pending: Cell(1, 1)),
+    )!;
+    expect(r.canSend, isFalse);
+  });
+
+  test('canCancel iff inFlight', () {
+    final ready = BoardRenderState.compose(
+      server: emptyServer(),
+      client: const TicTacToeClientState(),
+    )!;
+    expect(ready.canCancel, isFalse);
+    final inflight = BoardRenderState.compose(
+      server: emptyServer(),
+      client: const TicTacToeClientState(inFlight: true),
+    )!;
+    expect(inflight.canCancel, isTrue);
+  });
+
+  test('winning cells flagged', () {
+    final r = BoardRenderState.compose(
+      server: emptyServer(
+        winner: TicTacToeOutcome.user,
+        winningLine: const [Cell(0, 0), Cell(1, 1), Cell(2, 2)],
+      ),
+      client: const TicTacToeClientState(),
+    )!;
+    expect(r.cells[0][0].isWinning, isTrue);
+    expect(r.cells[1][1].isWinning, isTrue);
+    expect(r.cells[0][1].isWinning, isFalse);
+  });
+}

--- a/test/modules/tic_tac_toe/fakes.dart
+++ b/test/modules/tic_tac_toe/fakes.dart
@@ -1,0 +1,49 @@
+import 'dart:async';
+
+import 'package:soliplex_agent/soliplex_agent.dart';
+
+/// Minimal AgentSession stub for controller tests. `awaitResult` blocks
+/// until [completeSuccess] or [cancel]. `cancel` completes with an
+/// AgentFailure (the sealed AgentResult does not include AgentCancelled
+/// as a subtype here — failures cover the cancel/error branches the
+/// controller cares about).
+class FakeAgentSession implements AgentSession {
+  final Completer<AgentResult> _completer = Completer<AgentResult>();
+
+  void completeSuccess() {
+    if (_completer.isCompleted) return;
+    _completer.complete(
+      const AgentSuccess(
+        runId: 'fake-run',
+        threadKey: (
+          serverId: 's',
+          roomId: 'r',
+          threadId: 't',
+        ),
+        output: '',
+      ),
+    );
+  }
+
+  @override
+  Future<AgentResult> awaitResult({Duration? timeout}) => _completer.future;
+
+  @override
+  void cancel() {
+    if (_completer.isCompleted) return;
+    _completer.complete(
+      const AgentFailure(
+        reason: FailureReason.cancelled,
+        error: 'Session cancelled',
+        threadKey: (
+          serverId: 's',
+          roomId: 'r',
+          threadId: 't',
+        ),
+      ),
+    );
+  }
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}

--- a/test/modules/tic_tac_toe/fakes.dart
+++ b/test/modules/tic_tac_toe/fakes.dart
@@ -47,3 +47,17 @@ class FakeAgentSession implements AgentSession {
   @override
   dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
 }
+
+/// Minimal AgentRuntime stub for registry tests.
+class FakeAgentRuntime implements AgentRuntime {
+  FakeAgentRuntime() : threadState = ThreadState();
+  final ThreadState threadState;
+  StateBus get bus => threadState.bus;
+
+  @override
+  dynamic noSuchMethod(Invocation i) {
+    if (i.memberName == #ensureThreadState) return threadState;
+    if (i.memberName == #spawn) return Future.value(FakeAgentSession());
+    return super.noSuchMethod(i);
+  }
+}

--- a/test/modules/tic_tac_toe/integration/round_trip_test.dart
+++ b/test/modules/tic_tac_toe/integration/round_trip_test.dart
@@ -147,7 +147,7 @@ void main() {
       expect(runtime.lastOverlay, isNotNull);
       expect(runtime.lastRoomId, 'r');
       expect(runtime.lastThreadId, 't');
-      expect(runtime.lastPrompt, '');
+      expect(runtime.lastPrompt, 'Play (1, 1).');
     },
   );
 }

--- a/test/modules/tic_tac_toe/integration/round_trip_test.dart
+++ b/test/modules/tic_tac_toe/integration/round_trip_test.dart
@@ -1,0 +1,153 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:soliplex_agent/soliplex_agent.dart';
+import 'package:soliplex_frontend/src/modules/room/room_providers.dart';
+import 'package:soliplex_frontend/src/modules/room/run_registry.dart';
+import 'package:soliplex_frontend/src/modules/tic_tac_toe/tic_tac_toe_module.dart';
+import 'package:soliplex_frontend/src/modules/tic_tac_toe/ui/tic_tac_toe_board.dart';
+
+class _FakeRuntime implements AgentRuntime {
+  _FakeRuntime() : threadState = ThreadState();
+
+  final ThreadState threadState;
+  StateBus get bus => threadState.bus;
+
+  Map<String, dynamic>? lastOverlay;
+  String? lastRoomId;
+  String? lastThreadId;
+  String? lastPrompt;
+
+  @override
+  Future<AgentSession> spawn({
+    required String roomId,
+    required String prompt,
+    String? threadId,
+    Duration? timeout,
+    bool ephemeral = false,
+    bool autoDispose = false,
+    AgentSession? parent,
+    Map<String, dynamic>? stateOverlay,
+  }) async {
+    lastRoomId = roomId;
+    lastThreadId = threadId;
+    lastPrompt = prompt;
+    lastOverlay = stateOverlay;
+
+    final inbox = (stateOverlay!['_inbox']
+        as Map<String, dynamic>)['tic_tac_toe'] as Map<String, dynamic>;
+    if (inbox['intent'] == 'play') {
+      final move = inbox['move'] as Map<String, dynamic>;
+      final ur = move['row'] as int;
+      final uc = move['col'] as int;
+      bus.setAgentState({
+        'game': {
+          'id': 'g1',
+          'board': [
+            for (int r = 0; r < 3; r++)
+              [
+                for (int c = 0; c < 3; c++)
+                  if (r == ur && c == uc)
+                    'X'
+                  else if (r == 2 && c == 2)
+                    'O'
+                  else
+                    null,
+              ],
+          ],
+          'moves': [
+            {'player': 'user', 'row': ur, 'col': uc, 'mark': 'X'},
+            {'player': 'agent', 'row': 2, 'col': 2, 'mark': 'O'},
+          ],
+          'turn': 'user',
+          'winner': null,
+          'winning_line': null,
+        },
+      });
+    }
+    return _StubSession();
+  }
+
+  @override
+  dynamic noSuchMethod(Invocation i) {
+    if (i.memberName == #ensureThreadState) return threadState;
+    return super.noSuchMethod(i);
+  }
+}
+
+class _StubSession implements AgentSession {
+  @override
+  Future<AgentResult> awaitResult({Duration? timeout}) async =>
+      const AgentSuccess(
+        runId: 'fake-run',
+        threadKey: (serverId: 's', roomId: 'r', threadId: 't'),
+        output: '',
+      );
+
+  @override
+  void cancel() {}
+
+  @override
+  dynamic noSuchMethod(Invocation i) => super.noSuchMethod(i);
+}
+
+void main() {
+  testWidgets(
+    'binding round-trip: tap, server delta, board renders both moves',
+    (tester) async {
+      final runtime = _FakeRuntime();
+      runtime.bus.setAgentState({
+        'game': {
+          'id': 'g1',
+          'board': [
+            [null, null, null],
+            [null, null, null],
+            [null, null, null],
+          ],
+          'moves': <dynamic>[],
+          'turn': 'user',
+          'winner': null,
+          'winning_line': null,
+        },
+      });
+
+      final mod = TicTacToeAppModule();
+      final routes = mod.build();
+      addTearDown(mod.onDispose);
+
+      final runRegistry = RunRegistry();
+      addTearDown(runRegistry.dispose);
+
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [
+            ...routes.overrides,
+            runRegistryProvider.overrideWithValue(runRegistry),
+            roomActiveThreadProvider.overrideWithValue(
+              (
+                threadKey: (serverId: 's', roomId: 'r', threadId: 't'),
+                runtime: runtime,
+              ),
+            ),
+          ],
+          child: const MaterialApp(
+            home: Scaffold(body: TicTacToeBoard()),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.byKey(const Key('cell-1-1')));
+      await tester.pump();
+      await tester.tap(find.widgetWithText(ElevatedButton, 'Send'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('X'), findsOneWidget);
+      expect(find.text('O'), findsOneWidget);
+      expect(runtime.lastOverlay, isNotNull);
+      expect(runtime.lastRoomId, 'r');
+      expect(runtime.lastThreadId, 't');
+      expect(runtime.lastPrompt, '');
+    },
+  );
+}

--- a/test/modules/tic_tac_toe/tic_tac_toe_controller_test.dart
+++ b/test/modules/tic_tac_toe/tic_tac_toe_controller_test.dart
@@ -1,0 +1,349 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:soliplex_agent/soliplex_agent.dart';
+import 'package:soliplex_frontend/src/modules/tic_tac_toe/tic_tac_toe_controller.dart';
+import 'package:soliplex_frontend/src/modules/tic_tac_toe/tic_tac_toe_state.dart';
+
+import 'fakes.dart';
+
+class _FakeRuntime implements AgentRuntime {
+  final ThreadState threadState = ThreadState();
+  StateBus get bus => threadState.bus;
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) {
+    if (invocation.memberName == #ensureThreadState) {
+      return threadState;
+    }
+    if (invocation.memberName == #spawn) {
+      return Future.value(FakeAgentSession());
+    }
+    return super.noSuchMethod(invocation);
+  }
+}
+
+class _RecordingRuntime implements AgentRuntime {
+  _RecordingRuntime() : threadState = ThreadState();
+  final ThreadState threadState;
+  StateBus get bus => threadState.bus;
+  Map<String, dynamic>? lastStateOverlay;
+  String? lastRoomId;
+  String? lastThreadId;
+  String? lastPrompt;
+  late AgentSession sessionToReturn;
+
+  @override
+  Future<AgentSession> spawn({
+    required String roomId,
+    required String prompt,
+    String? threadId,
+    Duration? timeout,
+    bool ephemeral = false,
+    bool autoDispose = false,
+    AgentSession? parent,
+    Map<String, dynamic>? stateOverlay,
+  }) async {
+    lastRoomId = roomId;
+    lastThreadId = threadId;
+    lastPrompt = prompt;
+    lastStateOverlay = stateOverlay;
+    return sessionToReturn;
+  }
+
+  @override
+  dynamic noSuchMethod(Invocation i) {
+    if (i.memberName == #ensureThreadState) {
+      return threadState;
+    }
+    return super.noSuchMethod(i);
+  }
+}
+
+void main() {
+  late _FakeRuntime runtime;
+  late TicTacToeController controller;
+
+  setUp(() {
+    runtime = _FakeRuntime();
+    runtime.bus.setAgentState({
+      'game': {
+        'id': 'g1',
+        'board': List.generate(3, (_) => List.filled(3, null)),
+        'moves': <dynamic>[],
+        'turn': 'user',
+        'winner': null,
+        'winning_line': null,
+      },
+    });
+    controller = TicTacToeController(
+      threadKey: (serverId: 's', roomId: 'r', threadId: 't'),
+      runtime: runtime,
+    );
+  });
+
+  tearDown(() => controller.dispose());
+
+  test('clickCell stages pending', () {
+    controller.clickCell(1, 1);
+    expect(controller.state.value.pending, const Cell(1, 1));
+  });
+
+  test('clickCell on staged cell unstages (toggle)', () {
+    controller.clickCell(1, 1);
+    controller.clickCell(1, 1);
+    expect(controller.state.value.pending, isNull);
+  });
+
+  test('clickCell on different cell replaces pending', () {
+    controller.clickCell(1, 1);
+    controller.clickCell(2, 2);
+    expect(controller.state.value.pending, const Cell(2, 2));
+  });
+
+  test('clickCell ignored when game is null', () {
+    runtime.bus.setAgentState({});
+    controller.clickCell(0, 0);
+    expect(controller.state.value.pending, isNull);
+  });
+
+  test('clickCell ignored when cell occupied', () {
+    runtime.bus.setAgentState({
+      'game': {
+        'id': 'g1',
+        'board': [
+          ['X', null, null],
+          [null, null, null],
+          [null, null, null],
+        ],
+        'moves': <dynamic>[],
+        'turn': 'user',
+        'winner': null,
+        'winning_line': null,
+      },
+    });
+    controller.clickCell(0, 0);
+    expect(controller.state.value.pending, isNull);
+  });
+
+  test('clickUndo with pending clears pending only (no server)', () {
+    controller.clickCell(1, 1);
+    controller.clickUndo();
+    expect(controller.state.value.pending, isNull);
+    expect(controller.state.value.redoStack, isEmpty);
+  });
+
+  group('committed undo / redo', () {
+    test('undo with no pending and last mover agent pops a turn-pair', () {
+      runtime.bus.setAgentState({
+        'game': {
+          'id': 'g1',
+          'board': [
+            ['X', null, null],
+            ['O', null, null],
+            [null, null, null],
+          ],
+          'moves': [
+            {'player': 'user', 'row': 0, 'col': 0, 'mark': 'X'},
+            {'player': 'agent', 'row': 1, 'col': 0, 'mark': 'O'},
+          ],
+          'turn': 'user',
+          'winner': null,
+          'winning_line': null,
+        },
+      });
+      controller.clickUndo();
+      expect(controller.state.value.redoStack, hasLength(1));
+      expect(controller.state.value.redoStack.first.user, const Cell(0, 0));
+      expect(controller.state.value.redoStack.first.agent, const Cell(1, 0));
+      expect(controller.lastDispatchedIntent, isNotNull);
+      expect(controller.lastDispatchedIntent!['intent'], 'undo');
+      expect(controller.lastDispatchedIntent!['target_index'], 0);
+    });
+
+    test('undo with no pending and last mover user pops only user move', () {
+      runtime.bus.setAgentState({
+        'game': {
+          'id': 'g1',
+          'board': [
+            ['X', null, null],
+            [null, null, null],
+            [null, null, null],
+          ],
+          'moves': [
+            {'player': 'user', 'row': 0, 'col': 0, 'mark': 'X'},
+          ],
+          'turn': 'agent',
+          'winner': null,
+          'winning_line': null,
+        },
+      });
+      controller.clickUndo();
+      expect(controller.state.value.redoStack, hasLength(1));
+      expect(controller.state.value.redoStack.first.user, const Cell(0, 0));
+      expect(controller.state.value.redoStack.first.agent, isNull);
+      expect(controller.lastDispatchedIntent!['target_index'], 0);
+    });
+
+    test('redo dispatches with TurnPair from stack', () {
+      controller.applyTestSeed(
+        const TicTacToeClientState(
+          redoStack: [TurnPair(user: Cell(0, 0), agent: Cell(1, 0))],
+        ),
+      );
+      controller.clickRedo();
+      expect(controller.state.value.redoStack, isEmpty);
+      expect(controller.lastDispatchedIntent!['intent'], 'redo');
+    });
+
+    test('redo disabled while pending non-null', () {
+      controller.applyTestSeed(
+        const TicTacToeClientState(
+          pending: Cell(0, 0),
+          redoStack: [TurnPair(user: Cell(0, 1))],
+        ),
+      );
+      controller.clickRedo();
+      // No dispatch.
+      expect(controller.lastDispatchedIntent, isNull);
+      // redoStack untouched.
+      expect(controller.state.value.redoStack, hasLength(1));
+    });
+  });
+
+  group('lifecycle helpers', () {
+    test('newGame dispatches new_game intent', () async {
+      final recording = _RecordingRuntime();
+      recording.bus.setAgentState(const {});
+      recording.sessionToReturn = FakeAgentSession();
+      final c = TicTacToeController(
+        threadKey: (serverId: 's', roomId: 'r', threadId: 't'),
+        runtime: recording,
+      );
+      addTearDown(c.dispose);
+      c.newGame();
+      await Future<void>.delayed(Duration.zero);
+      expect(
+        recording.lastStateOverlay!['_inbox']['tic_tac_toe']['intent'],
+        'new_game',
+      );
+    });
+
+    test('toggleAutoSend flips the flag', () {
+      expect(controller.state.value.autoSend, isFalse);
+      controller.toggleAutoSend();
+      expect(controller.state.value.autoSend, isTrue);
+      controller.toggleAutoSend();
+      expect(controller.state.value.autoSend, isFalse);
+    });
+
+    test('setViewMode updates state', () {
+      controller.setViewMode(TicTacToeViewMode.fullscreen);
+      expect(controller.state.value.viewMode, TicTacToeViewMode.fullscreen);
+    });
+
+    test('auto-promote: hidden -> inline on first server game state', () {
+      // Reset bus to empty BEFORE constructing a fresh controller so that
+      // the controller starts with no game and viewMode == hidden.
+      runtime.bus.setAgentState(const {});
+      controller.dispose();
+      controller = TicTacToeController(
+        threadKey: (serverId: 's', roomId: 'r', threadId: 't'),
+        runtime: runtime,
+      );
+      expect(controller.state.value.viewMode, TicTacToeViewMode.hidden);
+      runtime.bus.setAgentState({
+        'game': {
+          'id': 'g1',
+          'board': List.generate(3, (_) => List.filled(3, null)),
+          'moves': <dynamic>[],
+          'turn': 'user',
+          'winner': null,
+          'winning_line': null,
+        },
+      });
+      expect(controller.state.value.viewMode, TicTacToeViewMode.inline);
+    });
+
+    test('auto-promote does not demote fullscreen', () {
+      controller.setViewMode(TicTacToeViewMode.fullscreen);
+      runtime.bus.setAgentState(const {});
+      runtime.bus.setAgentState({
+        'game': {
+          'id': 'g1',
+          'board': List.generate(3, (_) => List.filled(3, null)),
+          'moves': <dynamic>[],
+          'turn': 'user',
+          'winner': null,
+          'winning_line': null,
+        },
+      });
+      expect(controller.state.value.viewMode, TicTacToeViewMode.fullscreen);
+    });
+  });
+
+  group('send', () {
+    test('calls runtime.spawn with _inbox stateOverlay; sets inFlight true',
+        () async {
+      final recording = _RecordingRuntime();
+      recording.bus.setAgentState({
+        'game': {
+          'id': 'g1',
+          'board': List.generate(3, (_) => List.filled(3, null)),
+          'moves': <dynamic>[],
+          'turn': 'user',
+          'winner': null,
+          'winning_line': null,
+        },
+      });
+      final fakeSession = FakeAgentSession();
+      recording.sessionToReturn = fakeSession;
+      final c = TicTacToeController(
+        threadKey: (serverId: 's', roomId: 'r', threadId: 't'),
+        runtime: recording,
+      );
+      addTearDown(c.dispose);
+      c.clickCell(1, 1);
+      expect(c.state.value.pending, isNotNull);
+      c.send();
+      // Synchronously: inFlight must already be true even though spawn is
+      // async.
+      expect(c.state.value.inFlight, isTrue);
+      // Wait for the async spawn to register.
+      await Future<void>.delayed(Duration.zero);
+      expect(recording.lastRoomId, 'r');
+      expect(recording.lastThreadId, 't');
+      expect(recording.lastPrompt, '');
+      expect(
+        recording.lastStateOverlay!['_inbox']['tic_tac_toe']['intent'],
+        'play',
+      );
+    });
+
+    test('clears redoStack on send', () {
+      final recording = _RecordingRuntime();
+      recording.bus.setAgentState({
+        'game': {
+          'id': 'g1',
+          'board': List.generate(3, (_) => List.filled(3, null)),
+          'moves': <dynamic>[],
+          'turn': 'user',
+          'winner': null,
+          'winning_line': null,
+        },
+      });
+      recording.sessionToReturn = FakeAgentSession();
+      final c = TicTacToeController(
+        threadKey: (serverId: 's', roomId: 'r', threadId: 't'),
+        runtime: recording,
+      );
+      addTearDown(c.dispose);
+      c.applyTestSeed(
+        const TicTacToeClientState(
+          pending: Cell(1, 1),
+          redoStack: [TurnPair(user: Cell(0, 0), agent: Cell(1, 0))],
+        ),
+      );
+      c.send();
+      expect(c.state.value.redoStack, isEmpty);
+    });
+  });
+}

--- a/test/modules/tic_tac_toe/tic_tac_toe_controller_test.dart
+++ b/test/modules/tic_tac_toe/tic_tac_toe_controller_test.dart
@@ -311,7 +311,7 @@ void main() {
       await Future<void>.delayed(Duration.zero);
       expect(recording.lastRoomId, 'r');
       expect(recording.lastThreadId, 't');
-      expect(recording.lastPrompt, '');
+      expect(recording.lastPrompt, 'Play (1, 1).');
       expect(
         recording.lastStateOverlay!['_inbox']['tic_tac_toe']['intent'],
         'play',

--- a/test/modules/tic_tac_toe/tic_tac_toe_module_test.dart
+++ b/test/modules/tic_tac_toe/tic_tac_toe_module_test.dart
@@ -1,0 +1,17 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:soliplex_frontend/src/modules/tic_tac_toe/tic_tac_toe_module.dart';
+
+void main() {
+  test('build returns overrides for registry + two slots', () {
+    final mod = TicTacToeAppModule();
+    final routes = mod.build();
+    expect(routes.routes, isEmpty);
+    expect(routes.overrides, hasLength(3));
+  });
+
+  test('onDispose disposes the registry', () async {
+    final mod = TicTacToeAppModule();
+    mod.build();
+    await mod.onDispose();
+  });
+}

--- a/test/modules/tic_tac_toe/tic_tac_toe_projection_test.dart
+++ b/test/modules/tic_tac_toe/tic_tac_toe_projection_test.dart
@@ -1,0 +1,97 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:soliplex_frontend/src/modules/tic_tac_toe/tic_tac_toe_projection.dart';
+import 'package:soliplex_frontend/src/modules/tic_tac_toe/tic_tac_toe_server_state.dart';
+import 'package:soliplex_frontend/src/modules/tic_tac_toe/tic_tac_toe_state.dart';
+
+void main() {
+  const projection = TicTacToeProjection();
+
+  test('returns null when game key is missing', () {
+    expect(projection.project(const {}), isNull);
+  });
+
+  test('returns null when game is malformed', () {
+    expect(projection.project(const {'game': 'bogus'}), isNull);
+  });
+
+  test('parses a valid game state', () {
+    final result = projection.project({
+      'game': {
+        'id': 'g1',
+        'board': [
+          ['X', null, null],
+          [null, 'O', null],
+          [null, null, null],
+        ],
+        'moves': [
+          {'player': 'user', 'row': 0, 'col': 0, 'mark': 'X'},
+          {'player': 'agent', 'row': 1, 'col': 1, 'mark': 'O'},
+        ],
+        'turn': 'user',
+        'winner': null,
+        'winning_line': null,
+      },
+    });
+    expect(result, isNotNull);
+    expect(result!.id, 'g1');
+    expect(result.turn, TicTacToePlayer.user);
+    expect(result.winner, isNull);
+    expect(result.moves, hasLength(2));
+  });
+
+  test('parses winning_line into List<Cell>', () {
+    final result = projection.project({
+      'game': {
+        'id': 'g1',
+        'board': [
+          ['X', 'X', 'X'],
+          [null, null, null],
+          [null, null, null],
+        ],
+        'moves': [],
+        'turn': 'user',
+        'winner': 'user',
+        'winning_line': [
+          {'row': 0, 'col': 0},
+          {'row': 0, 'col': 1},
+          {'row': 0, 'col': 2},
+        ],
+      },
+    });
+    expect(result?.winner, TicTacToeOutcome.user);
+    expect(result?.winningLine, [
+      const Cell(0, 0),
+      const Cell(0, 1),
+      const Cell(0, 2),
+    ]);
+  });
+
+  test('rebuild radius — equal projection inputs yield equal outputs', () {
+    // Projection MUST produce value-equal outputs so computed signals
+    // can short-circuit when an unrelated agentState change leaves
+    // the game slice untouched.
+    final input1 = {
+      'game': {
+        'id': 'g1',
+        'board': [
+          [null, null, null],
+          [null, null, null],
+          [null, null, null],
+        ],
+        'moves': <dynamic>[],
+        'turn': 'user',
+        'winner': null,
+        'winning_line': null,
+      },
+      'unrelated': 'value-A',
+    };
+    final input2 = {
+      ...input1,
+      'unrelated': 'value-B', // changed; game slice unchanged
+    };
+    final out1 = projection.project(input1);
+    final out2 = projection.project(input2);
+    expect(out1, equals(out2));
+    expect(out1.hashCode, out2.hashCode);
+  });
+}

--- a/test/modules/tic_tac_toe/tic_tac_toe_registry_test.dart
+++ b/test/modules/tic_tac_toe/tic_tac_toe_registry_test.dart
@@ -1,0 +1,70 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:soliplex_frontend/src/modules/tic_tac_toe/tic_tac_toe_controller.dart';
+import 'package:soliplex_frontend/src/modules/tic_tac_toe/tic_tac_toe_registry.dart';
+
+import 'fakes.dart';
+
+void main() {
+  test('controllerFor caches by ThreadKey', () {
+    final reg = TicTacToeRegistry();
+    final runtime = FakeAgentRuntime();
+    final c1 = reg.controllerFor(
+      (serverId: 's', roomId: 'r', threadId: 't'),
+      () => TicTacToeController(
+        threadKey: (serverId: 's', roomId: 'r', threadId: 't'),
+        runtime: runtime,
+      ),
+    );
+    final c2 = reg.controllerFor(
+      (serverId: 's', roomId: 'r', threadId: 't'),
+      () => fail('factory should not be invoked twice'),
+    );
+    expect(identical(c1, c2), isTrue);
+  });
+
+  test('disposeFor removes and disposes', () {
+    final reg = TicTacToeRegistry();
+    final runtime = FakeAgentRuntime();
+    reg.controllerFor(
+      (serverId: 's', roomId: 'r', threadId: 't'),
+      () => TicTacToeController(
+        threadKey: (serverId: 's', roomId: 'r', threadId: 't'),
+        runtime: runtime,
+      ),
+    );
+    reg.disposeFor((serverId: 's', roomId: 'r', threadId: 't'));
+    var factoryCalls = 0;
+    reg.controllerFor(
+      (serverId: 's', roomId: 'r', threadId: 't'),
+      () {
+        factoryCalls++;
+        return TicTacToeController(
+          threadKey: (serverId: 's', roomId: 'r', threadId: 't'),
+          runtime: runtime,
+        );
+      },
+    );
+    expect(factoryCalls, 1);
+  });
+
+  test('disposeAll clears all', () {
+    final reg = TicTacToeRegistry();
+    final runtime = FakeAgentRuntime();
+    reg.controllerFor(
+      (serverId: 's', roomId: 'r', threadId: 't1'),
+      () => TicTacToeController(
+        threadKey: (serverId: 's', roomId: 'r', threadId: 't1'),
+        runtime: runtime,
+      ),
+    );
+    reg.controllerFor(
+      (serverId: 's', roomId: 'r', threadId: 't2'),
+      () => TicTacToeController(
+        threadKey: (serverId: 's', roomId: 'r', threadId: 't2'),
+        runtime: runtime,
+      ),
+    );
+    reg.disposeAll();
+    // Cannot call controllerFor after disposeAll (assert).
+  });
+}

--- a/test/modules/tic_tac_toe/tic_tac_toe_state_test.dart
+++ b/test/modules/tic_tac_toe/tic_tac_toe_state_test.dart
@@ -1,0 +1,44 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:soliplex_frontend/src/modules/tic_tac_toe/tic_tac_toe_state.dart';
+
+void main() {
+  group('Cell', () {
+    test('value equality', () {
+      expect(const Cell(1, 2), const Cell(1, 2));
+      expect(const Cell(1, 2), isNot(const Cell(2, 1)));
+    });
+  });
+
+  group('TurnPair', () {
+    test('agent move is optional', () {
+      const tp = TurnPair(user: Cell(0, 0));
+      expect(tp.agent, isNull);
+    });
+  });
+
+  group('TicTacToeClientState', () {
+    test('default values', () {
+      const s = TicTacToeClientState();
+      expect(s.pending, isNull);
+      expect(s.redoStack, isEmpty);
+      expect(s.viewMode, TicTacToeViewMode.hidden);
+      expect(s.autoSend, isFalse);
+      expect(s.inFlight, isFalse);
+      expect(s.lastError, isNull);
+      expect(s.unreadChatWhileFullscreen, 0);
+    });
+
+    test('copyWith pending', () {
+      const s = TicTacToeClientState();
+      final s2 = s.copyWith(pending: const Cell(1, 1));
+      expect(s2.pending, const Cell(1, 1));
+      expect(s.pending, isNull); // original unchanged
+    });
+
+    test('copyWith clearPending forces null', () {
+      const s = TicTacToeClientState(pending: Cell(0, 0));
+      final s2 = s.copyWith(clearPending: true);
+      expect(s2.pending, isNull);
+    });
+  });
+}

--- a/test/modules/tic_tac_toe/ui/tic_tac_toe_cell_test.dart
+++ b/test/modules/tic_tac_toe/ui/tic_tac_toe_cell_test.dart
@@ -1,0 +1,65 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:soliplex_frontend/src/modules/tic_tac_toe/board_render_state.dart';
+import 'package:soliplex_frontend/src/modules/tic_tac_toe/ui/tic_tac_toe_cell.dart';
+
+void main() {
+  testWidgets('renders mark text', (tester) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: TicTacToeCell(
+            render: const CellRender(
+              mark: 'X',
+              isPending: false,
+              isWinning: false,
+            ),
+            enabled: true,
+            onTap: () {},
+          ),
+        ),
+      ),
+    );
+    expect(find.text('X'), findsOneWidget);
+  });
+
+  testWidgets('shows pending indicator', (tester) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: TicTacToeCell(
+            render: const CellRender(
+              mark: 'X',
+              isPending: true,
+              isWinning: false,
+            ),
+            enabled: true,
+            onTap: () {},
+          ),
+        ),
+      ),
+    );
+    expect(find.byKey(const Key('tictactoe-cell-pending')), findsOneWidget);
+  });
+
+  testWidgets('disabled when enabled false', (tester) async {
+    var taps = 0;
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: TicTacToeCell(
+            render: const CellRender(
+              mark: null,
+              isPending: false,
+              isWinning: false,
+            ),
+            enabled: false,
+            onTap: () => taps++,
+          ),
+        ),
+      ),
+    );
+    await tester.tap(find.byType(TicTacToeCell));
+    expect(taps, 0);
+  });
+}

--- a/test/modules/tic_tac_toe/ui/tic_tac_toe_cell_test.dart
+++ b/test/modules/tic_tac_toe/ui/tic_tac_toe_cell_test.dart
@@ -11,6 +11,7 @@ void main() {
           body: TicTacToeCell(
             render: const CellRender(
               mark: 'X',
+              serverMark: 'X',
               isPending: false,
               isWinning: false,
             ),
@@ -23,13 +24,14 @@ void main() {
     expect(find.text('X'), findsOneWidget);
   });
 
-  testWidgets('shows pending indicator', (tester) async {
+  testWidgets('renders pending mark with the outline color', (tester) async {
     await tester.pumpWidget(
       MaterialApp(
         home: Scaffold(
           body: TicTacToeCell(
             render: const CellRender(
               mark: 'X',
+              serverMark: null,
               isPending: true,
               isWinning: false,
             ),
@@ -39,7 +41,9 @@ void main() {
         ),
       ),
     );
-    expect(find.byKey(const Key('tictactoe-cell-pending')), findsOneWidget);
+    final text = tester.widget<Text>(find.text('X'));
+    final BuildContext context = tester.element(find.byType(TicTacToeCell));
+    expect(text.style?.color, Theme.of(context).colorScheme.outline);
   });
 
   testWidgets('disabled when enabled false', (tester) async {
@@ -50,6 +54,7 @@ void main() {
           body: TicTacToeCell(
             render: const CellRender(
               mark: null,
+              serverMark: null,
               isPending: false,
               isWinning: false,
             ),

--- a/test/modules/tic_tac_toe/ui/tic_tac_toe_controls_test.dart
+++ b/test/modules/tic_tac_toe/ui/tic_tac_toe_controls_test.dart
@@ -18,6 +18,7 @@ BoardRenderState renderWith({
         3,
         (_) => const CellRender(
           mark: null,
+          serverMark: null,
           isPending: false,
           isWinning: false,
         ),
@@ -44,6 +45,8 @@ void main() {
           body: TicTacToeControls(
             render: renderWith(),
             autoSend: false,
+            isFullscreen: false,
+            unreadCount: 0,
             lastError: null,
             onSend: () {},
             onCancel: () {},
@@ -71,6 +74,8 @@ void main() {
           body: TicTacToeControls(
             render: renderWith(canSend: true),
             autoSend: false,
+            isFullscreen: false,
+            unreadCount: 0,
             lastError: null,
             onSend: () => sends++,
             onCancel: () {},
@@ -94,6 +99,8 @@ void main() {
           body: TicTacToeControls(
             render: renderWith(canUndo: true),
             autoSend: false,
+            isFullscreen: false,
+            unreadCount: 0,
             lastError: null,
             onSend: () {},
             onCancel: () {},
@@ -129,6 +136,8 @@ void main() {
           body: TicTacToeControls(
             render: renderWith(),
             autoSend: false,
+            isFullscreen: false,
+            unreadCount: 0,
             lastError: TicTacToeError.network,
             onSend: () {},
             onCancel: () {},
@@ -153,6 +162,8 @@ void main() {
           body: TicTacToeControls(
             render: renderWith(),
             autoSend: false,
+            isFullscreen: false,
+            unreadCount: 0,
             lastError: TicTacToeError.network,
             onSend: () {},
             onCancel: () {},

--- a/test/modules/tic_tac_toe/ui/tic_tac_toe_controls_test.dart
+++ b/test/modules/tic_tac_toe/ui/tic_tac_toe_controls_test.dart
@@ -1,0 +1,171 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:soliplex_frontend/src/modules/tic_tac_toe/board_render_state.dart';
+import 'package:soliplex_frontend/src/modules/tic_tac_toe/tic_tac_toe_server_state.dart';
+import 'package:soliplex_frontend/src/modules/tic_tac_toe/tic_tac_toe_state.dart';
+import 'package:soliplex_frontend/src/modules/tic_tac_toe/ui/tic_tac_toe_controls.dart';
+
+BoardRenderState renderWith({
+  bool canSend = false,
+  bool canCancel = false,
+  bool canUndo = false,
+  bool canRedo = false,
+}) {
+  return BoardRenderState(
+    cells: List.generate(
+      3,
+      (_) => List.generate(
+        3,
+        (_) => const CellRender(
+          mark: null,
+          isPending: false,
+          isWinning: false,
+        ),
+      ),
+    ),
+    turn: TicTacToePlayer.user,
+    winner: null,
+    winningLine: null,
+    pending: null,
+    canSend: canSend,
+    canCancel: canCancel,
+    canUndo: canUndo,
+    canRedo: canRedo,
+    canNewGame: true,
+    inFlight: canCancel,
+  );
+}
+
+void main() {
+  testWidgets('Send disabled when canSend=false', (tester) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: TicTacToeControls(
+            render: renderWith(),
+            autoSend: false,
+            lastError: null,
+            onSend: () {},
+            onCancel: () {},
+            onUndo: () {},
+            onRedo: () {},
+            onToggleAutoSend: () {},
+            onToggleFullscreen: () {},
+            onRetry: () {},
+          ),
+        ),
+      ),
+    );
+    final sendBtn = tester.widget<ElevatedButton>(
+      find.widgetWithText(ElevatedButton, 'Send'),
+    );
+    expect(sendBtn.onPressed, isNull);
+  });
+
+  testWidgets('Send enabled and triggers callback when canSend=true',
+      (tester) async {
+    var sends = 0;
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: TicTacToeControls(
+            render: renderWith(canSend: true),
+            autoSend: false,
+            lastError: null,
+            onSend: () => sends++,
+            onCancel: () {},
+            onUndo: () {},
+            onRedo: () {},
+            onToggleAutoSend: () {},
+            onToggleFullscreen: () {},
+            onRetry: () {},
+          ),
+        ),
+      ),
+    );
+    await tester.tap(find.widgetWithText(ElevatedButton, 'Send'));
+    expect(sends, 1);
+  });
+
+  testWidgets('Undo / Redo enablement reflects render flags', (tester) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: TicTacToeControls(
+            render: renderWith(canUndo: true),
+            autoSend: false,
+            lastError: null,
+            onSend: () {},
+            onCancel: () {},
+            onUndo: () {},
+            onRedo: () {},
+            onToggleAutoSend: () {},
+            onToggleFullscreen: () {},
+            onRetry: () {},
+          ),
+        ),
+      ),
+    );
+    final undoBtn = tester.widget<IconButton>(
+      find.ancestor(
+        of: find.byTooltip('Undo'),
+        matching: find.byType(IconButton),
+      ),
+    );
+    expect(undoBtn.onPressed, isNotNull);
+    final redoBtn = tester.widget<IconButton>(
+      find.ancestor(
+        of: find.byTooltip('Redo'),
+        matching: find.byType(IconButton),
+      ),
+    );
+    expect(redoBtn.onPressed, isNull);
+  });
+
+  testWidgets('renders error chip when lastError is set', (tester) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: TicTacToeControls(
+            render: renderWith(),
+            autoSend: false,
+            lastError: TicTacToeError.network,
+            onSend: () {},
+            onCancel: () {},
+            onUndo: () {},
+            onRedo: () {},
+            onToggleAutoSend: () {},
+            onToggleFullscreen: () {},
+            onRetry: () {},
+          ),
+        ),
+      ),
+    );
+    expect(find.byKey(const Key('tictactoe-error-chip')), findsOneWidget);
+    expect(find.text('Retry'), findsOneWidget);
+  });
+
+  testWidgets('Retry callback fires', (tester) async {
+    var retries = 0;
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: TicTacToeControls(
+            render: renderWith(),
+            autoSend: false,
+            lastError: TicTacToeError.network,
+            onSend: () {},
+            onCancel: () {},
+            onUndo: () {},
+            onRedo: () {},
+            onToggleAutoSend: () {},
+            onToggleFullscreen: () {},
+            onRetry: () => retries++,
+          ),
+        ),
+      ),
+    );
+    await tester.tap(find.text('Retry'));
+    expect(retries, 1);
+  });
+}


### PR DESCRIPTION
## Summary

Tic-tac-toe is the first concrete consumer of AG-UI's `StateDeltaEvent` channel for surface-driven UIs. It exercises the full bidirectional binding (tap → `stateOverlay` → server tool → `StateDelta` → bus → projection → widget rebuild) end-to-end and pins the protocol with an integration test.

Backend half lives on `feat/tic-tac-toe` of soliplex/soliplex (separate PR coming).

## What's in the box

### New module — `lib/src/modules/tic_tac_toe/`

- **State types**: `Cell`, `TurnPair`, `TicTacToeViewMode`, `TicTacToeError`, `TicTacToeClientState` (immutable, value-equal, `copyWith`).
- **Server-state record + projection**: `TicTacToeServerState` and `TicTacToeProjection extends StateProjection<TicTacToeServerState?>` — tolerant of malformed input (returns null).
- **`BoardRenderState.compose(server, client)`**: composite render record that maps the design doc's button-enablement table into `canSend` / `canCancel` / `canUndo` / `canRedo` / `canNewGame` flags. Cells expose both `mark` (rendered, including pending overlay) and `serverMark` (server-board occupancy, used for tap-enablement).
- **`TicTacToeController`**: per-thread controller. Constructor wires `bus.project(TicTacToeProjection())` → server signal, owns a `Signal<TicTacToeClientState>` for local overlay, exposes a `boardRender` `computed` that composes both. Implements every rule from the spec's click / button-enablement tables. `_runWithOverlay` builds an `_inbox.tic_tac_toe.<intent>` overlay and calls `runtime.spawn(prompt: ..., stateOverlay: ...)`. Server-state observer auto-promotes `viewMode` hidden→inline on first game, never demotes fullscreen, and clears `pending` once the server reflects the user's move. Optional `RunRegistry` parameter lets the controller observe ALL sessions on the thread (including chat) for the in-fullscreen unread-banner.
- **`TicTacToeRegistry` + `tictactoeRegistryProvider`**: per-thread controller registry, mirrors the project's existing `RunRegistry` pattern.
- **`TicTacToeAppModule`**: contributes three overrides — the registry plus the two room slot providers populated with the board / toolbar widgets.
- **UI widgets**: `TicTacToeCell`, `TicTacToeControls` (Send / Cancel / Undo / Redo / Autosend / Fullscreen + inline error chip with Retry — no SnackBars, per project convention), `TicTacToeBoard` (inline card with hide affordance + result banner + Play again), `TicTacToeFullscreenPage` (enlarged board, badge-decorated exit, transient banner on chat-during-fullscreen), `TicTacToeToolbarButton` (start-or-toggle, also handles the no-thread state by spawning a fresh thread + new game in one tap).

### Room module changes

- `roomAboveChatInputBuildersProvider` and `roomChatInputToolbarBuildersProvider`: two `Provider<List<WidgetBuilder>>` slots that the room screen renders. Default to const empty; modules override via `ProviderScope` to inject their widgets. `ChatInput` accepts `toolbarExtras` and spreads them between the existing attach icon and the text field.
- `roomActiveThreadProvider`: publishes `(threadKey, runtime)` so other modules can attach per-thread controllers without coupling to room internals. Wired by `_RoomScreenState._buildContent` from `_state.activeThreadView` + `widget.serverEntry.serverId` + `widget.roomId` + `_state.runtime`.
- `roomSpawnNewThreadProvider`: typedef'd callback for surfaces to start a thread from the no-thread state with a custom `stateOverlay`. Wired to `RoomState.sendToNewThread`.
- `runRegistryProvider`: `RunRegistry` exposed for cross-module observers (the controller's chat-streaming subscription).

### Shared package fix — `packages/soliplex_agent`

`RunOrchestrator._buildConversation` now strips wire-only `_inbox` from the cached baseState before merging the new overlay. The orchestrator was persisting the full wire payload (including `_inbox`) into `ThreadHistory`, then replaying it on the next run — so finishing a tic-tac-toe game and sending a chat message would re-issue the previous move's intent against the now-finished board, surfacing as `InvalidIntent("game already finished")`. Regression test added.

## Tests

- 46 tic-tac-toe unit + widget + integration tests, including the **binding round-trip** test that pumps a `TicTacToeBoard` against a fake runtime, taps a cell, taps Send, and asserts both the user's X and the agent's O render after the state delta lands.
- 1207 frontend tests total, all green. Analyzer 0 issues. Format clean.

## Test plan

- [x] `flutter analyze` → 0 issues
- [x] `flutter test --reporter failures-only` → 1207 passed
- [x] Backend smoke: `soliplex-cli serve` against the example installation, `GET /api/v1/rooms` returns 200 including `tic_tac_toe`
- [x] Manual round-trip: tap # icon (no-thread state) → game spawns + agent's pre-played opening move appears → tap a cell → tap Send → agent responds → undo / redo / new-game → talk chat about something unrelated → tic-tac-toe state untouched
- [x] Manual fullscreen: enter fullscreen → game playable → chat message arriving in another tab surfaces banner + bumps unread badge → exit fullscreen via icon button or hardware back / iOS swipe-back

## Out of scope (per the design doc's Out-of-scope section)

Game persistence across reload, multi-player, score tracking, configurable AI difficulty, animations beyond static highlighting, replay viewer. Plus the four follow-up press-on-binding items: multi-surface coordination, high-frequency surface (slider), `Surface.emit` / `bus.events` channel, cross-thread bus isolation. Each gets its own design doc when picked up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)