### PR TITLE
fix(room): address citation copy-button review feedback

### DIFF
--- a/lib/src/modules/room/ui/citations_section.dart
+++ b/lib/src/modules/room/ui/citations_section.dart
@@ -3,6 +3,7 @@ import 'package:flutter/services.dart';
 import 'package:soliplex_agent/soliplex_agent.dart' hide State;
 import 'package:url_launcher/url_launcher.dart';
 
+import '../../../shared/copy_button.dart';
 import 'markdown/flutter_markdown_plus_renderer.dart';
 
 class CitationsSection extends StatefulWidget {
@@ -32,54 +33,58 @@ class _CitationsSectionState extends State<CitationsSection> {
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
         const SizedBox(height: 8),
-        InkWell(
-          onTap: () => setState(() => _sectionExpanded = !_sectionExpanded),
-          borderRadius: BorderRadius.circular(8),
-          child: Padding(
-            padding: const EdgeInsets.symmetric(vertical: 4, horizontal: 4),
-            child: Row(
-              mainAxisSize: MainAxisSize.min,
-              children: [
-                Transform.flip(
-                  flipX: true,
-                  child: Icon(
-                    Icons.format_quote,
-                    size: 16,
-                    color: theme.colorScheme.onSurfaceVariant,
-                  ),
-                ),
-                const SizedBox(width: 4),
-                Text(
-                  '$count source${count == 1 ? '' : 's'}',
-                  style: theme.textTheme.labelSmall?.copyWith(
-                    color: theme.colorScheme.onSurfaceVariant,
-                  ),
-                ),
-                const SizedBox(width: 2),
-                Icon(
-                  _sectionExpanded ? Icons.expand_less : Icons.expand_more,
-                  size: 16,
-                  color: theme.colorScheme.onSurfaceVariant,
-                ),
-                const SizedBox(width: 4),
-                InkWell(
-                  onTap: () => _copyAllToClipboard(context),
-                  borderRadius: BorderRadius.circular(6),
-                  child: Padding(
-                    padding: const EdgeInsets.all(2),
-                    child: Tooltip(
-                      message: 'Copy all',
+        Row(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            InkWell(
+              onTap: () => setState(() => _sectionExpanded = !_sectionExpanded),
+              borderRadius: BorderRadius.circular(8),
+              child: Padding(
+                padding: const EdgeInsets.symmetric(vertical: 4, horizontal: 4),
+                child: Row(
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    Transform.flip(
+                      flipX: true,
                       child: Icon(
-                        Icons.copy_all,
+                        Icons.format_quote,
                         size: 16,
                         color: theme.colorScheme.onSurfaceVariant,
                       ),
                     ),
+                    const SizedBox(width: 4),
+                    Text(
+                      '$count source${count == 1 ? '' : 's'}',
+                      style: theme.textTheme.labelSmall?.copyWith(
+                        color: theme.colorScheme.onSurfaceVariant,
+                      ),
+                    ),
+                    const SizedBox(width: 2),
+                    Icon(
+                      _sectionExpanded ? Icons.expand_less : Icons.expand_more,
+                      size: 16,
+                      color: theme.colorScheme.onSurfaceVariant,
+                    ),
+                  ],
+                ),
+              ),
+            ),
+            if (count > 0)
+              SizedBox(
+                width: 32,
+                height: 32,
+                child: Center(
+                  child: CopyButton(
+                    icon: Icons.copy_all,
+                    iconSize: 16,
+                    tooltip: 'Copy all',
+                    text: widget.sourceReferences
+                        .map(_formatForClipboard)
+                        .join('\n\n---\n\n'),
                   ),
                 ),
-              ],
-            ),
-          ),
+              ),
+          ],
         ),
         if (_sectionExpanded) ...[
           const SizedBox(height: 4),
@@ -101,23 +106,6 @@ class _CitationsSectionState extends State<CitationsSection> {
           }),
         ],
       ],
-    );
-  }
-
-  Future<void> _copyAllToClipboard(BuildContext context) async {
-    final messenger = ScaffoldMessenger.maybeOf(context);
-    final blocks = widget.sourceReferences
-        .map(_formatForClipboard)
-        .toList(growable: false);
-    await Clipboard.setData(ClipboardData(text: blocks.join('\n\n---\n\n')));
-    final count = widget.sourceReferences.length;
-    messenger?.showSnackBar(
-      SnackBar(
-        content: Text(
-          count == 1 ? 'Citation copied' : '$count citations copied',
-        ),
-        duration: const Duration(seconds: 2),
-      ),
     );
   }
 }

