### PR TITLE
feat(soliplex_client): foundation types for orphan synthesis and event drops

### DIFF
--- a/lib/src/modules/room/ui/message_tile.dart
+++ b/lib/src/modules/room/ui/message_tile.dart
@@ -70,6 +70,10 @@ class MessageTile extends StatelessWidget {
             executionTracker: executionTracker,
             streamingActivity: streamingActivity,
           ),
+        // Phase 3 wires this up to dropped_event_message_tile.dart. Until
+        // then no production code creates a DroppedEventMessage so the arm
+        // is unreachable in practice.
+        DroppedEventMessage() => const SizedBox.shrink(),
       },
     );
   }

--- a/packages/soliplex_client/lib/src/api/agui_message_mapper.dart
+++ b/packages/soliplex_client/lib/src/api/agui_message_mapper.dart
@@ -15,7 +15,8 @@ import 'package:soliplex_client/src/domain/chat_message.dart';
 /// - [ToolCallMessage] → [AssistantMessage] with toolCalls, followed by
 ///   [ToolMessage]s for completed tool calls
 /// - [GenUiMessage] → [AssistantMessage] with descriptive content
-/// - [ErrorMessage] and [LoadingMessage] are skipped (transient messages)
+/// - [ErrorMessage], [LoadingMessage], and [DroppedEventMessage] are
+///   skipped (transient or frontend-only messages)
 List<Message> convertToAgui(List<ChatMessage> chatMessages) {
   final result = <Message>[];
 
@@ -32,7 +33,8 @@ List<Message> convertToAgui(List<ChatMessage> chatMessages) {
 
       case ErrorMessage():
       case LoadingMessage():
-        // Skip transient messages
+      case DroppedEventMessage():
+        // Skip transient or frontend-only messages
         continue;
     }
   }

--- a/packages/soliplex_client/lib/src/domain/chat_message.dart
+++ b/packages/soliplex_client/lib/src/domain/chat_message.dart
@@ -42,6 +42,22 @@ sealed class ChatMessage {
   int get hashCode => Object.hash(runtimeType, id);
 }
 
+/// Reason a run reached a terminal state without producing assistant text.
+///
+/// Set on a `TextMessage` (with empty `text`) synthesized when a run finishes
+/// with buffered thinking but no `TextMessageStart`/`Content`/`End` for an
+/// assistant reply.
+enum TerminalReason {
+  /// Run completed normally (`RunFinishedEvent`).
+  finished,
+
+  /// Run failed (`RunErrorEvent`).
+  failed,
+
+  /// Run was cancelled (`cancelRun`).
+  cancelled,
+}
+
 /// A text message.
 @immutable
 class TextMessage extends ChatMessage {
@@ -53,6 +69,7 @@ class TextMessage extends ChatMessage {
     required this.text,
     this.isStreaming = false,
     this.thinkingText = '',
+    this.terminalReason,
   });
 
   /// Creates a text message with the given ID and auto-generated timestamp.
@@ -62,6 +79,7 @@ class TextMessage extends ChatMessage {
     required String text,
     bool isStreaming = false,
     String thinkingText = '',
+    TerminalReason? terminalReason,
   }) {
     return TextMessage(
       id: id,
@@ -69,6 +87,7 @@ class TextMessage extends ChatMessage {
       text: text,
       isStreaming: isStreaming,
       thinkingText: thinkingText,
+      terminalReason: terminalReason,
       createdAt: DateTime.now(),
     );
   }
@@ -82,6 +101,12 @@ class TextMessage extends ChatMessage {
   /// The thinking/reasoning text if available.
   final String thinkingText;
 
+  /// Non-null when this message was synthesized for a run that terminated
+  /// without an assistant reply. Carries enough state for the tile to
+  /// render the appropriate "Run finished/failed/cancelled without a
+  /// response" copy.
+  final TerminalReason? terminalReason;
+
   /// Whether this message has thinking text.
   bool get hasThinkingText => thinkingText.isNotEmpty;
 
@@ -93,6 +118,7 @@ class TextMessage extends ChatMessage {
     String? text,
     bool? isStreaming,
     String? thinkingText,
+    TerminalReason? terminalReason,
   }) {
     return TextMessage(
       id: id ?? this.id,
@@ -101,6 +127,7 @@ class TextMessage extends ChatMessage {
       text: text ?? this.text,
       isStreaming: isStreaming ?? this.isStreaming,
       thinkingText: thinkingText ?? this.thinkingText,
+      terminalReason: terminalReason ?? this.terminalReason,
     );
   }
 
@@ -234,6 +261,82 @@ class LoadingMessage extends ChatMessage {
 
   @override
   String toString() => 'LoadingMessage(id: $id)';
+}
+
+/// Where a dropped event was caught.
+enum DropSource {
+  /// `decodeEventSafely` produced `DecodeFailed` — either malformed JSON or
+  /// a `type` field the decoder doesn't recognize.
+  decode,
+
+  /// The per-event-loop wrapper caught a throw from `processEvent` itself
+  /// or one of its downstream side effects (e.g., citation extraction).
+  eventProcessing,
+
+  /// Historical replay bridging or `ExecutionTracker._onEvent` threw on a
+  /// per-event basis.
+  activityProcessing,
+
+  /// Catch-all for future drop sites.
+  other,
+}
+
+/// An event the client received but couldn't decode or process, surfaced as
+/// a tile in the timeline so the user sees something happened and devs can
+/// inspect the raw payload.
+///
+/// Synthesized by the data-layer wrappers in Phase 3
+/// (`decodeEventSafely`, the per-event-loop wrapper, and the
+/// `historical_replay` / `ExecutionTracker` boundaries). Never sent over
+/// the wire.
+@immutable
+class DroppedEventMessage extends ChatMessage {
+  /// Creates a dropped-event message with all properties.
+  const DroppedEventMessage({
+    required super.id,
+    required super.createdAt,
+    required this.source,
+    required this.reason,
+    this.runId,
+    this.rawPayload,
+  }) : super(user: ChatUser.system);
+
+  /// Creates a dropped-event message with the given id and auto-generated
+  /// timestamp.
+  factory DroppedEventMessage.create({
+    required String id,
+    required DropSource source,
+    required String reason,
+    String? runId,
+    Map<String, dynamic>? rawPayload,
+  }) {
+    return DroppedEventMessage(
+      id: id,
+      source: source,
+      reason: reason,
+      runId: runId,
+      rawPayload: rawPayload,
+      createdAt: DateTime.now(),
+    );
+  }
+
+  /// Run the drop happened inside, when known. Null for non-run-scoped
+  /// drops (e.g., decode failures that arrive before any run is in flight).
+  final String? runId;
+
+  /// Where the drop was caught.
+  final DropSource source;
+
+  /// Short human-readable reason. Shown as the collapsed-state subtitle.
+  final String reason;
+
+  /// Original payload for inspection. Null when serialization itself
+  /// failed; the tile renders "(payload unavailable)" in that case.
+  final Map<String, dynamic>? rawPayload;
+
+  @override
+  String toString() =>
+      'DroppedEventMessage(id: $id, source: $source, reason: $reason)';
 }
 
 /// Status of a tool call.

--- a/packages/soliplex_client/test/api/agui_message_mapper_test.dart
+++ b/packages/soliplex_client/test/api/agui_message_mapper_test.dart
@@ -214,6 +214,21 @@ void main() {
 
         expect(aguiMessages, isEmpty);
       });
+
+      test('skips DroppedEventMessage', () {
+        final chatMessages = [
+          DroppedEventMessage(
+            id: 'drop-1',
+            createdAt: DateTime.now(),
+            source: DropSource.decode,
+            reason: 'unknown event type',
+          ),
+        ];
+
+        final aguiMessages = convertToAgui(chatMessages);
+
+        expect(aguiMessages, isEmpty);
+      });
     });
 
     group('mixed message list', () {

--- a/packages/soliplex_client/test/domain/chat_message_test.dart
+++ b/packages/soliplex_client/test/domain/chat_message_test.dart
@@ -186,6 +186,20 @@ void main() {
     });
   });
 
