### PR TITLE
fix(room): address workdir image preview review feedback

### DIFF
--- a/lib/src/modules/room/ui/workdir_files_section.dart
+++ b/lib/src/modules/room/ui/workdir_files_section.dart
@@ -243,6 +243,7 @@ class _WorkdirFileRowState extends State<_WorkdirFileRow> {
       context: context,
       filename: widget.file.filename,
       fetchBytes: fetch,
+      cannotPreview: _CannotPreview(onDownload: widget.onTap),
     );
   }
 }
@@ -340,22 +341,32 @@ class WorkdirImagePreviewPage extends StatefulWidget {
     super.key,
     required this.filename,
     required this.fetchBytes,
+    required this.cannotPreview,
     required this.useDialogLayout,
   });
 
   final String filename;
   final Future<Uint8List> Function() fetchBytes;
+
+  /// Rendered when the fetched bytes aren't a decodable image — empty
+  /// body, HTML error page, truncated download, etc. The caller owns the
+  /// affordance (typically a download button); this page just renders it
+  /// as a peer of the viewer.
+  final Widget cannotPreview;
+
   final bool useDialogLayout;
 
   static Future<void> show({
     required BuildContext context,
     required String filename,
     required Future<Uint8List> Function() fetchBytes,
+    required Widget cannotPreview,
   }) {
     final useDialog = MediaQuery.sizeOf(context).width >= 600;
     final child = WorkdirImagePreviewPage(
       filename: filename,
       fetchBytes: fetchBytes,
+      cannotPreview: cannotPreview,
       useDialogLayout: useDialog,
     );
     if (useDialog) {
@@ -402,18 +413,11 @@ class _WorkdirImagePreviewPageState extends State<WorkdirImagePreviewPage> {
         }
         final bytes = snapshot.data;
         if (bytes == null || bytes.isEmpty) {
-          return _buildError(context, 'Empty file');
+          return widget.cannotPreview;
         }
-        return Center(
-          child: InteractiveViewer(
-            minScale: 1.0,
-            maxScale: 4.0,
-            child: Image.memory(
-              bytes,
-              fit: BoxFit.contain,
-              errorBuilder: (context, error, _) => _buildError(context, error),
-            ),
-          ),
+        return _ImageOrFallback(
+          bytes: bytes,
+          fallback: widget.cannotPreview,
         );
       },
     );
@@ -504,6 +508,144 @@ class _WorkdirImagePreviewPageState extends State<WorkdirImagePreviewPage> {
         titleTextStyle: Theme.of(context).textTheme.titleMedium,
       ),
       body: _buildContent(context),
+    );
+  }
+}
+
+/// Renders [bytes] in an [InteractiveViewer]. If [Image.memory]'s
+/// decoder rejects the bytes, swaps in [fallback] as a peer of (not a
+/// descendant of) the viewer so its controls aren't pannable/zoomable.
+///
+/// Decode-failure state is owned here, not on the parent, so that a
+/// fresh widget instance (different bytes) starts clean.
+class _ImageOrFallback extends StatefulWidget {
+  const _ImageOrFallback({required this.bytes, required this.fallback});
+
+  final Uint8List bytes;
+  final Widget fallback;
+
+  @override
+  State<_ImageOrFallback> createState() => _ImageOrFallbackState();
+}
+
+class _ImageOrFallbackState extends State<_ImageOrFallback> {
+  bool _failed = false;
+
+  @override
+  void didUpdateWidget(_ImageOrFallback old) {
+    super.didUpdateWidget(old);
+    if (!identical(old.bytes, widget.bytes)) {
+      _failed = false;
+    }
+  }
+
+  void _markFailed() {
+    if (_failed) return;
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (mounted) setState(() => _failed = true);
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    if (_failed) return widget.fallback;
+    return Center(
+      child: InteractiveViewer(
+        minScale: 1.0,
+        maxScale: 4.0,
+        child: Image.memory(
+          widget.bytes,
+          fit: BoxFit.contain,
+          errorBuilder: (_, __, ___) {
+            _markFailed();
+            return const SizedBox.shrink();
+          },
+        ),
+      ),
+    );
+  }
+}
+
+/// Rendered when the bytes can't be displayed as an image — empty
+/// payload or post-fetch decode failure. Sits as a peer of
+/// [InteractiveViewer], not a descendant, so its Download button is not
+/// pannable/zoomable. Mirrors the file-row download feedback pattern
+/// (icon swap, no SnackBar).
+class _CannotPreview extends StatefulWidget {
+  const _CannotPreview({required this.onDownload});
+
+  final Future<DownloadOutcome> Function() onDownload;
+
+  @override
+  State<_CannotPreview> createState() => _CannotPreviewState();
+}
+
+class _CannotPreviewState extends State<_CannotPreview> {
+  _DownloadFeedback _feedback = _DownloadFeedback.idle;
+  bool _inFlight = false;
+  Timer? _revertTimer;
+
+  @override
+  void dispose() {
+    _revertTimer?.cancel();
+    super.dispose();
+  }
+
+  Future<void> _handleDownload() async {
+    if (_inFlight) return;
+    _inFlight = true;
+    DownloadOutcome outcome;
+    try {
+      outcome = await widget.onDownload();
+    } catch (_) {
+      outcome = DownloadOutcome.failed;
+    } finally {
+      _inFlight = false;
+    }
+    if (!mounted) return;
+    if (outcome == DownloadOutcome.cancelled) return;
+    setState(() {
+      _feedback = outcome == DownloadOutcome.success
+          ? _DownloadFeedback.success
+          : _DownloadFeedback.error;
+    });
+    _revertTimer?.cancel();
+    _revertTimer = Timer(const Duration(seconds: 2), () {
+      if (mounted) setState(() => _feedback = _DownloadFeedback.idle);
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final (icon, label) = switch (_feedback) {
+      _DownloadFeedback.idle => (Icons.download_outlined, 'Download'),
+      _DownloadFeedback.success => (Icons.check, 'Saved'),
+      _DownloadFeedback.error => (Icons.error_outline, "Couldn't save"),
+    };
+    return Center(
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Icon(
+            Icons.image_not_supported_outlined,
+            size: 48,
+            color: theme.colorScheme.onSurfaceVariant,
+          ),
+          const SizedBox(height: 12),
+          Text(
+            "Can't preview this file",
+            style: theme.textTheme.bodyMedium,
+          ),
+          const SizedBox(height: 16),
+          FilledButton.icon(
+            onPressed:
+                _feedback == _DownloadFeedback.idle ? _handleDownload : null,
+            icon: Icon(icon),
+            label: Text(label),
+          ),
+        ],
+      ),
     );
   }
 }

