### PR TITLE
feat(agent): bus + event observers on AgentRuntime

### DIFF
--- a/packages/soliplex_agent/lib/src/runtime/agent_runtime.dart
+++ b/packages/soliplex_agent/lib/src/runtime/agent_runtime.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 
+import 'package:ag_ui/ag_ui.dart' show BaseEvent;
 import 'package:signals_core/signals_core.dart';
 import 'package:soliplex_agent/src/host/platform_constraints.dart';
 import 'package:soliplex_agent/src/models/agent_result.dart';
@@ -17,6 +18,30 @@ import 'package:soliplex_agent/src/runtime/thread_state.dart';
 import 'package:soliplex_agent/src/tools/tool_registry_resolver.dart';
 import 'package:soliplex_client/soliplex_client.dart' show ThreadHistory;
 import 'package:soliplex_logging/soliplex_logging.dart';
+
+/// Callback receiving every per-thread `StateBus` write across the
+/// runtime, with the [ThreadKey] context the bus itself does not carry.
+///
+/// Wired from [AgentRuntime] into each per-thread bus the first time
+/// the runtime materialises a [ThreadState]. Used by debug surfaces
+/// (e.g. the in-app Bus Inspector) to record every commit.
+typedef ThreadBusObserver = void Function(
+  ThreadKey threadKey,
+  String? tag,
+  Map<String, dynamic> snapshot,
+);
+
+/// Callback receiving every raw AG-UI [BaseEvent] processed by any
+/// session in the runtime, paired with its [ThreadKey].
+///
+/// Lets diagnostics consumers correlate events with bus commits
+/// without the agent owning any tagging logic. The runtime itself
+/// makes no behavioural decision on the events; it only fans them
+/// out to the observer.
+typedef ThreadEventObserver = void Function(
+  ThreadKey threadKey,
+  BaseEvent event,
+);
 
 /// Facade for spawning and coordinating multiple [AgentSession]s.
 ///
@@ -54,6 +79,8 @@ class AgentRuntime {
     required Logger logger,
     AgentLlmProvider? llmProvider,
     SessionExtensionFactory? extensionFactory,
+    ThreadBusObserver? busObserver,
+    ThreadEventObserver? eventObserver,
     this.maxSpawnDepth = 10,
     this.rootTimeout,
   })  : serverId = connection.serverId,
@@ -65,6 +92,8 @@ class AgentRuntime {
             ),
         _toolRegistryResolver = toolRegistryResolver,
         _extensionFactory = extensionFactory,
+        _busObserver = busObserver,
+        _eventObserver = eventObserver,
         _platform = platform,
         _logger = logger;
 
