### PR TITLE
feat(client): StateBus observer + tag API

### DIFF
--- a/packages/soliplex_client/lib/src/application/state_bus.dart
+++ b/packages/soliplex_client/lib/src/application/state_bus.dart
@@ -2,6 +2,16 @@ import 'package:meta/meta.dart';
 import 'package:signals_core/signals_core.dart';
 import 'package:soliplex_client/src/domain/surface.dart';
 
+/// Callback invoked after every successful [StateBus] commit.
+///
+/// [tag] is the optional source label passed to [StateBus.setAgentState]
+/// or [StateBus.update]; `null` when the writer did not provide one.
+/// [snapshot] is the frozen post-commit agent-state map.
+typedef BusObserver = void Function(
+  String? tag,
+  Map<String, dynamic> snapshot,
+);
+
 /// Per-thread reactive bus that mirrors AG-UI agent state and runs
 /// registered surface projections over it.
 ///
@@ -25,6 +35,7 @@ class StateBus {
       : _agentState = signal(_freeze(initialAgentState));
 
   final Signal<Map<String, dynamic>> _agentState;
+  final List<BusObserver> _observers = [];
 
   bool _disposed = false;
 
@@ -34,11 +45,24 @@ class StateBus {
   /// even when delta application produces structurally-equal maps.
   ReadonlySignal<Map<String, dynamic>> get agentState => _agentState.readonly();
 
+  /// Register [observer] to be invoked after every successful commit.
+  /// Returns a disposer that detaches [observer] when called.
+  /// Adding an observer to a disposed bus is a no-op; the returned
+  /// disposer is then a no-op too.
+  void Function() addObserver(BusObserver observer) {
+    if (_disposed) return () {};
+    _observers.add(observer);
+    return () => _observers.remove(observer);
+  }
+
   /// Replace the entire agent-state map. Call when an AG-UI
-  /// `StateSnapshotEvent` arrives.
-  void setAgentState(Map<String, dynamic> next) {
+  /// `StateSnapshotEvent` arrives. Pass [tag] to label the source of
+  /// this write (e.g. `'agui.snapshot'`); observers receive the tag.
+  void setAgentState(Map<String, dynamic> next, {String? tag}) {
     if (_disposed) return;
-    _agentState.value = _freeze(next);
+    final frozen = _freeze(next);
+    _agentState.value = frozen;
+    _notifyObservers(tag, frozen);
   }
 
   /// Replace via a transform applied to the current map. Convenient
@@ -48,11 +72,26 @@ class StateBus {
   /// ```dart
   /// bus.update((current) => applyJsonPatch(current, deltaOps));
   /// ```
+  ///
+  /// Pass [tag] to label the source of this write; observers receive
+  /// the tag.
   void update(
-    Map<String, dynamic> Function(Map<String, dynamic> current) transform,
-  ) {
+    Map<String, dynamic> Function(Map<String, dynamic> current) transform, {
+    String? tag,
+  }) {
     if (_disposed) return;
-    _agentState.value = _freeze(transform(_agentState.value));
+    final frozen = _freeze(transform(_agentState.value));
+    _agentState.value = frozen;
+    _notifyObservers(tag, frozen);
+  }
+
+  void _notifyObservers(String? tag, Map<String, dynamic> snapshot) {
+    if (_observers.isEmpty) return;
+    // Iterate over a snapshot so an observer detaching itself during
+    // dispatch (e.g. via the returned disposer) does not skip siblings.
+    for (final observer in List<BusObserver>.of(_observers)) {
+      observer(tag, snapshot);
+    }
   }
 
   /// Register a [StateProjection] and receive a derived signal that
@@ -69,6 +108,7 @@ class StateBus {
   void dispose() {
     if (_disposed) return;
     _disposed = true;
+    _observers.clear();
     _agentState.dispose();
   }
 

--- a/packages/soliplex_client/test/application/state_bus_test.dart
+++ b/packages/soliplex_client/test/application/state_bus_test.dart
@@ -93,6 +93,79 @@ void main() {
       bus.dispose();
     });
 
+    test('addObserver fires after each commit with tag and snapshot', () {
+      final bus = StateBus();
+      final received = <(String?, Map<String, dynamic>)>[];
+      bus
+        ..addObserver((tag, snapshot) => received.add((tag, snapshot)))
+        ..setAgentState({'a': 1}, tag: 'agui.snapshot')
+        ..update((current) => {'a': (current['a'] as int) + 1}, tag: 'delta')
+        ..setAgentState({'a': 99}); // untagged
+
+      expect(received, hasLength(3));
+      expect(received[0].$1, 'agui.snapshot');
+      expect(received[0].$2['a'], 1);
+      expect(received[1].$1, 'delta');
+      expect(received[1].$2['a'], 2);
+      expect(received[2].$1, isNull);
+      expect(received[2].$2['a'], 99);
+      bus.dispose();
+    });
+
+    test('addObserver disposer detaches a single observer', () {
+      final bus = StateBus();
+      final a = <String?>[];
+      final b = <String?>[];
+      final disposeA = bus.addObserver((tag, _) => a.add(tag));
+      bus
+        ..addObserver((tag, _) => b.add(tag))
+        ..setAgentState({}, tag: 'first');
+      disposeA();
+      bus.setAgentState({}, tag: 'second');
+
+      expect(a, ['first']);
+      expect(b, ['first', 'second']);
+      bus.dispose();
+    });
+
+    test(
+      'observer detaching itself during dispatch does not skip siblings',
+      () {
+        final bus = StateBus();
+        final calls = <String>[];
+        late final void Function() disposeMid;
+        bus.addObserver((_, __) => calls.add('first'));
+        disposeMid = bus.addObserver((_, __) {
+          calls.add('mid');
+          disposeMid();
+        });
+        bus
+          ..addObserver((_, __) => calls.add('last'))
+          ..setAgentState({});
+        expect(calls, ['first', 'mid', 'last']);
+        bus.dispose();
+      },
+    );
+
+    test('dispose clears observers and stops further notifications', () {
+      final bus = StateBus();
+      final received = <String?>[];
+      bus
+        ..addObserver((tag, _) => received.add(tag))
+        ..setAgentState({}, tag: 'before')
+        ..dispose()
+        ..setAgentState({}, tag: 'after');
+
+      expect(received, ['before']);
+    });
+
+    test('addObserver on disposed bus returns a no-op disposer', () {
+      final bus = StateBus()..dispose();
+      // Must not throw.
+      final disposer = bus.addObserver((_, __) {});
+      disposer();
+    });
+
     test(
       'RagSnapshotProjection conforms to StateProjection and produces '
       'a typed snapshot from the rag namespace',


### PR DESCRIPTION
Part of #202 (1 of 4 stacked PRs). **Merge first** — base for the other three.

## What this changes

`StateBus` (in `soliplex_client`) gains:

- `void Function() addObserver(BusObserver observer)` — register a
  callback that fires after every successful commit. Returns a
  disposer for symmetric tear-down. Detaching during dispatch is
  safe (siblings still fire). Adding to a disposed bus is a no-op.
- Optional `String? tag` argument on `setAgentState` and `update` —
  writers can label the source of each commit, observers receive it.

## Why this shape

The upcoming Bus Inspector (#202) needs to record every state commit
with thread context. Putting the recording logic on a per-bus
observer keeps the bus pure (no inspector dependency) and lets any
future diagnostic plug in without modifying core code.

The `tag` argument is optional so existing callers don't change; the
agent layer will set it explicitly only at the seed paths
(`seed.initial`, `seed.history`).

## Testing

11 new unit tests cover dispatch ordering, dispose semantics, the
self-detaching-during-dispatch case, tag preservation, and disposed-bus
safety. Existing tests unchanged.

## Stack

1. **This PR** — StateBus observer + tag API
2. \`feat/agent-runtime-observers\` — bus + event observers on AgentRuntime
3. \`feat/bus-inspector-diagnostics\` — Bus Inspector module
4. \`feat/wire-bus-inspector\` — wire into shell