### PR TITLE
feat(diagnostics): Bus Inspector module — recorder, filter, screen

### DIFF
--- a/lib/src/modules/diagnostics/bus_filter.dart
+++ b/lib/src/modules/diagnostics/bus_filter.dart
@@ -1,0 +1,339 @@
+import 'package:flutter/foundation.dart';
+import 'package:soliplex_agent/soliplex_agent.dart' show ThreadKey;
+
+import 'bus_inspector.dart';
+import 'snapshot_diff.dart';
+
+/// Recognised key prefixes in the filter mini-language.
+///
+/// Tokens NOT prefixed by one of these are treated as bare text and
+/// must match at least one of the matchable fields (thread short id,
+/// room id, tag, or any changed path).
+const Set<String> kFilterKeys = {
+  'thread',
+  'room',
+  'server',
+  'tag',
+  'path',
+  'kind',
+};
+
+/// Row kinds the filter recognises via `kind:`. Bus commits are tagged
+/// `bus`; recorded raw AG-UI events are tagged `event`.
+enum RowKind { bus, event }
+
+/// Parsed filter applied to inspector rows; each non-null field must
+/// match for the row to pass. Bare terms must each match somewhere.
+///
+/// The same filter applies to both bus commits and event records;
+/// fields not relevant to a given row kind (e.g. `pathSubstr` on an
+/// event record) are skipped via the kind-aware match methods below.
+@immutable
+class BusFilter {
+  const BusFilter({
+    this.threadSubstr,
+    this.roomSubstr,
+    this.serverSubstr,
+    this.tagPattern,
+    this.pathSubstr,
+    this.kind,
+    this.bareTerms = const [],
+  });
+
+  static const BusFilter empty = BusFilter();
+
+  /// Substring match against `ThreadKey.threadId` (case-insensitive).
+  final String? threadSubstr;
+
+  /// Substring match against `ThreadKey.roomId` (case-insensitive).
+  final String? roomSubstr;
+
+  /// Substring match against `ThreadKey.serverId` (case-insensitive).
+  final String? serverSubstr;
+
+  /// Tag matcher — exact value, or prefix when input ends in `*`
+  /// (e.g. `agui.*`).
+  final TagPattern? tagPattern;
+
+  /// Substring match against any changed path in the diff
+  /// (case-insensitive). Only applies to bus rows.
+  final String? pathSubstr;
+
+  /// Row kind filter (`bus` or `event`). When set, rows of the other
+  /// kind are filtered out.
+  final RowKind? kind;
+
+  /// Bare (unprefixed) tokens. Each one must match at least one of:
+  /// thread short id, room id, server id, tag, or (for bus rows) any
+  /// changed path.
+  final List<String> bareTerms;
+
+  bool get isEmpty =>
+      threadSubstr == null &&
+      roomSubstr == null &&
+      serverSubstr == null &&
+      tagPattern == null &&
+      pathSubstr == null &&
+      kind == null &&
+      bareTerms.isEmpty;
+
+  bool matchesBus(BusEvent event, SnapshotDiff diff) {
+    if (kind != null && kind != RowKind.bus) return false;
+    if (threadSubstr != null &&
+        !_substr(event.threadKey.threadId, threadSubstr!)) {
+      return false;
+    }
+    if (roomSubstr != null && !_substr(event.threadKey.roomId, roomSubstr!)) {
+      return false;
+    }
+    if (serverSubstr != null &&
+        !_substr(event.threadKey.serverId, serverSubstr!)) {
+      return false;
+    }
+    if (tagPattern != null && !tagPattern!.matches(event.tag)) {
+      return false;
+    }
+    if (pathSubstr != null && !_anyPathContains(diff, pathSubstr!)) {
+      return false;
+    }
+    for (final term in bareTerms) {
+      if (!_anyBusFieldContains(event, diff, term)) return false;
+    }
+    return true;
+  }
+
+  bool matchesEvent(EventRecord record) {
+    if (kind != null && kind != RowKind.event) return false;
+    if (threadSubstr != null &&
+        !_substr(record.threadKey.threadId, threadSubstr!)) {
+      return false;
+    }
+    if (roomSubstr != null && !_substr(record.threadKey.roomId, roomSubstr!)) {
+      return false;
+    }
+    if (serverSubstr != null &&
+        !_substr(record.threadKey.serverId, serverSubstr!)) {
+      return false;
+    }
+    if (tagPattern != null && !tagPattern!.matches(record.tag)) {
+      return false;
+    }
+    // pathSubstr does not apply to event records — skip.
+    for (final term in bareTerms) {
+      if (!_anyEventFieldContains(record, term)) return false;
+    }
+    return true;
+  }
+
+  /// Backwards-compatible alias for [matchesBus].
+  bool matches(BusEvent event, SnapshotDiff diff) => matchesBus(event, diff);
+}
+
+/// A tag predicate: either an exact string or a prefix glob (input
+/// ending in `*`, where the `*` is interpreted as a wildcard).
+@immutable
+class TagPattern {
+  const TagPattern.exact(this.value) : isPrefix = false;
+  const TagPattern.prefix(this.value) : isPrefix = true;
+
+  final String value;
+  final bool isPrefix;
+
+  bool matches(String? tag) {
+    if (tag == null) return false;
+    if (isPrefix) return tag.toLowerCase().startsWith(value.toLowerCase());
+    return tag.toLowerCase() == value.toLowerCase();
+  }
+}
+
+/// Parses a filter string into a [BusFilter]. Whitespace separates
+/// tokens; tokens of the form `key:value` are recognised when `key` is
+/// in [kFilterKeys] (case-insensitive). Empty input → [BusFilter.empty].
+/// Later occurrences of the same prefix override earlier ones.
+BusFilter parseBusFilter(String input) {
+  final trimmed = input.trim();
+  if (trimmed.isEmpty) return BusFilter.empty;
+
+  String? thread;
+  String? room;
+  String? server;
+  TagPattern? tag;
+  String? path;
+  RowKind? kind;
+  final bare = <String>[];
+
+  for (final raw in trimmed.split(RegExp(r'\s+'))) {
+    if (raw.isEmpty) continue;
+    final colon = raw.indexOf(':');
+    if (colon > 0 && colon < raw.length - 1) {
+      final key = raw.substring(0, colon).toLowerCase();
+      final value = raw.substring(colon + 1);
+      if (kFilterKeys.contains(key)) {
+        switch (key) {
+          case 'thread':
+            thread = value;
+          case 'room':
+            room = value;
+          case 'server':
+            server = value;
+          case 'tag':
+            tag = value.endsWith('*')
+                ? TagPattern.prefix(value.substring(0, value.length - 1))
+                : TagPattern.exact(value);
+          case 'path':
+            path = value;
+          case 'kind':
+            switch (value.toLowerCase()) {
+              case 'bus':
+                kind = RowKind.bus;
+              case 'event':
+                kind = RowKind.event;
+              default:
+                bare.add(raw);
+            }
+        }
+        continue;
+      }
+    }
+    bare.add(raw);
+  }
+
+  return BusFilter(
+    threadSubstr: thread,
+    roomSubstr: room,
+    serverSubstr: server,
+    tagPattern: tag,
+    pathSubstr: path,
+    kind: kind,
+    bareTerms: List.unmodifiable(bare),
+  );
+}
+
+/// Identify the "current token" the user is editing at [cursor] inside
+/// [text]. Used by the search field to drive autocomplete suggestions.
+/// Returns `null` if the cursor is not inside any token.
+({String token, int start, int end})? currentTokenAt(String text, int cursor) {
+  if (cursor < 0 || cursor > text.length) return null;
+  // Walk left from cursor while non-whitespace.
+  var start = cursor;
+  while (start > 0 && !_isSpace(text.codeUnitAt(start - 1))) {
+    start--;
+  }
+  // Walk right from cursor while non-whitespace.
+  var end = cursor;
+  while (end < text.length && !_isSpace(text.codeUnitAt(end))) {
+    end++;
+  }
+  if (start == end) return null;
+  return (token: text.substring(start, end), start: start, end: end);
+}
+
+/// Build autocomplete suggestions for the token at [cursor] in [text]
+/// against the values present in [rows].
+///
+/// Behaviour:
+/// - `key:` (empty value) → all known values for that key
+/// - `key:partial` → values matching `partial` substring
+/// - bare partial → matching key names (`thread`, `room`, …) for the
+///   user to expand
+List<String> suggestionsFor({
+  required String text,
+  required int cursor,
+  required Iterable<BusEvent> events,
+  Iterable<EventRecord> records = const [],
+}) {
+  final at = currentTokenAt(text, cursor);
+  if (at == null) {
+    return kFilterKeys.map((k) => '$k:').toList();
+  }
+  final tok = at.token;
+  final colon = tok.indexOf(':');
+  if (colon < 0) {
+    final lower = tok.toLowerCase();
+    return [
+      for (final k in kFilterKeys)
+        if (k.startsWith(lower)) '$k:',
+    ];
+  }
+  final key = tok.substring(0, colon).toLowerCase();
+  final partial = tok.substring(colon + 1).toLowerCase();
+  if (!kFilterKeys.contains(key)) return const [];
+  final values = _valuesForKey(key, events, records);
+  return [
+    for (final v in values)
+      if (partial.isEmpty || v.toLowerCase().contains(partial)) '$key:$v',
+  ];
+}
+
+Set<String> _valuesForKey(
+  String key,
+  Iterable<BusEvent> events, [
+  Iterable<EventRecord> records = const [],
+]) {
+  final out = <String>{};
+  for (final e in events) {
+    switch (key) {
+      case 'thread':
+        out.add(_threadShort(e.threadKey));
+      case 'room':
+        out.add(e.threadKey.roomId);
+      case 'server':
+        out.add(e.threadKey.serverId);
+      case 'tag':
+        if (e.tag != null) out.add(e.tag!);
+      case 'kind':
+        out.add('bus');
+    }
+  }
+  for (final r in records) {
+    switch (key) {
+      case 'thread':
+        out.add(_threadShort(r.threadKey));
+      case 'room':
+        out.add(r.threadKey.roomId);
+      case 'server':
+        out.add(r.threadKey.serverId);
+      case 'tag':
+        out.add(r.tag);
+      case 'kind':
+        out.add('event');
+    }
+  }
+  return out;
+}
+
+String _threadShort(ThreadKey key) {
+  final tid = key.threadId;
+  return tid.length <= 6 ? tid : tid.substring(tid.length - 6);
+}
+
+bool _substr(String haystack, String needle) =>
+    haystack.toLowerCase().contains(needle.toLowerCase());
+
+bool _anyPathContains(SnapshotDiff diff, String needle) {
+  bool match(String s) => s.toLowerCase().contains(needle.toLowerCase());
+  return diff.added.any((c) => match(c.path)) ||
+      diff.removed.any((c) => match(c.path)) ||
+      diff.replaced.any((c) => match(c.path));
+}
+
+bool _anyBusFieldContains(BusEvent event, SnapshotDiff diff, String term) {
+  final t = term.toLowerCase();
+  if (_threadShort(event.threadKey).toLowerCase().contains(t)) return true;
+  if (event.threadKey.roomId.toLowerCase().contains(t)) return true;
+  if (event.threadKey.serverId.toLowerCase().contains(t)) return true;
+  if ((event.tag ?? '').toLowerCase().contains(t)) return true;
+  return _anyPathContains(diff, term);
+}
+
+bool _anyEventFieldContains(EventRecord record, String term) {
+  final t = term.toLowerCase();
+  if (_threadShort(record.threadKey).toLowerCase().contains(t)) return true;
+  if (record.threadKey.roomId.toLowerCase().contains(t)) return true;
+  if (record.threadKey.serverId.toLowerCase().contains(t)) return true;
+  if (record.tag.toLowerCase().contains(t)) return true;
+  return false;
+}
+
+bool _isSpace(int codeUnit) =>
+    codeUnit == 0x20 || codeUnit == 0x09 || codeUnit == 0x0A;

