### PR TITLE
feat(room): add copy buttons for citations

### DIFF
--- a/lib/src/modules/room/ui/citations_section.dart
+++ b/lib/src/modules/room/ui/citations_section.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:soliplex_agent/soliplex_agent.dart' hide State;
 import 'package:url_launcher/url_launcher.dart';
 
@@ -60,6 +61,22 @@ class _CitationsSectionState extends State<CitationsSection> {
                   size: 16,
                   color: theme.colorScheme.onSurfaceVariant,
                 ),
+                const SizedBox(width: 4),
+                InkWell(
+                  onTap: () => _copyAllToClipboard(context),
+                  borderRadius: BorderRadius.circular(6),
+                  child: Padding(
+                    padding: const EdgeInsets.all(2),
+                    child: Tooltip(
+                      message: 'Copy all',
+                      child: Icon(
+                        Icons.copy_all,
+                        size: 16,
+                        color: theme.colorScheme.onSurfaceVariant,
+                      ),
+                    ),
+                  ),
+                ),
               ],
             ),
           ),
@@ -84,6 +101,23 @@ class _CitationsSectionState extends State<CitationsSection> {
           }),
         ],
       ],
+    );
+  }
+
+  Future<void> _copyAllToClipboard(BuildContext context) async {
+    final messenger = ScaffoldMessenger.maybeOf(context);
+    final blocks = widget.sourceReferences
+        .map(_formatForClipboard)
+        .toList(growable: false);
+    await Clipboard.setData(ClipboardData(text: blocks.join('\n\n---\n\n')));
+    final count = widget.sourceReferences.length;
+    messenger?.showSnackBar(
+      SnackBar(
+        content: Text(
+          count == 1 ? 'Citation copied' : '$count citations copied',
+        ),
+        duration: const Duration(seconds: 2),
+      ),
     );
   }
 }
@@ -216,22 +250,71 @@ class _SourceReferenceRow extends StatelessWidget {
                 overflow: TextOverflow.ellipsis,
               ),
             ),
-          if (sourceReference.isPdf && onShowChunkVisualization != null)
-            Padding(
-              padding: const EdgeInsets.only(top: 4),
-              child: TextButton.icon(
-                onPressed: () => onShowChunkVisualization!(sourceReference),
-                icon: const Icon(Icons.picture_as_pdf, size: 16),
-                label: const Text('View in PDF'),
-                style: TextButton.styleFrom(
-                  padding: const EdgeInsets.symmetric(horizontal: 8),
-                  minimumSize: Size.zero,
-                  tapTargetSize: MaterialTapTargetSize.shrinkWrap,
+          Padding(
+            padding: const EdgeInsets.only(top: 4),
+            child: Wrap(
+              spacing: 8,
+              runSpacing: 4,
+              children: [
+                TextButton.icon(
+                  onPressed: () => _copyToClipboard(context),
+                  icon: const Icon(Icons.copy, size: 16),
+                  label: const Text('Copy'),
+                  style: TextButton.styleFrom(
+                    padding: const EdgeInsets.symmetric(horizontal: 8),
+                    minimumSize: Size.zero,
+                    tapTargetSize: MaterialTapTargetSize.shrinkWrap,
+                  ),
                 ),
-              ),
+                if (sourceReference.isPdf && onShowChunkVisualization != null)
+                  TextButton.icon(
+                    onPressed: () => onShowChunkVisualization!(sourceReference),
+                    icon: const Icon(Icons.picture_as_pdf, size: 16),
+                    label: const Text('View in PDF'),
+                    style: TextButton.styleFrom(
+                      padding: const EdgeInsets.symmetric(horizontal: 8),
+                      minimumSize: Size.zero,
+                      tapTargetSize: MaterialTapTargetSize.shrinkWrap,
+                    ),
+                  ),
+              ],
             ),
+          ),
         ],
       ),
     );
   }
+
+  Future<void> _copyToClipboard(BuildContext context) async {
+    final messenger = ScaffoldMessenger.maybeOf(context);
+    await Clipboard.setData(
+      ClipboardData(text: _formatForClipboard(sourceReference)),
+    );
+    messenger?.showSnackBar(
+      const SnackBar(
+        content: Text('Citation copied'),
+        duration: Duration(seconds: 2),
+      ),
+    );
+  }
+}
+
+String _formatForClipboard(SourceReference ref) {
+  final lines = <String>[ref.displayTitle];
+  if (ref.headings.isNotEmpty) {
+    lines.add(ref.headings.join(' > '));
+  }
+  final pages = ref.formattedPageNumbers;
+  if (pages != null) {
+    lines.add(pages);
+  }
+  if (ref.documentUri.isNotEmpty) {
+    lines.add(ref.documentUri);
+  }
+  if (ref.content.isNotEmpty) {
+    lines
+      ..add('')
+      ..add(ref.content);
+  }
+  return lines.join('\n');
 }