--- a/lib/src/modules/room/ui/workdir_files_section.dart
+++ b/lib/src/modules/room/ui/workdir_files_section.dart
@@ -425,6 +425,29 @@ class _WorkdirImagePreviewPageState extends State<WorkdirImagePreviewPage> {
 
   Widget _buildError(BuildContext context, Object error) {
     final theme = Theme.of(context);
+    // 404 is permanent for this session — the file is gone between list
+    // and preview. Retrying just refetches the same 404, so we show a
+    // dedicated "gone" state without a Retry button. The dialog's
+    // titlebar X is the way out.
+    if (error is NotFoundException) {
+      return Center(
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Icon(
+              Icons.info_outline,
+              size: 48,
+              color: theme.colorScheme.onSurfaceVariant,
+            ),
+            const SizedBox(height: 12),
+            Text(
+              'File no longer exists',
+              style: theme.textTheme.bodyMedium,
+            ),
+          ],
+        ),
+      );
+    }
     return Center(
       child: Column(
         mainAxisSize: MainAxisSize.min,
@@ -432,16 +455,8 @@ class _WorkdirImagePreviewPageState extends State<WorkdirImagePreviewPage> {
           Icon(Icons.error_outline, size: 48, color: theme.colorScheme.error),
           const SizedBox(height: 12),
           Text(
-            'Failed to load preview',
+            "Couldn't load preview",
             style: theme.textTheme.bodyMedium,
-          ),
-          const SizedBox(height: 4),
-          Text(
-            error.toString(),
-            style: theme.textTheme.bodySmall?.copyWith(
-              color: theme.colorScheme.onSurfaceVariant,
-            ),
-            textAlign: TextAlign.center,
           ),
           const SizedBox(height: 16),
           FilledButton.icon(

--- a/lib/src/modules/room/workdir_controller.dart
+++ b/lib/src/modules/room/workdir_controller.dart
@@ -129,12 +129,43 @@ class WorkdirController {
 
   /// Fetches the raw bytes for [file] without writing them to disk. Used
   /// by the in-app preview path; the save dialog is the download path.
+  ///
+  /// [NotFoundException] is logged at debug and rethrown so the preview
+  /// FutureBuilder can render its own error state — we deliberately do
+  /// not collapse 404 to empty bytes the way [fetchFiles] does, because
+  /// "the file is gone" should not look like a successful empty preview.
   Future<Uint8List> fetchBytes(
     String threadId,
     String runId,
     WorkdirFile file,
-  ) {
-    return _api.getRunWorkdirFile(_roomId, threadId, runId, file.filename);
+  ) async {
+    _logger.debug(
+      'workdir preview fetch start runId=$runId name=${file.filename}',
+    );
+    try {
+      final bytes = await _api.getRunWorkdirFile(
+        _roomId,
+        threadId,
+        runId,
+        file.filename,
+      );
+      _logger.debug(
+        'workdir preview fetch ok runId=$runId bytes=${bytes.length}',
+      );
+      return bytes;
+    } on NotFoundException {
+      _logger.debug(
+        'workdir preview fetch 404 runId=$runId name=${file.filename}',
+      );
+      rethrow;
+    } catch (e, st) {
+      _logger.warning(
+        'workdir preview fetch failed runId=$runId name=${file.filename}',
+        error: e,
+        stackTrace: st,
+      );
+      rethrow;
+    }
   }
 
   /// Drops every cached fetch result. Call when the user switches away

--- a/test/modules/room/ui/workdir_files_section_test.dart
+++ b/test/modules/room/ui/workdir_files_section_test.dart
@@ -391,6 +391,28 @@ void main() {
   });
 
   testWidgets(
+      'empty bytes short-circuit to Download (not Retry), no InteractiveViewer',
+      (tester) async {
+    await tester.pumpWidget(_wrap(WorkdirFilesSection(
+      runId: 'run-1',
+      fetchFiles: (_) async => [_file('plot.png')],
+      onDownload: (_, __) async => DownloadOutcome.success,
+      onPreview: (_, __) async => Uint8List(0),
+    )));
+    await tester.pump();
+
+    await tester.tap(find.byIcon(Icons.visibility_outlined));
+    await tester.pumpAndSettle();
+
+    // bytes.isEmpty short-circuits around _ImageOrFallback entirely —
+    // no decode attempt, no Retry-forever even on a non-errorBuilder
+    // path.
+    expect(find.byType(InteractiveViewer), findsNothing);
+    expect(find.text('Retry'), findsNothing);
+    expect(find.text('Download'), findsOneWidget);
+  });
+
+  testWidgets(
       'non-image bytes show Download (not Retry) as a peer of InteractiveViewer',
       (tester) async {
     await tester.pumpWidget(_wrap(WorkdirFilesSection(

--- a/test/modules/room/ui/workdir_files_section_test.dart
+++ b/test/modules/room/ui/workdir_files_section_test.dart
@@ -78,12 +78,20 @@ final Uint8List _tinyPng = Uint8List.fromList(const [
   0x82,
 ]);
 
+final Uint8List _htmlBytes =
+    Uint8List.fromList('<html><body>not an image</body></html>'.codeUnits);
+
 WorkdirFile _file(String name) =>
     WorkdirFile(filename: name, url: Uri.parse('https://example.test/$name'));
 
 Widget _wrap(Widget child) => MaterialApp(home: Scaffold(body: child));
 
 void main() {
+  // Image previews share Flutter's global imageCache; a partially-decoded
+  // entry from one test will resurface as a "Codec failed" error in the
+  // next, masking real failures.
+  setUp(() => PaintingBinding.instance.imageCache.clear());
+
   testWidgets('renders each filename when fetch returns a non-empty list',
       (tester) async {
     await tester.pumpWidget(_wrap(WorkdirFilesSection(
@@ -368,6 +376,37 @@ void main() {
 
     expect(fetchCalls, 2);
     expect(find.byType(Image), findsOneWidget);
+  });
+
+  testWidgets('.PNG (uppercase) is treated as previewable', (tester) async {
+    await tester.pumpWidget(_wrap(WorkdirFilesSection(
+      runId: 'run-1',
+      fetchFiles: (_) async => [_file('PLOT.PNG')],
+      onDownload: (_, __) async => DownloadOutcome.success,
+      onPreview: (_, __) async => _tinyPng,
+    )));
+    await tester.pump();
+
+    expect(find.byIcon(Icons.visibility_outlined), findsOneWidget);
+  });
+
+  testWidgets(
+      'non-image bytes show Download (not Retry) as a peer of InteractiveViewer',
+      (tester) async {
+    await tester.pumpWidget(_wrap(WorkdirFilesSection(
+      runId: 'run-1',
+      fetchFiles: (_) async => [_file('plot.png')],
+      onDownload: (_, __) async => DownloadOutcome.success,
+      onPreview: (_, __) async => _htmlBytes,
+    )));
+    await tester.pump();
+
+    await tester.tap(find.byIcon(Icons.visibility_outlined));
+    await tester.pumpAndSettle();
+
+    expect(find.byType(InteractiveViewer), findsNothing);
+    expect(find.text('Retry'), findsNothing);
+    expect(find.text('Download'), findsOneWidget);
   });
 
   testWidgets('second tap during feedback window is a no-op', (tester) async {

--- a/test/modules/room/ui/workdir_files_section_test.dart
+++ b/test/modules/room/ui/workdir_files_section_test.dart
@@ -351,7 +351,8 @@ void main() {
     expect(find.byType(Dialog), findsNothing);
   });
 
-  testWidgets('preview shows error + Retry when fetch fails', (tester) async {
+  testWidgets('preview shows generic error + Retry when fetch fails',
+      (tester) async {
     var fetchCalls = 0;
     await tester.pumpWidget(_wrap(WorkdirFilesSection(
       runId: 'run-1',
@@ -359,7 +360,7 @@ void main() {
       onDownload: (_, __) async => DownloadOutcome.success,
       onPreview: (_, __) async {
         fetchCalls++;
-        if (fetchCalls == 1) throw Exception('boom');
+        if (fetchCalls == 1) throw Exception('boom-internal-leak-do-not-show');
         return _tinyPng;
       },
     )));
@@ -368,14 +369,37 @@ void main() {
     await tester.tap(find.byIcon(Icons.visibility_outlined));
     await tester.pumpAndSettle();
 
-    expect(find.text('Failed to load preview'), findsOneWidget);
+    expect(find.text("Couldn't load preview"), findsOneWidget);
     expect(find.text('Retry'), findsOneWidget);
+    // Raw exception text must not leak to the UI.
+    expect(find.textContaining('boom-internal-leak-do-not-show'), findsNothing);
 
     await tester.tap(find.text('Retry'));
     await tester.pumpAndSettle();
 
     expect(fetchCalls, 2);
     expect(find.byType(Image), findsOneWidget);
+  });
+
+  testWidgets('preview shows "no longer exists" without Retry on 404',
+      (tester) async {
+    await tester.pumpWidget(_wrap(WorkdirFilesSection(
+      runId: 'run-1',
+      fetchFiles: (_) async => [_file('plot.png')],
+      onDownload: (_, __) async => DownloadOutcome.success,
+      onPreview: (_, __) async => throw const NotFoundException(
+        message: 'gone',
+        resource: '/x',
+      ),
+    )));
+    await tester.pump();
+
+    await tester.tap(find.byIcon(Icons.visibility_outlined));
+    await tester.pumpAndSettle();
+
+    expect(find.text('File no longer exists'), findsOneWidget);
+    // Retry on a permanent 404 just refetches the same 404 — no Retry.
+    expect(find.text('Retry'), findsNothing);
   });
 
   testWidgets('.PNG (uppercase) is treated as previewable', (tester) async {

--- a/test/modules/room/workdir_controller_test.dart
+++ b/test/modules/room/workdir_controller_test.dart
@@ -219,5 +219,18 @@ void main() {
       verify(() => api.getRunWorkdirFile('room-1', 't-1', 'r-1', 'preview.png'))
           .called(1);
     });
+
+    test('rethrows NotFoundException — does NOT swallow like fetchFiles does',
+        () async {
+      when(() => api.getRunWorkdirFile(any(), any(), any(), any())).thenThrow(
+        const NotFoundException(message: 'gone', resource: '/x'),
+      );
+      final controller = build();
+
+      await expectLater(
+        controller.fetchBytes('t', 'r', _file('missing.png')),
+        throwsA(isA<NotFoundException>()),
+      );
+    });
   });
 }


### PR DESCRIPTION
## Summary

Post-merge review follow-up for the workdir image preview feature (`feat/workdir/preview-artifact`). Addresses the three critical/important review items plus the test gaps called out as hygiene.

- `fetchBytes` now mirrors `download`'s try/catch shape (start/ok/failure logs with `runId`+`filename`, `NotFoundException` logged at debug). Always rethrows — deliberately does **not** collapse 404 to empty the way `fetchFiles` does, since "the file is gone" should not look like a successful empty preview.
- Preview dialog stops showing error UI inside `InteractiveViewer`. A new `_ImageOrFallback` wrapper owns the decode-failed state; when `Image.memory.errorBuilder` fires (non-image body, truncated download, mislabeled file), it swaps in a caller-provided fallback widget as a **peer** of the viewer, not a descendant. Retry-forever loop is gone — the fallback uses a Download button, not Retry.
- `WorkdirImagePreviewPage` takes a `cannotPreview` widget instead of a separate `onDownload` callback. The page no longer needs to know how the row downloads files; it just renders the fallback the caller assembled. Removes a knowledge-leakage smell flagged during refactor review.
- Three new tests pin the decisions: case-insensitive `.PNG` extension, empty-bytes routing (separate code path from `errorBuilder`), and non-image-bytes triggering the `errorBuilder` → fallback transition. One regression test for `fetchBytes`'s 404 contract.
- Latent test-suite bug fixed: `PaintingBinding.instance.imageCache` is now cleared in `setUp`. Partially-decoded entries from one test were resurfacing as "Codec failed" errors in the next; pre-change code was lucky that `pumpAndSettle` stopped before the error stream fired.

### Deviation from the review

The review proposed a magic-byte sniff (PNG/JPEG/GIF/WebP signatures) to gate `Image.memory`. I started there but dropped it on review pushback — the upfront-decode alternative (`ui.instantiateImageCodec`) doesn't resolve under fake-async, and the sniff added a state machine that hid a real test-suite bug. The simpler design — react to `errorBuilder` and lift the result out of the viewer — achieves the same UX goal (no retry-forever, clear download affordance) with less code and surfaces the cache-pollution bug instead of masking it.

## Test plan

- [x] `flutter test` — 1245/1245 passing.
- [x] `flutter analyze` — 0 issues.
- [x] `dart format` — clean.
- [x] Sanity-checked each new test by injecting the regression it's meant to catch (e.g., reverted `fetchBytes` to swallow 404 → 404 test goes red; restored "Empty file + Retry" → empty-bytes test goes red).
- [x] Manual: open a preview for a known-good `.png` from a recent run.
- [x] Manual: open a preview for a `.png` whose backend body is actually HTML (mock or break a route) — verify "Can't preview" branch with working Download.

🤖 Generated with [Claude Code](https://claude.com/claude-code)