--- a/lib/src/modules/diagnostics/bus_inspector.dart
+++ b/lib/src/modules/diagnostics/bus_inspector.dart
@@ -1,0 +1,158 @@
+import 'dart:collection';
+
+import 'package:flutter/foundation.dart';
+import 'package:soliplex_agent/soliplex_agent.dart';
+
+/// One recorded write to a per-thread `StateBus`.
+///
+/// Captures the [ThreadKey] context (which the bus itself does not
+/// carry), the resolved [tag] (either the writer-supplied label or one
+/// inferred from the most recent AG-UI event on the same thread),
+/// and a frozen snapshot of the state immediately after the commit.
+@immutable
+class BusEvent {
+  const BusEvent({
+    required this.timestamp,
+    required this.threadKey,
+    required this.tag,
+    required this.snapshot,
+  });
+
+  final DateTime timestamp;
+  final ThreadKey threadKey;
+  final String? tag;
+  final Map<String, dynamic> snapshot;
+}
+
+/// One recorded raw AG-UI event observed on a thread.
+///
+/// [tag] is derived from the event's runtime type (e.g.
+/// `ActivitySnapshotEvent` → `agui.activitysnapshot`) so the existing
+/// tag chip + `tag:` filter work uniformly for events and bus commits.
+@immutable
+class EventRecord {
+  EventRecord({
+    required this.timestamp,
+    required this.threadKey,
+    required this.event,
+  }) : tag = _tagFor(event);
+
+  final DateTime timestamp;
+  final ThreadKey threadKey;
+  final BaseEvent event;
+  final String tag;
+
+  static String _tagFor(BaseEvent event) {
+    final name = event.runtimeType.toString();
+    final stripped =
+        name.endsWith('Event') ? name.substring(0, name.length - 5) : name;
+    return 'agui.${stripped.toLowerCase()}';
+  }
+}
+
+/// Collects bus events for the bus inspector UI.
+///
+/// Wired into `AgentRuntime` via its `busObserver` and `eventObserver`
+/// constructor parameters: the runtime fans every per-thread bus
+/// commit and every raw AG-UI event into this recorder. The agent
+/// itself stays free of any tagging logic — the inspector retroactively
+/// labels each commit based on the most recent state event observed on
+/// the same thread.
+///
+/// Events are bounded: on overflow, the oldest event is dropped so a
+/// long-running session cannot grow memory without bound.
+class BusInspector with ChangeNotifier {
+  BusInspector({int maxEvents = 1000})
+      : _maxEvents = maxEvents > 0
+            ? maxEvents
+            : throw ArgumentError.value(
+                maxEvents,
+                'maxEvents',
+                'must be positive',
+              );
+
+  final int _maxEvents;
+  final ListQueue<BusEvent> _events = ListQueue<BusEvent>();
+  final ListQueue<EventRecord> _records = ListQueue<EventRecord>();
+
+  /// Most recent AG-UI state event seen per thread, used to infer the
+  /// tag for the next bus commit on that thread. Cleared after the
+  /// commit consumes it so subsequent untagged commits surface as
+  /// `agui.run-state` rather than re-using a stale tag.
+  final Map<ThreadKey, BaseEvent> _lastStateEventByThread = {};
+
+  bool _disposed = false;
+
+  /// Recorded bus commits, oldest first.
+  List<BusEvent> get events => List.unmodifiable(_events);
+
+  /// Recorded raw AG-UI events, oldest first.
+  List<EventRecord> get eventRecords => List.unmodifiable(_records);
+
+  void clear() {
+    if (_disposed) return;
+    _events.clear();
+    _records.clear();
+    _lastStateEventByThread.clear();
+    notifyListeners();
+  }
+
+  /// Sink callable as a `ThreadEventObserver` from `AgentRuntime`.
+  /// Records the event for the unified inspector timeline AND tracks
+  /// the latest state event per thread so [record] can label the next
+  /// bus commit accurately.
+  void recordEvent(ThreadKey threadKey, BaseEvent event) {
+    if (_disposed) return;
+    if (event is StateSnapshotEvent || event is StateDeltaEvent) {
+      _lastStateEventByThread[threadKey] = event;
+    }
+    _records.addLast(
+      EventRecord(
+        timestamp: DateTime.now(),
+        threadKey: threadKey,
+        event: event,
+      ),
+    );
+    if (_records.length > _maxEvents) _records.removeFirst();
+    notifyListeners();
+  }
+
+  /// Sink callable as a `ThreadBusObserver` from `AgentRuntime`.
+  /// If [tag] is non-null it is preserved verbatim (used by seed paths
+  /// like `seed.initial` / `seed.history`). Otherwise the inspector
+  /// infers the tag from the most recent state event on the same
+  /// thread; absence of one means the commit was driven by a non-state
+  /// run-state transition (tool yielding, run completion, …).
+  void record(
+    ThreadKey threadKey,
+    String? tag,
+    Map<String, dynamic> snapshot,
+  ) {
+    if (_disposed) return;
+    final resolved = tag ?? _inferTag(threadKey);
+    _events.addLast(
+      BusEvent(
+        timestamp: DateTime.now(),
+        threadKey: threadKey,
+        tag: resolved,
+        snapshot: snapshot,
+      ),
+    );
+    if (_events.length > _maxEvents) _events.removeFirst();
+    notifyListeners();
+  }
+
+  String _inferTag(ThreadKey threadKey) {
+    final last = _lastStateEventByThread.remove(threadKey);
+    if (last is StateSnapshotEvent) return 'agui.snapshot';
+    if (last is StateDeltaEvent) return 'agui.delta';
+    return 'agui.run-state';
+  }
+
+  @override
+  void dispose() {
+    if (_disposed) return;
+    _disposed = true;
+    super.dispose();
+  }
+}

--- a/lib/src/modules/diagnostics/snapshot_diff.dart
+++ b/lib/src/modules/diagnostics/snapshot_diff.dart
@@ -1,0 +1,188 @@
+import 'package:flutter/foundation.dart';
+
+/// One categorised change between two state snapshots.
+@immutable
+sealed class SnapshotChange {
+  const SnapshotChange(this.path);
+
+  /// Slash-joined JSON path, e.g. `/ui/narrations/0/text`.
+  final String path;
+}
+
+class AddedChange extends SnapshotChange {
+  const AddedChange(super.path, this.value);
+  final dynamic value;
+}
+
+class RemovedChange extends SnapshotChange {
+  const RemovedChange(super.path, this.value);
+  final dynamic value;
+}
+
+class ReplacedChange extends SnapshotChange {
+  const ReplacedChange(super.path, this.before, this.after);
+  final dynamic before;
+  final dynamic after;
+}
+
+/// Result of diffing two `Map<String, dynamic>` snapshots, broken out
+/// into added / removed / replaced for UI rendering.
+@immutable
+class SnapshotDiff {
+  const SnapshotDiff({
+    required this.added,
+    required this.removed,
+    required this.replaced,
+  });
+
+  const SnapshotDiff.empty()
+      : added = const [],
+        removed = const [],
+        replaced = const [];
+
+  final List<AddedChange> added;
+  final List<RemovedChange> removed;
+  final List<ReplacedChange> replaced;
+
+  bool get isEmpty => added.isEmpty && removed.isEmpty && replaced.isEmpty;
+
+  int get totalChanges => added.length + removed.length + replaced.length;
+
+  /// Compact summary like `+2 / -1 / ~3` for tile rendering. Empty
+  /// segments are dropped (so `+1` / `~2` etc.).
+  String get summary {
+    final parts = <String>[
+      if (added.isNotEmpty) '+${added.length}',
+      if (removed.isNotEmpty) '-${removed.length}',
+      if (replaced.isNotEmpty) '~${replaced.length}',
+    ];
+    return parts.isEmpty ? 'no change' : parts.join(' / ');
+  }
+}
+
+/// Compute the structural diff between two snapshots.
+///
+/// Pass `null` for [prior] to treat the comparison as "everything in
+/// [current] is new" — produces an `AddedChange` per top-level key.
+/// Recurses into nested maps; lists are compared by index. Leaf values
+/// are compared with `==`. Type mismatches at a path are recorded as a
+/// single replacement (no further recursion into the mismatched value).
+SnapshotDiff diffSnapshots(
+  Map<String, dynamic>? prior,
+  Map<String, dynamic> current,
+) {
+  final added = <AddedChange>[];
+  final removed = <RemovedChange>[];
+  final replaced = <ReplacedChange>[];
+  _diffMap(prior ?? const {}, current, '', added, removed, replaced);
+  return SnapshotDiff(
+    added: List.unmodifiable(added),
+    removed: List.unmodifiable(removed),
+    replaced: List.unmodifiable(replaced),
+  );
+}
+
+void _diffMap(
+  Map<dynamic, dynamic> a,
+  Map<dynamic, dynamic> b,
+  String basePath,
+  List<AddedChange> added,
+  List<RemovedChange> removed,
+  List<ReplacedChange> replaced,
+) {
+  for (final key in {...a.keys, ...b.keys}) {
+    final path = '$basePath/$key';
+    final inA = a.containsKey(key);
+    final inB = b.containsKey(key);
+    if (!inA) {
+      _walkAdds(b[key], path, added);
+    } else if (!inB) {
+      _walkRemoves(a[key], path, removed);
+    } else {
+      _diffValue(a[key], b[key], path, added, removed, replaced);
+    }
+  }
+}
+
+void _diffValue(
+  dynamic before,
+  dynamic after,
+  String path,
+  List<AddedChange> added,
+  List<RemovedChange> removed,
+  List<ReplacedChange> replaced,
+) {
+  if (before is Map && after is Map) {
+    _diffMap(before, after, path, added, removed, replaced);
+    return;
+  }
+  if (before is List && after is List) {
+    final maxLen = before.length > after.length ? before.length : after.length;
+    for (var i = 0; i < maxLen; i++) {
+      final childPath = '$path/$i';
+      if (i >= before.length) {
+        _walkAdds(after[i], childPath, added);
+      } else if (i >= after.length) {
+        _walkRemoves(before[i], childPath, removed);
+      } else {
+        _diffValue(before[i], after[i], childPath, added, removed, replaced);
+      }
+    }
+    return;
+  }
+  if (before != after) {
+    replaced.add(ReplacedChange(path, before, after));
+  }
+}
+
+/// Recursively emit one [AddedChange] per leaf inside [value]. Empty
+/// maps and lists surface as a single change at [path] so the user
+/// still sees that something appeared, just empty.
+void _walkAdds(dynamic value, String path, List<AddedChange> out) {
+  if (value is Map) {
+    if (value.isEmpty) {
+      out.add(AddedChange(path, value));
+      return;
+    }
+    for (final entry in value.entries) {
+      _walkAdds(entry.value, '$path/${entry.key}', out);
+    }
+    return;
+  }
+  if (value is List) {
+    if (value.isEmpty) {
+      out.add(AddedChange(path, value));
+      return;
+    }
+    for (var i = 0; i < value.length; i++) {
+      _walkAdds(value[i], '$path/$i', out);
+    }
+    return;
+  }
+  out.add(AddedChange(path, value));
+}
+
+/// Mirror of [_walkAdds] for removals.
+void _walkRemoves(dynamic value, String path, List<RemovedChange> out) {
+  if (value is Map) {
+    if (value.isEmpty) {
+      out.add(RemovedChange(path, value));
+      return;
+    }
+    for (final entry in value.entries) {
+      _walkRemoves(entry.value, '$path/${entry.key}', out);
+    }
+    return;
+  }
+  if (value is List) {
+    if (value.isEmpty) {
+      out.add(RemovedChange(path, value));
+      return;
+    }
+    for (var i = 0; i < value.length; i++) {
+      _walkRemoves(value[i], '$path/$i', out);
+    }
+    return;
+  }
+  out.add(RemovedChange(path, value));
+}