@@ -72,8 +101,17 @@ class AgentRuntime {
   final AgentLlmProvider _llmProvider;
   final ToolRegistryResolver _toolRegistryResolver;
   final SessionExtensionFactory? _extensionFactory;
+  final ThreadBusObserver? _busObserver;
+  final ThreadEventObserver? _eventObserver;
   final PlatformConstraints _platform;
   final Logger _logger;
+
+  /// Forwards [event] (received by an [AgentSession]) to the optional
+  /// runtime-level event observer. No-op when no observer is wired.
+  /// Internal: called from [AgentSession._bridgeBaseEvent].
+  void notifyThreadEvent(ThreadKey key, BaseEvent event) {
+    _eventObserver?.call(key, event);
+  }
 
   /// Identifies which backend server this runtime targets.
   final String serverId;
@@ -139,7 +177,7 @@ class AgentRuntime {
   ) {
     if (aguiState.isEmpty) return;
     final state = _threadStateFor(key);
-    state.bus.setAgentState(aguiState);
+    state.bus.setAgentState(aguiState, tag: 'seed.initial');
     _threadStates[key] = state.withHistory(
       ThreadHistory(messages: const [], aguiState: aguiState),
     );
@@ -155,7 +193,7 @@ class AgentRuntime {
   void seedThreadHistory(ThreadKey key, ThreadHistory history) {
     final state = _threadStateFor(key);
     if (history.aguiState.isNotEmpty) {
-      state.bus.setAgentState(history.aguiState);
+      state.bus.setAgentState(history.aguiState, tag: 'seed.history');
     }
     _threadStates[key] = state.withHistory(history);
   }
@@ -163,8 +201,23 @@ class AgentRuntime {
   /// Returns the per-thread state for [key], creating a fresh
   /// [ThreadState] if none has been registered yet. Internal helper —
   /// callers outside the runtime should use the seed APIs above.
-  ThreadState _threadStateFor(ThreadKey key) =>
-      _threadStates[key] ??= ThreadState();
+  ///
+  /// On first creation, the bus is wired to forward every commit to
+  /// [_busObserver] (when set), threading the [ThreadKey] context the
+  /// bus itself does not carry.
+  ThreadState _threadStateFor(ThreadKey key) {
+    final existing = _threadStates[key];
+    if (existing != null) return existing;
+    final state = ThreadState();
+    final observer = _busObserver;
+    if (observer != null) {
+      state.bus.addObserver(
+        (tag, snapshot) => observer(key, tag, snapshot),
+      );
+    }
+    _threadStates[key] = state;
+    return state;
+  }
 
   /// Returns the per-thread state for [key], or `null` if no state has
   /// been registered. Read-only public accessor for consumers that

--- a/packages/soliplex_agent/lib/src/runtime/agent_session.dart
+++ b/packages/soliplex_agent/lib/src/runtime/agent_session.dart
@@ -406,6 +406,10 @@ class AgentSession implements ToolExecutionContext {
     // event without each consumer re-listening to the orchestrator.
     final next = _aguiStateOf(runState);
     if (next != null) {
+      // Untagged at the agent layer. Diagnostics consumers (e.g. the
+      // bus inspector) correlate this commit with the most recent
+      // AG-UI event seen via the runtime's event observer to infer
+      // whether it was a snapshot, delta, or run-state-only update.
       bus.setAgentState(next);
     }
     switch (runState) {
@@ -428,7 +432,12 @@ class AgentSession implements ToolExecutionContext {
   /// Maps raw AG-UI [BaseEvent]s to [ExecutionEvent] emissions so that
   /// consumers observing [lastExecutionEvent] see streaming text, thinking,
   /// server tool calls, and terminal events without polling [runState].
+  ///
+  /// Also fans the raw event to the runtime's optional thread-event
+  /// observer so diagnostics consumers can subscribe without coupling
+  /// the agent to any inspector implementation.
   void _bridgeBaseEvent(BaseEvent event) {
+    _runtime.notifyThreadEvent(threadKey, event);
     final executionEvent = bridgeBaseEvent(event);
     if (executionEvent != null) emitEvent(executionEvent);
   }

--- a/packages/soliplex_agent/test/runtime/agent_runtime_test.dart
+++ b/packages/soliplex_agent/test/runtime/agent_runtime_test.dart
@@ -262,6 +262,49 @@ void main() {
       expect(capturedInput!.state, equals(initialState));
     });
 
+    test('busObserver receives every per-thread bus write with key + tag',
+        () async {
+      final received = <(ThreadKey, String?, Map<String, dynamic>)>[];
+      final runtime = AgentRuntime(
+        connection: mockConnection(),
+        toolRegistryResolver: (_) async => const ToolRegistry(),
+        platform: const NativePlatformConstraints(),
+        logger: logger,
+        busObserver: (key, tag, snapshot) => received.add((key, tag, snapshot)),
+      );
+
+      const key1 = (
+        serverId: 'default',
+        roomId: 'room-a',
+        threadId: 'thread-a',
+      );
+      const key2 = (
+        serverId: 'default',
+        roomId: 'room-b',
+        threadId: 'thread-b',
+      );
+
+      runtime
+        ..seedThreadState(key1, {'count': 1})
+        ..seedThreadHistory(
+          key2,
+          ThreadHistory(
+            messages: const [],
+            aguiState: const {'count': 2},
+          ),
+        );
+
+      expect(received, hasLength(2));
+      expect(received[0].$1, key1);
+      expect(received[0].$2, 'seed.initial');
+      expect(received[0].$3['count'], 1);
+      expect(received[1].$1, key2);
+      expect(received[1].$2, 'seed.history');
+      expect(received[1].$3['count'], 2);
+
+      await runtime.dispose();
+    });
+
     test('seedThreadState makes initial state available for spawn', () async {
       final initialState = <String, dynamic>{
         'rag': <String, dynamic>{

--- a/packages/soliplex_client/lib/src/application/state_bus.dart
+++ b/packages/soliplex_client/lib/src/application/state_bus.dart
@@ -2,6 +2,16 @@ import 'package:meta/meta.dart';
 import 'package:signals_core/signals_core.dart';
 import 'package:soliplex_client/src/domain/surface.dart';
 
+/// Callback invoked after every successful [StateBus] commit.
+///
+/// [tag] is the optional source label passed to [StateBus.setAgentState]
+/// or [StateBus.update]; `null` when the writer did not provide one.
+/// [snapshot] is the frozen post-commit agent-state map.
+typedef BusObserver = void Function(
+  String? tag,
+  Map<String, dynamic> snapshot,
+);
+
 /// Per-thread reactive bus that mirrors AG-UI agent state and runs
 /// registered surface projections over it.
 ///
@@ -25,6 +35,7 @@ class StateBus {
       : _agentState = signal(_freeze(initialAgentState));
 
   final Signal<Map<String, dynamic>> _agentState;
+  final List<BusObserver> _observers = [];
 
   bool _disposed = false;
 
@@ -34,11 +45,24 @@ class StateBus {
   /// even when delta application produces structurally-equal maps.
   ReadonlySignal<Map<String, dynamic>> get agentState => _agentState.readonly();
 
+  /// Register [observer] to be invoked after every successful commit.
+  /// Returns a disposer that detaches [observer] when called.
+  /// Adding an observer to a disposed bus is a no-op; the returned
+  /// disposer is then a no-op too.
+  void Function() addObserver(BusObserver observer) {
+    if (_disposed) return () {};
+    _observers.add(observer);
+    return () => _observers.remove(observer);
+  }
+
   /// Replace the entire agent-state map. Call when an AG-UI
-  /// `StateSnapshotEvent` arrives.
-  void setAgentState(Map<String, dynamic> next) {
+  /// `StateSnapshotEvent` arrives. Pass [tag] to label the source of
+  /// this write (e.g. `'agui.snapshot'`); observers receive the tag.
+  void setAgentState(Map<String, dynamic> next, {String? tag}) {
     if (_disposed) return;
-    _agentState.value = _freeze(next);
+    final frozen = _freeze(next);
+    _agentState.value = frozen;
+    _notifyObservers(tag, frozen);
   }
 
   /// Replace via a transform applied to the current map. Convenient
@@ -48,11 +72,26 @@ class StateBus {
   /// ```dart
   /// bus.update((current) => applyJsonPatch(current, deltaOps));
   /// ```
+  ///
+  /// Pass [tag] to label the source of this write; observers receive
+  /// the tag.
   void update(
-    Map<String, dynamic> Function(Map<String, dynamic> current) transform,
-  ) {
+    Map<String, dynamic> Function(Map<String, dynamic> current) transform, {
+    String? tag,
+  }) {
     if (_disposed) return;
-    _agentState.value = _freeze(transform(_agentState.value));
+    final frozen = _freeze(transform(_agentState.value));
+    _agentState.value = frozen;
+    _notifyObservers(tag, frozen);
+  }
+
+  void _notifyObservers(String? tag, Map<String, dynamic> snapshot) {
+    if (_observers.isEmpty) return;
+    // Iterate over a snapshot so an observer detaching itself during
+    // dispatch (e.g. via the returned disposer) does not skip siblings.
+    for (final observer in List<BusObserver>.of(_observers)) {
+      observer(tag, snapshot);
+    }
   }
 
   /// Register a [StateProjection] and receive a derived signal that
@@ -69,6 +108,7 @@ class StateBus {
   void dispose() {
     if (_disposed) return;
     _disposed = true;
+    _observers.clear();
     _agentState.dispose();
   }
 

--- a/packages/soliplex_client/test/application/state_bus_test.dart
+++ b/packages/soliplex_client/test/application/state_bus_test.dart
@@ -93,6 +93,79 @@ void main() {
       bus.dispose();
     });
 
+    test('addObserver fires after each commit with tag and snapshot', () {
+      final bus = StateBus();
+      final received = <(String?, Map<String, dynamic>)>[];
+      bus
+        ..addObserver((tag, snapshot) => received.add((tag, snapshot)))
+        ..setAgentState({'a': 1}, tag: 'agui.snapshot')
+        ..update((current) => {'a': (current['a'] as int) + 1}, tag: 'delta')
+        ..setAgentState({'a': 99}); // untagged
+
+      expect(received, hasLength(3));
+      expect(received[0].$1, 'agui.snapshot');
+      expect(received[0].$2['a'], 1);
+      expect(received[1].$1, 'delta');
+      expect(received[1].$2['a'], 2);
+      expect(received[2].$1, isNull);
+      expect(received[2].$2['a'], 99);
+      bus.dispose();
+    });
+
+    test('addObserver disposer detaches a single observer', () {
+      final bus = StateBus();
+      final a = <String?>[];
+      final b = <String?>[];
+      final disposeA = bus.addObserver((tag, _) => a.add(tag));
+      bus
+        ..addObserver((tag, _) => b.add(tag))
+        ..setAgentState({}, tag: 'first');
+      disposeA();
+      bus.setAgentState({}, tag: 'second');
+
+      expect(a, ['first']);
+      expect(b, ['first', 'second']);
+      bus.dispose();
+    });
+
+    test(
+      'observer detaching itself during dispatch does not skip siblings',
+      () {
+        final bus = StateBus();
+        final calls = <String>[];
+        late final void Function() disposeMid;
+        bus.addObserver((_, __) => calls.add('first'));
+        disposeMid = bus.addObserver((_, __) {
+          calls.add('mid');
+          disposeMid();
+        });
+        bus
+          ..addObserver((_, __) => calls.add('last'))
+          ..setAgentState({});
+        expect(calls, ['first', 'mid', 'last']);
+        bus.dispose();
+      },
+    );
+
+    test('dispose clears observers and stops further notifications', () {
+      final bus = StateBus();
+      final received = <String?>[];
+      bus
+        ..addObserver((tag, _) => received.add(tag))
+        ..setAgentState({}, tag: 'before')
+        ..dispose()
+        ..setAgentState({}, tag: 'after');
+
+      expect(received, ['before']);
+    });
+
+    test('addObserver on disposed bus returns a no-op disposer', () {
+      final bus = StateBus()..dispose();
+      // Must not throw.
+      final disposer = bus.addObserver((_, __) {});
+      disposer();
+    });
+
     test(
       'RagSnapshotProjection conforms to StateProjection and produces '
       'a typed snapshot from the rag namespace',


### PR DESCRIPTION
Part of #202 (2 of 4 stacked PRs). **Depends on #203 — merge that first** then rebase this.

## What this changes

`AgentRuntime` (in `soliplex_agent`) gains two optional observer hooks:

- \`ThreadBusObserver\` — receives every per-thread \`StateBus\` commit
  with the originating \`ThreadKey\`. Wired into the bus the first time
  the runtime materialises a \`ThreadState\`. Uses the \`tag\` argument
  introduced in #203.
- \`ThreadEventObserver\` — receives every raw AG-UI \`BaseEvent\` paired
  with the \`ThreadKey\` it was processed on. Forwarded from
  \`AgentSession._bridgeBaseEvent\` via a package-private
  \`notifyThreadEvent\` helper. The runtime makes no behavioural
  decision on the event; it only fans out.

\`seedThreadState\` and \`seedThreadHistory\` writes are now tagged
\`seed.initial\` and \`seed.history\` respectively so consumers can
distinguish initial state restoration from in-session updates.

## Why two hooks

For an inspector to render bus events as either \`agui.snapshot\` or
\`agui.delta\` we need to know what kind of AG-UI event drove each
commit. By the time \`AgentSession._onStateChange\` fires, both kinds
have been folded into \`conversation.aguiState\` and the source event
type is lost. Rather than thread that context through state objects,
exposing the raw event stream as a separate observer lets the
inspector do the correlation itself — and it opens the door for any
other diagnostic that wants the full event stream (activity timeline,
message ledger, tool-call inspector).

## Why \`bus.setAgentState(next)\` is untagged here

Diagnostics consumers correlate the commit with the most recent
AG-UI event observed on the same thread to infer the tag. Keeping
the agent layer untagged keeps it diagnostics-agnostic.

## Testing

Test exercises the bus-observer end-to-end via the seed APIs and
verifies the per-thread context (key + tag + snapshot) is delivered
correctly.

## Stack

1. #203 — StateBus observer + tag API
2. **This PR** — bus + event observers on AgentRuntime
3. \`feat/bus-inspector-diagnostics\` — Bus Inspector module
4. \`feat/wire-bus-inspector\` — wire into shell