### PR TITLE
feat: SSE resume with cancel-aware backoff and reconnect banner

### DIFF
--- a/lib/src/modules/room/run_registry.dart
+++ b/lib/src/modules/room/run_registry.dart
@@ -17,9 +17,10 @@ class CompletedRun extends RunOutcome {
 
 /// The run failed.
 class FailedRun extends RunOutcome {
-  const FailedRun(this.conversation, this.error);
+  const FailedRun(this.conversation, this.error, {required this.reason});
   final Conversation? conversation;
   final Object error;
+  final FailureReason reason;
 }
 
 /// The run was cancelled.
@@ -124,22 +125,32 @@ class RunRegistry {
     return switch (state) {
       CompletedState(:final conversation, :final runId) =>
         CompletedRun(conversation, runId: runId),
-      FailedState(:final conversation, :final error) =>
-        FailedRun(conversation, error),
+      FailedState(:final conversation, :final error, :final reason) =>
+        FailedRun(conversation, error, reason: reason),
       CancelledState(:final conversation) => CancelledRun(conversation),
       // No terminal RunState was captured (external dispose ran before
       // any terminal state arrived) — derive the outcome from result.
       null => switch (result) {
           AgentFailure(:final reason) when reason == FailureReason.cancelled =>
             CancelledRun(null),
-          AgentFailure(:final error) => FailedRun(null, error),
-          AgentTimedOut() => FailedRun(null, 'Session timed out'),
-          AgentSuccess() => FailedRun(null, 'Completed without terminal state'),
+          AgentFailure(:final error, :final reason) =>
+            FailedRun(null, error, reason: reason),
+          AgentTimedOut() => FailedRun(
+              null,
+              'Session timed out',
+              reason: FailureReason.internalError,
+            ),
+          AgentSuccess() => FailedRun(
+              null,
+              'Completed without terminal state',
+              reason: FailureReason.internalError,
+            ),
         },
       IdleState() || RunningState() || ToolYieldingState() => FailedRun(
           null,
           'Session result arrived in non-terminal state '
           '${state.runtimeType}: $result',
+          reason: FailureReason.internalError,
         ),
     };
   }

--- a/lib/src/modules/room/thread_view_state.dart
+++ b/lib/src/modules/room/thread_view_state.dart
@@ -246,9 +246,13 @@ class ThreadViewState {
     _activeSession.value = session;
     _sessionState.value = session.state;
     _runStateUnsub = session.runState.subscribe(_onRunState);
+    // `subscribe` fires synchronously with the new session's current
+    // value — null for fresh sessions, the live status for sessions
+    // restored from the registry. Either way, the mirror is up to date
+    // without an explicit reset (which would erase a live status from
+    // a restored session).
     _reconnectStatusUnsub =
         session.reconnectStatus.subscribe(_onReconnectStatus);
-    _reconnectStatus.value = null;
   }
 
   void _onReconnectStatus(ReconnectStatus? status) {
@@ -269,9 +273,9 @@ class ThreadViewState {
       case CompletedState(:final conversation):
         _detachSession();
         _messages.value = _messagesLoaded(conversation);
-      case FailedState(:final conversation, :final error):
+      case FailedState(:final conversation, :final reason, :final error):
         _detachSession();
-        _lastSendError.value = SendError(_friendlyMessage(error));
+        _lastSendError.value = SendError(_friendlyMessage(reason, error));
         if (conversation != null) {
           _messages.value = _messagesLoaded(conversation);
         }
@@ -323,12 +327,14 @@ class ThreadViewState {
   }
 
   /// Translates orchestrator failure copy into user-facing copy.
-  /// Resume-failure markers from `AgUiStreamClient` get a friendly
-  /// message; the skipped-event count, when present, is preserved as
-  /// a parenthetical so the user knows data was dropped along the way.
-  /// Other failures pass through unchanged.
-  String _friendlyMessage(String error) {
-    if (!error.startsWith(streamResumeFailedPrefix)) return error;
+  ///
+  /// `streamResumeFailed` failures get a friendly base message. The
+  /// skipped-event count, when present in the underlying error string,
+  /// is preserved as a parenthetical suffix — best-effort: the base
+  /// message still appears if the suffix format ever drifts. Other
+  /// failures pass through unchanged.
+  String _friendlyMessage(FailureReason reason, String error) {
+    if (reason != FailureReason.streamResumeFailed) return error;
     const base = 'Connection lost. The response may be incomplete — '
         'you can send your message again.';
     final skipped =
@@ -354,9 +360,10 @@ class ThreadViewState {
     switch (outcome) {
       case CompletedRun(:final conversation):
         _messages.value = _messagesLoaded(conversation);
-      case FailedRun(:final conversation, :final error):
+      case FailedRun(:final conversation, :final error, :final reason):
         // Apply friendly copy on re-attach, same as the live FailedState arm.
-        _lastSendError.value = SendError(_friendlyMessage(error.toString()));
+        _lastSendError.value =
+            SendError(_friendlyMessage(reason, error.toString()));
         if (conversation != null) {
           _messages.value = _messagesLoaded(conversation);
         }

--- a/lib/src/modules/room/thread_view_state.dart
+++ b/lib/src/modules/room/thread_view_state.dart
@@ -416,5 +416,6 @@ class ThreadViewState {
     _sessionState.dispose();
     _reconnectStatus.dispose();
     isCancellable.dispose();
+    pendingApproval.dispose();
   }
 }

--- a/lib/src/modules/room/thread_view_state.dart
+++ b/lib/src/modules/room/thread_view_state.dart
@@ -84,6 +84,7 @@ class ThreadViewState {
   CancelToken? _cancelToken;
   final Signal<AgentSession?> _activeSession = Signal<AgentSession?>(null);
   void Function()? _runStateUnsub;
+  void Function()? _reconnectStatusUnsub;
   bool _isDisposed = false;
 
   final SessionSpawner _spawner = SessionSpawner();
@@ -104,6 +105,18 @@ class ThreadViewState {
 
   final Signal<SendError?> _lastSendError = Signal<SendError?>(null);
   ReadonlySignal<SendError?> get lastSendError => _lastSendError;
+
+  /// Mirror of the active session's reconnect lifecycle. `null` means
+  /// no reconnect activity. The room screen renders a banner only for
+  /// [Reconnecting] / [Reconnected]; [ReconnectFailed] surfaces through
+  /// the existing [SendError] banner via [_friendlyMessage].
+  final Signal<ReconnectStatus?> _reconnectStatus =
+      Signal<ReconnectStatus?>(null);
+  ReadonlySignal<ReconnectStatus?> get reconnectStatus => _reconnectStatus;
+
+  /// Clears the reconnect banner. The "Reconnected" tile self-dismisses
+  /// after 4s in the widget; this is for explicit user dismissal.
+  void dismissReconnectStatus() => _reconnectStatus.value = null;
 
   // Persists historical trackers from loaded thread history and from
   // completed sessions (absorbed in _detachSession). Plain map — the live
@@ -209,6 +222,19 @@ class ThreadViewState {
     _activeSession.value = session;
     _sessionState.value = session.state;
     _runStateUnsub = session.runState.subscribe(_onRunState);
+    _reconnectStatusUnsub =
+        session.reconnectStatus.subscribe(_onReconnectStatus);
+    // Defensive — `subscribe` fires synchronously with the new session's
+    // `null` value, which would clear the mirror automatically. The
+    // explicit reset documents the fresh-start contract here at the
+    // call site and survives any future signals_core change that drops
+    // the synchronous-on-subscribe behavior.
+    _reconnectStatus.value = null;
+  }
+
+  void _onReconnectStatus(ReconnectStatus? status) {
+    if (_isDisposed) return;
+    _reconnectStatus.value = status;
   }
 
   void _onRunState(RunState runState) {
@@ -226,7 +252,7 @@ class ThreadViewState {
         _messages.value = _messagesLoaded(conversation);
       case FailedState(:final conversation, :final error):
         _detachSession();
-        _lastSendError.value = SendError(error);
+        _lastSendError.value = SendError(_friendlyMessage(error));
         if (conversation != null) {
           _messages.value = _messagesLoaded(conversation);
         }
@@ -265,9 +291,30 @@ class ThreadViewState {
     }
     _runStateUnsub?.call();
     _runStateUnsub = null;
+    _reconnectStatusUnsub?.call();
+    _reconnectStatusUnsub = null;
     _activeSession.value = null;
     _streamingState.value = null;
     _sessionState.value = null;
+    // Preserve `Reconnected` so its 4s auto-dismiss timer in the
+    // banner widget runs to completion. `Reconnecting` and
+    // `ReconnectFailed` have no auto-dismiss path of their own and a
+    // new session is about to attach (which clears via subscribe + the
+    // defensive reset in `_attachSession`).
+    if (_reconnectStatus.value is! Reconnected) {
+      _reconnectStatus.value = null;
+    }
+  }
+
+  /// Translates orchestrator failure copy into user-facing copy.
+  /// Resume-failure markers from `AgUiStreamClient` get a friendly
+  /// message; other failures pass through unchanged.
+  String _friendlyMessage(String error) {
+    if (error.startsWith(streamResumeFailedPrefix)) {
+      return 'Connection lost. The response may be incomplete — '
+          'you can send your message again.';
+    }
+    return error;
   }
 
   bool _restoreFromRegistry() {
@@ -340,5 +387,6 @@ class ThreadViewState {
     _cancelToken?.cancel('disposed');
     _detachSession();
     _sessionState.dispose();
+    _reconnectStatus.dispose();
   }
 }

--- a/lib/src/modules/room/thread_view_state.dart
+++ b/lib/src/modules/room/thread_view_state.dart
@@ -419,5 +419,6 @@ class ThreadViewState {
     _detachSession();
     _sessionState.dispose();
     _reconnectStatus.dispose();
+    isCancellable.dispose();
   }
 }

--- a/lib/src/modules/room/thread_view_state.dart
+++ b/lib/src/modules/room/thread_view_state.dart
@@ -359,7 +359,15 @@ class ThreadViewState {
       case CompletedRun(:final conversation):
         _messages.value = _messagesLoaded(conversation);
       case FailedRun(:final conversation, :final error):
-        _lastSendError.value = SendError(error);
+        // Mirrors the live `_onRunState` `FailedState` arm: a registered
+        // failure restored on re-attach must get the same friendly copy
+        // a live failure would, so the user never sees the raw
+        // `Stream resume failed: …` marker after a navigation round-trip.
+        // `FailedRun.error` is `Object` (may be a String from
+        // `FailedState.error`, or an exception from `AgentFailure.error`).
+        // `toString` is a no-op when the orchestrator already supplied
+        // a clean `String` and stringifies exceptions cleanly otherwise.
+        _lastSendError.value = SendError(_friendlyMessage(error.toString()));
         if (conversation != null) {
           _messages.value = _messagesLoaded(conversation);
         }

--- a/lib/src/modules/room/thread_view_state.dart
+++ b/lib/src/modules/room/thread_view_state.dart
@@ -107,9 +107,9 @@ class ThreadViewState {
   ReadonlySignal<SendError?> get lastSendError => _lastSendError;
 
   /// Mirror of the active session's reconnect lifecycle. `null` means
-  /// no reconnect activity. The room screen renders a banner only for
-  /// [Reconnecting] / [Reconnected]; [ReconnectFailed] surfaces through
-  /// the existing [SendError] banner via [_friendlyMessage].
+  /// no reconnect activity. UI surfaces this for [Reconnecting] and
+  /// [Reconnected] only — [ReconnectFailed] flows through
+  /// [lastSendError] with friendly copy applied.
   final Signal<ReconnectStatus?> _reconnectStatus =
       Signal<ReconnectStatus?>(null);
   ReadonlySignal<ReconnectStatus?> get reconnectStatus => _reconnectStatus;
@@ -149,18 +149,13 @@ class ThreadViewState {
     return session?.getExtension<HumanApprovalExtension>()?.stateSignal.value;
   });
 
-  /// Whether the cancel/stop affordance should be enabled.
+  /// Whether the cancel/stop affordance should take effect.
   ///
-  /// True only when [cancelRun] would actually take effect:
-  ///   - A spawn is in progress (handled by `_spawner.cancel`), or
-  ///   - The active session's orchestrator is in [RunningState] or
-  ///     [ToolYieldingState] (handled by `RunOrchestrator.cancelRun`'s
-  ///     `RunningState` / `ToolYieldingState` arms).
-  ///
-  /// Returns false during the brief window between session attach and
-  /// the first SSE event, where the orchestrator's run state is still
-  /// [IdleState] and `cancelRun` is a no-op (Gap 3 — see
-  /// `RunOrchestrator.cancelRun`'s default arm).
+  /// True when a spawn is in progress, or when the active session's
+  /// orchestrator is in a state from which [cancelRun] can actually
+  /// transition to [CancelledState]. False during the IdleState window
+  /// between session attach and the first SSE event, where [cancelRun]
+  /// would be a silent no-op.
   late final ReadonlySignal<bool> isCancellable = computed(() {
     if (_sessionState.value == AgentSessionState.spawning &&
         _activeSession.value == null) {
@@ -331,13 +326,16 @@ class ThreadViewState {
 
   /// Translates orchestrator failure copy into user-facing copy.
   /// Resume-failure markers from `AgUiStreamClient` get a friendly
-  /// message; other failures pass through unchanged.
+  /// message; the skipped-event count, when present, is preserved as
+  /// a parenthetical so the user knows data was dropped along the way.
+  /// Other failures pass through unchanged.
   String _friendlyMessage(String error) {
-    if (error.startsWith(streamResumeFailedPrefix)) {
-      return 'Connection lost. The response may be incomplete — '
-          'you can send your message again.';
-    }
-    return error;
+    if (!error.startsWith(streamResumeFailedPrefix)) return error;
+    const base = 'Connection lost. The response may be incomplete — '
+        'you can send your message again.';
+    final skipped =
+        RegExp(r'\(skipped \d+ malformed events?\)').firstMatch(error);
+    return skipped == null ? base : '$base ${skipped.group(0)}';
   }
 
   bool _restoreFromRegistry() {
@@ -359,14 +357,12 @@ class ThreadViewState {
       case CompletedRun(:final conversation):
         _messages.value = _messagesLoaded(conversation);
       case FailedRun(:final conversation, :final error):
-        // Mirrors the live `_onRunState` `FailedState` arm: a registered
-        // failure restored on re-attach must get the same friendly copy
-        // a live failure would, so the user never sees the raw
-        // `Stream resume failed: …` marker after a navigation round-trip.
-        // `FailedRun.error` is `Object` (may be a String from
-        // `FailedState.error`, or an exception from `AgentFailure.error`).
-        // `toString` is a no-op when the orchestrator already supplied
-        // a clean `String` and stringifies exceptions cleanly otherwise.
+        // Apply friendly copy symmetrically with the live `FailedState`
+        // arm so a registered failure restored on re-attach (e.g.
+        // after a navigation round-trip) doesn't surface the raw
+        // transport marker. `FailedRun.error` is `Object`; `toString`
+        // is a no-op when the orchestrator supplied a `String` and
+        // stringifies exceptions cleanly otherwise.
         _lastSendError.value = SendError(_friendlyMessage(error.toString()));
         if (conversation != null) {
           _messages.value = _messagesLoaded(conversation);

--- a/lib/src/modules/room/thread_view_state.dart
+++ b/lib/src/modules/room/thread_view_state.dart
@@ -163,8 +163,14 @@ class ThreadViewState {
     }
     final session = _activeSession.value;
     if (session == null) return false;
-    final runState = session.runState.value;
-    return runState is RunningState || runState is ToolYieldingState;
+    return switch (session.runState.value) {
+      RunningState() => true,
+      ToolYieldingState() => true,
+      IdleState() => false,
+      CompletedState() => false,
+      FailedState() => false,
+      CancelledState() => false,
+    };
   });
 
   /// Resolves [request] on the active session's [HumanApprovalExtension]

--- a/lib/src/modules/room/thread_view_state.dart
+++ b/lib/src/modules/room/thread_view_state.dart
@@ -114,8 +114,8 @@ class ThreadViewState {
       Signal<ReconnectStatus?>(null);
   ReadonlySignal<ReconnectStatus?> get reconnectStatus => _reconnectStatus;
 
-  /// Clears the reconnect banner. The "Reconnected" tile self-dismisses
-  /// after 4s in the widget; this is for explicit user dismissal.
+  /// Clears the reconnect banner. The "Reconnected" tile also auto-
+  /// dismisses; this is for explicit user dismissal.
   void dismissReconnectStatus() => _reconnectStatus.value = null;
 
   // Persists historical trackers from loaded thread history and from
@@ -248,11 +248,6 @@ class ThreadViewState {
     _runStateUnsub = session.runState.subscribe(_onRunState);
     _reconnectStatusUnsub =
         session.reconnectStatus.subscribe(_onReconnectStatus);
-    // Defensive — `subscribe` fires synchronously with the new session's
-    // `null` value, which would clear the mirror automatically. The
-    // explicit reset documents the fresh-start contract here at the
-    // call site and survives any future signals_core change that drops
-    // the synchronous-on-subscribe behavior.
     _reconnectStatus.value = null;
   }
 
@@ -320,11 +315,8 @@ class ThreadViewState {
     _activeSession.value = null;
     _streamingState.value = null;
     _sessionState.value = null;
-    // Preserve `Reconnected` so its 4s auto-dismiss timer in the
-    // banner widget runs to completion. `Reconnecting` and
-    // `ReconnectFailed` have no auto-dismiss path of their own and a
-    // new session is about to attach (which clears via subscribe + the
-    // defensive reset in `_attachSession`).
+    // Preserve `Reconnected` so its banner-side auto-dismiss runs.
+    // Other states have no auto-dismiss; clear them here.
     if (_reconnectStatus.value is! Reconnected) {
       _reconnectStatus.value = null;
     }
@@ -363,12 +355,7 @@ class ThreadViewState {
       case CompletedRun(:final conversation):
         _messages.value = _messagesLoaded(conversation);
       case FailedRun(:final conversation, :final error):
-        // Apply friendly copy symmetrically with the live `FailedState`
-        // arm so a registered failure restored on re-attach (e.g.
-        // after a navigation round-trip) doesn't surface the raw
-        // transport marker. `FailedRun.error` is `Object`; `toString`
-        // is a no-op when the orchestrator supplied a `String` and
-        // stringifies exceptions cleanly otherwise.
+        // Apply friendly copy on re-attach, same as the live FailedState arm.
         _lastSendError.value = SendError(_friendlyMessage(error.toString()));
         if (conversation != null) {
           _messages.value = _messagesLoaded(conversation);

--- a/lib/src/modules/room/thread_view_state.dart
+++ b/lib/src/modules/room/thread_view_state.dart
@@ -149,6 +149,29 @@ class ThreadViewState {
     return session?.getExtension<HumanApprovalExtension>()?.stateSignal.value;
   });
 
+  /// Whether the cancel/stop affordance should be enabled.
+  ///
+  /// True only when [cancelRun] would actually take effect:
+  ///   - A spawn is in progress (handled by `_spawner.cancel`), or
+  ///   - The active session's orchestrator is in [RunningState] or
+  ///     [ToolYieldingState] (handled by `RunOrchestrator.cancelRun`'s
+  ///     `RunningState` / `ToolYieldingState` arms).
+  ///
+  /// Returns false during the brief window between session attach and
+  /// the first SSE event, where the orchestrator's run state is still
+  /// [IdleState] and `cancelRun` is a no-op (Gap 3 — see
+  /// `RunOrchestrator.cancelRun`'s default arm).
+  late final ReadonlySignal<bool> isCancellable = computed(() {
+    if (_sessionState.value == AgentSessionState.spawning &&
+        _activeSession.value == null) {
+      return true;
+    }
+    final session = _activeSession.value;
+    if (session == null) return false;
+    final runState = session.runState.value;
+    return runState is RunningState || runState is ToolYieldingState;
+  });
+
   /// Resolves [request] on the active session's [HumanApprovalExtension]
   /// with [approved]. No-op if no session is attached, the session has no
   /// extension, or [request] is not the currently pending request.

--- a/lib/src/modules/room/ui/chat_input.dart
+++ b/lib/src/modules/room/ui/chat_input.dart
@@ -267,8 +267,8 @@ class _ChatInputState extends State<ChatInput> {
                 IconButton(
                   icon: const Icon(Icons.stop),
                   // `null` renders disabled. Suppresses cancels that would
-                  // be no-ops at the orchestrator level (see Gap 3 in
-                  // `RunOrchestrator.cancelRun`).
+                  // be a silent no-op at the orchestrator level — see
+                  // `RunOrchestrator.cancelRun`'s default arm.
                   onPressed: cancelEnabled ? widget.onCancel : null,
                 )
               else

--- a/lib/src/modules/room/ui/chat_input.dart
+++ b/lib/src/modules/room/ui/chat_input.dart
@@ -11,6 +11,7 @@ class ChatInput extends StatefulWidget {
     required this.onSend,
     required this.onCancel,
     this.sessionState,
+    this.cancelEnabled,
     this.controller,
     this.focusNode,
     this.enabled = true,
@@ -23,6 +24,14 @@ class ChatInput extends StatefulWidget {
   final void Function(String text) onSend;
   final void Function() onCancel;
   final ReadonlySignal<AgentSessionState?>? sessionState;
+
+  /// Optional gate for the Stop button. When provided, the Stop button
+  /// renders disabled (greyed out) while the signal reads `false` —
+  /// even though the input layout still shows it (because [sessionState]
+  /// is `spawning` or `running`). Use this to suppress cancels that
+  /// would otherwise be silently dropped by the orchestrator's idle
+  /// window. Defaults to `true` when omitted.
+  final ReadonlySignal<bool>? cancelEnabled;
   final TextEditingController? controller;
   final FocusNode? focusNode;
   final bool enabled;
@@ -109,6 +118,7 @@ class _ChatInputState extends State<ChatInput> {
     final state = widget.sessionState?.watch(context);
     final active = _isActive(state);
     final disabled = !widget.enabled || active;
+    final cancelEnabled = widget.cancelEnabled?.watch(context) ?? true;
 
     return Padding(
       padding: const EdgeInsets.all(8),
@@ -256,7 +266,10 @@ class _ChatInputState extends State<ChatInput> {
               if (active)
                 IconButton(
                   icon: const Icon(Icons.stop),
-                  onPressed: widget.onCancel,
+                  // `null` renders disabled. Suppresses cancels that would
+                  // be no-ops at the orchestrator level (see Gap 3 in
+                  // `RunOrchestrator.cancelRun`).
+                  onPressed: cancelEnabled ? widget.onCancel : null,
                 )
               else
                 ValueListenableBuilder<TextEditingValue>(

--- a/lib/src/modules/room/ui/chat_input.dart
+++ b/lib/src/modules/room/ui/chat_input.dart
@@ -25,12 +25,9 @@ class ChatInput extends StatefulWidget {
   final void Function() onCancel;
   final ReadonlySignal<AgentSessionState?>? sessionState;
 
-  /// Optional gate for the Stop button. When provided, the Stop button
-  /// renders disabled (greyed out) while the signal reads `false` —
-  /// even though the input layout still shows it (because [sessionState]
-  /// is `spawning` or `running`). Use this to suppress cancels that
-  /// would otherwise be silently dropped by the orchestrator's idle
-  /// window. Defaults to `true` when omitted.
+  /// When provided, the Stop button is disabled while this signal is
+  /// `false` (it still renders, since [sessionState] is `spawning` or
+  /// `running`). Defaults to `true`.
   final ReadonlySignal<bool>? cancelEnabled;
   final TextEditingController? controller;
   final FocusNode? focusNode;
@@ -266,9 +263,6 @@ class _ChatInputState extends State<ChatInput> {
               if (active)
                 IconButton(
                   icon: const Icon(Icons.stop),
-                  // `null` renders disabled. Suppresses cancels that would
-                  // be a silent no-op at the orchestrator level — see
-                  // `RunOrchestrator.cancelRun`'s default arm.
                   onPressed: cancelEnabled ? widget.onCancel : null,
                 )
               else

--- a/lib/src/modules/room/ui/room_screen.dart
+++ b/lib/src/modules/room/ui/room_screen.dart
@@ -7,7 +7,14 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 import 'package:signals_flutter/signals_flutter.dart';
 import 'package:soliplex_client/soliplex_client.dart'
-    show RagDocument, Room, SourceReferenceFormatting, buildDocumentFilter;
+    show
+        RagDocument,
+        ReconnectStatus,
+        Reconnected,
+        Reconnecting,
+        Room,
+        SourceReferenceFormatting,
+        buildDocumentFilter;
 import '../../../core/routes.dart';
 import '../../auth/server_entry.dart';
 import '../document_selections.dart';
@@ -839,6 +846,7 @@ class _RoomScreenState extends State<RoomScreen> {
     final status = threadView.messages.watch(context);
     final streaming = threadView.streamingState.watch(context);
     final sendError = threadView.lastSendError.watch(context);
+    final reconnectStatus = threadView.reconnectStatus.watch(context);
     final attachEnabled = room?.enableAttachments ?? false;
 
     _restoreUnsentText(sendError?.unsentText);
@@ -851,6 +859,12 @@ class _RoomScreenState extends State<RoomScreen> {
         ),
         Column(
           children: [
+            if (reconnectStatus is Reconnecting ||
+                reconnectStatus is Reconnected)
+              _ReconnectBanner(
+                status: reconnectStatus!,
+                onDismiss: threadView.dismissReconnectStatus,
+              ),
             Expanded(
               child: switch (status) {
                 MessagesLoading() => const Center(
@@ -1004,6 +1018,121 @@ class _SendErrorBanner extends StatelessWidget {
             constraints: const BoxConstraints(),
           ),
         ],
+      ),
+    );
+  }
+}
+
+/// Banner that surfaces in-flight SSE reconnect lifecycle states.
+///
+/// Renders [Reconnecting] and [Reconnected] only — [ReconnectFailed]
+/// flows through the existing `_SendErrorBanner` via
+/// `ThreadViewState._friendlyMessage`. The `is` guard at the call site
+/// in `_buildThreadBody` keeps `ReconnectFailed` out of this widget,
+/// so the `switch` here does not need a third arm.
+class _ReconnectBanner extends StatefulWidget {
+  const _ReconnectBanner({required this.status, required this.onDismiss});
+
+  final ReconnectStatus status;
+  final VoidCallback onDismiss;
+
+  @override
+  State<_ReconnectBanner> createState() => _ReconnectBannerState();
+}
+
+class _ReconnectBannerState extends State<_ReconnectBanner> {
+  Timer? _autoDismiss;
+
+  @override
+  void didUpdateWidget(covariant _ReconnectBanner oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (oldWidget.status.runtimeType != widget.status.runtimeType) {
+      _autoDismiss?.cancel();
+      _autoDismiss = null;
+      _scheduleAutoDismissIfNeeded();
+    }
+  }
+
+  @override
+  void initState() {
+    super.initState();
+    _scheduleAutoDismissIfNeeded();
+  }
+
+  void _scheduleAutoDismissIfNeeded() {
+    if (widget.status is Reconnected) {
+      _autoDismiss = Timer(
+        const Duration(seconds: 4),
+        () {
+          if (!mounted) return;
+          widget.onDismiss();
+        },
+      );
+    }
+  }
+
+  @override
+  void dispose() {
+    _autoDismiss?.cancel();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final scheme = theme.colorScheme;
+    final (icon, label) = switch (widget.status) {
+      Reconnecting() => (
+          const _SpinnerIcon(),
+          'Reconnecting…',
+        ),
+      Reconnected() => (
+          Icon(Icons.check_circle_outline, size: 16, color: scheme.primary),
+          'Reconnected.',
+        ),
+      // ignore: no_default_cases — guarded by call-site `is` check
+      _ => (const SizedBox.shrink(), ''),
+    };
+    return Container(
+      width: double.infinity,
+      padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+      color: scheme.secondaryContainer,
+      child: Row(
+        children: [
+          icon,
+          const SizedBox(width: 8),
+          Expanded(
+            child: Text(
+              label,
+              style: theme.textTheme.bodySmall?.copyWith(
+                color: scheme.onSecondaryContainer,
+              ),
+            ),
+          ),
+          IconButton(
+            icon: const Icon(Icons.close, size: 16),
+            onPressed: widget.onDismiss,
+            padding: EdgeInsets.zero,
+            constraints: const BoxConstraints(),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _SpinnerIcon extends StatelessWidget {
+  const _SpinnerIcon();
+
+  @override
+  Widget build(BuildContext context) {
+    final scheme = Theme.of(context).colorScheme;
+    return SizedBox(
+      height: 14,
+      width: 14,
+      child: CircularProgressIndicator(
+        strokeWidth: 2,
+        valueColor: AlwaysStoppedAnimation<Color>(scheme.primary),
       ),
     );
   }

--- a/lib/src/modules/room/ui/room_screen.dart
+++ b/lib/src/modules/room/ui/room_screen.dart
@@ -1024,13 +1024,11 @@ class _SendErrorBanner extends StatelessWidget {
   }
 }
 
-/// Banner that surfaces in-flight SSE reconnect lifecycle states.
+/// Banner for in-flight SSE reconnect lifecycle states.
 ///
-/// Renders [Reconnecting] and [Reconnected] only — [ReconnectFailed]
-/// flows through the existing `_SendErrorBanner` via
-/// `ThreadViewState._friendlyMessage`. The `is` guard at the call site
-/// in `_buildThreadBody` keeps `ReconnectFailed` out of this widget,
-/// so the `switch` here does not need a third arm.
+/// Renders [Reconnecting] and [Reconnected] only. Callers must filter
+/// out [ReconnectFailed] (which surfaces through the send-error
+/// banner) before passing a status to this widget.
 class _ReconnectBanner extends StatefulWidget {
   const _ReconnectBanner({required this.status, required this.onDismiss});
 

--- a/lib/src/modules/room/ui/room_screen.dart
+++ b/lib/src/modules/room/ui/room_screen.dart
@@ -1082,9 +1082,9 @@ class _ReconnectBannerState extends State<_ReconnectBanner> {
     final theme = Theme.of(context);
     final scheme = theme.colorScheme;
     final (icon, label) = switch (widget.status) {
-      Reconnecting() => (
+      Reconnecting(:final attempt) => (
           const _SpinnerIcon(),
-          'Reconnecting…',
+          'Reconnecting… (attempt $attempt)',
         ),
       Reconnected() => (
           Icon(Icons.check_circle_outline, size: 16, color: scheme.primary),

--- a/lib/src/modules/room/ui/room_screen.dart
+++ b/lib/src/modules/room/ui/room_screen.dart
@@ -9,6 +9,7 @@ import 'package:signals_flutter/signals_flutter.dart';
 import 'package:soliplex_client/soliplex_client.dart'
     show
         RagDocument,
+        ReconnectFailed,
         ReconnectStatus,
         Reconnected,
         Reconnecting,
@@ -1089,8 +1090,10 @@ class _ReconnectBannerState extends State<_ReconnectBanner> {
           Icon(Icons.check_circle_outline, size: 16, color: scheme.primary),
           'Reconnected.',
         ),
-      // ignore: no_default_cases — guarded by call-site `is` check
-      _ => (const SizedBox.shrink(), ''),
+      // Filtered at call site, but exhaustive here so a future
+      // ReconnectStatus subclass forces a build break instead of
+      // silently rendering an empty banner.
+      ReconnectFailed() => (const SizedBox.shrink(), ''),
     };
     return Container(
       width: double.infinity,

--- a/lib/src/modules/room/ui/room_screen.dart
+++ b/lib/src/modules/room/ui/room_screen.dart
@@ -942,6 +942,7 @@ class _RoomScreenState extends State<RoomScreen> {
               ),
               onCancel: threadView.cancelRun,
               sessionState: threadView.sessionState,
+              cancelEnabled: threadView.isCancellable,
               controller: _chatController,
               focusNode: _chatFocusNode,
               enabled: status is MessagesLoaded,

--- a/packages/soliplex_agent/lib/src/models/failure_reason.dart
+++ b/packages/soliplex_agent/lib/src/models/failure_reason.dart
@@ -13,6 +13,10 @@ enum FailureReason {
   /// Network lost — SSE stream ended without a terminal event.
   networkLost,
 
+  /// SSE `Last-Event-ID` resume failed — either the retry budget was
+  /// exhausted or a non-retryable error surfaced during a resume.
+  streamResumeFailed,
+
   /// Server returned 429 Too Many Requests.
   rateLimited,
 

--- a/packages/soliplex_agent/lib/src/orchestration/ag_ui_llm_provider.dart
+++ b/packages/soliplex_agent/lib/src/orchestration/ag_ui_llm_provider.dart
@@ -24,6 +24,7 @@ class AgUiLlmProvider implements AgentLlmProvider {
     required SimpleRunAgentInput input,
     String? existingRunId,
     CancelToken? cancelToken,
+    void Function(ReconnectStatus)? onReconnectStatus,
   }) async {
     final runId = existingRunId ?? await _createRun(key);
     final updatedInput = SimpleRunAgentInput(
@@ -38,6 +39,7 @@ class AgUiLlmProvider implements AgentLlmProvider {
       endpoint,
       updatedInput,
       cancelToken: cancelToken,
+      onReconnectStatus: onReconnectStatus,
     );
     return LlmRunHandle(runId: runId, events: events);
   }

--- a/packages/soliplex_agent/lib/src/orchestration/agent_llm_provider.dart
+++ b/packages/soliplex_agent/lib/src/orchestration/agent_llm_provider.dart
@@ -41,10 +41,16 @@ abstract interface class AgentLlmProvider {
   /// The provider handles run creation internally. The returned
   /// `LlmRunHandle.events` stream yields `BaseEvent`s that
   /// `RunOrchestrator` processes via the existing event pipeline.
+  ///
+  /// [onReconnectStatus] receives SSE reconnect lifecycle updates from
+  /// the AG-UI backend (the only provider that can drop and resume
+  /// mid-run). Other providers ignore the callback. Optional — null
+  /// means no reconnect surfacing.
   Future<LlmRunHandle> startRun({
     required ThreadKey key,
     required SimpleRunAgentInput input,
     String? existingRunId,
     CancelToken? cancelToken,
+    void Function(ReconnectStatus)? onReconnectStatus,
   });
 }

--- a/packages/soliplex_agent/lib/src/orchestration/chat_fn_llm_provider.dart
+++ b/packages/soliplex_agent/lib/src/orchestration/chat_fn_llm_provider.dart
@@ -53,6 +53,7 @@ class ChatFnLlmProvider implements AgentLlmProvider {
     required SimpleRunAgentInput input,
     String? existingRunId,
     CancelToken? cancelToken,
+    void Function(ReconnectStatus)? onReconnectStatus,
   }) async {
     final runId =
         existingRunId ?? 'local-${DateTime.now().microsecondsSinceEpoch}';

--- a/packages/soliplex_agent/lib/src/orchestration/chat_fn_llm_provider.dart
+++ b/packages/soliplex_agent/lib/src/orchestration/chat_fn_llm_provider.dart
@@ -118,7 +118,8 @@ class ChatFnLlmProvider implements AgentLlmProvider {
       // the runtime-type stringified into the user-facing message.
       rethrow;
     } on Object catch (e) {
-      yield RunErrorEvent(message: e.toString());
+      final msg = e is SoliplexException ? e.message : e.toString();
+      yield RunErrorEvent(message: msg);
     }
   }
 

--- a/packages/soliplex_agent/lib/src/orchestration/chat_fn_llm_provider.dart
+++ b/packages/soliplex_agent/lib/src/orchestration/chat_fn_llm_provider.dart
@@ -111,6 +111,12 @@ class ChatFnLlmProvider implements AgentLlmProvider {
       }
 
       yield RunFinishedEvent(threadId: key.threadId, runId: runId);
+    } on CancelledException {
+      // Surface cancels as a stream error so the orchestrator routes
+      // them to `CancelledState` via `_onStreamError`. Yielding a
+      // `RunErrorEvent` would land in `FailedState(serverError)` with
+      // the runtime-type stringified into the user-facing message.
+      rethrow;
     } on Object catch (e) {
       yield RunErrorEvent(message: e.toString());
     }

--- a/packages/soliplex_agent/lib/src/orchestration/error_classifier.dart
+++ b/packages/soliplex_agent/lib/src/orchestration/error_classifier.dart
@@ -6,6 +6,13 @@ import 'package:soliplex_client/soliplex_client.dart';
 /// Handles both `SoliplexException` hierarchy (from REST calls)
 /// and `AgUiError` hierarchy (from AG-UI streaming).
 FailureReason classifyError(Object error) {
+  // Match the typed resume failure before the generic NetworkException
+  // unwrap — `StreamResumeFailedException` is a `NetworkException`, so
+  // the unwrap would otherwise route it to whatever the underlying
+  // transport error classifies as (typically `networkLost`).
+  if (error is StreamResumeFailedException) {
+    return FailureReason.streamResumeFailed;
+  }
   if (error is NetworkException && error.originalError != null) {
     return classifyError(error.originalError!);
   }

--- a/packages/soliplex_agent/lib/src/orchestration/error_classifier.dart
+++ b/packages/soliplex_agent/lib/src/orchestration/error_classifier.dart
@@ -6,6 +6,9 @@ import 'package:soliplex_client/soliplex_client.dart';
 /// Handles both `SoliplexException` hierarchy (from REST calls)
 /// and `AgUiError` hierarchy (from AG-UI streaming).
 FailureReason classifyError(Object error) {
+  if (error is NetworkException && error.originalError != null) {
+    return classifyError(error.originalError!);
+  }
   if (error is AuthException) return FailureReason.authExpired;
   if (error is NetworkException) return FailureReason.networkLost;
   if (error is TransportError) return _classifyTransportError(error);

--- a/packages/soliplex_agent/lib/src/orchestration/run_orchestrator.dart
+++ b/packages/soliplex_agent/lib/src/orchestration/run_orchestrator.dart
@@ -335,6 +335,7 @@ class RunOrchestrator {
     ThreadHistory? cachedHistory,
     Map<String, dynamic>? stateOverlay,
   ) async {
+    _cancelToken ??= CancelToken();
     final conversation =
         _buildConversation(key, userMessage, cachedHistory, stateOverlay);
     final input = _buildInput(key, conversation);
@@ -396,6 +397,7 @@ class RunOrchestrator {
     ToolYieldingState yielding,
     List<ToolCallInfo> executedTools,
   ) async {
+    _cancelToken ??= CancelToken();
     final conversation = _buildResumeConversation(yielding, executedTools);
     final input = _buildInput(yielding.threadKey, conversation);
     final handle = await _llmProvider.startRun(

--- a/packages/soliplex_agent/lib/src/orchestration/run_orchestrator.dart
+++ b/packages/soliplex_agent/lib/src/orchestration/run_orchestrator.dart
@@ -231,22 +231,11 @@ class RunOrchestrator {
           CancelledState(threadKey: threadKey, conversation: conversation),
         );
       case _:
-        // TODO(gap-3): Cancel during the IdleState window between
-        // `runToCompletion` start and the first `_subscribeToStream`
-        // is silently dropped here — `_cancelToken` is non-null
-        // (initialized in `_initializeStream`) but no caller cancels
-        // it, so the pending `_llmProvider.startRun → createRun`
-        // await proceeds to completion. The window is a few hundred
-        // milliseconds while the createRun HTTP request is in flight.
-        // The Soliplex frontend hides this from users by gating the
-        // Stop button via `ThreadViewState.isCancellable`; non-UI
-        // consumers (e.g. CLI tools, bulk-cancel automation) can
-        // still hit it. Closing the gap requires storing the active
-        // threadKey at the top of `runToCompletion`, cancelling the
-        // token here + setting CancelledState, adding a
-        // `_currentState is CancelledState` recheck after the await
-        // in `_initializeStream`, and letting `_handleStartError`
-        // honor the cancelled state instead of routing to FailedState.
+        // No active run. Cancel during the IdleState window between
+        // `runToCompletion` and the first event is dropped here —
+        // the pending `createRun` await is not wired into this arm.
+        // Hosts that need to hide this window gate the cancel
+        // affordance on a separate is-cancellable signal.
         return;
     }
   }
@@ -434,8 +423,13 @@ class RunOrchestrator {
     );
     // Cancel/dispose during the await leaves state as CancelledState (or
     // disposed). Subscribing here would overwrite that with RunningState
-    // and silently resume the run after the user pressed Stop.
-    if (_disposed || _currentState is! ToolYieldingState) return;
+    // and silently resume the run after the user pressed Stop. Drain
+    // the unowned event stream so the underlying SSE socket releases —
+    // without subscribe-then-cancel, the HTTP transport holds it open.
+    if (_disposed || _currentState is! ToolYieldingState) {
+      unawaited(handle.events.listen(null).cancel());
+      return;
+    }
     _subscribeToStream(
       handle.events,
       RunningState(
@@ -863,14 +857,10 @@ class RunOrchestrator {
     _cancelToken = null;
   }
 
-  /// Surfaces a [SoliplexException]'s underlying message without the
-  /// `RuntimeType: ` prefix that `toString` adds.
-  ///
-  /// Downstream consumers like `ThreadViewState._friendlyMessage` match
-  /// on prefixes (e.g. [streamResumeFailedPrefix]) and would otherwise
-  /// have to know about the wrapper. Plain `Object` errors fall back to
-  /// `toString` so non-Soliplex exceptions still surface a usable
-  /// description.
+  /// Returns a clean message string for [error], unwrapping
+  /// [SoliplexException] so prefix-based matching downstream
+  /// (e.g. on [streamResumeFailedPrefix]) sees the raw message rather
+  /// than `RuntimeType: …`.
   String _messageOf(Object error) =>
       error is SoliplexException ? error.message : error.toString();
 }

--- a/packages/soliplex_agent/lib/src/orchestration/run_orchestrator.dart
+++ b/packages/soliplex_agent/lib/src/orchestration/run_orchestrator.dart
@@ -221,6 +221,12 @@ class RunOrchestrator {
           CancelledState(threadKey: threadKey, conversation: withCitations),
         );
       case ToolYieldingState(:final threadKey, :final conversation):
+        // A pending `_resumeStream` may be awaiting `_llmProvider.startRun`
+        // with the live cancel token. Cancel the token + cleanup so that
+        // await aborts before `_subscribeToStream` fires and overwrites
+        // the CancelledState we set below.
+        _cancelToken?.cancel();
+        _cleanup();
         _setState(
           CancelledState(threadKey: threadKey, conversation: conversation),
         );
@@ -385,6 +391,10 @@ class RunOrchestrator {
         }
         await _resumeStream(state, results);
       } on Object catch (e) {
+        // If `cancelRun` already transitioned to CancelledState, the
+        // exception is the byproduct of cancellation propagating through
+        // the in-flight `startRun` await — not a true failure.
+        if (_currentState is CancelledState) return _currentState;
         return _failFromYielding(key, state, e);
       }
     }
@@ -406,7 +416,10 @@ class RunOrchestrator {
       cancelToken: _cancelToken,
       onReconnectStatus: _activeOnReconnectStatus,
     );
-    if (_disposed) return;
+    // Cancel/dispose during the await leaves state as CancelledState (or
+    // disposed). Subscribing here would overwrite that with RunningState
+    // and silently resume the run after the user pressed Stop.
+    if (_disposed || _currentState is! ToolYieldingState) return;
     _subscribeToStream(
       handle.events,
       RunningState(

--- a/packages/soliplex_agent/lib/src/orchestration/run_orchestrator.dart
+++ b/packages/soliplex_agent/lib/src/orchestration/run_orchestrator.dart
@@ -105,10 +105,8 @@ class RunOrchestrator {
   int _subscriptionEpoch = 0;
   bool _runToCompletionActive = false;
 
-  /// Reconnect callback active during the current `runToCompletion`.
-  /// Threaded into every `_llmProvider.startRun` call within the
-  /// session — including post-tool-yield resumes — so the AG-UI
-  /// backend can surface SSE drops at any point in the run.
+  /// Reconnect callback for the active `runToCompletion`, threaded
+  /// through every `startRun` call (initial + post-tool-yield resumes).
   void Function(ReconnectStatus)? _activeOnReconnectStatus;
 
   /// The current state of the orchestrator.
@@ -148,7 +146,10 @@ class RunOrchestrator {
   }) async {
     _guardRunToCompletion();
     _runToCompletionActive = true;
-    _activeOnReconnectStatus = onReconnectStatus;
+    _activeOnReconnectStatus = (status) {
+      _logReconnectStatus(status);
+      onReconnectStatus?.call(status);
+    };
     _toolDepth = 0;
     try {
       try {
@@ -231,11 +232,9 @@ class RunOrchestrator {
           CancelledState(threadKey: threadKey, conversation: conversation),
         );
       case _:
-        // No active run. Cancel during the IdleState window between
-        // `runToCompletion` and the first event is dropped here —
-        // the pending `createRun` await is not wired into this arm.
-        // Hosts that need to hide this window gate the cancel
-        // affordance on a separate is-cancellable signal.
+        // IdleState (after `runToCompletion` started but before the first
+        // event) is not cancellable here — no cancel token is wired in
+        // for the in-flight `createRun`.
         _logger.warning(
           'cancelRun ignored: no cancellable run '
           '(state=${_currentState.runtimeType})',
@@ -389,7 +388,10 @@ class RunOrchestrator {
       try {
         results = await toolExecutor(state.pendingToolCalls);
       } on Object catch (e, stackTrace) {
-        return _failFromYielding(key, state, e, stackTrace);
+        if (e is CancelledException || e is CancellationError) {
+          return _cancelledFromYielding(key, state);
+        }
+        return _failToolExecution(key, state, e, stackTrace);
       }
       if (_disposed) return _cancelledFromYielding(key, state);
       if (_currentState is CancelledState) return _currentState;
@@ -404,7 +406,7 @@ class RunOrchestrator {
         // exception is the byproduct of cancellation propagating through
         // the in-flight `startRun` await — not a true failure.
         if (_currentState is CancelledState) return _currentState;
-        return _failFromYielding(key, state, e, stackTrace);
+        return _failResume(key, state, e, stackTrace);
       }
     }
   }
@@ -416,6 +418,8 @@ class RunOrchestrator {
     ToolYieldingState yielding,
     List<ToolCallInfo> executedTools,
   ) async {
+    // `_handleRunFinished` cleared the token for the tool-yield window;
+    // mint a fresh one for the resume.
     _cancelToken ??= CancelToken();
     final conversation = _buildResumeConversation(yielding, executedTools);
     final input = _buildInput(yielding.threadKey, conversation);
@@ -428,8 +432,7 @@ class RunOrchestrator {
     // Cancel/dispose during the await leaves state as CancelledState (or
     // disposed). Subscribing here would overwrite that with RunningState
     // and silently resume the run after the user pressed Stop. Drain
-    // the unowned event stream so the underlying SSE socket releases —
-    // without subscribe-then-cancel, the HTTP transport holds it open.
+    // the unowned event stream so the underlying SSE socket releases.
     if (_disposed || _currentState is! ToolYieldingState) {
       if (!_disposed && _currentState is! CancelledState) {
         _logger.warning(
@@ -437,7 +440,9 @@ class RunOrchestrator {
           '(state=${_currentState.runtimeType})',
         );
       }
-      unawaited(handle.events.listen(null).cancel());
+      // `onError` swallows errors that race the cancel — the drain is
+      // a byproduct of cancel/dispose, not an event we want to surface.
+      unawaited(handle.events.listen(null, onError: (_, __) {}).cancel());
       return;
     }
     _subscribeToStream(
@@ -459,21 +464,42 @@ class RunOrchestrator {
     return CancelledState(threadKey: key, conversation: state.conversation);
   }
 
-  /// Returns a [FailedState] for a tool execution error during the loop.
-  RunState _failFromYielding(
+  /// Returns a [FailedState] for an error thrown by the tool executor.
+  RunState _failToolExecution(
     ThreadKey key,
     ToolYieldingState state,
     Object error,
     StackTrace stackTrace,
   ) {
     _logger.error(
-      'Tool yielding failed',
+      'Tool execution failed',
       error: error,
       stackTrace: stackTrace,
     );
     final failed = FailedState(
       threadKey: key,
       reason: FailureReason.toolExecutionFailed,
+      error: _messageOf(error),
+      conversation: state.conversation,
+    );
+    _setState(failed);
+    return failed;
+  }
+
+  /// Returns a [FailedState] for an error thrown while resuming the run
+  /// after a tool yield. Routes the reason through [classifyError] so
+  /// transport-layer failures surface as their actual category rather
+  /// than as `toolExecutionFailed`.
+  RunState _failResume(
+    ThreadKey key,
+    ToolYieldingState state,
+    Object error,
+    StackTrace stackTrace,
+  ) {
+    _logger.error('Resume run failed', error: error, stackTrace: stackTrace);
+    final failed = FailedState(
+      threadKey: key,
+      reason: classifyError(error),
       error: _messageOf(error),
       conversation: state.conversation,
     );
@@ -883,4 +909,29 @@ class RunOrchestrator {
   /// than `RuntimeType: …`.
   String _messageOf(Object error) =>
       error is SoliplexException ? error.message : error.toString();
+
+  void _logReconnectStatus(ReconnectStatus status) {
+    switch (status) {
+      case Reconnecting(:final attempt, :final lastEventId, :final error):
+        _logger.info(
+          'SSE reconnecting (attempt $attempt)',
+          error: error,
+          attributes: {
+            'attempt': attempt,
+            if (lastEventId != null) 'lastEventId': lastEventId,
+          },
+        );
+      case Reconnected(:final attempt):
+        _logger.info(
+          'SSE reconnected after $attempt attempt(s)',
+          attributes: {'attempt': attempt},
+        );
+      case ReconnectFailed(:final attempt, :final error):
+        _logger.warning(
+          'SSE reconnect failed after $attempt attempt(s)',
+          error: error,
+          attributes: {'attempt': attempt},
+        );
+    }
+  }
 }

--- a/packages/soliplex_agent/lib/src/orchestration/run_orchestrator.dart
+++ b/packages/soliplex_agent/lib/src/orchestration/run_orchestrator.dart
@@ -807,7 +807,7 @@ class RunOrchestrator {
     _cleanup();
     final withCitations =
         _extractCitations(running.conversation, running.runId);
-    if (error is CancellationError) {
+    if (error is CancelledException || error is CancellationError) {
       _setState(
         CancelledState(
           threadKey: running.threadKey,
@@ -830,6 +830,16 @@ class RunOrchestrator {
 
   void _handleStartError(ThreadKey key, Object error, StackTrace stackTrace) {
     _cleanup();
+    if (error is CancelledException || error is CancellationError) {
+      // A cancel that fired while `_initializeStream → startRun` was
+      // in flight surfaces here. Route to `CancelledState` so the
+      // user-visible result mirrors mid-stream cancel handling —
+      // not a `FailedState(reason: internalError)`. Accepts both
+      // `CancelledException` (from our `CancelToken`) and
+      // `CancellationError` (Dart core / ag_ui interop).
+      _setState(CancelledState(threadKey: key));
+      return;
+    }
     final reason = classifyError(error);
     _logger.error('Failed to start run', error: error, stackTrace: stackTrace);
     _setState(

--- a/packages/soliplex_agent/lib/src/orchestration/run_orchestrator.dart
+++ b/packages/soliplex_agent/lib/src/orchestration/run_orchestrator.dart
@@ -456,12 +456,21 @@ class RunOrchestrator {
     );
   }
 
-  /// Returns a [CancelledState] from a tool-yielding context.
+  /// Transitions to [CancelledState] from a tool-yielding context.
+  ///
+  /// Mirrors the `_failX` helpers: fires the state through `_setState` so
+  /// `stateChanges` observers see the terminal transition. A no-op
+  /// constructor would leave `_currentState` at `ToolYieldingState`,
+  /// so `AgentSession._completeWith` would never run and `result` would
+  /// hang.
   CancelledState _cancelledFromYielding(
     ThreadKey key,
     ToolYieldingState state,
   ) {
-    return CancelledState(threadKey: key, conversation: state.conversation);
+    final cancelled =
+        CancelledState(threadKey: key, conversation: state.conversation);
+    _setState(cancelled);
+    return cancelled;
   }
 
   /// Returns a [FailedState] for an error thrown by the tool executor.

--- a/packages/soliplex_agent/lib/src/orchestration/run_orchestrator.dart
+++ b/packages/soliplex_agent/lib/src/orchestration/run_orchestrator.dart
@@ -236,6 +236,10 @@ class RunOrchestrator {
         // the pending `createRun` await is not wired into this arm.
         // Hosts that need to hide this window gate the cancel
         // affordance on a separate is-cancellable signal.
+        _logger.warning(
+          'cancelRun ignored: no cancellable run '
+          '(state=${_currentState.runtimeType})',
+        );
         return;
     }
   }
@@ -384,8 +388,8 @@ class RunOrchestrator {
       List<ToolCallInfo> results;
       try {
         results = await toolExecutor(state.pendingToolCalls);
-      } on Object catch (e) {
-        return _failFromYielding(key, state, e);
+      } on Object catch (e, stackTrace) {
+        return _failFromYielding(key, state, e, stackTrace);
       }
       if (_disposed) return _cancelledFromYielding(key, state);
       if (_currentState is CancelledState) return _currentState;
@@ -395,12 +399,12 @@ class RunOrchestrator {
           return _failDepthExceeded(key, state);
         }
         await _resumeStream(state, results);
-      } on Object catch (e) {
+      } on Object catch (e, stackTrace) {
         // If `cancelRun` already transitioned to CancelledState, the
         // exception is the byproduct of cancellation propagating through
         // the in-flight `startRun` await — not a true failure.
         if (_currentState is CancelledState) return _currentState;
-        return _failFromYielding(key, state, e);
+        return _failFromYielding(key, state, e, stackTrace);
       }
     }
   }
@@ -427,6 +431,12 @@ class RunOrchestrator {
     // the unowned event stream so the underlying SSE socket releases —
     // without subscribe-then-cancel, the HTTP transport holds it open.
     if (_disposed || _currentState is! ToolYieldingState) {
+      if (!_disposed && _currentState is! CancelledState) {
+        _logger.warning(
+          'resumeStream aborted: unexpected post-await state '
+          '(state=${_currentState.runtimeType})',
+        );
+      }
       unawaited(handle.events.listen(null).cancel());
       return;
     }
@@ -454,7 +464,13 @@ class RunOrchestrator {
     ThreadKey key,
     ToolYieldingState state,
     Object error,
+    StackTrace stackTrace,
   ) {
+    _logger.error(
+      'Tool yielding failed',
+      error: error,
+      stackTrace: stackTrace,
+    );
     final failed = FailedState(
       threadKey: key,
       reason: FailureReason.toolExecutionFailed,
@@ -648,6 +664,10 @@ class RunOrchestrator {
     RunningState initialState,
   ) {
     // Cancel stale subscription from the previous run.
+    // `_subscriptionEpoch` (incremented below) guards `onDone` only,
+    // which can fire after the new subscription replaces the old one.
+    // `onData`/`onError` cease firing on the cancelled subscription, so
+    // they need no epoch guard.
     unawaited(_subscription?.cancel());
     _subscription = null;
     _cancelToken ??= CancelToken();

--- a/packages/soliplex_agent/lib/src/orchestration/run_orchestrator.dart
+++ b/packages/soliplex_agent/lib/src/orchestration/run_orchestrator.dart
@@ -231,6 +231,22 @@ class RunOrchestrator {
           CancelledState(threadKey: threadKey, conversation: conversation),
         );
       case _:
+        // TODO(gap-3): Cancel during the IdleState window between
+        // `runToCompletion` start and the first `_subscribeToStream`
+        // is silently dropped here — `_cancelToken` is non-null
+        // (initialized in `_initializeStream`) but no caller cancels
+        // it, so the pending `_llmProvider.startRun → createRun`
+        // await proceeds to completion. The window is a few hundred
+        // milliseconds while the createRun HTTP request is in flight.
+        // The Soliplex frontend hides this from users by gating the
+        // Stop button via `ThreadViewState.isCancellable`; non-UI
+        // consumers (e.g. CLI tools, bulk-cancel automation) can
+        // still hit it. Closing the gap requires storing the active
+        // threadKey at the top of `runToCompletion`, cancelling the
+        // token here + setting CancelledState, adding a
+        // `_currentState is CancelledState` recheck after the await
+        // in `_initializeStream`, and letting `_handleStartError`
+        // honor the cancelled state instead of routing to FailedState.
         return;
     }
   }

--- a/packages/soliplex_agent/lib/src/orchestration/run_orchestrator.dart
+++ b/packages/soliplex_agent/lib/src/orchestration/run_orchestrator.dart
@@ -440,9 +440,14 @@ class RunOrchestrator {
           '(state=${_currentState.runtimeType})',
         );
       }
-      // `onError` swallows errors that race the cancel — the drain is
-      // a byproduct of cancel/dispose, not an event we want to surface.
-      unawaited(handle.events.listen(null, onError: (_, __) {}).cancel());
+      // The drain is a byproduct of cancel/dispose, not an event we
+      // want to surface — but log so a future bug landing here from a
+      // non-cancel path leaves a breadcrumb.
+      unawaited(
+        handle.events
+            .listen(null, onError: (Object e) => _logger.debug('drain: $e'))
+            .cancel(),
+      );
       return;
     }
     _subscribeToStream(

--- a/packages/soliplex_agent/lib/src/orchestration/run_orchestrator.dart
+++ b/packages/soliplex_agent/lib/src/orchestration/run_orchestrator.dart
@@ -105,6 +105,12 @@ class RunOrchestrator {
   int _subscriptionEpoch = 0;
   bool _runToCompletionActive = false;
 
+  /// Reconnect callback active during the current `runToCompletion`.
+  /// Threaded into every `_llmProvider.startRun` call within the
+  /// session — including post-tool-yield resumes — so the AG-UI
+  /// backend can surface SSE drops at any point in the run.
+  void Function(ReconnectStatus)? _activeOnReconnectStatus;
+
   /// The current state of the orchestrator.
   RunState get currentState => _currentState;
 
@@ -138,9 +144,11 @@ class RunOrchestrator {
     String? existingRunId,
     ThreadHistory? cachedHistory,
     Map<String, dynamic>? stateOverlay,
+    void Function(ReconnectStatus)? onReconnectStatus,
   }) async {
     _guardRunToCompletion();
     _runToCompletionActive = true;
+    _activeOnReconnectStatus = onReconnectStatus;
     _toolDepth = 0;
     try {
       try {
@@ -159,6 +167,7 @@ class RunOrchestrator {
       return await _driveToolLoop(key, toolExecutor);
     } finally {
       _runToCompletionActive = false;
+      _activeOnReconnectStatus = null;
     }
   }
 
@@ -334,6 +343,7 @@ class RunOrchestrator {
       input: input,
       existingRunId: existingRunId,
       cancelToken: _cancelToken,
+      onReconnectStatus: _activeOnReconnectStatus,
     );
     if (_disposed) return;
     _subscribeToStream(
@@ -392,6 +402,7 @@ class RunOrchestrator {
       key: yielding.threadKey,
       input: input,
       cancelToken: _cancelToken,
+      onReconnectStatus: _activeOnReconnectStatus,
     );
     if (_disposed) return;
     _subscribeToStream(

--- a/packages/soliplex_agent/lib/src/orchestration/run_orchestrator.dart
+++ b/packages/soliplex_agent/lib/src/orchestration/run_orchestrator.dart
@@ -464,7 +464,7 @@ class RunOrchestrator {
     final failed = FailedState(
       threadKey: key,
       reason: FailureReason.toolExecutionFailed,
-      error: error.toString(),
+      error: _messageOf(error),
       conversation: state.conversation,
     );
     _setState(failed);
@@ -822,7 +822,7 @@ class RunOrchestrator {
       FailedState(
         threadKey: running.threadKey,
         reason: reason,
-        error: error.toString(),
+        error: _messageOf(error),
         conversation: withCitations,
       ),
     );
@@ -833,7 +833,7 @@ class RunOrchestrator {
     final reason = classifyError(error);
     _logger.error('Failed to start run', error: error, stackTrace: stackTrace);
     _setState(
-      FailedState(threadKey: key, reason: reason, error: error.toString()),
+      FailedState(threadKey: key, reason: reason, error: _messageOf(error)),
     );
   }
 
@@ -852,4 +852,15 @@ class RunOrchestrator {
     _subscription = null;
     _cancelToken = null;
   }
+
+  /// Surfaces a [SoliplexException]'s underlying message without the
+  /// `RuntimeType: ` prefix that `toString` adds.
+  ///
+  /// Downstream consumers like `ThreadViewState._friendlyMessage` match
+  /// on prefixes (e.g. [streamResumeFailedPrefix]) and would otherwise
+  /// have to know about the wrapper. Plain `Object` errors fall back to
+  /// `toString` so non-Soliplex exceptions still surface a usable
+  /// description.
+  String _messageOf(Object error) =>
+      error is SoliplexException ? error.message : error.toString();
 }

--- a/packages/soliplex_agent/lib/src/orchestration/streaming_llm_provider.dart
+++ b/packages/soliplex_agent/lib/src/orchestration/streaming_llm_provider.dart
@@ -133,7 +133,8 @@ class StreamingLlmProvider implements AgentLlmProvider {
       // the runtime-type stringified into the user-facing message.
       rethrow;
     } on Object catch (e) {
-      yield RunErrorEvent(message: e.toString());
+      final msg = e is SoliplexException ? e.message : e.toString();
+      yield RunErrorEvent(message: msg);
     }
   }
 

--- a/packages/soliplex_agent/lib/src/orchestration/streaming_llm_provider.dart
+++ b/packages/soliplex_agent/lib/src/orchestration/streaming_llm_provider.dart
@@ -126,6 +126,12 @@ class StreamingLlmProvider implements AgentLlmProvider {
         yield TextMessageEndEvent(messageId: msgId);
       }
       yield RunFinishedEvent(threadId: key.threadId, runId: runId);
+    } on CancelledException {
+      // Surface cancels as a stream error so the orchestrator routes
+      // them to `CancelledState` via `_onStreamError`. Yielding a
+      // `RunErrorEvent` would land in `FailedState(serverError)` with
+      // the runtime-type stringified into the user-facing message.
+      rethrow;
     } on Object catch (e) {
       yield RunErrorEvent(message: e.toString());
     }

--- a/packages/soliplex_agent/lib/src/orchestration/streaming_llm_provider.dart
+++ b/packages/soliplex_agent/lib/src/orchestration/streaming_llm_provider.dart
@@ -38,6 +38,7 @@ class StreamingLlmProvider implements AgentLlmProvider {
     required SimpleRunAgentInput input,
     String? existingRunId,
     CancelToken? cancelToken,
+    void Function(ReconnectStatus)? onReconnectStatus,
   }) async {
     final runId =
         existingRunId ?? 'local-${DateTime.now().microsecondsSinceEpoch}';

--- a/packages/soliplex_agent/lib/src/runtime/agent_session.dart
+++ b/packages/soliplex_agent/lib/src/runtime/agent_session.dart
@@ -131,11 +131,9 @@ class AgentSession implements ToolExecutionContext {
   /// `session.agentState` and `bus.agentState` see the same snapshot
   /// at all times — no parallel compute path.
   ///
-  /// Hosts that previously subscribed to this signal and forwarded
-  /// values into a separate `StateBus` no longer need to: the bus is
-  /// already the source. Subscribe to `bus.agentState` directly when
-  /// reaching the bus is more natural (e.g. inside `bus.project(...)`
-  /// projections).
+  /// Hosts can subscribe to `bus.agentState` directly when reaching
+  /// the bus is more natural (e.g. inside `bus.project(...)`
+  /// projections) — both views see the same snapshot.
   ReadonlySignal<Map<String, dynamic>> get agentState => bus.agentState;
 
   /// The per-thread reactive bus this session writes into. Owned by
@@ -356,21 +354,10 @@ class AgentSession implements ToolExecutionContext {
   }
 
   /// Bridges reconnect-lifecycle callbacks from `RunOrchestrator` /
-  /// `AgUiStreamClient` into the [reconnectStatus] signal. Defensive
-  /// try/catch ensures a misbehaving listener can never propagate back
-  /// into the run and convert a transient drop into a hard failure.
+  /// `AgUiStreamClient` into the [reconnectStatus] signal.
   void _onReconnectStatus(ReconnectStatus status) {
     if (_disposed) return;
-    try {
-      _reconnectStatusSignal.value = status;
-    } on Object catch (e, st) {
-      _logger.warning(
-        'Reconnect status listener threw (session=$id, '
-        'thread=${threadKey.threadId})',
-        error: e,
-        stackTrace: st,
-      );
-    }
+    _reconnectStatusSignal.value = status;
   }
 
   /// Releases all resources, cascading to children first.

--- a/packages/soliplex_agent/lib/src/runtime/agent_session.dart
+++ b/packages/soliplex_agent/lib/src/runtime/agent_session.dart
@@ -83,6 +83,8 @@ class AgentSession implements ToolExecutionContext {
     AgentSessionState.spawning,
   );
   final Signal<ExecutionEvent?> _executionEventSignal = signal(null);
+  final Signal<ReconnectStatus?> _reconnectStatusSignal =
+      signal<ReconnectStatus?>(null);
 
   /// Child sessions spawned by this session.
   List<AgentSession> get children => List.unmodifiable(_children);
@@ -154,6 +156,15 @@ class AgentSession implements ToolExecutionContext {
   /// Reactive signal tracking the most recent [ExecutionEvent].
   ReadonlySignal<ExecutionEvent?> get lastExecutionEvent =>
       _executionEventSignal.readonly();
+
+  /// Reactive signal tracking SSE stream reconnect lifecycle.
+  ///
+  /// `null` means no reconnect activity. Emits [Reconnecting] while a
+  /// resume attempt is in flight, [Reconnected] on the first decoded
+  /// event after a successful resume, [ReconnectFailed] when the retry
+  /// budget is exhausted. Hosts can mirror this into a banner.
+  ReadonlySignal<ReconnectStatus?> get reconnectStatus =>
+      _reconnectStatusSignal.readonly();
 
   /// Waits for the session result with an optional timeout.
   Future<AgentResult> awaitResult({Duration? timeout}) {
@@ -339,8 +350,27 @@ class AgentSession implements ToolExecutionContext {
         existingRunId: existingRunId,
         cachedHistory: cachedHistory,
         stateOverlay: stateOverlay,
+        onReconnectStatus: _onReconnectStatus,
       ),
     );
+  }
+
+  /// Bridges reconnect-lifecycle callbacks from `RunOrchestrator` /
+  /// `AgUiStreamClient` into the [reconnectStatus] signal. Defensive
+  /// try/catch ensures a misbehaving listener can never propagate back
+  /// into the run and convert a transient drop into a hard failure.
+  void _onReconnectStatus(ReconnectStatus status) {
+    if (_disposed) return;
+    try {
+      _reconnectStatusSignal.value = status;
+    } on Object catch (e, st) {
+      _logger.warning(
+        'Reconnect status listener threw (session=$id, '
+        'thread=${threadKey.threadId})',
+        error: e,
+        stackTrace: st,
+      );
+    }
   }
 
   /// Releases all resources, cascading to children first.
@@ -382,6 +412,7 @@ class AgentSession implements ToolExecutionContext {
     _runStateSignal.dispose();
     _sessionStateSignal.dispose();
     _executionEventSignal.dispose();
+    _reconnectStatusSignal.dispose();
   }
 
   // ---------------------------------------------------------------------------

--- a/packages/soliplex_agent/lib/src/runtime/agent_session.dart
+++ b/packages/soliplex_agent/lib/src/runtime/agent_session.dart
@@ -130,10 +130,6 @@ class AgentSession implements ToolExecutionContext {
   /// fed by `_onStateChange` on every [RunState] transition, so
   /// `session.agentState` and `bus.agentState` see the same snapshot
   /// at all times — no parallel compute path.
-  ///
-  /// Hosts can subscribe to `bus.agentState` directly when reaching
-  /// the bus is more natural (e.g. inside `bus.project(...)`
-  /// projections) — both views see the same snapshot.
   ReadonlySignal<Map<String, dynamic>> get agentState => bus.agentState;
 
   /// The per-thread reactive bus this session writes into. Owned by

--- a/packages/soliplex_agent/test/host/runtime_agent_api_test.dart
+++ b/packages/soliplex_agent/test/host/runtime_agent_api_test.dart
@@ -90,6 +90,8 @@ void main() {
         any(),
         any(),
         cancelToken: any(named: 'cancelToken'),
+        resumePolicy: any(named: 'resumePolicy'),
+        onReconnectStatus: any(named: 'onReconnectStatus'),
       ),
     ).thenAnswer((_) => Stream.fromIterable(_happyPathEvents(text)));
   }
@@ -141,6 +143,8 @@ void main() {
           any(),
           any(),
           cancelToken: any(named: 'cancelToken'),
+          resumePolicy: any(named: 'resumePolicy'),
+          onReconnectStatus: any(named: 'onReconnectStatus'),
         ),
       ).thenAnswer((_) => controller.stream);
 
@@ -190,6 +194,8 @@ void main() {
           any(),
           any(),
           cancelToken: any(named: 'cancelToken'),
+          resumePolicy: any(named: 'resumePolicy'),
+          onReconnectStatus: any(named: 'onReconnectStatus'),
         ),
       ).thenAnswer((_) => controller.stream);
 

--- a/packages/soliplex_agent/test/models/failure_reason_test.dart
+++ b/packages/soliplex_agent/test/models/failure_reason_test.dart
@@ -3,8 +3,8 @@ import 'package:test/test.dart';
 
 void main() {
   group('FailureReason', () {
-    test('has exactly 7 values', () {
-      expect(FailureReason.values, hasLength(7));
+    test('has exactly 8 values', () {
+      expect(FailureReason.values, hasLength(8));
     });
 
     test('contains all expected values', () {
@@ -14,6 +14,7 @@ void main() {
           FailureReason.serverError,
           FailureReason.authExpired,
           FailureReason.networkLost,
+          FailureReason.streamResumeFailed,
           FailureReason.rateLimited,
           FailureReason.toolExecutionFailed,
           FailureReason.internalError,

--- a/packages/soliplex_agent/test/orchestration/ag_ui_llm_provider_test.dart
+++ b/packages/soliplex_agent/test/orchestration/ag_ui_llm_provider_test.dart
@@ -57,6 +57,8 @@ void main() {
             any(),
             any(),
             cancelToken: any(named: 'cancelToken'),
+            resumePolicy: any(named: 'resumePolicy'),
+            onReconnectStatus: any(named: 'onReconnectStatus'),
           ),
         ).thenAnswer((_) => const Stream.empty());
 
@@ -78,6 +80,8 @@ void main() {
             any(),
             any(),
             cancelToken: any(named: 'cancelToken'),
+            resumePolicy: any(named: 'resumePolicy'),
+            onReconnectStatus: any(named: 'onReconnectStatus'),
           ),
         ).thenAnswer((_) => const Stream.empty());
 
@@ -100,6 +104,8 @@ void main() {
             any(),
             any(),
             cancelToken: any(named: 'cancelToken'),
+            resumePolicy: any(named: 'resumePolicy'),
+            onReconnectStatus: any(named: 'onReconnectStatus'),
           ),
         ).thenAnswer((_) => const Stream.empty());
 
@@ -117,6 +123,8 @@ void main() {
             'rooms/room-1/agui/thread-1/run-99',
             any(),
             cancelToken: any(named: 'cancelToken'),
+            resumePolicy: any(named: 'resumePolicy'),
+            onReconnectStatus: any(named: 'onReconnectStatus'),
           ),
         ).called(1);
       });
@@ -127,6 +135,8 @@ void main() {
             any(),
             any(),
             cancelToken: any(named: 'cancelToken'),
+            resumePolicy: any(named: 'resumePolicy'),
+            onReconnectStatus: any(named: 'onReconnectStatus'),
           ),
         ).thenAnswer((_) => const Stream.empty());
 
@@ -145,6 +155,8 @@ void main() {
             any(),
             captureAny(),
             cancelToken: any(named: 'cancelToken'),
+            resumePolicy: any(named: 'resumePolicy'),
+            onReconnectStatus: any(named: 'onReconnectStatus'),
           ),
         ).captured;
 

--- a/packages/soliplex_agent/test/orchestration/error_classifier_test.dart
+++ b/packages/soliplex_agent/test/orchestration/error_classifier_test.dart
@@ -43,6 +43,22 @@ void main() {
       });
     });
 
+    group('NetworkException unwrap', () {
+      test('unwraps to AuthException original cause as authExpired', () {
+        const original = AuthException(message: '401');
+        const wrapped = NetworkException(
+          message: 'Stream resume failed: …',
+          originalError: original,
+        );
+        expect(classifyError(wrapped), equals(FailureReason.authExpired));
+      });
+
+      test('falls back to networkLost when originalError is null', () {
+        const wrapped = NetworkException(message: 'connection reset');
+        expect(classifyError(wrapped), equals(FailureReason.networkLost));
+      });
+    });
+
     group('unknown errors', () {
       test('FormatException maps to internalError', () {
         const error = FormatException('bad json');

--- a/packages/soliplex_agent/test/orchestration/run_orchestrator_test.dart
+++ b/packages/soliplex_agent/test/orchestration/run_orchestrator_test.dart
@@ -117,6 +117,8 @@ void main() {
         any(),
         any(),
         cancelToken: any(named: 'cancelToken'),
+        resumePolicy: any(named: 'resumePolicy'),
+        onReconnectStatus: any(named: 'onReconnectStatus'),
       ),
     ).thenAnswer((_) => stream);
   }
@@ -828,6 +830,8 @@ void main() {
           any(),
           any(),
           cancelToken: any(named: 'cancelToken'),
+          resumePolicy: any(named: 'resumePolicy'),
+          onReconnectStatus: any(named: 'onReconnectStatus'),
         ),
       ).thenAnswer((_) {
         callCount++;
@@ -905,6 +909,8 @@ void main() {
           any(),
           any(),
           cancelToken: any(named: 'cancelToken'),
+          resumePolicy: any(named: 'resumePolicy'),
+          onReconnectStatus: any(named: 'onReconnectStatus'),
         ),
       ).thenAnswer((_) {
         callCount++;
@@ -948,6 +954,8 @@ void main() {
           any(),
           any(),
           cancelToken: any(named: 'cancelToken'),
+          resumePolicy: any(named: 'resumePolicy'),
+          onReconnectStatus: any(named: 'onReconnectStatus'),
         ),
       ).thenAnswer((_) => Stream.fromIterable(_toolCallEvents()));
 
@@ -1215,6 +1223,8 @@ void main() {
           any(),
           captureAny(),
           cancelToken: any(named: 'cancelToken'),
+          resumePolicy: any(named: 'resumePolicy'),
+          onReconnectStatus: any(named: 'onReconnectStatus'),
         ),
       ).captured;
 
@@ -1242,6 +1252,8 @@ void main() {
             any(),
             captureAny(),
             cancelToken: any(named: 'cancelToken'),
+            resumePolicy: any(named: 'resumePolicy'),
+            onReconnectStatus: any(named: 'onReconnectStatus'),
           ),
         ).thenAnswer((_) {
           callCount++;
@@ -1282,6 +1294,8 @@ void main() {
             any(),
             captureAny(),
             cancelToken: any(named: 'cancelToken'),
+            resumePolicy: any(named: 'resumePolicy'),
+            onReconnectStatus: any(named: 'onReconnectStatus'),
           ),
         ).captured;
 
@@ -1309,6 +1323,8 @@ void main() {
           any(),
           captureAny(),
           cancelToken: any(named: 'cancelToken'),
+          resumePolicy: any(named: 'resumePolicy'),
+          onReconnectStatus: any(named: 'onReconnectStatus'),
         ),
       ).thenAnswer((_) {
         callCount++;
@@ -1373,6 +1389,8 @@ void main() {
           any(),
           captureAny(),
           cancelToken: any(named: 'cancelToken'),
+          resumePolicy: any(named: 'resumePolicy'),
+          onReconnectStatus: any(named: 'onReconnectStatus'),
         ),
       ).captured;
 
@@ -1417,6 +1435,8 @@ void main() {
           any(),
           captureAny(),
           cancelToken: any(named: 'cancelToken'),
+          resumePolicy: any(named: 'resumePolicy'),
+          onReconnectStatus: any(named: 'onReconnectStatus'),
         ),
       ).captured;
 
@@ -1604,6 +1624,8 @@ void main() {
           any(),
           any(),
           cancelToken: any(named: 'cancelToken'),
+          resumePolicy: any(named: 'resumePolicy'),
+          onReconnectStatus: any(named: 'onReconnectStatus'),
         ),
       ).thenAnswer((_) {
         callCount++;
@@ -1709,6 +1731,8 @@ void main() {
           any(),
           any(),
           cancelToken: any(named: 'cancelToken'),
+          resumePolicy: any(named: 'resumePolicy'),
+          onReconnectStatus: any(named: 'onReconnectStatus'),
         ),
       ).thenAnswer((_) {
         callCount++;

--- a/packages/soliplex_agent/test/orchestration/run_orchestrator_test.dart
+++ b/packages/soliplex_agent/test/orchestration/run_orchestrator_test.dart
@@ -301,6 +301,44 @@ void main() {
         await controller.close();
       },
     );
+
+    test(
+      'FailedState.error unwraps SoliplexException to its message',
+      () async {
+        // The friendly-error rewrite in
+        // `ThreadViewState._friendlyMessage` matches
+        // `error.startsWith(streamResumeFailedPrefix)`. Without
+        // unwrapping, `SoliplexException.toString()` adds a
+        // `RuntimeType: ` prefix that defeats the match — the user
+        // ends up seeing the raw nested exception text instead of
+        // "Connection lost. The response may be incomplete — you
+        // can send your message again."
+        stubCreateRun();
+        final controller = StreamController<BaseEvent>();
+        addTearDown(controller.close);
+        stubRunAgent(stream: controller.stream);
+
+        await orchestrator.startRun(key: _key, userMessage: 'Hi');
+        await Future<void>.delayed(Duration.zero);
+
+        controller.addError(
+          const NetworkException(
+            message: 'Stream resume failed: transient',
+          ),
+        );
+        await Future<void>.delayed(Duration.zero);
+
+        expect(orchestrator.currentState, isA<FailedState>());
+        final failed = orchestrator.currentState as FailedState;
+        expect(
+          failed.error,
+          equals('Stream resume failed: transient'),
+          reason: 'must surface NetworkException.message — not the '
+              'type-prefixed toString — so the friendly-message '
+              "contract's startsWith check matches",
+        );
+      },
+    );
   });
 
   group('cancel', () {

--- a/packages/soliplex_agent/test/orchestration/run_orchestrator_test.dart
+++ b/packages/soliplex_agent/test/orchestration/run_orchestrator_test.dart
@@ -1271,6 +1271,52 @@ void main() {
 
       expect(orchestrator.currentState, isA<CancelledState>());
     });
+
+    test(
+      'CancelledException through stream → CancelledState (not FailedState)',
+      () async {
+        // `_onStreamError` previously only checked `is CancellationError`
+        // (the Dart-core type used by `CancelableOperation`). Our
+        // `CancelToken` throws `CancelledException` (a
+        // `SoliplexException`), so cancellations surfacing through
+        // the stream landed in `FailedState(reason: internalError)`
+        // instead of `CancelledState`. The fix accepts both shapes;
+        // this pins the `CancelledException` arm. (The
+        // `CancellationError` arm is exercised by
+        // `run_to_completion_test.dart`'s
+        // `'completer resolves for CancelledState'`.)
+        stubCreateRun();
+        final controller = StreamController<BaseEvent>();
+        addTearDown(controller.close);
+        stubRunAgent(stream: controller.stream);
+
+        await orchestrator.startRun(key: _key, userMessage: 'Hi');
+        await Future<void>.delayed(Duration.zero);
+        expect(orchestrator.currentState, isA<RunningState>());
+
+        controller.addError(const CancelledException(reason: 'user'));
+        await Future<void>.delayed(Duration.zero);
+
+        expect(orchestrator.currentState, isA<CancelledState>());
+      },
+    );
+
+    test(
+      'CancelledException from initial startRun → CancelledState',
+      () async {
+        // Mirrors the `_handleStartError` companion fix. If a cancel
+        // fires while the orchestrator is awaiting the very first
+        // `startRun` (the IdleState window), `_handleStartError`
+        // must route to `CancelledState` rather than classify the
+        // exception into `FailedState`.
+        when(() => api.createRun(any(), any()))
+            .thenThrow(const CancelledException(reason: 'user'));
+
+        await orchestrator.startRun(key: _key, userMessage: 'Hi');
+
+        expect(orchestrator.currentState, isA<CancelledState>());
+      },
+    );
   });
 
   group('graceful SSE close', () {

--- a/packages/soliplex_agent/test/orchestration/run_orchestrator_test.dart
+++ b/packages/soliplex_agent/test/orchestration/run_orchestrator_test.dart
@@ -1181,15 +1181,11 @@ void main() {
       await Future<void>.delayed(Duration.zero);
       expect(orchestrator.currentState, isA<ToolYieldingState>());
 
-      // Make the *resume* createRun hang — this is the await we'll
-      // cancel into.
       final resumeCreateRun = Completer<RunInfo>();
       when(
         () => api.createRun(any(), any()),
       ).thenAnswer((_) => resumeCreateRun.future);
 
-      // Release the tool executor; orchestrator is now suspended on
-      // resumeCreateRun.future inside _resumeStream.
       toolExecutorTrigger.complete();
       await Future<void>.delayed(Duration.zero);
       expect(orchestrator.currentState, isA<ToolYieldingState>());
@@ -1201,7 +1197,6 @@ void main() {
         reason: 'cancelRun must transition to CancelledState immediately',
       );
 
-      // Simulate createRun completing despite the cancel.
       resumeCreateRun.complete(_runInfo());
       final result = await runFuture;
 

--- a/packages/soliplex_agent/test/orchestration/run_orchestrator_test.dart
+++ b/packages/soliplex_agent/test/orchestration/run_orchestrator_test.dart
@@ -1070,11 +1070,10 @@ void main() {
 
     test('cancelRun during RunningState cancels the token passed to runAgent',
         () async {
-      // Regression for the orchestrator → SSE-client cancel handshake:
-      // before commit 3b9dd40, `_cancelToken` was null when handed to
-      // `runAgent`, so cancellation could not propagate to the in-flight
-      // SSE stream. This test pins the contract that the orchestrator
-      // (a) passes a non-null token and (b) cancels it on cancelRun.
+      // Pins the orchestrator → SSE-client cancel handshake: the
+      // orchestrator must (a) pass a non-null token to `runAgent`
+      // and (b) cancel it on `cancelRun`, so cancellation propagates
+      // to the in-flight SSE stream.
       CancelToken? capturedToken;
       final controller = StreamController<BaseEvent>();
       addTearDown(controller.close);
@@ -1120,15 +1119,16 @@ void main() {
 
     test('cancelRun during _resumeStream createRun await yields CancelledState',
         () async {
-      // Regression for three coupled gaps that trigger when the user
-      // presses Stop during a tool-yield resume:
-      //   - cancelRun's ToolYieldingState arm must cancel the live token
+      // Pins three coupled contracts that fire when the user presses
+      // Stop during a tool-yield resume:
+      //   - cancelRun's ToolYieldingState arm cancels the live token
       //     so the in-flight createRun await aborts.
-      //   - _resumeStream must not call _subscribeToStream after the
+      //   - _resumeStream does not call _subscribeToStream after the
       //     await if state has transitioned away from ToolYieldingState
-      //     (otherwise CancelledState is overwritten with RunningState).
-      //   - _driveToolLoop's catch must not turn the resulting
-      //     CancellationException into FailedState.
+      //     (otherwise CancelledState would be overwritten with
+      //     RunningState).
+      //   - _driveToolLoop's catch routes a cancel-byproduct exception
+      //     to CancelledState, not FailedState.
       orchestrator = RunOrchestrator(
         llmProvider: AgUiLlmProvider(
           api: api,
@@ -1139,12 +1139,18 @@ void main() {
       );
       stubCreateRun();
       // First runAgent call: tool call events drive us to ToolYieldingState.
-      // Second runAgent call: resume; an empty stream is enough — if the
-      // post-await state check fails to fire, `_subscribeToStream` would
-      // run, transition to RunningState, observe `onDone`, and end in
-      // FailedState (`_onStreamDone`'s "Stream ended without terminal
-      // event" path). The fix keeps the state at CancelledState instead.
+      // Second runAgent call: resume; an empty stream is enough. The
+      // post-await `_currentState is! ToolYieldingState` guard in
+      // `_resumeStream` prevents `_subscribeToStream` from running —
+      // if it ran, RunningState would overwrite CancelledState, then
+      // `_onStreamDone` would flip to FailedState via the "Stream
+      // ended without terminal event" path.
       var runAgentCallCount = 0;
+      var resumeStreamSubscribeCount = 0;
+      final resumeStreamController = StreamController<BaseEvent>(
+        onListen: () => resumeStreamSubscribeCount++,
+      );
+      addTearDown(resumeStreamController.close);
       when(
         () => agUiStreamClient.runAgent(
           any(),
@@ -1158,7 +1164,7 @@ void main() {
         if (runAgentCallCount == 1) {
           return Stream.fromIterable(_toolCallEvents());
         }
-        return const Stream<BaseEvent>.empty();
+        return resumeStreamController.stream;
       });
 
       // Block the tool executor so the test can re-stub createRun before
@@ -1202,12 +1208,19 @@ void main() {
       expect(
         result,
         isA<CancelledState>(),
-        reason: 'state must remain CancelledState — without the fix, '
-            '`_subscribeToStream` would overwrite it with RunningState, '
-            'and the empty resume stream would then flip to FailedState '
-            'via `_onStreamDone`',
+        reason: 'state must remain CancelledState; without the post-await '
+            'guard, `_subscribeToStream` would overwrite it with '
+            'RunningState and the empty resume stream would then flip '
+            'to FailedState via `_onStreamDone`',
       );
       expect(runAgentCallCount, equals(2));
+      expect(
+        resumeStreamSubscribeCount,
+        equals(1),
+        reason: 'orchestrator must drain the abandoned LlmRunHandle.events '
+            'stream so the underlying SSE socket releases — without the '
+            'subscribe-then-cancel, the HTTP transport would hold it open',
+      );
     });
   });
 
@@ -1275,16 +1288,12 @@ void main() {
     test(
       'CancelledException through stream → CancelledState (not FailedState)',
       () async {
-        // `_onStreamError` previously only checked `is CancellationError`
-        // (the Dart-core type used by `CancelableOperation`). Our
-        // `CancelToken` throws `CancelledException` (a
-        // `SoliplexException`), so cancellations surfacing through
-        // the stream landed in `FailedState(reason: internalError)`
-        // instead of `CancelledState`. The fix accepts both shapes;
-        // this pins the `CancelledException` arm. (The
-        // `CancellationError` arm is exercised by
-        // `run_to_completion_test.dart`'s
-        // `'completer resolves for CancelledState'`.)
+        // Pins that `_onStreamError` routes both cancellation shapes
+        // to `CancelledState`: `CancelledException` (from our
+        // `CancelToken`) and Dart-core `CancellationError` (from
+        // `CancelableOperation`). The `CancellationError` arm is
+        // exercised by `run_to_completion_test.dart`'s
+        // `'completer resolves for CancelledState'`.
         stubCreateRun();
         final controller = StreamController<BaseEvent>();
         addTearDown(controller.close);
@@ -1304,11 +1313,9 @@ void main() {
     test(
       'CancelledException from initial startRun → CancelledState',
       () async {
-        // Mirrors the `_handleStartError` companion fix. If a cancel
-        // fires while the orchestrator is awaiting the very first
-        // `startRun` (the IdleState window), `_handleStartError`
-        // must route to `CancelledState` rather than classify the
-        // exception into `FailedState`.
+        // Pins that `_handleStartError` routes a cancel during the
+        // initial `startRun` await (the IdleState window) to
+        // `CancelledState`, not `FailedState`.
         when(() => api.createRun(any(), any()))
             .thenThrow(const CancelledException(reason: 'user'));
 

--- a/packages/soliplex_agent/test/orchestration/run_orchestrator_test.dart
+++ b/packages/soliplex_agent/test/orchestration/run_orchestrator_test.dart
@@ -1014,6 +1014,56 @@ void main() {
       expect(failed.reason, equals(FailureReason.toolExecutionFailed));
       expect(failed.error, contains('depth limit'));
     });
+
+    test('NetworkException during resume → FailedState(networkLost)', () async {
+      // The post-tool-yield resume goes through `_failResume`, which must
+      // route via `classifyError` rather than hardcoding
+      // `toolExecutionFailed`. A transport drop on the resume should
+      // surface as `networkLost` so the UI can render reconnect copy
+      // instead of a tool-failure message.
+      orchestrator = RunOrchestrator(
+        llmProvider: AgUiLlmProvider(
+          api: api,
+          agUiStreamClient: agUiStreamClient,
+        ),
+        toolRegistry: _registryWith(),
+        logger: logger,
+      );
+      stubCreateRun();
+      var runAgentCallCount = 0;
+      when(
+        () => agUiStreamClient.runAgent(
+          any(),
+          any(),
+          cancelToken: any(named: 'cancelToken'),
+          resumePolicy: any(named: 'resumePolicy'),
+          onReconnectStatus: any(named: 'onReconnectStatus'),
+        ),
+      ).thenAnswer((_) {
+        runAgentCallCount++;
+        if (runAgentCallCount == 1) {
+          return Stream.fromIterable(_toolCallEvents());
+        }
+        return Stream<BaseEvent>.error(
+          const NetworkException(message: 'transport drop on resume'),
+        );
+      });
+
+      final result = await orchestrator.runToCompletion(
+        key: _key,
+        userMessage: 'Weather?',
+        toolExecutor: (_) async => _executedTools(),
+      );
+
+      expect(result, isA<FailedState>());
+      final failed = result as FailedState;
+      expect(
+        failed.reason,
+        equals(FailureReason.networkLost),
+        reason: 'transport failure during resume must classify as '
+            'networkLost, not toolExecutionFailed',
+      );
+    });
   });
 
   group('cancel during yield', () {

--- a/packages/soliplex_agent/test/orchestration/run_orchestrator_test.dart
+++ b/packages/soliplex_agent/test/orchestration/run_orchestrator_test.dart
@@ -1029,6 +1029,148 @@ void main() {
         ),
       );
     });
+
+    test('cancelRun during RunningState cancels the token passed to runAgent',
+        () async {
+      // Regression for the orchestrator → SSE-client cancel handshake:
+      // before commit 3b9dd40, `_cancelToken` was null when handed to
+      // `runAgent`, so cancellation could not propagate to the in-flight
+      // SSE stream. This test pins the contract that the orchestrator
+      // (a) passes a non-null token and (b) cancels it on cancelRun.
+      CancelToken? capturedToken;
+      final controller = StreamController<BaseEvent>();
+      addTearDown(controller.close);
+      when(
+        () => agUiStreamClient.runAgent(
+          any(),
+          any(),
+          cancelToken: any(named: 'cancelToken'),
+          resumePolicy: any(named: 'resumePolicy'),
+          onReconnectStatus: any(named: 'onReconnectStatus'),
+        ),
+      ).thenAnswer((invocation) {
+        capturedToken = invocation.namedArguments[#cancelToken] as CancelToken?;
+        return controller.stream;
+      });
+      stubCreateRun();
+
+      unawaited(
+        orchestrator.runToCompletion(
+          key: _key,
+          userMessage: 'Hi',
+          toolExecutor: (_) async => [],
+        ),
+      );
+      await Future<void>.delayed(Duration.zero);
+      expect(orchestrator.currentState, isA<RunningState>());
+      expect(
+        capturedToken,
+        isNotNull,
+        reason: 'orchestrator must pass a non-null cancel token',
+      );
+      expect(capturedToken!.isCancelled, isFalse);
+
+      orchestrator.cancelRun();
+
+      expect(
+        capturedToken!.isCancelled,
+        isTrue,
+        reason: "cancelRun must propagate to the SSE client's token",
+      );
+      expect(orchestrator.currentState, isA<CancelledState>());
+    });
+
+    test('cancelRun during _resumeStream createRun await yields CancelledState',
+        () async {
+      // Regression for three coupled gaps that trigger when the user
+      // presses Stop during a tool-yield resume:
+      //   - cancelRun's ToolYieldingState arm must cancel the live token
+      //     so the in-flight createRun await aborts.
+      //   - _resumeStream must not call _subscribeToStream after the
+      //     await if state has transitioned away from ToolYieldingState
+      //     (otherwise CancelledState is overwritten with RunningState).
+      //   - _driveToolLoop's catch must not turn the resulting
+      //     CancellationException into FailedState.
+      orchestrator = RunOrchestrator(
+        llmProvider: AgUiLlmProvider(
+          api: api,
+          agUiStreamClient: agUiStreamClient,
+        ),
+        toolRegistry: _registryWith(),
+        logger: logger,
+      );
+      stubCreateRun();
+      // First runAgent call: tool call events drive us to ToolYieldingState.
+      // Second runAgent call: resume; an empty stream is enough — if the
+      // post-await state check fails to fire, `_subscribeToStream` would
+      // run, transition to RunningState, observe `onDone`, and end in
+      // FailedState (`_onStreamDone`'s "Stream ended without terminal
+      // event" path). The fix keeps the state at CancelledState instead.
+      var runAgentCallCount = 0;
+      when(
+        () => agUiStreamClient.runAgent(
+          any(),
+          any(),
+          cancelToken: any(named: 'cancelToken'),
+          resumePolicy: any(named: 'resumePolicy'),
+          onReconnectStatus: any(named: 'onReconnectStatus'),
+        ),
+      ).thenAnswer((_) {
+        runAgentCallCount++;
+        if (runAgentCallCount == 1) {
+          return Stream.fromIterable(_toolCallEvents());
+        }
+        return const Stream<BaseEvent>.empty();
+      });
+
+      // Block the tool executor so the test can re-stub createRun before
+      // _resumeStream fires.
+      final toolExecutorTrigger = Completer<void>();
+      final runFuture = orchestrator.runToCompletion(
+        key: _key,
+        userMessage: 'Weather?',
+        toolExecutor: (_) async {
+          await toolExecutorTrigger.future;
+          return _executedTools();
+        },
+      );
+      await Future<void>.delayed(Duration.zero);
+      expect(orchestrator.currentState, isA<ToolYieldingState>());
+
+      // Make the *resume* createRun hang — this is the await we'll
+      // cancel into.
+      final resumeCreateRun = Completer<RunInfo>();
+      when(
+        () => api.createRun(any(), any()),
+      ).thenAnswer((_) => resumeCreateRun.future);
+
+      // Release the tool executor; orchestrator is now suspended on
+      // resumeCreateRun.future inside _resumeStream.
+      toolExecutorTrigger.complete();
+      await Future<void>.delayed(Duration.zero);
+      expect(orchestrator.currentState, isA<ToolYieldingState>());
+
+      orchestrator.cancelRun();
+      expect(
+        orchestrator.currentState,
+        isA<CancelledState>(),
+        reason: 'cancelRun must transition to CancelledState immediately',
+      );
+
+      // Simulate createRun completing despite the cancel.
+      resumeCreateRun.complete(_runInfo());
+      final result = await runFuture;
+
+      expect(
+        result,
+        isA<CancelledState>(),
+        reason: 'state must remain CancelledState — without the fix, '
+            '`_subscribeToStream` would overwrite it with RunningState, '
+            'and the empty resume stream would then flip to FailedState '
+            'via `_onStreamDone`',
+      );
+      expect(runAgentCallCount, equals(2));
+    });
   });
 
   group('cancel during async gap', () {

--- a/packages/soliplex_agent/test/orchestration/run_to_completion_test.dart
+++ b/packages/soliplex_agent/test/orchestration/run_to_completion_test.dart
@@ -123,6 +123,8 @@ void main() {
         any(),
         any(),
         cancelToken: any(named: 'cancelToken'),
+        resumePolicy: any(named: 'resumePolicy'),
+        onReconnectStatus: any(named: 'onReconnectStatus'),
       ),
     ).thenAnswer((_) => stream);
   }
@@ -202,6 +204,8 @@ void main() {
           any(),
           any(),
           cancelToken: any(named: 'cancelToken'),
+          resumePolicy: any(named: 'resumePolicy'),
+          onReconnectStatus: any(named: 'onReconnectStatus'),
         ),
       ).thenAnswer((_) {
         callCount++;
@@ -235,6 +239,8 @@ void main() {
           any(),
           any(),
           cancelToken: any(named: 'cancelToken'),
+          resumePolicy: any(named: 'resumePolicy'),
+          onReconnectStatus: any(named: 'onReconnectStatus'),
         ),
       ).thenAnswer((_) {
         callCount++;
@@ -271,6 +277,8 @@ void main() {
           any(),
           any(),
           cancelToken: any(named: 'cancelToken'),
+          resumePolicy: any(named: 'resumePolicy'),
+          onReconnectStatus: any(named: 'onReconnectStatus'),
         ),
       ).thenAnswer((_) => Stream.fromIterable(_toolCallEvents()));
 
@@ -544,6 +552,8 @@ void main() {
           any(),
           any(),
           cancelToken: any(named: 'cancelToken'),
+          resumePolicy: any(named: 'resumePolicy'),
+          onReconnectStatus: any(named: 'onReconnectStatus'),
         ),
       ).thenAnswer((_) {
         callCount++;
@@ -658,6 +668,8 @@ void main() {
           any(),
           any(),
           cancelToken: any(named: 'cancelToken'),
+          resumePolicy: any(named: 'resumePolicy'),
+          onReconnectStatus: any(named: 'onReconnectStatus'),
         ),
       ).thenAnswer((_) {
         callCount++;

--- a/packages/soliplex_agent/test/runtime/agent_runtime_signal_test.dart
+++ b/packages/soliplex_agent/test/runtime/agent_runtime_signal_test.dart
@@ -101,6 +101,8 @@ void main() {
         any(),
         any(),
         cancelToken: any(named: 'cancelToken'),
+        resumePolicy: any(named: 'resumePolicy'),
+        onReconnectStatus: any(named: 'onReconnectStatus'),
       ),
     ).thenAnswer((_) => stream);
   }

--- a/packages/soliplex_agent/test/runtime/agent_runtime_test.dart
+++ b/packages/soliplex_agent/test/runtime/agent_runtime_test.dart
@@ -173,6 +173,8 @@ void main() {
         any(),
         any(),
         cancelToken: any(named: 'cancelToken'),
+        resumePolicy: any(named: 'resumePolicy'),
+        onReconnectStatus: any(named: 'onReconnectStatus'),
       ),
     ).thenAnswer((_) => stream);
   }
@@ -245,6 +247,8 @@ void main() {
           any(),
           any(),
           cancelToken: any(named: 'cancelToken'),
+          resumePolicy: any(named: 'resumePolicy'),
+          onReconnectStatus: any(named: 'onReconnectStatus'),
         ),
       ).thenAnswer((invocation) {
         capturedInput =
@@ -283,6 +287,8 @@ void main() {
           any(),
           any(),
           cancelToken: any(named: 'cancelToken'),
+          resumePolicy: any(named: 'resumePolicy'),
+          onReconnectStatus: any(named: 'onReconnectStatus'),
         ),
       ).thenAnswer((invocation) {
         capturedInput =
@@ -342,6 +348,8 @@ void main() {
           any(),
           any(),
           cancelToken: any(named: 'cancelToken'),
+          resumePolicy: any(named: 'resumePolicy'),
+          onReconnectStatus: any(named: 'onReconnectStatus'),
         ),
       ).thenAnswer((invocation) {
         capturedInput =
@@ -487,6 +495,8 @@ void main() {
           any(),
           any(),
           cancelToken: any(named: 'cancelToken'),
+          resumePolicy: any(named: 'resumePolicy'),
+          onReconnectStatus: any(named: 'onReconnectStatus'),
         ),
       ).thenAnswer((_) {
         callCount++;
@@ -943,6 +953,8 @@ void main() {
           any(),
           any(),
           cancelToken: any(named: 'cancelToken'),
+          resumePolicy: any(named: 'resumePolicy'),
+          onReconnectStatus: any(named: 'onReconnectStatus'),
         ),
       ).thenAnswer((_) => controller1.stream);
 
@@ -981,6 +993,8 @@ void main() {
           any(),
           any(),
           cancelToken: any(named: 'cancelToken'),
+          resumePolicy: any(named: 'resumePolicy'),
+          onReconnectStatus: any(named: 'onReconnectStatus'),
         ),
       ).thenAnswer((invocation) {
         capturedInput =
@@ -1096,6 +1110,8 @@ void main() {
           any(),
           any(),
           cancelToken: any(named: 'cancelToken'),
+          resumePolicy: any(named: 'resumePolicy'),
+          onReconnectStatus: any(named: 'onReconnectStatus'),
         ),
       ).thenAnswer((_) {
         callCount++;
@@ -1148,6 +1164,8 @@ void main() {
           any(),
           any(),
           cancelToken: any(named: 'cancelToken'),
+          resumePolicy: any(named: 'resumePolicy'),
+          onReconnectStatus: any(named: 'onReconnectStatus'),
         ),
       ).thenAnswer((_) {
         callCount++;
@@ -1343,6 +1361,8 @@ void main() {
           any(),
           captureAny(),
           cancelToken: any(named: 'cancelToken'),
+          resumePolicy: any(named: 'resumePolicy'),
+          onReconnectStatus: any(named: 'onReconnectStatus'),
         ),
       ).captured;
 
@@ -1375,6 +1395,8 @@ void main() {
           any(),
           captureAny(),
           cancelToken: any(named: 'cancelToken'),
+          resumePolicy: any(named: 'resumePolicy'),
+          onReconnectStatus: any(named: 'onReconnectStatus'),
         ),
       ).captured;
 
@@ -1413,6 +1435,8 @@ void main() {
           any(),
           captureAny(),
           cancelToken: any(named: 'cancelToken'),
+          resumePolicy: any(named: 'resumePolicy'),
+          onReconnectStatus: any(named: 'onReconnectStatus'),
         ),
       ).captured;
 

--- a/packages/soliplex_agent/test/runtime/agent_session_signal_test.dart
+++ b/packages/soliplex_agent/test/runtime/agent_session_signal_test.dart
@@ -110,6 +110,8 @@ void main() {
         any(),
         any(),
         cancelToken: any(named: 'cancelToken'),
+        resumePolicy: any(named: 'resumePolicy'),
+        onReconnectStatus: any(named: 'onReconnectStatus'),
       ),
     ).thenAnswer((_) => stream);
   }

--- a/packages/soliplex_agent/test/runtime/agent_session_test.dart
+++ b/packages/soliplex_agent/test/runtime/agent_session_test.dart
@@ -193,6 +193,8 @@ void main() {
         any(),
         any(),
         cancelToken: any(named: 'cancelToken'),
+        resumePolicy: any(named: 'resumePolicy'),
+        onReconnectStatus: any(named: 'onReconnectStatus'),
       ),
     ).thenAnswer((_) => stream);
   }
@@ -266,6 +268,8 @@ void main() {
           any(),
           any(),
           cancelToken: any(named: 'cancelToken'),
+          resumePolicy: any(named: 'resumePolicy'),
+          onReconnectStatus: any(named: 'onReconnectStatus'),
         ),
       ).thenAnswer((_) {
         callCount++;
@@ -300,6 +304,8 @@ void main() {
           any(),
           any(),
           cancelToken: any(named: 'cancelToken'),
+          resumePolicy: any(named: 'resumePolicy'),
+          onReconnectStatus: any(named: 'onReconnectStatus'),
         ),
       ).thenAnswer((_) {
         callCount++;
@@ -336,6 +342,8 @@ void main() {
           any(),
           any(),
           cancelToken: any(named: 'cancelToken'),
+          resumePolicy: any(named: 'resumePolicy'),
+          onReconnectStatus: any(named: 'onReconnectStatus'),
         ),
       ).thenAnswer((_) {
         callCount++;
@@ -629,6 +637,8 @@ void main() {
           any(),
           any(),
           cancelToken: any(named: 'cancelToken'),
+          resumePolicy: any(named: 'resumePolicy'),
+          onReconnectStatus: any(named: 'onReconnectStatus'),
         ),
       ).thenAnswer((_) {
         callCount++;
@@ -785,6 +795,8 @@ void main() {
             any(),
             any(),
             cancelToken: any(named: 'cancelToken'),
+            resumePolicy: any(named: 'resumePolicy'),
+            onReconnectStatus: any(named: 'onReconnectStatus'),
           ),
         ).thenAnswer((_) {
           callCount++;
@@ -832,6 +844,8 @@ void main() {
           any(),
           any(),
           cancelToken: any(named: 'cancelToken'),
+          resumePolicy: any(named: 'resumePolicy'),
+          onReconnectStatus: any(named: 'onReconnectStatus'),
         ),
       ).thenAnswer((_) {
         callCount++;
@@ -875,6 +889,8 @@ void main() {
           any(),
           any(),
           cancelToken: any(named: 'cancelToken'),
+          resumePolicy: any(named: 'resumePolicy'),
+          onReconnectStatus: any(named: 'onReconnectStatus'),
         ),
       ).thenAnswer((_) {
         callCount++;

--- a/packages/soliplex_agent/test/runtime/concurrency_experiments_test.dart
+++ b/packages/soliplex_agent/test/runtime/concurrency_experiments_test.dart
@@ -215,6 +215,8 @@ void main() {
         any(),
         any(),
         cancelToken: any(named: 'cancelToken'),
+        resumePolicy: any(named: 'resumePolicy'),
+        onReconnectStatus: any(named: 'onReconnectStatus'),
       ),
     ).thenAnswer((_) => stream);
   }
@@ -239,6 +241,8 @@ void main() {
           any(),
           any(),
           cancelToken: any(named: 'cancelToken'),
+          resumePolicy: any(named: 'resumePolicy'),
+          onReconnectStatus: any(named: 'onReconnectStatus'),
         ),
       ).thenAnswer((_) {
         callCount++;
@@ -281,6 +285,8 @@ void main() {
           any(),
           any(),
           cancelToken: any(named: 'cancelToken'),
+          resumePolicy: any(named: 'resumePolicy'),
+          onReconnectStatus: any(named: 'onReconnectStatus'),
         ),
       ).thenAnswer((_) {
         callCount++;
@@ -383,6 +389,8 @@ void main() {
           any(),
           any(),
           cancelToken: any(named: 'cancelToken'),
+          resumePolicy: any(named: 'resumePolicy'),
+          onReconnectStatus: any(named: 'onReconnectStatus'),
         ),
       ).thenAnswer((_) => controllers[callIdx++].stream);
 
@@ -551,6 +559,8 @@ void main() {
           any(),
           any(),
           cancelToken: any(named: 'cancelToken'),
+          resumePolicy: any(named: 'resumePolicy'),
+          onReconnectStatus: any(named: 'onReconnectStatus'),
         ),
       ).thenAnswer((_) {
         callCount++;
@@ -623,6 +633,8 @@ void main() {
           any(),
           any(),
           cancelToken: any(named: 'cancelToken'),
+          resumePolicy: any(named: 'resumePolicy'),
+          onReconnectStatus: any(named: 'onReconnectStatus'),
         ),
       ).thenAnswer((_) {
         callCount++;
@@ -684,6 +696,8 @@ void main() {
           any(),
           any(),
           cancelToken: any(named: 'cancelToken'),
+          resumePolicy: any(named: 'resumePolicy'),
+          onReconnectStatus: any(named: 'onReconnectStatus'),
         ),
       ).thenAnswer((_) {
         callCount++;
@@ -742,6 +756,8 @@ void main() {
           any(),
           any(),
           cancelToken: any(named: 'cancelToken'),
+          resumePolicy: any(named: 'resumePolicy'),
+          onReconnectStatus: any(named: 'onReconnectStatus'),
         ),
       ).thenAnswer((_) {
         callCount++;
@@ -790,6 +806,8 @@ void main() {
           any(),
           any(),
           cancelToken: any(named: 'cancelToken'),
+          resumePolicy: any(named: 'resumePolicy'),
+          onReconnectStatus: any(named: 'onReconnectStatus'),
         ),
       ).thenAnswer((_) {
         callCount++;
@@ -851,6 +869,8 @@ void main() {
           any(),
           any(),
           cancelToken: any(named: 'cancelToken'),
+          resumePolicy: any(named: 'resumePolicy'),
+          onReconnectStatus: any(named: 'onReconnectStatus'),
         ),
       ).thenAnswer((_) {
         callCount++;
@@ -917,6 +937,8 @@ void main() {
           any(),
           any(),
           cancelToken: any(named: 'cancelToken'),
+          resumePolicy: any(named: 'resumePolicy'),
+          onReconnectStatus: any(named: 'onReconnectStatus'),
         ),
       ).thenAnswer((_) {
         callCount++;

--- a/packages/soliplex_agent/test/runtime/multi_server_runtime_test.dart
+++ b/packages/soliplex_agent/test/runtime/multi_server_runtime_test.dart
@@ -72,7 +72,13 @@ void _stubHappyPath(
   ).thenAnswer((_) async => _runInfo(threadId));
   when(() => api.deleteThread(any(), any())).thenAnswer((_) async {});
   when(
-    () => agUi.runAgent(any(), any(), cancelToken: any(named: 'cancelToken')),
+    () => agUi.runAgent(
+      any(),
+      any(),
+      cancelToken: any(named: 'cancelToken'),
+      resumePolicy: any(named: 'resumePolicy'),
+      onReconnectStatus: any(named: 'onReconnectStatus'),
+    ),
   ).thenAnswer(
     (_) => stream ?? Stream.fromIterable(_happyPathEvents(threadId)),
   );

--- a/packages/soliplex_agent/test/runtime/session_children_test.dart
+++ b/packages/soliplex_agent/test/runtime/session_children_test.dart
@@ -102,6 +102,8 @@ void main() {
         any(),
         any(),
         cancelToken: any(named: 'cancelToken'),
+        resumePolicy: any(named: 'resumePolicy'),
+        onReconnectStatus: any(named: 'onReconnectStatus'),
       ),
     ).thenAnswer((_) => stream);
   }
@@ -245,6 +247,8 @@ void main() {
           any(),
           any(),
           cancelToken: any(named: 'cancelToken'),
+          resumePolicy: any(named: 'resumePolicy'),
+          onReconnectStatus: any(named: 'onReconnectStatus'),
         ),
       ).thenAnswer((_) {
         callCount++;

--- a/packages/soliplex_client/lib/src/errors/exceptions.dart
+++ b/packages/soliplex_client/lib/src/errors/exceptions.dart
@@ -76,21 +76,13 @@ class NetworkException extends SoliplexException {
 
 /// Exception thrown when the SSE `Last-Event-ID` resume budget is
 /// exhausted or a non-retryable error occurs during a resume attempt.
-///
-/// Carries [skippedEventCount] so consumers can surface a typed count
-/// of malformed events that were dropped during streaming, rather than
-/// parsing the message string.
 class StreamResumeFailedException extends NetworkException {
   /// Creates a stream-resume-failed exception.
   const StreamResumeFailedException({
     required super.message,
     super.originalError,
     super.stackTrace,
-    this.skippedEventCount = 0,
   });
-
-  /// Number of malformed events skipped over the run. Zero is common.
-  final int skippedEventCount;
 
   @override
   String toString() => 'StreamResumeFailedException: $message';

--- a/packages/soliplex_client/lib/src/errors/exceptions.dart
+++ b/packages/soliplex_client/lib/src/errors/exceptions.dart
@@ -74,6 +74,28 @@ class NetworkException extends SoliplexException {
   }
 }
 
+/// Exception thrown when the SSE `Last-Event-ID` resume budget is
+/// exhausted or a non-retryable error occurs during a resume attempt.
+///
+/// Carries [skippedEventCount] so consumers can surface a typed count
+/// of malformed events that were dropped during streaming, rather than
+/// parsing the message string.
+class StreamResumeFailedException extends NetworkException {
+  /// Creates a stream-resume-failed exception.
+  const StreamResumeFailedException({
+    required super.message,
+    super.originalError,
+    super.stackTrace,
+    this.skippedEventCount = 0,
+  });
+
+  /// Number of malformed events skipped over the run. Zero is common.
+  final int skippedEventCount;
+
+  @override
+  String toString() => 'StreamResumeFailedException: $message';
+}
+
 /// Exception thrown when an API error occurs (4xx, 5xx except 401/403/404).
 ///
 /// UI should show error message.

--- a/packages/soliplex_client/lib/src/http/agui_stream_client.dart
+++ b/packages/soliplex_client/lib/src/http/agui_stream_client.dart
@@ -97,7 +97,6 @@ class AgUiStreamClient {
           throw StreamResumeFailedException(
             message: _resumeFailureMessage(e, skippedEventCount),
             originalError: e,
-            skippedEventCount: skippedEventCount,
           );
         }
         attempt += 1;
@@ -183,7 +182,6 @@ class AgUiStreamClient {
         throw StreamResumeFailedException(
           message: _resumeFailureMessage(streamError, skippedEventCount),
           originalError: streamError,
-          skippedEventCount: skippedEventCount,
         );
       }
 

--- a/packages/soliplex_client/lib/src/http/agui_stream_client.dart
+++ b/packages/soliplex_client/lib/src/http/agui_stream_client.dart
@@ -13,9 +13,10 @@ import 'package:soliplex_client/src/http/resume_policy.dart';
 import 'package:soliplex_client/src/utils/cancel_token.dart';
 import 'package:soliplex_client/src/utils/url_builder.dart';
 
-/// Marker prefix on [NetworkException.message] when [AgUiStreamClient]
-/// wraps a resume failure. Consumers match on this prefix to render
-/// user-friendly copy in place of the raw transport error.
+/// Diagnostic prefix used inside
+/// [StreamResumeFailedException.message]. Kept for log/test
+/// readability; consumers should match on [StreamResumeFailedException]
+/// rather than this string.
 const String streamResumeFailedPrefix = 'Stream resume failed:';
 
 /// Streams AG-UI events using the Soliplex HTTP stack directly.
@@ -93,9 +94,10 @@ class AgUiStreamClient {
             ReconnectFailed(attempt: attempt, error: e),
           );
           _flushSkippedWarning(skippedEventCount);
-          throw NetworkException(
+          throw StreamResumeFailedException(
             message: _resumeFailureMessage(e, skippedEventCount),
             originalError: e,
+            skippedEventCount: skippedEventCount,
           );
         }
         attempt += 1;
@@ -178,9 +180,10 @@ class AgUiStreamClient {
           ReconnectFailed(attempt: attempt, error: streamError),
         );
         _flushSkippedWarning(skippedEventCount);
-        throw NetworkException(
+        throw StreamResumeFailedException(
           message: _resumeFailureMessage(streamError, skippedEventCount),
           originalError: streamError,
+          skippedEventCount: skippedEventCount,
         );
       }
 

--- a/packages/soliplex_client/lib/src/http/agui_stream_client.dart
+++ b/packages/soliplex_client/lib/src/http/agui_stream_client.dart
@@ -114,6 +114,7 @@ class AgUiStreamClient {
       var sawTerminalEvent = false;
       var announcedResume = !isResumeRequest;
       Object? streamError;
+      StackTrace? streamErrorStack;
 
       try {
         // Construct the parser inside the try so a synchronous throw
@@ -146,8 +147,9 @@ class AgUiStreamClient {
         }
       } on CancelledException {
         rethrow;
-      } on Object catch (e) {
+      } on Object catch (e, st) {
         streamError = e;
+        streamErrorStack = st;
         developer.log(
           'SSE stream dropped after id=${lastEventId ?? "<none>"}: $e',
           name: _logName,
@@ -161,10 +163,13 @@ class AgUiStreamClient {
       }
 
       if (lastEventId == null) {
+        // No id was ever emitted, so no resume is possible. Rethrow the
+        // underlying error directly — wrapping with `streamResumeFailedPrefix`
+        // would mislead consumers into treating this as a resume failure.
         _flushSkippedWarning(skippedEventCount);
-        throw NetworkException(
-          message: _resumeFailureMessage(streamError, skippedEventCount),
-          originalError: streamError,
+        Error.throwWithStackTrace(
+          streamError,
+          streamErrorStack ?? StackTrace.current,
         );
       }
 
@@ -320,20 +325,12 @@ class AgUiStreamClient {
       }),
     );
     await completer.future;
-    // Idempotent: a no-op when the timer has already fired or been
-    // cancelled. Belt-and-suspenders against a future refactor that
-    // adds a path through `await completer.future` without firing
-    // either branch.
     timer.cancel();
     token.throwIfCancelled();
   }
 
-  /// Surfaces a non-zero skipped-event count. Always emits a
-  /// `developer.log` summary on the same `_logName` channel as the
-  /// per-event skip logs, and also forwards to [_onWarning] when the
-  /// host opted in to structured handling. Stateless — callers must
-  /// invoke this exactly once per terminal step (each `return`/`throw`
-  /// path inside `runAgent`).
+  /// Logs and forwards a non-zero skipped-event count via [_onWarning].
+  /// Caller invokes once per terminal exit from `runAgent`.
   void _flushSkippedWarning(int count) {
     if (count == 0) return;
     final noun = count == 1 ? 'event' : 'events';
@@ -343,9 +340,10 @@ class AgUiStreamClient {
   }
 
   String _resumeFailureMessage(Object error, int skippedEventCount) {
-    if (skippedEventCount == 0) return '$streamResumeFailedPrefix $error';
+    final inner = error is SoliplexException ? error.message : error.toString();
+    if (skippedEventCount == 0) return '$streamResumeFailedPrefix $inner';
     final noun = skippedEventCount == 1 ? 'event' : 'events';
-    return '$streamResumeFailedPrefix $error '
+    return '$streamResumeFailedPrefix $inner '
         '(skipped $skippedEventCount malformed $noun)';
   }
 

--- a/packages/soliplex_client/lib/src/http/agui_stream_client.dart
+++ b/packages/soliplex_client/lib/src/http/agui_stream_client.dart
@@ -1,111 +1,357 @@
+import 'dart:async';
 import 'dart:convert';
 import 'dart:developer' as developer;
 
 import 'package:ag_ui/ag_ui.dart' hide CancelToken;
 // ignore: implementation_imports
 import 'package:ag_ui/src/sse/sse_parser.dart';
+import 'package:meta/meta.dart';
+import 'package:soliplex_client/src/errors/exceptions.dart';
+import 'package:soliplex_client/src/http/http_response.dart';
 import 'package:soliplex_client/src/http/http_transport.dart';
+import 'package:soliplex_client/src/http/resume_policy.dart';
 import 'package:soliplex_client/src/utils/cancel_token.dart';
 import 'package:soliplex_client/src/utils/url_builder.dart';
+
+/// Marker prefix used by `AgUiStreamClient` when wrapping a resume
+/// failure into [NetworkException]. `ThreadViewState._friendlyMessage`
+/// (in the Flutter app) matches this prefix to render user-friendly
+/// "Connection lost" copy.
+///
+/// Both sides of the contract import this constant so a typo cannot
+/// drift across the two callsites. A future structured
+/// `FailureReason.resumeFailed` enum value would replace this string
+/// match end-to-end; out of scope for this port.
+const String streamResumeFailedPrefix = 'Stream resume failed:';
 
 /// Streams AG-UI events using the Soliplex HTTP stack directly.
 ///
 /// Replaces [AgUiClient] usage in pure Dart packages. Routes SSE through
 /// [HttpTransport] so status code mapping, auth, observability, cancel
-/// wrapping, and platform clients apply automatically. No retry, no
-/// reconnection, no duplicate CancelToken.
+/// wrapping, and platform clients apply automatically.
+///
+/// Implements transparent resume via the SSE `Last-Event-ID` header:
+/// when the stream drops mid-run, the client reconnects and reports
+/// progress through an optional [ReconnectStatus] callback. On
+/// exhausted retries — or any retryable failure during a resume that
+/// the policy can no longer cover — `runAgent` throws [NetworkException]
+/// whose message starts with [streamResumeFailedPrefix].
 class AgUiStreamClient {
   /// Creates a client that streams AG-UI events via [httpTransport].
+  ///
+  /// [resumePolicy] configures the SSE reconnect behavior; pass
+  /// [ResumePolicy.noRetry] to opt out entirely. Per-call overrides are
+  /// accepted on [runAgent].
   AgUiStreamClient({
     required HttpTransport httpTransport,
     required UrlBuilder urlBuilder,
     void Function(String message)? onWarning,
+    ResumePolicy resumePolicy = const ResumePolicy(),
   })  : _httpTransport = httpTransport,
         _urlBuilder = urlBuilder,
-        _onWarning = onWarning;
+        _onWarning = onWarning,
+        _resumePolicy = resumePolicy;
 
   final HttpTransport _httpTransport;
   final UrlBuilder _urlBuilder;
   final void Function(String message)? _onWarning;
+  final ResumePolicy _resumePolicy;
+
+  static const _logName = 'soliplex_client.agui_stream';
 
   /// Streams AG-UI events for a run.
   ///
-  /// Posts [input] to [endpoint] and parses the SSE response into
-  /// typed [BaseEvent]s. The endpoint is relative to the base URL
-  /// (e.g. `'rooms/my-room/agui/thread-1/run-1'`).
+  /// Posts [input] to [endpoint] and parses the SSE response into typed
+  /// [BaseEvent]s. The endpoint is relative to the base URL (e.g.
+  /// `'rooms/my-room/agui/thread-1/run-1'`).
+  ///
+  /// Reconnect lifecycle is reported through [onReconnectStatus] (a
+  /// [Reconnecting] before each retry, [Reconnected] on the first
+  /// decoded event after a successful retry, [ReconnectFailed] when the
+  /// retry budget is exhausted). On terminal transport failure the
+  /// stream throws [NetworkException] whose message starts with
+  /// [streamResumeFailedPrefix].
   Stream<BaseEvent> runAgent(
     String endpoint,
     SimpleRunAgentInput input, {
     CancelToken? cancelToken,
+    ResumePolicy? resumePolicy,
+    void Function(ReconnectStatus)? onReconnectStatus,
   }) async* {
-    final response = await _httpTransport.requestStream(
-      'POST',
-      _urlBuilder.build(path: endpoint),
-      headers: {
-        'Content-Type': 'application/json',
-        'Accept': 'text/event-stream',
-      },
-      body: input.toJson(),
-      cancelToken: cancelToken,
-    );
-
-    final sseMessages = SseParser().parseBytes(response.body);
-    const decoder = EventDecoder();
+    final policy = resumePolicy ?? _resumePolicy;
+    final uri = _urlBuilder.build(path: endpoint);
+    final body = input.toJson();
+    String? lastEventId;
+    var attempt = 0;
     var skippedEventCount = 0;
 
-    await for (final message in sseMessages) {
-      if (message.data == null || message.data!.isEmpty) continue;
+    while (true) {
+      final isResumeRequest = lastEventId != null;
+      final StreamedHttpResponse response;
       try {
-        final jsonData = json.decode(message.data!);
-        if (jsonData is Map<String, dynamic>) {
-          yield decoder.decodeJson(jsonData);
-        } else if (jsonData is List) {
-          for (final item in jsonData) {
-            if (item is Map<String, dynamic>) {
-              try {
-                yield decoder.decodeJson(item);
-              } on DecodingError catch (e) {
-                skippedEventCount++;
-                developer.log(
-                  'Skipped undecodable AG-UI event in batch: $e',
-                  name: 'soliplex_client.agui_stream',
-                  level: 900,
-                );
-              }
-            } else {
-              skippedEventCount++;
-              developer.log(
-                'Skipped non-object item in AG-UI batch: '
-                '${item.runtimeType}',
-                name: 'soliplex_client.agui_stream',
-                level: 900,
-              );
-            }
-          }
+        response = await _attempt(uri, body, lastEventId, cancelToken);
+      } on CancelledException {
+        rethrow;
+      } on Object catch (e) {
+        if (!isResumeRequest) rethrow;
+        if (!_retryable(e) || !_canRetry(policy, attempt)) {
+          onReconnectStatus?.call(
+            ReconnectFailed(attempts: attempt, error: e.toString()),
+          );
+          _flushSkippedWarning(skippedEventCount);
+          throw NetworkException(
+            message: _resumeFailureMessage(e, skippedEventCount),
+            originalError: e,
+          );
         }
-      } on FormatException catch (e) {
-        skippedEventCount++;
-        developer.log(
-          'Skipped malformed JSON in SSE event: $e',
-          name: 'soliplex_client.agui_stream',
-          level: 900,
+        attempt += 1;
+        onReconnectStatus?.call(
+          Reconnecting(
+            attempt: attempt,
+            lastEventId: lastEventId,
+            error: e.toString(),
+          ),
         );
-      } on DecodingError catch (e) {
-        skippedEventCount++;
+        _logAttempt(attempt, lastEventId, e);
+        await raceBackoff(policy.backoffFor(attempt), cancelToken);
+        continue;
+      }
+
+      var sawTerminalEvent = false;
+      var announcedResume = !isResumeRequest;
+      Object? streamError;
+
+      try {
+        // Construct the parser inside the try so a synchronous throw
+        // from `parseBytes` is caught by the same handler as mid-stream
+        // errors.
+        final messages = SseParser().parseBytes(response.body);
+        await for (final message in messages) {
+          if (message.id != null && message.id!.isNotEmpty) {
+            lastEventId = message.id;
+          }
+          if (message.data == null || message.data!.isEmpty) continue;
+
+          final result = _decodeOne(message.data!);
+          skippedEventCount += result.skipped;
+          if (result.events.isEmpty) continue;
+
+          if (!announcedResume) {
+            _logSuccess(attempt, lastEventId);
+            onReconnectStatus?.call(Reconnected(attempt: attempt));
+            announcedResume = true;
+            attempt = 0;
+          }
+          for (final ev in result.events) {
+            if (ev is RunFinishedEvent || ev is RunErrorEvent) {
+              sawTerminalEvent = true;
+            }
+            yield ev;
+          }
+          if (sawTerminalEvent) break;
+        }
+      } on CancelledException {
+        rethrow;
+      } on Object catch (e) {
+        streamError = e;
         developer.log(
-          'Skipped undecodable AG-UI event: $e',
-          name: 'soliplex_client.agui_stream',
+          'SSE stream dropped after id=${lastEventId ?? "<none>"}: $e',
+          name: _logName,
           level: 900,
         );
       }
-    }
-    if (skippedEventCount > 0) {
-      _onWarning?.call(
-        'Skipped $skippedEventCount malformed event(s) during streaming',
+
+      if (sawTerminalEvent || streamError == null) {
+        _flushSkippedWarning(skippedEventCount);
+        return;
+      }
+
+      if (lastEventId == null) {
+        _flushSkippedWarning(skippedEventCount);
+        throw NetworkException(
+          message: _resumeFailureMessage(streamError, skippedEventCount),
+          originalError: streamError,
+        );
+      }
+
+      if (!_canRetry(policy, attempt)) {
+        onReconnectStatus?.call(
+          ReconnectFailed(attempts: attempt, error: streamError.toString()),
+        );
+        _flushSkippedWarning(skippedEventCount);
+        throw NetworkException(
+          message: _resumeFailureMessage(streamError, skippedEventCount),
+          originalError: streamError,
+        );
+      }
+
+      attempt += 1;
+      onReconnectStatus?.call(
+        Reconnecting(
+          attempt: attempt,
+          lastEventId: lastEventId,
+          error: streamError.toString(),
+        ),
       );
+      _logAttempt(attempt, lastEventId, streamError);
+      await raceBackoff(policy.backoffFor(attempt), cancelToken);
     }
   }
 
   /// Closes the underlying transport.
   void close() => _httpTransport.close();
+
+  bool _retryable(Object e) => switch (e) {
+        CancelledException() => false,
+        AuthException() || NotFoundException() => false,
+        ApiException(:final statusCode) =>
+          statusCode >= 500 && statusCode < 600,
+        NetworkException() => true,
+        _ => false,
+      };
+
+  bool _canRetry(ResumePolicy policy, int attemptsSoFar) =>
+      policy.enabled && attemptsSoFar < policy.maxAttempts;
+
+  Future<StreamedHttpResponse> _attempt(
+    Uri uri,
+    Object body,
+    String? lastEventId,
+    CancelToken? cancelToken,
+  ) {
+    return _httpTransport.requestStream(
+      'POST',
+      uri,
+      headers: {
+        'Content-Type': 'application/json',
+        'Accept': 'text/event-stream',
+        if (lastEventId != null) 'Last-Event-ID': lastEventId,
+      },
+      body: body,
+      cancelToken: cancelToken,
+    );
+  }
+
+  /// Decodes one SSE `data:` line into 0..N typed [BaseEvent]s. Returns
+  /// the decoded events and the skip count from this single line. The
+  /// caller accumulates skipped counts across the run.
+  ///
+  ///   - Single-event JSON object → `(events: [decoded], skipped: 0)`.
+  ///   - JSON array batch → `(events: [decoded...], skipped: N)`
+  ///     where N counts items that failed [EventDecoder.decodeJson].
+  ///   - Malformed JSON → `(events: [], skipped: 1)`.
+  ({List<BaseEvent> events, int skipped}) _decodeOne(String data) {
+    const decoder = EventDecoder();
+    final decoded = <BaseEvent>[];
+    var skipped = 0;
+    try {
+      final jsonData = json.decode(data);
+      if (jsonData is Map<String, dynamic>) {
+        decoded.add(decoder.decodeJson(jsonData));
+      } else if (jsonData is List) {
+        for (final item in jsonData) {
+          if (item is Map<String, dynamic>) {
+            try {
+              decoded.add(decoder.decodeJson(item));
+            } on DecodingError catch (e) {
+              skipped++;
+              developer.log(
+                'Skipped undecodable AG-UI event in batch: $e',
+                name: _logName,
+                level: 900,
+              );
+            }
+          } else {
+            skipped++;
+            developer.log(
+              'Skipped non-object item in AG-UI batch: ${item.runtimeType}',
+              name: _logName,
+              level: 900,
+            );
+          }
+        }
+      } else {
+        // JSON scalar (string/number/bool/null) at the top level —
+        // not a valid AG-UI payload. Count it so Decision 6's
+        // diagnostic surfaces this kind of server-side anomaly.
+        skipped++;
+        developer.log(
+          'Skipped non-object JSON scalar in SSE event: '
+          '${jsonData.runtimeType}',
+          name: _logName,
+          level: 900,
+        );
+      }
+    } on FormatException catch (e) {
+      skipped++;
+      developer.log(
+        'Skipped malformed JSON in SSE event: $e',
+        name: _logName,
+        level: 900,
+      );
+    } on DecodingError catch (e) {
+      skipped++;
+      developer.log(
+        'Skipped undecodable AG-UI event: $e',
+        name: _logName,
+        level: 900,
+      );
+    }
+    return (events: decoded, skipped: skipped);
+  }
+
+  /// Cancel-aware backoff: races a delay against the cancel token so a
+  /// cancel during a long backoff resolves in microseconds rather than
+  /// after the full delay. Throws [CancelledException] when the token
+  /// fires before the delay elapses.
+  ///
+  /// Exposed for direct unit testing of Decision 3 (cancel-aware
+  /// backoff). Not part of the public API.
+  @visibleForTesting
+  static Future<void> raceBackoff(Duration d, CancelToken? token) async {
+    if (token == null) {
+      await Future<void>.delayed(d);
+      return;
+    }
+    await Future.any<void>([
+      Future<void>.delayed(d),
+      token.whenCancelled,
+    ]);
+    token.throwIfCancelled();
+  }
+
+  /// Surfaces a non-zero skipped-event count via the warning callback.
+  /// Stateless — callers must invoke this exactly once per terminal
+  /// step (each `return`/`throw` path inside `runAgent`).
+  void _flushSkippedWarning(int count) {
+    if (count > 0) {
+      _onWarning?.call(
+        'Skipped $count malformed event(s) during streaming',
+      );
+    }
+  }
+
+  String _resumeFailureMessage(Object error, int skippedEventCount) {
+    final skippedSuffix = skippedEventCount > 0
+        ? ' (skipped $skippedEventCount malformed events)'
+        : '';
+    return '$streamResumeFailedPrefix $error$skippedSuffix';
+  }
+
+  void _logAttempt(int attempt, String? lastId, Object? err) {
+    developer.log(
+      'Resuming SSE with Last-Event-ID=$lastId (attempt $attempt)'
+      '${err != null ? ': $err' : ''}',
+      name: _logName,
+      level: 800,
+    );
+  }
+
+  void _logSuccess(int attempt, String? lastId) {
+    developer.log(
+      'Resume succeeded after $attempt attempt(s), last id=$lastId',
+      name: _logName,
+      level: 800,
+    );
+  }
 }

--- a/packages/soliplex_client/lib/src/http/agui_stream_client.dart
+++ b/packages/soliplex_client/lib/src/http/agui_stream_client.dart
@@ -13,15 +13,9 @@ import 'package:soliplex_client/src/http/resume_policy.dart';
 import 'package:soliplex_client/src/utils/cancel_token.dart';
 import 'package:soliplex_client/src/utils/url_builder.dart';
 
-/// Marker prefix used by `AgUiStreamClient` when wrapping a resume
-/// failure into [NetworkException]. `ThreadViewState._friendlyMessage`
-/// (in the Flutter app) matches this prefix to render user-friendly
-/// "Connection lost" copy.
-///
-/// Both sides of the contract import this constant so a typo cannot
-/// drift across the two callsites. A future structured
-/// `FailureReason.resumeFailed` enum value would replace this string
-/// match end-to-end; out of scope for this port.
+/// Marker prefix on [NetworkException.message] when [AgUiStreamClient]
+/// wraps a resume failure. Consumers match on this prefix to render
+/// user-friendly copy in place of the raw transport error.
 const String streamResumeFailedPrefix = 'Stream resume failed:';
 
 /// Streams AG-UI events using the Soliplex HTTP stack directly.
@@ -96,7 +90,7 @@ class AgUiStreamClient {
         if (!isResumeRequest) rethrow;
         if (!_retryable(e) || !_canRetry(policy, attempt)) {
           onReconnectStatus?.call(
-            ReconnectFailed(attempts: attempt, error: e.toString()),
+            ReconnectFailed(attempt: attempt, error: e),
           );
           _flushSkippedWarning(skippedEventCount);
           throw NetworkException(
@@ -176,7 +170,7 @@ class AgUiStreamClient {
 
       if (!_canRetry(policy, attempt)) {
         onReconnectStatus?.call(
-          ReconnectFailed(attempts: attempt, error: streamError.toString()),
+          ReconnectFailed(attempt: attempt, error: streamError),
         );
         _flushSkippedWarning(skippedEventCount);
         throw NetworkException(
@@ -198,7 +192,7 @@ class AgUiStreamClient {
     }
   }
 
-  /// Closes the underlying transport.
+  /// Closes the underlying transport. Subsequent [runAgent] calls fail.
   void close() => _httpTransport.close();
 
   bool _retryable(Object e) => switch (e) {
@@ -272,8 +266,8 @@ class AgUiStreamClient {
         }
       } else {
         // JSON scalar (string/number/bool/null) at the top level —
-        // not a valid AG-UI payload. Count it so Decision 6's
-        // diagnostic surfaces this kind of server-side anomaly.
+        // not a valid AG-UI payload. Counted so the skipped-event
+        // diagnostic surfaces server-side anomalies of this shape.
         skipped++;
         developer.log(
           'Skipped non-object JSON scalar in SSE event: '
@@ -305,15 +299,8 @@ class AgUiStreamClient {
   /// after the full delay. Throws [CancelledException] when the token
   /// fires before the delay elapses.
   ///
-  /// The earlier implementation used
-  /// `Future.any([Future.delayed(d), token.whenCancelled])`, which left
-  /// the loser's `Timer` running until expiry — so cancelling a
-  /// long-cap (8s) backoff repeatedly accumulated stranded Timers in
-  /// the event loop. This version owns the `Timer` so cancel can
-  /// `.cancel()` it.
-  ///
-  /// Exposed for direct unit testing of Decision 3 (cancel-aware
-  /// backoff). Not part of the public API.
+  /// Owns its underlying [Timer] so cancel can stop it directly,
+  /// avoiding stranded timers that would otherwise expire on their own.
   @visibleForTesting
   static Future<void> raceBackoff(Duration d, CancelToken? token) async {
     if (token == null) {
@@ -339,15 +326,17 @@ class AgUiStreamClient {
     token.throwIfCancelled();
   }
 
-  /// Surfaces a non-zero skipped-event count via the warning callback.
-  /// Stateless — callers must invoke this exactly once per terminal
-  /// step (each `return`/`throw` path inside `runAgent`).
+  /// Surfaces a non-zero skipped-event count. Always emits a
+  /// `developer.log` summary (matches per-event log channel) and
+  /// also forwards to [_onWarning] when the host opted in to
+  /// structured handling. Stateless — callers must invoke this
+  /// exactly once per terminal step (each `return`/`throw` path
+  /// inside `runAgent`).
   void _flushSkippedWarning(int count) {
-    if (count > 0) {
-      _onWarning?.call(
-        'Skipped $count malformed event(s) during streaming',
-      );
-    }
+    if (count == 0) return;
+    final message = 'Skipped $count malformed event(s) during streaming';
+    developer.log(message, name: _logName, level: 900);
+    _onWarning?.call(message);
   }
 
   String _resumeFailureMessage(Object error, int skippedEventCount) {

--- a/packages/soliplex_client/lib/src/http/agui_stream_client.dart
+++ b/packages/soliplex_client/lib/src/http/agui_stream_client.dart
@@ -305,6 +305,13 @@ class AgUiStreamClient {
   /// after the full delay. Throws [CancelledException] when the token
   /// fires before the delay elapses.
   ///
+  /// The earlier implementation used
+  /// `Future.any([Future.delayed(d), token.whenCancelled])`, which left
+  /// the loser's `Timer` running until expiry — so cancelling a
+  /// long-cap (8s) backoff repeatedly accumulated stranded Timers in
+  /// the event loop. This version owns the `Timer` so cancel can
+  /// `.cancel()` it.
+  ///
   /// Exposed for direct unit testing of Decision 3 (cancel-aware
   /// backoff). Not part of the public API.
   @visibleForTesting
@@ -313,10 +320,22 @@ class AgUiStreamClient {
       await Future<void>.delayed(d);
       return;
     }
-    await Future.any<void>([
-      Future<void>.delayed(d),
-      token.whenCancelled,
-    ]);
+    final completer = Completer<void>();
+    final timer = Timer(d, () {
+      if (!completer.isCompleted) completer.complete();
+    });
+    unawaited(
+      token.whenCancelled.then((_) {
+        timer.cancel();
+        if (!completer.isCompleted) completer.complete();
+      }),
+    );
+    await completer.future;
+    // Idempotent: a no-op when the timer has already fired or been
+    // cancelled. Belt-and-suspenders against a future refactor that
+    // adds a path through `await completer.future` without firing
+    // either branch.
+    timer.cancel();
     token.throwIfCancelled();
   }
 

--- a/packages/soliplex_client/lib/src/http/agui_stream_client.dart
+++ b/packages/soliplex_client/lib/src/http/agui_stream_client.dart
@@ -103,7 +103,7 @@ class AgUiStreamClient {
           Reconnecting(
             attempt: attempt,
             lastEventId: lastEventId,
-            error: e.toString(),
+            error: e,
           ),
         );
         _logAttempt(attempt, lastEventId, e);
@@ -184,7 +184,7 @@ class AgUiStreamClient {
         Reconnecting(
           attempt: attempt,
           lastEventId: lastEventId,
-          error: streamError.toString(),
+          error: streamError,
         ),
       );
       _logAttempt(attempt, lastEventId, streamError);
@@ -232,8 +232,10 @@ class AgUiStreamClient {
   ///
   ///   - Single-event JSON object → `(events: [decoded], skipped: 0)`.
   ///   - JSON array batch → `(events: [decoded...], skipped: N)`
-  ///     where N counts items that failed [EventDecoder.decodeJson].
-  ///   - Malformed JSON → `(events: [], skipped: 1)`.
+  ///     where N counts items that fail to decode or are not JSON
+  ///     objects.
+  ///   - Malformed JSON or any top-level decode failure
+  ///     → `(events: [], skipped: 1)`.
   ({List<BaseEvent> events, int skipped}) _decodeOne(String data) {
     const decoder = EventDecoder();
     final decoded = <BaseEvent>[];
@@ -327,23 +329,24 @@ class AgUiStreamClient {
   }
 
   /// Surfaces a non-zero skipped-event count. Always emits a
-  /// `developer.log` summary (matches per-event log channel) and
-  /// also forwards to [_onWarning] when the host opted in to
-  /// structured handling. Stateless — callers must invoke this
-  /// exactly once per terminal step (each `return`/`throw` path
-  /// inside `runAgent`).
+  /// `developer.log` summary on the same `_logName` channel as the
+  /// per-event skip logs, and also forwards to [_onWarning] when the
+  /// host opted in to structured handling. Stateless — callers must
+  /// invoke this exactly once per terminal step (each `return`/`throw`
+  /// path inside `runAgent`).
   void _flushSkippedWarning(int count) {
     if (count == 0) return;
-    final message = 'Skipped $count malformed event(s) during streaming';
+    final noun = count == 1 ? 'event' : 'events';
+    final message = 'Skipped $count malformed $noun during streaming';
     developer.log(message, name: _logName, level: 900);
     _onWarning?.call(message);
   }
 
   String _resumeFailureMessage(Object error, int skippedEventCount) {
-    final skippedSuffix = skippedEventCount > 0
-        ? ' (skipped $skippedEventCount malformed events)'
-        : '';
-    return '$streamResumeFailedPrefix $error$skippedSuffix';
+    if (skippedEventCount == 0) return '$streamResumeFailedPrefix $error';
+    final noun = skippedEventCount == 1 ? 'event' : 'events';
+    return '$streamResumeFailedPrefix $error '
+        '(skipped $skippedEventCount malformed $noun)';
   }
 
   void _logAttempt(int attempt, String? lastId, Object? err) {

--- a/packages/soliplex_client/lib/src/http/http.dart
+++ b/packages/soliplex_client/lib/src/http/http.dart
@@ -10,6 +10,7 @@ export 'http_transport.dart';
 export 'multipart_encoder.dart';
 export 'observable_http_client.dart';
 export 'refreshing_http_client.dart';
+export 'resume_policy.dart';
 export 'soliplex_http_adapter.dart';
 export 'soliplex_http_client.dart';
 export 'token_refresher.dart';

--- a/packages/soliplex_client/lib/src/http/resume_policy.dart
+++ b/packages/soliplex_client/lib/src/http/resume_policy.dart
@@ -45,6 +45,11 @@ class ResumePolicy {
   bool get enabled => maxAttempts > 0;
 
   /// Backoff for a 1-based [attempt] index (first retry = 1).
+  ///
+  /// Result is bounded to `[0, maxBackoff]`. Jitter is applied after
+  /// the geometric ramp is clamped to `maxBackoff`, then the result is
+  /// re-clamped — so the documented [maxBackoff] is a strict ceiling
+  /// rather than a pre-jitter midpoint.
   Duration backoffFor(int attempt) {
     assert(attempt >= 1, 'attempt is 1-based');
     final raw =
@@ -52,7 +57,8 @@ class ResumePolicy {
     final capped = min(raw.toDouble(), maxBackoff.inMilliseconds.toDouble());
     final rnd = _random ?? Random();
     final jitterFactor = 1.0 + (rnd.nextDouble() * 2 - 1) * jitter;
-    final ms = (capped * jitterFactor).round().clamp(0, 1 << 30);
+    final ms =
+        (capped * jitterFactor).round().clamp(0, maxBackoff.inMilliseconds);
     return Duration(milliseconds: ms);
   }
 }

--- a/packages/soliplex_client/lib/src/http/resume_policy.dart
+++ b/packages/soliplex_client/lib/src/http/resume_policy.dart
@@ -72,8 +72,6 @@ class ResumePolicy {
 /// callback. The callback is the only channel for reconnect lifecycle —
 /// the `BaseEvent` stream is reserved for actual server events.
 sealed class ReconnectStatus {
-  /// Subclass-only constructor for the sealed [ReconnectStatus]
-  /// hierarchy. `const` so subclasses can be `const` themselves.
   const ReconnectStatus();
 }
 

--- a/packages/soliplex_client/lib/src/http/resume_policy.dart
+++ b/packages/soliplex_client/lib/src/http/resume_policy.dart
@@ -1,0 +1,110 @@
+import 'dart:math';
+
+/// Configuration for SSE stream resume behavior on `AgUiStreamClient`.
+///
+/// The client reconnects with a `Last-Event-ID` header when the SSE
+/// stream drops mid-run. [maxAttempts] bounds the retry budget; each
+/// attempt waits `initialBackoff * backoffMultiplier^(attempt-1)` capped
+/// at [maxBackoff], plus ±[jitter] random jitter.
+class ResumePolicy {
+  /// Creates a resume policy. Defaults: 5 attempts, 500ms → 8s exponential
+  /// backoff, ±20% jitter.
+  const ResumePolicy({
+    this.maxAttempts = 5,
+    this.initialBackoff = const Duration(milliseconds: 500),
+    this.maxBackoff = const Duration(seconds: 8),
+    this.backoffMultiplier = 2.0,
+    this.jitter = 0.2,
+    Random? random,
+  }) : _random = random;
+
+  /// One attempt, no retries — the pre-resume behavior. Useful for
+  /// tests and consumers that want to opt out of resume.
+  const ResumePolicy.noRetry() : this(maxAttempts: 0);
+
+  /// Maximum number of consecutive resume attempts after a drop before
+  /// giving up. `0` disables resume.
+  final int maxAttempts;
+
+  /// Delay before the first resume attempt after a drop.
+  final Duration initialBackoff;
+
+  /// Upper bound on per-attempt backoff duration.
+  final Duration maxBackoff;
+
+  /// Geometric growth factor applied per attempt.
+  final double backoffMultiplier;
+
+  /// Random jitter fraction applied to each backoff, in the range
+  /// `[-jitter, +jitter]`. `0.2` means ±20%.
+  final double jitter;
+
+  final Random? _random;
+
+  /// Whether resume is enabled (i.e. [maxAttempts] &gt; 0).
+  bool get enabled => maxAttempts > 0;
+
+  /// Backoff for a 1-based [attempt] index (first retry = 1).
+  Duration backoffFor(int attempt) {
+    assert(attempt >= 1, 'attempt is 1-based');
+    final raw =
+        initialBackoff.inMilliseconds * pow(backoffMultiplier, attempt - 1);
+    final capped = min(raw.toDouble(), maxBackoff.inMilliseconds.toDouble());
+    final rnd = _random ?? Random();
+    final jitterFactor = 1.0 + (rnd.nextDouble() * 2 - 1) * jitter;
+    final ms = (capped * jitterFactor).round().clamp(0, 1 << 30);
+    return Duration(milliseconds: ms);
+  }
+}
+
+/// Typed lifecycle of an SSE reconnect attempt.
+///
+/// Delivered via `AgUiStreamClient.runAgent`'s `onReconnectStatus`
+/// callback. The callback is the only channel for reconnect lifecycle —
+/// the `BaseEvent` stream is reserved for actual server events.
+sealed class ReconnectStatus {
+  /// Const subclass constructor.
+  const ReconnectStatus();
+}
+
+/// A resume attempt is about to begin.
+class Reconnecting extends ReconnectStatus {
+  /// Creates a [Reconnecting] status.
+  const Reconnecting({
+    required this.attempt,
+    this.lastEventId,
+    this.error,
+  });
+
+  /// 1-based attempt index (first retry = 1).
+  final int attempt;
+
+  /// The `Last-Event-ID` the client is about to reconnect with.
+  final String? lastEventId;
+
+  /// Error message that triggered the drop, for display.
+  final String? error;
+}
+
+/// Resume succeeded — the stream is live again.
+class Reconnected extends ReconnectStatus {
+  /// Creates a [Reconnected] status.
+  const Reconnected({required this.attempt});
+
+  /// Attempt number that succeeded (1-based).
+  final int attempt;
+}
+
+/// Resume budget exhausted. The run fails terminally; the client throws
+/// `NetworkException` (with `streamResumeFailedPrefix`) immediately
+/// after delivering this status.
+class ReconnectFailed extends ReconnectStatus {
+  /// Creates a [ReconnectFailed] status.
+  const ReconnectFailed({required this.attempts, this.error});
+
+  /// Total number of attempts performed before giving up.
+  final int attempts;
+
+  /// Error message from the last attempt, for display.
+  final String? error;
+}

--- a/packages/soliplex_client/lib/src/http/resume_policy.dart
+++ b/packages/soliplex_client/lib/src/http/resume_policy.dart
@@ -16,10 +16,13 @@ class ResumePolicy {
     this.backoffMultiplier = 2.0,
     this.jitter = 0.2,
     Random? random,
-  }) : _random = random;
+  })  : _random = random,
+        assert(maxAttempts >= 0, 'maxAttempts must be non-negative'),
+        assert(backoffMultiplier >= 1.0, 'backoffMultiplier must be >= 1.0'),
+        assert(jitter >= 0 && jitter <= 1, 'jitter must be in [0, 1]');
 
-  /// One attempt, no retries — the pre-resume behavior. Useful for
-  /// tests and consumers that want to opt out of resume.
+  /// One attempt, no retries. Useful for tests and consumers that
+  /// want to opt out of resume.
   const ResumePolicy.noRetry() : this(maxAttempts: 0);
 
   /// Maximum number of consecutive resume attempts after a drop before
@@ -69,18 +72,19 @@ class ResumePolicy {
 /// callback. The callback is the only channel for reconnect lifecycle —
 /// the `BaseEvent` stream is reserved for actual server events.
 sealed class ReconnectStatus {
-  /// Const subclass constructor.
+  /// Subclass-only constructor for the sealed [ReconnectStatus]
+  /// hierarchy. `const` so subclasses can be `const` themselves.
   const ReconnectStatus();
 }
 
 /// A resume attempt is about to begin.
 class Reconnecting extends ReconnectStatus {
-  /// Creates a [Reconnecting] status.
+  /// Marks a resume attempt about to start at [attempt].
   const Reconnecting({
     required this.attempt,
     this.lastEventId,
     this.error,
-  });
+  }) : assert(attempt >= 1, 'attempt is 1-based');
 
   /// 1-based attempt index (first retry = 1).
   final int attempt;
@@ -88,14 +92,15 @@ class Reconnecting extends ReconnectStatus {
   /// The `Last-Event-ID` the client is about to reconnect with.
   final String? lastEventId;
 
-  /// Error message that triggered the drop, for display.
-  final String? error;
+  /// Error that triggered the drop. Consumers stringify on demand.
+  final Object? error;
 }
 
 /// Resume succeeded — the stream is live again.
 class Reconnected extends ReconnectStatus {
-  /// Creates a [Reconnected] status.
-  const Reconnected({required this.attempt});
+  /// Marks the first successful event after a resume on [attempt].
+  const Reconnected({required this.attempt})
+      : assert(attempt >= 1, 'attempt is 1-based');
 
   /// Attempt number that succeeded (1-based).
   final int attempt;
@@ -105,12 +110,13 @@ class Reconnected extends ReconnectStatus {
 /// `NetworkException` (with `streamResumeFailedPrefix`) immediately
 /// after delivering this status.
 class ReconnectFailed extends ReconnectStatus {
-  /// Creates a [ReconnectFailed] status.
-  const ReconnectFailed({required this.attempts, this.error});
+  /// Marks the resume budget as exhausted after [attempt] tries.
+  const ReconnectFailed({required this.attempt, this.error})
+      : assert(attempt >= 1, 'attempt is 1-based');
 
-  /// Total number of attempts performed before giving up.
-  final int attempts;
+  /// Total number of attempts performed before giving up (1-based).
+  final int attempt;
 
-  /// Error message from the last attempt, for display.
-  final String? error;
+  /// Error from the last attempt. Consumers stringify on demand.
+  final Object? error;
 }

--- a/packages/soliplex_client/test/http/_constant_random.dart
+++ b/packages/soliplex_client/test/http/_constant_random.dart
@@ -1,0 +1,18 @@
+import 'dart:math';
+
+/// Deterministic [Random] that always returns [value] from [nextDouble].
+/// Used to drive `ResumePolicy.backoffFor` to a known jitter point in
+/// tests. Other [Random] methods aren't called by the production code
+/// under test, so they're unimplemented.
+class ConstantRandom implements Random {
+  ConstantRandom(this.value);
+
+  final double value;
+
+  @override
+  double nextDouble() => value;
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) =>
+      throw UnimplementedError('ConstantRandom.${invocation.memberName}');
+}

--- a/packages/soliplex_client/test/http/agui_stream_client_test.dart
+++ b/packages/soliplex_client/test/http/agui_stream_client_test.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 import 'dart:convert';
+import 'dart:math' show Random;
 
 import 'package:ag_ui/ag_ui.dart' hide CancelToken;
 import 'package:fake_async/fake_async.dart';
@@ -72,6 +73,22 @@ const _fastPolicy = ResumePolicy(
   maxBackoff: Duration(milliseconds: 2),
   jitter: 0,
 );
+
+/// Deterministic [Random] that always returns [value] from
+/// [nextDouble]. Used to drive `ResumePolicy.backoffFor` to a known
+/// jitter point in tests. Other [Random] methods aren't called by
+/// the production code under test, so they're unimplemented.
+class _ConstantRandom implements Random {
+  _ConstantRandom(this.value);
+  final double value;
+
+  @override
+  double nextDouble() => value;
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) =>
+      throw UnimplementedError('_ConstantRandom.${invocation.memberName}');
+}
 
 void main() {
   late MockHttpTransport mockTransport;
@@ -1059,6 +1076,32 @@ void main() {
           async.elapse(const Duration(milliseconds: 1001));
           expect(completed, isTrue);
         });
+      });
+
+      test('backoff respects maxBackoff under worst-case +jitter', () {
+        // The original `backoffFor` clamped to `maxBackoff` before
+        // applying ±jitter — so the worst-case +jitter on the cap
+        // exceeded the documented ceiling. `backoffFor` is pure math
+        // (returns a `Duration` without sleeping), so values are kept
+        // small for readability — the contract is "post-jitter result
+        // must not exceed maxBackoff" regardless of magnitude.
+        final policy = ResumePolicy(
+          initialBackoff: const Duration(milliseconds: 10),
+          maxBackoff: const Duration(milliseconds: 100),
+          jitter: 0.5,
+          random: _ConstantRandom(0.999),
+        );
+        // attempt 5: raw = 10 * 2^4 = 160 ms → cap to 100 ms.
+        // jitterFactor ≈ 1.499 → 150 ms pre-fix; clamped to 100 post-fix.
+        expect(
+          policy.backoffFor(5),
+          const Duration(milliseconds: 100),
+        );
+        // Higher attempts: ramp keeps growing; cap holds.
+        expect(
+          policy.backoffFor(10),
+          const Duration(milliseconds: 100),
+        );
       });
 
       test('cancel cancels the underlying delay Timer', () {

--- a/packages/soliplex_client/test/http/agui_stream_client_test.dart
+++ b/packages/soliplex_client/test/http/agui_stream_client_test.dart
@@ -1,11 +1,14 @@
+import 'dart:async';
 import 'dart:convert';
 
 import 'package:ag_ui/ag_ui.dart' hide CancelToken;
+import 'package:fake_async/fake_async.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:soliplex_client/src/errors/exceptions.dart';
 import 'package:soliplex_client/src/http/agui_stream_client.dart';
 import 'package:soliplex_client/src/http/http_response.dart';
 import 'package:soliplex_client/src/http/http_transport.dart';
+import 'package:soliplex_client/src/http/resume_policy.dart';
 import 'package:soliplex_client/src/utils/cancel_token.dart';
 import 'package:soliplex_client/src/utils/url_builder.dart';
 import 'package:test/test.dart';
@@ -24,6 +27,51 @@ Stream<List<int>> sseByteStream(List<Map<String, dynamic>> events) {
   }
   return Stream.value(utf8.encode(buffer.toString()));
 }
+
+/// Encodes (id, event) pairs into a byte stream with explicit `id:` fields.
+Stream<List<int>> sseByteStreamWithIds(
+  List<(String, Map<String, dynamic>)> events,
+) {
+  final buffer = StringBuffer();
+  for (final (id, event) in events) {
+    buffer
+      ..writeln('id: $id')
+      ..writeln('data: ${json.encode(event)}')
+      ..writeln();
+  }
+  return Stream.value(utf8.encode(buffer.toString()));
+}
+
+/// Emits bytes for [events] with ids, then errors with [error], to
+/// simulate a mid-stream connection drop.
+Stream<List<int>> sseByteStreamThenError(
+  List<(String, Map<String, dynamic>)> events,
+  Object error,
+) {
+  final controller = StreamController<List<int>>();
+  Future<void>(() async {
+    final buffer = StringBuffer();
+    for (final (id, event) in events) {
+      buffer
+        ..writeln('id: $id')
+        ..writeln('data: ${json.encode(event)}')
+        ..writeln();
+    }
+    controller.add(utf8.encode(buffer.toString()));
+    // Yield so the parser can process before we inject the error.
+    await Future<void>.delayed(Duration.zero);
+    controller.addError(error);
+    await controller.close();
+  });
+  return controller.stream;
+}
+
+/// Fast policy for unit tests — minimal backoff, no jitter.
+const _fastPolicy = ResumePolicy(
+  initialBackoff: Duration(milliseconds: 1),
+  maxBackoff: Duration(milliseconds: 2),
+  jitter: 0,
+);
 
 void main() {
   late MockHttpTransport mockTransport;
@@ -55,98 +103,6 @@ void main() {
     const input = SimpleRunAgentInput();
 
     group('runAgent', () {
-      test('passes CancelToken to requestStream', () async {
-        final token = CancelToken();
-
-        when(
-          () => mockTransport.requestStream(
-            any(),
-            any(),
-            headers: any(named: 'headers'),
-            body: any(named: 'body'),
-            cancelToken: any(named: 'cancelToken'),
-          ),
-        ).thenAnswer(
-          (_) async =>
-              StreamedHttpResponse(statusCode: 200, body: sseByteStream([])),
-        );
-
-        await client.runAgent(endpoint, input, cancelToken: token).toList();
-
-        final captured = verify(
-          () => mockTransport.requestStream(
-            any(),
-            any(),
-            headers: any(named: 'headers'),
-            body: any(named: 'body'),
-            cancelToken: captureAny(named: 'cancelToken'),
-          ),
-        ).captured;
-
-        expect(captured.single, same(token));
-      });
-
-      test('builds correct URI from endpoint', () async {
-        when(
-          () => mockTransport.requestStream(
-            any(),
-            any(),
-            headers: any(named: 'headers'),
-            body: any(named: 'body'),
-            cancelToken: any(named: 'cancelToken'),
-          ),
-        ).thenAnswer(
-          (_) async =>
-              StreamedHttpResponse(statusCode: 200, body: sseByteStream([])),
-        );
-
-        await client.runAgent(endpoint, input).toList();
-
-        final captured = verify(
-          () => mockTransport.requestStream(
-            'POST',
-            captureAny(),
-            headers: any(named: 'headers'),
-            body: any(named: 'body'),
-            cancelToken: any(named: 'cancelToken'),
-          ),
-        ).captured;
-
-        final uri = captured.single as Uri;
-        expect(uri.toString(), '$baseUrl/$endpoint');
-      });
-
-      test('sends correct headers', () async {
-        when(
-          () => mockTransport.requestStream(
-            any(),
-            any(),
-            headers: any(named: 'headers'),
-            body: any(named: 'body'),
-            cancelToken: any(named: 'cancelToken'),
-          ),
-        ).thenAnswer(
-          (_) async =>
-              StreamedHttpResponse(statusCode: 200, body: sseByteStream([])),
-        );
-
-        await client.runAgent(endpoint, input).toList();
-
-        final captured = verify(
-          () => mockTransport.requestStream(
-            any(),
-            any(),
-            headers: captureAny(named: 'headers'),
-            body: any(named: 'body'),
-            cancelToken: any(named: 'cancelToken'),
-          ),
-        ).captured;
-
-        final headers = captured.single as Map<String, String>;
-        expect(headers['Content-Type'], 'application/json');
-        expect(headers['Accept'], 'text/event-stream');
-      });
-
       test('parses single SSE events into BaseEvents', () async {
         final events = [
           {'type': 'RUN_STARTED', 'threadId': 'thread-1', 'runId': 'run-1'},
@@ -329,39 +285,6 @@ void main() {
         expect(result[1], isA<RunFinishedEvent>());
       });
 
-      test('skips bad event in batch without dropping remaining', () async {
-        final batch = [
-          {'type': 'RUN_STARTED', 'threadId': 't-1', 'runId': 'r-1'},
-          {'type': 'TOTALLY_UNKNOWN_EVENT', 'foo': 'bar'},
-          {'type': 'RUN_FINISHED', 'threadId': 't-1', 'runId': 'r-1'},
-        ];
-
-        final sseBody = StringBuffer()
-          ..writeln('data: ${json.encode(batch)}')
-          ..writeln();
-
-        when(
-          () => mockTransport.requestStream(
-            any(),
-            any(),
-            headers: any(named: 'headers'),
-            body: any(named: 'body'),
-            cancelToken: any(named: 'cancelToken'),
-          ),
-        ).thenAnswer(
-          (_) async => StreamedHttpResponse(
-            statusCode: 200,
-            body: Stream.value(utf8.encode(sseBody.toString())),
-          ),
-        );
-
-        final result = await client.runAgent(endpoint, input).toList();
-
-        expect(result, hasLength(2));
-        expect(result[0], isA<RunStartedEvent>());
-        expect(result[1], isA<RunFinishedEvent>());
-      });
-
       test('skips malformed JSON and continues streaming', () async {
         final sseBody = StringBuffer()
           ..writeln('data: not valid json at all')
@@ -434,6 +357,54 @@ void main() {
         expect(warnings[0], contains('1 malformed event'));
       });
 
+      test(
+        'mixed batch with two undecodable items reports skipped=2',
+        () async {
+          // Decision 2: _decodeOne returns ({events, skipped}); the
+          // caller-side accumulator must count both undecodable items
+          // and surface them as a single onWarning at clean termination.
+          final warnings = <String>[];
+          final clientWithWarning = AgUiStreamClient(
+            httpTransport: mockTransport,
+            urlBuilder: UrlBuilder(baseUrl),
+            onWarning: warnings.add,
+          );
+          addTearDown(clientWithWarning.close);
+
+          final batch = [
+            {'type': 'RUN_STARTED', 'threadId': 't-1', 'runId': 'r-1'},
+            {'type': 'TOTALLY_UNKNOWN_EVENT', 'a': 1},
+            'not even an object',
+            {'type': 'RUN_FINISHED', 'threadId': 't-1', 'runId': 'r-1'},
+          ];
+          final sseBody = StringBuffer()
+            ..writeln('data: ${json.encode(batch)}')
+            ..writeln();
+
+          when(
+            () => mockTransport.requestStream(
+              any(),
+              any(),
+              headers: any(named: 'headers'),
+              body: any(named: 'body'),
+              cancelToken: any(named: 'cancelToken'),
+            ),
+          ).thenAnswer(
+            (_) async => StreamedHttpResponse(
+              statusCode: 200,
+              body: Stream.value(utf8.encode(sseBody.toString())),
+            ),
+          );
+
+          final result =
+              await clientWithWarning.runAgent(endpoint, input).toList();
+
+          expect(result, hasLength(2));
+          expect(warnings, hasLength(1));
+          expect(warnings.single, contains('Skipped 2 malformed event'));
+        },
+      );
+
       test('propagates CancelledException from transport', () async {
         when(
           () => mockTransport.requestStream(
@@ -452,11 +423,642 @@ void main() {
       });
     });
 
-    group('close', () {
-      test('delegates to httpTransport.close()', () {
-        client.close();
+    group('resume', () {
+      test('resumes after mid-stream drop using Last-Event-ID', () async {
+        // Decision 1: reconnect lifecycle flows through the
+        // onReconnectStatus callback, NOT via synthetic CustomEvents
+        // on the BaseEvent stream.
+        final statuses = <ReconnectStatus>[];
+        final resumeClient = AgUiStreamClient(
+          httpTransport: mockTransport,
+          urlBuilder: UrlBuilder(baseUrl),
+          resumePolicy: _fastPolicy,
+        );
+        addTearDown(resumeClient.close);
 
-        verify(() => mockTransport.close()).called(1);
+        // First call: 2 events with ids, then a connection drop.
+        when(
+          () => mockTransport.requestStream(
+            any(),
+            any(),
+            headers: any(named: 'headers'),
+            body: any(named: 'body'),
+            cancelToken: any(named: 'cancelToken'),
+          ),
+        ).thenAnswer(
+          (_) async => StreamedHttpResponse(
+            statusCode: 200,
+            body: sseByteStreamThenError(
+              [
+                (
+                  'run-1:0',
+                  {
+                    'type': 'RUN_STARTED',
+                    'threadId': 't-1',
+                    'runId': 'run-1',
+                  },
+                ),
+                (
+                  'run-1:1',
+                  {
+                    'type': 'TEXT_MESSAGE_START',
+                    'messageId': 'm-1',
+                    'role': 'assistant',
+                  },
+                ),
+              ],
+              const NetworkException(message: 'connection reset'),
+            ),
+          ),
+        );
+
+        final events = <BaseEvent>[];
+        final run = resumeClient.runAgent(
+          endpoint,
+          input,
+          onReconnectStatus: statuses.add,
+        );
+        final iterator = StreamIterator<BaseEvent>(run);
+
+        // Drain the first two real events. Then re-stub the transport
+        // for the resume request before consuming further.
+        await iterator.moveNext();
+        events.add(iterator.current);
+        await iterator.moveNext();
+        events.add(iterator.current);
+
+        // Swap the stub to return events 2..3 + RUN_FINISHED.
+        when(
+          () => mockTransport.requestStream(
+            any(),
+            any(),
+            headers: any(named: 'headers'),
+            body: any(named: 'body'),
+            cancelToken: any(named: 'cancelToken'),
+          ),
+        ).thenAnswer(
+          (_) async => StreamedHttpResponse(
+            statusCode: 200,
+            body: sseByteStreamWithIds([
+              (
+                'run-1:2',
+                {
+                  'type': 'TEXT_MESSAGE_CONTENT',
+                  'messageId': 'm-1',
+                  'delta': 'hi',
+                },
+              ),
+              (
+                'run-1:3',
+                {'type': 'TEXT_MESSAGE_END', 'messageId': 'm-1'},
+              ),
+              (
+                'run-1:4',
+                {
+                  'type': 'RUN_FINISHED',
+                  'threadId': 't-1',
+                  'runId': 'run-1',
+                },
+              ),
+            ]),
+          ),
+        );
+
+        while (await iterator.moveNext()) {
+          events.add(iterator.current);
+        }
+
+        // Verify second call included Last-Event-ID.
+        final captured = verify(
+          () => mockTransport.requestStream(
+            any(),
+            any(),
+            headers: captureAny(named: 'headers'),
+            body: any(named: 'body'),
+            cancelToken: any(named: 'cancelToken'),
+          ),
+        ).captured;
+        expect(captured, hasLength(2));
+        final firstHeaders = captured[0] as Map<String, String>;
+        final secondHeaders = captured[1] as Map<String, String>;
+        expect(firstHeaders.containsKey('Last-Event-ID'), isFalse);
+        expect(secondHeaders['Last-Event-ID'], 'run-1:1');
+
+        // Reconnect lifecycle on the callback, in order.
+        expect(statuses, hasLength(2));
+        expect(statuses[0], isA<Reconnecting>());
+        expect((statuses[0] as Reconnecting).attempt, 1);
+        expect((statuses[0] as Reconnecting).lastEventId, 'run-1:1');
+        expect(statuses[1], isA<Reconnected>());
+        expect((statuses[1] as Reconnected).attempt, 1);
+
+        // No CustomEvents leaked into the BaseEvent stream.
+        expect(events.whereType<CustomEvent>(), isEmpty);
+
+        // Run events delivered end-to-end.
+        expect(events.whereType<RunStartedEvent>(), hasLength(1));
+        expect(events.whereType<TextMessageContentEvent>(), hasLength(1));
+        expect(events.whereType<RunFinishedEvent>(), hasLength(1));
+      });
+
+      test(
+        'multi-resume: cursor preserved across two consecutive drops',
+        () async {
+          // Plan A4: drops twice consecutively → Reconnecting × 2,
+          // Reconnected × 1. Resume #1 fails at the transport layer
+          // (no body events yielded → no Reconnected fires); resume #2
+          // succeeds and fires Reconnected once.
+          final statuses = <ReconnectStatus>[];
+          final resumeClient = AgUiStreamClient(
+            httpTransport: mockTransport,
+            urlBuilder: UrlBuilder(baseUrl),
+            resumePolicy: _fastPolicy,
+          );
+          addTearDown(resumeClient.close);
+
+          var callCount = 0;
+          when(
+            () => mockTransport.requestStream(
+              any(),
+              any(),
+              headers: any(named: 'headers'),
+              body: any(named: 'body'),
+              cancelToken: any(named: 'cancelToken'),
+            ),
+          ).thenAnswer((_) async {
+            callCount++;
+            if (callCount == 1) {
+              // Initial: yield :0 with id, then drop.
+              return StreamedHttpResponse(
+                statusCode: 200,
+                body: sseByteStreamThenError(
+                  [
+                    (
+                      'run-1:0',
+                      {
+                        'type': 'RUN_STARTED',
+                        'threadId': 't-1',
+                        'runId': 'run-1',
+                      },
+                    ),
+                  ],
+                  const NetworkException(message: 'drop 1'),
+                ),
+              );
+            }
+            if (callCount == 2) {
+              // Resume #1: transport rejects connection — no body
+              // events ever flow, so no Reconnected fires.
+              throw const NetworkException(message: 'drop 2');
+            }
+            // Resume #2: yield finish.
+            return StreamedHttpResponse(
+              statusCode: 200,
+              body: sseByteStreamWithIds([
+                (
+                  'run-1:1',
+                  {
+                    'type': 'RUN_FINISHED',
+                    'threadId': 't-1',
+                    'runId': 'run-1',
+                  },
+                ),
+              ]),
+            );
+          });
+
+          final events = await resumeClient
+              .runAgent(
+                endpoint,
+                input,
+                onReconnectStatus: statuses.add,
+              )
+              .toList();
+
+          expect(callCount, 3);
+
+          final captured = verify(
+            () => mockTransport.requestStream(
+              any(),
+              any(),
+              headers: captureAny(named: 'headers'),
+              body: any(named: 'body'),
+              cancelToken: any(named: 'cancelToken'),
+            ),
+          ).captured;
+          expect(captured, hasLength(3));
+          final h1 = captured[0] as Map<String, String>;
+          final h2 = captured[1] as Map<String, String>;
+          final h3 = captured[2] as Map<String, String>;
+          expect(h1.containsKey('Last-Event-ID'), isFalse);
+          // Both resumes carry the cursor from the only event yielded
+          // so far. Resume #1 didn't yield, so the cursor stays at :0.
+          expect(h2['Last-Event-ID'], 'run-1:0');
+          expect(h3['Last-Event-ID'], 'run-1:0');
+
+          // Reconnecting × 2, Reconnected × 1.
+          expect(statuses.whereType<Reconnecting>(), hasLength(2));
+          expect(statuses.whereType<Reconnected>(), hasLength(1));
+          expect(statuses.whereType<ReconnectFailed>(), isEmpty);
+          expect(statuses.first, isA<Reconnecting>());
+          expect((statuses[0] as Reconnecting).attempt, 1);
+          expect((statuses[1] as Reconnecting).attempt, 2);
+          expect(statuses.last, isA<Reconnected>());
+          expect((statuses.last as Reconnected).attempt, 2);
+
+          expect(events.whereType<RunFinishedEvent>(), hasLength(1));
+        },
+      );
+
+      test(
+        'retry-budget exhausted: throws NetworkException with marker prefix',
+        () async {
+          // Decision 4: streamResumeFailedPrefix is the exact prefix of
+          // the thrown NetworkException's message on retry exhaustion.
+          final statuses = <ReconnectStatus>[];
+          final resumeClient = AgUiStreamClient(
+            httpTransport: mockTransport,
+            urlBuilder: UrlBuilder(baseUrl),
+            resumePolicy: const ResumePolicy(
+              maxAttempts: 2,
+              initialBackoff: Duration(milliseconds: 1),
+              maxBackoff: Duration(milliseconds: 1),
+              jitter: 0,
+            ),
+          );
+          addTearDown(resumeClient.close);
+
+          var callCount = 0;
+          when(
+            () => mockTransport.requestStream(
+              any(),
+              any(),
+              headers: any(named: 'headers'),
+              body: any(named: 'body'),
+              cancelToken: any(named: 'cancelToken'),
+            ),
+          ).thenAnswer((_) async {
+            callCount++;
+            if (callCount == 1) {
+              return StreamedHttpResponse(
+                statusCode: 200,
+                body: sseByteStreamThenError(
+                  [
+                    (
+                      'run-2:0',
+                      {
+                        'type': 'RUN_STARTED',
+                        'threadId': 't-1',
+                        'runId': 'run-2',
+                      },
+                    ),
+                  ],
+                  const NetworkException(message: 'drop 1'),
+                ),
+              );
+            }
+            throw NetworkException(message: 'drop $callCount');
+          });
+
+          await expectLater(
+            resumeClient
+                .runAgent(
+                  endpoint,
+                  input,
+                  onReconnectStatus: statuses.add,
+                )
+                .toList(),
+            throwsA(
+              isA<NetworkException>().having(
+                (e) => e.message,
+                'message',
+                startsWith(streamResumeFailedPrefix),
+              ),
+            ),
+          );
+
+          // Reconnecting × 2, then ReconnectFailed × 1.
+          expect(statuses.whereType<Reconnecting>(), hasLength(2));
+          expect(statuses.whereType<ReconnectFailed>(), hasLength(1));
+          expect(statuses.last, isA<ReconnectFailed>());
+          expect((statuses.last as ReconnectFailed).attempts, 2);
+          expect(callCount, 3); // initial + 2 retries
+        },
+      );
+
+      test(
+        'retry exhaustion still flushes skipped-event warning and embeds '
+        'count in NetworkException message',
+        () async {
+          // Decision 6: skipped-event diagnostics survive terminal
+          // failure. Both _onWarning AND the thrown message carry the
+          // count.
+          final warnings = <String>[];
+          final resumeClient = AgUiStreamClient(
+            httpTransport: mockTransport,
+            urlBuilder: UrlBuilder(baseUrl),
+            onWarning: warnings.add,
+            resumePolicy: const ResumePolicy(
+              maxAttempts: 1,
+              initialBackoff: Duration(milliseconds: 1),
+              maxBackoff: Duration(milliseconds: 1),
+              jitter: 0,
+            ),
+          );
+          addTearDown(resumeClient.close);
+
+          // Initial: yield a batch with 2 undecodable items + one good
+          // event with id, then drop.
+          final batch = [
+            {'type': 'RUN_STARTED', 'threadId': 't-1', 'runId': 'run-3'},
+            {'type': 'TOTALLY_UNKNOWN_EVENT', 'a': 1},
+            'plain string in batch',
+          ];
+          final initialBytes = StreamController<List<int>>();
+          unawaited(
+            Future<void>(() async {
+              final buf = StringBuffer()
+                ..writeln('id: run-3:0')
+                ..writeln('data: ${json.encode(batch)}')
+                ..writeln();
+              initialBytes.add(utf8.encode(buf.toString()));
+              await Future<void>.delayed(Duration.zero);
+              initialBytes.addError(const NetworkException(message: 'drop'));
+              await initialBytes.close();
+            }),
+          );
+
+          var callCount = 0;
+          when(
+            () => mockTransport.requestStream(
+              any(),
+              any(),
+              headers: any(named: 'headers'),
+              body: any(named: 'body'),
+              cancelToken: any(named: 'cancelToken'),
+            ),
+          ).thenAnswer((_) async {
+            callCount++;
+            if (callCount == 1) {
+              return StreamedHttpResponse(
+                statusCode: 200,
+                body: initialBytes.stream,
+              );
+            }
+            // Resume attempt fails terminally.
+            throw const NetworkException(message: 'drop again');
+          });
+
+          await expectLater(
+            resumeClient.runAgent(endpoint, input).toList(),
+            throwsA(
+              isA<NetworkException>().having(
+                (e) => e.message,
+                'message',
+                allOf(
+                  startsWith(streamResumeFailedPrefix),
+                  contains('skipped 2 malformed events'),
+                ),
+              ),
+            ),
+          );
+
+          // _onWarning still fires once with the count.
+          expect(warnings, hasLength(1));
+          expect(warnings.single, contains('Skipped 2 malformed event'));
+        },
+      );
+
+      test(
+        'no-cursor mid-flight drop: NetworkException carries marker prefix',
+        () async {
+          // Decision 5 (friendly-message routing): when the stream
+          // errors before any id has been seen, there is nothing to
+          // resume against, but we still wrap the failure so the UI
+          // renders friendly copy via _friendlyMessage.
+          final resumeClient = AgUiStreamClient(
+            httpTransport: mockTransport,
+            urlBuilder: UrlBuilder(baseUrl),
+            resumePolicy: _fastPolicy,
+          );
+          addTearDown(resumeClient.close);
+
+          // Yield one event WITHOUT an id, then drop.
+          final controller = StreamController<List<int>>();
+          unawaited(
+            Future<void>(() async {
+              final buf = StringBuffer()
+                ..writeln(
+                  'data: ${json.encode({
+                        'type': 'RUN_STARTED',
+                        'threadId': 't-1',
+                        'runId': 'r-1',
+                      })}',
+                )
+                ..writeln();
+              controller.add(utf8.encode(buf.toString()));
+              await Future<void>.delayed(Duration.zero);
+              controller.addError(const NetworkException(message: 'mid drop'));
+              await controller.close();
+            }),
+          );
+
+          when(
+            () => mockTransport.requestStream(
+              any(),
+              any(),
+              headers: any(named: 'headers'),
+              body: any(named: 'body'),
+              cancelToken: any(named: 'cancelToken'),
+            ),
+          ).thenAnswer(
+            (_) async => StreamedHttpResponse(
+              statusCode: 200,
+              body: controller.stream,
+            ),
+          );
+
+          await expectLater(
+            resumeClient.runAgent(endpoint, input).toList(),
+            throwsA(
+              isA<NetworkException>().having(
+                (e) => e.message,
+                'message',
+                startsWith(streamResumeFailedPrefix),
+              ),
+            ),
+          );
+          // No retry attempt was made — there was no cursor.
+          verify(
+            () => mockTransport.requestStream(
+              any(),
+              any(),
+              headers: any(named: 'headers'),
+              body: any(named: 'body'),
+              cancelToken: any(named: 'cancelToken'),
+            ),
+          ).called(1);
+        },
+      );
+
+      test(
+        'initial-connect failure rethrows raw NetworkException without marker',
+        () async {
+          // The marker prefix is reserved for resume-attempt failures.
+          // An initial POST that fails must surface the original
+          // exception unchanged so callers can react accordingly.
+          final resumeClient = AgUiStreamClient(
+            httpTransport: mockTransport,
+            urlBuilder: UrlBuilder(baseUrl),
+            resumePolicy: _fastPolicy,
+          );
+          addTearDown(resumeClient.close);
+
+          when(
+            () => mockTransport.requestStream(
+              any(),
+              any(),
+              headers: any(named: 'headers'),
+              body: any(named: 'body'),
+              cancelToken: any(named: 'cancelToken'),
+            ),
+          ).thenThrow(const NetworkException(message: 'connect refused'));
+
+          await expectLater(
+            resumeClient.runAgent(endpoint, input).toList(),
+            throwsA(
+              isA<NetworkException>().having(
+                (e) => e.message,
+                'message',
+                isNot(startsWith(streamResumeFailedPrefix)),
+              ),
+            ),
+          );
+          verify(
+            () => mockTransport.requestStream(
+              any(),
+              any(),
+              headers: any(named: 'headers'),
+              body: any(named: 'body'),
+              cancelToken: any(named: 'cancelToken'),
+            ),
+          ).called(1);
+        },
+      );
+
+      test(
+        'auth error during resume → ReconnectFailed + NetworkException',
+        () async {
+          final statuses = <ReconnectStatus>[];
+          final resumeClient = AgUiStreamClient(
+            httpTransport: mockTransport,
+            urlBuilder: UrlBuilder(baseUrl),
+            resumePolicy: _fastPolicy,
+          );
+          addTearDown(resumeClient.close);
+
+          var callCount = 0;
+          when(
+            () => mockTransport.requestStream(
+              any(),
+              any(),
+              headers: any(named: 'headers'),
+              body: any(named: 'body'),
+              cancelToken: any(named: 'cancelToken'),
+            ),
+          ).thenAnswer((_) async {
+            callCount++;
+            if (callCount == 1) {
+              return StreamedHttpResponse(
+                statusCode: 200,
+                body: sseByteStreamThenError(
+                  [
+                    (
+                      'run-3:0',
+                      {
+                        'type': 'RUN_STARTED',
+                        'threadId': 't-1',
+                        'runId': 'run-3',
+                      },
+                    ),
+                  ],
+                  const NetworkException(message: 'drop'),
+                ),
+              );
+            }
+            throw const AuthException(message: 'Unauthorized', statusCode: 401);
+          });
+
+          await expectLater(
+            resumeClient
+                .runAgent(
+                  endpoint,
+                  input,
+                  onReconnectStatus: statuses.add,
+                )
+                .toList(),
+            throwsA(
+              isA<NetworkException>().having(
+                (e) => e.message,
+                'message',
+                startsWith(streamResumeFailedPrefix),
+              ),
+            ),
+          );
+
+          expect(statuses.whereType<Reconnecting>(), hasLength(1));
+          expect(statuses.whereType<ReconnectFailed>(), hasLength(1));
+        },
+      );
+    });
+
+    group('raceBackoff (Decision 3 — cancel-aware backoff)', () {
+      test('returns normally when delay elapses without cancellation', () {
+        fakeAsync((async) {
+          final token = CancelToken();
+          var completed = false;
+          unawaited(
+            AgUiStreamClient.raceBackoff(const Duration(seconds: 1), token)
+                .then((_) => completed = true),
+          );
+
+          async.elapse(const Duration(milliseconds: 999));
+          expect(completed, isFalse);
+          async.elapse(const Duration(milliseconds: 2));
+          expect(completed, isTrue);
+        });
+      });
+
+      test('throws CancelledException promptly when cancelled mid-delay',
+          () async {
+        final token = CancelToken();
+        final stopwatch = Stopwatch()..start();
+        // Cancel after 10ms while a 5-second backoff is in progress.
+        Future<void>.delayed(
+          const Duration(milliseconds: 10),
+          () => token.cancel('user cancel'),
+        );
+
+        await expectLater(
+          AgUiStreamClient.raceBackoff(const Duration(seconds: 5), token),
+          throwsA(isA<CancelledException>()),
+        );
+        // The cancel-aware race must resolve well before the full
+        // backoff. Generous 1-second cap protects against CI jitter
+        // while still proving we didn't sit on the 5-second delay.
+        expect(stopwatch.elapsedMilliseconds, lessThan(1000));
+      });
+
+      test('without a token, just delays', () {
+        fakeAsync((async) {
+          var completed = false;
+          unawaited(
+            AgUiStreamClient.raceBackoff(const Duration(seconds: 1), null)
+                .then((_) => completed = true),
+          );
+          async.elapse(const Duration(milliseconds: 1001));
+          expect(completed, isTrue);
+        });
       });
     });
   });

--- a/packages/soliplex_client/test/http/agui_stream_client_test.dart
+++ b/packages/soliplex_client/test/http/agui_stream_client_test.dart
@@ -1,6 +1,5 @@
 import 'dart:async';
 import 'dart:convert';
-import 'dart:math' show Random;
 
 import 'package:ag_ui/ag_ui.dart' hide CancelToken;
 import 'package:fake_async/fake_async.dart';
@@ -13,6 +12,8 @@ import 'package:soliplex_client/src/http/resume_policy.dart';
 import 'package:soliplex_client/src/utils/cancel_token.dart';
 import 'package:soliplex_client/src/utils/url_builder.dart';
 import 'package:test/test.dart';
+
+import '_constant_random.dart';
 
 class MockHttpTransport extends Mock implements HttpTransport {}
 
@@ -73,22 +74,6 @@ const _fastPolicy = ResumePolicy(
   maxBackoff: Duration(milliseconds: 2),
   jitter: 0,
 );
-
-/// Deterministic [Random] that always returns [value] from
-/// [nextDouble]. Used to drive `ResumePolicy.backoffFor` to a known
-/// jitter point in tests. Other [Random] methods aren't called by
-/// the production code under test, so they're unimplemented.
-class _ConstantRandom implements Random {
-  _ConstantRandom(this.value);
-  final double value;
-
-  @override
-  double nextDouble() => value;
-
-  @override
-  dynamic noSuchMethod(Invocation invocation) =>
-      throw UnimplementedError('_ConstantRandom.${invocation.memberName}');
-}
 
 void main() {
   late MockHttpTransport mockTransport;
@@ -845,12 +830,13 @@ void main() {
       );
 
       test(
-        'no-cursor mid-flight drop: NetworkException carries marker prefix',
+        'no-cursor mid-flight drop rethrows raw error without marker',
         () async {
-          // When the stream errors before any id has been seen, there
-          // is nothing to resume against, but the failure is still
-          // wrapped with `streamResumeFailedPrefix` so consumers can
-          // render friendly copy.
+          // When the stream errors before any id has been seen, no
+          // resume is possible — so the failure must surface as the
+          // original exception, not be re-labelled as a resume failure
+          // (which would mislead consumers into showing reconnect copy
+          // for a connection that never reconnected).
           final resumeClient = AgUiStreamClient(
             httpTransport: mockTransport,
             urlBuilder: UrlBuilder(baseUrl),
@@ -899,7 +885,10 @@ void main() {
               isA<NetworkException>().having(
                 (e) => e.message,
                 'message',
-                startsWith(streamResumeFailedPrefix),
+                allOf(
+                  equals('mid drop'),
+                  isNot(startsWith(streamResumeFailedPrefix)),
+                ),
               ),
             ),
           );
@@ -1085,7 +1074,7 @@ void main() {
           initialBackoff: const Duration(milliseconds: 10),
           maxBackoff: const Duration(milliseconds: 100),
           jitter: 0.5,
-          random: _ConstantRandom(0.999),
+          random: ConstantRandom(0.999),
         );
         // attempt 5: raw = 10 * 2^4 = 160 ms → cap to 100 ms.
         // jitterFactor ≈ 1.499 applied to the 100 ms cap → re-clamped

--- a/packages/soliplex_client/test/http/agui_stream_client_test.dart
+++ b/packages/soliplex_client/test/http/agui_stream_client_test.dart
@@ -377,9 +377,8 @@ void main() {
       test(
         'mixed batch with two undecodable items reports skipped=2',
         () async {
-          // Decision 2: _decodeOne returns ({events, skipped}); the
-          // caller-side accumulator must count both undecodable items
-          // and surface them as a single onWarning at clean termination.
+          // The caller accumulates skips across batches and surfaces
+          // them through a single `onWarning` at clean termination.
           final warnings = <String>[];
           final clientWithWarning = AgUiStreamClient(
             httpTransport: mockTransport,
@@ -442,9 +441,9 @@ void main() {
 
     group('resume', () {
       test('resumes after mid-stream drop using Last-Event-ID', () async {
-        // Decision 1: reconnect lifecycle flows through the
-        // onReconnectStatus callback, NOT via synthetic CustomEvents
-        // on the BaseEvent stream.
+        // Reconnect lifecycle flows through the `onReconnectStatus`
+        // callback — never as synthetic events on the `BaseEvent`
+        // stream.
         final statuses = <ReconnectStatus>[];
         final resumeClient = AgUiStreamClient(
           httpTransport: mockTransport,
@@ -581,10 +580,10 @@ void main() {
       test(
         'multi-resume: cursor preserved across two consecutive drops',
         () async {
-          // Plan A4: drops twice consecutively → Reconnecting × 2,
-          // Reconnected × 1. Resume #1 fails at the transport layer
-          // (no body events yielded → no Reconnected fires); resume #2
-          // succeeds and fires Reconnected once.
+          // Two consecutive drops → Reconnecting × 2, Reconnected × 1.
+          // Resume #1 fails at the transport layer (no body events
+          // yielded → no Reconnected fires); resume #2 succeeds and
+          // fires Reconnected once.
           final statuses = <ReconnectStatus>[];
           final resumeClient = AgUiStreamClient(
             httpTransport: mockTransport,
@@ -690,8 +689,8 @@ void main() {
       test(
         'retry-budget exhausted: throws NetworkException with marker prefix',
         () async {
-          // Decision 4: streamResumeFailedPrefix is the exact prefix of
-          // the thrown NetworkException's message on retry exhaustion.
+          // `streamResumeFailedPrefix` must be the exact prefix of the
+          // thrown `NetworkException` message on retry exhaustion.
           final statuses = <ReconnectStatus>[];
           final resumeClient = AgUiStreamClient(
             httpTransport: mockTransport,
@@ -758,7 +757,7 @@ void main() {
           expect(statuses.whereType<Reconnecting>(), hasLength(2));
           expect(statuses.whereType<ReconnectFailed>(), hasLength(1));
           expect(statuses.last, isA<ReconnectFailed>());
-          expect((statuses.last as ReconnectFailed).attempts, 2);
+          expect((statuses.last as ReconnectFailed).attempt, 2);
           expect(callCount, 3); // initial + 2 retries
         },
       );
@@ -767,9 +766,8 @@ void main() {
         'retry exhaustion still flushes skipped-event warning and embeds '
         'count in NetworkException message',
         () async {
-          // Decision 6: skipped-event diagnostics survive terminal
-          // failure. Both _onWarning AND the thrown message carry the
-          // count.
+          // Skipped-event diagnostics survive terminal failure. Both
+          // `_onWarning` AND the thrown message carry the count.
           final warnings = <String>[];
           final resumeClient = AgUiStreamClient(
             httpTransport: mockTransport,
@@ -849,10 +847,10 @@ void main() {
       test(
         'no-cursor mid-flight drop: NetworkException carries marker prefix',
         () async {
-          // Decision 5 (friendly-message routing): when the stream
-          // errors before any id has been seen, there is nothing to
-          // resume against, but we still wrap the failure so the UI
-          // renders friendly copy via _friendlyMessage.
+          // When the stream errors before any id has been seen, there
+          // is nothing to resume against, but the failure is still
+          // wrapped with `streamResumeFailedPrefix` so consumers can
+          // render friendly copy.
           final resumeClient = AgUiStreamClient(
             httpTransport: mockTransport,
             urlBuilder: UrlBuilder(baseUrl),
@@ -1029,7 +1027,7 @@ void main() {
       );
     });
 
-    group('raceBackoff (Decision 3 — cancel-aware backoff)', () {
+    group('raceBackoff (cancel-aware backoff)', () {
       test('returns normally when delay elapses without cancellation', () {
         fakeAsync((async) {
           final token = CancelToken();
@@ -1079,12 +1077,10 @@ void main() {
       });
 
       test('backoff respects maxBackoff under worst-case +jitter', () {
-        // The original `backoffFor` clamped to `maxBackoff` before
-        // applying ±jitter — so the worst-case +jitter on the cap
-        // exceeded the documented ceiling. `backoffFor` is pure math
-        // (returns a `Duration` without sleeping), so values are kept
-        // small for readability — the contract is "post-jitter result
-        // must not exceed maxBackoff" regardless of magnitude.
+        // Pins the `backoffFor` contract: the post-jitter result must
+        // not exceed `maxBackoff`. `backoffFor` is pure math (returns
+        // a `Duration` without sleeping), so values are kept small
+        // for readability — the contract holds regardless of magnitude.
         final policy = ResumePolicy(
           initialBackoff: const Duration(milliseconds: 10),
           maxBackoff: const Duration(milliseconds: 100),
@@ -1092,7 +1088,8 @@ void main() {
           random: _ConstantRandom(0.999),
         );
         // attempt 5: raw = 10 * 2^4 = 160 ms → cap to 100 ms.
-        // jitterFactor ≈ 1.499 → 150 ms pre-fix; clamped to 100 post-fix.
+        // jitterFactor ≈ 1.499 applied to the 100 ms cap → re-clamped
+        // back to 100 ms by the post-jitter clamp.
         expect(
           policy.backoffFor(5),
           const Duration(milliseconds: 100),
@@ -1105,11 +1102,11 @@ void main() {
       });
 
       test('cancel cancels the underlying delay Timer', () {
-        // Regression: the original `Future.any([Future.delayed, …])`
-        // left the losing `Timer` alive until full expiry. With a
-        // cap of 8 s and frequent cancels, that stranded a Timer per
-        // cancel in the event loop. The fix owns the Timer; this
-        // test pins it via `FakeAsync.pendingTimers`.
+        // Pins that cancel actually stops the delay Timer instead of
+        // leaving it to expire on its own — verified via
+        // `FakeAsync.pendingTimers`. At high cap durations and
+        // frequent cancels, a leaked timer per cancel would
+        // accumulate in the event loop.
         fakeAsync((async) {
           final token = CancelToken();
           unawaited(

--- a/packages/soliplex_client/test/http/agui_stream_client_test.dart
+++ b/packages/soliplex_client/test/http/agui_stream_client_test.dart
@@ -1060,6 +1060,34 @@ void main() {
           expect(completed, isTrue);
         });
       });
+
+      test('cancel cancels the underlying delay Timer', () {
+        // Regression: the original `Future.any([Future.delayed, …])`
+        // left the losing `Timer` alive until full expiry. With a
+        // cap of 8 s and frequent cancels, that stranded a Timer per
+        // cancel in the event loop. The fix owns the Timer; this
+        // test pins it via `FakeAsync.pendingTimers`.
+        fakeAsync((async) {
+          final token = CancelToken();
+          unawaited(
+            AgUiStreamClient.raceBackoff(const Duration(seconds: 5), token)
+                .catchError((_) {}),
+          );
+          // Microtasks drain so the Timer is registered.
+          async.elapse(Duration.zero);
+          expect(async.pendingTimers, hasLength(1));
+
+          token.cancel('user');
+          // Drain microtasks so the cancel handler runs and cancels
+          // the timer; we don't elapse the full 5 s.
+          async.elapse(Duration.zero);
+          expect(
+            async.pendingTimers,
+            isEmpty,
+            reason: 'cancel must cancel the underlying delay Timer',
+          );
+        });
+      });
     });
   });
 }

--- a/packages/soliplex_client/test/http/resume_policy_test.dart
+++ b/packages/soliplex_client/test/http/resume_policy_test.dart
@@ -1,7 +1,7 @@
-import 'dart:math';
-
 import 'package:soliplex_client/src/http/resume_policy.dart';
 import 'package:test/test.dart';
+
+import '_constant_random.dart';
 
 void main() {
   group('ResumePolicy construction', () {
@@ -48,7 +48,7 @@ void main() {
       final policy = ResumePolicy(
         initialBackoff: const Duration(milliseconds: 250),
         jitter: 0,
-        random: Random(0),
+        random: ConstantRandom(0),
       );
       expect(policy.backoffFor(1), const Duration(milliseconds: 250));
     });
@@ -61,7 +61,7 @@ void main() {
         initialBackoff: const Duration(milliseconds: 100),
         maxBackoff: const Duration(milliseconds: 200),
         jitter: 1,
-        random: _ConstantRandom(0),
+        random: ConstantRandom(0),
       );
       expect(policy.backoffFor(1), Duration.zero);
     });
@@ -100,19 +100,4 @@ void main() {
       expect(status.error, same(exception));
     });
   });
-}
-
-class _ConstantRandom implements Random {
-  _ConstantRandom(this._value);
-
-  final double _value;
-
-  @override
-  bool nextBool() => false;
-
-  @override
-  double nextDouble() => _value;
-
-  @override
-  int nextInt(int max) => 0;
 }

--- a/packages/soliplex_client/test/http/resume_policy_test.dart
+++ b/packages/soliplex_client/test/http/resume_policy_test.dart
@@ -5,10 +5,10 @@ import 'package:test/test.dart';
 
 void main() {
   group('ResumePolicy construction', () {
-    test('default constructor enables resume with sensible defaults', () {
+    test('default constructor enables resume', () {
       const policy = ResumePolicy();
       expect(policy.enabled, isTrue);
-      expect(policy.maxAttempts, 5);
+      expect(policy.maxAttempts, greaterThan(0));
     });
 
     test('noRetry factory disables resume', () {
@@ -53,15 +53,17 @@ void main() {
       expect(policy.backoffFor(1), const Duration(milliseconds: 250));
     });
 
-    test('jitter floors the result at 0 (never negative)', () {
+    test('worst-case negative jitter clamps at zero, not below', () {
+      // jitterFactor = 1 + (0*2 - 1) * 1.0 = 0 → 100 ms * 0 = 0 ms.
+      // Pins that the post-jitter clamp lower bound is exactly zero,
+      // not "any non-negative value".
       final policy = ResumePolicy(
         initialBackoff: const Duration(milliseconds: 100),
         maxBackoff: const Duration(milliseconds: 200),
         jitter: 1,
         random: _ConstantRandom(0),
       );
-      final result = policy.backoffFor(1);
-      expect(result.inMicroseconds, greaterThanOrEqualTo(0));
+      expect(policy.backoffFor(1), Duration.zero);
     });
 
     test('asserts attempt is 1-based', () {

--- a/packages/soliplex_client/test/http/resume_policy_test.dart
+++ b/packages/soliplex_client/test/http/resume_policy_test.dart
@@ -1,0 +1,116 @@
+import 'dart:math';
+
+import 'package:soliplex_client/src/http/resume_policy.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('ResumePolicy construction', () {
+    test('default constructor enables resume with sensible defaults', () {
+      const policy = ResumePolicy();
+      expect(policy.enabled, isTrue);
+      expect(policy.maxAttempts, 5);
+    });
+
+    test('noRetry factory disables resume', () {
+      const policy = ResumePolicy.noRetry();
+      expect(policy.enabled, isFalse);
+      expect(policy.maxAttempts, 0);
+    });
+
+    test('rejects negative maxAttempts', () {
+      expect(
+        () => ResumePolicy(maxAttempts: -1),
+        throwsA(isA<AssertionError>()),
+      );
+    });
+
+    test('rejects backoffMultiplier below 1.0 (geometric must grow)', () {
+      expect(
+        () => ResumePolicy(backoffMultiplier: 0.9),
+        throwsA(isA<AssertionError>()),
+      );
+    });
+
+    test('rejects jitter outside [0, 1]', () {
+      expect(
+        () => ResumePolicy(jitter: -0.1),
+        throwsA(isA<AssertionError>()),
+      );
+      expect(
+        () => ResumePolicy(jitter: 1.5),
+        throwsA(isA<AssertionError>()),
+      );
+    });
+  });
+
+  group('ResumePolicy.backoffFor', () {
+    test('attempt=1 returns initialBackoff under zero jitter', () {
+      final policy = ResumePolicy(
+        initialBackoff: const Duration(milliseconds: 250),
+        jitter: 0,
+        random: Random(0),
+      );
+      expect(policy.backoffFor(1), const Duration(milliseconds: 250));
+    });
+
+    test('jitter floors the result at 0 (never negative)', () {
+      final policy = ResumePolicy(
+        initialBackoff: const Duration(milliseconds: 100),
+        maxBackoff: const Duration(milliseconds: 200),
+        jitter: 1,
+        random: _ConstantRandom(0),
+      );
+      final result = policy.backoffFor(1);
+      expect(result.inMicroseconds, greaterThanOrEqualTo(0));
+    });
+
+    test('asserts attempt is 1-based', () {
+      const policy = ResumePolicy();
+      expect(() => policy.backoffFor(0), throwsA(isA<AssertionError>()));
+    });
+  });
+
+  group('ReconnectStatus invariants', () {
+    test('Reconnecting rejects attempt < 1', () {
+      expect(
+        () => Reconnecting(attempt: 0),
+        throwsA(isA<AssertionError>()),
+      );
+    });
+
+    test('Reconnected rejects attempt < 1', () {
+      expect(
+        () => Reconnected(attempt: 0),
+        throwsA(isA<AssertionError>()),
+      );
+    });
+
+    test('ReconnectFailed rejects attempt < 1', () {
+      expect(
+        () => ReconnectFailed(attempt: 0),
+        throwsA(isA<AssertionError>()),
+      );
+    });
+
+    test('error field carries arbitrary Object?, not just String', () {
+      final exception = StateError('original');
+      final status = Reconnecting(attempt: 1, error: exception);
+      expect(status.error, same(exception));
+    });
+  });
+}
+
+class _ConstantRandom implements Random {
+  _ConstantRandom(this._value);
+
+  final double _value;
+
+  @override
+  bool nextBool() => false;
+
+  @override
+  double nextDouble() => _value;
+
+  @override
+  int nextInt(int max) => 0;
+}

--- a/test/modules/room/thread_view_state_test.dart
+++ b/test/modules/room/thread_view_state_test.dart
@@ -22,10 +22,12 @@ class _FakeAgentSession implements AgentSession {
   _FakeAgentSession({List<SessionExtension> extensions = const []})
       : _runState = Signal<RunState>(const IdleState()),
         _lastExecutionEvent = Signal<ExecutionEvent?>(null),
+        _reconnectStatus = Signal<ReconnectStatus?>(null),
         _extensions = extensions;
 
   final Signal<RunState> _runState;
   final Signal<ExecutionEvent?> _lastExecutionEvent;
+  final Signal<ReconnectStatus?> _reconnectStatus;
   final Completer<AgentResult> _resultCompleter = Completer<AgentResult>();
   final List<SessionExtension> _extensions;
   bool cancelCalled = false;
@@ -38,6 +40,9 @@ class _FakeAgentSession implements AgentSession {
 
   @override
   ReadonlySignal<ExecutionEvent?> get lastExecutionEvent => _lastExecutionEvent;
+
+  @override
+  ReadonlySignal<ReconnectStatus?> get reconnectStatus => _reconnectStatus;
 
   @override
   Future<AgentResult> get result => _resultCompleter.future;
@@ -54,6 +59,9 @@ class _FakeAgentSession implements AgentSession {
   }
 
   void emit(RunState state) => _runState.value = state;
+
+  void emitReconnect(ReconnectStatus? status) =>
+      _reconnectStatus.value = status;
 
   void complete(AgentResult result) => _resultCompleter.complete(result);
 
@@ -870,6 +878,177 @@ void main() {
 
         expect(state.pendingApproval.value, isNotNull);
         expect(state.pendingApproval.value!.toolCallId, 'tc-B');
+
+        state.dispose();
+      },
+    );
+  });
+
+  group('reconnect status', () {
+    test(
+      'FailedState whose error starts with streamResumeFailedPrefix maps '
+      'to friendly SendError copy',
+      () async {
+        api.nextThreadHistory = ThreadHistory(messages: const []);
+
+        final state = ThreadViewState(
+          connection: connection,
+          roomId: 'room-1',
+          threadId: 'thread-1',
+          registry: registry,
+        );
+        await Future<void>.delayed(Duration.zero);
+
+        final session = _FakeAgentSession();
+        state.attachSession(session);
+
+        session.emit(
+          FailedState(
+            threadKey: (
+              serverId: 'test-server',
+              roomId: 'room-1',
+              threadId: 'thread-1',
+            ),
+            reason: FailureReason.networkLost,
+            error: '$streamResumeFailedPrefix NetworkException: server gone',
+          ),
+        );
+
+        final sendError = state.lastSendError.value;
+        expect(sendError, isNotNull);
+        expect(sendError!.error, contains('Connection lost'));
+        expect(sendError.error, contains('send your message again'));
+
+        state.dispose();
+      },
+    );
+
+    test(
+      'FailedState without the marker prefix passes the raw error through',
+      () async {
+        api.nextThreadHistory = ThreadHistory(messages: const []);
+
+        final state = ThreadViewState(
+          connection: connection,
+          roomId: 'room-1',
+          threadId: 'thread-1',
+          registry: registry,
+        );
+        await Future<void>.delayed(Duration.zero);
+
+        final session = _FakeAgentSession();
+        state.attachSession(session);
+
+        session.emit(
+          FailedState(
+            threadKey: (
+              serverId: 'test-server',
+              roomId: 'room-1',
+              threadId: 'thread-1',
+            ),
+            reason: FailureReason.serverError,
+            error: 'Some other failure',
+          ),
+        );
+
+        expect(state.lastSendError.value?.error, 'Some other failure');
+
+        state.dispose();
+      },
+    );
+
+    test('mirrors session.reconnectStatus into reconnectStatus signal',
+        () async {
+      api.nextThreadHistory = ThreadHistory(messages: const []);
+
+      final state = ThreadViewState(
+        connection: connection,
+        roomId: 'room-1',
+        threadId: 'thread-1',
+        registry: registry,
+      );
+      await Future<void>.delayed(Duration.zero);
+
+      final session = _FakeAgentSession();
+      state.attachSession(session);
+      expect(state.reconnectStatus.value, isNull);
+
+      session.emitReconnect(
+        const Reconnecting(attempt: 1, lastEventId: 'r:0'),
+      );
+      expect(state.reconnectStatus.value, isA<Reconnecting>());
+
+      session.emitReconnect(const Reconnected(attempt: 1));
+      expect(state.reconnectStatus.value, isA<Reconnected>());
+
+      state.dispose();
+    });
+
+    test(
+      'attaching a new session clears non-Reconnected mirrored state',
+      () async {
+        // Plan B2 step 5: only `Reconnected` survives `_detachSession`
+        // (so its 4s auto-dismiss timer can run). Other states clear.
+        api.nextThreadHistory = ThreadHistory(messages: const []);
+
+        final state = ThreadViewState(
+          connection: connection,
+          roomId: 'room-1',
+          threadId: 'thread-1',
+          registry: registry,
+        );
+        await Future<void>.delayed(Duration.zero);
+
+        final sessionA = _FakeAgentSession();
+        state.attachSession(sessionA);
+        sessionA.emitReconnect(const Reconnecting(attempt: 1));
+        expect(state.reconnectStatus.value, isA<Reconnecting>());
+
+        // Detach + attach a new session: Reconnecting must clear since
+        // its presence would imply a stale in-flight banner.
+        final sessionB = _FakeAgentSession();
+        state.attachSession(sessionB);
+        expect(state.reconnectStatus.value, isNull);
+
+        state.dispose();
+      },
+    );
+
+    test(
+      'detach preserves Reconnected so the auto-dismiss timer can run',
+      () async {
+        api.nextThreadHistory = ThreadHistory(messages: const []);
+
+        final state = ThreadViewState(
+          connection: connection,
+          roomId: 'room-1',
+          threadId: 'thread-1',
+          registry: registry,
+        );
+        await Future<void>.delayed(Duration.zero);
+
+        final session = _FakeAgentSession();
+        state.attachSession(session);
+        session.emitReconnect(const Reconnected(attempt: 1));
+        expect(state.reconnectStatus.value, isA<Reconnected>());
+
+        // Detach via a terminal CompletedState. Reconnected must survive
+        // so the banner widget's 4s auto-dismiss timer can complete.
+        session.emit(
+          CompletedState(
+            threadKey: (
+              serverId: 'test-server',
+              roomId: 'room-1',
+              threadId: 'thread-1',
+            ),
+            runId: 'run-1',
+            conversation: const Conversation(
+              threadId: 'thread-1',
+              messages: [],
+            ),
+          ),
+        );
+        expect(state.reconnectStatus.value, isA<Reconnected>());
 
         state.dispose();
       },

--- a/test/modules/room/thread_view_state_test.dart
+++ b/test/modules/room/thread_view_state_test.dart
@@ -886,8 +886,8 @@ void main() {
 
   group('reconnect status', () {
     test(
-      'FailedState whose error starts with streamResumeFailedPrefix maps '
-      'to friendly SendError copy',
+      'FailedState with streamResumeFailed reason maps to friendly '
+      'SendError copy',
       () async {
         api.nextThreadHistory = ThreadHistory(messages: const []);
 
@@ -909,7 +909,7 @@ void main() {
               roomId: 'room-1',
               threadId: 'thread-1',
             ),
-            reason: FailureReason.networkLost,
+            reason: FailureReason.streamResumeFailed,
             error: '$streamResumeFailedPrefix NetworkException: server gone',
           ),
         );
@@ -947,7 +947,7 @@ void main() {
               roomId: 'room-1',
               threadId: 'thread-1',
             ),
-            reason: FailureReason.networkLost,
+            reason: FailureReason.streamResumeFailed,
             error: '$streamResumeFailedPrefix NetworkException: server gone '
                 '(skipped 3 malformed events)',
           ),

--- a/test/modules/room/thread_view_state_test.dart
+++ b/test/modules/room/thread_view_state_test.dart
@@ -924,6 +924,45 @@ void main() {
     );
 
     test(
+      'FailedState with skipped-events suffix preserves the count in '
+      'friendly copy',
+      () async {
+        api.nextThreadHistory = ThreadHistory(messages: const []);
+
+        final state = ThreadViewState(
+          connection: connection,
+          roomId: 'room-1',
+          threadId: 'thread-1',
+          registry: registry,
+        );
+        await Future<void>.delayed(Duration.zero);
+
+        final session = _FakeAgentSession();
+        state.attachSession(session);
+
+        session.emit(
+          FailedState(
+            threadKey: (
+              serverId: 'test-server',
+              roomId: 'room-1',
+              threadId: 'thread-1',
+            ),
+            reason: FailureReason.networkLost,
+            error: '$streamResumeFailedPrefix NetworkException: server gone '
+                '(skipped 3 malformed events)',
+          ),
+        );
+
+        final sendError = state.lastSendError.value;
+        expect(sendError, isNotNull);
+        expect(sendError!.error, contains('Connection lost'));
+        expect(sendError.error, contains('(skipped 3 malformed events)'));
+
+        state.dispose();
+      },
+    );
+
+    test(
       'FailedState without the marker prefix passes the raw error through',
       () async {
         api.nextThreadHistory = ThreadHistory(messages: const []);
@@ -987,8 +1026,9 @@ void main() {
     test(
       'attaching a new session clears non-Reconnected mirrored state',
       () async {
-        // Plan B2 step 5: only `Reconnected` survives `_detachSession`
-        // (so its 4s auto-dismiss timer can run). Other states clear.
+        // Only `Reconnected` survives `_detachSession` (so its 4s
+        // auto-dismiss timer can run). Other states clear so a stale
+        // in-flight banner does not linger across sessions.
         api.nextThreadHistory = ThreadHistory(messages: const []);
 
         final state = ThreadViewState(
@@ -1057,9 +1097,9 @@ void main() {
 
   group('isCancellable', () {
     test('false during the post-attach IdleState window', () async {
-      // The Gap 3 regression: session is attached but the orchestrator
-      // hasn't emitted RunningState yet. Without the gate, the Stop
-      // button is rendered enabled but `cancelRun` is a silent no-op.
+      // Session is attached but the orchestrator hasn't emitted
+      // RunningState yet. Without this gate, the Stop button would
+      // be enabled but `cancelRun` is a silent no-op in this window.
       api.nextThreadHistory = ThreadHistory(messages: const []);
       final state = ThreadViewState(
         connection: connection,

--- a/test/modules/room/thread_view_state_test.dart
+++ b/test/modules/room/thread_view_state_test.dart
@@ -1054,4 +1054,100 @@ void main() {
       },
     );
   });
+
+  group('isCancellable', () {
+    test('false during the post-attach IdleState window', () async {
+      // The Gap 3 regression: session is attached but the orchestrator
+      // hasn't emitted RunningState yet. Without the gate, the Stop
+      // button is rendered enabled but `cancelRun` is a silent no-op.
+      api.nextThreadHistory = ThreadHistory(messages: const []);
+      final state = ThreadViewState(
+        connection: connection,
+        roomId: 'room-1',
+        threadId: 'thread-1',
+        registry: registry,
+      );
+      await Future<void>.delayed(Duration.zero);
+
+      final session = _FakeAgentSession();
+      state.attachSession(session);
+      // Session attached, runState defaults to IdleState.
+      expect(state.isCancellable.value, isFalse);
+
+      state.dispose();
+    });
+
+    test('true once the orchestrator emits RunningState', () async {
+      // Pins the positive side of the gate. Without this, regressing
+      // the `RunningState` arm to always return false would silently
+      // disable the Stop button for normal runs and pass the IdleState
+      // test above.
+      api.nextThreadHistory = ThreadHistory(messages: const []);
+      final state = ThreadViewState(
+        connection: connection,
+        roomId: 'room-1',
+        threadId: 'thread-1',
+        registry: registry,
+      );
+      await Future<void>.delayed(Duration.zero);
+
+      final session = _FakeAgentSession();
+      state.attachSession(session);
+      session.emit(
+        RunningState(
+          threadKey: (
+            serverId: 'test-server',
+            roomId: 'room-1',
+            threadId: 'thread-1',
+          ),
+          runId: 'run-1',
+          conversation: const Conversation(
+            threadId: 'thread-1',
+            messages: [],
+          ),
+          streaming: const AwaitingText(),
+        ),
+      );
+      expect(state.isCancellable.value, isTrue);
+
+      state.dispose();
+    });
+
+    test('true while in ToolYieldingState', () async {
+      // Independent of the RunningState case: the orchestrator's
+      // `cancelRun` `ToolYieldingState` arm cancels the in-flight
+      // `_resumeStream → startRun` await, and the UI gate must
+      // expose that capability.
+      api.nextThreadHistory = ThreadHistory(messages: const []);
+      final state = ThreadViewState(
+        connection: connection,
+        roomId: 'room-1',
+        threadId: 'thread-1',
+        registry: registry,
+      );
+      await Future<void>.delayed(Duration.zero);
+
+      final session = _FakeAgentSession();
+      state.attachSession(session);
+      session.emit(
+        ToolYieldingState(
+          threadKey: (
+            serverId: 'test-server',
+            roomId: 'room-1',
+            threadId: 'thread-1',
+          ),
+          runId: 'run-1',
+          conversation: const Conversation(
+            threadId: 'thread-1',
+            messages: [],
+          ),
+          pendingToolCalls: const [],
+          toolDepth: 0,
+        ),
+      );
+      expect(state.isCancellable.value, isTrue);
+
+      state.dispose();
+    });
+  });
 }


### PR DESCRIPTION
## Summary

- `AgUiStreamClient` now reconnects on SSE drop using the `Last-Event-ID` header. A typed `ResumePolicy` (capped exponential backoff with jitter) bounds the retry budget, and `raceBackoff` makes long backoffs cancel-responsive.
- Reconnect lifecycle (`Reconnecting` / `Reconnected` / `ReconnectFailed`) is threaded from the SSE client through `AgentLlmProvider` → `RunOrchestrator` → `AgentSession.reconnectStatus` signal, then mirrored into `ThreadViewState.reconnectStatus` for the UI.
- New `_ReconnectBanner` shows in-flight reconnect status with auto-dismiss for `Reconnected`. `ReconnectFailed` flows through the existing send-error banner with friendly copy (`Connection lost. The response may be incomplete — you can send your message again.`), preserving the skipped-event count when present.
- Resume failure is structurally classified end-to-end: new `StreamResumeFailedException`, new `FailureReason.streamResumeFailed`, anchoring on the enum in `_friendlyMessage`.
- Cancel routing tightened across the lifecycle: cancel during `startRun` await, cancel during tool-yield resume, and cancel during a tool-executor callback all converge on `CancelledState`. The Stop button is gated by `isCancellable` (a sealed-state-exhaustive computed) so it doesn't fire while no cancel token is wired.

## Test plan

- [x] `dart test packages/soliplex_client/test/http/resume_policy_test.dart` (new) — construction asserts, 1-based invariants, `backoffFor` math
- [x] `dart test packages/soliplex_client/test/http/agui_stream_client_test.dart` — extended with resume / cancel-during-backoff / mid-stream-no-id cases
- [x] `dart test packages/soliplex_agent/test/orchestration/run_orchestrator_test.dart` — extended with cancel-during-resume drain, tool-yield cancel terminal-state, transport-failure-during-resume routing
- [x] `flutter test test/modules/room/thread_view_state_test.dart` — friendly-copy + skipped-suffix preservation
- [x] `dart analyze` clean across all packages
- [x] Manual: trigger a backend SSE drop mid-stream, confirm reconnect banner appears, then resumes; trigger budget exhaustion, confirm friendly copy in send-error banner

🤖 Generated with [Claude Code](https://claude.com/claude-code)