### PR TITLE
feat: dropped-event carrier surfaces undecodable AG-UI events as tiles

### DIFF
--- a/lib/src/modules/room/execution_tracker.dart
+++ b/lib/src/modules/room/execution_tracker.dart
@@ -95,7 +95,11 @@ class ExecutionTracker {
       // here would propagate up through the signals subscription that
       // pushed the event, destabilising any downstream observers. Log
       // and skip the mutation instead — surrounding events keep flowing.
-      _logger.warning(
+      // The drop is deliberately UI-silent: chat-message boundaries mint
+      // the drop tile; double-minting from this projection would surface
+      // the same backend event as two tiles. Logged at error so Sentry
+      // still sees the schema/code drift.
+      _logger.error(
         'ExecutionTracker dropped ${event.runtimeType}',
         error: e,
         stackTrace: st,

--- a/lib/src/modules/room/execution_tracker.dart
+++ b/lib/src/modules/room/execution_tracker.dart
@@ -88,6 +88,22 @@ class ExecutionTracker {
   void _onEvent(ExecutionEvent? event) {
     assert(!_isFrozen, 'Cannot process events on a frozen ExecutionTracker');
     if (event == null) return;
+    try {
+      _dispatch(event);
+    } on Object catch (e, st) {
+      // The tracker is a derived projection of the event stream; a throw
+      // here would propagate up through the signals subscription that
+      // pushed the event, destabilising any downstream observers. Log
+      // and skip the mutation instead — surrounding events keep flowing.
+      _logger.warning(
+        'ExecutionTracker dropped ${event.runtimeType}',
+        error: e,
+        stackTrace: st,
+      );
+    }
+  }
+
+  void _dispatch(ExecutionEvent event) {
     switch (event) {
       case ThinkingStarted():
         _completeActiveStep();

--- a/lib/src/modules/room/execution_tracker_extension.dart
+++ b/lib/src/modules/room/execution_tracker_extension.dart
@@ -65,12 +65,13 @@ class ExecutionTrackerExtension extends SessionExtension
   void _onRunState(RunState runState) {
     final session = _session;
     if (session == null) {
-      // Proving safety today relies on signals' subscription teardown
-      // happening synchronously before _session is cleared in onDispose;
-      // that invariant is fragile across signals upgrades. Defensive
-      // early return costs two lines.
+      // signals teardown is assumed synchronous w.r.t. onDispose, but
+      // that's a fragile invariant — guard explicitly. Capture the
+      // current stack so a future upgrade that breaks the ordering
+      // shows up in Sentry with a breadcrumb to the dispatching site.
       _logger.warning(
         '_onRunState fired after dispose; ignoring',
+        stackTrace: StackTrace.current,
         attributes: {'runState': runState.runtimeType.toString()},
       );
       return;

--- a/lib/src/modules/room/execution_tracker_extension.dart
+++ b/lib/src/modules/room/execution_tracker_extension.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/foundation.dart' show visibleForTesting;
 import 'package:soliplex_agent/soliplex_agent.dart';
 
 import 'execution_tracker.dart';
@@ -16,10 +17,12 @@ import 'tracker_registry.dart';
 class ExecutionTrackerExtension extends SessionExtension
     with StatefulSessionExtension<Map<String, ExecutionTracker>> {
   ExecutionTrackerExtension({required Logger logger})
-      : _registry = TrackerRegistry(logger: logger) {
+      : _logger = logger,
+        _registry = TrackerRegistry(logger: logger) {
     setInitialState(const <String, ExecutionTracker>{});
   }
 
+  final Logger _logger;
   final TrackerRegistry _registry;
   void Function()? _runStateUnsub;
   AgentSession? _session;
@@ -53,8 +56,25 @@ class ExecutionTrackerExtension extends SessionExtension
     super.onDispose();
   }
 
+  /// Test entrypoint for [_onRunState]. Production code routes through
+  /// the signal subscription; tests use this to drive the post-dispose
+  /// path that production can't reach without racing the signals teardown.
+  @visibleForTesting
+  void debugPushRunState(RunState runState) => _onRunState(runState);
+
   void _onRunState(RunState runState) {
-    final session = _session!;
+    final session = _session;
+    if (session == null) {
+      // Proving safety today relies on signals' subscription teardown
+      // happening synchronously before _session is cleared in onDispose;
+      // that invariant is fragile across signals upgrades. Defensive
+      // early return costs two lines.
+      _logger.warning(
+        '_onRunState fired after dispose; ignoring',
+        attributes: {'runState': runState.runtimeType.toString()},
+      );
+      return;
+    }
     switch (runState) {
       case RunningState(:final streaming):
         _registry.onStreaming(streaming, session.lastExecutionEvent);

--- a/lib/src/modules/room/execution_tracker_extension.dart
+++ b/lib/src/modules/room/execution_tracker_extension.dart
@@ -66,8 +66,11 @@ class ExecutionTrackerExtension extends SessionExtension
     final session = _session;
     if (session == null) {
       // signals teardown is assumed synchronous w.r.t. onDispose, but
-      // that's a fragile invariant across signals upgrades.
-      _logger.warning(
+      // that's a fragile invariant across signals upgrades. Reaching
+      // here means the invariant broke — `error`-level so Sentry can
+      // page on a regression instead of having the breadcrumb buried
+      // among warnings.
+      _logger.error(
         '_onRunState fired after dispose; ignoring',
         stackTrace: StackTrace.current,
         attributes: {'runState': runState.runtimeType.toString()},

--- a/lib/src/modules/room/execution_tracker_extension.dart
+++ b/lib/src/modules/room/execution_tracker_extension.dart
@@ -66,9 +66,7 @@ class ExecutionTrackerExtension extends SessionExtension
     final session = _session;
     if (session == null) {
       // signals teardown is assumed synchronous w.r.t. onDispose, but
-      // that's a fragile invariant — guard explicitly. Capture the
-      // current stack so a future upgrade that breaks the ordering
-      // shows up in Sentry with a breadcrumb to the dispatching site.
+      // that's a fragile invariant across signals upgrades.
       _logger.warning(
         '_onRunState fired after dispose; ignoring',
         stackTrace: StackTrace.current,

--- a/lib/src/modules/room/historical_replay.dart
+++ b/lib/src/modules/room/historical_replay.dart
@@ -29,8 +29,11 @@ final Logger _logger =
 ///   [noResponseMessageId] for the run so the synthesized no-response
 ///   tile has a tracker to attach to.
 ///
-/// A throw from [bridge] is logged and the offending event skipped so
-/// surrounding events in the same bundle still bucket correctly.
+/// A throw from [bridge] is logged at error and the offending event
+/// skipped so surrounding events in the same bundle still bucket
+/// correctly. The drop is deliberately UI-silent: chat-message
+/// boundaries mint the drop tile; double-minting from this tracker
+/// projection would surface the same backend event as two tiles.
 /// [bridge] defaults to [bridgeBaseEvent] and is overridable for tests.
 Map<String, ExecutionTracker> replayToTrackers(
   List<RunEventBundle> runs, {
@@ -45,7 +48,7 @@ Map<String, ExecutionTracker> replayToTrackers(
     try {
       return bridge(raw);
     } on Object catch (e, st) {
-      _logger.warning(
+      _logger.error(
         'bridge threw on ${raw.runtimeType}; event skipped',
         error: e,
         stackTrace: st,

--- a/lib/src/modules/room/historical_replay.dart
+++ b/lib/src/modules/room/historical_replay.dart
@@ -1,7 +1,14 @@
+import 'package:flutter/foundation.dart' show visibleForTesting;
 import 'package:soliplex_agent/soliplex_agent.dart';
 import 'package:soliplex_logging/soliplex_logging.dart';
 
 import 'execution_tracker.dart';
+
+/// Signature for the per-event AG-UI → execution-event bridger. The
+/// production implementation is the top-level [bridgeBaseEvent] from
+/// `soliplex_agent`; tests inject throwing variants to exercise the
+/// per-event catch in [replayToTrackers].
+typedef ExecutionBridge = ExecutionEvent? Function(BaseEvent event);
 
 final Logger _logger =
     LogManager.instance.getLogger('soliplex_frontend.historical_replay');
@@ -21,11 +28,35 @@ final Logger _logger =
 ///   `ToolCallStart`. Bucket events (including any prior pending) under
 ///   [noResponseMessageId] for the run so the synthesized no-response
 ///   tile has a tracker to attach to.
-Map<String, ExecutionTracker> replayToTrackers(List<RunEventBundle> runs) {
+///
+/// Each call to [bridge] is wrapped in a try/catch — a throw on one
+/// event is logged and skipped, so surrounding events in the same
+/// bundle still bucket correctly. Per-event (not per-bundle) is the
+/// right granularity here: bucket assignment is decided before
+/// bridging, so a skipped event just leaves a hole in the timeline
+/// instead of losing the rest of the bundle. [bridge] defaults to the
+/// production [bridgeBaseEvent] and is overridable for tests.
+Map<String, ExecutionTracker> replayToTrackers(
+  List<RunEventBundle> runs, {
+  @visibleForTesting ExecutionBridge bridge = bridgeBaseEvent,
+}) {
   final buckets = <String, List<ExecutionEvent>>{};
   // Hoisted across bundles: tool-yield events accumulate here until the
   // next normal bundle's first assistant message absorbs them.
   final pending = <ExecutionEvent>[];
+
+  ExecutionEvent? bridgeOrLog(BaseEvent raw) {
+    try {
+      return bridge(raw);
+    } on Object catch (e, st) {
+      _logger.warning(
+        'bridge threw on ${raw.runtimeType}; event skipped',
+        error: e,
+        stackTrace: st,
+      );
+      return null;
+    }
+  }
 
   for (final bundle in runs) {
     final hasAssistantStart = bundle.events.any(
@@ -47,7 +78,7 @@ Map<String, ExecutionTracker> replayToTrackers(List<RunEventBundle> runs) {
           }
         }
 
-        final execEvent = bridgeBaseEvent(raw);
+        final execEvent = bridgeOrLog(raw);
         if (execEvent == null) continue;
 
         if (currentMessageId != null) {
@@ -58,7 +89,7 @@ Map<String, ExecutionTracker> replayToTrackers(List<RunEventBundle> runs) {
       }
     } else if (hasToolCall) {
       for (final raw in bundle.events) {
-        final execEvent = bridgeBaseEvent(raw);
+        final execEvent = bridgeOrLog(raw);
         if (execEvent == null) continue;
         pending.add(execEvent);
       }
@@ -70,7 +101,7 @@ Map<String, ExecutionTracker> replayToTrackers(List<RunEventBundle> runs) {
         pending.clear();
       }
       for (final raw in bundle.events) {
-        final execEvent = bridgeBaseEvent(raw);
+        final execEvent = bridgeOrLog(raw);
         if (execEvent == null) continue;
         bucket.add(execEvent);
       }

--- a/lib/src/modules/room/historical_replay.dart
+++ b/lib/src/modules/room/historical_replay.dart
@@ -29,13 +29,9 @@ final Logger _logger =
 ///   [noResponseMessageId] for the run so the synthesized no-response
 ///   tile has a tracker to attach to.
 ///
-/// Each call to [bridge] is wrapped in a try/catch — a throw on one
-/// event is logged and skipped, so surrounding events in the same
-/// bundle still bucket correctly. Per-event (not per-bundle) is the
-/// right granularity here: bucket assignment is decided before
-/// bridging, so a skipped event just leaves a hole in the timeline
-/// instead of losing the rest of the bundle. [bridge] defaults to the
-/// production [bridgeBaseEvent] and is overridable for tests.
+/// A throw from [bridge] is logged and the offending event skipped so
+/// surrounding events in the same bundle still bucket correctly.
+/// [bridge] defaults to [bridgeBaseEvent] and is overridable for tests.
 Map<String, ExecutionTracker> replayToTrackers(
   List<RunEventBundle> runs, {
   @visibleForTesting ExecutionBridge bridge = bridgeBaseEvent,

--- a/lib/src/modules/room/thread_view_state.dart
+++ b/lib/src/modules/room/thread_view_state.dart
@@ -328,18 +328,12 @@ class ThreadViewState {
 
   /// Translates orchestrator failure copy into user-facing copy.
   ///
-  /// `streamResumeFailed` failures get a friendly base message. The
-  /// skipped-event count, when present in the underlying error string,
-  /// is preserved as a parenthetical suffix — best-effort: the base
-  /// message still appears if the suffix format ever drifts. Other
+  /// `streamResumeFailed` failures get a friendly base message; other
   /// failures pass through unchanged.
   String _friendlyMessage(FailureReason reason, String error) {
     if (reason != FailureReason.streamResumeFailed) return error;
-    const base = 'Connection lost. The response may be incomplete — '
+    return 'Connection lost. The response may be incomplete — '
         'you can send your message again.';
-    final skipped =
-        RegExp(r'\(skipped \d+ malformed events?\)').firstMatch(error);
-    return skipped == null ? base : '$base ${skipped.group(0)}';
   }
 
   bool _restoreFromRegistry() {

--- a/lib/src/modules/room/ui/dropped_event_message_tile.dart
+++ b/lib/src/modules/room/ui/dropped_event_message_tile.dart
@@ -7,10 +7,6 @@ import '../../diagnostics/ui/json_tree_view.dart';
 /// Renders a [DroppedEventMessage] as a low-emphasis, collapsed-by-default
 /// card. Schema-drift events in production should show as a quiet hint,
 /// not a wall of warnings.
-///
-/// Collapsed: a single line `"Couldn't process 1 event ($source)"`.
-/// Expanded: source + runId subtitle, plus a [JsonTreeView] for `Map`
-/// payloads (raw text for null/non-Map payloads).
 class DroppedEventMessageTile extends StatefulWidget {
   const DroppedEventMessageTile({super.key, required this.message});
 

--- a/lib/src/modules/room/ui/dropped_event_message_tile.dart
+++ b/lib/src/modules/room/ui/dropped_event_message_tile.dart
@@ -1,0 +1,124 @@
+import 'package:flutter/material.dart';
+import 'package:soliplex_agent/soliplex_agent.dart' hide State;
+
+import '../../diagnostics/models/json_tree_model.dart';
+import '../../diagnostics/ui/json_tree_view.dart';
+
+/// Renders a [DroppedEventMessage] as a low-emphasis, collapsed-by-default
+/// card. Schema-drift events in production should show as a quiet hint,
+/// not a wall of warnings.
+///
+/// Collapsed: a single line `"Couldn't process 1 event ($source)"`.
+/// Expanded: source + runId subtitle, plus a [JsonTreeView] for `Map`
+/// payloads (raw text for null/non-Map payloads).
+class DroppedEventMessageTile extends StatefulWidget {
+  const DroppedEventMessageTile({super.key, required this.message});
+
+  final DroppedEventMessage message;
+
+  @override
+  State<DroppedEventMessageTile> createState() =>
+      _DroppedEventMessageTileState();
+}
+
+class _DroppedEventMessageTileState extends State<DroppedEventMessageTile> {
+  bool _expanded = false;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final muted = theme.colorScheme.onSurfaceVariant;
+    final mono = theme.textTheme.bodySmall?.copyWith(
+      fontFamily: 'monospace',
+      color: muted,
+    );
+
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: 2, horizontal: 8),
+      child: InkWell(
+        onTap: () => setState(() => _expanded = !_expanded),
+        borderRadius: BorderRadius.circular(6),
+        child: Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 4),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Row(
+                children: [
+                  Icon(
+                    Icons.warning_amber_outlined,
+                    size: 16,
+                    color: muted,
+                  ),
+                  const SizedBox(width: 6),
+                  Expanded(
+                    child: Text(
+                      _collapsedLabel(),
+                      style: theme.textTheme.bodySmall?.copyWith(
+                        color: muted,
+                      ),
+                    ),
+                  ),
+                  Icon(
+                    _expanded ? Icons.expand_less : Icons.expand_more,
+                    size: 16,
+                    color: muted,
+                  ),
+                ],
+              ),
+              if (_expanded) ...[
+                const SizedBox(height: 6),
+                Padding(
+                  padding: const EdgeInsets.only(left: 22),
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Text(
+                        _subtitle(),
+                        style: theme.textTheme.bodySmall?.copyWith(
+                          color: muted,
+                        ),
+                      ),
+                      const SizedBox(height: 6),
+                      _payload(theme, mono),
+                    ],
+                  ),
+                ),
+              ],
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+
+  String _collapsedLabel() {
+    return "Couldn't process 1 event (${_humanizeSource(widget.message.source)})";
+  }
+
+  String _subtitle() {
+    final runId = widget.message.runId;
+    final reason = widget.message.reason;
+    return runId == null ? reason : 'run $runId — $reason';
+  }
+
+  Widget _payload(ThemeData theme, TextStyle? mono) {
+    final raw = widget.message.rawPayload;
+    if (raw == null) {
+      return Text(
+        '(payload unavailable)',
+        style: mono?.copyWith(fontStyle: FontStyle.italic),
+      );
+    }
+    return JsonTreeView(nodes: buildJsonTree(raw));
+  }
+
+  String _humanizeSource(DropSource source) {
+    switch (source) {
+      case DropSource.decode:
+        return 'decode';
+      case DropSource.eventProcessing:
+        return 'processing';
+    }
+  }
+}

--- a/lib/src/modules/room/ui/dropped_event_message_tile.dart
+++ b/lib/src/modules/room/ui/dropped_event_message_tile.dart
@@ -110,6 +110,11 @@ class _DroppedEventMessageTileState extends State<DroppedEventMessageTile> {
         style: mono?.copyWith(fontStyle: FontStyle.italic),
       );
     }
+    if (raw is String) {
+      // Top-level JSON parse failure: show the raw bytes the parser
+      // rejected, so a developer can see the malformed wire content.
+      return SelectableText(raw, style: mono);
+    }
     return JsonTreeView(nodes: buildJsonTree(raw));
   }
 

--- a/lib/src/modules/room/ui/message_tile.dart
+++ b/lib/src/modules/room/ui/message_tile.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:soliplex_agent/soliplex_agent.dart';
 
 import '../execution_tracker.dart';
+import 'dropped_event_message_tile.dart';
 import 'error_message_tile.dart';
 import 'gen_ui_tile.dart';
 import 'loading_message_tile.dart';
@@ -77,19 +78,7 @@ class MessageTile extends StatelessWidget {
             executionTracker: executionTracker,
             streamingActivity: streamingActivity,
           ),
-        // No production path currently synthesizes DroppedEventMessage.
-        // Render a visible placeholder so a regression that starts
-        // producing them is observable instead of an invisible gap.
-        DroppedEventMessage(:final reason) => Padding(
-            padding: const EdgeInsets.symmetric(vertical: 4, horizontal: 8),
-            child: Text(
-              '[Dropped event: $reason]',
-              style: Theme.of(context).textTheme.bodySmall?.copyWith(
-                    color: Theme.of(context).colorScheme.onSurfaceVariant,
-                    fontStyle: FontStyle.italic,
-                  ),
-            ),
-          ),
+        final DroppedEventMessage m => DroppedEventMessageTile(message: m),
       },
     );
   }

--- a/lib/src/modules/room/ui/no_response_tile_widget.dart
+++ b/lib/src/modules/room/ui/no_response_tile_widget.dart
@@ -93,18 +93,18 @@ class _TerminalReasonBubble extends StatelessWidget {
     return Container(
       padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 10),
       decoration: BoxDecoration(
-        color: theme.colorScheme.surfaceContainerHighest,
+        color: theme.colorScheme.tertiaryContainer,
         borderRadius: BorderRadius.circular(12),
       ),
       child: Row(
         children: [
-          Icon(icon, size: 16, color: theme.colorScheme.onSurfaceVariant),
+          Icon(icon, size: 16, color: theme.colorScheme.onTertiaryContainer),
           const SizedBox(width: 8),
           Expanded(
             child: Text(
               label,
               style: theme.textTheme.bodyMedium?.copyWith(
-                color: theme.colorScheme.onSurfaceVariant,
+                color: theme.colorScheme.onTertiaryContainer,
                 fontStyle: FontStyle.italic,
               ),
             ),

--- a/lib/src/modules/room/ui/room_screen.dart
+++ b/lib/src/modules/room/ui/room_screen.dart
@@ -8,6 +8,7 @@ import 'package:go_router/go_router.dart';
 import 'package:signals_flutter/signals_flutter.dart';
 import 'package:soliplex_client/soliplex_client.dart'
     show
+        MalformedResponseException,
         RagDocument,
         ReconnectFailed,
         ReconnectStatus,
@@ -882,9 +883,15 @@ class _RoomScreenState extends State<RoomScreen> {
                     child: CircularProgressIndicator(),
                   ),
                 MessagesFailed(:final error) => ErrorRetryPanel(
-                    title: 'Failed to load messages',
+                    title: error is MalformedResponseException
+                        ? "Couldn't display thread history"
+                        : 'Failed to load messages',
                     error: error,
-                    onRetry: threadView.refresh,
+                    // Shape-drift is a backend bug — retry won't help, so
+                    // hide the button rather than misleading the user.
+                    onRetry: error is MalformedResponseException
+                        ? null
+                        : threadView.refresh,
                   ),
                 MessagesLoaded(:final messages, :final messageStates) =>
                   computeDisplayMessages(messages, streaming).isEmpty

--- a/packages/soliplex_agent/lib/src/orchestration/ag_ui_llm_provider.dart
+++ b/packages/soliplex_agent/lib/src/orchestration/ag_ui_llm_provider.dart
@@ -5,8 +5,7 @@ import 'package:soliplex_client/soliplex_client.dart';
 /// AG-UI backend adapter implementing [AgentLlmProvider].
 ///
 /// Wraps [SoliplexApi] (run creation) and [AgUiStreamClient] (SSE streaming)
-/// into the unified [AgentLlmProvider] contract. Zero behavior change from
-/// the pre-Phase 3 wiring — this is a mechanical extraction.
+/// into the [AgentLlmProvider] contract.
 class AgUiLlmProvider implements AgentLlmProvider {
   /// Creates an [AgUiLlmProvider] from existing AG-UI clients.
   const AgUiLlmProvider({

--- a/packages/soliplex_agent/lib/src/orchestration/agent_llm_provider.dart
+++ b/packages/soliplex_agent/lib/src/orchestration/agent_llm_provider.dart
@@ -31,9 +31,9 @@ class LlmRunHandle {
 ///
 /// Two construction paths:
 /// - **AG-UI backend:** `AgUiLlmProvider` wraps `SoliplexApi` +
-///   `AgUiStreamClient` — the existing backend path.
-/// - **Direct SDK:** A future provider wrapping `soliplex_completions`
-///   providers, synthesizing AG-UI events from LLM responses.
+///   `AgUiStreamClient` for SSE-driven runs.
+/// - **Direct SDK:** providers wrapping `soliplex_completions`
+///   synthesize AG-UI events from LLM responses in-process.
 ///
 /// `RunOrchestrator` depends only on this interface, decoupling it from
 /// any specific backend.
@@ -43,7 +43,7 @@ abstract interface class AgentLlmProvider {
   ///
   /// The provider handles run creation internally. The returned
   /// `LlmRunHandle.events` stream yields `DecodeOutcome`s that
-  /// `RunOrchestrator` processes via the existing event pipeline.
+  /// `RunOrchestrator` projects into conversation state.
   ///
   /// [onReconnectStatus] receives SSE reconnect lifecycle updates from
   /// the AG-UI backend (the only provider that can drop and resume

--- a/packages/soliplex_agent/lib/src/orchestration/agent_llm_provider.dart
+++ b/packages/soliplex_agent/lib/src/orchestration/agent_llm_provider.dart
@@ -42,7 +42,7 @@ abstract interface class AgentLlmProvider {
   /// event stream.
   ///
   /// The provider handles run creation internally. The returned
-  /// `LlmRunHandle.events` stream yields `BaseEvent`s that
+  /// `LlmRunHandle.events` stream yields `DecodeOutcome`s that
   /// `RunOrchestrator` processes via the existing event pipeline.
   ///
   /// [onReconnectStatus] receives SSE reconnect lifecycle updates from

--- a/packages/soliplex_agent/lib/src/orchestration/agent_llm_provider.dart
+++ b/packages/soliplex_agent/lib/src/orchestration/agent_llm_provider.dart
@@ -5,9 +5,10 @@ import 'package:soliplex_client/soliplex_client.dart';
 /// Handle for an active LLM run.
 ///
 /// Returned by [AgentLlmProvider.startRun]. The [events] stream yields
-/// AG-UI `BaseEvent`s regardless of the underlying backend — backend
-/// implementations emit events natively, while direct-SDK implementations
-/// synthesize them from LLM responses.
+/// [DecodeOutcome]s — `DecodedEvent` for structurally-valid AG-UI events
+/// and `DecodeFailed` for payloads the live decoder couldn't parse.
+/// Backends that synthesize events in-process emit only `DecodedEvent`s;
+/// the AG-UI backend can emit either as it parses the SSE stream.
 @immutable
 class LlmRunHandle {
   /// Creates an [LlmRunHandle].
@@ -16,12 +17,14 @@ class LlmRunHandle {
   /// Unique identifier for this run.
   final String runId;
 
-  /// Stream of AG-UI events for the run.
+  /// Stream of decode outcomes for the run.
   ///
-  /// Terminates with `RunFinishedEvent` on success or `RunErrorEvent` on
-  /// failure. The stream may also end without a terminal event (network
-  /// loss), which `RunOrchestrator` handles as a failure.
-  final Stream<BaseEvent> events;
+  /// `DecodedEvent` arrivals terminate with `RunFinishedEvent` on success
+  /// or `RunErrorEvent` on failure. The stream may also end without a
+  /// terminal event (network loss), which `RunOrchestrator` handles as a
+  /// failure. `DecodeFailed` arrivals surface as drop tiles in the
+  /// conversation; the run continues processing subsequent events.
+  final Stream<DecodeOutcome> events;
 }
 
 /// Contract for backends that can drive agent runs.

--- a/packages/soliplex_agent/lib/src/orchestration/chat_fn_llm_provider.dart
+++ b/packages/soliplex_agent/lib/src/orchestration/chat_fn_llm_provider.dart
@@ -61,13 +61,13 @@ class ChatFnLlmProvider implements AgentLlmProvider {
     return LlmRunHandle(runId: runId, events: events);
   }
 
-  Stream<BaseEvent> _run(
+  Stream<DecodeOutcome> _run(
     ThreadKey key,
     SimpleRunAgentInput input,
     String runId,
     CancelToken? cancelToken,
   ) async* {
-    yield RunStartedEvent(threadId: key.threadId, runId: runId);
+    yield _wrap(RunStartedEvent(threadId: key.threadId, runId: runId));
 
     if (cancelToken?.isCancelled ?? false) return;
 
@@ -86,31 +86,31 @@ class ChatFnLlmProvider implements AgentLlmProvider {
       switch (parsed) {
         case TextResponse(:final text):
           final msgId = 'msg-${DateTime.now().microsecondsSinceEpoch}';
-          yield TextMessageStartEvent(messageId: msgId);
-          yield TextMessageContentEvent(messageId: msgId, delta: text);
-          yield TextMessageEndEvent(messageId: msgId);
+          yield _wrap(TextMessageStartEvent(messageId: msgId));
+          yield _wrap(TextMessageContentEvent(messageId: msgId, delta: text));
+          yield _wrap(TextMessageEndEvent(messageId: msgId));
 
         case ToolCallResponse(:final prefixText, :final name, :final arguments):
           if (prefixText.isNotEmpty) {
             final textMsgId =
                 'msg-text-${DateTime.now().microsecondsSinceEpoch}';
-            yield TextMessageStartEvent(messageId: textMsgId);
-            yield TextMessageContentEvent(
-              messageId: textMsgId,
-              delta: prefixText,
+            yield _wrap(TextMessageStartEvent(messageId: textMsgId));
+            yield _wrap(
+              TextMessageContentEvent(messageId: textMsgId, delta: prefixText),
             );
-            yield TextMessageEndEvent(messageId: textMsgId);
+            yield _wrap(TextMessageEndEvent(messageId: textMsgId));
           }
           final tcId = 'tc-${DateTime.now().microsecondsSinceEpoch}';
-          yield ToolCallStartEvent(toolCallId: tcId, toolCallName: name);
-          yield ToolCallArgsEvent(
-            toolCallId: tcId,
-            delta: jsonEncode(arguments),
+          yield _wrap(
+            ToolCallStartEvent(toolCallId: tcId, toolCallName: name),
           );
-          yield ToolCallEndEvent(toolCallId: tcId);
+          yield _wrap(
+            ToolCallArgsEvent(toolCallId: tcId, delta: jsonEncode(arguments)),
+          );
+          yield _wrap(ToolCallEndEvent(toolCallId: tcId));
       }
 
-      yield RunFinishedEvent(threadId: key.threadId, runId: runId);
+      yield _wrap(RunFinishedEvent(threadId: key.threadId, runId: runId));
     } on CancelledException {
       // Surface cancels as a stream error so the orchestrator routes
       // them to `CancelledState` via `_onStreamError`. Yielding a
@@ -119,9 +119,14 @@ class ChatFnLlmProvider implements AgentLlmProvider {
       rethrow;
     } on Object catch (e) {
       final msg = e is SoliplexException ? e.message : e.toString();
-      yield RunErrorEvent(message: msg);
+      yield _wrap(RunErrorEvent(message: msg));
     }
   }
+
+  /// `rawJson` is `const {}` because synthesized events have no source
+  /// JSON; if `processEvent` ever throws on one, the resulting drop tile
+  /// will carry an empty payload.
+  static DecodedEvent _wrap(BaseEvent event) => DecodedEvent(event, const {});
 
   /// Converts AG-UI messages to simple role/content pairs for the
   /// [ChatFn].

--- a/packages/soliplex_agent/lib/src/orchestration/chat_fn_llm_provider.dart
+++ b/packages/soliplex_agent/lib/src/orchestration/chat_fn_llm_provider.dart
@@ -5,6 +5,10 @@ import 'package:soliplex_agent/src/models/thread_key.dart';
 import 'package:soliplex_agent/src/orchestration/agent_llm_provider.dart';
 import 'package:soliplex_agent/src/orchestration/tool_call_parser.dart';
 import 'package:soliplex_client/soliplex_client.dart';
+import 'package:soliplex_logging/soliplex_logging.dart';
+
+final Logger _logger =
+    LogManager.instance.getLogger('soliplex_agent.chat_fn_llm_provider');
 
 /// Callback type for LLM chat.
 ///
@@ -30,9 +34,9 @@ typedef ChatFn = Future<String> Function(
 ///
 /// Wraps a [ChatFn] callback, converts AG-UI messages to simple
 /// role/content pairs, and synthesizes AG-UI events from the LLM's
-/// text response. Tool calling uses a text-based protocol (Phase 1)
-/// — the system prompt instructs the LLM to emit fenced `tool_call`
-/// blocks that [parseToolCallResponse] extracts.
+/// text response. Tool calling uses a text-based protocol — the
+/// system prompt instructs the LLM to emit fenced `tool_call` blocks
+/// that [parseToolCallResponse] extracts.
 class ChatFnLlmProvider implements AgentLlmProvider {
   /// Creates a [ChatFnLlmProvider].
   ///
@@ -125,7 +129,12 @@ class ChatFnLlmProvider implements AgentLlmProvider {
       // `RunErrorEvent` would land in `FailedState(serverError)` with
       // the runtime-type stringified into the user-facing message.
       rethrow;
-    } on Object catch (e) {
+    } on Object catch (e, st) {
+      _logger.error(
+        'ChatFnLlmProvider run failed',
+        error: e,
+        stackTrace: st,
+      );
       final msg = e is SoliplexException ? e.message : e.toString();
       yield synthesizedDecoded(RunErrorEvent(message: msg));
     }

--- a/packages/soliplex_agent/lib/src/orchestration/chat_fn_llm_provider.dart
+++ b/packages/soliplex_agent/lib/src/orchestration/chat_fn_llm_provider.dart
@@ -67,7 +67,9 @@ class ChatFnLlmProvider implements AgentLlmProvider {
     String runId,
     CancelToken? cancelToken,
   ) async* {
-    yield _wrap(RunStartedEvent(threadId: key.threadId, runId: runId));
+    yield synthesizedDecoded(
+      RunStartedEvent(threadId: key.threadId, runId: runId),
+    );
 
     if (cancelToken?.isCancelled ?? false) return;
 
@@ -86,31 +88,37 @@ class ChatFnLlmProvider implements AgentLlmProvider {
       switch (parsed) {
         case TextResponse(:final text):
           final msgId = 'msg-${DateTime.now().microsecondsSinceEpoch}';
-          yield _wrap(TextMessageStartEvent(messageId: msgId));
-          yield _wrap(TextMessageContentEvent(messageId: msgId, delta: text));
-          yield _wrap(TextMessageEndEvent(messageId: msgId));
+          yield synthesizedDecoded(TextMessageStartEvent(messageId: msgId));
+          yield synthesizedDecoded(
+            TextMessageContentEvent(messageId: msgId, delta: text),
+          );
+          yield synthesizedDecoded(TextMessageEndEvent(messageId: msgId));
 
         case ToolCallResponse(:final prefixText, :final name, :final arguments):
           if (prefixText.isNotEmpty) {
             final textMsgId =
                 'msg-text-${DateTime.now().microsecondsSinceEpoch}';
-            yield _wrap(TextMessageStartEvent(messageId: textMsgId));
-            yield _wrap(
+            yield synthesizedDecoded(
+              TextMessageStartEvent(messageId: textMsgId),
+            );
+            yield synthesizedDecoded(
               TextMessageContentEvent(messageId: textMsgId, delta: prefixText),
             );
-            yield _wrap(TextMessageEndEvent(messageId: textMsgId));
+            yield synthesizedDecoded(TextMessageEndEvent(messageId: textMsgId));
           }
           final tcId = 'tc-${DateTime.now().microsecondsSinceEpoch}';
-          yield _wrap(
+          yield synthesizedDecoded(
             ToolCallStartEvent(toolCallId: tcId, toolCallName: name),
           );
-          yield _wrap(
+          yield synthesizedDecoded(
             ToolCallArgsEvent(toolCallId: tcId, delta: jsonEncode(arguments)),
           );
-          yield _wrap(ToolCallEndEvent(toolCallId: tcId));
+          yield synthesizedDecoded(ToolCallEndEvent(toolCallId: tcId));
       }
 
-      yield _wrap(RunFinishedEvent(threadId: key.threadId, runId: runId));
+      yield synthesizedDecoded(
+        RunFinishedEvent(threadId: key.threadId, runId: runId),
+      );
     } on CancelledException {
       // Surface cancels as a stream error so the orchestrator routes
       // them to `CancelledState` via `_onStreamError`. Yielding a
@@ -119,14 +127,9 @@ class ChatFnLlmProvider implements AgentLlmProvider {
       rethrow;
     } on Object catch (e) {
       final msg = e is SoliplexException ? e.message : e.toString();
-      yield _wrap(RunErrorEvent(message: msg));
+      yield synthesizedDecoded(RunErrorEvent(message: msg));
     }
   }
-
-  /// `rawJson` is `const {}` because synthesized events have no source
-  /// JSON; if `processEvent` ever throws on one, the resulting drop tile
-  /// will carry an empty payload.
-  static DecodedEvent _wrap(BaseEvent event) => DecodedEvent(event, const {});
 
   /// Converts AG-UI messages to simple role/content pairs for the
   /// [ChatFn].

--- a/packages/soliplex_agent/lib/src/orchestration/run_orchestrator.dart
+++ b/packages/soliplex_agent/lib/src/orchestration/run_orchestrator.dart
@@ -906,7 +906,7 @@ class RunOrchestrator {
     required DropSource source,
     required Object error,
     required StackTrace? stackTrace,
-    required Object rawData,
+    required Object? rawData,
     required int eventIndex,
     Type? eventTypeForLog,
   }) {

--- a/packages/soliplex_agent/lib/src/orchestration/run_orchestrator.dart
+++ b/packages/soliplex_agent/lib/src/orchestration/run_orchestrator.dart
@@ -1,6 +1,5 @@
 import 'dart:async';
 
-import 'package:meta/meta.dart';
 import 'package:soliplex_agent/src/models/failure_reason.dart';
 import 'package:soliplex_agent/src/models/thread_key.dart';
 import 'package:soliplex_agent/src/orchestration/agent_llm_provider.dart';
@@ -65,21 +64,15 @@ typedef ToolExecutorCallback = Future<List<ToolCallInfo>> Function(
 /// (JSON Schema). The backend rejects tool definitions without it.
 class RunOrchestrator {
   /// Creates a [RunOrchestrator] with the given dependencies.
-  ///
-  /// [citationExtractor] is an injection point for tests that need to
-  /// observe failure paths inside [_extractCitations]. Production callers
-  /// leave it null and get the default [CitationExtractor].
   RunOrchestrator({
     required AgentLlmProvider llmProvider,
     required ToolRegistry toolRegistry,
     required Logger logger,
     int maxToolDepth = defaultMaxToolDepth,
-    @visibleForTesting CitationExtractor? citationExtractor,
   })  : _llmProvider = llmProvider,
         _toolRegistry = toolRegistry,
         _logger = logger,
-        _maxToolDepth = maxToolDepth,
-        _citationExtractor = citationExtractor ?? CitationExtractor();
+        _maxToolDepth = maxToolDepth;
 
   /// Default maximum tool-call depth before the orchestrator aborts.
   static const defaultMaxToolDepth = 10;
@@ -89,7 +82,7 @@ class RunOrchestrator {
   final Logger _logger;
   final int _maxToolDepth;
 
-  final CitationExtractor _citationExtractor;
+  final CitationExtractor _citationExtractor = CitationExtractor();
 
   Map<String, dynamic> _preRunAguiState = const {};
   String? _userMessageId;
@@ -1012,9 +1005,13 @@ class RunOrchestrator {
   /// final [MessageState] carries the last segment's run ID — the one whose
   /// output the user sees and may submit feedback on.
   ///
-  /// Catches any throw downstream (extractor schema drift, malformed
-  /// citations) and returns the conversation unchanged so the run
-  /// completes. The throw bypasses the [_preRunAguiState] update so the
+  /// `CitationExtractor.extractNew` calls into generated schema types
+  /// (`RagSnapshot.resolveCitation`, `SourceReference`'s ctor on
+  /// non-null fields the wire might omit) — schema drift can surface
+  /// here as a runtime throw. The catch returns the conversation
+  /// unchanged so the run still completes, mirroring the existing
+  /// catch-and-log pattern around `RagSnapshot.fromJson` one layer
+  /// down. The throw bypasses the [_preRunAguiState] update so the
   /// next run's diff still resolves against the prior baseline; only
   /// this segment's citations are skipped. No drop tile — citations
   /// are a derived projection, not user-facing content.

--- a/packages/soliplex_agent/lib/src/orchestration/run_orchestrator.dart
+++ b/packages/soliplex_agent/lib/src/orchestration/run_orchestrator.dart
@@ -861,13 +861,11 @@ class RunOrchestrator {
   void _onEvent(DecodeOutcome outcome) {
     final eventIndex = _liveEventCounter++;
     switch (outcome) {
-      case DecodeFailed(:final error, :final rawData):
-        // Decode failures never reach the tracker — there's no decoded
-        // event to project. Surface as a tile in the conversation and
-        // continue processing the next event in the stream.
+      case DecodeFailed(:final error, :final rawData, :final stackTrace):
         _appendDropTile(
           source: DropSource.decode,
           error: error,
+          stackTrace: stackTrace,
           rawData: rawData,
           eventIndex: eventIndex,
         );
@@ -882,39 +880,45 @@ class RunOrchestrator {
               processEvent(running.conversation, running.streaming, event);
           _mapEventResult(running, result, event);
         } on Object catch (e, st) {
-          _logger.error(
-            'processEvent threw on ${event.runtimeType}',
-            error: e,
-            stackTrace: st,
-          );
           _appendDropTile(
             source: DropSource.eventProcessing,
             error: e,
+            stackTrace: st,
             rawData: rawJson,
             eventIndex: eventIndex,
+            eventTypeForLog: event.runtimeType,
           );
         }
     }
   }
 
-  /// Appends a [DroppedEventMessage] to the running conversation. No-op
-  /// when the orchestrator isn't in [RunningState] (e.g., a stray event
-  /// after terminal cleanup) — those drops are logged at warning so the
-  /// gap is observable without hitting the conversation.
+  /// Appends a [DroppedEventMessage] to the running conversation and
+  /// logs at error with [stackTrace] so Sentry / `BackendLogSink` get a
+  /// breadcrumb. No-op when the orchestrator isn't in [RunningState]
+  /// (a stray event after terminal cleanup) — that path also logs with
+  /// the stack so the gap stays observable.
   void _appendDropTile({
     required DropSource source,
     required Object error,
+    required StackTrace? stackTrace,
     required Object rawData,
     required int eventIndex,
+    Type? eventTypeForLog,
   }) {
+    final logMessage = eventTypeForLog == null
+        ? 'Dropped event (${source.name})'
+        : 'processEvent threw on $eventTypeForLog';
+    _logger.error(logMessage, error: error, stackTrace: stackTrace);
+
     final running = _currentState;
     if (running is! RunningState) {
       _logger.warning(
         'Drop tile not appended: orchestrator not in RunningState',
+        error: error,
+        stackTrace: stackTrace,
         attributes: {
           'state': running.runtimeType.toString(),
           'source': source.name,
-          'error': error.toString(),
         },
       );
       return;

--- a/packages/soliplex_agent/lib/src/orchestration/run_orchestrator.dart
+++ b/packages/soliplex_agent/lib/src/orchestration/run_orchestrator.dart
@@ -108,13 +108,9 @@ class RunOrchestrator {
   /// `events[i]`. The replay path
   /// (`SoliplexApi._replayEventsToHistory`) increments its loop index
   /// once per stored event; this counter increments once per outcome.
-  /// They produce identical drop-tile ids when those two cardinalities
-  /// match — i.e., the AG-UI backend must store one event per
-  /// outcome the live decoder produces. If a future change makes
-  /// `AgUiStreamClient._decodeOne` emit multiple outcomes per stored
-  /// event (e.g., persisting batched SSE frames verbatim), reload-time
-  /// drop ids will diverge from the live ids and the conversation
-  /// will not round-trip.
+  /// Drop-tile ids only round-trip when those cardinalities match —
+  /// i.e., the AG-UI backend must store one event per outcome the live
+  /// decoder produces.
   int _liveEventCounter = 0;
 
   // runToCompletion infrastructure
@@ -132,14 +128,15 @@ class RunOrchestrator {
   /// Broadcast stream of state transitions.
   Stream<RunState> get stateChanges => _controller.stream;
 
-  /// Broadcast stream of structurally-valid AG-UI events received on the
-  /// active subscription.
+  /// Broadcast stream of AG-UI events whose application-layer
+  /// processing succeeded on the active subscription.
   ///
   /// Used by `AgentSession` to bridge server-side events into the
   /// `ExecutionEvent` signal without duplicating event processing logic.
-  /// Decode failures are surfaced as [DroppedEventMessage] tiles in the
-  /// conversation and never reach this stream — the tracker only sees
-  /// events the decoder accepted.
+  /// Decode failures and `processEvent` throws surface as
+  /// [DroppedEventMessage] tiles in the conversation and never reach
+  /// this stream, so a tracker observing it stays consistent with the
+  /// conversation state.
   Stream<BaseEvent> get baseEvents => _baseEventController.stream;
 
   /// The current cancellation token for the active run.
@@ -875,9 +872,6 @@ class RunOrchestrator {
           eventIndex: eventIndex,
         );
       case DecodedEvent(:final event, :final rawJson):
-        if (!_baseEventController.isClosed) {
-          _baseEventController.add(event);
-        }
         final running = _currentState;
         if (running is! RunningState) return;
         try {
@@ -893,15 +887,21 @@ class RunOrchestrator {
             eventIndex: eventIndex,
             eventTypeForLog: event.runtimeType,
           );
+          return;
+        }
+        if (!_baseEventController.isClosed) {
+          _baseEventController.add(event);
         }
     }
   }
 
   /// Appends a [DroppedEventMessage] to the running conversation and
   /// logs at error with [stackTrace] so Sentry / `BackendLogSink` get a
-  /// breadcrumb. No-op when the orchestrator isn't in [RunningState]
-  /// (a stray event after terminal cleanup) — that path also logs with
-  /// the stack so the gap stays observable.
+  /// breadcrumb. When the orchestrator isn't in [RunningState] (a
+  /// stray event after terminal cleanup), the tile can't be appended;
+  /// the original error is already logged at error severity above, so
+  /// the unappended-tile branch logs at warning severity to avoid a
+  /// duplicate page while still leaving an audit breadcrumb.
   void _appendDropTile({
     required DropSource source,
     required Object error,
@@ -1027,12 +1027,11 @@ class RunOrchestrator {
   /// data-drift and programming bugs — propagating instead would
   /// abort a working run with no user benefit. Logged at `error`
   /// with stack trace so Sentry / `BackendLogSink` still surface
-  /// real bugs. Mirrors the existing catch-and-log pattern around
-  /// `RagSnapshot.fromJson` one layer down. The throw bypasses the
-  /// [_preRunAguiState] update at the next line so the next run's
-  /// diff still resolves against the prior baseline; only this
-  /// segment's citations are skipped. No drop tile — citations are
-  /// a derived projection, not user-facing content.
+  /// real bugs. The throw bypasses the [_preRunAguiState] update at
+  /// the next line so the next run's diff still resolves against the
+  /// prior baseline; only this segment's citations are skipped. No
+  /// drop tile — citations are a derived projection, not user-facing
+  /// content.
   Conversation _extractCitations(Conversation conversation, String runId) {
     try {
       final userMessageId = _userMessageId;

--- a/packages/soliplex_agent/lib/src/orchestration/run_orchestrator.dart
+++ b/packages/soliplex_agent/lib/src/orchestration/run_orchestrator.dart
@@ -1014,9 +1014,10 @@ class RunOrchestrator {
   ///
   /// Catches any throw downstream (extractor schema drift, malformed
   /// citations) and returns the conversation unchanged so the run
-  /// completes. Citation index drifts until the next run updates it;
-  /// messages still render. No drop tile — citations are a derived
-  /// projection, not user-facing content.
+  /// completes. The throw bypasses the [_preRunAguiState] update so the
+  /// next run's diff still resolves against the prior baseline; only
+  /// this segment's citations are skipped. No drop tile — citations
+  /// are a derived projection, not user-facing content.
   Conversation _extractCitations(Conversation conversation, String runId) {
     try {
       final userMessageId = _userMessageId;

--- a/packages/soliplex_agent/lib/src/orchestration/run_orchestrator.dart
+++ b/packages/soliplex_agent/lib/src/orchestration/run_orchestrator.dart
@@ -96,9 +96,14 @@ class RunOrchestrator {
   bool _disposed = false;
   bool _disposing = false;
   CancelToken? _cancelToken;
-  StreamSubscription<BaseEvent>? _subscription;
+  StreamSubscription<DecodeOutcome>? _subscription;
   bool _receivedTerminalEvent = false;
   int _toolDepth = 0;
+
+  /// Index for the next event observed on the active subscription. Reset
+  /// in [_subscribeToStream] so each run mints monotonically increasing
+  /// drop-tile ids that pair with that run's id.
+  int _liveEventCounter = 0;
 
   // runToCompletion infrastructure
   Completer<RunState>? _terminalCompleter;
@@ -115,10 +120,14 @@ class RunOrchestrator {
   /// Broadcast stream of state transitions.
   Stream<RunState> get stateChanges => _controller.stream;
 
-  /// Broadcast stream of raw AG-UI events received from the SSE connection.
+  /// Broadcast stream of structurally-valid AG-UI events received on the
+  /// active subscription.
   ///
   /// Used by `AgentSession` to bridge server-side events into the
   /// `ExecutionEvent` signal without duplicating event processing logic.
+  /// Decode failures are surfaced as [DroppedEventMessage] tiles in the
+  /// conversation and never reach this stream — the tracker only sees
+  /// events the decoder accepted.
   Stream<BaseEvent> get baseEvents => _baseEventController.stream;
 
   /// The current cancellation token for the active run.
@@ -445,7 +454,7 @@ class RunOrchestrator {
   /// cancelling releases the underlying socket. `onError` routes through
   /// `Logger.error` so a future bug landing here from a non-cancel path
   /// leaves a Sentry-grade breadcrumb instead of an unhandled future.
-  void _drainUnownedStream(Stream<BaseEvent> events, String errorMessage) {
+  void _drainUnownedStream(Stream<DecodeOutcome> events, String errorMessage) {
     unawaited(
       events
           .listen(
@@ -815,7 +824,7 @@ class RunOrchestrator {
   }
 
   void _subscribeToStream(
-    Stream<BaseEvent> events,
+    Stream<DecodeOutcome> events,
     RunningState initialState,
   ) {
     // Cancel stale subscription from the previous run.
@@ -827,6 +836,7 @@ class RunOrchestrator {
     _subscription = null;
     _cancelToken ??= CancelToken();
     _receivedTerminalEvent = false;
+    _liveEventCounter = 0;
     _terminalCompleter = Completer<RunState>();
     _subscriptionEpoch++;
     final epoch = _subscriptionEpoch;
@@ -841,14 +851,80 @@ class RunOrchestrator {
     );
   }
 
-  void _onEvent(BaseEvent event) {
-    if (!_baseEventController.isClosed) {
-      _baseEventController.add(event);
+  void _onEvent(DecodeOutcome outcome) {
+    final eventIndex = _liveEventCounter++;
+    switch (outcome) {
+      case DecodeFailed(:final error, :final rawData):
+        // Decode failures never reach the tracker — there's no decoded
+        // event to project. Surface as a tile in the conversation and
+        // continue processing the next event in the stream.
+        _appendDropTile(
+          source: DropSource.decode,
+          error: error,
+          rawData: rawData,
+          eventIndex: eventIndex,
+        );
+      case DecodedEvent(:final event, :final rawJson):
+        if (!_baseEventController.isClosed) {
+          _baseEventController.add(event);
+        }
+        final running = _currentState;
+        if (running is! RunningState) return;
+        try {
+          final result =
+              processEvent(running.conversation, running.streaming, event);
+          _mapEventResult(running, result, event);
+        } on Object catch (e, st) {
+          _logger.error(
+            'processEvent threw on ${event.runtimeType}',
+            error: e,
+            stackTrace: st,
+          );
+          _appendDropTile(
+            source: DropSource.eventProcessing,
+            error: e,
+            rawData: rawJson,
+            eventIndex: eventIndex,
+          );
+        }
     }
+  }
+
+  /// Appends a [DroppedEventMessage] to the running conversation. No-op
+  /// when the orchestrator isn't in [RunningState] (e.g., a stray event
+  /// after terminal cleanup) — those drops are logged at warning so the
+  /// gap is observable without hitting the conversation.
+  void _appendDropTile({
+    required DropSource source,
+    required Object error,
+    required Object rawData,
+    required int eventIndex,
+  }) {
     final running = _currentState;
-    if (running is! RunningState) return;
-    final result = processEvent(running.conversation, running.streaming, event);
-    _mapEventResult(running, result, event);
+    if (running is! RunningState) {
+      _logger.warning(
+        'Drop tile not appended: orchestrator not in RunningState',
+        attributes: {
+          'state': running.runtimeType.toString(),
+          'source': source.name,
+          'error': error.toString(),
+        },
+      );
+      return;
+    }
+    final id = 'dropped-${running.runId}-$eventIndex';
+    final tile = DroppedEventMessage.create(
+      id: id,
+      source: source,
+      reason: error.toString(),
+      runId: running.runId,
+      rawPayload: rawData is Map<String, dynamic> ? rawData : null,
+    );
+    _setState(
+      running.copyWith(
+        conversation: running.conversation.withAppendedMessage(tile),
+      ),
+    );
   }
 
   void _mapEventResult(

--- a/packages/soliplex_agent/lib/src/orchestration/run_orchestrator.dart
+++ b/packages/soliplex_agent/lib/src/orchestration/run_orchestrator.dart
@@ -103,6 +103,18 @@ class RunOrchestrator {
   /// Index for the next event observed on the active subscription. Reset
   /// in [_subscribeToStream] so each run mints monotonically increasing
   /// drop-tile ids that pair with that run's id.
+  ///
+  /// Cross-path id alignment assumes one [DecodeOutcome] per backend-stored
+  /// `events[i]`. The replay path
+  /// (`SoliplexApi._replayEventsToHistory`) increments its loop index
+  /// once per stored event; this counter increments once per outcome.
+  /// They produce identical drop-tile ids when those two cardinalities
+  /// match — i.e., the AG-UI backend must store one event per
+  /// outcome the live decoder produces. If a future change makes
+  /// `AgUiStreamClient._decodeOne` emit multiple outcomes per stored
+  /// event (e.g., persisting batched SSE frames verbatim), reload-time
+  /// drop ids will diverge from the live ids and the conversation
+  /// will not round-trip.
   int _liveEventCounter = 0;
 
   // runToCompletion infrastructure
@@ -1008,13 +1020,19 @@ class RunOrchestrator {
   /// `CitationExtractor.extractNew` calls into generated schema types
   /// (`RagSnapshot.resolveCitation`, `SourceReference`'s ctor on
   /// non-null fields the wire might omit) — schema drift can surface
-  /// here as a runtime throw. The catch returns the conversation
-  /// unchanged so the run still completes, mirroring the existing
-  /// catch-and-log pattern around `RagSnapshot.fromJson` one layer
-  /// down. The throw bypasses the [_preRunAguiState] update so the
-  /// next run's diff still resolves against the prior baseline; only
-  /// this segment's citations are skipped. No drop tile — citations
-  /// are a derived projection, not user-facing content.
+  /// here as `FormatException`, `TypeError` (null on non-null), or
+  /// other generated-type throws. Catching `Object` is deliberate:
+  /// citations are a derived projection, so fail-soft (skip
+  /// citations, complete the run) is the right UX for both
+  /// data-drift and programming bugs — propagating instead would
+  /// abort a working run with no user benefit. Logged at `error`
+  /// with stack trace so Sentry / `BackendLogSink` still surface
+  /// real bugs. Mirrors the existing catch-and-log pattern around
+  /// `RagSnapshot.fromJson` one layer down. The throw bypasses the
+  /// [_preRunAguiState] update at the next line so the next run's
+  /// diff still resolves against the prior baseline; only this
+  /// segment's citations are skipped. No drop tile — citations are
+  /// a derived projection, not user-facing content.
   Conversation _extractCitations(Conversation conversation, String runId) {
     try {
       final userMessageId = _userMessageId;
@@ -1045,7 +1063,7 @@ class RunOrchestrator {
       );
       return conversation.withMessageState(userMessageId, messageState);
     } on Object catch (e, st) {
-      _logger.warning(
+      _logger.error(
         'Citation extraction failed for run $runId',
         error: e,
         stackTrace: st,

--- a/packages/soliplex_agent/lib/src/orchestration/run_orchestrator.dart
+++ b/packages/soliplex_agent/lib/src/orchestration/run_orchestrator.dart
@@ -1008,11 +1008,11 @@ class RunOrchestrator {
   /// final [MessageState] carries the last segment's run ID — the one whose
   /// output the user sees and may submit feedback on.
   ///
-  /// Wraps the body in a Tier-1 catch: any throw downstream (extractor
-  /// schema drift, malformed citations) returns the conversation unchanged
-  /// so the run completes. Citation index drifts until the next run
-  /// updates it; messages still render. No drop tile — citations are a
-  /// derived projection, not user-facing content.
+  /// Catches any throw downstream (extractor schema drift, malformed
+  /// citations) and returns the conversation unchanged so the run
+  /// completes. Citation index drifts until the next run updates it;
+  /// messages still render. No drop tile — citations are a derived
+  /// projection, not user-facing content.
   Conversation _extractCitations(Conversation conversation, String runId) {
     try {
       final userMessageId = _userMessageId;

--- a/packages/soliplex_agent/lib/src/orchestration/run_orchestrator.dart
+++ b/packages/soliplex_agent/lib/src/orchestration/run_orchestrator.dart
@@ -929,7 +929,7 @@ class RunOrchestrator {
       source: source,
       reason: error.toString(),
       runId: running.runId,
-      rawPayload: rawData is Map<String, dynamic> ? rawData : null,
+      rawPayload: rawData,
     );
     _setState(
       running.copyWith(

--- a/packages/soliplex_agent/lib/src/orchestration/run_orchestrator.dart
+++ b/packages/soliplex_agent/lib/src/orchestration/run_orchestrator.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 
+import 'package:meta/meta.dart';
 import 'package:soliplex_agent/src/models/failure_reason.dart';
 import 'package:soliplex_agent/src/models/thread_key.dart';
 import 'package:soliplex_agent/src/orchestration/agent_llm_provider.dart';
@@ -64,15 +65,21 @@ typedef ToolExecutorCallback = Future<List<ToolCallInfo>> Function(
 /// (JSON Schema). The backend rejects tool definitions without it.
 class RunOrchestrator {
   /// Creates a [RunOrchestrator] with the given dependencies.
+  ///
+  /// [citationExtractor] is an injection point for tests that need to
+  /// observe failure paths inside [_extractCitations]. Production callers
+  /// leave it null and get the default [CitationExtractor].
   RunOrchestrator({
     required AgentLlmProvider llmProvider,
     required ToolRegistry toolRegistry,
     required Logger logger,
     int maxToolDepth = defaultMaxToolDepth,
+    @visibleForTesting CitationExtractor? citationExtractor,
   })  : _llmProvider = llmProvider,
         _toolRegistry = toolRegistry,
         _logger = logger,
-        _maxToolDepth = maxToolDepth;
+        _maxToolDepth = maxToolDepth,
+        _citationExtractor = citationExtractor ?? CitationExtractor();
 
   /// Default maximum tool-call depth before the orchestrator aborts.
   static const defaultMaxToolDepth = 10;
@@ -82,7 +89,7 @@ class RunOrchestrator {
   final Logger _logger;
   final int _maxToolDepth;
 
-  final CitationExtractor _citationExtractor = CitationExtractor();
+  final CitationExtractor _citationExtractor;
 
   Map<String, dynamic> _preRunAguiState = const {};
   String? _userMessageId;
@@ -1000,34 +1007,49 @@ class RunOrchestrator {
   /// In multi-segment tool loops, [runId] is overwritten each segment so the
   /// final [MessageState] carries the last segment's run ID — the one whose
   /// output the user sees and may submit feedback on.
+  ///
+  /// Wraps the body in a Tier-1 catch: any throw downstream (extractor
+  /// schema drift, malformed citations) returns the conversation unchanged
+  /// so the run completes. Citation index drifts until the next run
+  /// updates it; messages still render. No drop tile — citations are a
+  /// derived projection, not user-facing content.
   Conversation _extractCitations(Conversation conversation, String runId) {
-    final userMessageId = _userMessageId;
-    if (userMessageId == null) return conversation;
+    try {
+      final userMessageId = _userMessageId;
+      if (userMessageId == null) return conversation;
 
-    final citations = _citationExtractor.extractNew(
-      _preRunAguiState,
-      conversation.aguiState,
-    );
-    _preRunAguiState = conversation.aguiState;
+      final citations = _citationExtractor.extractNew(
+        _preRunAguiState,
+        conversation.aguiState,
+      );
+      _preRunAguiState = conversation.aguiState;
 
-    final existing = conversation.messageStates[userMessageId];
-    final seenChunkIds = <String>{};
-    final mergedCitations = <SourceReference>[];
-    for (final ref in [
-      if (existing != null) ...existing.sourceReferences,
-      ...citations,
-    ]) {
-      if (seenChunkIds.add(ref.chunkId)) {
-        mergedCitations.add(ref);
+      final existing = conversation.messageStates[userMessageId];
+      final seenChunkIds = <String>{};
+      final mergedCitations = <SourceReference>[];
+      for (final ref in [
+        if (existing != null) ...existing.sourceReferences,
+        ...citations,
+      ]) {
+        if (seenChunkIds.add(ref.chunkId)) {
+          mergedCitations.add(ref);
+        }
       }
-    }
 
-    final messageState = MessageState(
-      userMessageId: userMessageId,
-      sourceReferences: mergedCitations,
-      runId: runId,
-    );
-    return conversation.withMessageState(userMessageId, messageState);
+      final messageState = MessageState(
+        userMessageId: userMessageId,
+        sourceReferences: mergedCitations,
+        runId: runId,
+      );
+      return conversation.withMessageState(userMessageId, messageState);
+    } on Object catch (e, st) {
+      _logger.warning(
+        'Citation extraction failed for run $runId',
+        error: e,
+        stackTrace: st,
+      );
+      return conversation;
+    }
   }
 
   void _onStreamDone() {

--- a/packages/soliplex_agent/lib/src/orchestration/streaming_llm_provider.dart
+++ b/packages/soliplex_agent/lib/src/orchestration/streaming_llm_provider.dart
@@ -46,13 +46,13 @@ class StreamingLlmProvider implements AgentLlmProvider {
     return LlmRunHandle(runId: runId, events: events);
   }
 
-  Stream<BaseEvent> _run(
+  Stream<DecodeOutcome> _run(
     ThreadKey key,
     SimpleRunAgentInput input,
     String runId,
     CancelToken? cancelToken,
   ) async* {
-    yield RunStartedEvent(threadId: key.threadId, runId: runId);
+    yield _wrap(RunStartedEvent(threadId: key.threadId, runId: runId));
 
     if (cancelToken?.isCancelled ?? false) return;
 
@@ -84,48 +84,52 @@ class StreamingLlmProvider implements AgentLlmProvider {
             if (currentMsgId == null) {
               final msgId = 'msg-${DateTime.now().microsecondsSinceEpoch}';
               currentMsgId = msgId;
-              yield TextMessageStartEvent(messageId: msgId);
+              yield _wrap(TextMessageStartEvent(messageId: msgId));
             }
-            yield TextMessageContentEvent(messageId: currentMsgId, delta: text);
+            yield _wrap(
+              TextMessageContentEvent(messageId: currentMsgId, delta: text),
+            );
 
           case LlmTextDone():
             if (currentMsgId case final msgId?) {
-              yield TextMessageEndEvent(messageId: msgId);
+              yield _wrap(TextMessageEndEvent(messageId: msgId));
               currentMsgId = null;
             }
 
           case LlmToolCallStart(:final callId, :final name):
             // Close any open text message first.
             if (currentMsgId case final msgId?) {
-              yield TextMessageEndEvent(messageId: msgId);
+              yield _wrap(TextMessageEndEvent(messageId: msgId));
               currentMsgId = null;
             }
-            yield ToolCallStartEvent(toolCallId: callId, toolCallName: name);
+            yield _wrap(
+              ToolCallStartEvent(toolCallId: callId, toolCallName: name),
+            );
 
           case LlmToolCallArgsDelta(:final callId, :final delta):
-            yield ToolCallArgsEvent(toolCallId: callId, delta: delta);
+            yield _wrap(ToolCallArgsEvent(toolCallId: callId, delta: delta));
 
           case LlmToolCallDone(:final callId):
-            yield ToolCallEndEvent(toolCallId: callId);
+            yield _wrap(ToolCallEndEvent(toolCallId: callId));
 
           case LlmDone():
             if (currentMsgId case final msgId?) {
-              yield TextMessageEndEvent(messageId: msgId);
+              yield _wrap(TextMessageEndEvent(messageId: msgId));
             }
-            yield RunFinishedEvent(threadId: key.threadId, runId: runId);
+            yield _wrap(RunFinishedEvent(threadId: key.threadId, runId: runId));
             return;
 
           case LlmError(:final message):
-            yield RunErrorEvent(message: message);
+            yield _wrap(RunErrorEvent(message: message));
             return;
         }
       }
 
       // Stream ended without explicit done — synthesize finish.
       if (currentMsgId case final msgId?) {
-        yield TextMessageEndEvent(messageId: msgId);
+        yield _wrap(TextMessageEndEvent(messageId: msgId));
       }
-      yield RunFinishedEvent(threadId: key.threadId, runId: runId);
+      yield _wrap(RunFinishedEvent(threadId: key.threadId, runId: runId));
     } on CancelledException {
       // Surface cancels as a stream error so the orchestrator routes
       // them to `CancelledState` via `_onStreamError`. Yielding a
@@ -134,9 +138,14 @@ class StreamingLlmProvider implements AgentLlmProvider {
       rethrow;
     } on Object catch (e) {
       final msg = e is SoliplexException ? e.message : e.toString();
-      yield RunErrorEvent(message: msg);
+      yield _wrap(RunErrorEvent(message: msg));
     }
   }
+
+  /// `rawJson` is `const {}` because synthesized events have no source
+  /// JSON; if `processEvent` ever throws on one, the resulting drop tile
+  /// will carry an empty payload.
+  static DecodedEvent _wrap(BaseEvent event) => DecodedEvent(event, const {});
 
   List<LlmChatMessage> _convertMessages(SimpleRunAgentInput input) {
     final result = <LlmChatMessage>[];

--- a/packages/soliplex_agent/lib/src/orchestration/streaming_llm_provider.dart
+++ b/packages/soliplex_agent/lib/src/orchestration/streaming_llm_provider.dart
@@ -23,9 +23,9 @@ typedef StreamingChatFn = Stream<LlmEvent> Function({
 /// [AgentLlmProvider] backed by a streaming LLM callback with native
 /// tool calling support.
 ///
-/// Maps [LlmEvent] to AG-UI [BaseEvent] in real-time.
-/// Replaces `ChatFnLlmProvider` for providers that support streaming
-/// and native tool calling (via open_responses).
+/// Maps [LlmEvent] to AG-UI [BaseEvent] in real-time. Use for providers
+/// that support streaming and native tool calling (via open_responses);
+/// non-streaming providers go through `ChatFnLlmProvider` instead.
 class StreamingLlmProvider implements AgentLlmProvider {
   /// Creates a [StreamingLlmProvider].
   StreamingLlmProvider({required StreamingChatFn chatFn, this.systemPrompt})

--- a/packages/soliplex_agent/lib/src/orchestration/streaming_llm_provider.dart
+++ b/packages/soliplex_agent/lib/src/orchestration/streaming_llm_provider.dart
@@ -3,6 +3,10 @@ import 'dart:async';
 import 'package:soliplex_agent/src/models/thread_key.dart';
 import 'package:soliplex_agent/src/orchestration/agent_llm_provider.dart';
 import 'package:soliplex_client/soliplex_client.dart';
+import 'package:soliplex_logging/soliplex_logging.dart';
+
+final Logger _logger =
+    LogManager.instance.getLogger('soliplex_agent.streaming_llm_provider');
 
 /// Callback type for streaming LLM chat with tool support.
 ///
@@ -144,7 +148,12 @@ class StreamingLlmProvider implements AgentLlmProvider {
       // `RunErrorEvent` would land in `FailedState(serverError)` with
       // the runtime-type stringified into the user-facing message.
       rethrow;
-    } on Object catch (e) {
+    } on Object catch (e, st) {
+      _logger.error(
+        'StreamingLlmProvider run failed',
+        error: e,
+        stackTrace: st,
+      );
       final msg = e is SoliplexException ? e.message : e.toString();
       yield synthesizedDecoded(RunErrorEvent(message: msg));
     }

--- a/packages/soliplex_agent/lib/src/orchestration/streaming_llm_provider.dart
+++ b/packages/soliplex_agent/lib/src/orchestration/streaming_llm_provider.dart
@@ -52,7 +52,9 @@ class StreamingLlmProvider implements AgentLlmProvider {
     String runId,
     CancelToken? cancelToken,
   ) async* {
-    yield _wrap(RunStartedEvent(threadId: key.threadId, runId: runId));
+    yield synthesizedDecoded(
+      RunStartedEvent(threadId: key.threadId, runId: runId),
+    );
 
     if (cancelToken?.isCancelled ?? false) return;
 
@@ -84,52 +86,58 @@ class StreamingLlmProvider implements AgentLlmProvider {
             if (currentMsgId == null) {
               final msgId = 'msg-${DateTime.now().microsecondsSinceEpoch}';
               currentMsgId = msgId;
-              yield _wrap(TextMessageStartEvent(messageId: msgId));
+              yield synthesizedDecoded(TextMessageStartEvent(messageId: msgId));
             }
-            yield _wrap(
+            yield synthesizedDecoded(
               TextMessageContentEvent(messageId: currentMsgId, delta: text),
             );
 
           case LlmTextDone():
             if (currentMsgId case final msgId?) {
-              yield _wrap(TextMessageEndEvent(messageId: msgId));
+              yield synthesizedDecoded(TextMessageEndEvent(messageId: msgId));
               currentMsgId = null;
             }
 
           case LlmToolCallStart(:final callId, :final name):
             // Close any open text message first.
             if (currentMsgId case final msgId?) {
-              yield _wrap(TextMessageEndEvent(messageId: msgId));
+              yield synthesizedDecoded(TextMessageEndEvent(messageId: msgId));
               currentMsgId = null;
             }
-            yield _wrap(
+            yield synthesizedDecoded(
               ToolCallStartEvent(toolCallId: callId, toolCallName: name),
             );
 
           case LlmToolCallArgsDelta(:final callId, :final delta):
-            yield _wrap(ToolCallArgsEvent(toolCallId: callId, delta: delta));
+            yield synthesizedDecoded(
+              ToolCallArgsEvent(toolCallId: callId, delta: delta),
+            );
 
           case LlmToolCallDone(:final callId):
-            yield _wrap(ToolCallEndEvent(toolCallId: callId));
+            yield synthesizedDecoded(ToolCallEndEvent(toolCallId: callId));
 
           case LlmDone():
             if (currentMsgId case final msgId?) {
-              yield _wrap(TextMessageEndEvent(messageId: msgId));
+              yield synthesizedDecoded(TextMessageEndEvent(messageId: msgId));
             }
-            yield _wrap(RunFinishedEvent(threadId: key.threadId, runId: runId));
+            yield synthesizedDecoded(
+              RunFinishedEvent(threadId: key.threadId, runId: runId),
+            );
             return;
 
           case LlmError(:final message):
-            yield _wrap(RunErrorEvent(message: message));
+            yield synthesizedDecoded(RunErrorEvent(message: message));
             return;
         }
       }
 
       // Stream ended without explicit done — synthesize finish.
       if (currentMsgId case final msgId?) {
-        yield _wrap(TextMessageEndEvent(messageId: msgId));
+        yield synthesizedDecoded(TextMessageEndEvent(messageId: msgId));
       }
-      yield _wrap(RunFinishedEvent(threadId: key.threadId, runId: runId));
+      yield synthesizedDecoded(
+        RunFinishedEvent(threadId: key.threadId, runId: runId),
+      );
     } on CancelledException {
       // Surface cancels as a stream error so the orchestrator routes
       // them to `CancelledState` via `_onStreamError`. Yielding a
@@ -138,14 +146,9 @@ class StreamingLlmProvider implements AgentLlmProvider {
       rethrow;
     } on Object catch (e) {
       final msg = e is SoliplexException ? e.message : e.toString();
-      yield _wrap(RunErrorEvent(message: msg));
+      yield synthesizedDecoded(RunErrorEvent(message: msg));
     }
   }
-
-  /// `rawJson` is `const {}` because synthesized events have no source
-  /// JSON; if `processEvent` ever throws on one, the resulting drop tile
-  /// will carry an empty payload.
-  static DecodedEvent _wrap(BaseEvent event) => DecodedEvent(event, const {});
 
   List<LlmChatMessage> _convertMessages(SimpleRunAgentInput input) {
     final result = <LlmChatMessage>[];

--- a/packages/soliplex_agent/test/host/runtime_agent_api_test.dart
+++ b/packages/soliplex_agent/test/host/runtime_agent_api_test.dart
@@ -10,6 +10,12 @@ import 'package:test/test.dart';
 // Mocks
 // ---------------------------------------------------------------------------
 
+/// Adapts a test event stream to the orchestrator's `DecodeOutcome`
+/// contract. Hand-written events have no source JSON, so `rawJson` is
+/// `const {}`.
+Stream<DecodeOutcome> _wrap(Stream<BaseEvent> s) =>
+    s.map<DecodeOutcome>((e) => DecodedEvent(e, const {}));
+
 class MockSoliplexApi extends Mock implements SoliplexApi {}
 
 class MockAgUiStreamClient extends Mock implements AgUiStreamClient {}
@@ -93,7 +99,7 @@ void main() {
         resumePolicy: any(named: 'resumePolicy'),
         onReconnectStatus: any(named: 'onReconnectStatus'),
       ),
-    ).thenAnswer((_) => Stream.fromIterable(_happyPathEvents(text)));
+    ).thenAnswer((_) => _wrap(Stream.fromIterable(_happyPathEvents(text))));
   }
 
   group('RuntimeAgentApi', () {
@@ -146,7 +152,7 @@ void main() {
           resumePolicy: any(named: 'resumePolicy'),
           onReconnectStatus: any(named: 'onReconnectStatus'),
         ),
-      ).thenAnswer((_) => controller.stream);
+      ).thenAnswer((_) => _wrap(controller.stream));
 
       final handle = await agentApi.spawnAgent(_roomId, 'test');
       controller.add(const RunStartedEvent(threadId: _threadId, runId: _runId));
@@ -197,7 +203,7 @@ void main() {
           resumePolicy: any(named: 'resumePolicy'),
           onReconnectStatus: any(named: 'onReconnectStatus'),
         ),
-      ).thenAnswer((_) => controller.stream);
+      ).thenAnswer((_) => _wrap(controller.stream));
 
       final handle = await agentApi.spawnAgent(_roomId, 'test');
       controller.add(const RunStartedEvent(threadId: _threadId, runId: _runId));

--- a/packages/soliplex_agent/test/orchestration/chat_fn_llm_provider_test.dart
+++ b/packages/soliplex_agent/test/orchestration/chat_fn_llm_provider_test.dart
@@ -21,7 +21,10 @@ void main() {
       );
 
       final handle = await provider.startRun(key: key, input: input0());
-      final events = await handle.events.toList();
+      final events = (await handle.events.toList())
+          .whereType<DecodedEvent>()
+          .map((d) => d.event)
+          .toList();
 
       expect(events[0], isA<RunStartedEvent>());
       expect(events[1], isA<TextMessageStartEvent>());
@@ -44,7 +47,10 @@ void main() {
       );
 
       final handle = await provider.startRun(key: key, input: input0());
-      final events = await handle.events.toList();
+      final events = (await handle.events.toList())
+          .whereType<DecodedEvent>()
+          .map((d) => d.event)
+          .toList();
 
       expect(events[0], isA<RunStartedEvent>());
       expect(events[1], isA<ToolCallStartEvent>());
@@ -66,7 +72,10 @@ Let me check.
       );
 
       final handle = await provider.startRun(key: key, input: input0());
-      final events = await handle.events.toList();
+      final events = (await handle.events.toList())
+          .whereType<DecodedEvent>()
+          .map((d) => d.event)
+          .toList();
 
       expect(events[0], isA<RunStartedEvent>());
       // Prefix text events.
@@ -90,7 +99,10 @@ Let me check.
       );
 
       final handle = await provider.startRun(key: key, input: input0());
-      final events = await handle.events.toList();
+      final events = (await handle.events.toList())
+          .whereType<DecodedEvent>()
+          .map((d) => d.event)
+          .toList();
 
       expect(events[0], isA<RunStartedEvent>());
       expect(events[1], isA<TextMessageStartEvent>());
@@ -106,7 +118,10 @@ Let me check.
       );
 
       final handle = await provider.startRun(key: key, input: input0());
-      final events = await handle.events.toList();
+      final events = (await handle.events.toList())
+          .whereType<DecodedEvent>()
+          .map((d) => d.event)
+          .toList();
 
       expect(events[0], isA<RunStartedEvent>());
       expect(events[1], isA<RunErrorEvent>());
@@ -128,7 +143,10 @@ Let me check.
       );
 
       expect(handle.runId, 'my-run-42');
-      final events = await handle.events.toList();
+      final events = (await handle.events.toList())
+          .whereType<DecodedEvent>()
+          .map((d) => d.event)
+          .toList();
       expect((events[0] as RunStartedEvent).runId, 'my-run-42');
     });
 
@@ -163,7 +181,10 @@ Let me check.
         key: key,
         input: input0(tools: tools),
       );
-      await handle.events.toList();
+      (await handle.events.toList())
+          .whereType<DecodedEvent>()
+          .map((d) => d.event)
+          .toList();
 
       expect(capturedSystemPrompt, contains('You are helpful.'));
       expect(capturedSystemPrompt, contains('## Available Tools'));
@@ -185,7 +206,10 @@ Let me check.
         key: key,
         input: input0(tools: []),
       );
-      await handle.events.toList();
+      (await handle.events.toList())
+          .whereType<DecodedEvent>()
+          .map((d) => d.event)
+          .toList();
 
       expect(capturedSystemPrompt, contains('You are helpful.'));
       expect(capturedSystemPrompt, isNot(contains('## Available Tools')));
@@ -209,7 +233,10 @@ Let me check.
       );
 
       final handle = await provider.startRun(key: key, input: input);
-      await handle.events.toList();
+      (await handle.events.toList())
+          .whereType<DecodedEvent>()
+          .map((d) => d.event)
+          .toList();
 
       expect(capturedMessages, hasLength(3));
       expect(capturedMessages![0].role, 'user');
@@ -240,7 +267,10 @@ Let me check.
       );
 
       final handle = await provider.startRun(key: key, input: input);
-      await handle.events.toList();
+      (await handle.events.toList())
+          .whereType<DecodedEvent>()
+          .map((d) => d.event)
+          .toList();
 
       expect(capturedMessages, hasLength(1));
       expect(capturedMessages![0].role, 'user');
@@ -261,7 +291,10 @@ Let me check.
         input: input0(),
         cancelToken: cancelToken,
       );
-      final events = await handle.events.toList();
+      final events = (await handle.events.toList())
+          .whereType<DecodedEvent>()
+          .map((d) => d.event)
+          .toList();
 
       // Only RunStartedEvent, then stream ends (cancelled before chatFn).
       expect(events[0], isA<RunStartedEvent>());

--- a/packages/soliplex_agent/test/orchestration/chat_fn_llm_provider_test.dart
+++ b/packages/soliplex_agent/test/orchestration/chat_fn_llm_provider_test.dart
@@ -21,10 +21,7 @@ void main() {
       );
 
       final handle = await provider.startRun(key: key, input: input0());
-      final events = (await handle.events.toList())
-          .whereType<DecodedEvent>()
-          .map((d) => d.event)
-          .toList();
+      final events = await _decodedEvents(handle);
 
       expect(events[0], isA<RunStartedEvent>());
       expect(events[1], isA<TextMessageStartEvent>());
@@ -47,10 +44,7 @@ void main() {
       );
 
       final handle = await provider.startRun(key: key, input: input0());
-      final events = (await handle.events.toList())
-          .whereType<DecodedEvent>()
-          .map((d) => d.event)
-          .toList();
+      final events = await _decodedEvents(handle);
 
       expect(events[0], isA<RunStartedEvent>());
       expect(events[1], isA<ToolCallStartEvent>());
@@ -72,10 +66,7 @@ Let me check.
       );
 
       final handle = await provider.startRun(key: key, input: input0());
-      final events = (await handle.events.toList())
-          .whereType<DecodedEvent>()
-          .map((d) => d.event)
-          .toList();
+      final events = await _decodedEvents(handle);
 
       expect(events[0], isA<RunStartedEvent>());
       // Prefix text events.
@@ -99,10 +90,7 @@ Let me check.
       );
 
       final handle = await provider.startRun(key: key, input: input0());
-      final events = (await handle.events.toList())
-          .whereType<DecodedEvent>()
-          .map((d) => d.event)
-          .toList();
+      final events = await _decodedEvents(handle);
 
       expect(events[0], isA<RunStartedEvent>());
       expect(events[1], isA<TextMessageStartEvent>());
@@ -118,10 +106,7 @@ Let me check.
       );
 
       final handle = await provider.startRun(key: key, input: input0());
-      final events = (await handle.events.toList())
-          .whereType<DecodedEvent>()
-          .map((d) => d.event)
-          .toList();
+      final events = await _decodedEvents(handle);
 
       expect(events[0], isA<RunStartedEvent>());
       expect(events[1], isA<RunErrorEvent>());
@@ -143,10 +128,7 @@ Let me check.
       );
 
       expect(handle.runId, 'my-run-42');
-      final events = (await handle.events.toList())
-          .whereType<DecodedEvent>()
-          .map((d) => d.event)
-          .toList();
+      final events = await _decodedEvents(handle);
       expect((events[0] as RunStartedEvent).runId, 'my-run-42');
     });
 
@@ -291,10 +273,7 @@ Let me check.
         input: input0(),
         cancelToken: cancelToken,
       );
-      final events = (await handle.events.toList())
-          .whereType<DecodedEvent>()
-          .map((d) => d.event)
-          .toList();
+      final events = await _decodedEvents(handle);
 
       // Only RunStartedEvent, then stream ends (cancelled before chatFn).
       expect(events[0], isA<RunStartedEvent>());
@@ -302,3 +281,9 @@ Let me check.
     });
   });
 }
+
+Future<List<BaseEvent>> _decodedEvents(LlmRunHandle handle) async =>
+    (await handle.events.toList())
+        .whereType<DecodedEvent>()
+        .map((d) => d.event)
+        .toList();

--- a/packages/soliplex_agent/test/orchestration/run_orchestrator_test.dart
+++ b/packages/soliplex_agent/test/orchestration/run_orchestrator_test.dart
@@ -2648,4 +2648,184 @@ void main() {
       },
     );
   });
+
+  group('live drop tiles', () {
+    test(
+      'DecodeFailed yields a DroppedEventMessage(decode); run still '
+      'finishes and the tracker never sees the failure',
+      () async {
+        stubCreateRun();
+        final controller = StreamController<DecodeOutcome>();
+        when(
+          () => agUiStreamClient.runAgent(
+            any(),
+            any(),
+            cancelToken: any(named: 'cancelToken'),
+            resumePolicy: any(named: 'resumePolicy'),
+            onReconnectStatus: any(named: 'onReconnectStatus'),
+          ),
+        ).thenAnswer((_) => controller.stream);
+
+        final trackerEvents = <BaseEvent>[];
+        final trackerSub = orchestrator.baseEvents.listen(trackerEvents.add);
+        addTearDown(trackerSub.cancel);
+
+        await orchestrator.startRun(key: _key, userMessage: 'Hi');
+        // Backend run-started, then an undecodable payload, then a
+        // structurally-valid text turn, then RunFinished.
+        controller
+          ..add(
+            const DecodedEvent(
+              RunStartedEvent(threadId: 'thread-1', runId: _runId),
+              {'type': 'RUN_STARTED'},
+            ),
+          )
+          ..add(
+            const DecodeFailed(
+              FormatException('boom'),
+              <String, dynamic>{'type': 'GIBBERISH', 'foo': 'bar'},
+            ),
+          )
+          ..add(
+            const DecodedEvent(
+              TextMessageStartEvent(messageId: 'msg-1'),
+              {'type': 'TEXT_MESSAGE_START'},
+            ),
+          )
+          ..add(
+            const DecodedEvent(
+              TextMessageContentEvent(
+                messageId: 'msg-1',
+                delta: 'Hello',
+              ),
+              {'type': 'TEXT_MESSAGE_CONTENT'},
+            ),
+          )
+          ..add(
+            const DecodedEvent(
+              TextMessageEndEvent(messageId: 'msg-1'),
+              {'type': 'TEXT_MESSAGE_END'},
+            ),
+          )
+          ..add(
+            const DecodedEvent(
+              RunFinishedEvent(threadId: 'thread-1', runId: _runId),
+              {'type': 'RUN_FINISHED'},
+            ),
+          );
+        await Future<void>.delayed(Duration.zero);
+
+        expect(orchestrator.currentState, isA<CompletedState>());
+        final completed = orchestrator.currentState as CompletedState;
+        final messages = completed.conversation.messages;
+        // user message + drop tile + assistant reply.
+        final drops = messages.whereType<DroppedEventMessage>().toList();
+        expect(drops, hasLength(1));
+        expect(drops.single.source, equals(DropSource.decode));
+        expect(drops.single.runId, equals(_runId));
+        expect(drops.single.id, startsWith('dropped-$_runId-'));
+        expect(drops.single.rawPayload, containsPair('type', 'GIBBERISH'));
+        // The reply still landed.
+        expect(
+          messages.whereType<TextMessage>().where((m) => m.text == 'Hello'),
+          hasLength(1),
+        );
+        // Tracker never saw the DecodeFailed payload — only structurally
+        // valid events reach the BaseEvent stream.
+        expect(
+          trackerEvents.map((e) => e.runtimeType).toList(),
+          equals([
+            RunStartedEvent,
+            TextMessageStartEvent,
+            TextMessageContentEvent,
+            TextMessageEndEvent,
+            RunFinishedEvent,
+          ]),
+        );
+
+        await controller.close();
+      },
+    );
+
+    test(
+      'a processEvent throw yields DroppedEventMessage(eventProcessing); '
+      'subsequent events still process',
+      () async {
+        stubCreateRun();
+        final controller = StreamController<DecodeOutcome>();
+        when(
+          () => agUiStreamClient.runAgent(
+            any(),
+            any(),
+            cancelToken: any(named: 'cancelToken'),
+            resumePolicy: any(named: 'resumePolicy'),
+            onReconnectStatus: any(named: 'onReconnectStatus'),
+          ),
+        ).thenAnswer((_) => controller.stream);
+
+        await orchestrator.startRun(key: _key, userMessage: 'Hi');
+        controller
+          ..add(
+            const DecodedEvent(
+              RunStartedEvent(threadId: 'thread-1', runId: _runId),
+              {'type': 'RUN_STARTED'},
+            ),
+          )
+          // Non-Map snapshot triggers the cast throw inside
+          // _processStateSnapshot — the wrapper catches it.
+          ..add(
+            const DecodedEvent(
+              StateSnapshotEvent(snapshot: ['not', 'a', 'map']),
+              {
+                'type': 'STATE_SNAPSHOT',
+                'snapshot': ['not', 'a', 'map'],
+              },
+            ),
+          )
+          ..add(
+            const DecodedEvent(
+              TextMessageStartEvent(messageId: 'msg-1'),
+              {'type': 'TEXT_MESSAGE_START'},
+            ),
+          )
+          ..add(
+            const DecodedEvent(
+              TextMessageContentEvent(
+                messageId: 'msg-1',
+                delta: 'survived',
+              ),
+              {'type': 'TEXT_MESSAGE_CONTENT'},
+            ),
+          )
+          ..add(
+            const DecodedEvent(
+              TextMessageEndEvent(messageId: 'msg-1'),
+              {'type': 'TEXT_MESSAGE_END'},
+            ),
+          )
+          ..add(
+            const DecodedEvent(
+              RunFinishedEvent(threadId: 'thread-1', runId: _runId),
+              {'type': 'RUN_FINISHED'},
+            ),
+          );
+        await Future<void>.delayed(Duration.zero);
+
+        expect(orchestrator.currentState, isA<CompletedState>());
+        final completed = orchestrator.currentState as CompletedState;
+        final messages = completed.conversation.messages;
+        final drops = messages.whereType<DroppedEventMessage>().toList();
+        expect(drops, hasLength(1));
+        expect(drops.single.source, equals(DropSource.eventProcessing));
+        expect(drops.single.rawPayload, containsPair('type', 'STATE_SNAPSHOT'));
+        // The text turn that arrived after the throw still rendered.
+        expect(
+          messages.whereType<TextMessage>().where((m) => m.text == 'survived'),
+          hasLength(1),
+        );
+
+        await controller.close();
+      },
+    );
+  });
 }

--- a/packages/soliplex_agent/test/orchestration/run_orchestrator_test.dart
+++ b/packages/soliplex_agent/test/orchestration/run_orchestrator_test.dart
@@ -2653,12 +2653,8 @@ void main() {
         expect(orchestrator.currentState, isA<CompletedState>());
         final completed = orchestrator.currentState as CompletedState;
         final messages = completed.conversation.messages;
-        // Drop tile sits inline between the user input and the
-        // assistant reply — `_appendDropTile` runs on each
-        // `DecodeFailed` rather than buffering and flushing at the
-        // end of the run. A future buffer-then-flush refactor would
-        // silently push the tile to the end of the conversation;
-        // pinning the order here catches that.
+        // Drop tile must sit between the user input and the assistant
+        // reply, not be flushed at run-end.
         expect(
           messages.map((m) => m.runtimeType).toList(),
           equals([TextMessage, DroppedEventMessage, TextMessage]),
@@ -2674,8 +2670,10 @@ void main() {
           messages.whereType<TextMessage>().where((m) => m.text == 'Hello'),
           hasLength(1),
         );
-        // Tracker never saw the DecodeFailed payload — only structurally
-        // valid events reach the BaseEvent stream.
+        // Tracker never saw the DecodeFailed payload — only events
+        // whose application-layer processing succeeded reach
+        // baseEvents, keeping the tracker consistent with the
+        // conversation.
         expect(
           trackerEvents.map((e) => e.runtimeType).toList(),
           equals([
@@ -2706,6 +2704,10 @@ void main() {
             onReconnectStatus: any(named: 'onReconnectStatus'),
           ),
         ).thenAnswer((_) => controller.stream);
+
+        final trackerEvents = <BaseEvent>[];
+        final trackerSub = orchestrator.baseEvents.listen(trackerEvents.add);
+        addTearDown(trackerSub.cancel);
 
         await orchestrator.startRun(key: _key, userMessage: 'Hi');
         controller
@@ -2766,6 +2768,19 @@ void main() {
         expect(
           messages.whereType<TextMessage>().where((m) => m.text == 'survived'),
           hasLength(1),
+        );
+        // The throwing StateSnapshotEvent never reaches baseEvents —
+        // a tracker observing the stream stays consistent with the
+        // conversation, which never reflected the bad snapshot.
+        expect(
+          trackerEvents.map((e) => e.runtimeType).toList(),
+          equals([
+            RunStartedEvent,
+            TextMessageStartEvent,
+            TextMessageContentEvent,
+            TextMessageEndEvent,
+            RunFinishedEvent,
+          ]),
         );
 
         await controller.close();

--- a/packages/soliplex_agent/test/orchestration/run_orchestrator_test.dart
+++ b/packages/soliplex_agent/test/orchestration/run_orchestrator_test.dart
@@ -69,6 +69,12 @@ ToolRegistry _registryWith({String toolName = 'weather'}) {
   );
 }
 
+/// Adapts a test event stream to the orchestrator's `DecodeOutcome`
+/// contract. Hand-written events have no source JSON, so `rawJson` is
+/// `const {}`.
+Stream<DecodeOutcome> _wrap(Stream<BaseEvent> s) =>
+    s.map<DecodeOutcome>((e) => DecodedEvent(e, const {}));
+
 List<ToolCallInfo> _executedTools() => [
       const ToolCallInfo(
         id: 'tc-1',
@@ -120,7 +126,9 @@ void main() {
         resumePolicy: any(named: 'resumePolicy'),
         onReconnectStatus: any(named: 'onReconnectStatus'),
       ),
-    ).thenAnswer((_) => stream);
+    ).thenAnswer(
+      (_) => stream.map<DecodeOutcome>((e) => DecodedEvent(e, const {})),
+    );
   }
 
   group('happy path', () {
@@ -1155,6 +1163,8 @@ void main() {
       required Stream<BaseEvent> second,
     }) {
       callCount = 0;
+      Stream<DecodeOutcome> wrap(Stream<BaseEvent> s) =>
+          s.map<DecodeOutcome>((e) => DecodedEvent(e, const {}));
       when(
         () => agUiStreamClient.runAgent(
           any(),
@@ -1165,7 +1175,7 @@ void main() {
         ),
       ).thenAnswer((_) {
         callCount++;
-        return callCount == 1 ? first : second;
+        return callCount == 1 ? wrap(first) : wrap(second);
       });
     }
 
@@ -1245,9 +1255,9 @@ void main() {
       ).thenAnswer((_) {
         callCount++;
         if (callCount <= 2) {
-          return Stream.fromIterable(_toolCallEvents());
+          return _wrap(Stream.fromIterable(_toolCallEvents()));
         }
-        return Stream.fromIterable(_resumeTextEvents());
+        return _wrap(Stream.fromIterable(_resumeTextEvents()));
       });
 
       await orchestrator.startRun(key: _key, userMessage: 'Weather?');
@@ -1287,7 +1297,7 @@ void main() {
           resumePolicy: any(named: 'resumePolicy'),
           onReconnectStatus: any(named: 'onReconnectStatus'),
         ),
-      ).thenAnswer((_) => Stream.fromIterable(_toolCallEvents()));
+      ).thenAnswer((_) => _wrap(Stream.fromIterable(_toolCallEvents())));
 
       await orchestrator.startRun(key: _key, userMessage: 'Weather?');
       await Future<void>.delayed(Duration.zero);
@@ -1334,10 +1344,12 @@ void main() {
       ).thenAnswer((_) {
         runAgentCallCount++;
         if (runAgentCallCount == 1) {
-          return Stream.fromIterable(_toolCallEvents());
+          return _wrap(Stream.fromIterable(_toolCallEvents()));
         }
-        return Stream<BaseEvent>.error(
-          const NetworkException(message: 'transport drop on resume'),
+        return _wrap(
+          Stream<BaseEvent>.error(
+            const NetworkException(message: 'transport drop on resume'),
+          ),
         );
       });
 
@@ -1429,7 +1441,7 @@ void main() {
         ),
       ).thenAnswer((invocation) {
         capturedToken = invocation.namedArguments[#cancelToken] as CancelToken?;
-        return controller.stream;
+        return _wrap(controller.stream);
       });
       stubCreateRun();
 
@@ -1504,9 +1516,9 @@ void main() {
       ).thenAnswer((_) {
         runAgentCallCount++;
         if (runAgentCallCount == 1) {
-          return Stream.fromIterable(_toolCallEvents());
+          return _wrap(Stream.fromIterable(_toolCallEvents()));
         }
-        return resumeStreamController.stream;
+        return _wrap(resumeStreamController.stream);
       });
 
       // Block the tool executor so the test can re-stub createRun before
@@ -1853,7 +1865,10 @@ void main() {
       final input = captured.first as SimpleRunAgentInput;
       final state = input.state as Map<String, dynamic>;
       expect(state, containsPair('filter', 'docs'));
-      expect(state, containsPair('citations', <String>[]));
+      expect(
+        state,
+        containsPair('citations', <String>[]),
+      );
     });
 
     test(
@@ -1881,25 +1896,27 @@ void main() {
           callCount++;
           if (callCount == 1) {
             // First run: emit state snapshot + tool call.
-            return Stream.fromIterable([
-              const RunStartedEvent(threadId: 'thread-1', runId: _runId),
-              const StateSnapshotEvent(
-                snapshot: {'rag_context': 'doc-42', 'turn': 1},
-              ),
-              const ToolCallStartEvent(
-                toolCallId: 'tc-1',
-                toolCallName: 'weather',
-              ),
-              const ToolCallArgsEvent(
-                toolCallId: 'tc-1',
-                delta: '{"city":"NYC"}',
-              ),
-              const ToolCallEndEvent(toolCallId: 'tc-1'),
-              const RunFinishedEvent(threadId: 'thread-1', runId: _runId),
-            ]);
+            return _wrap(
+              Stream<BaseEvent>.fromIterable([
+                const RunStartedEvent(threadId: 'thread-1', runId: _runId),
+                const StateSnapshotEvent(
+                  snapshot: {'rag_context': 'doc-42', 'turn': 1},
+                ),
+                const ToolCallStartEvent(
+                  toolCallId: 'tc-1',
+                  toolCallName: 'weather',
+                ),
+                const ToolCallArgsEvent(
+                  toolCallId: 'tc-1',
+                  delta: '{"city":"NYC"}',
+                ),
+                const ToolCallEndEvent(toolCallId: 'tc-1'),
+                const RunFinishedEvent(threadId: 'thread-1', runId: _runId),
+              ]),
+            );
           }
           // Second run: just complete.
-          return Stream.fromIterable(_resumeTextEvents());
+          return _wrap(Stream.fromIterable(_resumeTextEvents()));
         });
 
         await orchestrator.startRun(key: _key, userMessage: 'Weather?');
@@ -1952,42 +1969,51 @@ void main() {
         callCount++;
         if (callCount == 1) {
           // Run 1: set initial state + yield tool.
-          return Stream.fromIterable([
-            const RunStartedEvent(threadId: 'thread-1', runId: _runId),
-            const StateSnapshotEvent(snapshot: {'turn': 1, 'docs': <String>[]}),
-            const ToolCallStartEvent(
-              toolCallId: 'tc-1',
-              toolCallName: 'weather',
-            ),
-            const ToolCallArgsEvent(
-              toolCallId: 'tc-1',
-              delta: '{"city":"NYC"}',
-            ),
-            const ToolCallEndEvent(toolCallId: 'tc-1'),
-            const RunFinishedEvent(threadId: 'thread-1', runId: _runId),
-          ]);
+          return _wrap(
+            Stream<BaseEvent>.fromIterable([
+              const RunStartedEvent(threadId: 'thread-1', runId: _runId),
+              const StateSnapshotEvent(
+                snapshot: {'turn': 1, 'docs': <String>[]},
+              ),
+              const ToolCallStartEvent(
+                toolCallId: 'tc-1',
+                toolCallName: 'weather',
+              ),
+              const ToolCallArgsEvent(
+                toolCallId: 'tc-1',
+                delta: '{"city":"NYC"}',
+              ),
+              const ToolCallEndEvent(toolCallId: 'tc-1'),
+              const RunFinishedEvent(threadId: 'thread-1', runId: _runId),
+            ]),
+          );
         }
         if (callCount == 2) {
           // Run 2: update state via new snapshot + yield tool again.
-          return Stream.fromIterable([
-            const RunStartedEvent(threadId: 'thread-1', runId: _runId),
-            const StateSnapshotEvent(
-              snapshot: {
-                'turn': 2,
-                'docs': ['doc-a'],
-              },
-            ),
-            const ToolCallStartEvent(
-              toolCallId: 'tc-2',
-              toolCallName: 'weather',
-            ),
-            const ToolCallArgsEvent(toolCallId: 'tc-2', delta: '{"city":"LA"}'),
-            const ToolCallEndEvent(toolCallId: 'tc-2'),
-            const RunFinishedEvent(threadId: 'thread-1', runId: _runId),
-          ]);
+          return _wrap(
+            Stream<BaseEvent>.fromIterable([
+              const RunStartedEvent(threadId: 'thread-1', runId: _runId),
+              const StateSnapshotEvent(
+                snapshot: {
+                  'turn': 2,
+                  'docs': ['doc-a'],
+                },
+              ),
+              const ToolCallStartEvent(
+                toolCallId: 'tc-2',
+                toolCallName: 'weather',
+              ),
+              const ToolCallArgsEvent(
+                toolCallId: 'tc-2',
+                delta: '{"city":"LA"}',
+              ),
+              const ToolCallEndEvent(toolCallId: 'tc-2'),
+              const RunFinishedEvent(threadId: 'thread-1', runId: _runId),
+            ]),
+          );
         }
         // Run 3: complete.
-        return Stream.fromIterable(_resumeTextEvents());
+        return _wrap(Stream.fromIterable(_resumeTextEvents()));
       });
 
       final result = await orchestrator.runToCompletion(
@@ -2034,7 +2060,10 @@ void main() {
       final input3 = captured[2] as SimpleRunAgentInput;
       final state3 = input3.state as Map<String, dynamic>;
       expect(state3, containsPair('turn', 2));
-      expect(state3['docs'], equals(['doc-a']));
+      expect(
+        state3['docs'],
+        equals(['doc-a']),
+      );
     });
 
     test('empty state sent when no cachedHistory or snapshots', () async {
@@ -2252,8 +2281,42 @@ void main() {
       ).thenAnswer((_) {
         callCount++;
         if (callCount == 1) {
-          return Stream.fromIterable([
+          return _wrap(
+            Stream<BaseEvent>.fromIterable([
+              const RunStartedEvent(threadId: 'thread-1', runId: _runId),
+              const StateSnapshotEvent(
+                snapshot: {
+                  'rag': {
+                    'citation_index': {
+                      'chunk-1': {
+                        'chunk_id': 'chunk-1',
+                        'content': 'First citation',
+                        'document_id': 'doc-1',
+                        'document_uri': 'https://example.com/doc1.pdf',
+                      },
+                    },
+                    'citations': ['chunk-1'],
+                  },
+                },
+              ),
+              const ToolCallStartEvent(
+                toolCallId: 'tc-1',
+                toolCallName: 'weather',
+              ),
+              const ToolCallArgsEvent(
+                toolCallId: 'tc-1',
+                delta: '{"city":"NYC"}',
+              ),
+              const ToolCallEndEvent(toolCallId: 'tc-1'),
+              const RunFinishedEvent(threadId: 'thread-1', runId: _runId),
+            ]),
+          );
+        }
+        return _wrap(
+          Stream<BaseEvent>.fromIterable([
             const RunStartedEvent(threadId: 'thread-1', runId: _runId),
+            const TextMessageStartEvent(messageId: 'msg-2'),
+            const TextMessageContentEvent(messageId: 'msg-2', delta: 'Done'),
             const StateSnapshotEvent(
               snapshot: {
                 'rag': {
@@ -2264,51 +2327,21 @@ void main() {
                       'document_id': 'doc-1',
                       'document_uri': 'https://example.com/doc1.pdf',
                     },
+                    'chunk-2': {
+                      'chunk_id': 'chunk-2',
+                      'content': 'Second citation',
+                      'document_id': 'doc-2',
+                      'document_uri': 'https://example.com/doc2.pdf',
+                    },
                   },
-                  'citations': ['chunk-1'],
+                  'citations': ['chunk-1', 'chunk-2'],
                 },
               },
             ),
-            const ToolCallStartEvent(
-              toolCallId: 'tc-1',
-              toolCallName: 'weather',
-            ),
-            const ToolCallArgsEvent(
-              toolCallId: 'tc-1',
-              delta: '{"city":"NYC"}',
-            ),
-            const ToolCallEndEvent(toolCallId: 'tc-1'),
+            const TextMessageEndEvent(messageId: 'msg-2'),
             const RunFinishedEvent(threadId: 'thread-1', runId: _runId),
-          ]);
-        }
-        return Stream.fromIterable([
-          const RunStartedEvent(threadId: 'thread-1', runId: _runId),
-          const TextMessageStartEvent(messageId: 'msg-2'),
-          const TextMessageContentEvent(messageId: 'msg-2', delta: 'Done'),
-          const StateSnapshotEvent(
-            snapshot: {
-              'rag': {
-                'citation_index': {
-                  'chunk-1': {
-                    'chunk_id': 'chunk-1',
-                    'content': 'First citation',
-                    'document_id': 'doc-1',
-                    'document_uri': 'https://example.com/doc1.pdf',
-                  },
-                  'chunk-2': {
-                    'chunk_id': 'chunk-2',
-                    'content': 'Second citation',
-                    'document_id': 'doc-2',
-                    'document_uri': 'https://example.com/doc2.pdf',
-                  },
-                },
-                'citations': ['chunk-1', 'chunk-2'],
-              },
-            },
-          ),
-          const TextMessageEndEvent(messageId: 'msg-2'),
-          const RunFinishedEvent(threadId: 'thread-1', runId: _runId),
-        ]);
+          ]),
+        );
       });
 
       final result = await orchestrator.runToCompletion(
@@ -2360,8 +2393,52 @@ void main() {
         callCount++;
         if (callCount == 1) {
           // Segment 1: ask() returns chunk-1 and chunk-2.
-          return Stream.fromIterable([
+          return _wrap(
+            Stream<BaseEvent>.fromIterable([
+              const RunStartedEvent(threadId: 'thread-1', runId: _runId),
+              const StateSnapshotEvent(
+                snapshot: {
+                  'rag': {
+                    'citation_index': {
+                      'chunk-1': {
+                        'chunk_id': 'chunk-1',
+                        'content': 'First',
+                        'document_id': 'doc-1',
+                        'document_uri': 'file:///doc1.pdf',
+                      },
+                      'chunk-2': {
+                        'chunk_id': 'chunk-2',
+                        'content': 'Second',
+                        'document_id': 'doc-1',
+                        'document_uri': 'file:///doc1.pdf',
+                      },
+                    },
+                    'citations': ['chunk-1', 'chunk-2'],
+                  },
+                },
+              ),
+              const ToolCallStartEvent(
+                toolCallId: 'tc-1',
+                toolCallName: 'weather',
+              ),
+              const ToolCallArgsEvent(
+                toolCallId: 'tc-1',
+                delta: '{"city":"NYC"}',
+              ),
+              const ToolCallEndEvent(toolCallId: 'tc-1'),
+              const RunFinishedEvent(threadId: 'thread-1', runId: _runId),
+            ]),
+          );
+        }
+        // Segment 2: ask() returns chunk-2 (duplicate) and chunk-3 (new).
+        return _wrap(
+          Stream<BaseEvent>.fromIterable([
             const RunStartedEvent(threadId: 'thread-1', runId: _runId),
+            const TextMessageStartEvent(messageId: 'msg-2'),
+            const TextMessageContentEvent(
+              messageId: 'msg-2',
+              delta: 'Done',
+            ),
             const StateSnapshotEvent(
               snapshot: {
                 'rag': {
@@ -2378,61 +2455,21 @@ void main() {
                       'document_id': 'doc-1',
                       'document_uri': 'file:///doc1.pdf',
                     },
+                    'chunk-3': {
+                      'chunk_id': 'chunk-3',
+                      'content': 'Third',
+                      'document_id': 'doc-2',
+                      'document_uri': 'file:///doc2.pdf',
+                    },
                   },
-                  'citations': ['chunk-1', 'chunk-2'],
+                  'citations': ['chunk-1', 'chunk-2', 'chunk-3'],
                 },
               },
             ),
-            const ToolCallStartEvent(
-              toolCallId: 'tc-1',
-              toolCallName: 'weather',
-            ),
-            const ToolCallArgsEvent(
-              toolCallId: 'tc-1',
-              delta: '{"city":"NYC"}',
-            ),
-            const ToolCallEndEvent(toolCallId: 'tc-1'),
+            const TextMessageEndEvent(messageId: 'msg-2'),
             const RunFinishedEvent(threadId: 'thread-1', runId: _runId),
-          ]);
-        }
-        // Segment 2: ask() returns chunk-2 (duplicate) and chunk-3 (new).
-        return Stream.fromIterable([
-          const RunStartedEvent(threadId: 'thread-1', runId: _runId),
-          const TextMessageStartEvent(messageId: 'msg-2'),
-          const TextMessageContentEvent(
-            messageId: 'msg-2',
-            delta: 'Done',
-          ),
-          const StateSnapshotEvent(
-            snapshot: {
-              'rag': {
-                'citation_index': {
-                  'chunk-1': {
-                    'chunk_id': 'chunk-1',
-                    'content': 'First',
-                    'document_id': 'doc-1',
-                    'document_uri': 'file:///doc1.pdf',
-                  },
-                  'chunk-2': {
-                    'chunk_id': 'chunk-2',
-                    'content': 'Second',
-                    'document_id': 'doc-1',
-                    'document_uri': 'file:///doc1.pdf',
-                  },
-                  'chunk-3': {
-                    'chunk_id': 'chunk-3',
-                    'content': 'Third',
-                    'document_id': 'doc-2',
-                    'document_uri': 'file:///doc2.pdf',
-                  },
-                },
-                'citations': ['chunk-1', 'chunk-2', 'chunk-3'],
-              },
-            },
-          ),
-          const TextMessageEndEvent(messageId: 'msg-2'),
-          const RunFinishedEvent(threadId: 'thread-1', runId: _runId),
-        ]);
+          ]),
+        );
       });
 
       final result = await orchestrator.runToCompletion(

--- a/packages/soliplex_agent/test/orchestration/run_orchestrator_test.dart
+++ b/packages/soliplex_agent/test/orchestration/run_orchestrator_test.dart
@@ -21,18 +21,6 @@ class _FakeSimpleRunAgentInput extends Fake implements SimpleRunAgentInput {}
 
 class _FakeCancelToken extends Fake implements CancelToken {}
 
-/// Throws on every `extractNew` call. Used to drive the catch in
-/// `RunOrchestrator._extractCitations`.
-class _ThrowingCitationExtractor extends CitationExtractor {
-  @override
-  List<SourceReference> extractNew(
-    Map<String, dynamic> previousState,
-    Map<String, dynamic> currentState,
-  ) {
-    throw StateError('citation extraction simulated failure');
-  }
-}
-
 // ---------------------------------------------------------------------------
 // Fixtures
 // ---------------------------------------------------------------------------
@@ -2598,55 +2586,6 @@ void main() {
 
       await controller.close();
     });
-  });
-
-  group('citation extraction error handling', () {
-    test(
-      'throw inside _extractCitations does not abort the run or surface a '
-      'tile; warning is logged',
-      () async {
-        // Use a throwing extractor injected via the @visibleForTesting
-        // ctor parameter — a single test exercises all five
-        // _extractCitations call sites because every terminal path on
-        // a successful run routes through _handleRunFinished.
-        orchestrator.dispose();
-        orchestrator = RunOrchestrator(
-          llmProvider: AgUiLlmProvider(
-            api: api,
-            agUiStreamClient: agUiStreamClient,
-          ),
-          toolRegistry: const ToolRegistry(),
-          logger: logger,
-          citationExtractor: _ThrowingCitationExtractor(),
-        );
-        stubCreateRun();
-        stubRunAgent(stream: Stream.fromIterable(_happyPathEvents()));
-
-        await orchestrator.startRun(key: _key, userMessage: 'Hi');
-        await Future<void>.delayed(Duration.zero);
-
-        // Run completes despite the citation extraction throw.
-        expect(orchestrator.currentState, isA<CompletedState>());
-        final completed = orchestrator.currentState as CompletedState;
-        // No DroppedEventMessage — citation failures are log-only.
-        expect(
-          completed.conversation.messages
-              .whereType<DroppedEventMessage>()
-              .toList(),
-          isEmpty,
-        );
-        // Logger.warning was called for the citation failure. Mocktail's
-        // Mock returns null for unstubbed methods, so we verify the call
-        // happened with a runId-bearing message.
-        verify(
-          () => logger.warning(
-            any(that: contains('Citation extraction failed')),
-            error: any(named: 'error'),
-            stackTrace: any(named: 'stackTrace'),
-          ),
-        ).called(greaterThanOrEqualTo(1));
-      },
-    );
   });
 
   group('live drop tiles', () {

--- a/packages/soliplex_agent/test/orchestration/run_orchestrator_test.dart
+++ b/packages/soliplex_agent/test/orchestration/run_orchestrator_test.dart
@@ -21,6 +21,18 @@ class _FakeSimpleRunAgentInput extends Fake implements SimpleRunAgentInput {}
 
 class _FakeCancelToken extends Fake implements CancelToken {}
 
+/// Throws on every `extractNew` call. Used to drive the Tier-1 catch in
+/// `RunOrchestrator._extractCitations`.
+class _ThrowingCitationExtractor extends CitationExtractor {
+  @override
+  List<SourceReference> extractNew(
+    Map<String, dynamic> previousState,
+    Map<String, dynamic> currentState,
+  ) {
+    throw StateError('citation extraction simulated failure');
+  }
+}
+
 // ---------------------------------------------------------------------------
 // Fixtures
 // ---------------------------------------------------------------------------
@@ -2586,5 +2598,54 @@ void main() {
 
       await controller.close();
     });
+  });
+
+  group('citation extraction Tier-1 wrap', () {
+    test(
+      'throw inside _extractCitations does not abort the run or surface a '
+      'tile; warning is logged',
+      () async {
+        // Use a throwing extractor injected via the @visibleForTesting
+        // ctor parameter — a single test exercises all five
+        // _extractCitations call sites because every terminal path on
+        // a successful run routes through _handleRunFinished.
+        orchestrator.dispose();
+        orchestrator = RunOrchestrator(
+          llmProvider: AgUiLlmProvider(
+            api: api,
+            agUiStreamClient: agUiStreamClient,
+          ),
+          toolRegistry: const ToolRegistry(),
+          logger: logger,
+          citationExtractor: _ThrowingCitationExtractor(),
+        );
+        stubCreateRun();
+        stubRunAgent(stream: Stream.fromIterable(_happyPathEvents()));
+
+        await orchestrator.startRun(key: _key, userMessage: 'Hi');
+        await Future<void>.delayed(Duration.zero);
+
+        // Run completes despite the citation extraction throw.
+        expect(orchestrator.currentState, isA<CompletedState>());
+        final completed = orchestrator.currentState as CompletedState;
+        // No DroppedEventMessage — Tier-1 stays log-only.
+        expect(
+          completed.conversation.messages
+              .whereType<DroppedEventMessage>()
+              .toList(),
+          isEmpty,
+        );
+        // Logger.warning was called for the citation failure. Mocktail's
+        // Mock returns null for unstubbed methods, so we verify the call
+        // happened with a runId-bearing message.
+        verify(
+          () => logger.warning(
+            any(that: contains('Citation extraction failed')),
+            error: any(named: 'error'),
+            stackTrace: any(named: 'stackTrace'),
+          ),
+        ).called(greaterThanOrEqualTo(1));
+      },
+    );
   });
 }

--- a/packages/soliplex_agent/test/orchestration/run_orchestrator_test.dart
+++ b/packages/soliplex_agent/test/orchestration/run_orchestrator_test.dart
@@ -2766,5 +2766,136 @@ void main() {
         await controller.close();
       },
     );
+
+    test(
+      'live DecodeFailed with String rawData preserves it on the tile',
+      () async {
+        // Top-level JSON parse failures arrive with `rawData: String`.
+        // The orchestrator must pass that through unmodified — the tile
+        // widget renders the raw bytes so a developer can inspect the
+        // wire content the parser rejected.
+        stubCreateRun();
+        final controller = StreamController<DecodeOutcome>();
+        when(
+          () => agUiStreamClient.runAgent(
+            any(),
+            any(),
+            cancelToken: any(named: 'cancelToken'),
+            resumePolicy: any(named: 'resumePolicy'),
+            onReconnectStatus: any(named: 'onReconnectStatus'),
+          ),
+        ).thenAnswer((_) => controller.stream);
+
+        await orchestrator.startRun(key: _key, userMessage: 'Hi');
+        controller
+          ..add(
+            const DecodedEvent(
+              RunStartedEvent(threadId: 'thread-1', runId: _runId),
+              {'type': 'RUN_STARTED'},
+            ),
+          )
+          ..add(
+            const DecodeFailed(
+              FormatException('Unexpected character'),
+              'not valid json at all',
+            ),
+          )
+          ..add(
+            const DecodedEvent(
+              RunFinishedEvent(threadId: 'thread-1', runId: _runId),
+              {'type': 'RUN_FINISHED'},
+            ),
+          );
+        await Future<void>.delayed(Duration.zero);
+
+        final completed = orchestrator.currentState as CompletedState;
+        final drop = completed.conversation.messages
+            .whereType<DroppedEventMessage>()
+            .single;
+        expect(drop.rawPayload, equals('not valid json at all'));
+
+        await controller.close();
+      },
+    );
+
+    test(
+      'live drop tile ids align with the replay formula at the same '
+      'event position',
+      () async {
+        // Live mints `dropped-${runId}-${eventIndex}` from a per-event
+        // counter; replay mints `dropped-${runId}-${i}` from the loop
+        // index over backend-stored events. Both formulas must produce
+        // the same id for the same backend event so reload reconstructs
+        // the same drop set. This pins the live counter's positional
+        // invariant; the replay-side companion is in
+        // `soliplex_api_test.dart`'s `replay drop tile ids are
+        // deterministic across reloads`.
+        stubCreateRun();
+        final controller = StreamController<DecodeOutcome>();
+        when(
+          () => agUiStreamClient.runAgent(
+            any(),
+            any(),
+            cancelToken: any(named: 'cancelToken'),
+            resumePolicy: any(named: 'resumePolicy'),
+            onReconnectStatus: any(named: 'onReconnectStatus'),
+          ),
+        ).thenAnswer((_) => controller.stream);
+
+        await orchestrator.startRun(key: _key, userMessage: 'Hi');
+        // Outcome positions: 0 RunStarted, 1 DecodeFailed, 2 TextStart,
+        // 3 STATE_SNAPSHOT (throws inside processEvent), 4 RunFinished.
+        controller
+          ..add(
+            const DecodedEvent(
+              RunStartedEvent(threadId: 'thread-1', runId: _runId),
+              {'type': 'RUN_STARTED'},
+            ),
+          )
+          ..add(
+            const DecodeFailed(
+              FormatException('boom'),
+              {'type': 'GIBBERISH'},
+            ),
+          )
+          ..add(
+            const DecodedEvent(
+              TextMessageStartEvent(messageId: 'msg-1'),
+              {'type': 'TEXT_MESSAGE_START'},
+            ),
+          )
+          ..add(
+            const DecodedEvent(
+              StateSnapshotEvent(snapshot: ['not', 'a', 'map']),
+              {
+                'type': 'STATE_SNAPSHOT',
+                'snapshot': ['not', 'a', 'map'],
+              },
+            ),
+          )
+          ..add(
+            const DecodedEvent(
+              RunFinishedEvent(threadId: 'thread-1', runId: _runId),
+              {'type': 'RUN_FINISHED'},
+            ),
+          );
+        await Future<void>.delayed(Duration.zero);
+
+        final completed = orchestrator.currentState as CompletedState;
+        final drops = completed.conversation.messages
+            .whereType<DroppedEventMessage>()
+            .map((m) => m.id)
+            .toList();
+        // Replay over the same backend events would mint these same
+        // ids — `dropped-<runId>-<positional-index>` aligns the live
+        // counter to the replay loop's `i`.
+        expect(
+          drops,
+          equals(['dropped-$_runId-1', 'dropped-$_runId-3']),
+        );
+
+        await controller.close();
+      },
+    );
   });
 }

--- a/packages/soliplex_agent/test/orchestration/run_orchestrator_test.dart
+++ b/packages/soliplex_agent/test/orchestration/run_orchestrator_test.dart
@@ -126,9 +126,7 @@ void main() {
         resumePolicy: any(named: 'resumePolicy'),
         onReconnectStatus: any(named: 'onReconnectStatus'),
       ),
-    ).thenAnswer(
-      (_) => stream.map<DecodeOutcome>((e) => DecodedEvent(e, const {})),
-    );
+    ).thenAnswer((_) => _wrap(stream));
   }
 
   group('happy path', () {
@@ -1163,8 +1161,6 @@ void main() {
       required Stream<BaseEvent> second,
     }) {
       callCount = 0;
-      Stream<DecodeOutcome> wrap(Stream<BaseEvent> s) =>
-          s.map<DecodeOutcome>((e) => DecodedEvent(e, const {}));
       when(
         () => agUiStreamClient.runAgent(
           any(),
@@ -1175,7 +1171,7 @@ void main() {
         ),
       ).thenAnswer((_) {
         callCount++;
-        return callCount == 1 ? wrap(first) : wrap(second);
+        return callCount == 1 ? _wrap(first) : _wrap(second);
       });
     }
 
@@ -2657,7 +2653,16 @@ void main() {
         expect(orchestrator.currentState, isA<CompletedState>());
         final completed = orchestrator.currentState as CompletedState;
         final messages = completed.conversation.messages;
-        // user message + drop tile + assistant reply.
+        // Drop tile sits inline between the user input and the
+        // assistant reply — `_appendDropTile` runs on each
+        // `DecodeFailed` rather than buffering and flushing at the
+        // end of the run. A future buffer-then-flush refactor would
+        // silently push the tile to the end of the conversation;
+        // pinning the order here catches that.
+        expect(
+          messages.map((m) => m.runtimeType).toList(),
+          equals([TextMessage, DroppedEventMessage, TextMessage]),
+        );
         final drops = messages.whereType<DroppedEventMessage>().toList();
         expect(drops, hasLength(1));
         expect(drops.single.source, equals(DropSource.decode));

--- a/packages/soliplex_agent/test/orchestration/run_orchestrator_test.dart
+++ b/packages/soliplex_agent/test/orchestration/run_orchestrator_test.dart
@@ -21,7 +21,7 @@ class _FakeSimpleRunAgentInput extends Fake implements SimpleRunAgentInput {}
 
 class _FakeCancelToken extends Fake implements CancelToken {}
 
-/// Throws on every `extractNew` call. Used to drive the Tier-1 catch in
+/// Throws on every `extractNew` call. Used to drive the catch in
 /// `RunOrchestrator._extractCitations`.
 class _ThrowingCitationExtractor extends CitationExtractor {
   @override
@@ -2600,7 +2600,7 @@ void main() {
     });
   });
 
-  group('citation extraction Tier-1 wrap', () {
+  group('citation extraction error handling', () {
     test(
       'throw inside _extractCitations does not abort the run or surface a '
       'tile; warning is logged',
@@ -2628,7 +2628,7 @@ void main() {
         // Run completes despite the citation extraction throw.
         expect(orchestrator.currentState, isA<CompletedState>());
         final completed = orchestrator.currentState as CompletedState;
-        // No DroppedEventMessage — Tier-1 stays log-only.
+        // No DroppedEventMessage — citation failures are log-only.
         expect(
           completed.conversation.messages
               .whereType<DroppedEventMessage>()

--- a/packages/soliplex_agent/test/orchestration/run_to_completion_test.dart
+++ b/packages/soliplex_agent/test/orchestration/run_to_completion_test.dart
@@ -11,6 +11,12 @@ import 'package:test/test.dart';
 // Mocks
 // ---------------------------------------------------------------------------
 
+/// Adapts a test event stream to the orchestrator's `DecodeOutcome`
+/// contract. Hand-written events have no source JSON, so `rawJson` is
+/// `const {}`.
+Stream<DecodeOutcome> _wrap(Stream<BaseEvent> s) =>
+    s.map<DecodeOutcome>((e) => DecodedEvent(e, const {}));
+
 class MockSoliplexApi extends Mock implements SoliplexApi {}
 
 class MockAgUiStreamClient extends Mock implements AgUiStreamClient {}
@@ -126,7 +132,9 @@ void main() {
         resumePolicy: any(named: 'resumePolicy'),
         onReconnectStatus: any(named: 'onReconnectStatus'),
       ),
-    ).thenAnswer((_) => stream);
+    ).thenAnswer(
+      (_) => stream.map<DecodeOutcome>((e) => DecodedEvent(e, const {})),
+    );
   }
 
   group('runToCompletion', () {
@@ -210,8 +218,8 @@ void main() {
       ).thenAnswer((_) {
         callCount++;
         return callCount == 1
-            ? Stream.fromIterable(_toolCallEvents())
-            : Stream.fromIterable(_resumeTextEvents());
+            ? _wrap(Stream.fromIterable(_toolCallEvents()))
+            : _wrap(Stream.fromIterable(_resumeTextEvents()));
       });
 
       final result = await orchestrator.runToCompletion(
@@ -246,9 +254,9 @@ void main() {
         callCount++;
         // First 3 calls yield tools, 4th completes with text.
         if (callCount <= 3) {
-          return Stream.fromIterable(_toolCallEvents());
+          return _wrap(Stream.fromIterable(_toolCallEvents()));
         }
-        return Stream.fromIterable(_resumeTextEvents());
+        return _wrap(Stream.fromIterable(_resumeTextEvents()));
       });
 
       final result = await orchestrator.runToCompletion(
@@ -280,7 +288,7 @@ void main() {
           resumePolicy: any(named: 'resumePolicy'),
           onReconnectStatus: any(named: 'onReconnectStatus'),
         ),
-      ).thenAnswer((_) => Stream.fromIterable(_toolCallEvents()));
+      ).thenAnswer((_) => _wrap(Stream.fromIterable(_toolCallEvents())));
 
       final result = await orchestrator.runToCompletion(
         key: _key,
@@ -557,8 +565,8 @@ void main() {
         ),
       ).thenAnswer((_) {
         callCount++;
-        if (callCount == 1) return firstController.stream;
-        return Stream.fromIterable(_resumeTextEvents());
+        if (callCount == 1) return _wrap(firstController.stream);
+        return _wrap(Stream.fromIterable(_resumeTextEvents()));
       });
 
       final future = orchestrator.runToCompletion(
@@ -616,7 +624,7 @@ void main() {
       );
       stubCreateRun();
       stubRunAgent(
-        stream: Stream.fromIterable([
+        stream: Stream<BaseEvent>.fromIterable([
           const RunStartedEvent(threadId: 'thread-1', runId: _runId),
           const RunErrorEvent(message: 'backend error'),
         ]),
@@ -674,8 +682,8 @@ void main() {
       ).thenAnswer((_) {
         callCount++;
         return callCount == 1
-            ? Stream.fromIterable(_toolCallEvents())
-            : Stream.fromIterable(_resumeTextEvents());
+            ? _wrap(Stream.fromIterable(_toolCallEvents()))
+            : _wrap(Stream.fromIterable(_resumeTextEvents()));
       });
 
       // Verify the intermediate ToolYieldingState was emitted.

--- a/packages/soliplex_agent/test/orchestration/streaming_llm_provider_test.dart
+++ b/packages/soliplex_agent/test/orchestration/streaming_llm_provider_test.dart
@@ -32,7 +32,10 @@ void main() {
           ),
         );
 
-        final events = await handle.events.toList();
+        final events = (await handle.events.toList())
+            .whereType<DecodedEvent>()
+            .map((d) => d.event)
+            .toList();
 
         expect(events[0], isA<RunStartedEvent>());
         expect(events[1], isA<TextMessageStartEvent>());
@@ -80,7 +83,10 @@ void main() {
         ),
       );
 
-      final events = await handle.events.toList();
+      final events = (await handle.events.toList())
+          .whereType<DecodedEvent>()
+          .map((d) => d.event)
+          .toList();
 
       expect(events[0], isA<RunStartedEvent>());
       expect(events[1], isA<ToolCallStartEvent>());
@@ -114,7 +120,10 @@ void main() {
         ),
       );
 
-      final events = await handle.events.toList();
+      final events = (await handle.events.toList())
+          .whereType<DecodedEvent>()
+          .map((d) => d.event)
+          .toList();
 
       // RunStarted, TextStart, TextContent, TextEnd, ToolStart, ToolArgs,
       // ToolEnd, RunFinished
@@ -145,7 +154,10 @@ void main() {
         ),
       );
 
-      final events = await handle.events.toList();
+      final events = (await handle.events.toList())
+          .whereType<DecodedEvent>()
+          .map((d) => d.event)
+          .toList();
 
       expect(events[0], isA<RunStartedEvent>());
       expect(events[1], isA<RunErrorEvent>());
@@ -172,7 +184,10 @@ void main() {
         ),
       );
 
-      final events = await handle.events.toList();
+      final events = (await handle.events.toList())
+          .whereType<DecodedEvent>()
+          .map((d) => d.event)
+          .toList();
 
       expect(events[0], isA<RunStartedEvent>());
       expect(events[1], isA<RunErrorEvent>());
@@ -200,7 +215,10 @@ void main() {
         ),
       );
 
-      final events = await handle.events.toList();
+      final events = (await handle.events.toList())
+          .whereType<DecodedEvent>()
+          .map((d) => d.event)
+          .toList();
 
       // Should synthesize TextEnd and RunFinished
       expect(events.last, isA<RunFinishedEvent>());
@@ -365,7 +383,8 @@ void main() {
         cancelToken: token,
       );
 
-      await for (final event in handle.events) {
+      await for (final outcome in handle.events) {
+        final event = (outcome as DecodedEvent).event;
         if (event is TextMessageContentEvent) {
           deltaCount++;
           if (deltaCount >= 3) {

--- a/packages/soliplex_agent/test/orchestration/streaming_llm_provider_test.dart
+++ b/packages/soliplex_agent/test/orchestration/streaming_llm_provider_test.dart
@@ -32,10 +32,7 @@ void main() {
           ),
         );
 
-        final events = (await handle.events.toList())
-            .whereType<DecodedEvent>()
-            .map((d) => d.event)
-            .toList();
+        final events = await _decodedEvents(handle);
 
         expect(events[0], isA<RunStartedEvent>());
         expect(events[1], isA<TextMessageStartEvent>());
@@ -83,10 +80,7 @@ void main() {
         ),
       );
 
-      final events = (await handle.events.toList())
-          .whereType<DecodedEvent>()
-          .map((d) => d.event)
-          .toList();
+      final events = await _decodedEvents(handle);
 
       expect(events[0], isA<RunStartedEvent>());
       expect(events[1], isA<ToolCallStartEvent>());
@@ -120,10 +114,7 @@ void main() {
         ),
       );
 
-      final events = (await handle.events.toList())
-          .whereType<DecodedEvent>()
-          .map((d) => d.event)
-          .toList();
+      final events = await _decodedEvents(handle);
 
       // RunStarted, TextStart, TextContent, TextEnd, ToolStart, ToolArgs,
       // ToolEnd, RunFinished
@@ -154,10 +145,7 @@ void main() {
         ),
       );
 
-      final events = (await handle.events.toList())
-          .whereType<DecodedEvent>()
-          .map((d) => d.event)
-          .toList();
+      final events = await _decodedEvents(handle);
 
       expect(events[0], isA<RunStartedEvent>());
       expect(events[1], isA<RunErrorEvent>());
@@ -184,10 +172,7 @@ void main() {
         ),
       );
 
-      final events = (await handle.events.toList())
-          .whereType<DecodedEvent>()
-          .map((d) => d.event)
-          .toList();
+      final events = await _decodedEvents(handle);
 
       expect(events[0], isA<RunStartedEvent>());
       expect(events[1], isA<RunErrorEvent>());
@@ -215,10 +200,7 @@ void main() {
         ),
       );
 
-      final events = (await handle.events.toList())
-          .whereType<DecodedEvent>()
-          .map((d) => d.event)
-          .toList();
+      final events = await _decodedEvents(handle);
 
       // Should synthesize TextEnd and RunFinished
       expect(events.last, isA<RunFinishedEvent>());
@@ -422,3 +404,9 @@ void main() {
     });
   });
 }
+
+Future<List<BaseEvent>> _decodedEvents(LlmRunHandle handle) async =>
+    (await handle.events.toList())
+        .whereType<DecodedEvent>()
+        .map((d) => d.event)
+        .toList();

--- a/packages/soliplex_agent/test/runtime/agent_runtime_signal_test.dart
+++ b/packages/soliplex_agent/test/runtime/agent_runtime_signal_test.dart
@@ -104,7 +104,9 @@ void main() {
         resumePolicy: any(named: 'resumePolicy'),
         onReconnectStatus: any(named: 'onReconnectStatus'),
       ),
-    ).thenAnswer((_) => stream);
+    ).thenAnswer(
+      (_) => stream.map<DecodeOutcome>((e) => DecodedEvent(e, const {})),
+    );
   }
 
   group('sessions signal', () {

--- a/packages/soliplex_agent/test/runtime/agent_runtime_test.dart
+++ b/packages/soliplex_agent/test/runtime/agent_runtime_test.dart
@@ -11,6 +11,12 @@ import 'package:test/test.dart';
 // Mocks
 // ---------------------------------------------------------------------------
 
+/// Adapts a test event stream to the orchestrator's `DecodeOutcome`
+/// contract. Hand-written events have no source JSON, so `rawJson` is
+/// `const {}`.
+Stream<DecodeOutcome> _wrap(Stream<BaseEvent> s) =>
+    s.map<DecodeOutcome>((e) => DecodedEvent(e, const {}));
+
 class MockSoliplexApi extends Mock implements SoliplexApi {}
 
 class MockAgUiStreamClient extends Mock implements AgUiStreamClient {}
@@ -176,7 +182,9 @@ void main() {
         resumePolicy: any(named: 'resumePolicy'),
         onReconnectStatus: any(named: 'onReconnectStatus'),
       ),
-    ).thenAnswer((_) => stream);
+    ).thenAnswer(
+      (_) => stream.map<DecodeOutcome>((e) => DecodedEvent(e, const {})),
+    );
   }
 
   group('spawn', () {
@@ -253,7 +261,7 @@ void main() {
       ).thenAnswer((invocation) {
         capturedInput =
             invocation.positionalArguments[1] as SimpleRunAgentInput;
-        return Stream.fromIterable(_happyPathEvents());
+        return _wrap(Stream.fromIterable(_happyPathEvents()));
       });
 
       final session = await runtime.spawn(
@@ -293,7 +301,7 @@ void main() {
       ).thenAnswer((invocation) {
         capturedInput =
             invocation.positionalArguments[1] as SimpleRunAgentInput;
-        return Stream.fromIterable(_happyPathEvents());
+        return _wrap(Stream.fromIterable(_happyPathEvents()));
       });
 
       final session = await runtime.spawn(
@@ -354,7 +362,7 @@ void main() {
       ).thenAnswer((invocation) {
         capturedInput =
             invocation.positionalArguments[1] as SimpleRunAgentInput;
-        return Stream.fromIterable(_happyPathEvents());
+        return _wrap(Stream.fromIterable(_happyPathEvents()));
       });
 
       final session = await runtime.spawn(
@@ -500,7 +508,9 @@ void main() {
         ),
       ).thenAnswer((_) {
         callCount++;
-        return callCount == 1 ? controllerA.stream : controllerB.stream;
+        return callCount == 1
+            ? _wrap(controllerA.stream)
+            : _wrap(controllerB.stream);
       });
 
       final sessionA = await runtime.spawn(roomId: _roomId, prompt: 'A');
@@ -956,7 +966,7 @@ void main() {
           resumePolicy: any(named: 'resumePolicy'),
           onReconnectStatus: any(named: 'onReconnectStatus'),
         ),
-      ).thenAnswer((_) => controller1.stream);
+      ).thenAnswer((_) => _wrap(controller1.stream));
 
       final s1 = await runtime.spawn(
         roomId: _roomId,
@@ -999,16 +1009,18 @@ void main() {
       ).thenAnswer((invocation) {
         capturedInput =
             invocation.positionalArguments[1] as SimpleRunAgentInput;
-        return Stream.fromIterable([
-          const RunStartedEvent(
-            threadId: 'thread-fail',
-            runId: 'run-2',
-          ),
-          const RunFinishedEvent(
-            threadId: 'thread-fail',
-            runId: 'run-2',
-          ),
-        ]);
+        return _wrap(
+          Stream<BaseEvent>.fromIterable([
+            const RunStartedEvent(
+              threadId: 'thread-fail',
+              runId: 'run-2',
+            ),
+            const RunFinishedEvent(
+              threadId: 'thread-fail',
+              runId: 'run-2',
+            ),
+          ]),
+        );
       });
 
       final s2 = await runtime.spawn(
@@ -1116,8 +1128,8 @@ void main() {
       ).thenAnswer((_) {
         callCount++;
         return callCount == 1
-            ? Stream.fromIterable(_toolCallEvents())
-            : Stream.fromIterable(_resumeTextEvents());
+            ? _wrap(Stream.fromIterable(_toolCallEvents()))
+            : _wrap(Stream.fromIterable(_resumeTextEvents()));
       });
 
       final session = await runtime.spawn(roomId: _roomId, prompt: 'Weather?');
@@ -1171,20 +1183,22 @@ void main() {
         callCount++;
         // First call: tool yield; second call: resume with text
         return callCount == 1
-            ? Stream.fromIterable([
-                const RunStartedEvent(threadId: _threadId, runId: _runId),
-                const ToolCallStartEvent(
-                  toolCallId: 'tc-py',
-                  toolCallName: 'execute_python',
-                ),
-                const ToolCallArgsEvent(
-                  toolCallId: 'tc-py',
-                  delta: '{"code":"print(1)"}',
-                ),
-                const ToolCallEndEvent(toolCallId: 'tc-py'),
-                const RunFinishedEvent(threadId: _threadId, runId: _runId),
-              ])
-            : Stream.fromIterable(_resumeTextEvents());
+            ? _wrap(
+                Stream<BaseEvent>.fromIterable([
+                  const RunStartedEvent(threadId: _threadId, runId: _runId),
+                  const ToolCallStartEvent(
+                    toolCallId: 'tc-py',
+                    toolCallName: 'execute_python',
+                  ),
+                  const ToolCallArgsEvent(
+                    toolCallId: 'tc-py',
+                    delta: '{"code":"print(1)"}',
+                  ),
+                  const ToolCallEndEvent(toolCallId: 'tc-py'),
+                  const RunFinishedEvent(threadId: _threadId, runId: _runId),
+                ]),
+              )
+            : _wrap(Stream.fromIterable(_resumeTextEvents()));
       });
 
       final session = await runtime.spawn(roomId: _roomId, prompt: 'Run code');

--- a/packages/soliplex_agent/test/runtime/agent_session_signal_test.dart
+++ b/packages/soliplex_agent/test/runtime/agent_session_signal_test.dart
@@ -113,7 +113,9 @@ void main() {
         resumePolicy: any(named: 'resumePolicy'),
         onReconnectStatus: any(named: 'onReconnectStatus'),
       ),
-    ).thenAnswer((_) => stream);
+    ).thenAnswer(
+      (_) => stream.map<DecodeOutcome>((e) => DecodedEvent(e, const {})),
+    );
   }
 
   group('runState signal', () {

--- a/packages/soliplex_agent/test/runtime/agent_session_test.dart
+++ b/packages/soliplex_agent/test/runtime/agent_session_test.dart
@@ -11,6 +11,12 @@ import 'package:test/test.dart';
 // Mocks
 // ---------------------------------------------------------------------------
 
+/// Adapts a test event stream to the orchestrator's `DecodeOutcome`
+/// contract. Hand-written events have no source JSON, so `rawJson` is
+/// `const {}`.
+Stream<DecodeOutcome> _wrap(Stream<BaseEvent> s) =>
+    s.map<DecodeOutcome>((e) => DecodedEvent(e, const {}));
+
 class MockSoliplexApi extends Mock implements SoliplexApi {}
 
 class MockAgUiStreamClient extends Mock implements AgUiStreamClient {}
@@ -196,7 +202,9 @@ void main() {
         resumePolicy: any(named: 'resumePolicy'),
         onReconnectStatus: any(named: 'onReconnectStatus'),
       ),
-    ).thenAnswer((_) => stream);
+    ).thenAnswer(
+      (_) => stream.map<DecodeOutcome>((e) => DecodedEvent(e, const {})),
+    );
   }
 
   group('happy path', () {
@@ -274,8 +282,8 @@ void main() {
       ).thenAnswer((_) {
         callCount++;
         return callCount == 1
-            ? Stream.fromIterable(_toolCallEvents())
-            : Stream.fromIterable(_resumeTextEvents());
+            ? _wrap(Stream.fromIterable(_toolCallEvents()))
+            : _wrap(Stream.fromIterable(_resumeTextEvents()));
       });
 
       final session = createSession(
@@ -310,9 +318,9 @@ void main() {
       ).thenAnswer((_) {
         callCount++;
         if (callCount <= 2) {
-          return Stream.fromIterable(_toolCallEvents());
+          return _wrap(Stream.fromIterable(_toolCallEvents()));
         }
-        return Stream.fromIterable(_resumeTextEvents());
+        return _wrap(Stream.fromIterable(_resumeTextEvents()));
       });
 
       final session = createSession(
@@ -348,8 +356,8 @@ void main() {
       ).thenAnswer((_) {
         callCount++;
         return callCount == 1
-            ? Stream.fromIterable(_toolCallEvents())
-            : Stream.fromIterable(_resumeTextEvents());
+            ? _wrap(Stream.fromIterable(_toolCallEvents()))
+            : _wrap(Stream.fromIterable(_resumeTextEvents()));
       });
 
       final session = createSession(
@@ -421,7 +429,7 @@ void main() {
     test('stream error → AgentFailure', () async {
       stubCreateRun();
       stubRunAgent(
-        stream: Stream.fromIterable([
+        stream: Stream<BaseEvent>.fromIterable([
           const RunStartedEvent(threadId: 'thread-1', runId: _runId),
           const RunErrorEvent(message: 'backend error'),
         ]),
@@ -643,17 +651,19 @@ void main() {
       ).thenAnswer((_) {
         callCount++;
         return callCount == 1
-            ? Stream.fromIterable([
-                const RunStartedEvent(threadId: 'thread-1', runId: _runId),
-                const ToolCallStartEvent(
-                  toolCallId: 'tc-ext',
-                  toolCallName: 'ext_tool',
-                ),
-                const ToolCallArgsEvent(toolCallId: 'tc-ext', delta: '{}'),
-                const ToolCallEndEvent(toolCallId: 'tc-ext'),
-                const RunFinishedEvent(threadId: 'thread-1', runId: _runId),
-              ])
-            : Stream.fromIterable(_resumeTextEvents());
+            ? _wrap(
+                Stream<BaseEvent>.fromIterable([
+                  const RunStartedEvent(threadId: 'thread-1', runId: _runId),
+                  const ToolCallStartEvent(
+                    toolCallId: 'tc-ext',
+                    toolCallName: 'ext_tool',
+                  ),
+                  const ToolCallArgsEvent(toolCallId: 'tc-ext', delta: '{}'),
+                  const ToolCallEndEvent(toolCallId: 'tc-ext'),
+                  const RunFinishedEvent(threadId: 'thread-1', runId: _runId),
+                ]),
+              )
+            : _wrap(Stream.fromIterable(_resumeTextEvents()));
       });
 
       // Build session with extension tool merged into registry.
@@ -801,8 +811,8 @@ void main() {
         ).thenAnswer((_) {
           callCount++;
           return callCount == 1
-              ? Stream.fromIterable(_toolCallEvents())
-              : Stream.fromIterable(_resumeTextEvents());
+              ? _wrap(Stream.fromIterable(_toolCallEvents()))
+              : _wrap(Stream.fromIterable(_resumeTextEvents()));
         });
 
         final session = createSession(
@@ -850,8 +860,8 @@ void main() {
       ).thenAnswer((_) {
         callCount++;
         return callCount == 1
-            ? Stream.fromIterable(_toolCallEvents())
-            : Stream.fromIterable(_resumeTextEvents());
+            ? _wrap(Stream.fromIterable(_toolCallEvents()))
+            : _wrap(Stream.fromIterable(_resumeTextEvents()));
       });
 
       final session = createSession(
@@ -895,8 +905,8 @@ void main() {
       ).thenAnswer((_) {
         callCount++;
         return callCount == 1
-            ? Stream.fromIterable(_toolCallEvents())
-            : Stream.fromIterable(_resumeTextEvents());
+            ? _wrap(Stream.fromIterable(_toolCallEvents()))
+            : _wrap(Stream.fromIterable(_resumeTextEvents()));
       });
 
       final session = createSession(
@@ -937,7 +947,7 @@ void main() {
     test('ActivitySnapshotEvent bridges to ActivitySnapshot', () async {
       stubCreateRun();
       stubRunAgent(
-        stream: Stream.fromIterable([
+        stream: Stream<BaseEvent>.fromIterable([
           const RunStartedEvent(threadId: 'thread-1', runId: _runId),
           const ActivitySnapshotEvent(
             messageId: 'msg-1',
@@ -976,7 +986,7 @@ void main() {
     test('StepStartedEvent bridges to StepProgress', () async {
       stubCreateRun();
       stubRunAgent(
-        stream: Stream.fromIterable([
+        stream: Stream<BaseEvent>.fromIterable([
           const RunStartedEvent(threadId: 'thread-1', runId: _runId),
           const StepStartedEvent(stepName: 'planning'),
           const TextMessageStartEvent(messageId: 'msg-1'),

--- a/packages/soliplex_agent/test/runtime/concurrency_experiments_test.dart
+++ b/packages/soliplex_agent/test/runtime/concurrency_experiments_test.dart
@@ -22,6 +22,12 @@ import 'package:test/test.dart';
 // Mocks
 // ---------------------------------------------------------------------------
 
+/// Adapts a test event stream to the orchestrator's `DecodeOutcome`
+/// contract. Hand-written events have no source JSON, so `rawJson` is
+/// `const {}`.
+Stream<DecodeOutcome> _wrap(Stream<BaseEvent> s) =>
+    s.map<DecodeOutcome>((e) => DecodedEvent(e, const {}));
+
 class _MockSoliplexApi extends Mock implements SoliplexApi {}
 
 class _MockAgUiStreamClient extends Mock implements AgUiStreamClient {}
@@ -218,7 +224,9 @@ void main() {
         resumePolicy: any(named: 'resumePolicy'),
         onReconnectStatus: any(named: 'onReconnectStatus'),
       ),
-    ).thenAnswer((_) => stream);
+    ).thenAnswer(
+      (_) => stream.map<DecodeOutcome>((e) => DecodedEvent(e, const {})),
+    );
   }
 
   // =========================================================================
@@ -246,7 +254,9 @@ void main() {
         ),
       ).thenAnswer((_) {
         callCount++;
-        return callCount == 1 ? controllerA.stream : controllerB.stream;
+        return callCount == 1
+            ? _wrap(controllerA.stream)
+            : _wrap(controllerB.stream);
       });
 
       final sessionA = await runtime.spawn(roomId: _roomId, prompt: 'A');
@@ -290,7 +300,9 @@ void main() {
         ),
       ).thenAnswer((_) {
         callCount++;
-        return callCount == 1 ? controllerA.stream : controllerB.stream;
+        return callCount == 1
+            ? _wrap(controllerA.stream)
+            : _wrap(controllerB.stream);
       });
 
       final sessionA = await runtime.spawn(roomId: _roomId, prompt: 'A');
@@ -392,7 +404,7 @@ void main() {
           resumePolicy: any(named: 'resumePolicy'),
           onReconnectStatus: any(named: 'onReconnectStatus'),
         ),
-      ).thenAnswer((_) => controllers[callIdx++].stream);
+      ).thenAnswer((_) => _wrap(controllers[callIdx++].stream));
 
       // Await first `limit` to ensure they're tracked before queuing.
       final sessions = <AgentSession>[];
@@ -566,11 +578,11 @@ void main() {
         callCount++;
         switch (callCount) {
           case 1:
-            return slowA.stream;
+            return _wrap(slowA.stream);
           case 2:
-            return slowB.stream;
+            return _wrap(slowB.stream);
           default:
-            return Stream.fromIterable(_happyPathEvents());
+            return _wrap(Stream.fromIterable(_happyPathEvents()));
         }
       });
 
@@ -640,8 +652,8 @@ void main() {
         callCount++;
         // Calls 1–2: tool events; calls 3–4: resume events.
         return callCount <= 2
-            ? Stream.fromIterable(_toolCallEvents())
-            : Stream.fromIterable(_resumeTextEvents());
+            ? _wrap(Stream.fromIterable(_toolCallEvents()))
+            : _wrap(Stream.fromIterable(_resumeTextEvents()));
       });
 
       final sessionA = await runtime.spawn(roomId: _roomId, prompt: 'A');
@@ -703,8 +715,8 @@ void main() {
         callCount++;
         // Calls 1–2: tool events; calls 3–4: resume events.
         return callCount <= 2
-            ? Stream.fromIterable(_toolCallEvents())
-            : Stream.fromIterable(_resumeTextEvents());
+            ? _wrap(Stream.fromIterable(_toolCallEvents()))
+            : _wrap(Stream.fromIterable(_resumeTextEvents()));
       });
 
       final sw = Stopwatch()..start();
@@ -761,7 +773,9 @@ void main() {
         ),
       ).thenAnswer((_) {
         callCount++;
-        return callCount == 1 ? controllerA.stream : controllerB.stream;
+        return callCount == 1
+            ? _wrap(controllerA.stream)
+            : _wrap(controllerB.stream);
       });
 
       await runtime.spawn(roomId: _roomId, prompt: 'With bridge');
@@ -812,8 +826,8 @@ void main() {
       ).thenAnswer((_) {
         callCount++;
         return callCount.isOdd
-            ? Stream.fromIterable(_toolCallEvents())
-            : Stream.fromIterable(_resumeTextEvents());
+            ? _wrap(Stream.fromIterable(_toolCallEvents()))
+            : _wrap(Stream.fromIterable(_resumeTextEvents()));
       });
 
       // Await first spawn to ensure tracking before queuing.
@@ -875,8 +889,8 @@ void main() {
       ).thenAnswer((_) {
         callCount++;
         return callCount <= n
-            ? Stream.fromIterable(_toolCallEvents())
-            : Stream.fromIterable(_resumeTextEvents());
+            ? _wrap(Stream.fromIterable(_toolCallEvents()))
+            : _wrap(Stream.fromIterable(_resumeTextEvents()));
       });
 
       final sw = Stopwatch()..start();
@@ -943,8 +957,8 @@ void main() {
       ).thenAnswer((_) {
         callCount++;
         return callCount <= n
-            ? Stream.fromIterable(_toolCallEvents())
-            : Stream.fromIterable(_resumeTextEvents());
+            ? _wrap(Stream.fromIterable(_toolCallEvents()))
+            : _wrap(Stream.fromIterable(_resumeTextEvents()));
       });
 
       final sw = Stopwatch()..start();

--- a/packages/soliplex_agent/test/runtime/multi_server_runtime_test.dart
+++ b/packages/soliplex_agent/test/runtime/multi_server_runtime_test.dart
@@ -10,6 +10,12 @@ import 'package:test/test.dart';
 // Mocks
 // ---------------------------------------------------------------------------
 
+/// Adapts a test event stream to the orchestrator's `DecodeOutcome`
+/// contract. Hand-written events have no source JSON, so `rawJson` is
+/// `const {}`.
+Stream<DecodeOutcome> _wrap(Stream<BaseEvent> s) =>
+    s.map<DecodeOutcome>((e) => DecodedEvent(e, const {}));
+
 class MockSoliplexApi extends Mock implements SoliplexApi {}
 
 class MockAgUiStreamClient extends Mock implements AgUiStreamClient {}
@@ -80,7 +86,9 @@ void _stubHappyPath(
       onReconnectStatus: any(named: 'onReconnectStatus'),
     ),
   ).thenAnswer(
-    (_) => stream ?? Stream.fromIterable(_happyPathEvents(threadId)),
+    (_) => stream != null
+        ? _wrap(stream)
+        : _wrap(Stream.fromIterable(_happyPathEvents(threadId))),
   );
 }
 

--- a/packages/soliplex_agent/test/runtime/session_children_test.dart
+++ b/packages/soliplex_agent/test/runtime/session_children_test.dart
@@ -10,6 +10,12 @@ import 'package:test/test.dart';
 // Mocks
 // ---------------------------------------------------------------------------
 
+/// Adapts a test event stream to the orchestrator's `DecodeOutcome`
+/// contract. Hand-written events have no source JSON, so `rawJson` is
+/// `const {}`.
+Stream<DecodeOutcome> _wrap(Stream<BaseEvent> s) =>
+    s.map<DecodeOutcome>((e) => DecodedEvent(e, const {}));
+
 class MockSoliplexApi extends Mock implements SoliplexApi {}
 
 class MockAgUiStreamClient extends Mock implements AgUiStreamClient {}
@@ -105,7 +111,9 @@ void main() {
         resumePolicy: any(named: 'resumePolicy'),
         onReconnectStatus: any(named: 'onReconnectStatus'),
       ),
-    ).thenAnswer((_) => stream);
+    ).thenAnswer(
+      (_) => stream.map<DecodeOutcome>((e) => DecodedEvent(e, const {})),
+    );
   }
 
   group('parent-child ownership', () {
@@ -253,8 +261,8 @@ void main() {
       ).thenAnswer((_) {
         callCount++;
         return callCount == 1
-            ? parentController.stream
-            : Stream.fromIterable(_happyPathEvents());
+            ? _wrap(parentController.stream)
+            : _wrap(Stream.fromIterable(_happyPathEvents()));
       });
 
       final parent = await runtime.spawn(roomId: _roomA, prompt: 'Hello');

--- a/packages/soliplex_client/lib/src/api/soliplex_api.dart
+++ b/packages/soliplex_client/lib/src/api/soliplex_api.dart
@@ -769,13 +769,14 @@ class SoliplexApi {
         final eventJson = events[i];
         final outcome = decodeMapSafely(eventJson);
         switch (outcome) {
-          case DecodeFailed(:final error):
+          case DecodeFailed(:final error, :final stackTrace):
             developer.log(
               'replay: decode failed at events[$i] '
               '(type=${eventJson['type']}) in run $runId of thread $threadId.',
               name: 'soliplex_client.replay',
               level: 900,
               error: error,
+              stackTrace: stackTrace,
             );
             conversation = conversation.withAppendedMessage(
               DroppedEventMessage.create(

--- a/packages/soliplex_client/lib/src/api/soliplex_api.dart
+++ b/packages/soliplex_client/lib/src/api/soliplex_api.dart
@@ -26,6 +26,9 @@ import 'package:soliplex_client/src/http/http_transport.dart';
 import 'package:soliplex_client/src/http/multipart_encoder.dart';
 import 'package:soliplex_client/src/utils/cancel_token.dart';
 import 'package:soliplex_client/src/utils/url_builder.dart';
+import 'package:soliplex_logging/soliplex_logging.dart';
+
+final Logger _logger = LogManager.instance.getLogger('soliplex_client.api');
 
 /// API client for Soliplex backend CRUD operations.
 ///
@@ -764,25 +767,37 @@ class SoliplexApi {
       final decodedEvents = <BaseEvent>[];
       for (var i = 0; i < events.length; i++) {
         final eventJson = events[i];
+        void appendDrop({
+          required DropSource source,
+          required Object error,
+          required StackTrace stackTrace,
+          required String stage,
+        }) {
+          _logger.error(
+            'replay: $stage failed at events[$i] '
+            '(type=${eventJson['type']}) in run $runId of thread $threadId.',
+            error: error,
+            stackTrace: stackTrace,
+          );
+          conversation = conversation.withAppendedMessage(
+            DroppedEventMessage.create(
+              id: 'dropped-$runId-$i',
+              source: source,
+              reason: error.toString(),
+              runId: runId,
+              rawPayload: eventJson,
+            ),
+          );
+        }
+
         final outcome = decodeMapSafely(eventJson);
         switch (outcome) {
           case DecodeFailed(:final error, :final stackTrace):
-            developer.log(
-              'replay: decode failed at events[$i] '
-              '(type=${eventJson['type']}) in run $runId of thread $threadId.',
-              name: 'soliplex_client.replay',
-              level: 900,
+            appendDrop(
+              source: DropSource.decode,
               error: error,
-              stackTrace: stackTrace,
-            );
-            conversation = conversation.withAppendedMessage(
-              DroppedEventMessage.create(
-                id: 'dropped-$runId-$i',
-                source: DropSource.decode,
-                reason: error.toString(),
-                runId: runId,
-                rawPayload: eventJson,
-              ),
+              stackTrace: stackTrace ?? StackTrace.current,
+              stage: 'decode',
             );
           case DecodedEvent(:final event):
             decodedEvents.add(event);
@@ -791,23 +806,11 @@ class SoliplexApi {
               conversation = result.conversation;
               streaming = result.streaming;
             } on Object catch (error, stackTrace) {
-              developer.log(
-                'replay: processEvent threw on events[$i] '
-                '(type=${eventJson['type']}) in run $runId of '
-                'thread $threadId.',
-                name: 'soliplex_client.replay',
-                level: 900,
+              appendDrop(
+                source: DropSource.eventProcessing,
                 error: error,
                 stackTrace: stackTrace,
-              );
-              conversation = conversation.withAppendedMessage(
-                DroppedEventMessage.create(
-                  id: 'dropped-$runId-$i',
-                  source: DropSource.eventProcessing,
-                  reason: error.toString(),
-                  runId: runId,
-                  rawPayload: eventJson,
-                ),
+                stage: 'processEvent',
               );
             }
         }

--- a/packages/soliplex_client/lib/src/api/soliplex_api.dart
+++ b/packages/soliplex_client/lib/src/api/soliplex_api.dart
@@ -762,8 +762,7 @@ class SoliplexApi {
         }
       }
 
-      // Decode + process per-event; failures append a drop tile so one
-      // bad event can't abort replay.
+      // Per-event try/catch so one bad event can't abort replay.
       final decodedEvents = <BaseEvent>[];
       for (var i = 0; i < events.length; i++) {
         final eventJson = events[i];

--- a/packages/soliplex_client/lib/src/api/soliplex_api.dart
+++ b/packages/soliplex_client/lib/src/api/soliplex_api.dart
@@ -76,12 +76,17 @@ class SoliplexApi {
 
   /// LRU cache for run events. Completed runs are immutable, so safe to cache.
   /// Uses insertion order - oldest entries are at the front.
-  final _runEventsCache = <String, List<Map<String, dynamic>>>{};
+  ///
+  /// Cached as `List<dynamic>` so a backend that emits non-Map items
+  /// (shape drift) round-trips through the cache without throwing on
+  /// access; the replay loop in [_replayEventsToHistory] mints a drop
+  /// tile for any non-Map item it encounters.
+  final _runEventsCache = <String, List<dynamic>>{};
 
   String _runCacheKey(String threadId, String runId) => '$threadId:$runId';
 
   /// Adds to cache with LRU eviction.
-  void _cacheRunEvents(String key, List<Map<String, dynamic>> events) {
+  void _cacheRunEvents(String key, List<dynamic> events) {
     // Remove if exists (to update position for LRU)
     _runEventsCache.remove(key);
 
@@ -94,7 +99,7 @@ class SoliplexApi {
   }
 
   /// Gets from cache and updates LRU position.
-  List<Map<String, dynamic>>? _getCachedRunEvents(String key) {
+  List<dynamic>? _getCachedRunEvents(String key) {
     final events = _runEventsCache.remove(key);
     if (events != null) {
       _runEventsCache[key] = events; // Re-add to move to end (most recent)
@@ -601,12 +606,23 @@ class SoliplexApi {
       cancelToken: cancelToken,
     );
 
-    final runs = response['runs'] as Map<String, dynamic>? ?? {};
+    // Defensive: backend shape drift on the envelope (e.g., `runs`
+    // becoming a list, run entries that aren't Maps, missing run_id)
+    // would otherwise abort the entire history load. Fall through to
+    // empty/skipped instead so the rest of the thread still renders.
+    final rawRuns = response['runs'];
+    final runs =
+        rawRuns is Map<String, dynamic> ? rawRuns : const <String, dynamic>{};
     if (runs.isEmpty) return ThreadHistory(messages: const []);
 
     // 2. Get completed run IDs sorted by creation time
     final completedRunIds = _sortRunsByCreationTime(runs)
-        .where((e) => (e.value as Map<String, dynamic>)['finished'] != null)
+        .where((e) {
+          final value = e.value;
+          return value is Map<String, dynamic> &&
+              value['finished'] != null &&
+              value['run_id'] is String;
+        })
         .map((e) => (e.value as Map<String, dynamic>)['run_id'] as String)
         .toList();
 
@@ -623,7 +639,7 @@ class SoliplexApi {
         (Object e) {
           // Log transient failure but continue with other runs
           _onWarning?.call('Failed to fetch events for run $runId: $e');
-          return (runId: runId, events: <Map<String, dynamic>>[]);
+          return (runId: runId, events: <dynamic>[]);
         },
         // Only catch transient errors - show partial results for batch ops:
         // - NetworkException: network blip, retry might succeed
@@ -637,10 +653,9 @@ class SoliplexApi {
 
     // 4. Collect events in run order (results may arrive out of order)
     final runIdToEvents = {for (final r in results) r.runId: r.events};
-    final eventsPerRun =
-        <({String runId, List<Map<String, dynamic>> events})>[];
+    final eventsPerRun = <({String runId, List<dynamic> events})>[];
     for (final runId in completedRunIds) {
-      final runEvents = runIdToEvents[runId] ?? [];
+      final runEvents = runIdToEvents[runId] ?? const <dynamic>[];
       if (runEvents.isNotEmpty) {
         eventsPerRun.add((runId: runId, events: runEvents));
       }
@@ -655,7 +670,13 @@ class SoliplexApi {
   /// Returns events including synthetic user message events extracted from
   /// run_input.messages. The backend stores user input separately from
   /// streamed events, so we synthesize TEXT_MESSAGE events for them.
-  Future<List<Map<String, dynamic>>> _fetchRunEvents(
+  ///
+  /// Returns `List<dynamic>` rather than `List<Map<String, dynamic>>`:
+  /// shape drift on the wire (a non-Map item slipping into `events`)
+  /// must reach [_replayEventsToHistory] as data, not throw at the cast
+  /// site. The replay loop type-checks each item and mints a drop tile
+  /// for non-Map entries.
+  Future<List<dynamic>> _fetchRunEvents(
     String roomId,
     String threadId,
     String runId, {
@@ -676,11 +697,11 @@ class SoliplexApi {
     // Extract user messages from run_input and create synthetic events
     final userMessageEvents = _extractUserMessageEvents(rawRun);
 
-    final events =
-        (rawRun['events'] as List<dynamic>? ?? []).cast<Map<String, dynamic>>();
+    final rawEvents = rawRun['events'];
+    final events = rawEvents is List ? rawEvents : const <dynamic>[];
 
     // Combine: user message events first, then actual streamed events
-    final allEvents = [...userMessageEvents, ...events];
+    final allEvents = <dynamic>[...userMessageEvents, ...events];
     _cacheRunEvents(cacheKey, allEvents);
     return allEvents;
   }
@@ -694,26 +715,36 @@ class SoliplexApi {
   List<Map<String, dynamic>> _extractUserMessageEvents(
     Map<String, dynamic> rawRun,
   ) {
-    final runInput = rawRun['run_input'] as Map<String, dynamic>?;
-    if (runInput == null) return [];
+    // Type-checked rather than cast: shape drift on `run_input` or
+    // `messages` should silently degrade to "no synthetic user message"
+    // rather than abort the run-level fetch.
+    final runInput = rawRun['run_input'];
+    if (runInput is! Map<String, dynamic>) return [];
 
-    final messages = runInput['messages'] as List<dynamic>? ?? [];
+    final rawMessages = runInput['messages'];
+    final messages = rawMessages is List ? rawMessages : const <dynamic>[];
 
     // Find the last user message — the one that initiated this run.
     Map<String, dynamic>? lastUserMessage;
     for (var i = messages.length - 1; i >= 0; i--) {
       final raw = messages[i];
       if (raw is! Map<String, dynamic>) continue;
-      if ((raw['role'] as String? ?? 'user') == 'user') {
+      final role = raw['role'];
+      if ((role is String ? role : 'user') == 'user') {
         lastUserMessage = raw;
         break;
       }
     }
     if (lastUserMessage == null) return [];
 
-    final runId = rawRun['run_id'] as String? ?? 'unknown';
-    final id = lastUserMessage['id'] as String? ?? 'user-$runId';
-    final content = lastUserMessage['content'] as String? ?? '';
+    final runId =
+        rawRun['run_id'] is String ? rawRun['run_id'] as String : 'unknown';
+    final id = lastUserMessage['id'] is String
+        ? lastUserMessage['id'] as String
+        : 'user-$runId';
+    final content = lastUserMessage['content'] is String
+        ? lastUserMessage['content'] as String
+        : '';
 
     return [
       {'type': 'TEXT_MESSAGE_START', 'messageId': id, 'role': 'user'},
@@ -732,7 +763,7 @@ class SoliplexApi {
   /// messages. Each run's citations are keyed by the user message ID that
   /// initiated that run.
   ThreadHistory _replayEventsToHistory(
-    List<({String runId, List<Map<String, dynamic>> events})> eventsPerRun,
+    List<({String runId, List<dynamic> events})> eventsPerRun,
     String threadId,
   ) {
     if (eventsPerRun.isEmpty) return ThreadHistory(messages: const []);
@@ -749,16 +780,18 @@ class SoliplexApi {
 
       // Find user message ID from LAST TEXT_MESSAGE_START with role=user.
       // The run_input.messages contains ALL conversation messages, but the
-      // LAST user message is the one that initiated THIS run.
+      // LAST user message is the one that initiated THIS run. Non-Map
+      // items are skipped here; the main loop below mints a drop tile
+      // for each.
       String? userMessageId;
       for (final eventJson in events) {
-        final type = eventJson['type'] as String?;
-        if (type == 'TEXT_MESSAGE_START') {
-          final role = eventJson['role'] as String?;
-          if (role == 'user') {
-            userMessageId = eventJson['messageId'] as String?;
-            // Don't break - keep iterating to find the last one
-          }
+        if (eventJson is! Map<String, dynamic>) continue;
+        if (eventJson['type'] != 'TEXT_MESSAGE_START') continue;
+        if (eventJson['role'] != 'user') continue;
+        final messageId = eventJson['messageId'];
+        if (messageId is String) {
+          userMessageId = messageId;
+          // Don't break - keep iterating to find the last one
         }
       }
 
@@ -771,10 +804,12 @@ class SoliplexApi {
           required Object error,
           required StackTrace stackTrace,
           required String stage,
+          required Object? rawPayload,
+          String? typeForLog,
         }) {
           _logger.error(
             'replay: $stage failed at events[$i] '
-            '(type=${eventJson['type']}) in run $runId of thread $threadId.',
+            '(type=$typeForLog) in run $runId of thread $threadId.',
             error: error,
             stackTrace: stackTrace,
           );
@@ -784,12 +819,29 @@ class SoliplexApi {
               source: source,
               reason: error.toString(),
               runId: runId,
-              rawPayload: eventJson,
+              rawPayload: rawPayload,
             ),
           );
         }
 
+        if (eventJson is! Map<String, dynamic>) {
+          appendDrop(
+            source: DropSource.decode,
+            error: FormatException(
+              'Non-object item in AG-UI events: ${eventJson.runtimeType}',
+            ),
+            stackTrace: StackTrace.current,
+            stage: 'decode',
+            rawPayload: eventJson,
+            typeForLog: '<non-map>',
+          );
+          continue;
+        }
+
         final outcome = decodeMapSafely(eventJson);
+        final type = eventJson['type'] is String
+            ? eventJson['type'] as String
+            : '<missing>';
         switch (outcome) {
           case DecodeFailed(:final error, :final stackTrace):
             appendDrop(
@@ -797,6 +849,8 @@ class SoliplexApi {
               error: error,
               stackTrace: stackTrace ?? StackTrace.current,
               stage: 'decode',
+              rawPayload: eventJson,
+              typeForLog: type,
             );
           case DecodedEvent(:final event):
             decodedEvents.add(event);
@@ -810,6 +864,8 @@ class SoliplexApi {
                 error: error,
                 stackTrace: stackTrace,
                 stage: 'processEvent',
+                rawPayload: eventJson,
+                typeForLog: type,
               );
             }
         }
@@ -838,16 +894,23 @@ class SoliplexApi {
     );
   }
 
-  /// Sorts runs by creation time (oldest first).
+  /// Sorts runs by creation time (oldest first). Non-Map run values
+  /// sort to the end; the caller filters them out before fetching.
   List<MapEntry<String, dynamic>> _sortRunsByCreationTime(
     Map<String, dynamic> runs,
   ) {
     return runs.entries.toList()
       ..sort((a, b) {
-        final aData = a.value as Map<String, dynamic>;
-        final bData = b.value as Map<String, dynamic>;
-        final aCreated = aData['created'] as String?;
-        final bCreated = bData['created'] as String?;
+        final aData = a.value is Map<String, dynamic>
+            ? a.value as Map<String, dynamic>
+            : const <String, dynamic>{};
+        final bData = b.value is Map<String, dynamic>
+            ? b.value as Map<String, dynamic>
+            : const <String, dynamic>{};
+        final aCreated =
+            aData['created'] is String ? aData['created'] as String : null;
+        final bCreated =
+            bData['created'] is String ? bData['created'] as String : null;
 
         if (aCreated == null && bCreated == null) return 0;
         if (aCreated == null) return 1;

--- a/packages/soliplex_client/lib/src/api/soliplex_api.dart
+++ b/packages/soliplex_client/lib/src/api/soliplex_api.dart
@@ -5,8 +5,10 @@ import 'package:ag_ui/ag_ui.dart' hide CancelToken;
 import 'package:soliplex_client/src/api/mappers.dart';
 import 'package:soliplex_client/src/application/agui_event_processor.dart';
 import 'package:soliplex_client/src/application/citation_extractor.dart';
+import 'package:soliplex_client/src/application/decode_outcome.dart';
 import 'package:soliplex_client/src/application/streaming_state.dart';
 import 'package:soliplex_client/src/domain/backend_version_info.dart';
+import 'package:soliplex_client/src/domain/chat_message.dart';
 import 'package:soliplex_client/src/domain/chunk_visualization.dart';
 import 'package:soliplex_client/src/domain/conversation.dart';
 import 'package:soliplex_client/src/domain/feedback_type.dart';
@@ -734,11 +736,9 @@ class SoliplexApi {
 
     var conversation = Conversation.empty(threadId: threadId);
     var streaming = const AwaitingText() as StreamingState;
-    const decoder = EventDecoder();
     final extractor = CitationExtractor();
     final messageStates = <String, MessageState>{};
     final runs = <RunEventBundle>[];
-    var skippedEventCount = 0;
 
     for (final (:runId, :events) in eventsPerRun) {
       // Capture AG-UI state before processing this run
@@ -759,32 +759,59 @@ class SoliplexApi {
         }
       }
 
-      // Process all events in this run.
-      //
-      // Catches any error so that one malformed event (decode failure,
-      // unexpected shape, cast failure inside processEvent) cannot abort
-      // replay and leave the user with a half-loaded thread. Bad events
-      // are skipped, surrounding messages still appear, and the
-      // skippedEventCount surfaces as a non-blocking warning below.
+      // Process all events in this run. The two boundaries that can lose
+      // user-facing content are the decode boundary (`decodeMapSafely`)
+      // and `processEvent` itself; both append a `DroppedEventMessage`
+      // at the failure position so a malformed event can't abort replay
+      // and leave the user with a half-loaded thread.
       final decodedEvents = <BaseEvent>[];
       for (var i = 0; i < events.length; i++) {
         final eventJson = events[i];
-        try {
-          final event = decoder.decodeJson(eventJson);
-          decodedEvents.add(event);
-          final result = processEvent(conversation, streaming, event);
-          conversation = result.conversation;
-          streaming = result.streaming;
-        } on Object catch (error, stackTrace) {
-          skippedEventCount++;
-          developer.log(
-            'replay: skipping events[$i] (type=${eventJson['type']}) '
-            'in run $runId of thread $threadId.',
-            name: 'soliplex_client.replay',
-            level: 900,
-            error: error,
-            stackTrace: stackTrace,
-          );
+        final outcome = decodeMapSafely(eventJson);
+        switch (outcome) {
+          case DecodeFailed(:final error):
+            developer.log(
+              'replay: decode failed at events[$i] '
+              '(type=${eventJson['type']}) in run $runId of thread $threadId.',
+              name: 'soliplex_client.replay',
+              level: 900,
+              error: error,
+            );
+            conversation = conversation.withAppendedMessage(
+              DroppedEventMessage.create(
+                id: 'dropped-$runId-$i',
+                source: DropSource.decode,
+                reason: error.toString(),
+                runId: runId,
+                rawPayload: eventJson,
+              ),
+            );
+          case DecodedEvent(:final event):
+            decodedEvents.add(event);
+            try {
+              final result = processEvent(conversation, streaming, event);
+              conversation = result.conversation;
+              streaming = result.streaming;
+            } on Object catch (error, stackTrace) {
+              developer.log(
+                'replay: processEvent threw on events[$i] '
+                '(type=${eventJson['type']}) in run $runId of '
+                'thread $threadId.',
+                name: 'soliplex_client.replay',
+                level: 900,
+                error: error,
+                stackTrace: stackTrace,
+              );
+              conversation = conversation.withAppendedMessage(
+                DroppedEventMessage.create(
+                  id: 'dropped-$runId-$i',
+                  source: DropSource.eventProcessing,
+                  reason: error.toString(),
+                  runId: runId,
+                  rawPayload: eventJson,
+                ),
+              );
+            }
         }
       }
       runs.add(RunEventBundle(runId: runId, events: decodedEvents));
@@ -801,13 +828,6 @@ class SoliplexApi {
           runId: runId,
         );
       }
-    }
-
-    if (skippedEventCount > 0) {
-      _onWarning?.call(
-        'Skipped $skippedEventCount malformed event(s) '
-        'while loading thread $threadId',
-      );
     }
 
     return ThreadHistory(

--- a/packages/soliplex_client/lib/src/api/soliplex_api.dart
+++ b/packages/soliplex_client/lib/src/api/soliplex_api.dart
@@ -759,11 +759,8 @@ class SoliplexApi {
         }
       }
 
-      // Process all events in this run. The two boundaries that can lose
-      // user-facing content are the decode boundary (`decodeMapSafely`)
-      // and `processEvent` itself; both append a `DroppedEventMessage`
-      // at the failure position so a malformed event can't abort replay
-      // and leave the user with a half-loaded thread.
+      // Decode + process per-event; failures append a drop tile so one
+      // bad event can't abort replay.
       final decodedEvents = <BaseEvent>[];
       for (var i = 0; i < events.length; i++) {
         final eventJson = events[i];

--- a/packages/soliplex_client/lib/src/api/soliplex_api.dart
+++ b/packages/soliplex_client/lib/src/api/soliplex_api.dart
@@ -606,27 +606,65 @@ class SoliplexApi {
       cancelToken: cancelToken,
     );
 
-    // Defensive: backend shape drift on the envelope (e.g., `runs`
-    // becoming a list, run entries that aren't Maps, missing run_id)
-    // would otherwise abort the entire history load. Fall through to
-    // empty/skipped instead so the rest of the thread still renders.
+    // Envelope-level shape drift (`runs` arrives as a list/scalar instead
+    // of a map) is a backend bug — retry can't fix it. Throw so the UI
+    // surfaces a non-retryable error rather than rendering an empty
+    // thread (which is indistinguishable from a fresh thread). Null /
+    // missing stays a legitimate empty thread.
     final rawRuns = response['runs'];
+    if (rawRuns != null && rawRuns is! Map<String, dynamic>) {
+      throw MalformedResponseException(
+        message: 'Thread history `runs` field has unexpected shape: '
+            '${rawRuns.runtimeType}',
+      );
+    }
     final runs =
         rawRuns is Map<String, dynamic> ? rawRuns : const <String, dynamic>{};
     if (runs.isEmpty) return ThreadHistory(messages: const []);
 
-    // 2. Get completed run IDs sorted by creation time
-    final completedRunIds = _sortRunsByCreationTime(runs)
-        .where((e) {
-          final value = e.value;
-          return value is Map<String, dynamic> &&
-              value['finished'] != null &&
-              value['run_id'] is String;
-        })
-        .map((e) => (e.value as Map<String, dynamic>)['run_id'] as String)
-        .toList();
+    // 2. Walk runs in creation order, collecting:
+    //    - completed run ids → fetched in parallel below
+    //    - malformed entries → preserved as drop-tile placeholders so the
+    //      run is visibly absent rather than silently filtered out
+    //    Unfinished runs are skipped without surfacing — they are still
+    //    in flight, not corrupted.
+    final completedRunIds = <String>[];
+    final preFetchDrops =
+        <({String runId, MalformedResponseException error})>[];
+    for (final entry in _sortRunsByCreationTime(runs)) {
+      final value = entry.value;
+      if (value is! Map<String, dynamic>) {
+        preFetchDrops.add(
+          (
+            runId: entry.key,
+            error: MalformedResponseException(
+              message: 'Run entry ${entry.key} has unexpected shape: '
+                  '${value.runtimeType}',
+            ),
+          ),
+        );
+        continue;
+      }
+      if (value['finished'] == null) continue;
+      final rawRunId = value['run_id'];
+      if (rawRunId is! String) {
+        preFetchDrops.add(
+          (
+            runId: entry.key,
+            error: MalformedResponseException(
+              message: 'Run entry ${entry.key} missing `run_id` (got '
+                  '${rawRunId.runtimeType})',
+            ),
+          ),
+        );
+        continue;
+      }
+      completedRunIds.add(rawRunId);
+    }
 
-    if (completedRunIds.isEmpty) return ThreadHistory(messages: const []);
+    if (completedRunIds.isEmpty && preFetchDrops.isEmpty) {
+      return ThreadHistory(messages: const []);
+    }
 
     // 3. Fetch all run events in parallel (cache handles duplicates)
     final eventFutures = completedRunIds.map((runId) {
@@ -635,11 +673,18 @@ class SoliplexApi {
         threadId,
         runId,
         cancelToken: cancelToken,
-      ).then((events) => (runId: runId, events: events)).catchError(
+      )
+          .then(
+        (events) => (runId: runId, events: events, fetchError: null as Object?),
+      )
+          .catchError(
         (Object e) {
-          // Log transient failure but continue with other runs
+          // Log transient failure but continue with other runs. The
+          // fetchError below carries the same exception into the replay
+          // loop, which mints a drop tile so the run is visibly missing
+          // rather than silently absent.
           _onWarning?.call('Failed to fetch events for run $runId: $e');
-          return (runId: runId, events: <dynamic>[]);
+          return (runId: runId, events: <dynamic>[], fetchError: e as Object?);
         },
         // Only catch transient errors - show partial results for batch ops:
         // - NetworkException: network blip, retry might succeed
@@ -651,14 +696,39 @@ class SoliplexApi {
 
     final results = await Future.wait(eventFutures);
 
-    // 4. Collect events in run order (results may arrive out of order)
-    final runIdToEvents = {for (final r in results) r.runId: r.events};
-    final eventsPerRun = <({String runId, List<dynamic> events})>[];
-    for (final runId in completedRunIds) {
-      final runEvents = runIdToEvents[runId] ?? const <dynamic>[];
-      if (runEvents.isNotEmpty) {
-        eventsPerRun.add((runId: runId, events: runEvents));
+    // 4. Collect events in run order (results may arrive out of order),
+    //    interleaving pre-fetch drops at their original creation-order
+    //    position by walking the original sort once.
+    final fetchByRunId = {for (final r in results) r.runId: r};
+    final preFetchByRunKey = {for (final d in preFetchDrops) d.runId: d.error};
+    final eventsPerRun =
+        <({String runId, List<dynamic> events, Object? fetchError})>[];
+    for (final entry in _sortRunsByCreationTime(runs)) {
+      final preFetchError = preFetchByRunKey[entry.key];
+      if (preFetchError != null) {
+        eventsPerRun.add(
+          (
+            runId: entry.key,
+            events: const <dynamic>[],
+            fetchError: preFetchError,
+          ),
+        );
+        continue;
       }
+      final value = entry.value;
+      if (value is! Map<String, dynamic>) continue;
+      if (value['finished'] == null) continue;
+      final rawRunId = value['run_id'];
+      if (rawRunId is! String) continue;
+      final fetched = fetchByRunId[rawRunId];
+      if (fetched == null) continue;
+      eventsPerRun.add(
+        (
+          runId: rawRunId,
+          events: fetched.events,
+          fetchError: fetched.fetchError,
+        ),
+      );
     }
 
     // 5. Replay events to reconstruct history (messages + AG-UI state)
@@ -763,7 +833,8 @@ class SoliplexApi {
   /// messages. Each run's citations are keyed by the user message ID that
   /// initiated that run.
   ThreadHistory _replayEventsToHistory(
-    List<({String runId, List<dynamic> events})> eventsPerRun,
+    List<({String runId, List<dynamic> events, Object? fetchError})>
+        eventsPerRun,
     String threadId,
   ) {
     if (eventsPerRun.isEmpty) return ThreadHistory(messages: const []);
@@ -774,7 +845,27 @@ class SoliplexApi {
     final messageStates = <String, MessageState>{};
     final runs = <RunEventBundle>[];
 
-    for (final (:runId, :events) in eventsPerRun) {
+    for (final (:runId, :events, :fetchError) in eventsPerRun) {
+      // Run-level fetch failure (transient HTTP error or pre-fetch
+      // shape-drift on the run entry) → mint one drop tile in place so
+      // the run is visibly missing from the timeline rather than
+      // silently absent. `events` may still be empty (transient failure)
+      // or non-empty if a future code path attaches partial data.
+      if (fetchError != null) {
+        _logger.error(
+          'replay: run $runId in thread $threadId could not be fetched.',
+          error: fetchError,
+        );
+        conversation = conversation.withAppendedMessage(
+          DroppedEventMessage.create(
+            id: 'dropped-$runId-fetch',
+            source: DropSource.decode,
+            reason: fetchError.toString(),
+            runId: runId,
+          ),
+        );
+      }
+
       // Capture AG-UI state before processing this run
       final previousAguiState = conversation.aguiState;
 

--- a/packages/soliplex_client/lib/src/application/agui_event_processor.dart
+++ b/packages/soliplex_client/lib/src/application/agui_event_processor.dart
@@ -762,18 +762,13 @@ EventProcessingResult _processStateSnapshot(
   StreamingState streaming,
   dynamic snapshot,
 ) {
-  if (snapshot is! Map<String, dynamic>) {
-    _logger.warning(
-      'StateSnapshotEvent: skipping non-Map snapshot; state unchanged.',
-      attributes: {'snapshotType': snapshot.runtimeType.toString()},
-    );
-    return EventProcessingResult(
-      conversation: conversation,
-      streaming: streaming,
-    );
-  }
+  // The cast throws on non-Map snapshots. The per-event-loop wrappers
+  // in `RunOrchestrator._onEvent` and `SoliplexApi._replayEventsToHistory`
+  // catch the throw and append a `DroppedEventMessage` at the failure
+  // position; surrounding events still process.
   return EventProcessingResult(
-    conversation: conversation.copyWith(aguiState: snapshot),
+    conversation:
+        conversation.copyWith(aguiState: snapshot as Map<String, dynamic>),
     streaming: streaming,
   );
 }

--- a/packages/soliplex_client/lib/src/application/application.dart
+++ b/packages/soliplex_client/lib/src/application/application.dart
@@ -1,5 +1,6 @@
 export 'agui_event_processor.dart';
 export 'citation_extractor.dart';
+export 'decode_outcome.dart';
 export 'no_response_synthesis.dart';
 export 'rag_snapshot.dart';
 export 'state_bus.dart';

--- a/packages/soliplex_client/lib/src/application/decode_outcome.dart
+++ b/packages/soliplex_client/lib/src/application/decode_outcome.dart
@@ -30,29 +30,33 @@ class DecodedEvent extends DecodeOutcome {
 
 /// A failed decode capturing the original payload for diagnostics.
 ///
-/// [rawData] may be a `Map` (decoder failure on a single event), a `String`
-/// (top-level JSON parse failure), or a non-Map JSON value (list/scalar).
+/// [rawData] is shape-polymorphic: a `Map` (decoder failure on a single
+/// event), a `String` (top-level JSON parse failure), or a non-Map JSON
+/// value (list/scalar). The downstream drop-tile widget renders all three.
 @immutable
 class DecodeFailed extends DecodeOutcome {
   /// Creates a decode-failure outcome.
-  const DecodeFailed(this.error, this.rawData);
+  const DecodeFailed(this.error, this.rawData, [this.stackTrace]);
 
   /// The error thrown by the decoder or JSON parser.
   final Object error;
 
   /// The raw payload that failed to decode.
   final Object rawData;
+
+  /// Stack trace from the throw site, when available. The drop-tile
+  /// minter forwards this to `Logger.error` so Sentry-grade breadcrumbs
+  /// pinpoint the originating call.
+  final StackTrace? stackTrace;
 }
 
-/// Decodes a single JSON object into a [DecodeOutcome].
-///
-/// Catches every throw from [EventDecoder.decodeJson] (unknown event types,
-/// missing required fields, type mismatches) and returns a [DecodeFailed]
-/// envelope so callers can render a tile at the failure position.
+/// Decodes a single JSON object into a [DecodeOutcome]. Captures the
+/// stack trace alongside the error so the drop-tile log carries a
+/// breadcrumb back to the throwing decoder arm.
 DecodeOutcome decodeMapSafely(Map<String, dynamic> map) {
   try {
     return DecodedEvent(const EventDecoder().decodeJson(map), map);
-  } on Object catch (e) {
-    return DecodeFailed(e, map);
+  } on Object catch (e, st) {
+    return DecodeFailed(e, map, st);
   }
 }

--- a/packages/soliplex_client/lib/src/application/decode_outcome.dart
+++ b/packages/soliplex_client/lib/src/application/decode_outcome.dart
@@ -1,0 +1,58 @@
+import 'package:ag_ui/ag_ui.dart';
+import 'package:meta/meta.dart';
+
+/// Result of decoding a single AG-UI event payload.
+///
+/// Used at both the live SSE boundary (`AgUiStreamClient`) and the replay
+/// boundary (`SoliplexApi._replayEventsToHistory`) so a malformed or
+/// unrecognized event surfaces as a tile in the conversation rather than
+/// aborting the run.
+@immutable
+sealed class DecodeOutcome {
+  const DecodeOutcome();
+}
+
+/// A successfully decoded event paired with its original JSON form.
+///
+/// The original JSON is retained so a downstream throw inside `processEvent`
+/// can attach it to a `DroppedEventMessage` without reflection.
+@immutable
+class DecodedEvent extends DecodeOutcome {
+  /// Creates a decoded-event outcome.
+  const DecodedEvent(this.event, this.rawJson);
+
+  /// The decoded AG-UI event.
+  final BaseEvent event;
+
+  /// The original JSON object the event was decoded from.
+  final Map<String, dynamic> rawJson;
+}
+
+/// A failed decode capturing the original payload for diagnostics.
+///
+/// [rawData] may be a `Map` (decoder failure on a single event), a `String`
+/// (top-level JSON parse failure), or a non-Map JSON value (list/scalar).
+@immutable
+class DecodeFailed extends DecodeOutcome {
+  /// Creates a decode-failure outcome.
+  const DecodeFailed(this.error, this.rawData);
+
+  /// The error thrown by the decoder or JSON parser.
+  final Object error;
+
+  /// The raw payload that failed to decode.
+  final Object rawData;
+}
+
+/// Decodes a single JSON object into a [DecodeOutcome].
+///
+/// Catches every throw from [EventDecoder.decodeJson] (unknown event types,
+/// missing required fields, type mismatches) and returns a [DecodeFailed]
+/// envelope so callers can render a tile at the failure position.
+DecodeOutcome decodeMapSafely(Map<String, dynamic> map) {
+  try {
+    return DecodedEvent(const EventDecoder().decodeJson(map), map);
+  } on Object catch (e) {
+    return DecodeFailed(e, map);
+  }
+}

--- a/packages/soliplex_client/lib/src/application/decode_outcome.dart
+++ b/packages/soliplex_client/lib/src/application/decode_outcome.dart
@@ -32,8 +32,9 @@ class DecodedEvent extends DecodeOutcome {
 /// A failed decode capturing the original payload for diagnostics.
 ///
 /// [rawData] is shape-polymorphic: a `Map` (decoder failure on a single
-/// event), a `String` (top-level JSON parse failure), or a non-Map JSON
-/// value (list/scalar). The downstream drop-tile widget renders all three.
+/// event), a `String` (top-level JSON parse failure), a non-Map JSON
+/// value (list/scalar), or `null` when the payload itself was the JSON
+/// `null` literal. The downstream drop-tile widget renders all four.
 @immutable
 class DecodeFailed extends DecodeOutcome {
   /// Captures the [error] thrown by the decoder, the [rawData] that
@@ -45,7 +46,7 @@ class DecodeFailed extends DecodeOutcome {
   final Object error;
 
   /// The raw payload that failed to decode.
-  final Object rawData;
+  final Object? rawData;
 
   /// Stack trace from the throw site, when available. The drop-tile
   /// minter forwards this to `Logger.error` so Sentry-grade breadcrumbs

--- a/packages/soliplex_client/lib/src/application/decode_outcome.dart
+++ b/packages/soliplex_client/lib/src/application/decode_outcome.dart
@@ -14,11 +14,12 @@ sealed class DecodeOutcome {
 
 /// A successfully decoded event paired with its original JSON form.
 ///
-/// The original JSON is retained so a downstream throw inside `processEvent`
-/// can attach it to a `DroppedEventMessage` without reflection.
+/// The original JSON is retained so a `processEvent` throw can attach
+/// the raw payload to its drop tile.
 @immutable
 class DecodedEvent extends DecodeOutcome {
-  /// Creates a decoded-event outcome.
+  /// Pairs the decoded AG-UI [event] with the original [rawJson] it was
+  /// decoded from.
   const DecodedEvent(this.event, this.rawJson);
 
   /// The decoded AG-UI event.
@@ -35,7 +36,9 @@ class DecodedEvent extends DecodeOutcome {
 /// value (list/scalar). The downstream drop-tile widget renders all three.
 @immutable
 class DecodeFailed extends DecodeOutcome {
-  /// Creates a decode-failure outcome.
+  /// Captures the [error] thrown by the decoder, the [rawData] that
+  /// failed to decode, and the [stackTrace] at the throw site (when
+  /// available) for breadcrumbs.
   const DecodeFailed(this.error, this.rawData, [this.stackTrace]);
 
   /// The error thrown by the decoder or JSON parser.
@@ -60,3 +63,11 @@ DecodeOutcome decodeMapSafely(Map<String, dynamic> map) {
     return DecodeFailed(e, map, st);
   }
 }
+
+/// Wraps a synthesized AG-UI event for providers that build events
+/// in-process (e.g., `ChatFnLlmProvider`, `StreamingLlmProvider`).
+/// Their events have no source JSON, so `rawJson` is `const {}`; if
+/// `processEvent` ever throws on one, the resulting drop tile carries
+/// an empty payload.
+DecodedEvent synthesizedDecoded(BaseEvent event) =>
+    DecodedEvent(event, const {});

--- a/packages/soliplex_client/lib/src/domain/chat_message.dart
+++ b/packages/soliplex_client/lib/src/domain/chat_message.dart
@@ -335,30 +335,27 @@ class LoadingMessage extends ChatMessage {
 
 /// Where a dropped event was caught.
 enum DropSource {
-  /// `decodeEventSafely` produced `DecodeFailed` — either malformed JSON or
+  /// `decodeMapSafely` produced `DecodeFailed` — either malformed JSON or
   /// a `type` field the decoder doesn't recognize.
   decode,
 
-  /// The per-event-loop wrapper caught a throw from `processEvent` itself
-  /// or one of its downstream side effects (e.g., citation extraction).
+  /// The per-event-loop wrapper caught a throw from `processEvent` itself.
+  /// Citation extraction, historical replay bridging, and tracker projection
+  /// failures stay log-only (Tier-1) and do not synthesize a tile.
   eventProcessing,
-
-  /// Historical replay bridging or `ExecutionTracker._onEvent` threw on a
-  /// per-event basis.
-  activityProcessing,
-
-  /// Catch-all for future drop sites.
-  other,
 }
 
 /// An event the client received but couldn't decode or process, surfaced as
 /// a tile in the timeline so the user sees something happened and devs can
 /// inspect the raw payload.
 ///
-/// Synthesized by the data-layer wrappers in Phase 3
-/// (`decodeEventSafely`, the per-event-loop wrapper, and the
-/// `historical_replay` / `ExecutionTracker` boundaries). Never sent over
-/// the wire.
+/// Synthesized at the two content-bearing boundaries: the decode boundary
+/// (`decodeMapSafely` returns `DecodeFailed`) and the per-event-loop body
+/// in `RunOrchestrator._onEvent` / `SoliplexApi._replayEventsToHistory`
+/// (`processEvent` threw). Tier-1 boundaries (citation extraction,
+/// historical replay bridging, tracker projection) log only without
+/// minting a tile — failures there don't lose user-facing content. Never
+/// sent over the wire (filtered in `agui_message_mapper.dart`).
 @immutable
 class DroppedEventMessage extends ChatMessage {
   /// Creates a dropped-event message with all properties.

--- a/packages/soliplex_client/lib/src/domain/chat_message.dart
+++ b/packages/soliplex_client/lib/src/domain/chat_message.dart
@@ -335,13 +335,11 @@ class LoadingMessage extends ChatMessage {
 
 /// Where a dropped event was caught.
 enum DropSource {
-  /// `decodeMapSafely` produced `DecodeFailed` — either malformed JSON or
-  /// a `type` field the decoder doesn't recognize.
+  /// The decoder rejected the payload — malformed JSON, a non-object
+  /// scalar, an unknown event type, or a schema mismatch on a known type.
   decode,
 
   /// The per-event-loop wrapper caught a throw from `processEvent` itself.
-  /// Citation extraction, historical replay bridging, and tracker projection
-  /// failures stay log-only and do not synthesize a tile.
   eventProcessing,
 }
 

--- a/packages/soliplex_client/lib/src/domain/chat_message.dart
+++ b/packages/soliplex_client/lib/src/domain/chat_message.dart
@@ -341,7 +341,7 @@ enum DropSource {
 
   /// The per-event-loop wrapper caught a throw from `processEvent` itself.
   /// Citation extraction, historical replay bridging, and tracker projection
-  /// failures stay log-only (Tier-1) and do not synthesize a tile.
+  /// failures stay log-only and do not synthesize a tile.
   eventProcessing,
 }
 
@@ -349,13 +349,13 @@ enum DropSource {
 /// a tile in the timeline so the user sees something happened and devs can
 /// inspect the raw payload.
 ///
-/// Synthesized at the two content-bearing boundaries: the decode boundary
+/// Synthesized at two content-bearing boundaries: the decode boundary
 /// (`decodeMapSafely` returns `DecodeFailed`) and the per-event-loop body
 /// in `RunOrchestrator._onEvent` / `SoliplexApi._replayEventsToHistory`
-/// (`processEvent` threw). Tier-1 boundaries (citation extraction,
-/// historical replay bridging, tracker projection) log only without
-/// minting a tile — failures there don't lose user-facing content. Never
-/// sent over the wire (filtered in `agui_message_mapper.dart`).
+/// (`processEvent` threw). Citation extraction, historical replay
+/// bridging, and tracker projection log only without minting a tile —
+/// failures there don't lose user-facing content. Never sent over the
+/// wire (filtered in `agui_message_mapper.dart`).
 @immutable
 class DroppedEventMessage extends ChatMessage {
   /// Creates a dropped-event message with all properties.

--- a/packages/soliplex_client/lib/src/domain/chat_message.dart
+++ b/packages/soliplex_client/lib/src/domain/chat_message.dart
@@ -375,7 +375,7 @@ class DroppedEventMessage extends ChatMessage {
     required DropSource source,
     required String reason,
     String? runId,
-    Map<String, dynamic>? rawPayload,
+    Object? rawPayload,
   }) {
     return DroppedEventMessage(
       id: id,
@@ -397,9 +397,12 @@ class DroppedEventMessage extends ChatMessage {
   /// Short human-readable reason. Shown as the collapsed-state subtitle.
   final String reason;
 
-  /// Original payload for inspection. Null when serialization itself
-  /// failed; the tile renders "(payload unavailable)" in that case.
-  final Map<String, dynamic>? rawPayload;
+  /// Original payload for inspection. Shape mirrors `DecodeFailed.rawData`:
+  /// `Map` for per-event decoder failures, `String` for top-level JSON
+  /// parse failures, or any non-Map JSON value (list/scalar). Null when
+  /// the surrounding boundary couldn't carry the payload at all; the
+  /// tile renders "(payload unavailable)" in that case.
+  final Object? rawPayload;
 
   @override
   String toString() =>

--- a/packages/soliplex_client/lib/src/errors/exceptions.dart
+++ b/packages/soliplex_client/lib/src/errors/exceptions.dart
@@ -170,6 +170,26 @@ class CancelledException extends SoliplexException {
   }
 }
 
+/// Exception thrown when the server returned a 200-level response whose
+/// shape doesn't match the contract (e.g. an envelope field that should
+/// be a Map arrived as a List or scalar).
+///
+/// Distinct from [ApiException] (server reported a real failure status)
+/// and [NetworkException] (transport blip): retry won't help — the
+/// backend is producing well-formed-HTTP responses with malformed
+/// payloads. UI should surface a non-retryable error.
+class MalformedResponseException extends SoliplexException {
+  /// Creates a malformed-response exception.
+  const MalformedResponseException({
+    required super.message,
+    super.originalError,
+    super.stackTrace,
+  });
+
+  @override
+  String toString() => 'MalformedResponseException: $message';
+}
+
 /// Exception thrown when an unexpected, non-Soliplex error must be
 /// surfaced through the client's error channel.
 ///

--- a/packages/soliplex_client/lib/src/http/agui_stream_client.dart
+++ b/packages/soliplex_client/lib/src/http/agui_stream_client.dart
@@ -247,8 +247,8 @@ class AgUiStreamClient {
     final dynamic jsonData;
     try {
       jsonData = json.decode(data);
-    } on FormatException catch (e) {
-      return [DecodeFailed(e, data)];
+    } on FormatException catch (e, st) {
+      return [DecodeFailed(e, data, st)];
     }
     if (jsonData is Map<String, dynamic>) {
       outcomes.add(decodeMapSafely(jsonData));
@@ -263,6 +263,7 @@ class AgUiStreamClient {
                 'Non-object item in AG-UI batch: ${item.runtimeType}',
               ),
               item as Object,
+              StackTrace.current,
             ),
           );
         }
@@ -274,6 +275,7 @@ class AgUiStreamClient {
             'Non-object JSON scalar in SSE event: ${jsonData.runtimeType}',
           ),
           jsonData as Object,
+          StackTrace.current,
         ),
       );
     }

--- a/packages/soliplex_client/lib/src/http/agui_stream_client.dart
+++ b/packages/soliplex_client/lib/src/http/agui_stream_client.dart
@@ -6,6 +6,7 @@ import 'package:ag_ui/ag_ui.dart' hide CancelToken;
 // ignore: implementation_imports
 import 'package:ag_ui/src/sse/sse_parser.dart';
 import 'package:meta/meta.dart';
+import 'package:soliplex_client/src/application/decode_outcome.dart';
 import 'package:soliplex_client/src/errors/exceptions.dart';
 import 'package:soliplex_client/src/http/http_response.dart';
 import 'package:soliplex_client/src/http/http_transport.dart';
@@ -40,33 +41,32 @@ class AgUiStreamClient {
   AgUiStreamClient({
     required HttpTransport httpTransport,
     required UrlBuilder urlBuilder,
-    void Function(String message)? onWarning,
     ResumePolicy resumePolicy = const ResumePolicy(),
   })  : _httpTransport = httpTransport,
         _urlBuilder = urlBuilder,
-        _onWarning = onWarning,
         _resumePolicy = resumePolicy;
 
   final HttpTransport _httpTransport;
   final UrlBuilder _urlBuilder;
-  final void Function(String message)? _onWarning;
   final ResumePolicy _resumePolicy;
 
   static const _logName = 'soliplex_client.agui_stream';
 
-  /// Streams AG-UI events for a run.
+  /// Streams AG-UI decode outcomes for a run.
   ///
-  /// Posts [input] to [endpoint] and parses the SSE response into typed
-  /// [BaseEvent]s. The endpoint is relative to the base URL (e.g.
-  /// `'rooms/my-room/agui/thread-1/run-1'`).
+  /// Posts [input] to [endpoint] and parses each SSE `data:` line into a
+  /// sequence of [DecodeOutcome]s — [DecodedEvent] for items the decoder
+  /// accepts and [DecodeFailed] for malformed JSON, unknown event types,
+  /// or non-object scalars. The endpoint is relative to the base URL
+  /// (e.g. `'rooms/my-room/agui/thread-1/run-1'`).
   ///
   /// Reconnect lifecycle is reported through [onReconnectStatus] (a
   /// [Reconnecting] before each retry, [Reconnected] on the first
-  /// decoded event after a successful retry, [ReconnectFailed] when the
-  /// retry budget is exhausted). On terminal transport failure the
-  /// stream throws [NetworkException] whose message starts with
-  /// [streamResumeFailedPrefix].
-  Stream<BaseEvent> runAgent(
+  /// outcome of any kind after a successful retry, [ReconnectFailed]
+  /// when the retry budget is exhausted). On terminal transport failure
+  /// the stream throws [StreamResumeFailedException] whose message
+  /// starts with [streamResumeFailedPrefix].
+  Stream<DecodeOutcome> runAgent(
     String endpoint,
     SimpleRunAgentInput input, {
     CancelToken? cancelToken,
@@ -78,7 +78,6 @@ class AgUiStreamClient {
     final body = input.toJson();
     String? lastEventId;
     var attempt = 0;
-    var skippedEventCount = 0;
 
     while (true) {
       final isResumeRequest = lastEventId != null;
@@ -93,9 +92,9 @@ class AgUiStreamClient {
           onReconnectStatus?.call(
             ReconnectFailed(attempt: attempt, error: e),
           );
-          _flushSkippedWarning(skippedEventCount);
           throw StreamResumeFailedException(
-            message: _resumeFailureMessage(e, skippedEventCount),
+            message: '$streamResumeFailedPrefix '
+                '${e is SoliplexException ? e.message : e}',
             originalError: e,
           );
         }
@@ -128,9 +127,8 @@ class AgUiStreamClient {
           }
           if (message.data == null || message.data!.isEmpty) continue;
 
-          final result = _decodeOne(message.data!);
-          skippedEventCount += result.skipped;
-          if (result.events.isEmpty) continue;
+          final outcomes = _decodeOne(message.data!);
+          if (outcomes.isEmpty) continue;
 
           if (!announcedResume) {
             _logSuccess(attempt, lastEventId);
@@ -138,11 +136,14 @@ class AgUiStreamClient {
             announcedResume = true;
             attempt = 0;
           }
-          for (final ev in result.events) {
-            if (ev is RunFinishedEvent || ev is RunErrorEvent) {
-              sawTerminalEvent = true;
+          for (final outcome in outcomes) {
+            if (outcome is DecodedEvent) {
+              final ev = outcome.event;
+              if (ev is RunFinishedEvent || ev is RunErrorEvent) {
+                sawTerminalEvent = true;
+              }
             }
-            yield ev;
+            yield outcome;
           }
           if (sawTerminalEvent) break;
         }
@@ -159,7 +160,6 @@ class AgUiStreamClient {
       }
 
       if (sawTerminalEvent || streamError == null) {
-        _flushSkippedWarning(skippedEventCount);
         return;
       }
 
@@ -167,7 +167,6 @@ class AgUiStreamClient {
         // No id was ever emitted, so no resume is possible. Rethrow the
         // underlying error directly — wrapping with `streamResumeFailedPrefix`
         // would mislead consumers into treating this as a resume failure.
-        _flushSkippedWarning(skippedEventCount);
         Error.throwWithStackTrace(
           streamError,
           streamErrorStack ?? StackTrace.current,
@@ -178,9 +177,11 @@ class AgUiStreamClient {
         onReconnectStatus?.call(
           ReconnectFailed(attempt: attempt, error: streamError),
         );
-        _flushSkippedWarning(skippedEventCount);
+        final inner = streamError is SoliplexException
+            ? streamError.message
+            : streamError.toString();
         throw StreamResumeFailedException(
-          message: _resumeFailureMessage(streamError, skippedEventCount),
+          message: '$streamResumeFailedPrefix $inner',
           originalError: streamError,
         );
       }
@@ -232,74 +233,51 @@ class AgUiStreamClient {
     );
   }
 
-  /// Decodes one SSE `data:` line into 0..N typed [BaseEvent]s. Returns
-  /// the decoded events and the skip count from this single line. The
-  /// caller accumulates skipped counts across the run.
+  /// Decodes one SSE `data:` line into 0..N [DecodeOutcome]s.
   ///
-  ///   - Single-event JSON object → `(events: [decoded], skipped: 0)`.
-  ///   - JSON array batch → `(events: [decoded...], skipped: N)`
-  ///     where N counts items that fail to decode or are not JSON
-  ///     objects.
-  ///   - Malformed JSON or any top-level decode failure
-  ///     → `(events: [], skipped: 1)`.
-  ({List<BaseEvent> events, int skipped}) _decodeOne(String data) {
-    const decoder = EventDecoder();
-    final decoded = <BaseEvent>[];
-    var skipped = 0;
+  ///   - Single-event JSON object → one outcome via [decodeMapSafely].
+  ///   - JSON array batch → one outcome per item; non-Map items become
+  ///     [DecodeFailed] with the raw value as `rawData`.
+  ///   - Top-level JSON parse failure → single [DecodeFailed] carrying
+  ///     the raw `String`.
+  ///   - Top-level scalar (string/number/bool/null) → single
+  ///     [DecodeFailed] carrying the raw value.
+  List<DecodeOutcome> _decodeOne(String data) {
+    final outcomes = <DecodeOutcome>[];
+    final dynamic jsonData;
     try {
-      final jsonData = json.decode(data);
-      if (jsonData is Map<String, dynamic>) {
-        decoded.add(decoder.decodeJson(jsonData));
-      } else if (jsonData is List) {
-        for (final item in jsonData) {
-          if (item is Map<String, dynamic>) {
-            try {
-              decoded.add(decoder.decodeJson(item));
-            } on DecodingError catch (e) {
-              skipped++;
-              developer.log(
-                'Skipped undecodable AG-UI event in batch: $e',
-                name: _logName,
-                level: 900,
-              );
-            }
-          } else {
-            skipped++;
-            developer.log(
-              'Skipped non-object item in AG-UI batch: ${item.runtimeType}',
-              name: _logName,
-              level: 900,
-            );
-          }
-        }
-      } else {
-        // JSON scalar (string/number/bool/null) at the top level —
-        // not a valid AG-UI payload. Counted so the skipped-event
-        // diagnostic surfaces server-side anomalies of this shape.
-        skipped++;
-        developer.log(
-          'Skipped non-object JSON scalar in SSE event: '
-          '${jsonData.runtimeType}',
-          name: _logName,
-          level: 900,
-        );
-      }
+      jsonData = json.decode(data);
     } on FormatException catch (e) {
-      skipped++;
-      developer.log(
-        'Skipped malformed JSON in SSE event: $e',
-        name: _logName,
-        level: 900,
-      );
-    } on DecodingError catch (e) {
-      skipped++;
-      developer.log(
-        'Skipped undecodable AG-UI event: $e',
-        name: _logName,
-        level: 900,
+      return [DecodeFailed(e, data)];
+    }
+    if (jsonData is Map<String, dynamic>) {
+      outcomes.add(decodeMapSafely(jsonData));
+    } else if (jsonData is List) {
+      for (final item in jsonData) {
+        if (item is Map<String, dynamic>) {
+          outcomes.add(decodeMapSafely(item));
+        } else {
+          outcomes.add(
+            DecodeFailed(
+              FormatException(
+                'Non-object item in AG-UI batch: ${item.runtimeType}',
+              ),
+              item as Object,
+            ),
+          );
+        }
+      }
+    } else {
+      outcomes.add(
+        DecodeFailed(
+          FormatException(
+            'Non-object JSON scalar in SSE event: ${jsonData.runtimeType}',
+          ),
+          jsonData as Object,
+        ),
       );
     }
-    return (events: decoded, skipped: skipped);
+    return outcomes;
   }
 
   /// Cancel-aware backoff: races a delay against the cancel token so a
@@ -328,24 +306,6 @@ class AgUiStreamClient {
     await completer.future;
     timer.cancel();
     token.throwIfCancelled();
-  }
-
-  /// Logs and forwards a non-zero skipped-event count via [_onWarning].
-  /// Caller invokes once per terminal exit from `runAgent`.
-  void _flushSkippedWarning(int count) {
-    if (count == 0) return;
-    final noun = count == 1 ? 'event' : 'events';
-    final message = 'Skipped $count malformed $noun during streaming';
-    developer.log(message, name: _logName, level: 900);
-    _onWarning?.call(message);
-  }
-
-  String _resumeFailureMessage(Object error, int skippedEventCount) {
-    final inner = error is SoliplexException ? error.message : error.toString();
-    if (skippedEventCount == 0) return '$streamResumeFailedPrefix $inner';
-    final noun = skippedEventCount == 1 ? 'event' : 'events';
-    return '$streamResumeFailedPrefix $inner '
-        '(skipped $skippedEventCount malformed $noun)';
   }
 
   void _logAttempt(int attempt, String? lastId, Object? err) {

--- a/packages/soliplex_client/lib/src/http/agui_stream_client.dart
+++ b/packages/soliplex_client/lib/src/http/agui_stream_client.dart
@@ -237,10 +237,10 @@ class AgUiStreamClient {
   ///
   ///   - Single-event JSON object → one outcome via [decodeMapSafely].
   ///   - JSON array batch → one outcome per item; non-Map items become
-  ///     [DecodeFailed] with the raw value as `rawData`.
+  ///     [DecodeFailed] with the raw value (or `null`) as `rawData`.
   ///   - Top-level JSON parse failure → single [DecodeFailed] carrying
   ///     the raw `String`.
-  ///   - Top-level scalar (string/number/bool/null) → single
+  ///   - Top-level scalar (string/number/bool) or JSON `null` → single
   ///     [DecodeFailed] carrying the raw value.
   List<DecodeOutcome> _decodeOne(String data) {
     final outcomes = <DecodeOutcome>[];
@@ -262,7 +262,7 @@ class AgUiStreamClient {
               FormatException(
                 'Non-object item in AG-UI batch: ${item.runtimeType}',
               ),
-              item as Object,
+              item,
               StackTrace.current,
             ),
           );
@@ -274,7 +274,7 @@ class AgUiStreamClient {
           FormatException(
             'Non-object JSON scalar in SSE event: ${jsonData.runtimeType}',
           ),
-          jsonData as Object,
+          jsonData,
           StackTrace.current,
         ),
       );

--- a/packages/soliplex_client/lib/src/http/agui_stream_client.dart
+++ b/packages/soliplex_client/lib/src/http/agui_stream_client.dart
@@ -22,9 +22,9 @@ const String streamResumeFailedPrefix = 'Stream resume failed:';
 
 /// Streams AG-UI events using the Soliplex HTTP stack directly.
 ///
-/// Replaces [AgUiClient] usage in pure Dart packages. Routes SSE through
-/// [HttpTransport] so status code mapping, auth, observability, cancel
-/// wrapping, and platform clients apply automatically.
+/// Routes SSE through [HttpTransport] so status code mapping, auth,
+/// observability, cancel wrapping, and platform clients apply
+/// automatically.
 ///
 /// Implements transparent resume via the SSE `Last-Event-ID` header:
 /// when the stream drops mid-run, the client reconnects and reports

--- a/packages/soliplex_client/test/api/soliplex_api_test.dart
+++ b/packages/soliplex_client/test/api/soliplex_api_test.dart
@@ -2322,6 +2322,115 @@ void main() {
         expect((history.messages[2] as TextMessage).text, equals('after'));
       });
 
+      test('non-Map item in events list mints a drop tile in place', () async {
+        // Backend shape drift: an item in `events` is a JSON scalar or
+        // null instead of a Map. Pre-fix the lazy `.cast<Map>()` threw
+        // at access time inside the replay loop and aborted the entire
+        // history load; now each non-Map item becomes its own drop tile
+        // and the surrounding events still reconstruct.
+        when(
+          () => mockTransport.request<Map<String, dynamic>>(
+            'GET',
+            Uri.parse(
+              'https://api.example.com/api/v1/rooms/room-123/agui/thread-456',
+            ),
+            cancelToken: any(named: 'cancelToken'),
+            fromJson: any(named: 'fromJson'),
+            body: any(named: 'body'),
+            headers: any(named: 'headers'),
+            timeout: any(named: 'timeout'),
+          ),
+        ).thenAnswer(
+          (_) async => {
+            'room_id': 'room-123',
+            'thread_id': 'thread-456',
+            'runs': {
+              'run-1': {
+                'run_id': 'run-1',
+                'created': '2026-01-07T01:00:00.000Z',
+                'finished': '2026-01-07T01:01:00.000Z',
+              },
+            },
+          },
+        );
+
+        when(
+          () => mockTransport.request<Map<String, dynamic>>(
+            'GET',
+            Uri.parse(
+              'https://api.example.com/api/v1/rooms/room-123/agui/thread-456/run-1',
+            ),
+            cancelToken: any(named: 'cancelToken'),
+            fromJson: any(named: 'fromJson'),
+            body: any(named: 'body'),
+            headers: any(named: 'headers'),
+            timeout: any(named: 'timeout'),
+          ),
+        ).thenAnswer(
+          (_) async => {
+            'run_id': 'run-1',
+            'events': <dynamic>[
+              null,
+              42,
+              {
+                'type': 'TEXT_MESSAGE_START',
+                'messageId': 'msg-1',
+                'role': 'assistant',
+              },
+              {
+                'type': 'TEXT_MESSAGE_CONTENT',
+                'messageId': 'msg-1',
+                'delta': 'survived',
+              },
+              {'type': 'TEXT_MESSAGE_END', 'messageId': 'msg-1'},
+            ],
+          },
+        );
+
+        final history = await api.getThreadHistory('room-123', 'thread-456');
+
+        final drops = history.messages.whereType<DroppedEventMessage>();
+        expect(drops, hasLength(2));
+        expect(drops.every((d) => d.source == DropSource.decode), isTrue);
+        expect(drops.map((d) => d.rawPayload), equals([null, 42]));
+        // Surviving valid events still reconstruct as a TextMessage.
+        final texts = history.messages.whereType<TextMessage>();
+        expect(texts, hasLength(1));
+        expect(texts.single.text, equals('survived'));
+      });
+
+      test('non-Map `runs` field returns empty history without throwing',
+          () async {
+        // Backend shape drift on the envelope: `runs` arrives as a list
+        // instead of a Map. Pre-fix this `as Map<String, dynamic>?`
+        // cast threw and surfaced as MessagesFailed; now it falls
+        // through to an empty history.
+        when(
+          () => mockTransport.request<Map<String, dynamic>>(
+            'GET',
+            Uri.parse(
+              'https://api.example.com/api/v1/rooms/room-123/agui/thread-456',
+            ),
+            cancelToken: any(named: 'cancelToken'),
+            fromJson: any(named: 'fromJson'),
+            body: any(named: 'body'),
+            headers: any(named: 'headers'),
+            timeout: any(named: 'timeout'),
+          ),
+        ).thenAnswer(
+          (_) async => {
+            'room_id': 'room-123',
+            'thread_id': 'thread-456',
+            'runs': <dynamic>['not-a-map'],
+          },
+        );
+
+        final history = await api.getThreadHistory('room-123', 'thread-456');
+
+        expect(history.messages, isEmpty);
+        expect(history.runs, isEmpty);
+      });
+
       test(
         'processEvent-throw drop tile preserves the original wire JSON, '
         'not a reconstruction from the decoded event',

--- a/packages/soliplex_client/test/api/soliplex_api_test.dart
+++ b/packages/soliplex_client/test/api/soliplex_api_test.dart
@@ -1442,9 +1442,11 @@ void main() {
 
         final messages = await api.getThreadHistory('room-123', 'thread-456');
 
-        // Should still return messages from successful run
-        expect(messages.messages.length, equals(1));
-        expect((messages.messages[0] as TextMessage).text, equals('First'));
+        // Successful run renders normally; failed run mints a drop tile
+        // so it's visibly missing rather than silently absent.
+        expect(messages.messages.whereType<TextMessage>().single.text, 'First');
+        final drop = messages.messages.whereType<DroppedEventMessage>().single;
+        expect(drop.runId, 'run-2');
       });
 
       test('returns empty list when no runs', () async {
@@ -1572,6 +1574,38 @@ void main() {
 
         expect(history.messages, isEmpty);
       });
+
+      test(
+        'throws MalformedResponseException when runs envelope is non-Map',
+        () async {
+          // 200 OK response whose `runs` field has the wrong shape — retry
+          // won't help; the UI must surface a non-retryable error rather
+          // than rendering an empty thread (which would be
+          // indistinguishable from a fresh thread).
+          when(
+            () => mockTransport.request<Map<String, dynamic>>(
+              'GET',
+              any(),
+              cancelToken: any(named: 'cancelToken'),
+              fromJson: any(named: 'fromJson'),
+              body: any(named: 'body'),
+              headers: any(named: 'headers'),
+              timeout: any(named: 'timeout'),
+            ),
+          ).thenAnswer(
+            (_) async => {
+              'room_id': 'room-123',
+              'thread_id': 'thread-456',
+              'runs': <dynamic>['unexpected', 'list', 'shape'],
+            },
+          );
+
+          await expectLater(
+            api.getThreadHistory('room-123', 'thread-456'),
+            throwsA(isA<MalformedResponseException>()),
+          );
+        },
+      );
 
       test('validates non-empty roomId', () {
         expect(
@@ -2399,37 +2433,94 @@ void main() {
         expect(texts.single.text, equals('survived'));
       });
 
-      test('non-Map `runs` field returns empty history without throwing',
-          () async {
-        // Backend shape drift on the envelope: `runs` arrives as a list
-        // instead of a Map. Pre-fix this `as Map<String, dynamic>?`
-        // cast threw and surfaced as MessagesFailed; now it falls
-        // through to an empty history.
-        when(
-          () => mockTransport.request<Map<String, dynamic>>(
-            'GET',
-            Uri.parse(
-              'https://api.example.com/api/v1/rooms/room-123/agui/thread-456',
+      test(
+        'transient run-fetch failure mints a drop tile so the run is '
+        'visibly missing from history',
+        () async {
+          // Pre-fix, a NetworkException on a single run was logged via
+          // onWarning and the run vanished entirely from the timeline,
+          // making the rest of the thread look like it had a hole. The
+          // drop tile now signals "this run failed to load" in-place.
+          when(
+            () => mockTransport.request<Map<String, dynamic>>(
+              'GET',
+              Uri.parse(
+                'https://api.example.com/api/v1/rooms/room-123/agui/thread-456',
+              ),
+              cancelToken: any(named: 'cancelToken'),
+              fromJson: any(named: 'fromJson'),
+              body: any(named: 'body'),
+              headers: any(named: 'headers'),
+              timeout: any(named: 'timeout'),
             ),
-            cancelToken: any(named: 'cancelToken'),
-            fromJson: any(named: 'fromJson'),
-            body: any(named: 'body'),
-            headers: any(named: 'headers'),
-            timeout: any(named: 'timeout'),
-          ),
-        ).thenAnswer(
-          (_) async => {
-            'room_id': 'room-123',
-            'thread_id': 'thread-456',
-            'runs': <dynamic>['not-a-map'],
-          },
-        );
+          ).thenAnswer(
+            (_) async => {
+              'room_id': 'room-123',
+              'thread_id': 'thread-456',
+              'runs': {
+                'run-1': {
+                  'run_id': 'run-1',
+                  'created': '2026-01-07T01:00:00.000Z',
+                  'finished': '2026-01-07T01:01:00.000Z',
+                },
+              },
+            },
+          );
+          when(
+            () => mockTransport.request<Map<String, dynamic>>(
+              'GET',
+              Uri.parse(
+                'https://api.example.com/api/v1/rooms/room-123/agui/thread-456/run-1',
+              ),
+              cancelToken: any(named: 'cancelToken'),
+              fromJson: any(named: 'fromJson'),
+              body: any(named: 'body'),
+              headers: any(named: 'headers'),
+              timeout: any(named: 'timeout'),
+            ),
+          ).thenThrow(const NetworkException(message: 'Connection failed'));
 
-        final history = await api.getThreadHistory('room-123', 'thread-456');
+          final history = await api.getThreadHistory('room-123', 'thread-456');
 
-        expect(history.messages, isEmpty);
-        expect(history.runs, isEmpty);
-      });
+          final drop = history.messages.whereType<DroppedEventMessage>().single;
+          expect(drop.runId, 'run-1');
+          expect(drop.reason, contains('Connection failed'));
+        },
+      );
+
+      test(
+        'non-Map run entry in runs envelope mints a drop tile so the run '
+        'is visibly absent from replay',
+        () async {
+          // Pre-fix, a non-Map entry inside the `runs` map was silently
+          // filtered out — the run vanished without trace.
+          when(
+            () => mockTransport.request<Map<String, dynamic>>(
+              'GET',
+              any(),
+              cancelToken: any(named: 'cancelToken'),
+              fromJson: any(named: 'fromJson'),
+              body: any(named: 'body'),
+              headers: any(named: 'headers'),
+              timeout: any(named: 'timeout'),
+            ),
+          ).thenAnswer(
+            (_) async => {
+              'room_id': 'room-123',
+              'thread_id': 'thread-456',
+              'runs': {
+                'run-1': 'not-a-map',
+              },
+            },
+          );
+
+          final history = await api.getThreadHistory('room-123', 'thread-456');
+
+          final drop = history.messages.whereType<DroppedEventMessage>().single;
+          expect(drop.runId, 'run-1');
+          expect(drop.reason, contains('shape'));
+        },
+      );
 
       test(
         'processEvent-throw drop tile preserves the original wire JSON, '
@@ -2614,13 +2705,16 @@ void main() {
           ),
         ).thenThrow(const NotFoundException(message: 'Run not found'));
 
-        // Should not throw - returns empty history gracefully
+        // Should not throw - the deleted run becomes a drop tile so the
+        // gap is visible, and onWarning still fires so callers tracking
+        // partial-load signals continue to receive them.
         final history = await apiWithWarning.getThreadHistory(
           'room-123',
           'thread-456',
         );
 
-        expect(history.messages, isEmpty);
+        final drop = history.messages.whereType<DroppedEventMessage>().single;
+        expect(drop.runId, 'run-1');
         expect(warnings, hasLength(1));
         expect(warnings[0], contains('run-1'));
 

--- a/packages/soliplex_client/test/api/soliplex_api_test.dart
+++ b/packages/soliplex_client/test/api/soliplex_api_test.dart
@@ -2323,6 +2323,80 @@ void main() {
         expect((history.messages[2] as TextMessage).text, equals('after'));
       });
 
+      test(
+        'processEvent-throw drop tile preserves the original wire JSON, '
+        'not a reconstruction from the decoded event',
+        () async {
+          // The drop tile's `rawPayload` must be the JSON the decoder
+          // saw — not a re-serialization of the `BaseEvent`. Marker
+          // field `_wireOnlyField` is on the wire but not on the
+          // `StateSnapshotEvent` shape; if a future refactor "helpfully"
+          // reconstructs `rawJson` from the decoded event, the marker
+          // would disappear and this test would fail.
+          when(
+            () => mockTransport.request<Map<String, dynamic>>(
+              'GET',
+              Uri.parse(
+                'https://api.example.com/api/v1/rooms/room-123/agui/thread-456',
+              ),
+              cancelToken: any(named: 'cancelToken'),
+              fromJson: any(named: 'fromJson'),
+              body: any(named: 'body'),
+              headers: any(named: 'headers'),
+              timeout: any(named: 'timeout'),
+            ),
+          ).thenAnswer(
+            (_) async => {
+              'room_id': 'room-123',
+              'thread_id': 'thread-456',
+              'runs': {
+                'run-1': {
+                  'run_id': 'run-1',
+                  'created': '2026-01-07T01:00:00.000Z',
+                  'finished': '2026-01-07T01:01:00.000Z',
+                },
+              },
+            },
+          );
+
+          when(
+            () => mockTransport.request<Map<String, dynamic>>(
+              'GET',
+              Uri.parse(
+                'https://api.example.com/api/v1/rooms/room-123/agui/thread-456/run-1',
+              ),
+              cancelToken: any(named: 'cancelToken'),
+              fromJson: any(named: 'fromJson'),
+              body: any(named: 'body'),
+              headers: any(named: 'headers'),
+              timeout: any(named: 'timeout'),
+            ),
+          ).thenAnswer(
+            (_) async => {
+              'run_id': 'run-1',
+              'events': [
+                {
+                  'type': 'STATE_SNAPSHOT',
+                  'snapshot': ['not', 'a', 'map'],
+                  '_wireOnlyField': 'survives-because-rawJson-is-the-wire',
+                },
+              ],
+            },
+          );
+
+          final history = await api.getThreadHistory('room-123', 'thread-456');
+
+          final drop = history.messages.whereType<DroppedEventMessage>().single;
+          expect(
+            drop.rawPayload,
+            containsPair(
+              '_wireOnlyField',
+              'survives-because-rawJson-is-the-wire',
+            ),
+          );
+        },
+      );
+
       test('calls onWarning callback on partial failure', () async {
         final warnings = <String>[];
         final apiWithWarning = SoliplexApi(

--- a/packages/soliplex_client/test/api/soliplex_api_test.dart
+++ b/packages/soliplex_client/test/api/soliplex_api_test.dart
@@ -2080,14 +2080,8 @@ void main() {
         },
       );
 
-      test('skips undecodable events and warns', () async {
-        final warnings = <String>[];
-        final apiWithWarning = SoliplexApi(
-          transport: mockTransport,
-          urlBuilder: urlBuilder,
-          onWarning: warnings.add,
-        );
-
+      test('yields a DroppedEventMessage for undecodable replay events',
+          () async {
         when(
           () => mockTransport.request<Map<String, dynamic>>(
             'GET',
@@ -2146,26 +2140,103 @@ void main() {
           },
         );
 
-        final history =
-            await apiWithWarning.getThreadHistory('room-123', 'thread-456');
+        final history = await api.getThreadHistory('room-123', 'thread-456');
 
-        expect(history.messages, hasLength(1));
-        expect(
-          (history.messages[0] as TextMessage).text,
-          equals('Hello'),
+        // A drop tile sits at the unknown event's position; the
+        // surrounding text message still renders.
+        expect(history.messages, hasLength(2));
+        expect(history.messages[0], isA<DroppedEventMessage>());
+        final drop = history.messages[0] as DroppedEventMessage;
+        expect(drop.source, equals(DropSource.decode));
+        expect(drop.runId, equals('run-1'));
+        expect(drop.id, equals('dropped-run-1-0'));
+        expect(drop.rawPayload, containsPair('type', 'TOTALLY_UNKNOWN_EVENT'));
+        expect((history.messages[1] as TextMessage).text, equals('Hello'));
+      });
+
+      test('replay drop tile ids are deterministic across reloads', () async {
+        // Same raw events on two replays produce drop tiles with the
+        // same ids — the live conversation rebuilds deterministically
+        // from backend events on reload (see Step 3.8 id scheme).
+        final eventsResponse = {
+          'run_id': 'run-1',
+          'events': [
+            {'type': 'TOTALLY_UNKNOWN_EVENT', 'foo': 'bar'},
+            {
+              'type': 'TEXT_MESSAGE_START',
+              'messageId': 'msg-1',
+              'role': 'assistant',
+            },
+            {
+              'type': 'TEXT_MESSAGE_CONTENT',
+              'messageId': 'msg-1',
+              'delta': 'Hello',
+            },
+            {'type': 'TEXT_MESSAGE_END', 'messageId': 'msg-1'},
+          ],
+        };
+        when(
+          () => mockTransport.request<Map<String, dynamic>>(
+            'GET',
+            Uri.parse(
+              'https://api.example.com/api/v1/rooms/room-123/agui/thread-456',
+            ),
+            cancelToken: any(named: 'cancelToken'),
+            fromJson: any(named: 'fromJson'),
+            body: any(named: 'body'),
+            headers: any(named: 'headers'),
+            timeout: any(named: 'timeout'),
+          ),
+        ).thenAnswer(
+          (_) async => {
+            'room_id': 'room-123',
+            'thread_id': 'thread-456',
+            'runs': {
+              'run-1': {
+                'run_id': 'run-1',
+                'created': '2026-01-07T01:00:00.000Z',
+                'finished': '2026-01-07T01:01:00.000Z',
+              },
+            },
+          },
         );
-        expect(warnings, hasLength(1));
-        expect(warnings[0], contains('Skipped 1 malformed event'));
+        when(
+          () => mockTransport.request<Map<String, dynamic>>(
+            'GET',
+            Uri.parse(
+              'https://api.example.com/api/v1/rooms/room-123/agui/thread-456/run-1',
+            ),
+            cancelToken: any(named: 'cancelToken'),
+            fromJson: any(named: 'fromJson'),
+            body: any(named: 'body'),
+            headers: any(named: 'headers'),
+            timeout: any(named: 'timeout'),
+          ),
+        ).thenAnswer((_) async => eventsResponse);
 
-        apiWithWarning.close();
+        final first = await api.getThreadHistory('room-123', 'thread-456');
+        // Build a second SoliplexApi so the run-events cache doesn't
+        // shortcut the second replay.
+        final api2 = SoliplexApi(
+          transport: mockTransport,
+          urlBuilder: urlBuilder,
+        );
+        final second = await api2.getThreadHistory('room-123', 'thread-456');
+        api2.close();
+
+        final firstId =
+            first.messages.whereType<DroppedEventMessage>().single.id;
+        final secondId =
+            second.messages.whereType<DroppedEventMessage>().single.id;
+        expect(firstId, equals(secondId));
       });
 
       test('replay survives a STATE_SNAPSHOT with a non-Map snapshot',
           () async {
         // Backend shape drift used to throw an unguarded cast inside
-        // processEvent, abort the replay, and reject getThreadHistory —
-        // leaving the user with no messages at all. After Phase 1 the bad
-        // event is a no-op and surrounding messages still appear.
+        // processEvent and abort the replay. The per-event wrapper now
+        // catches that throw, mints a `DroppedEventMessage` at the
+        // failure position, and lets surrounding messages render.
         when(
           () => mockTransport.request<Map<String, dynamic>>(
             'GET',
@@ -2240,9 +2311,16 @@ void main() {
 
         final history = await api.getThreadHistory('room-123', 'thread-456');
 
-        expect(history.messages, hasLength(2));
+        // The two text messages bracket a drop tile at the bad
+        // STATE_SNAPSHOT's position.
+        expect(history.messages, hasLength(3));
         expect((history.messages[0] as TextMessage).text, equals('before'));
-        expect((history.messages[1] as TextMessage).text, equals('after'));
+        expect(history.messages[1], isA<DroppedEventMessage>());
+        expect(
+          (history.messages[1] as DroppedEventMessage).source,
+          equals(DropSource.eventProcessing),
+        );
+        expect((history.messages[2] as TextMessage).text, equals('after'));
       });
 
       test('calls onWarning callback on partial failure', () async {

--- a/packages/soliplex_client/test/api/soliplex_api_test.dart
+++ b/packages/soliplex_client/test/api/soliplex_api_test.dart
@@ -2157,7 +2157,7 @@ void main() {
       test('replay drop tile ids are deterministic across reloads', () async {
         // Same raw events on two replays produce drop tiles with the
         // same ids — the live conversation rebuilds deterministically
-        // from backend events on reload (see Step 3.8 id scheme).
+        // from backend events on reload.
         final eventsResponse = {
           'run_id': 'run-1',
           'events': [
@@ -2233,10 +2233,9 @@ void main() {
 
       test('replay survives a STATE_SNAPSHOT with a non-Map snapshot',
           () async {
-        // Backend shape drift used to throw an unguarded cast inside
-        // processEvent and abort the replay. The per-event wrapper now
-        // catches that throw, mints a `DroppedEventMessage` at the
-        // failure position, and lets surrounding messages render.
+        // A non-Map snapshot triggers the cast throw inside
+        // processEvent; the per-event wrapper appends a drop tile at
+        // the failure position and replay continues.
         when(
           () => mockTransport.request<Map<String, dynamic>>(
             'GET',

--- a/packages/soliplex_client/test/application/agui_event_processor_test.dart
+++ b/packages/soliplex_client/test/application/agui_event_processor_test.dart
@@ -1584,27 +1584,17 @@ void main() {
         expect(result.streaming, equals(streaming));
       });
 
-      test('StateSnapshotEvent with non-Map snapshot throws', () {
-        // ag_ui's `State = dynamic` lets a backend send any shape. The
-        // cast inside `_processStateSnapshot` throws on non-Map values;
-        // the caller (replay loop / orchestrator) catches the throw and
-        // appends a `DroppedEventMessage` at the failure position.
-        const event = StateSnapshotEvent(snapshot: ['unexpected', 'list']);
-
-        expect(
-          () => processEvent(conversation, streaming, event),
-          throwsA(isA<TypeError>()),
-        );
-      });
-
-      test('StateSnapshotEvent with null snapshot throws', () {
-        const event = StateSnapshotEvent(snapshot: null);
-
-        expect(
-          () => processEvent(conversation, streaming, event),
-          throwsA(isA<TypeError>()),
-        );
-      });
+      // Non-Map and null `StateSnapshotEvent.snapshot` cause the cast
+      // inside `_processStateSnapshot` to throw — by design. The
+      // wrappers in `RunOrchestrator._onEvent` and
+      // `SoliplexApi._replayEventsToHistory` catch the throw and mint
+      // a drop tile at the failure position. Behavioral coverage lives
+      // there:
+      //   - run_orchestrator_test.dart "live drop tiles"
+      //   - soliplex_api_test.dart "replay survives a STATE_SNAPSHOT
+      //     with a non-Map snapshot"
+      // No test on the cast itself — that's a Dart language guarantee,
+      // not a decision this code makes.
 
       test('StateDeltaEvent applies JSON Patch to aguiState', () {
         final conversationWithState = conversation.copyWith(

--- a/packages/soliplex_client/test/application/agui_event_processor_test.dart
+++ b/packages/soliplex_client/test/application/agui_event_processor_test.dart
@@ -1584,29 +1584,26 @@ void main() {
         expect(result.streaming, equals(streaming));
       });
 
-      test('StateSnapshotEvent with non-Map snapshot is a no-op', () {
+      test('StateSnapshotEvent with non-Map snapshot throws', () {
         // ag_ui's `State = dynamic` lets a backend send any shape. The
-        // frontend must not crash on cast — it must keep the prior state
-        // and continue processing.
-        final priorState = {'kept': 'as-is'};
-        final conversationWithState = conversation.copyWith(
-          aguiState: priorState,
-        );
+        // cast inside `_processStateSnapshot` throws on non-Map values;
+        // the caller (replay loop / orchestrator) catches the throw and
+        // appends a `DroppedEventMessage` at the failure position.
         const event = StateSnapshotEvent(snapshot: ['unexpected', 'list']);
 
-        final result = processEvent(conversationWithState, streaming, event);
-
-        expect(result.conversation.aguiState, equals(priorState));
-        expect(result.streaming, equals(streaming));
+        expect(
+          () => processEvent(conversation, streaming, event),
+          throwsA(isA<TypeError>()),
+        );
       });
 
-      test('StateSnapshotEvent with null snapshot is a no-op', () {
+      test('StateSnapshotEvent with null snapshot throws', () {
         const event = StateSnapshotEvent(snapshot: null);
 
-        final result = processEvent(conversation, streaming, event);
-
-        expect(result.conversation.aguiState, equals(conversation.aguiState));
-        expect(result.streaming, equals(streaming));
+        expect(
+          () => processEvent(conversation, streaming, event),
+          throwsA(isA<TypeError>()),
+        );
       });
 
       test('StateDeltaEvent applies JSON Patch to aguiState', () {

--- a/packages/soliplex_client/test/application/decode_outcome_test.dart
+++ b/packages/soliplex_client/test/application/decode_outcome_test.dart
@@ -33,15 +33,18 @@ void main() {
       expect(failed.error, isNotNull);
       expect(failed.rawData, equals(raw));
     });
+  });
 
-    test('returns DecodeFailed for missing required fields', () {
-      // TEXT_MESSAGE_START requires messageId; omitting it triggers a
-      // decoder failure that the wrapper must catch rather than propagate.
-      final raw = <String, dynamic>{'type': 'TEXT_MESSAGE_START'};
-
-      final outcome = decodeMapSafely(raw);
-
-      expect(outcome, isA<DecodeFailed>());
-    });
+  test('EventDecoder rejects unknown event types', () {
+    // Build-time guard against a future ag_ui release that introduces a
+    // fallback variant (e.g., decoding unknown types into `RawEvent` /
+    // `CustomEvent`). The drop-tile carrier relies on the throw — if
+    // ag_ui starts succeeding on unknown types instead, our boundary
+    // silently flips from "drop tile" to "pass-through unknown event"
+    // and `decodeMapSafely` stops emitting `DecodeFailed` for them.
+    expect(
+      () => const EventDecoder().decodeJson({'type': 'NOT_A_REAL_EVENT_TYPE'}),
+      throwsA(isNotNull),
+    );
   });
 }

--- a/packages/soliplex_client/test/application/decode_outcome_test.dart
+++ b/packages/soliplex_client/test/application/decode_outcome_test.dart
@@ -1,0 +1,47 @@
+import 'package:soliplex_client/soliplex_client.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('decodeMapSafely', () {
+    test('returns DecodedEvent with the decoded event and original Map', () {
+      final raw = <String, dynamic>{
+        'type': 'TEXT_MESSAGE_START',
+        'messageId': 'msg-1',
+        'role': 'user',
+      };
+
+      final outcome = decodeMapSafely(raw);
+
+      expect(outcome, isA<DecodedEvent>());
+      final decoded = outcome as DecodedEvent;
+      expect(decoded.event, isA<TextMessageStartEvent>());
+      expect(
+        identical(decoded.rawJson, raw),
+        isTrue,
+        reason: 'rawJson should be the same Map passed in',
+      );
+    });
+
+    test('returns DecodeFailed when the decoder throws', () {
+      // Unknown event type — the decoder throws on EventType.fromString.
+      final raw = <String, dynamic>{'type': 'NOT_A_REAL_EVENT_TYPE'};
+
+      final outcome = decodeMapSafely(raw);
+
+      expect(outcome, isA<DecodeFailed>());
+      final failed = outcome as DecodeFailed;
+      expect(failed.error, isNotNull);
+      expect(failed.rawData, equals(raw));
+    });
+
+    test('returns DecodeFailed for missing required fields', () {
+      // TEXT_MESSAGE_START requires messageId; omitting it triggers a
+      // decoder failure that the wrapper must catch rather than propagate.
+      final raw = <String, dynamic>{'type': 'TEXT_MESSAGE_START'};
+
+      final outcome = decodeMapSafely(raw);
+
+      expect(outcome, isA<DecodeFailed>());
+    });
+  });
+}

--- a/packages/soliplex_client/test/application/decode_outcome_test.dart
+++ b/packages/soliplex_client/test/application/decode_outcome_test.dart
@@ -32,6 +32,12 @@ void main() {
       final failed = outcome as DecodeFailed;
       expect(failed.error, isNotNull);
       expect(failed.rawData, equals(raw));
+      // The stack trace is the source of every drop-tile breadcrumb
+      // downstream: orchestrator, replay, and the logger calls all
+      // forward `failed.stackTrace`. If `decodeMapSafely` stops
+      // capturing it, every Sentry breadcrumb on this path loses its
+      // throw site.
+      expect(failed.stackTrace, isNotNull);
     });
   });
 

--- a/packages/soliplex_client/test/http/agui_stream_client_test.dart
+++ b/packages/soliplex_client/test/http/agui_stream_client_test.dart
@@ -4,6 +4,7 @@ import 'dart:convert';
 import 'package:ag_ui/ag_ui.dart' hide CancelToken;
 import 'package:fake_async/fake_async.dart';
 import 'package:mocktail/mocktail.dart';
+import 'package:soliplex_client/src/application/decode_outcome.dart';
 import 'package:soliplex_client/src/errors/exceptions.dart';
 import 'package:soliplex_client/src/http/agui_stream_client.dart';
 import 'package:soliplex_client/src/http/http_response.dart';
@@ -75,6 +76,12 @@ const _fastPolicy = ResumePolicy(
   jitter: 0,
 );
 
+/// Extracts the [BaseEvent]s from a list of [DecodeOutcome]s, dropping
+/// [DecodeFailed] entries. Test helper for assertions that only care about
+/// the structurally-valid events the run produced.
+List<BaseEvent> _decodedOnly(List<DecodeOutcome> outcomes) =>
+    outcomes.whereType<DecodedEvent>().map((d) => d.event).toList();
+
 void main() {
   late MockHttpTransport mockTransport;
   late AgUiStreamClient client;
@@ -137,7 +144,8 @@ void main() {
           ),
         );
 
-        final result = await client.runAgent(endpoint, input).toList();
+        final result =
+            _decodedOnly(await client.runAgent(endpoint, input).toList());
 
         expect(result, hasLength(5));
         expect(result[0], isA<RunStartedEvent>());
@@ -174,7 +182,8 @@ void main() {
           ),
         );
 
-        final result = await client.runAgent(endpoint, input).toList();
+        final result =
+            _decodedOnly(await client.runAgent(endpoint, input).toList());
 
         expect(result, hasLength(2));
         expect(result[0], isA<RunStartedEvent>());
@@ -210,7 +219,8 @@ void main() {
           ),
         );
 
-        final result = await client.runAgent(endpoint, input).toList();
+        final result =
+            _decodedOnly(await client.runAgent(endpoint, input).toList());
 
         expect(result, hasLength(1));
         expect(result[0], isA<RunStartedEvent>());
@@ -258,7 +268,7 @@ void main() {
         );
       });
 
-      test('skips unknown event types and continues streaming', () async {
+      test('yields DecodeFailed for unknown event types', () async {
         final events = [
           {'type': 'RUN_STARTED', 'threadId': 't-1', 'runId': 'r-1'},
           {'type': 'TOTALLY_UNKNOWN_EVENT', 'foo': 'bar'},
@@ -282,12 +292,16 @@ void main() {
 
         final result = await client.runAgent(endpoint, input).toList();
 
-        expect(result, hasLength(2));
-        expect(result[0], isA<RunStartedEvent>());
-        expect(result[1], isA<RunFinishedEvent>());
+        expect(result, hasLength(3));
+        expect(result[0], isA<DecodedEvent>());
+        expect((result[0] as DecodedEvent).event, isA<RunStartedEvent>());
+        expect(result[1], isA<DecodeFailed>());
+        expect((result[1] as DecodeFailed).rawData, equals(events[1]));
+        expect(result[2], isA<DecodedEvent>());
+        expect((result[2] as DecodedEvent).event, isA<RunFinishedEvent>());
       });
 
-      test('skips malformed JSON and continues streaming', () async {
+      test('yields DecodeFailed for malformed JSON', () async {
         final sseBody = StringBuffer()
           ..writeln('data: not valid json at all')
           ..writeln()
@@ -317,61 +331,20 @@ void main() {
 
         final result = await client.runAgent(endpoint, input).toList();
 
-        expect(result, hasLength(1));
-        expect(result[0], isA<RunStartedEvent>());
-      });
-
-      test('calls onWarning with count when events are skipped', () async {
-        final warnings = <String>[];
-        final clientWithWarning = AgUiStreamClient(
-          httpTransport: mockTransport,
-          urlBuilder: UrlBuilder(baseUrl),
-          onWarning: warnings.add,
-        );
-        addTearDown(clientWithWarning.close);
-
-        final events = [
-          {'type': 'RUN_STARTED', 'threadId': 't-1', 'runId': 'r-1'},
-          {'type': 'TOTALLY_UNKNOWN_EVENT', 'foo': 'bar'},
-          {'type': 'RUN_FINISHED', 'threadId': 't-1', 'runId': 'r-1'},
-        ];
-
-        when(
-          () => mockTransport.requestStream(
-            any(),
-            any(),
-            headers: any(named: 'headers'),
-            body: any(named: 'body'),
-            cancelToken: any(named: 'cancelToken'),
-          ),
-        ).thenAnswer(
-          (_) async => StreamedHttpResponse(
-            statusCode: 200,
-            body: sseByteStream(events),
-          ),
-        );
-
-        final result =
-            await clientWithWarning.runAgent(endpoint, input).toList();
-
         expect(result, hasLength(2));
-        expect(warnings, hasLength(1));
-        expect(warnings[0], contains('1 malformed event'));
+        expect(result[0], isA<DecodeFailed>());
+        // Top-level JSON parse failure carries the raw String as rawData.
+        expect(
+          (result[0] as DecodeFailed).rawData,
+          equals('not valid json at all'),
+        );
+        expect(result[1], isA<DecodedEvent>());
+        expect((result[1] as DecodedEvent).event, isA<RunStartedEvent>());
       });
 
       test(
-        'mixed batch with two undecodable items reports skipped=2',
+        'mixed batch yields DecodeFailed per undecodable item',
         () async {
-          // The caller accumulates skips across batches and surfaces
-          // them through a single `onWarning` at clean termination.
-          final warnings = <String>[];
-          final clientWithWarning = AgUiStreamClient(
-            httpTransport: mockTransport,
-            urlBuilder: UrlBuilder(baseUrl),
-            onWarning: warnings.add,
-          );
-          addTearDown(clientWithWarning.close);
-
           final batch = [
             {'type': 'RUN_STARTED', 'threadId': 't-1', 'runId': 'r-1'},
             {'type': 'TOTALLY_UNKNOWN_EVENT', 'a': 1},
@@ -397,12 +370,11 @@ void main() {
             ),
           );
 
-          final result =
-              await clientWithWarning.runAgent(endpoint, input).toList();
+          final result = await client.runAgent(endpoint, input).toList();
 
-          expect(result, hasLength(2));
-          expect(warnings, hasLength(1));
-          expect(warnings.single, contains('Skipped 2 malformed event'));
+          expect(result, hasLength(4));
+          expect(result.whereType<DecodeFailed>(), hasLength(2));
+          expect(result.whereType<DecodedEvent>(), hasLength(2));
         },
       );
 
@@ -473,20 +445,20 @@ void main() {
           ),
         );
 
-        final events = <BaseEvent>[];
+        final outcomes = <DecodeOutcome>[];
         final run = resumeClient.runAgent(
           endpoint,
           input,
           onReconnectStatus: statuses.add,
         );
-        final iterator = StreamIterator<BaseEvent>(run);
+        final iterator = StreamIterator<DecodeOutcome>(run);
 
         // Drain the first two real events. Then re-stub the transport
         // for the resume request before consuming further.
         await iterator.moveNext();
-        events.add(iterator.current);
+        outcomes.add(iterator.current);
         await iterator.moveNext();
-        events.add(iterator.current);
+        outcomes.add(iterator.current);
 
         // Swap the stub to return events 2..3 + RUN_FINISHED.
         when(
@@ -526,8 +498,9 @@ void main() {
         );
 
         while (await iterator.moveNext()) {
-          events.add(iterator.current);
+          outcomes.add(iterator.current);
         }
+        final events = _decodedOnly(outcomes);
 
         // Verify second call included Last-Event-ID.
         final captured = verify(
@@ -628,13 +601,15 @@ void main() {
             );
           });
 
-          final events = await resumeClient
-              .runAgent(
-                endpoint,
-                input,
-                onReconnectStatus: statuses.add,
-              )
-              .toList();
+          final events = _decodedOnly(
+            await resumeClient
+                .runAgent(
+                  endpoint,
+                  input,
+                  onReconnectStatus: statuses.add,
+                )
+                .toList(),
+          );
 
           expect(callCount, 3);
 
@@ -748,16 +723,12 @@ void main() {
       );
 
       test(
-        'retry exhaustion still flushes skipped-event warning and embeds '
-        'count in NetworkException message',
+        'retry exhaustion throws StreamResumeFailed; per-item DecodeFailed '
+        'is yielded inline before the throw',
         () async {
-          // Skipped-event diagnostics survive terminal failure. Both
-          // `_onWarning` AND the thrown message carry the count.
-          final warnings = <String>[];
           final resumeClient = AgUiStreamClient(
             httpTransport: mockTransport,
             urlBuilder: UrlBuilder(baseUrl),
-            onWarning: warnings.add,
             resumePolicy: const ResumePolicy(
               maxAttempts: 1,
               initialBackoff: Duration(milliseconds: 1),
@@ -809,23 +780,27 @@ void main() {
             throw const NetworkException(message: 'drop again');
           });
 
+          // Drain through the iterator so we can collect the
+          // pre-failure outcomes before the resume exhausts.
+          final outcomes = <DecodeOutcome>[];
           await expectLater(
-            resumeClient.runAgent(endpoint, input).toList(),
+            () async {
+              await for (final outcome
+                  in resumeClient.runAgent(endpoint, input)) {
+                outcomes.add(outcome);
+              }
+            }(),
             throwsA(
-              isA<NetworkException>().having(
+              isA<StreamResumeFailedException>().having(
                 (e) => e.message,
                 'message',
-                allOf(
-                  startsWith(streamResumeFailedPrefix),
-                  contains('skipped 2 malformed events'),
-                ),
+                startsWith(streamResumeFailedPrefix),
               ),
             ),
           );
 
-          // _onWarning still fires once with the count.
-          expect(warnings, hasLength(1));
-          expect(warnings.single, contains('Skipped 2 malformed event'));
+          expect(outcomes.whereType<DecodeFailed>(), hasLength(2));
+          expect(outcomes.whereType<DecodedEvent>(), hasLength(1));
         },
       );
 

--- a/packages/soliplex_client/test/http/agui_stream_client_test.dart
+++ b/packages/soliplex_client/test/http/agui_stream_client_test.dart
@@ -378,6 +378,88 @@ void main() {
         },
       );
 
+      test(
+        'top-level `data: null` yields DecodeFailed(rawData: null), '
+        'no reconnect',
+        () async {
+          // Pre-fix this hit `jsonData as Object` which throws TypeError;
+          // the outer SSE catch routed the throw as a stream error and
+          // triggered a reconnect attempt. The contract is "decode
+          // failure → drop tile carrier", not "decode failure → reconnect".
+          final sseBody = StringBuffer()
+            ..writeln('data: null')
+            ..writeln()
+            ..writeln(
+              'data: ${json.encode({
+                    'type': 'RUN_STARTED',
+                    'threadId': 't-1',
+                    'runId': 'r-1',
+                  })}',
+            )
+            ..writeln();
+
+          when(
+            () => mockTransport.requestStream(
+              any(),
+              any(),
+              headers: any(named: 'headers'),
+              body: any(named: 'body'),
+              cancelToken: any(named: 'cancelToken'),
+            ),
+          ).thenAnswer(
+            (_) async => StreamedHttpResponse(
+              statusCode: 200,
+              body: Stream.value(utf8.encode(sseBody.toString())),
+            ),
+          );
+
+          final result = await client.runAgent(endpoint, input).toList();
+
+          expect(result, hasLength(2));
+          expect(result[0], isA<DecodeFailed>());
+          expect((result[0] as DecodeFailed).rawData, isNull);
+          expect(result[1], isA<DecodedEvent>());
+          expect((result[1] as DecodedEvent).event, isA<RunStartedEvent>());
+        },
+      );
+
+      test('null item inside a batch yields per-item DecodeFailed', () async {
+        // Pre-fix this hit `item as Object` for the null item, which
+        // throws and aborts the surrounding batch via the outer SSE
+        // catch. Each non-Map item must produce its own DecodeFailed
+        // so surrounding valid items still surface.
+        final batch = <dynamic>[
+          null,
+          {'type': 'RUN_STARTED', 'threadId': 't-1', 'runId': 'r-1'},
+        ];
+        final sseBody = StringBuffer()
+          ..writeln('data: ${json.encode(batch)}')
+          ..writeln();
+
+        when(
+          () => mockTransport.requestStream(
+            any(),
+            any(),
+            headers: any(named: 'headers'),
+            body: any(named: 'body'),
+            cancelToken: any(named: 'cancelToken'),
+          ),
+        ).thenAnswer(
+          (_) async => StreamedHttpResponse(
+            statusCode: 200,
+            body: Stream.value(utf8.encode(sseBody.toString())),
+          ),
+        );
+
+        final result = await client.runAgent(endpoint, input).toList();
+
+        expect(result, hasLength(2));
+        expect(result[0], isA<DecodeFailed>());
+        expect((result[0] as DecodeFailed).rawData, isNull);
+        expect(result[1], isA<DecodedEvent>());
+        expect((result[1] as DecodedEvent).event, isA<RunStartedEvent>());
+      });
+
       test('propagates CancelledException from transport', () async {
         when(
           () => mockTransport.requestStream(

--- a/test/modules/room/execution_tracker_extension_test.dart
+++ b/test/modules/room/execution_tracker_extension_test.dart
@@ -133,4 +133,23 @@ void main() {
       isFalse,
     );
   });
+
+  test('post-dispose runState arrival logs and returns; does not crash', () {
+    // The teardown order in `onDispose` cancels the subscription before
+    // clearing `_session`, but signals' dispatch ordering across upgrades
+    // isn't a guarantee we want to rely on. Drive the post-dispose path
+    // directly via `debugPushRunState` to confirm the null-check holds.
+    ext.onDispose();
+
+    expect(
+      () => ext.debugPushRunState(
+        CancelledState.duringRun(
+          threadKey: _key,
+          runId: _runId,
+          conversation: _conversationWith(const []),
+        ),
+      ),
+      returnsNormally,
+    );
+  });
 }

--- a/test/modules/room/execution_tracker_test.dart
+++ b/test/modules/room/execution_tracker_test.dart
@@ -585,6 +585,41 @@ void main() {
     expect(tracker.isThinkingStreaming.value, isFalse);
     expect(tracker.steps.value.single.status, StepStatus.completed);
   });
+
+  test(
+    'a throw inside a switch arm is caught; subsequent events still process',
+    () {
+      // ActivitySnapshot with an unrecognized activityType makes
+      // `SkillToolCallActivity.fromRecord` return null. The warning that
+      // fires next reads `content.keys.toList().toString()` while
+      // building its attributes — a Map whose `keys` getter throws makes
+      // that argument-evaluation throw, propagating into the switch arm.
+      // The wrap catches it; the tracker keeps responding to events.
+      events.value = ActivitySnapshot(
+        messageId: 'msg-1',
+        activityType: 'unknown_activity',
+        content: _ThrowingMap(),
+        timestamp: 1,
+        replace: false,
+      );
+
+      // The tracker survives and still bridges later events.
+      events.value = const ThinkingStarted();
+      expect(tracker.steps.value, hasLength(1));
+      expect(tracker.steps.value.single.label, 'Thinking');
+      expect(tracker.isThinkingStreaming.value, isTrue);
+    },
+  );
+}
+
+/// A `Map<String, dynamic>` whose `keys` getter throws. Used to drive the
+/// argument-evaluation throw in `_upsertSkillToolCall`'s warning call.
+class _ThrowingMap implements Map<String, dynamic> {
+  @override
+  Iterable<String> get keys => throw StateError('keys access blew up');
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
 }
 
 extension on StepStatus {

--- a/test/modules/room/historical_replay_test.dart
+++ b/test/modules/room/historical_replay_test.dart
@@ -4,6 +4,18 @@ import 'package:soliplex_agent/soliplex_agent.dart';
 import 'package:soliplex_frontend/src/modules/room/historical_replay.dart';
 import 'package:soliplex_frontend/src/modules/room/ui/execution/timeline_entry.dart';
 
+/// Returns a bridger that throws on one specific [TextMessageContentEvent]
+/// `messageId`. Used to verify the per-event try/catch in
+/// `replayToTrackers`.
+ExecutionEvent? Function(BaseEvent) _bridgerThrowingOn(String poisonId) {
+  return (event) {
+    if (event is TextMessageContentEvent && event.messageId == poisonId) {
+      throw StateError('bridge simulated failure on $poisonId');
+    }
+    return bridgeBaseEvent(event);
+  };
+}
+
 void main() {
   group('replayToTrackers', () {
     test('returns empty map for empty runs', () {
@@ -310,5 +322,46 @@ void main() {
       expect(trackers['asst-1']!.steps.value, isEmpty);
       expect(trackers['asst-2']!.steps.value, hasLength(1));
     });
+
+    test(
+      'a throw inside the bridger drops only that event; surrounding '
+      'events still bridge',
+      () {
+        final runs = [
+          RunEventBundle(
+            runId: 'run-1',
+            events: const [
+              RunStartedEvent(threadId: 't-1', runId: 'run-1'),
+              ReasoningMessageStartEvent(messageId: 'think-1'),
+              ReasoningMessageContentEvent(
+                messageId: 'think-1',
+                delta: 'reasoning…',
+              ),
+              ReasoningMessageEndEvent(messageId: 'think-1'),
+              TextMessageStartEvent(messageId: 'asst-1'),
+              // The bridger throws on this delta.
+              TextMessageContentEvent(messageId: 'asst-1', delta: 'poison'),
+              // Subsequent events must still bridge.
+              TextMessageContentEvent(messageId: 'asst-1', delta: 'survives'),
+              TextMessageEndEvent(messageId: 'asst-1'),
+              RunFinishedEvent(threadId: 't-1', runId: 'run-1'),
+            ],
+          ),
+        ];
+
+        final trackers = replayToTrackers(
+          runs,
+          bridge: _bridgerThrowingOn('asst-1'),
+        );
+
+        expect(trackers.keys, ['asst-1']);
+        final tracker = trackers['asst-1']!;
+        // The thinking step bridged before the poison event.
+        expect(tracker.steps.value, hasLength(1));
+        expect(tracker.steps.value.first.label, 'Thinking');
+        // The thinking content survived.
+        expect(tracker.thinkingBlocks.value, ['reasoning…']);
+      },
+    );
   });
 }

--- a/test/modules/room/thread_view_state_test.dart
+++ b/test/modules/room/thread_view_state_test.dart
@@ -924,45 +924,6 @@ void main() {
     );
 
     test(
-      'FailedState with skipped-events suffix preserves the count in '
-      'friendly copy',
-      () async {
-        api.nextThreadHistory = ThreadHistory(messages: const []);
-
-        final state = ThreadViewState(
-          connection: connection,
-          roomId: 'room-1',
-          threadId: 'thread-1',
-          registry: registry,
-        );
-        await Future<void>.delayed(Duration.zero);
-
-        final session = _FakeAgentSession();
-        state.attachSession(session);
-
-        session.emit(
-          FailedState.preRun(
-            threadKey: (
-              serverId: 'test-server',
-              roomId: 'room-1',
-              threadId: 'thread-1',
-            ),
-            reason: FailureReason.streamResumeFailed,
-            error: '$streamResumeFailedPrefix NetworkException: server gone '
-                '(skipped 3 malformed events)',
-          ),
-        );
-
-        final sendError = state.lastSendError.value;
-        expect(sendError, isNotNull);
-        expect(sendError!.error, contains('Connection lost'));
-        expect(sendError.error, contains('(skipped 3 malformed events)'));
-
-        state.dispose();
-      },
-    );
-
-    test(
       'FailedState without the marker prefix passes the raw error through',
       () async {
         api.nextThreadHistory = ThreadHistory(messages: const []);

--- a/test/modules/room/ui/dropped_event_message_tile_test.dart
+++ b/test/modules/room/ui/dropped_event_message_tile_test.dart
@@ -1,0 +1,107 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:soliplex_agent/soliplex_agent.dart' hide State;
+import 'package:soliplex_frontend/src/modules/room/ui/dropped_event_message_tile.dart';
+
+Future<void> _pump(WidgetTester tester, DroppedEventMessage message) {
+  return tester.pumpWidget(
+    MaterialApp(
+      home: Scaffold(
+        body: DroppedEventMessageTile(message: message),
+      ),
+    ),
+  );
+}
+
+void main() {
+  testWidgets('collapsed shows the one-liner with humanized source', (
+    tester,
+  ) async {
+    final msg = DroppedEventMessage.create(
+      id: 'dropped-run-1-3',
+      source: DropSource.decode,
+      reason: 'unknown event type',
+      runId: 'run-1',
+      rawPayload: const {'type': 'WIDGET'},
+    );
+
+    await _pump(tester, msg);
+
+    expect(find.text("Couldn't process 1 event (decode)"), findsOneWidget);
+    // Subtitle / payload are hidden until expanded.
+    expect(find.text('run run-1 — unknown event type'), findsNothing);
+    expect(find.byIcon(Icons.expand_more), findsOneWidget);
+  });
+
+  testWidgets('eventProcessing source humanizes to "processing"', (
+    tester,
+  ) async {
+    final msg = DroppedEventMessage.create(
+      id: 'dropped-run-1-3',
+      source: DropSource.eventProcessing,
+      reason: 'cast failed',
+      runId: 'run-1',
+      rawPayload: const {},
+    );
+
+    await _pump(tester, msg);
+
+    expect(
+      find.text("Couldn't process 1 event (processing)"),
+      findsOneWidget,
+    );
+  });
+
+  testWidgets('tapping expands and reveals subtitle + JSON payload', (
+    tester,
+  ) async {
+    final msg = DroppedEventMessage.create(
+      id: 'dropped-run-1-3',
+      source: DropSource.decode,
+      reason: 'unknown event type',
+      runId: 'run-1',
+      rawPayload: const {'type': 'WIDGET', 'foo': 'bar'},
+    );
+
+    await _pump(tester, msg);
+    await tester.tap(find.byType(InkWell));
+    await tester.pump();
+
+    expect(find.text('run run-1 — unknown event type'), findsOneWidget);
+    expect(find.byIcon(Icons.expand_less), findsOneWidget);
+    // Both Map keys appear somewhere in the JSON tree.
+    expect(find.textContaining('type'), findsWidgets);
+    expect(find.textContaining('foo'), findsWidgets);
+  });
+
+  testWidgets('null rawPayload renders "(payload unavailable)"', (
+    tester,
+  ) async {
+    final msg = DroppedEventMessage.create(
+      id: 'dropped-pre-run-123',
+      source: DropSource.decode,
+      reason: 'top-level JSON parse failure',
+    );
+
+    await _pump(tester, msg);
+    await tester.tap(find.byType(InkWell));
+    await tester.pump();
+
+    expect(find.text('(payload unavailable)'), findsOneWidget);
+  });
+
+  testWidgets('omits runId from subtitle when null', (tester) async {
+    final msg = DroppedEventMessage.create(
+      id: 'dropped-pre-run-123',
+      source: DropSource.decode,
+      reason: 'top-level parse failure',
+    );
+
+    await _pump(tester, msg);
+    await tester.tap(find.byType(InkWell));
+    await tester.pump();
+
+    // Subtitle is just the reason, no "run …" prefix.
+    expect(find.text('top-level parse failure'), findsOneWidget);
+  });
+}

--- a/test/modules/room/ui/dropped_event_message_tile_test.dart
+++ b/test/modules/room/ui/dropped_event_message_tile_test.dart
@@ -104,4 +104,26 @@ void main() {
     // Subtitle is just the reason, no "run …" prefix.
     expect(find.text('top-level parse failure'), findsOneWidget);
   });
+
+  testWidgets('String rawPayload renders the raw bytes verbatim', (
+    tester,
+  ) async {
+    // Top-level JSON parse failures arrive with a String rawPayload —
+    // the wire content the parser rejected. A user expanding the tile
+    // should see exactly those bytes, not "(payload unavailable)".
+    final msg = DroppedEventMessage.create(
+      id: 'dropped-pre-run-456',
+      source: DropSource.decode,
+      reason: 'FormatException: Unexpected character',
+      rawPayload: 'not valid json at all',
+    );
+
+    await _pump(tester, msg);
+    await tester.tap(find.byType(InkWell));
+    await tester.pump();
+
+    expect(find.text('not valid json at all'), findsOneWidget);
+    // Belt-and-suspenders: not the unavailable fallback.
+    expect(find.text('(payload unavailable)'), findsNothing);
+  });
 }


### PR DESCRIPTION
## Summary

- Introduces `DroppedEventMessage`, a low-emphasis carrier that mints in the conversation when an AG-UI event fails to decode (`AgUiStreamClient`) or fails to project (`processEvent` throw). Replaces the prior silent skip path, so schema drift becomes a quiet user-visible hint plus a structured logger breadcrumb.
- Adds the `DecodeOutcome` sum type at both content-bearing boundaries — live SSE in `RunOrchestrator._onEvent` and replay in `SoliplexApi._replayEventsToHistory` — keeping the run alive when one event fails. Drop-tile ids align across live and replay so reload reproduces the same conversation. Tiles never round-trip to the LLM (filtered in `agui_message_mapper`).
- Hardens defensive containment in projections: `ExecutionTracker._onEvent`, `replayToTrackers`, the citation extractor, and synth providers all preserve stack traces and route through `soliplex_logging`. `ExecutionTrackerExtension` is hardened against post-dispose `runState` arrivals.
- Gates `RunOrchestrator.baseEvents` on `processEvent` success so a tracker observing the stream stays consistent with the conversation — events whose application-layer projection threw are excluded.

## Test plan

- [x] `flutter analyze` (zero warnings)
- [x] `dart format`
- [x] `soliplex_agent` test suite (78 tests)
- [x] `soliplex_client` test suite (1448 tests, integration tag excluded — they need a live backend)
- [x] `soliplex_frontend` test suite (614 tests)
- [x] Live drop-tile rendering pinned end-to-end (`run_orchestrator_test.dart` "live drop tiles")
- [x] Replay drop-tile rendering pinned end-to-end (`soliplex_api_test.dart` "replay survives ...")
- [x] Cross-path drop-id alignment pinned by both formula tests
- [x] Wire-leak filter pinned (`agui_message_mapper` skip arm + regression test)

🤖 Generated with [Claude Code](https://claude.com/claude-code)