--- a/test/modules/room/ui/citations_section_test.dart
+++ b/test/modules/room/ui/citations_section_test.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:soliplex_agent/soliplex_agent.dart' hide State;
 
@@ -159,5 +160,94 @@ void main() {
     await tester.pump();
 
     expect(tappedRef?.documentId, 'doc-2');
+  });
+
+  testWidgets('copy button writes citation details to the clipboard',
+      (tester) async {
+    String? copied;
+    tester.binding.defaultBinaryMessenger.setMockMethodCallHandler(
+      SystemChannels.platform,
+      (call) async {
+        if (call.method == 'Clipboard.setData') {
+          copied = (call.arguments as Map)['text'] as String;
+        }
+        return null;
+      },
+    );
+    addTearDown(() {
+      tester.binding.defaultBinaryMessenger.setMockMethodCallHandler(
+        SystemChannels.platform,
+        null,
+      );
+    });
+
+    await tester.pumpWidget(_wrap(
+      CitationsSection(
+        sourceReferences: [
+          _ref(
+            index: 1,
+            title: 'Doc',
+            headings: ['Chapter 1', 'Section 2'],
+            content: 'Preview text here',
+            pageNumbers: [5, 6],
+          ),
+        ],
+      ),
+    ));
+
+    await tester.tap(find.text('1 source'));
+    await tester.pump();
+    await tester.tap(find.text('Doc'));
+    await tester.pump();
+
+    await tester.tap(find.widgetWithText(TextButton, 'Copy'));
+    await tester.pump();
+
+    expect(copied, isNotNull);
+    expect(copied, contains('Doc'));
+    expect(copied, contains('Chapter 1 > Section 2'));
+    expect(copied, contains('p.5-6'));
+    expect(copied, contains('file://doc-1.txt'));
+    expect(copied, contains('Preview text here'));
+    expect(find.text('Citation copied'), findsOneWidget);
+  });
+
+  testWidgets('copy-all button copies every citation', (tester) async {
+    String? copied;
+    tester.binding.defaultBinaryMessenger.setMockMethodCallHandler(
+      SystemChannels.platform,
+      (call) async {
+        if (call.method == 'Clipboard.setData') {
+          copied = (call.arguments as Map)['text'] as String;
+        }
+        return null;
+      },
+    );
+    addTearDown(() {
+      tester.binding.defaultBinaryMessenger.setMockMethodCallHandler(
+        SystemChannels.platform,
+        null,
+      );
+    });
+
+    await tester.pumpWidget(_wrap(
+      CitationsSection(
+        sourceReferences: [
+          _ref(index: 1, title: 'Alpha', content: 'first'),
+          _ref(index: 2, title: 'Beta', content: 'second'),
+        ],
+      ),
+    ));
+
+    await tester.tap(find.byTooltip('Copy all'));
+    await tester.pump();
+
+    expect(copied, isNotNull);
+    expect(copied, contains('Alpha'));
+    expect(copied, contains('first'));
+    expect(copied, contains('Beta'));
+    expect(copied, contains('second'));
+    expect(copied, contains('---'));
+    expect(find.text('2 citations copied'), findsOneWidget);
   });
 }


### PR DESCRIPTION
## Summary

Closes #216.

- Per-citation **Copy** button in the expanded source row, next to **View in PDF**.
- **Copy-all** icon (`Icons.copy_all`) in the section header, available whether or not the section is expanded.
- Both copy a plain-text block — title, headings, page numbers, URL, and the chunk content. Copy-all joins blocks with `\n\n---\n\n`.
- SnackBar feedback on each copy ("Citation copied" / "N citations copied").

## Test plan

- [x] `flutter analyze` — clean.
- [x] `flutter test test/modules/room/ui/citations_section_test.dart` — 10/10 passing (8 existing + 2 new for per-citation copy and copy-all).
- [x] Manual: open a room with a RAG agent, send a query that returns citations, verify the copy-all icon in the header and per-citation Copy button each write the expected fields to the clipboard.