### PR TITLE
feat(room): preview workdir image artifacts in-app

### DIFF
--- a/lib/src/modules/room/ui/message_tile.dart
+++ b/lib/src/modules/room/ui/message_tile.dart
@@ -23,6 +23,7 @@ class MessageTile extends StatelessWidget {
     this.onShowChunkVisualization,
     this.onFetchWorkdirFiles,
     this.onDownloadWorkdirFile,
+    this.onPreviewWorkdirFile,
     this.executionTracker,
     this.streamingActivity,
   });
@@ -37,6 +38,7 @@ class MessageTile extends StatelessWidget {
   final void Function(SourceReference)? onShowChunkVisualization;
   final FetchWorkdirFiles? onFetchWorkdirFiles;
   final DownloadWorkdirFile? onDownloadWorkdirFile;
+  final FetchWorkdirFileBytes? onPreviewWorkdirFile;
   final ExecutionTracker? executionTracker;
   final ActivityType? streamingActivity;
 
@@ -60,6 +62,7 @@ class MessageTile extends StatelessWidget {
             onShowChunkVisualization: onShowChunkVisualization,
             onFetchWorkdirFiles: onFetchWorkdirFiles,
             onDownloadWorkdirFile: onDownloadWorkdirFile,
+            onPreviewWorkdirFile: onPreviewWorkdirFile,
             executionTracker: executionTracker,
             streamingActivity: streamingActivity,
           ),

--- a/lib/src/modules/room/ui/message_timeline.dart
+++ b/lib/src/modules/room/ui/message_timeline.dart
@@ -25,6 +25,7 @@ class MessageTimeline extends StatefulWidget {
     this.onShowChunkVisualization,
     this.onFetchWorkdirFiles,
     this.onDownloadWorkdirFile,
+    this.onPreviewWorkdirFile,
   });
 
   final String roomId;
@@ -38,6 +39,7 @@ class MessageTimeline extends StatefulWidget {
   final void Function(SourceReference)? onShowChunkVisualization;
   final FetchWorkdirFiles? onFetchWorkdirFiles;
   final DownloadWorkdirFile? onDownloadWorkdirFile;
+  final FetchWorkdirFileBytes? onPreviewWorkdirFile;
 
   @override
   State<MessageTimeline> createState() => _MessageTimelineState();
@@ -218,6 +220,7 @@ class _MessageTimelineState extends State<MessageTimeline> {
                       onShowChunkVisualization: widget.onShowChunkVisualization,
                       onFetchWorkdirFiles: widget.onFetchWorkdirFiles,
                       onDownloadWorkdirFile: widget.onDownloadWorkdirFile,
+                      onPreviewWorkdirFile: widget.onPreviewWorkdirFile,
                       executionTracker: widget.executionTrackers[message.id] ??
                           (message is LoadingMessage
                               ? widget.executionTrackers[awaitingTrackerKey]

--- a/lib/src/modules/room/ui/room_screen.dart
+++ b/lib/src/modules/room/ui/room_screen.dart
@@ -946,6 +946,12 @@ class _RoomScreenState extends State<RoomScreen> {
                             runId,
                             file,
                           ),
+                          onPreviewWorkdirFile: (runId, file) =>
+                              _workdirs.fetchBytes(
+                            threadView.threadId,
+                            runId,
+                            file,
+                          ),
                         ),
               },
             ),

--- a/lib/src/modules/room/ui/text_message_tile.dart
+++ b/lib/src/modules/room/ui/text_message_tile.dart
@@ -24,6 +24,7 @@ class TextMessageTile extends StatelessWidget {
     this.onShowChunkVisualization,
     this.onFetchWorkdirFiles,
     this.onDownloadWorkdirFile,
+    this.onPreviewWorkdirFile,
     this.executionTracker,
     this.streamingActivity,
   });