--- a/lib/src/modules/room/ui/citations_section.dart
+++ b/lib/src/modules/room/ui/citations_section.dart
@@ -77,9 +77,9 @@ class _CitationsSectionState extends State<CitationsSection> {
                     icon: Icons.copy_all,
                     iconSize: 16,
                     tooltip: 'Copy all',
-                    text: widget.sourceReferences
-                        .map(_formatForClipboard)
-                        .join('\n\n---\n\n'),
+                    text: formatAllCitationsForClipboard(
+                      widget.sourceReferences,
+                    ),
                   ),
                 ),
               ),
@@ -187,7 +187,7 @@ class _SourceReferenceRow extends StatelessWidget {
                 height: 32,
                 child: Center(
                   child: CopyButton(
-                    text: _formatForClipboard(sourceReference),
+                    text: formatCitationForClipboard(sourceReference),
                     tooltip: 'Copy citation $badgeNumber',
                     iconSize: 16,
                   ),
@@ -281,7 +281,8 @@ class _SourceReferenceRow extends StatelessWidget {
   }
 }
 
-String _formatForClipboard(SourceReference ref) {
+@visibleForTesting
+String formatCitationForClipboard(SourceReference ref) {
   final lines = <String>[ref.displayTitle];
   if (ref.headings.isNotEmpty) {
     lines.add(ref.headings.join(' > '));
@@ -300,3 +301,7 @@ String _formatForClipboard(SourceReference ref) {
   }
   return lines.join('\n');
 }
+
+@visibleForTesting
+String formatAllCitationsForClipboard(List<SourceReference> refs) =>
+    refs.map(formatCitationForClipboard).join('\n\n---\n\n');

--- a/lib/src/modules/room/ui/citations_section.dart
+++ b/lib/src/modules/room/ui/citations_section.dart
@@ -1,5 +1,4 @@
 import 'package:flutter/material.dart';
-import 'package:flutter/services.dart';
 import 'package:soliplex_agent/soliplex_agent.dart' hide State;
 import 'package:url_launcher/url_launcher.dart';
 
@@ -134,55 +133,79 @@ class _SourceReferenceRow extends StatelessWidget {
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
-          InkWell(
-            onTap: onToggle,
-            borderRadius: BorderRadius.circular(8),
-            child: Padding(
-              padding: const EdgeInsets.symmetric(vertical: 4),
-              child: Row(
-                children: [
-                  Container(
-                    width: 24,
-                    height: 24,
-                    decoration: BoxDecoration(
-                      color: theme.colorScheme.primaryContainer,
-                      borderRadius: BorderRadius.circular(6),
-                    ),
-                    alignment: Alignment.center,
-                    child: Text(
-                      '$badgeNumber',
-                      style: theme.textTheme.labelSmall?.copyWith(
-                        color: theme.colorScheme.onPrimaryContainer,
-                        fontWeight: FontWeight.bold,
-                      ),
+          Row(
+            children: [
+              Expanded(
+                child: InkWell(
+                  onTap: onToggle,
+                  borderRadius: BorderRadius.circular(8),
+                  child: Padding(
+                    padding: const EdgeInsets.symmetric(vertical: 4),
+                    child: Row(
+                      children: [
+                        Container(
+                          width: 24,
+                          height: 24,
+                          decoration: BoxDecoration(
+                            color: theme.colorScheme.primaryContainer,
+                            borderRadius: BorderRadius.circular(6),
+                          ),
+                          alignment: Alignment.center,
+                          child: Text(
+                            '$badgeNumber',
+                            style: theme.textTheme.labelSmall?.copyWith(
+                              color: theme.colorScheme.onPrimaryContainer,
+                              fontWeight: FontWeight.bold,
+                            ),
+                          ),
+                        ),
+                        const SizedBox(width: 8),
+                        Expanded(
+                          child: Text(
+                            sourceReference.displayTitle,
+                            style: theme.textTheme.bodySmall,
+                            maxLines: 1,
+                            overflow: TextOverflow.ellipsis,
+                          ),
+                        ),
+                        if (sourceReference.formattedPageNumbers != null) ...[
+                          const SizedBox(width: 4),
+                          Text(
+                            sourceReference.formattedPageNumbers!,
+                            style: theme.textTheme.labelSmall?.copyWith(
+                              color: theme.colorScheme.onSurfaceVariant,
+                            ),
+                          ),
+                        ],
+                      ],
                     ),
                   ),
-                  const SizedBox(width: 8),
-                  Expanded(
-                    child: Text(
-                      sourceReference.displayTitle,
-                      style: theme.textTheme.bodySmall,
-                      maxLines: 1,
-                      overflow: TextOverflow.ellipsis,
-                    ),
+                ),
+              ),
+              SizedBox(
+                width: 32,
+                height: 32,
+                child: Center(
+                  child: CopyButton(
+                    text: _formatForClipboard(sourceReference),
+                    tooltip: 'Copy citation $badgeNumber',
+                    iconSize: 16,
                   ),
-                  if (sourceReference.formattedPageNumbers != null) ...[
-                    const SizedBox(width: 4),
-                    Text(
-                      sourceReference.formattedPageNumbers!,
-                      style: theme.textTheme.labelSmall?.copyWith(
-                        color: theme.colorScheme.onSurfaceVariant,
-                      ),
-                    ),
-                  ],
-                  Icon(
+                ),
+              ),
+              InkWell(
+                onTap: onToggle,
+                borderRadius: BorderRadius.circular(8),
+                child: Padding(
+                  padding: const EdgeInsets.all(8),
+                  child: Icon(
                     isExpanded ? Icons.expand_less : Icons.expand_more,
                     size: 16,
                     color: theme.colorScheme.onSurfaceVariant,
                   ),
-                ],
+                ),
               ),
-            ),
+            ],
           ),
           if (isExpanded) _buildExpandedContent(context, theme),
         ],
@@ -238,50 +261,21 @@ class _SourceReferenceRow extends StatelessWidget {
                 overflow: TextOverflow.ellipsis,
               ),
             ),
-          Padding(
-            padding: const EdgeInsets.only(top: 4),
-            child: Wrap(
-              spacing: 8,
-              runSpacing: 4,
-              children: [
-                TextButton.icon(
-                  onPressed: () => _copyToClipboard(context),
-                  icon: const Icon(Icons.copy, size: 16),
-                  label: const Text('Copy'),
-                  style: TextButton.styleFrom(
-                    padding: const EdgeInsets.symmetric(horizontal: 8),
-                    minimumSize: Size.zero,
-                    tapTargetSize: MaterialTapTargetSize.shrinkWrap,
-                  ),
+          if (sourceReference.isPdf && onShowChunkVisualization != null)
+            Padding(
+              padding: const EdgeInsets.only(top: 4),
+              child: TextButton.icon(
+                onPressed: () => onShowChunkVisualization!(sourceReference),
+                icon: const Icon(Icons.picture_as_pdf, size: 16),
+                label: const Text('View in PDF'),
+                style: TextButton.styleFrom(
+                  padding: const EdgeInsets.symmetric(horizontal: 8),
+                  minimumSize: Size.zero,
+                  tapTargetSize: MaterialTapTargetSize.shrinkWrap,
                 ),
-                if (sourceReference.isPdf && onShowChunkVisualization != null)
-                  TextButton.icon(
-                    onPressed: () => onShowChunkVisualization!(sourceReference),
-                    icon: const Icon(Icons.picture_as_pdf, size: 16),
-                    label: const Text('View in PDF'),
-                    style: TextButton.styleFrom(
-                      padding: const EdgeInsets.symmetric(horizontal: 8),
-                      minimumSize: Size.zero,
-                      tapTargetSize: MaterialTapTargetSize.shrinkWrap,
-                    ),
-                  ),
-              ],
+              ),
             ),
-          ),
         ],
-      ),
-    );
-  }
-
-  Future<void> _copyToClipboard(BuildContext context) async {
-    final messenger = ScaffoldMessenger.maybeOf(context);
-    await Clipboard.setData(
-      ClipboardData(text: _formatForClipboard(sourceReference)),
-    );
-    messenger?.showSnackBar(
-      const SnackBar(
-        content: Text('Citation copied'),
-        duration: Duration(seconds: 2),
       ),
     );
   }

--- a/lib/src/shared/copy_button.dart
+++ b/lib/src/shared/copy_button.dart
@@ -9,11 +9,13 @@ class CopyButton extends StatefulWidget {
     required this.text,
     this.tooltip = 'Copy',
     this.iconSize = 20,
+    this.icon = Icons.copy,
   });
 
   final String text;
   final String tooltip;
   final double iconSize;
+  final IconData icon;
 
   @override
   State<CopyButton> createState() => _CopyButtonState();
@@ -59,7 +61,7 @@ class _CopyButtonState extends State<CopyButton> {
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
     final (icon, color) = switch (_feedback) {
-      _CopyFeedback.idle => (Icons.copy, theme.colorScheme.onSurfaceVariant),
+      _CopyFeedback.idle => (widget.icon, theme.colorScheme.onSurfaceVariant),
       _CopyFeedback.success => (
           Icons.check,
           theme.colorScheme.onSurfaceVariant

--- a/test/modules/room/ui/citations_section_test.dart
+++ b/test/modules/room/ui/citations_section_test.dart
@@ -1,5 +1,4 @@
 import 'package:flutter/material.dart';
-import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:soliplex_agent/soliplex_agent.dart' hide State;
 
@@ -162,92 +161,65 @@ void main() {
     expect(tappedRef?.documentId, 'doc-2');
   });
 
-  testWidgets('copy button writes citation details to the clipboard',
-      (tester) async {
-    String? copied;
-    tester.binding.defaultBinaryMessenger.setMockMethodCallHandler(
-      SystemChannels.platform,
-      (call) async {
-        if (call.method == 'Clipboard.setData') {
-          copied = (call.arguments as Map)['text'] as String;
-        }
-        return null;
-      },
-    );
-    addTearDown(() {
-      tester.binding.defaultBinaryMessenger.setMockMethodCallHandler(
-        SystemChannels.platform,
-        null,
+  group('formatCitationForClipboard', () {
+    test('emits title, headings, pages, uri, and content in order', () {
+      final ref = _ref(
+        index: 1,
+        title: 'Doc',
+        headings: ['Chapter 1', 'Section 2'],
+        pageNumbers: [5, 6],
+        content: 'Preview text here',
+      );
+
+      expect(
+        formatCitationForClipboard(ref),
+        'Doc\n'
+        'Chapter 1 > Section 2\n'
+        'p.5-6\n'
+        'file://doc-1.txt\n'
+        '\n'
+        'Preview text here',
       );
     });
 
-    await tester.pumpWidget(_wrap(
-      CitationsSection(
-        sourceReferences: [
-          _ref(
-            index: 1,
-            title: 'Doc',
-            headings: ['Chapter 1', 'Section 2'],
-            content: 'Preview text here',
-            pageNumbers: [5, 6],
-          ),
-        ],
-      ),
-    ));
+    test('omits headings, pages, uri, and content when absent', () {
+      final ref = SourceReference(
+        documentId: 'doc-1',
+        documentUri: '',
+        content: '',
+        chunkId: 'chunk-1',
+        documentTitle: 'Doc',
+        headings: const [],
+        pageNumbers: const [],
+        index: 1,
+      );
 
-    await tester.tap(find.text('1 source'));
-    await tester.pump();
-    await tester.tap(find.text('Doc'));
-    await tester.pump();
-
-    await tester.tap(find.widgetWithText(TextButton, 'Copy'));
-    await tester.pump();
-
-    expect(copied, isNotNull);
-    expect(copied, contains('Doc'));
-    expect(copied, contains('Chapter 1 > Section 2'));
-    expect(copied, contains('p.5-6'));
-    expect(copied, contains('file://doc-1.txt'));
-    expect(copied, contains('Preview text here'));
-    expect(find.text('Citation copied'), findsOneWidget);
+      expect(formatCitationForClipboard(ref), 'Doc');
+    });
   });
 
-  testWidgets('copy-all button copies every citation', (tester) async {
-    String? copied;
-    tester.binding.defaultBinaryMessenger.setMockMethodCallHandler(
-      SystemChannels.platform,
-      (call) async {
-        if (call.method == 'Clipboard.setData') {
-          copied = (call.arguments as Map)['text'] as String;
-        }
-        return null;
-      },
-    );
-    addTearDown(() {
-      tester.binding.defaultBinaryMessenger.setMockMethodCallHandler(
-        SystemChannels.platform,
-        null,
+  group('formatAllCitationsForClipboard', () {
+    test('formats a single ref without trailing separator', () {
+      expect(
+        formatAllCitationsForClipboard([
+          _ref(index: 1, title: 'Alpha', content: 'first'),
+        ]),
+        formatCitationForClipboard(
+          _ref(index: 1, title: 'Alpha', content: 'first'),
+        ),
       );
     });
 
-    await tester.pumpWidget(_wrap(
-      CitationsSection(
-        sourceReferences: [
-          _ref(index: 1, title: 'Alpha', content: 'first'),
-          _ref(index: 2, title: 'Beta', content: 'second'),
-        ],
-      ),
-    ));
+    test('joins multiple refs with a blank-line/rule/blank-line separator', () {
+      final alpha = _ref(index: 1, title: 'Alpha', content: 'first');
+      final beta = _ref(index: 2, title: 'Beta', content: 'second');
 
-    await tester.tap(find.byTooltip('Copy all'));
-    await tester.pump();
-
-    expect(copied, isNotNull);
-    expect(copied, contains('Alpha'));
-    expect(copied, contains('first'));
-    expect(copied, contains('Beta'));
-    expect(copied, contains('second'));
-    expect(copied, contains('---'));
-    expect(find.text('2 citations copied'), findsOneWidget);
+      expect(
+        formatAllCitationsForClipboard([alpha, beta]),
+        '${formatCitationForClipboard(alpha)}'
+        '\n\n---\n\n'
+        '${formatCitationForClipboard(beta)}',
+      );
+    });
   });
 }


### PR DESCRIPTION
## Summary

Follow-up to #218 addressing the post-merge code review. Routes the citation copy actions through the shared `CopyButton` so failures surface instead of being silently dropped, restructures both the header and per-row layouts to remove a nested-`InkWell` hit-test bug, and enforces a 32×32 tap target on every copy/chevron action.

- **Reuse the shared CopyButton** for both header and per-row copy, replacing two ad-hoc `Clipboard.setData` + `SnackBar` paths. Errors now surface as `Icons.error_outline` instead of being swallowed; per-citation `Semantics` labels disambiguate screen-reader announcements.
- **Hoist per-row copy out of the expanded body** into the title line alongside the chevron, so users can copy a citation without expanding it first.
- **Restructure header and per-row layouts** into sibling tap regions. The previous outer `InkWell` wrapping the whole row caused taps in the padding around an inner copy `InkWell` to fall through to the section toggle.
- **Pin the clipboard contract** with direct unit tests over `formatCitationForClipboard` and `formatAllCitationsForClipboard`. Drops the previous copy-flow widget tests, which were retesting `CopyButton`'s tap/clipboard plumbing already covered in `copy_button_test.dart`.

## Test plan

- [x] `mcp__dart__analyze_files` — clean
- [x] `mcp__dart__run_tests test/modules/room/ui/citations_section_test.dart` — 12/12 passing
- [x] Visual: header copy-all swaps icon on click; with zero refs (unreachable in prod) the icon is hidden
- [x] Visual: per-row copy is visible on the title line without expanding; tapping it does not toggle the row
- [x] Visual: chevron padding hit area toggles expansion; copy padding does not

🤖 Generated with [Claude Code](https://claude.com/claude-code)