+  group('DroppedEventMessage', () {
+    test('user is system (not assistant or user)', () {
+      // The constructor hardcodes ChatUser.system. Encoded decision:
+      // dropped events are diagnostics, not chat turns from any party.
+      final message = DroppedEventMessage.create(
+        id: 'drop-1',
+        source: DropSource.decode,
+        reason: 'unknown event type',
+      );
+
+      expect(message.user, equals(ChatUser.system));
+    });
+  });
+
   group('ErrorMessage', () {
     test('create with message', () {
       final message = ErrorMessage.create(
@@ -404,6 +418,11 @@ void main() {
           data: const {},
         ),
         LoadingMessage.create(id: 'loading-1'),
+        DroppedEventMessage.create(
+          id: 'drop-1',
+          source: DropSource.decode,
+          reason: 'malformed JSON',
+        ),
       ];
 
       final types = messages.map((m) {
@@ -413,10 +432,14 @@ void main() {
           ToolCallMessage() => 'toolCall',
           GenUiMessage() => 'genUi',
           LoadingMessage() => 'loading',
+          DroppedEventMessage() => 'dropped',
         };
       }).toList();
 
-      expect(types, equals(['text', 'error', 'toolCall', 'genUi', 'loading']));
+      expect(
+        types,
+        equals(['text', 'error', 'toolCall', 'genUi', 'loading', 'dropped']),
+      );
     });
 
     test('extract text from different message types', () {


### PR DESCRIPTION
## Summary

Phase 1 of the multi-PR plan to make AG-UI handling resilient to schema drift. Adds the domain-layer scaffolding the next two PRs will build on. **No runtime behavior change yet** — synthesis and drop carriers are wired up in follow-up PRs.

### What's added

- **`TerminalReason { finished, failed, cancelled }`** + an optional `terminalReason` field on `TextMessage`. An assistant `TextMessage` with empty `text` and non-null `terminalReason` is the carrier for "run terminated without an assistant reply but produced thinking" (orphan synthesis). A field, not a new subtype, because such a message IS a chat turn — the model produced it, just without final tokens.
- **`DroppedEventMessage`** (new sealed `ChatMessage` subtype) carrying `id`, `runId?`, `source`, `reason`, `rawPayload?`. Will be synthesized in the next PR at data-layer boundaries (decode, per-event-loop, activity processing) when an event can't be decoded or processed; surfaced inline at the failure position so users see something happened and devs can inspect the raw payload.
- **`DropSource { decode, eventProcessing, activityProcessing, other }`**.

The asymmetry (one is a flag, the other is a subtype) is intentional. They're different concepts: "completed-but-empty turn" vs. "injected diagnostic." Implementation tracks the concept.

### Wiring changes

- `agui_message_mapper.convertToAgui` skips `DroppedEventMessage` (frontend-only synthesis, never sent over the wire as history).
- `MessageTile` switch arm for `DroppedEventMessage` renders `SizedBox.shrink()` until the next PR wires up the real tile. No production code creates one yet; the arm is unreachable in practice.

## Test plan

- [x] `dart format` — clean
- [x] `flutter analyze` — no errors
- [x] `flutter test` — all 1203 tests pass
- [ ] No manual repro needed: zero runtime behavior change. Phase 2 (orphan synthesis) and Phase 3 (drop carriers) introduce the user-facing changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)