@@ -37,6 +38,7 @@ class TextMessageTile extends StatelessWidget {
   final void Function(SourceReference)? onShowChunkVisualization;
   final FetchWorkdirFiles? onFetchWorkdirFiles;
   final DownloadWorkdirFile? onDownloadWorkdirFile;
+  final FetchWorkdirFileBytes? onPreviewWorkdirFile;
   final ExecutionTracker? executionTracker;
   final ActivityType? streamingActivity;
 
@@ -119,6 +121,7 @@ class TextMessageTile extends StatelessWidget {
             runId: runId!,
             fetchFiles: onFetchWorkdirFiles!,
             onDownload: onDownloadWorkdirFile!,
+            onPreview: onPreviewWorkdirFile,
           ),
       ],
     );

--- a/lib/src/modules/room/ui/workdir_files_section.dart
+++ b/lib/src/modules/room/ui/workdir_files_section.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+import 'dart:typed_data';
 
 import 'package:flutter/material.dart';
 import 'package:soliplex_client/soliplex_client.dart' hide State;
@@ -12,17 +13,42 @@ typedef DownloadWorkdirFile = Future<DownloadOutcome> Function(
   WorkdirFile file,
 );
 
+typedef FetchWorkdirFileBytes = Future<Uint8List> Function(
+  String runId,
+  WorkdirFile file,
+);
+
+const _imageExtensions = {
+  '.png',
+  '.jpg',
+  '.jpeg',
+  '.gif',
+  '.webp',
+  '.bmp',
+};
+
+bool _isPreviewableImage(String filename) {
+  final dot = filename.lastIndexOf('.');
+  if (dot <= 0) return false;
+  return _imageExtensions.contains(filename.substring(dot).toLowerCase());
+}
+
 class WorkdirFilesSection extends StatefulWidget {
   const WorkdirFilesSection({
     super.key,
     required this.runId,
     required this.fetchFiles,
     required this.onDownload,
+    this.onPreview,
   });
 
   final String runId;
   final FetchWorkdirFiles fetchFiles;
   final DownloadWorkdirFile onDownload;
+
+  /// When non-null, image files render an eye icon that opens a
+  /// full-screen preview backed by bytes from this callback.
+  final FetchWorkdirFileBytes? onPreview;
 
   @override
   State<WorkdirFilesSection> createState() => _WorkdirFilesSectionState();
@@ -68,6 +94,9 @@ class _WorkdirFilesSectionState extends State<WorkdirFilesSection> {
                       _WorkdirFileRow(
                         file: file,
                         onTap: () => widget.onDownload(widget.runId, file),
+                        onPreview: widget.onPreview == null
+                            ? null
+                            : () => widget.onPreview!(widget.runId, file),
                       ),
                   ],
                 ),
@@ -81,10 +110,15 @@ class _WorkdirFilesSectionState extends State<WorkdirFilesSection> {
 }
 
 class _WorkdirFileRow extends StatefulWidget {
-  const _WorkdirFileRow({required this.file, required this.onTap});
+  const _WorkdirFileRow({
+    required this.file,
+    required this.onTap,
+    this.onPreview,
+  });
 
   final WorkdirFile file;
   final Future<DownloadOutcome> Function() onTap;
+  final Future<Uint8List> Function()? onPreview;
 
   @override
   State<_WorkdirFileRow> createState() => _WorkdirFileRowState();
@@ -153,6 +187,8 @@ class _WorkdirFileRowState extends State<_WorkdirFileRow> {
           "Couldn't save",
         ),
     };
+    final canPreview =
+        widget.onPreview != null && _isPreviewableImage(widget.file.filename);
     return InkWell(
       onTap: _feedback == _DownloadFeedback.idle ? _handleTap : null,
       borderRadius: BorderRadius.circular(6),
@@ -172,6 +208,24 @@ class _WorkdirFileRowState extends State<_WorkdirFileRow> {
                 style: theme.textTheme.bodySmall,
               ),
             ),