--- a/lib/src/modules/diagnostics/ui/bus_inspector_screen.dart
+++ b/lib/src/modules/diagnostics/ui/bus_inspector_screen.dart
@@ -1,0 +1,1225 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+import 'package:soliplex_agent/soliplex_agent.dart' show BaseEvent, ThreadKey;
+
+import '../../auth/auth_providers.dart';
+import '../bus_filter.dart';
+import '../bus_inspector.dart';
+import '../models/json_tree_model.dart';
+import '../snapshot_diff.dart';
+import 'json_tree_view.dart';
+
+const double _wideBreakpoint = 720;
+const double _sidebarWidth = 260;
+
+class BusInspectorScreen extends ConsumerStatefulWidget {
+  const BusInspectorScreen({required this.inspector, super.key});
+
+  final BusInspector inspector;
+
+  @override
+  ConsumerState<BusInspectorScreen> createState() => _BusInspectorScreenState();
+}
+
+class _BusInspectorScreenState extends ConsumerState<BusInspectorScreen> {
+  /// `null` means "All events"; otherwise filter to a single thread.
+  ThreadKey? _selectedThread;
+
+  final TextEditingController _filterController = TextEditingController();
+
+  @override
+  void dispose() {
+    _filterController.dispose();
+    super.dispose();
+  }
+
+  void _openThread(ThreadKey key) {
+    final entry = ref.read(serverManagerProvider).servers.value[key.serverId];
+    if (entry == null) return;
+    context.go('/room/${entry.alias}/${key.roomId}/thread/${key.threadId}');
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return ListenableBuilder(
+      listenable: widget.inspector,
+      builder: (context, _) {
+        final allRows = _buildUnifiedRows(
+          widget.inspector.events,
+          widget.inspector.eventRecords,
+        );
+        final threadStats = _summariseThreads(allRows);
+        final filter = parseBusFilter(_filterController.text);
+        final scopedRows = _selectedThread == null
+            ? allRows
+            : allRows.where((r) => r.threadKey == _selectedThread).toList();
+        final visibleRows = filter.isEmpty
+            ? scopedRows
+            : scopedRows.where((r) => r.matchesFilter(filter)).toList();
+        final reversed = visibleRows.reversed.toList();
+
+        return Scaffold(
+          appBar: AppBar(
+            title: const Text('Bus Inspector'),
+            actions: [
+              IconButton(
+                icon: const Icon(Icons.delete_outline),
+                onPressed: allRows.isEmpty
+                    ? null
+                    : () {
+                        widget.inspector.clear();
+                      },
+                tooltip: 'Clear all events',
+              ),
+            ],
+          ),
+          body: LayoutBuilder(
+            builder: (context, constraints) {
+              final isWide = constraints.maxWidth >= _wideBreakpoint;
+              if (isWide) {
+                return Row(
+                  children: [
+                    SizedBox(
+                      width: _sidebarWidth,
+                      child: _ThreadSidebar(
+                        stats: threadStats,
+                        totalEventCount: allRows.length,
+                        selected: _selectedThread,
+                        onSelect: (key) =>
+                            setState(() => _selectedThread = key),
+                      ),
+                    ),
+                    const VerticalDivider(width: 1),
+                    Expanded(
+                      child: _EventsPane(
+                        rows: reversed,
+                        filterController: _filterController,
+                        events: widget.inspector.events,
+                        eventRecords: widget.inspector.eventRecords,
+                        onFilterChanged: () => setState(() {}),
+                        onOpenThread: _openThread,
+                      ),
+                    ),
+                  ],
+                );
+              }
+              // Narrow: sidebar OR events. Sidebar shows when no
+              // thread is selected; selecting one swaps to events.
+              if (_selectedThread == null && _filterController.text.isEmpty) {
+                return _ThreadSidebar(
+                  stats: threadStats,
+                  totalEventCount: allRows.length,
+                  selected: null,
+                  onSelect: (key) => setState(() => _selectedThread = key),
+                );
+              }
+              return _EventsPane(
+                rows: reversed,
+                filterController: _filterController,
+                events: widget.inspector.events,
+                eventRecords: widget.inspector.eventRecords,
+                onFilterChanged: () => setState(() {}),
+                onOpenThread: _openThread,
+                onBack: () => setState(() {
+                  _selectedThread = null;
+                  _filterController.clear();
+                }),
+              );
+            },
+          ),
+        );
+      },
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Sidebar
+// ---------------------------------------------------------------------------
+
+class _ThreadStat {
+  _ThreadStat({
+    required this.key,
+    required this.eventCount,
+    required this.lastEventAt,
+  });
+
+  final ThreadKey key;
+  final int eventCount;
+  final DateTime lastEventAt;
+}
+
+List<_ThreadStat> _summariseThreads(List<_Row> rows) {
+  final stats = <ThreadKey, _ThreadStat>{};
+  for (final row in rows) {
+    final existing = stats[row.threadKey];
+    if (existing == null) {
+      stats[row.threadKey] = _ThreadStat(
+        key: row.threadKey,
+        eventCount: 1,
+        lastEventAt: row.timestamp,
+      );
+    } else {
+      stats[row.threadKey] = _ThreadStat(
+        key: existing.key,
+        eventCount: existing.eventCount + 1,
+        lastEventAt: row.timestamp.isAfter(existing.lastEventAt)
+            ? row.timestamp
+            : existing.lastEventAt,
+      );
+    }
+  }
+  final list = stats.values.toList()
+    ..sort((a, b) => b.lastEventAt.compareTo(a.lastEventAt));
+  return list;
+}
+
+class _ThreadSidebar extends StatelessWidget {
+  const _ThreadSidebar({
+    required this.stats,
+    required this.totalEventCount,
+    required this.selected,
+    required this.onSelect,
+  });
+
+  final List<_ThreadStat> stats;
+  final int totalEventCount;
+  final ThreadKey? selected;
+  final ValueChanged<ThreadKey?> onSelect;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Material(
+      color: theme.colorScheme.surfaceContainerLow,
+      child: ListView(
+        children: [
+          ListTile(
+            selected: selected == null,
+            dense: true,
+            leading: const Icon(Icons.all_inbox_outlined, size: 20),
+            title: const Text('All events'),
+            trailing: Text(
+              '$totalEventCount',
+              style: theme.textTheme.labelSmall,
+            ),
+            onTap: () => onSelect(null),
+          ),
+          if (stats.isNotEmpty) const Divider(height: 1),
+          for (final s in stats)
+            ListTile(
+              selected: selected == s.key,
+              dense: true,
+              leading: Container(
+                width: 12,
+                height: 12,
+                decoration: BoxDecoration(
+                  color: _threadColor(s.key),
+                  shape: BoxShape.circle,
+                ),
+              ),
+              title: Text(
+                s.key.roomId,
+                maxLines: 1,
+                overflow: TextOverflow.ellipsis,
+                style: theme.textTheme.bodyMedium,
+              ),
+              subtitle: Text(
+                '${_threadShort(s.key)} · last ${_formatTime(s.lastEventAt)}',
+                maxLines: 1,
+                overflow: TextOverflow.ellipsis,
+                style: theme.textTheme.bodySmall?.copyWith(
+                  fontFamily: 'monospace',
+                  color: theme.colorScheme.onSurfaceVariant,
+                ),
+              ),
+              trailing: Text(
+                '${s.eventCount}',
+                style: theme.textTheme.labelSmall,
+              ),
+              onTap: () => onSelect(s.key),
+            ),
+        ],
+      ),
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Events pane (filter + list + inline detail)
+// ---------------------------------------------------------------------------
+
+class _EventsPane extends StatefulWidget {
+  const _EventsPane({
+    required this.rows,
+    required this.filterController,
+    required this.events,
+    required this.eventRecords,
+    required this.onFilterChanged,
+    required this.onOpenThread,
+    this.onBack,
+  });
+
+  final List<_Row> rows;
+  final TextEditingController filterController;
+  final List<BusEvent> events;
+  final List<EventRecord> eventRecords;
+  final VoidCallback onFilterChanged;
+  final void Function(ThreadKey) onOpenThread;
+  final VoidCallback? onBack;
+
+  @override
+  State<_EventsPane> createState() => _EventsPaneState();
+}
+
+class _EventsPaneState extends State<_EventsPane> {
+  int? _selectedIndex;
+
+  @override
+  Widget build(BuildContext context) {
+    final rows = widget.rows;
+    return Column(
+      children: [
+        _FilterBar(
+          controller: widget.filterController,
+          events: widget.events,
+          eventRecords: widget.eventRecords,
+          onChanged: () {
+            widget.onFilterChanged();
+            setState(() => _selectedIndex = null);
+          },
+          onBack: widget.onBack,
+        ),
+        const Divider(height: 1),
+        Expanded(
+          child: rows.isEmpty
+              ? _buildEmptyState(context)
+              : LayoutBuilder(
+                  builder: (context, constraints) {
+                    final isWide = constraints.maxWidth >= 600;
+                    if (isWide) {
+                      return _buildMasterDetail(context, rows);
+                    }
+                    return _buildList(context, rows, sheetMode: true);
+                  },
+                ),
+        ),
+      ],
+    );
+  }
+
+  Widget _buildEmptyState(BuildContext context) {
+    final theme = Theme.of(context);
+    return Center(
+      child: Padding(
+        padding: const EdgeInsets.all(24),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Icon(
+              Icons.bubble_chart_outlined,
+              size: 56,
+              color: theme.colorScheme.onSurfaceVariant,
+            ),
+            const SizedBox(height: 16),
+            Text(
+              widget.filterController.text.isEmpty
+                  ? 'No bus events yet'
+                  : 'No events match this filter',
+              style: theme.textTheme.titleMedium?.copyWith(
+                color: theme.colorScheme.onSurfaceVariant,
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildList(
+    BuildContext context,
+    List<_Row> rows, {
+    required bool sheetMode,
+  }) {
+    return ListView.separated(
+      itemCount: rows.length,
+      separatorBuilder: (_, __) => const Divider(height: 1),
+      itemBuilder: (context, index) => _RowTile(
+        row: rows[index],
+        selected: _selectedIndex == index,
+        onTap: sheetMode
+            ? () => _showDetailSheet(context, rows[index])
+            : () => setState(() => _selectedIndex = index),
+        onOpenThread: () => widget.onOpenThread(rows[index].threadKey),
+      ),
+    );
+  }
+
+  Widget _buildMasterDetail(BuildContext context, List<_Row> rows) {
+    final selected = _selectedIndex != null && _selectedIndex! < rows.length
+        ? rows[_selectedIndex!]
+        : null;
+    return Row(
+      children: [
+        SizedBox(
+          width: 360,
+          child: _buildList(context, rows, sheetMode: false),
+        ),
+        const VerticalDivider(width: 1),
+        Expanded(
+          child: selected == null
+              ? _buildDetailPlaceholder(context)
+              : SingleChildScrollView(
+                  child: _RowDetail(
+                    row: selected,
+                    onOpenThread: () => widget.onOpenThread(selected.threadKey),
+                  ),
+                ),
+        ),
+      ],
+    );
+  }
+
+  Widget _buildDetailPlaceholder(BuildContext context) {
+    final theme = Theme.of(context);
+    return Center(
+      child: Text(
+        'Select an event to inspect its diff.',
+        style: theme.textTheme.bodyMedium?.copyWith(
+          color: theme.colorScheme.onSurfaceVariant,
+        ),
+      ),
+    );
+  }
+
+  Future<void> _showDetailSheet(BuildContext context, _Row row) {
+    return showModalBottomSheet<void>(
+      context: context,
+      isScrollControlled: true,
+      builder: (_) => DraggableScrollableSheet(
+        expand: false,
+        initialChildSize: 0.75,
+        builder: (_, scrollController) => SingleChildScrollView(
+          controller: scrollController,
+          child: _RowDetail(
+            row: row,
+            onOpenThread: () => widget.onOpenThread(row.threadKey),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Filter bar with inline autocomplete chips
+// ---------------------------------------------------------------------------
+
+class _FilterBar extends StatefulWidget {
+  const _FilterBar({
+    required this.controller,
+    required this.events,
+    required this.eventRecords,
+    required this.onChanged,
+    this.onBack,
+  });
+
+  final TextEditingController controller;
+  final List<BusEvent> events;
+  final List<EventRecord> eventRecords;
+  final VoidCallback onChanged;
+  final VoidCallback? onBack;
+
+  @override
+  State<_FilterBar> createState() => _FilterBarState();
+}
+
+class _FilterBarState extends State<_FilterBar> {
+  final FocusNode _focus = FocusNode();
+
+  @override
+  void initState() {
+    super.initState();
+    widget.controller.addListener(_onTextChanged);
+    _focus.addListener(_onFocusChanged);
+  }
+
+  @override
+  void dispose() {
+    widget.controller.removeListener(_onTextChanged);
+    _focus
+      ..removeListener(_onFocusChanged)
+      ..dispose();
+    super.dispose();
+  }
+
+  void _onTextChanged() {
+    widget.onChanged();
+    setState(() {});
+  }
+
+  void _onFocusChanged() => setState(() {});
+
+  void _applySuggestion(String suggestion) {
+    final cursor = widget.controller.selection.baseOffset.clamp(
+      0,
+      widget.controller.text.length,
+    );
+    final at = currentTokenAt(widget.controller.text, cursor);
+    final start = at?.start ?? cursor;
+    final end = at?.end ?? cursor;
+    final before = widget.controller.text.substring(0, start);
+    final after = widget.controller.text.substring(end);
+    // Append a trailing space if there isn't one — lets the user type
+    // the next filter immediately without manual delimiter.
+    final needsSpace = after.isEmpty || !after.startsWith(' ');
+    final inserted = needsSpace ? '$suggestion ' : suggestion;
+    final replaced = '$before$inserted$after';
+    final newCursor = (before + inserted).length;
+    widget.controller.value = TextEditingValue(
+      text: replaced,
+      selection: TextSelection.collapsed(offset: newCursor),
+    );
+    _focus.requestFocus();
+  }
+
+  void _removeToken(int index) {
+    final tokens = widget.controller.text.split(RegExp(r'\s+'))
+      ..removeWhere((t) => t.isEmpty);
+    if (index < 0 || index >= tokens.length) return;
+    tokens.removeAt(index);
+    widget.controller.text = tokens.join(' ');
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final cursor = widget.controller.selection.baseOffset.clamp(
+      0,
+      widget.controller.text.length,
+    );
+    final suggestions = _focus.hasFocus
+        ? suggestionsFor(
+            text: widget.controller.text,
+            cursor: cursor,
+            events: widget.events,
+            records: widget.eventRecords,
+          ).take(8).toList()
+        : <String>[];
+
+    final activeTokens = widget.controller.text
+        .split(RegExp(r'\s+'))
+        .where((t) => t.isNotEmpty)
+        .toList();
+
+    return TapRegion(
+      groupId: 'bus-filter-bar',
+      child: Padding(
+        padding: const EdgeInsets.fromLTRB(12, 8, 12, 8),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            Row(
+              children: [
+                if (widget.onBack != null)
+                  IconButton(
+                    icon: const Icon(Icons.arrow_back),
+                    onPressed: widget.onBack,
+                    tooltip: 'Back to threads',
+                  ),
+                Expanded(
+                  child: TextField(
+                    controller: widget.controller,
+                    focusNode: _focus,
+                    // Default unfocuses the field on any outside tap,
+                    // which kills the suggestion chips: the rebuild
+                    // triggered by focus loss unmounts the chip before
+                    // its `onPressed` can fire. Override with a no-op
+                    // so the field keeps focus until the user
+                    // explicitly leaves the filter area.
+                    onTapOutside: (_) {},
+                    decoration: InputDecoration(
+                      isDense: true,
+                      prefixIcon: const Icon(Icons.search, size: 18),
+                      suffixIcon: widget.controller.text.isEmpty
+                          ? null
+                          : IconButton(
+                              icon: const Icon(Icons.close, size: 18),
+                              onPressed: () => widget.controller.clear(),
+                              tooltip: 'Clear filter',
+                            ),
+                      hintText:
+                          'Filter: kind:bus|event tag:agui.* thread:abc path:/ui',
+                      hintStyle: theme.textTheme.bodySmall?.copyWith(
+                        fontFamily: 'monospace',
+                      ),
+                      border: const OutlineInputBorder(),
+                      contentPadding: const EdgeInsets.symmetric(
+                        horizontal: 8,
+                        vertical: 8,
+                      ),
+                    ),
+                    style: theme.textTheme.bodyMedium
+                        ?.copyWith(fontFamily: 'monospace'),
+                  ),
+                ),
+              ],
+            ),
+            if (activeTokens.isNotEmpty) ...[
+              const SizedBox(height: 6),
+              Wrap(
+                spacing: 6,
+                runSpacing: 4,
+                children: [
+                  for (var i = 0; i < activeTokens.length; i++)
+                    InputChip(
+                      label: Text(
+                        activeTokens[i],
+                        style: theme.textTheme.bodySmall
+                            ?.copyWith(fontFamily: 'monospace'),
+                      ),
+                      onDeleted: () => _removeToken(i),
+                      deleteIcon: const Icon(Icons.close, size: 14),
+                      visualDensity: VisualDensity.compact,
+                      materialTapTargetSize: MaterialTapTargetSize.shrinkWrap,
+                    ),
+                ],
+              ),
+            ],
+            if (suggestions.isNotEmpty) ...[
+              const SizedBox(height: 6),
+              SizedBox(
+                height: 32,
+                child: ListView.separated(
+                  scrollDirection: Axis.horizontal,
+                  itemCount: suggestions.length,
+                  separatorBuilder: (_, __) => const SizedBox(width: 6),
+                  itemBuilder: (_, index) {
+                    final s = suggestions[index];
+                    return ActionChip(
+                      label: Text(
+                        s,
+                        style: theme.textTheme.bodySmall
+                            ?.copyWith(fontFamily: 'monospace'),
+                      ),
+                      onPressed: () {
+                        debugPrint('[BUS-INSPECTOR] chip onPressed: "$s"');
+                        _applySuggestion(s);
+                      },
+                      visualDensity: VisualDensity.compact,
+                      materialTapTargetSize: MaterialTapTargetSize.shrinkWrap,
+                    );
+                  },
+                ),
+              ),
+            ],
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Unified row hierarchy + builder
+// ---------------------------------------------------------------------------
+
+sealed class _Row {
+  DateTime get timestamp;
+  ThreadKey get threadKey;
+  String? get tag;
+
+  bool matchesFilter(BusFilter filter);
+}
+
+class _BusRow extends _Row {
+  _BusRow({required this.event, required this.diff});
+
+  final BusEvent event;
+  final SnapshotDiff diff;
+
+  @override
+  DateTime get timestamp => event.timestamp;
+  @override
+  ThreadKey get threadKey => event.threadKey;
+  @override
+  String? get tag => event.tag;
+
+  @override
+  bool matchesFilter(BusFilter filter) => filter.matchesBus(event, diff);
+}
+
+class _AguiEventRow extends _Row {
+  _AguiEventRow({required this.record});
+
+  final EventRecord record;
+
+  @override
+  DateTime get timestamp => record.timestamp;
+  @override
+  ThreadKey get threadKey => record.threadKey;
+  @override
+  String? get tag => record.tag;
+
+  @override
+  bool matchesFilter(BusFilter filter) => filter.matchesEvent(record);
+}
+
+/// Combine bus commits + raw event records into one timestamp-ordered
+/// list. Bus rows compute their per-thread diff against the previous
+/// commit on the same thread; no-op commits (empty diff) are dropped.
+List<_Row> _buildUnifiedRows(
+  List<BusEvent> commits,
+  List<EventRecord> records,
+) {
+  final lastSnapshotPerThread = <ThreadKey, Map<String, dynamic>>{};
+  final busRows = <_BusRow>[];
+  for (final event in commits) {
+    final prior = lastSnapshotPerThread[event.threadKey];
+    final diff = diffSnapshots(prior, event.snapshot);
+    lastSnapshotPerThread[event.threadKey] = event.snapshot;
+    if (diff.isEmpty) continue;
+    busRows.add(_BusRow(event: event, diff: diff));
+  }
+  final eventRows = records.map((r) => _AguiEventRow(record: r));
+  return [...busRows, ...eventRows]
+    ..sort((a, b) => a.timestamp.compareTo(b.timestamp));
+}
+
+// ---------------------------------------------------------------------------
+// Tiles + details (dispatch on row kind)
+// ---------------------------------------------------------------------------
+
+class _RowTile extends StatelessWidget {
+  const _RowTile({
+    required this.row,
+    required this.selected,
+    required this.onTap,
+    required this.onOpenThread,
+  });
+
+  final _Row row;
+  final bool selected;
+  final VoidCallback onTap;
+  final VoidCallback onOpenThread;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final (subtitle, summary) = switch (row) {
+      _BusRow(:final diff) => (
+          _firstChangedPath(diff) ?? _threadShort(row.threadKey),
+          diff.summary,
+        ),
+      _AguiEventRow(:final record) => (
+          _eventSubtitle(record.event),
+          'event',
+        ),
+    };
+    return ListTile(
+      selected: selected,
+      onTap: onTap,
+      dense: true,
+      leading: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Container(
+            width: 4,
+            height: 32,
+            decoration: BoxDecoration(
+              color: _threadColor(row.threadKey),
+              borderRadius: BorderRadius.circular(2),
+            ),
+          ),
+          const SizedBox(width: 8),
+          _RowKindBadge(row: row),
+          const SizedBox(width: 6),
+          _TagChip(tag: row.tag),
+        ],
+      ),
+      title: Row(
+        children: [
+          Text(
+            _formatTime(row.timestamp),
+            style:
+                theme.textTheme.bodyMedium?.copyWith(fontFamily: 'monospace'),
+          ),
+          const SizedBox(width: 8),
+          Expanded(
+            child: Text(
+              summary,
+              style: theme.textTheme.bodySmall?.copyWith(
+                fontFamily: 'monospace',
+                color: theme.colorScheme.primary,
+              ),
+            ),
+          ),
+        ],
+      ),
+      subtitle: Text(
+        subtitle,
+        maxLines: 1,
+        overflow: TextOverflow.ellipsis,
+        style: theme.textTheme.bodySmall?.copyWith(
+          color: theme.colorScheme.onSurfaceVariant,
+          fontFamily: 'monospace',
+        ),
+      ),
+      trailing: IconButton(
+        icon: const Icon(Icons.open_in_new, size: 18),
+        tooltip: 'Open thread ${_threadShort(row.threadKey)}',
+        onPressed: onOpenThread,
+        visualDensity: VisualDensity.compact,
+      ),
+    );
+  }
+}
+
+class _RowKindBadge extends StatelessWidget {
+  const _RowKindBadge({required this.row});
+
+  final _Row row;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final isBus = row is _BusRow;
+    final label = isBus ? 'bus' : 'event';
+    final color = isBus
+        ? theme.colorScheme.tertiaryContainer
+        : theme.colorScheme.primaryContainer;
+    final fg = isBus
+        ? theme.colorScheme.onTertiaryContainer
+        : theme.colorScheme.onPrimaryContainer;
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 1),
+      decoration: BoxDecoration(
+        color: color,
+        borderRadius: BorderRadius.circular(3),
+      ),
+      child: Text(
+        label,
+        style: theme.textTheme.labelSmall?.copyWith(
+          color: fg,
+          fontFamily: 'monospace',
+          fontSize: 10,
+        ),
+      ),
+    );
+  }
+}
+
+class _RowDetail extends StatelessWidget {
+  const _RowDetail({required this.row, required this.onOpenThread});
+
+  final _Row row;
+  final VoidCallback onOpenThread;
+
+  @override
+  Widget build(BuildContext context) => switch (row) {
+        _BusRow() =>
+          _BusRowDetail(row: row as _BusRow, onOpenThread: onOpenThread),
+        _AguiEventRow() => _AguiEventDetail(
+            row: row as _AguiEventRow,
+            onOpenThread: onOpenThread,
+          ),
+      };
+}
+
+class _BusRowDetail extends StatefulWidget {
+  const _BusRowDetail({required this.row, required this.onOpenThread});
+
+  final _BusRow row;
+  final VoidCallback onOpenThread;
+
+  @override
+  State<_BusRowDetail> createState() => _BusRowDetailState();
+}
+
+class _BusRowDetailState extends State<_BusRowDetail> {
+  bool _showFullSnapshot = false;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final diff = widget.row.diff;
+    return Padding(
+      padding: const EdgeInsets.all(16),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            children: [
+              _TagChip(tag: widget.row.event.tag),
+              const SizedBox(width: 12),
+              Text(
+                _formatTime(widget.row.event.timestamp),
+                style: theme.textTheme.titleMedium
+                    ?.copyWith(fontFamily: 'monospace'),
+              ),
+              const Spacer(),
+              Text(
+                diff.summary,
+                style: theme.textTheme.bodyMedium?.copyWith(
+                  fontFamily: 'monospace',
+                  color: theme.colorScheme.primary,
+                ),
+              ),
+            ],
+          ),
+          const SizedBox(height: 8),
+          _ThreadHeaderRow(
+            threadKey: widget.row.event.threadKey,
+            onOpenThread: widget.onOpenThread,
+          ),
+          const Divider(height: 24),
+          if (diff.isEmpty)
+            Padding(
+              padding: const EdgeInsets.symmetric(vertical: 8),
+              child: Text(
+                'No changes vs prior commit on this thread.',
+                style: theme.textTheme.bodySmall?.copyWith(
+                  color: theme.colorScheme.onSurfaceVariant,
+                ),
+              ),
+            )
+          else
+            _DiffList(diff: diff),
+          const SizedBox(height: 16),
+          TextButton.icon(
+            onPressed: () =>
+                setState(() => _showFullSnapshot = !_showFullSnapshot),
+            icon: Icon(
+              _showFullSnapshot ? Icons.expand_less : Icons.expand_more,
+              size: 18,
+            ),
+            label: Text(_showFullSnapshot
+                ? 'Hide full snapshot'
+                : 'Show full snapshot'),
+            style: TextButton.styleFrom(
+              padding: EdgeInsets.zero,
+              minimumSize: const Size(0, 32),
+              tapTargetSize: MaterialTapTargetSize.shrinkWrap,
+              alignment: Alignment.centerLeft,
+            ),
+          ),
+          if (_showFullSnapshot)
+            Padding(
+              padding: const EdgeInsets.only(top: 8),
+              child: JsonTreeView(
+                nodes: buildJsonTree(widget.row.event.snapshot),
+              ),
+            ),
+        ],
+      ),
+    );
+  }
+}
+
+class _AguiEventDetail extends StatelessWidget {
+  const _AguiEventDetail({required this.row, required this.onOpenThread});
+
+  final _AguiEventRow row;
+  final VoidCallback onOpenThread;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final event = row.record.event;
+    final json = _eventJson(event);
+    return Padding(
+      padding: const EdgeInsets.all(16),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            children: [
+              _TagChip(tag: row.record.tag),
+              const SizedBox(width: 12),
+              Text(
+                _formatTime(row.record.timestamp),
+                style: theme.textTheme.titleMedium
+                    ?.copyWith(fontFamily: 'monospace'),
+              ),
+              const Spacer(),
+              Text(
+                event.runtimeType.toString(),
+                style: theme.textTheme.bodyMedium?.copyWith(
+                  fontFamily: 'monospace',
+                  color: theme.colorScheme.onSurfaceVariant,
+                ),
+              ),
+            ],
+          ),
+          const SizedBox(height: 8),
+          _ThreadHeaderRow(
+            threadKey: row.record.threadKey,
+            onOpenThread: onOpenThread,
+          ),
+          const Divider(height: 24),
+          if (json.isEmpty)
+            Text(
+              '(no payload — event is fields-only)',
+              style: theme.textTheme.bodySmall?.copyWith(
+                color: theme.colorScheme.onSurfaceVariant,
+                fontStyle: FontStyle.italic,
+              ),
+            )
+          else
+            JsonTreeView(nodes: buildJsonTree(json)),
+        ],
+      ),
+    );
+  }
+}
+
+class _ThreadHeaderRow extends StatelessWidget {
+  const _ThreadHeaderRow({
+    required this.threadKey,
+    required this.onOpenThread,
+  });
+
+  final ThreadKey threadKey;
+  final VoidCallback onOpenThread;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Row(
+      children: [
+        Expanded(
+          child: SelectableText(
+            'thread: ${_threadFull(threadKey)}',
+            style: theme.textTheme.bodySmall?.copyWith(
+              color: theme.colorScheme.onSurfaceVariant,
+              fontFamily: 'monospace',
+            ),
+          ),
+        ),
+        TextButton.icon(
+          onPressed: onOpenThread,
+          icon: const Icon(Icons.open_in_new, size: 16),
+          label: const Text('Open thread'),
+          style: TextButton.styleFrom(
+            padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 0),
+            minimumSize: const Size(0, 32),
+            visualDensity: VisualDensity.compact,
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+class _DiffList extends StatelessWidget {
+  const _DiffList({required this.diff});
+
+  final SnapshotDiff diff;
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        for (final c in diff.added) _ChangeLine.added(c),
+        for (final c in diff.removed) _ChangeLine.removed(c),
+        for (final c in diff.replaced) _ChangeLine.replaced(c),
+      ],
+    );
+  }
+}
+
+class _ChangeLine extends StatelessWidget {
+  const _ChangeLine._({
+    required this.path,
+    required this.symbol,
+    required this.color,
+    required this.value,
+  });
+
+  factory _ChangeLine.added(AddedChange c) => _ChangeLine._(
+        path: c.path,
+        symbol: '+',
+        color: Colors.green.shade700,
+        value: _formatValue(c.value),
+      );
+
+  factory _ChangeLine.removed(RemovedChange c) => _ChangeLine._(
+        path: c.path,
+        symbol: '-',
+        color: Colors.red.shade700,
+        value: _formatValue(c.value),
+      );
+
+  factory _ChangeLine.replaced(ReplacedChange c) => _ChangeLine._(
+        path: c.path,
+        symbol: '~',
+        color: Colors.amber.shade800,
+        value: '${_formatValue(c.before)} → ${_formatValue(c.after)}',
+      );
+
+  final String path;
+  final String symbol;
+  final Color color;
+  final String value;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: 2),
+      child: SelectableText.rich(
+        TextSpan(
+          style: theme.textTheme.bodySmall?.copyWith(fontFamily: 'monospace'),
+          children: [
+            TextSpan(
+              text: '$symbol ',
+              style: TextStyle(color: color, fontWeight: FontWeight.bold),
+            ),
+            TextSpan(
+              text: path,
+              style: TextStyle(color: theme.colorScheme.onSurface),
+            ),
+            const TextSpan(text: '  '),
+            TextSpan(
+              text: value,
+              style: TextStyle(color: theme.colorScheme.onSurfaceVariant),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _TagChip extends StatelessWidget {
+  const _TagChip({required this.tag});
+
+  final String? tag;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final displayTag = tag ?? 'untagged';
+    final bg = tag == null
+        ? theme.colorScheme.surfaceContainerHighest
+        : theme.colorScheme.secondaryContainer;
+    final fg = tag == null
+        ? theme.colorScheme.onSurfaceVariant
+        : theme.colorScheme.onSecondaryContainer;
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 2),
+      decoration: BoxDecoration(
+        color: bg,
+        borderRadius: BorderRadius.circular(4),
+      ),
+      child: Text(
+        displayTag,
+        style: theme.textTheme.labelSmall?.copyWith(
+          color: fg,
+          fontFamily: 'monospace',
+        ),
+      ),
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+Color _threadColor(ThreadKey key) {
+  const palette = <Color>[
+    Color(0xFF1976D2),
+    Color(0xFF388E3C),
+    Color(0xFF7B1FA2),
+    Color(0xFFE64A19),
+    Color(0xFFC2185B),
+    Color(0xFF00796B),
+    Color(0xFF5D4037),
+    Color(0xFF455A64),
+  ];
+  return palette[key.threadId.hashCode.abs() % palette.length];
+}
+
+String _formatTime(DateTime t) {
+  final h = t.hour.toString().padLeft(2, '0');
+  final m = t.minute.toString().padLeft(2, '0');
+  final s = t.second.toString().padLeft(2, '0');
+  final ms = t.millisecond.toString().padLeft(3, '0');
+  return '$h:$m:$s.$ms';
+}
+
+String _threadShort(ThreadKey key) {
+  final tid = key.threadId;
+  return tid.length <= 6 ? tid : tid.substring(tid.length - 6);
+}
+
+String _threadFull(ThreadKey key) =>
+    '${key.serverId}/${key.roomId}/${key.threadId}';
+
+String? _firstChangedPath(SnapshotDiff diff) {
+  if (diff.added.isNotEmpty) return diff.added.first.path;
+  if (diff.replaced.isNotEmpty) return diff.replaced.first.path;
+  if (diff.removed.isNotEmpty) return diff.removed.first.path;
+  return null;
+}
+
+/// One-line summary used as the tile subtitle for an AG-UI event row.
+/// Picks the most informative field from the event's JSON form
+/// (messageId, activityType, etc.); falls back to runtime type.
+String _eventSubtitle(BaseEvent event) {
+  final json = _eventJson(event);
+  // Boring fields the user already sees elsewhere (timestamp + the
+  // tag derived from runtime type covers `type`).
+  const skip = {'type', 'eventType', 'timestamp', 'rawEvent'};
+  for (final entry in json.entries) {
+    if (skip.contains(entry.key)) continue;
+    final value = entry.value;
+    if (value == null) continue;
+    final repr = _briefValue(value);
+    return '${entry.key}=$repr';
+  }
+  return event.runtimeType.toString();
+}
+
+/// Pulls the event's structured fields via `toJson()`. All ag_ui
+/// `BaseEvent` subclasses provide this; it is the authoritative
+/// payload representation.
+Map<String, dynamic> _eventJson(BaseEvent event) {
+  try {
+    return event.toJson();
+  } on Object {
+    // toJson can in principle throw; fall back to an empty map so the
+    // detail view still renders the runtime type.
+    return const {};
+  }
+}
+
+String _briefValue(dynamic value) {
+  if (value is String) {
+    if (value.length > 60) return '"${value.substring(0, 57)}..."';
+    return '"$value"';
+  }
+  if (value is num || value is bool) return value.toString();
+  if (value is Map) {
+    return '{…} (${value.length} key${value.length == 1 ? '' : 's'})';
+  }
+  if (value is List) return '[…] (${value.length})';
+  return value.toString();
+}
+
+String _formatValue(dynamic value) {
+  if (value == null) return 'null';
+  if (value is String) {
+    if (value.length > 60) return '"${value.substring(0, 57)}..."';
+    return '"$value"';
+  }
+  if (value is num || value is bool) return value.toString();
+  if (value is Map) {
+    return '{…} (${value.length} key${value.length == 1 ? '' : 's'})';
+  }
+  if (value is List) return '[…] (${value.length})';
+  return value.toString();
+}

--- a/packages/soliplex_agent/lib/src/runtime/agent_runtime.dart
+++ b/packages/soliplex_agent/lib/src/runtime/agent_runtime.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 
+import 'package:ag_ui/ag_ui.dart' show BaseEvent;
 import 'package:signals_core/signals_core.dart';
 import 'package:soliplex_agent/src/host/platform_constraints.dart';
 import 'package:soliplex_agent/src/models/agent_result.dart';
@@ -17,6 +18,30 @@ import 'package:soliplex_agent/src/runtime/thread_state.dart';
 import 'package:soliplex_agent/src/tools/tool_registry_resolver.dart';
 import 'package:soliplex_client/soliplex_client.dart' show ThreadHistory;
 import 'package:soliplex_logging/soliplex_logging.dart';
+
+/// Callback receiving every per-thread `StateBus` write across the
+/// runtime, with the [ThreadKey] context the bus itself does not carry.
+///
+/// Wired from [AgentRuntime] into each per-thread bus the first time
+/// the runtime materialises a [ThreadState]. Used by debug surfaces
+/// (e.g. the in-app Bus Inspector) to record every commit.
+typedef ThreadBusObserver = void Function(
+  ThreadKey threadKey,
+  String? tag,
+  Map<String, dynamic> snapshot,
+);
+
+/// Callback receiving every raw AG-UI [BaseEvent] processed by any
+/// session in the runtime, paired with its [ThreadKey].
+///
+/// Lets diagnostics consumers correlate events with bus commits
+/// without the agent owning any tagging logic. The runtime itself
+/// makes no behavioural decision on the events; it only fans them
+/// out to the observer.
+typedef ThreadEventObserver = void Function(
+  ThreadKey threadKey,
+  BaseEvent event,
+);
 
 /// Facade for spawning and coordinating multiple [AgentSession]s.
 ///
@@ -54,6 +79,8 @@ class AgentRuntime {
     required Logger logger,
     AgentLlmProvider? llmProvider,
     SessionExtensionFactory? extensionFactory,
+    ThreadBusObserver? busObserver,
+    ThreadEventObserver? eventObserver,
     this.maxSpawnDepth = 10,
     this.rootTimeout,
   })  : serverId = connection.serverId,
@@ -65,6 +92,8 @@ class AgentRuntime {
             ),
         _toolRegistryResolver = toolRegistryResolver,
         _extensionFactory = extensionFactory,
+        _busObserver = busObserver,
+        _eventObserver = eventObserver,
         _platform = platform,
         _logger = logger;
 
@@ -72,8 +101,17 @@ class AgentRuntime {
   final AgentLlmProvider _llmProvider;
   final ToolRegistryResolver _toolRegistryResolver;
   final SessionExtensionFactory? _extensionFactory;
+  final ThreadBusObserver? _busObserver;
+  final ThreadEventObserver? _eventObserver;
   final PlatformConstraints _platform;
   final Logger _logger;
+
+  /// Forwards [event] (received by an [AgentSession]) to the optional
+  /// runtime-level event observer. No-op when no observer is wired.
+  /// Internal: called from [AgentSession._bridgeBaseEvent].
+  void notifyThreadEvent(ThreadKey key, BaseEvent event) {
+    _eventObserver?.call(key, event);
+  }
 
   /// Identifies which backend server this runtime targets.
   final String serverId;
@@ -139,7 +177,7 @@ class AgentRuntime {
   ) {
     if (aguiState.isEmpty) return;
     final state = _threadStateFor(key);
-    state.bus.setAgentState(aguiState);
+    state.bus.setAgentState(aguiState, tag: 'seed.initial');
     _threadStates[key] = state.withHistory(
       ThreadHistory(messages: const [], aguiState: aguiState),
     );
@@ -155,7 +193,7 @@ class AgentRuntime {
   void seedThreadHistory(ThreadKey key, ThreadHistory history) {
     final state = _threadStateFor(key);
     if (history.aguiState.isNotEmpty) {
-      state.bus.setAgentState(history.aguiState);
+      state.bus.setAgentState(history.aguiState, tag: 'seed.history');
     }
     _threadStates[key] = state.withHistory(history);
   }
@@ -163,8 +201,23 @@ class AgentRuntime {
   /// Returns the per-thread state for [key], creating a fresh
   /// [ThreadState] if none has been registered yet. Internal helper —
   /// callers outside the runtime should use the seed APIs above.
-  ThreadState _threadStateFor(ThreadKey key) =>
-      _threadStates[key] ??= ThreadState();
+  ///
+  /// On first creation, the bus is wired to forward every commit to
+  /// [_busObserver] (when set), threading the [ThreadKey] context the
+  /// bus itself does not carry.
+  ThreadState _threadStateFor(ThreadKey key) {
+    final existing = _threadStates[key];
+    if (existing != null) return existing;
+    final state = ThreadState();
+    final observer = _busObserver;
+    if (observer != null) {
+      state.bus.addObserver(
+        (tag, snapshot) => observer(key, tag, snapshot),
+      );
+    }
+    _threadStates[key] = state;
+    return state;
+  }
 
   /// Returns the per-thread state for [key], or `null` if no state has
   /// been registered. Read-only public accessor for consumers that

--- a/packages/soliplex_agent/lib/src/runtime/agent_session.dart
+++ b/packages/soliplex_agent/lib/src/runtime/agent_session.dart
@@ -406,6 +406,10 @@ class AgentSession implements ToolExecutionContext {
     // event without each consumer re-listening to the orchestrator.
     final next = _aguiStateOf(runState);
     if (next != null) {
+      // Untagged at the agent layer. Diagnostics consumers (e.g. the
+      // bus inspector) correlate this commit with the most recent
+      // AG-UI event seen via the runtime's event observer to infer
+      // whether it was a snapshot, delta, or run-state-only update.
       bus.setAgentState(next);
     }
     switch (runState) {
@@ -428,7 +432,12 @@ class AgentSession implements ToolExecutionContext {
   /// Maps raw AG-UI [BaseEvent]s to [ExecutionEvent] emissions so that
   /// consumers observing [lastExecutionEvent] see streaming text, thinking,
   /// server tool calls, and terminal events without polling [runState].
+  ///
+  /// Also fans the raw event to the runtime's optional thread-event
+  /// observer so diagnostics consumers can subscribe without coupling
+  /// the agent to any inspector implementation.
   void _bridgeBaseEvent(BaseEvent event) {
+    _runtime.notifyThreadEvent(threadKey, event);
     final executionEvent = bridgeBaseEvent(event);
     if (executionEvent != null) emitEvent(executionEvent);
   }

--- a/packages/soliplex_agent/test/runtime/agent_runtime_test.dart
+++ b/packages/soliplex_agent/test/runtime/agent_runtime_test.dart
@@ -262,6 +262,49 @@ void main() {
       expect(capturedInput!.state, equals(initialState));
     });
 
+    test('busObserver receives every per-thread bus write with key + tag',
+        () async {
+      final received = <(ThreadKey, String?, Map<String, dynamic>)>[];
+      final runtime = AgentRuntime(
+        connection: mockConnection(),
+        toolRegistryResolver: (_) async => const ToolRegistry(),
+        platform: const NativePlatformConstraints(),
+        logger: logger,
+        busObserver: (key, tag, snapshot) => received.add((key, tag, snapshot)),
+      );
+
+      const key1 = (
+        serverId: 'default',
+        roomId: 'room-a',
+        threadId: 'thread-a',
+      );
+      const key2 = (
+        serverId: 'default',
+        roomId: 'room-b',
+        threadId: 'thread-b',
+      );
+
+      runtime
+        ..seedThreadState(key1, {'count': 1})
+        ..seedThreadHistory(
+          key2,
+          ThreadHistory(
+            messages: const [],
+            aguiState: const {'count': 2},
+          ),
+        );
+
+      expect(received, hasLength(2));
+      expect(received[0].$1, key1);
+      expect(received[0].$2, 'seed.initial');
+      expect(received[0].$3['count'], 1);
+      expect(received[1].$1, key2);
+      expect(received[1].$2, 'seed.history');
+      expect(received[1].$3['count'], 2);
+
+      await runtime.dispose();
+    });
+
     test('seedThreadState makes initial state available for spawn', () async {
       final initialState = <String, dynamic>{
         'rag': <String, dynamic>{

--- a/packages/soliplex_client/lib/src/application/state_bus.dart
+++ b/packages/soliplex_client/lib/src/application/state_bus.dart
@@ -2,6 +2,16 @@ import 'package:meta/meta.dart';
 import 'package:signals_core/signals_core.dart';
 import 'package:soliplex_client/src/domain/surface.dart';
 
+/// Callback invoked after every successful [StateBus] commit.
+///
+/// [tag] is the optional source label passed to [StateBus.setAgentState]
+/// or [StateBus.update]; `null` when the writer did not provide one.
+/// [snapshot] is the frozen post-commit agent-state map.
+typedef BusObserver = void Function(
+  String? tag,
+  Map<String, dynamic> snapshot,
+);
+
 /// Per-thread reactive bus that mirrors AG-UI agent state and runs
 /// registered surface projections over it.
 ///
@@ -25,6 +35,7 @@ class StateBus {
       : _agentState = signal(_freeze(initialAgentState));
 
   final Signal<Map<String, dynamic>> _agentState;
+  final List<BusObserver> _observers = [];
 
   bool _disposed = false;
 
@@ -34,11 +45,24 @@ class StateBus {
   /// even when delta application produces structurally-equal maps.
   ReadonlySignal<Map<String, dynamic>> get agentState => _agentState.readonly();
 
+  /// Register [observer] to be invoked after every successful commit.
+  /// Returns a disposer that detaches [observer] when called.
+  /// Adding an observer to a disposed bus is a no-op; the returned
+  /// disposer is then a no-op too.
+  void Function() addObserver(BusObserver observer) {
+    if (_disposed) return () {};
+    _observers.add(observer);
+    return () => _observers.remove(observer);
+  }
+
   /// Replace the entire agent-state map. Call when an AG-UI
-  /// `StateSnapshotEvent` arrives.
-  void setAgentState(Map<String, dynamic> next) {
+  /// `StateSnapshotEvent` arrives. Pass [tag] to label the source of
+  /// this write (e.g. `'agui.snapshot'`); observers receive the tag.
+  void setAgentState(Map<String, dynamic> next, {String? tag}) {
     if (_disposed) return;
-    _agentState.value = _freeze(next);
+    final frozen = _freeze(next);
+    _agentState.value = frozen;
+    _notifyObservers(tag, frozen);
   }
 
   /// Replace via a transform applied to the current map. Convenient
@@ -48,11 +72,26 @@ class StateBus {
   /// ```dart
   /// bus.update((current) => applyJsonPatch(current, deltaOps));
   /// ```
+  ///
+  /// Pass [tag] to label the source of this write; observers receive
+  /// the tag.
   void update(
-    Map<String, dynamic> Function(Map<String, dynamic> current) transform,
-  ) {
+    Map<String, dynamic> Function(Map<String, dynamic> current) transform, {
+    String? tag,
+  }) {
     if (_disposed) return;
-    _agentState.value = _freeze(transform(_agentState.value));
+    final frozen = _freeze(transform(_agentState.value));
+    _agentState.value = frozen;
+    _notifyObservers(tag, frozen);
+  }
+
+  void _notifyObservers(String? tag, Map<String, dynamic> snapshot) {
+    if (_observers.isEmpty) return;
+    // Iterate over a snapshot so an observer detaching itself during
+    // dispatch (e.g. via the returned disposer) does not skip siblings.
+    for (final observer in List<BusObserver>.of(_observers)) {
+      observer(tag, snapshot);
+    }
   }
 
   /// Register a [StateProjection] and receive a derived signal that
@@ -69,6 +108,7 @@ class StateBus {
   void dispose() {
     if (_disposed) return;
     _disposed = true;
+    _observers.clear();
     _agentState.dispose();
   }
 

--- a/packages/soliplex_client/test/application/state_bus_test.dart
+++ b/packages/soliplex_client/test/application/state_bus_test.dart
@@ -93,6 +93,79 @@ void main() {
       bus.dispose();
     });
 
+    test('addObserver fires after each commit with tag and snapshot', () {
+      final bus = StateBus();
+      final received = <(String?, Map<String, dynamic>)>[];
+      bus
+        ..addObserver((tag, snapshot) => received.add((tag, snapshot)))
+        ..setAgentState({'a': 1}, tag: 'agui.snapshot')
+        ..update((current) => {'a': (current['a'] as int) + 1}, tag: 'delta')
+        ..setAgentState({'a': 99}); // untagged
+
+      expect(received, hasLength(3));
+      expect(received[0].$1, 'agui.snapshot');
+      expect(received[0].$2['a'], 1);
+      expect(received[1].$1, 'delta');
+      expect(received[1].$2['a'], 2);
+      expect(received[2].$1, isNull);
+      expect(received[2].$2['a'], 99);
+      bus.dispose();
+    });
+
+    test('addObserver disposer detaches a single observer', () {
+      final bus = StateBus();
+      final a = <String?>[];
+      final b = <String?>[];
+      final disposeA = bus.addObserver((tag, _) => a.add(tag));
+      bus
+        ..addObserver((tag, _) => b.add(tag))
+        ..setAgentState({}, tag: 'first');
+      disposeA();
+      bus.setAgentState({}, tag: 'second');
+
+      expect(a, ['first']);
+      expect(b, ['first', 'second']);
+      bus.dispose();
+    });
+
+    test(
+      'observer detaching itself during dispatch does not skip siblings',
+      () {
+        final bus = StateBus();
+        final calls = <String>[];
+        late final void Function() disposeMid;
+        bus.addObserver((_, __) => calls.add('first'));
+        disposeMid = bus.addObserver((_, __) {
+          calls.add('mid');
+          disposeMid();
+        });
+        bus
+          ..addObserver((_, __) => calls.add('last'))
+          ..setAgentState({});
+        expect(calls, ['first', 'mid', 'last']);
+        bus.dispose();
+      },
+    );
+
+    test('dispose clears observers and stops further notifications', () {
+      final bus = StateBus();
+      final received = <String?>[];
+      bus
+        ..addObserver((tag, _) => received.add(tag))
+        ..setAgentState({}, tag: 'before')
+        ..dispose()
+        ..setAgentState({}, tag: 'after');
+
+      expect(received, ['before']);
+    });
+
+    test('addObserver on disposed bus returns a no-op disposer', () {
+      final bus = StateBus()..dispose();
+      // Must not throw.
+      final disposer = bus.addObserver((_, __) {});
+      disposer();
+    });
+
     test(
       'RagSnapshotProjection conforms to StateProjection and produces '
       'a typed snapshot from the rag namespace',

--- a/test/modules/diagnostics/bus_filter_test.dart
+++ b/test/modules/diagnostics/bus_filter_test.dart
@@ -1,0 +1,209 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:soliplex_frontend/src/modules/diagnostics/bus_filter.dart';
+import 'package:soliplex_frontend/src/modules/diagnostics/bus_inspector.dart';
+import 'package:soliplex_frontend/src/modules/diagnostics/snapshot_diff.dart';
+
+BusEvent _event({
+  String server = 'srv',
+  String room = 'weather',
+  String thread = 'thread-abc123',
+  String? tag = 'agui.snapshot',
+  Map<String, dynamic> snapshot = const {},
+}) =>
+    BusEvent(
+      timestamp: DateTime.utc(2026, 5, 1),
+      threadKey: (serverId: server, roomId: room, threadId: thread),
+      tag: tag,
+      snapshot: snapshot,
+    );
+
+void main() {
+  group('parseBusFilter', () {
+    test('empty input yields empty filter', () {
+      expect(parseBusFilter('').isEmpty, isTrue);
+      expect(parseBusFilter('   ').isEmpty, isTrue);
+    });
+
+    test('parses each known key prefix', () {
+      final f = parseBusFilter(
+          'thread:abc room:weather server:srv tag:agui.snapshot path:/ui');
+      expect(f.threadSubstr, 'abc');
+      expect(f.roomSubstr, 'weather');
+      expect(f.serverSubstr, 'srv');
+      expect(f.tagPattern!.value, 'agui.snapshot');
+      expect(f.tagPattern!.isPrefix, isFalse);
+      expect(f.pathSubstr, '/ui');
+      expect(f.bareTerms, isEmpty);
+    });
+
+    test('tag glob with trailing * is a prefix pattern', () {
+      final f = parseBusFilter('tag:agui.*');
+      expect(f.tagPattern!.value, 'agui.');
+      expect(f.tagPattern!.isPrefix, isTrue);
+    });
+
+    test('unknown prefixes fall through to bareTerms', () {
+      final f = parseBusFilter('foo:bar plain');
+      expect(f.bareTerms, ['foo:bar', 'plain']);
+    });
+
+    test('later occurrence of same key overrides earlier', () {
+      final f = parseBusFilter('thread:aaa thread:bbb');
+      expect(f.threadSubstr, 'bbb');
+    });
+
+    test('empty value (key:) is treated as bare token', () {
+      final f = parseBusFilter('thread:');
+      // colon is at position len-1 → not a recognised k:v pair.
+      expect(f.bareTerms, ['thread:']);
+      expect(f.threadSubstr, isNull);
+    });
+  });
+
+  group('BusFilter.matches', () {
+    test('empty filter matches everything', () {
+      expect(
+        BusFilter.empty
+            .matches(_event(), const SnapshotDiff.empty()),
+        isTrue,
+      );
+    });
+
+    test('thread substring is case-insensitive', () {
+      final f = parseBusFilter('thread:ABC');
+      expect(f.matches(_event(), const SnapshotDiff.empty()), isTrue);
+      expect(
+        f.matches(_event(thread: 'thread-xyz'), const SnapshotDiff.empty()),
+        isFalse,
+      );
+    });
+
+    test('room and server substrings filter independently', () {
+      final f = parseBusFilter('room:weather server:srv');
+      expect(f.matches(_event(), const SnapshotDiff.empty()), isTrue);
+      expect(
+        f.matches(_event(room: 'maps'), const SnapshotDiff.empty()),
+        isFalse,
+      );
+      expect(
+        f.matches(_event(server: 'other'), const SnapshotDiff.empty()),
+        isFalse,
+      );
+    });
+
+    test('tag exact match', () {
+      final f = parseBusFilter('tag:agui.snapshot');
+      expect(f.matches(_event(), const SnapshotDiff.empty()), isTrue);
+      expect(
+        f.matches(_event(tag: 'seed.initial'), const SnapshotDiff.empty()),
+        isFalse,
+      );
+    });
+
+    test('tag prefix glob', () {
+      final f = parseBusFilter('tag:seed.*');
+      expect(
+        f.matches(_event(tag: 'seed.initial'), const SnapshotDiff.empty()),
+        isTrue,
+      );
+      expect(
+        f.matches(_event(tag: 'seed.history'), const SnapshotDiff.empty()),
+        isTrue,
+      );
+      expect(
+        f.matches(_event(tag: 'agui.snapshot'), const SnapshotDiff.empty()),
+        isFalse,
+      );
+    });
+
+    test('null tag never matches a tag pattern', () {
+      final f = parseBusFilter('tag:agui.*');
+      expect(
+        f.matches(_event(tag: null), const SnapshotDiff.empty()),
+        isFalse,
+      );
+    });
+
+    test('path filter scans all change kinds', () {
+      final diff = diffSnapshots(
+        {'a': 1},
+        {
+          'a': 2, // replaced /a
+          'ui': {'narrations': true}, // added /ui, /ui/narrations
+        },
+      );
+      final f = parseBusFilter('path:narrations');
+      expect(f.matches(_event(), diff), isTrue);
+      final g = parseBusFilter('path:nope');
+      expect(g.matches(_event(), diff), isFalse);
+    });
+
+    test('bare term must match at least one field', () {
+      final diff = diffSnapshots({}, {
+        'rag': {'q': 'temperature'},
+      });
+      final f = parseBusFilter('weather');
+      expect(f.matches(_event(), diff), isTrue); // matches roomId
+
+      final g = parseBusFilter('rag');
+      expect(g.matches(_event(), diff), isTrue); // matches a path
+
+      final h = parseBusFilter('zzz');
+      expect(h.matches(_event(), diff), isFalse);
+    });
+
+    test('multiple bare terms must each match somewhere', () {
+      final f = parseBusFilter('weather agui');
+      expect(
+        f.matches(_event(), const SnapshotDiff.empty()),
+        isTrue, // 'weather' in roomId, 'agui' in tag
+      );
+      final g = parseBusFilter('weather missing');
+      expect(g.matches(_event(), const SnapshotDiff.empty()), isFalse);
+    });
+  });
+
+  group('suggestionsFor', () {
+    final events = [
+      _event(thread: 'thread-aaaa11', room: 'weather', tag: 'agui.snapshot'),
+      _event(thread: 'thread-bbbb22', room: 'maps', tag: 'seed.initial'),
+      _event(thread: 'thread-cccc33', room: 'maps', tag: null),
+    ];
+
+    test('empty input lists all key prefixes', () {
+      final s = suggestionsFor(text: '', cursor: 0, events: events);
+      expect(s, equals(kFilterKeys.map((k) => '$k:').toList()));
+    });
+
+    test('partial bare token suggests matching keys', () {
+      final s = suggestionsFor(text: 'thr', cursor: 3, events: events);
+      expect(s, ['thread:']);
+    });
+
+    test('"key:" with empty value lists known values', () {
+      final s = suggestionsFor(text: 'tag:', cursor: 4, events: events);
+      expect(s.toSet(), {'tag:agui.snapshot', 'tag:seed.initial'});
+    });
+
+    test('"key:partial" filters by substring', () {
+      final s =
+          suggestionsFor(text: 'thread:bb', cursor: 9, events: events);
+      // last 6 chars of thread-bbbb22 -> 'bbbb22'
+      expect(s, ['thread:bbbb22']);
+    });
+
+    test('null tags are not suggested for tag:', () {
+      final s = suggestionsFor(text: 'tag:', cursor: 4, events: events);
+      expect(s.where((v) => v.contains('null')), isEmpty);
+    });
+
+    test('cursor in whitespace returns key list', () {
+      final s = suggestionsFor(
+        text: 'thread:abc ',
+        cursor: 11,
+        events: events,
+      );
+      expect(s, equals(kFilterKeys.map((k) => '$k:').toList()));
+    });
+  });
+}

--- a/test/modules/diagnostics/bus_inspector_test.dart
+++ b/test/modules/diagnostics/bus_inspector_test.dart
@@ -1,0 +1,171 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:soliplex_agent/soliplex_agent.dart';
+import 'package:soliplex_frontend/src/modules/diagnostics/bus_inspector.dart';
+
+void main() {
+  group('BusInspector', () {
+    const key = (
+      serverId: 's',
+      roomId: 'r',
+      threadId: 't',
+    );
+    const otherKey = (
+      serverId: 's',
+      roomId: 'r',
+      threadId: 'other',
+    );
+
+    test('starts empty', () {
+      final inspector = BusInspector();
+      addTearDown(inspector.dispose);
+      expect(inspector.events, isEmpty);
+    });
+
+    test('explicit tag is preserved verbatim', () {
+      final inspector = BusInspector()
+        ..record(key, 'seed.initial', {'a': 1})
+        ..record(key, 'seed.history', {'a': 2});
+      addTearDown(inspector.dispose);
+
+      expect(inspector.events.map((e) => e.tag).toList(),
+          ['seed.initial', 'seed.history']);
+    });
+
+    test('null tag falls back to agui.run-state when no event seen', () {
+      final inspector = BusInspector()..record(key, null, {});
+      addTearDown(inspector.dispose);
+      expect(inspector.events.single.tag, 'agui.run-state');
+    });
+
+    test('record after StateSnapshotEvent is tagged agui.snapshot', () {
+      final inspector = BusInspector()
+        ..recordEvent(key, const StateSnapshotEvent(snapshot: {'x': 1}))
+        ..record(key, null, {'x': 1});
+      addTearDown(inspector.dispose);
+      expect(inspector.events.single.tag, 'agui.snapshot');
+    });
+
+    test('record after StateDeltaEvent is tagged agui.delta', () {
+      final inspector = BusInspector()
+        ..recordEvent(key, const StateDeltaEvent(delta: []))
+        ..record(key, null, {'x': 1});
+      addTearDown(inspector.dispose);
+      expect(inspector.events.single.tag, 'agui.delta');
+    });
+
+    test('inferred tag is consumed: next untagged commit is run-state', () {
+      final inspector = BusInspector()
+        ..recordEvent(key, const StateSnapshotEvent(snapshot: {}))
+        ..record(key, null, {})
+        ..record(key, null, {});
+      addTearDown(inspector.dispose);
+      expect(inspector.events.map((e) => e.tag).toList(),
+          ['agui.snapshot', 'agui.run-state']);
+    });
+
+    test('per-thread inference: events on key A do not affect key B', () {
+      final inspector = BusInspector()
+        ..recordEvent(key, const StateSnapshotEvent(snapshot: {}))
+        ..record(otherKey, null, {});
+      addTearDown(inspector.dispose);
+      // The state event was on `key`, so the otherKey commit must NOT
+      // be tagged agui.snapshot.
+      expect(inspector.events.single.tag, 'agui.run-state');
+    });
+
+    test('non-state events do not influence tagging', () {
+      final inspector = BusInspector()
+        ..recordEvent(
+          key,
+          const TextMessageStartEvent(messageId: 'm-1'),
+        )
+        ..record(key, null, {});
+      addTearDown(inspector.dispose);
+      expect(inspector.events.single.tag, 'agui.run-state');
+    });
+
+    test('most recent state event wins when several arrive in a row', () {
+      final inspector = BusInspector()
+        ..recordEvent(key, const StateSnapshotEvent(snapshot: {}))
+        ..recordEvent(key, const StateDeltaEvent(delta: []))
+        ..record(key, null, {});
+      addTearDown(inspector.dispose);
+      expect(inspector.events.single.tag, 'agui.delta');
+    });
+
+    test('record notifies listeners', () {
+      final inspector = BusInspector();
+      addTearDown(inspector.dispose);
+      var calls = 0;
+      inspector.addListener(() => calls++);
+
+      inspector.record(key, null, {});
+      expect(calls, 1);
+    });
+
+    test('recordEvent appends to event records and notifies', () {
+      final inspector = BusInspector();
+      addTearDown(inspector.dispose);
+      var calls = 0;
+      inspector.addListener(() => calls++);
+
+      inspector.recordEvent(key, const StateSnapshotEvent(snapshot: {}));
+      expect(calls, 1);
+      expect(inspector.eventRecords, hasLength(1));
+      expect(inspector.eventRecords.single.tag, 'agui.statesnapshot');
+    });
+
+    test('event tag is derived from runtime type, lowercased', () {
+      final inspector = BusInspector()
+        ..recordEvent(key, const StateDeltaEvent(delta: []))
+        ..recordEvent(
+          key,
+          const TextMessageStartEvent(messageId: 'm-1'),
+        )
+        ..recordEvent(key, const RunFinishedEvent(threadId: 't', runId: 'r'));
+      addTearDown(inspector.dispose);
+      expect(
+        inspector.eventRecords.map((r) => r.tag).toList(),
+        ['agui.statedelta', 'agui.textmessagestart', 'agui.runfinished'],
+      );
+    });
+
+    test('overflow drops oldest events', () {
+      final inspector = BusInspector(maxEvents: 3);
+      addTearDown(inspector.dispose);
+      for (var i = 0; i < 5; i++) {
+        inspector.record(key, 't$i', {'i': i});
+      }
+      expect(inspector.events.map((e) => e.tag).toList(), ['t2', 't3', 't4']);
+    });
+
+    test('clear empties events, resets pending tags, notifies', () {
+      final inspector = BusInspector()
+        ..recordEvent(key, const StateSnapshotEvent(snapshot: {}))
+        ..record(key, null, {});
+      addTearDown(inspector.dispose);
+      var clearedNotifications = 0;
+      inspector.addListener(() => clearedNotifications++);
+      inspector
+        ..clear()
+        ..record(key, null, {});
+      expect(inspector.events.single.tag, 'agui.run-state');
+      expect(clearedNotifications, 2); // clear + record
+    });
+
+    test('record after dispose is a no-op', () {
+      final inspector = BusInspector()..dispose();
+      inspector.record(key, null, {});
+    });
+
+    test('recordEvent after dispose is a no-op', () {
+      final inspector = BusInspector()..dispose();
+      inspector.recordEvent(key, const StateSnapshotEvent(snapshot: {}));
+    });
+
+    test('rejects non-positive maxEvents', () {
+      expect(() => BusInspector(maxEvents: 0), throwsArgumentError);
+      expect(() => BusInspector(maxEvents: -1), throwsArgumentError);
+    });
+  });
+}

--- a/test/modules/diagnostics/snapshot_diff_test.dart
+++ b/test/modules/diagnostics/snapshot_diff_test.dart
@@ -1,0 +1,135 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:soliplex_frontend/src/modules/diagnostics/snapshot_diff.dart';
+
+void main() {
+  group('diffSnapshots', () {
+    test('null prior produces an added change per top-level key', () {
+      final diff = diffSnapshots(null, {'a': 1, 'b': 2});
+      expect(diff.added.map((c) => c.path).toSet(), {'/a', '/b'});
+      expect(diff.removed, isEmpty);
+      expect(diff.replaced, isEmpty);
+    });
+
+    test('empty prior is treated like null', () {
+      final diff = diffSnapshots({}, {'a': 1});
+      expect(diff.added, hasLength(1));
+      expect(diff.added.single.path, '/a');
+    });
+
+    test('identical snapshots produce no changes', () {
+      final diff = diffSnapshots(
+        {
+          'a': 1,
+          'nested': {'x': true},
+        },
+        {
+          'a': 1,
+          'nested': {'x': true},
+        },
+      );
+      expect(diff.isEmpty, isTrue);
+      expect(diff.summary, 'no change');
+    });
+
+    test('detects added, removed, and replaced top-level keys', () {
+      final diff = diffSnapshots(
+        {'keep': 1, 'drop': 2, 'change': 'before'},
+        {'keep': 1, 'change': 'after', 'add': 9},
+      );
+      expect(diff.added.single.path, '/add');
+      expect(diff.removed.single.path, '/drop');
+      expect(diff.replaced.single.path, '/change');
+      expect(diff.replaced.single.before, 'before');
+      expect(diff.replaced.single.after, 'after');
+      expect(diff.summary, '+1 / -1 / ~1');
+    });
+
+    test('recurses into nested maps and reports leaf paths', () {
+      final diff = diffSnapshots(
+        {
+          'ui': {
+            'hud': {'mode': 'idle', 'extra': 'gone'},
+          },
+        },
+        {
+          'ui': {
+            'hud': {'mode': 'active', 'new': true},
+          },
+        },
+      );
+      expect(diff.replaced.single.path, '/ui/hud/mode');
+      expect(diff.added.single.path, '/ui/hud/new');
+      expect(diff.removed.single.path, '/ui/hud/extra');
+    });
+
+    test('list extension is reported as added at index', () {
+      final diff = diffSnapshots(
+        {
+          'narrations': ['a'],
+        },
+        {
+          'narrations': ['a', 'b', 'c'],
+        },
+      );
+      expect(
+        diff.added.map((c) => c.path).toList(),
+        ['/narrations/1', '/narrations/2'],
+      );
+    });
+
+    test('list shrink is reported as removed at index', () {
+      final diff = diffSnapshots(
+        {
+          'narrations': ['a', 'b', 'c'],
+        },
+        {
+          'narrations': ['a'],
+        },
+      );
+      expect(
+        diff.removed.map((c) => c.path).toList(),
+        ['/narrations/1', '/narrations/2'],
+      );
+    });
+
+    test('list element replacement', () {
+      final diff = diffSnapshots(
+        {
+          'list': [
+            {'id': 1, 'name': 'old'},
+          ],
+        },
+        {
+          'list': [
+            {'id': 1, 'name': 'new'},
+          ],
+        },
+      );
+      expect(diff.replaced.single.path, '/list/0/name');
+      expect(diff.replaced.single.before, 'old');
+      expect(diff.replaced.single.after, 'new');
+    });
+
+    test('type mismatch at a path is one replacement, no recursion', () {
+      final diff = diffSnapshots(
+        {
+          'value': {'nested': 'map'},
+        },
+        {
+          'value': 'now a string',
+        },
+      );
+      expect(diff.replaced.single.path, '/value');
+      expect(diff.added, isEmpty);
+      expect(diff.removed, isEmpty);
+    });
+
+    test('summary drops empty segments', () {
+      final addedOnly = diffSnapshots({}, {'x': 1});
+      expect(addedOnly.summary, '+1');
+
+      final replacedOnly = diffSnapshots({'x': 1}, {'x': 2});
+      expect(replacedOnly.summary, '~1');
+    });
+  });
+}


### PR DESCRIPTION
Part of #202 (3 of 4 stacked PRs). **Depends on #203 and #204 — merge those first** then rebase this.

## What this changes

Self-contained diagnostics module under
\`lib/src/modules/diagnostics/\` providing an in-app inspector for the
per-thread \`StateBus\` and the AG-UI event stream that drives it.
**All new files; no existing call sites change.** Wiring into the
shell happens in #205.

### Components

- **\`BusInspector\`** — \`ChangeNotifier\` recorder with two bounded
  queues (commits + raw events). Sinks shaped to match
  \`ThreadBusObserver\` (\`record\`) and \`ThreadEventObserver\`
  (\`recordEvent\`) so the host flavor wires it through
  \`AgentRuntime\` directly.
- **Tag inference** — \`recordEvent\` tracks the most recent
  \`StateSnapshotEvent\` / \`StateDeltaEvent\` per thread; when an
  untagged bus commit arrives, the inspector labels it
  \`agui.snapshot\`, \`agui.delta\`, or \`agui.run-state\` accordingly.
  Explicit tags pass through verbatim. Event records derive their own
  tag from the runtime type (\`ActivitySnapshotEvent\` →
  \`agui.activitysnapshot\`).
- **\`snapshot_diff.dart\`** — pure-Dart structural differ. Walks
  added/removed subtrees recursively so a fresh nested branch
  surfaces as one leaf path per value, not a single coarse \`/parent\`
  change.
- **\`bus_filter.dart\`** — small filter mini-language with prefixes
  \`thread:\`, \`room:\`, \`server:\`, \`tag:\`, \`path:\`, and
  \`kind:bus|event\`, plus bare-text fallback. \`tag:foo*\` is a prefix
  glob. \`suggestionsFor(...)\` powers autocomplete chips.
- **\`BusInspectorScreen\`** — master-detail UI. Sidebar lists "All
  events" plus one row per active thread. Right pane shows a filter
  \`TextField\` with autocomplete chips and active-filter pills (each
  removable via X), then a unified timestamp-ordered timeline mixing
  bus rows and event rows distinguished by a \`bus\`/\`event\` kind
  badge. Bus row detail renders the diff plus a collapsible full
  snapshot. Event row detail renders the event's \`toJson()\` payload
  via \`JsonTreeView\`.

### One Flutter quirk worth flagging

\`TextField.onTapOutside: (_) {}\` is a no-op so the field keeps focus
while users tap suggestion chips. Without this, the rebuild
triggered by Flutter's default unfocus-on-outside-tap unmounted the
chip before its \`onPressed\` could fire — chips were unselectable.

## Testing

~50 unit tests across the differ, filter parser/matcher, suggestion
generator, and \`BusInspector\` recording semantics. Widget tests for
the screen are not included in this PR; manual smoke testing on
macOS confirmed the workflow end-to-end.

## Stack

1. #203 — StateBus observer + tag API
2. #204 — bus + event observers on AgentRuntime
3. **This PR** — Bus Inspector module
4. \`feat/wire-bus-inspector\` — wire into shell