+            if (canPreview) ...[
+              InkWell(
+                onTap: () => _openPreview(context),
+                borderRadius: BorderRadius.circular(6),
+                child: Padding(
+                  padding: const EdgeInsets.all(2),
+                  child: Tooltip(
+                    message: 'Preview',
+                    child: Icon(
+                      Icons.visibility_outlined,
+                      size: 16,
+                      color: theme.colorScheme.onSurfaceVariant,
+                    ),
+                  ),
+                ),
+              ),
+              const SizedBox(width: 8),
+            ],
             Tooltip(
               message: tooltip,
               child: Icon(icon, size: 16, color: color),
@@ -179,6 +233,16 @@ class _WorkdirFileRowState extends State<_WorkdirFileRow> {
           ],
         ),
       ),
+    );
+  }
+
+  void _openPreview(BuildContext context) {
+    final fetch = widget.onPreview;
+    if (fetch == null) return;
+    WorkdirImagePreviewPage.show(
+      context: context,
+      filename: widget.file.filename,
+      fetchBytes: fetch,
     );
   }
 }
@@ -266,6 +330,182 @@ double _measure(String text, TextStyle? style) {
     maxLines: 1,
   )..layout();
   return painter.width;
+}
+
+/// Full-screen image preview for workdir artifacts. Fetches the bytes
+/// lazily via [fetchBytes] so the bytes are not pulled until the user
+/// actually opens the preview.
+class WorkdirImagePreviewPage extends StatefulWidget {
+  const WorkdirImagePreviewPage({
+    super.key,
+    required this.filename,
+    required this.fetchBytes,
+    required this.useDialogLayout,
+  });
+
+  final String filename;
+  final Future<Uint8List> Function() fetchBytes;
+  final bool useDialogLayout;
+
+  static Future<void> show({
+    required BuildContext context,
+    required String filename,
+    required Future<Uint8List> Function() fetchBytes,
+  }) {
+    final useDialog = MediaQuery.sizeOf(context).width >= 600;
+    final child = WorkdirImagePreviewPage(
+      filename: filename,
+      fetchBytes: fetchBytes,
+      useDialogLayout: useDialog,
+    );
+    if (useDialog) {
+      return showDialog<void>(
+        context: context,
+        barrierDismissible: true,
+        builder: (_) => child,
+      );
+    }
+    return Navigator.of(context).push<void>(
+      MaterialPageRoute(builder: (_) => child),
+    );
+  }
+
+  @override
+  State<WorkdirImagePreviewPage> createState() =>
+      _WorkdirImagePreviewPageState();
+}
+
+class _WorkdirImagePreviewPageState extends State<WorkdirImagePreviewPage> {
+  late Future<Uint8List> _future;
+
+  @override
+  void initState() {
+    super.initState();
+    _future = widget.fetchBytes();
+  }
+
+  void _retry() {
+    setState(() {
+      _future = widget.fetchBytes();
+    });
+  }
+
+  Widget _buildContent(BuildContext context) {
+    return FutureBuilder<Uint8List>(
+      future: _future,
+      builder: (context, snapshot) {
+        if (snapshot.connectionState != ConnectionState.done) {
+          return const Center(child: CircularProgressIndicator());
+        }
+        if (snapshot.hasError) {
+          return _buildError(context, snapshot.error!);
+        }
+        final bytes = snapshot.data;
+        if (bytes == null || bytes.isEmpty) {
+          return _buildError(context, 'Empty file');
+        }
+        return Center(
+          child: InteractiveViewer(
+            minScale: 1.0,
+            maxScale: 4.0,
+            child: Image.memory(
+              bytes,
+              fit: BoxFit.contain,
+              errorBuilder: (context, error, _) => _buildError(context, error),
+            ),
+          ),
+        );
+      },
+    );
+  }
+
+  Widget _buildError(BuildContext context, Object error) {
+    final theme = Theme.of(context);
+    return Center(
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Icon(Icons.error_outline, size: 48, color: theme.colorScheme.error),
+          const SizedBox(height: 12),
+          Text(
+            'Failed to load preview',
+            style: theme.textTheme.bodyMedium,
+          ),
+          const SizedBox(height: 4),
+          Text(
+            error.toString(),
+            style: theme.textTheme.bodySmall?.copyWith(
+              color: theme.colorScheme.onSurfaceVariant,
+            ),
+            textAlign: TextAlign.center,
+          ),
+          const SizedBox(height: 16),
+          FilledButton.icon(
+            onPressed: _retry,
+            icon: const Icon(Icons.refresh),
+            label: const Text('Retry'),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildTitleBar(BuildContext context) {
+    final theme = Theme.of(context);
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(16, 12, 8, 8),
+      child: Row(
+        children: [
+          Expanded(
+            child: Text(
+              widget.filename,
+              style: theme.textTheme.titleMedium,
+              maxLines: 1,
+              overflow: TextOverflow.ellipsis,
+            ),
+          ),
+          IconButton(
+            icon: const Icon(Icons.close),
+            tooltip: 'Close',
+            onPressed: () => Navigator.of(context).pop(),
+          ),
+        ],
+      ),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    if (widget.useDialogLayout) {
+      return Dialog(
+        insetPadding: const EdgeInsets.all(16),
+        child: ConstrainedBox(
+          constraints: BoxConstraints(
+            maxWidth: 800,
+            maxHeight: MediaQuery.sizeOf(context).height * 0.85,
+          ),
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              _buildTitleBar(context),
+              Expanded(child: _buildContent(context)),
+            ],
+          ),
+        ),
+      );
+    }
+    return Scaffold(
+      appBar: AppBar(
+        title: Text(
+          widget.filename,
+          maxLines: 1,
+          overflow: TextOverflow.ellipsis,
+        ),
+        titleTextStyle: Theme.of(context).textTheme.titleMedium,
+      ),
+      body: _buildContent(context),
+    );
+  }
 }
 
 class _WorkdirErrorRow extends StatelessWidget {

--- a/lib/src/modules/room/workdir_controller.dart
+++ b/lib/src/modules/room/workdir_controller.dart
@@ -127,6 +127,16 @@ class WorkdirController {
     }
   }
 
+  /// Fetches the raw bytes for [file] without writing them to disk. Used
+  /// by the in-app preview path; the save dialog is the download path.
+  Future<Uint8List> fetchBytes(
+    String threadId,
+    String runId,
+    WorkdirFile file,
+  ) {
+    return _api.getRunWorkdirFile(_roomId, threadId, runId, file.filename);
+  }
+
   /// Drops every cached fetch result. Call when the user switches away
   /// from a thread so the next thread starts with a clean cache.
   void clearCache() => _cache.clear();

--- a/test/modules/room/ui/workdir_files_section_test.dart
+++ b/test/modules/room/ui/workdir_files_section_test.dart
@@ -1,10 +1,82 @@
 import 'dart:async';
+import 'dart:typed_data';
 
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:soliplex_client/soliplex_client.dart';
 
 import 'package:soliplex_frontend/src/modules/room/ui/workdir_files_section.dart';
+
+/// Minimal 1x1 transparent PNG so [Image.memory] can decode in tests.
+final Uint8List _tinyPng = Uint8List.fromList(const [
+  0x89,
+  0x50,
+  0x4E,
+  0x47,
+  0x0D,
+  0x0A,
+  0x1A,
+  0x0A,
+  0x00,
+  0x00,
+  0x00,
+  0x0D,
+  0x49,
+  0x48,
+  0x44,
+  0x52,
+  0x00,
+  0x00,
+  0x00,
+  0x01,
+  0x00,
+  0x00,
+  0x00,
+  0x01,
+  0x08,
+  0x06,
+  0x00,
+  0x00,
+  0x00,
+  0x1F,
+  0x15,
+  0xC4,
+  0x89,
+  0x00,
+  0x00,
+  0x00,
+  0x0D,
+  0x49,
+  0x44,
+  0x41,
+  0x54,
+  0x78,
+  0x9C,
+  0x63,
+  0x00,
+  0x01,
+  0x00,
+  0x00,
+  0x05,
+  0x00,
+  0x01,
+  0x0D,
+  0x0A,
+  0x2D,
+  0xB4,
+  0x00,
+  0x00,
+  0x00,
+  0x00,
+  0x49,
+  0x45,
+  0x4E,
+  0x44,
+  0xAE,
+  0x42,
+  0x60,
+  0x82,
+]);
 
 WorkdirFile _file(String name) =>
     WorkdirFile(filename: name, url: Uri.parse('https://example.test/$name'));
@@ -195,6 +267,107 @@ void main() {
 
     completer.complete(DownloadOutcome.success);
     await tester.pumpAndSettle();
+  });
+
+  testWidgets(
+      'preview eye icon shown only for image files when onPreview is wired',
+      (tester) async {
+    await tester.pumpWidget(_wrap(WorkdirFilesSection(
+      runId: 'run-1',
+      fetchFiles: (_) async => [_file('plot.png'), _file('report.pdf')],
+      onDownload: (_, __) async => DownloadOutcome.success,
+      onPreview: (_, __) async => _tinyPng,
+    )));
+    await tester.pump();
+
+    expect(find.byIcon(Icons.visibility_outlined), findsOneWidget);
+  });
+
+  testWidgets('preview eye icon hidden when onPreview is null even for images',
+      (tester) async {
+    await tester.pumpWidget(_wrap(WorkdirFilesSection(
+      runId: 'run-1',
+      fetchFiles: (_) async => [_file('plot.png')],
+      onDownload: (_, __) async => DownloadOutcome.success,
+    )));
+    await tester.pump();
+
+    expect(find.byIcon(Icons.visibility_outlined), findsNothing);
+  });
+
+  testWidgets('tapping the eye opens the preview page and fetches bytes',
+      (tester) async {
+    var fetchCalls = 0;
+    await tester.pumpWidget(_wrap(WorkdirFilesSection(
+      runId: 'run-7',
+      fetchFiles: (_) async => [_file('plot.png')],
+      onDownload: (_, __) async => DownloadOutcome.success,
+      onPreview: (runId, file) async {
+        fetchCalls++;
+        expect(runId, 'run-7');
+        expect(file.filename, 'plot.png');
+        return _tinyPng;
+      },
+    )));
+    await tester.pump();
+
+    await tester.tap(find.byIcon(Icons.visibility_outlined));
+    await tester.pumpAndSettle();
+
+    expect(fetchCalls, 1);
+    expect(find.byType(Image), findsOneWidget);
+    expect(find.byIcon(Icons.close), findsOneWidget);
+  });
+
+  testWidgets('preview close (X) dismisses the dialog', (tester) async {
+    // Force dialog layout by giving the root a wide size.
+    tester.view.physicalSize = const Size(1200, 1600);
+    tester.view.devicePixelRatio = 1.0;
+    addTearDown(tester.view.resetPhysicalSize);
+
+    await tester.pumpWidget(_wrap(WorkdirFilesSection(
+      runId: 'run-1',
+      fetchFiles: (_) async => [_file('plot.png')],
+      onDownload: (_, __) async => DownloadOutcome.success,
+      onPreview: (_, __) async => _tinyPng,
+    )));
+    await tester.pump();
+
+    await tester.tap(find.byIcon(Icons.visibility_outlined));
+    await tester.pumpAndSettle();
+    expect(find.byType(Dialog), findsOneWidget);
+
+    await tester.tap(find.byIcon(Icons.close));
+    await tester.pumpAndSettle();
+
+    expect(find.byType(Dialog), findsNothing);
+  });
+
+  testWidgets('preview shows error + Retry when fetch fails', (tester) async {
+    var fetchCalls = 0;
+    await tester.pumpWidget(_wrap(WorkdirFilesSection(
+      runId: 'run-1',
+      fetchFiles: (_) async => [_file('plot.png')],
+      onDownload: (_, __) async => DownloadOutcome.success,
+      onPreview: (_, __) async {
+        fetchCalls++;
+        if (fetchCalls == 1) throw Exception('boom');
+        return _tinyPng;
+      },
+    )));
+    await tester.pump();
+
+    await tester.tap(find.byIcon(Icons.visibility_outlined));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Failed to load preview'), findsOneWidget);
+    expect(find.text('Retry'), findsOneWidget);
+
+    await tester.tap(find.text('Retry'));
+    await tester.pumpAndSettle();
+
+    expect(fetchCalls, 2);
+    expect(find.byType(Image), findsOneWidget);
   });
 
   testWidgets('second tap during feedback window is a no-op', (tester) async {

--- a/test/modules/room/workdir_controller_test.dart
+++ b/test/modules/room/workdir_controller_test.dart
@@ -196,4 +196,28 @@ void main() {
       );
     });
   });
+
+  group('fetchBytes', () {
+    test('returns API bytes and skips the save dialog', () async {
+      final bytes = Uint8List.fromList([9, 9, 9]);
+      when(() => api.getRunWorkdirFile(any(), any(), any(), any()))
+          .thenAnswer((_) async => bytes);
+
+      var saveCalls = 0;
+      final controller = build(
+        saveFile: ({required String fileName, required Uint8List bytes}) async {
+          saveCalls++;
+          return '/tmp/$fileName';
+        },
+      );
+
+      final out =
+          await controller.fetchBytes('t-1', 'r-1', _file('preview.png'));
+
+      expect(out, bytes);
+      expect(saveCalls, 0);
+      verify(() => api.getRunWorkdirFile('room-1', 't-1', 'r-1', 'preview.png'))
+          .called(1);
+    });
+  });
 }


### PR DESCRIPTION
## Summary

Closes #217.

- Adds an eye icon (`Icons.visibility_outlined`) next to the download icon
for workdir files whose extension marks them as a previewable image
(`png`, `jpg`/`jpeg`, `gif`, `webp`, `bmp`).
- Tapping opens a full-screen `WorkdirImagePreviewPage`:
- `Dialog` layout with an X close button on screens ≥ 600 px wide.
- `Scaffold` + `AppBar` (back/close) on narrow screens.
- `Image.memory` inside an `InteractiveViewer` for pinch/zoom.
- Loading spinner, plus error state with Retry.
- Bytes are fetched lazily when the page opens via the same
`getRunWorkdirFile` endpoint already used for download — no save
dialog. The pattern mirrors `ChunkVisualizationPage` for citations.
- Out of scope: previewing non-image artifacts (PDF, text, JSON…).
The eye icon simply doesn't appear for those files; download still
works as before. Happy to extend in a follow-up if there's appetite.

## Implementation notes

- New `WorkdirController.fetchBytes(threadId, runId, file)` returns the
raw bytes without invoking `saveFile`, so the preview path is
decoupled from the download path.
- New `FetchWorkdirFileBytes` typedef threaded through the existing
callback chain: `room_screen.dart` → `MessageTimeline` →
`MessageTile` → `TextMessageTile` → `WorkdirFilesSection`. The
callback is optional everywhere; passing `null` reverts to the
pre-existing download-only behavior.
- Image detection is extension-based at parse time — no MIME sniffing,
no extra network round-trip.

## Test plan

- [x] `flutter analyze` — clean.
- [x] `flutter test` — full suite passes (1238 tests, 6 new).
- Eye icon visible only for image filenames when `onPreview` is wired.
- Eye icon hidden when `onPreview` is `null`, even for images.
- Tapping the eye fetches bytes and shows the preview with `Image` + close button.
- X dismisses the dialog on wide layouts.
- Failed fetch shows error + Retry; Retry re-invokes the fetch.
- `WorkdirController.fetchBytes` returns bytes without calling `saveFile`.
- [x] Manual: open a room with a sandbox-enabled agent, ask it to
produce an image artifact (e.g. a matplotlib PNG), confirm the eye
icon appears, the preview opens, pinch-zoom works, and X closes.
- [x] Manual: confirm non-image artifacts still show only the download
icon and download as before.