### PR TITLE
fix(room): two bugs in the AG-UI events bubble (ACTIVITY_DELTA + reload)

### DIFF
--- a/lib/src/modules/room/execution_tracker.dart
+++ b/lib/src/modules/room/execution_tracker.dart
@@ -65,6 +65,14 @@ class ExecutionTracker {
   ReadonlySignal<List<SkillToolCallActivity>> get skillToolCalls =>
       _skillToolCalls;
 
+  /// Last raw [ActivityRecord] seen for each `messageId`. [ActivityDelta]
+  /// applies a jsonpatch to the cached content here, re-decodes, and
+  /// upserts the result back into [_skillToolCalls] and the timeline.
+  /// The decoded `SkillToolCallActivity` can't be patched directly
+  /// because its constructor lossily transforms `args` from JSON string
+  /// to a map.
+  final Map<String, ActivityRecord> _activityRecords = {};
+
   /// Timeline of steps with their nested activities, in arrival order.
   /// Activities that arrive while a step is active are nested under that
   /// step; activities arriving outside any active step are emitted as
@@ -175,6 +183,18 @@ class ExecutionTracker {
           timestamp: timestamp,
           replace: replace,
         );
+      case ActivityDelta(
+          :final messageId,
+          :final activityType,
+          :final patch,
+          :final timestamp,
+        ):
+        _applyActivityDelta(
+          messageId: messageId,
+          activityType: activityType,
+          patch: patch,
+          timestamp: timestamp,
+        );
       case TextDelta() ||
             StateUpdated() ||
             StepProgress() ||
@@ -217,10 +237,65 @@ class ExecutionTracker {
       return;
     }
 
+    _activityRecords[messageId] = record;
     if (existingIndex >= 0) {
       _skillToolCalls.value = [...current]..[existingIndex] = decoded;
     } else {
       _skillToolCalls.value = [...current, decoded];
+    }
+    _upsertActivityInTimeline(decoded);
+  }
+
+  void _applyActivityDelta({
+    required String messageId,
+    required String activityType,
+    required List<dynamic> patch,
+    required int? timestamp,
+  }) {
+    final existing = _activityRecords[messageId];
+    if (existing == null) {
+      // AG-UI spec: ACTIVITY_DELTA must follow a prior ACTIVITY_SNAPSHOT
+      // for the same messageId. An out-of-order delta has nothing to
+      // patch; log and drop so a backend ordering bug is observable
+      // instead of silently losing state.
+      _logger.warning(
+        'ActivityDelta with no prior snapshot; patch dropped',
+        attributes: {
+          'messageId': messageId,
+          'activityType': activityType,
+          'patchOps': patch.length,
+        },
+      );
+      return;
+    }
+
+    final patched = applyJsonPatch(existing.content, patch);
+    final updated = ActivityRecord(
+      messageId: messageId,
+      activityType: activityType,
+      content: patched,
+      timestamp: timestamp ?? existing.timestamp,
+    );
+    final decoded = SkillToolCallActivity.fromRecord(updated);
+    if (decoded == null) {
+      _logger.warning(
+        'ActivityDelta produced an undecodable record; patch dropped',
+        attributes: {
+          'messageId': messageId,
+          'activityType': activityType,
+          'contentKeys': patched.keys.toList().toString(),
+        },
+      );
+      return;
+    }
+
+    _activityRecords[messageId] = updated;
+    final calls = _skillToolCalls.value;
+    final idx = calls.indexWhere((a) => a.messageId == messageId);
+    if (idx >= 0) {
+      _skillToolCalls.value = [...calls]..[idx] = decoded;
+    } else {
+      _skillToolCalls.value = [...calls, decoded];
     }
     _upsertActivityInTimeline(decoded);
   }

--- a/lib/src/modules/room/historical_replay.dart
+++ b/lib/src/modules/room/historical_replay.dart
@@ -29,6 +29,12 @@ final Logger _logger =
 ///   [noResponseMessageId] for the run so the synthesized no-response
 ///   tile has a tracker to attach to.
 ///
+/// When the run sequence ends with hoisted `pending` events (the last
+/// bundle was tool-yield with no follow-up), the events bucket under
+/// `noResponseMessageId(lastToolYieldRunId)` so they attach to the
+/// no-response tile the chat-message side synthesizes for the same
+/// run — the live bubble survives a reload.
+///
 /// A throw from [bridge] is logged at error and the offending event
 /// skipped so surrounding events in the same bundle still bucket
 /// correctly. The drop is deliberately UI-silent: chat-message
@@ -41,8 +47,11 @@ Map<String, ExecutionTracker> replayToTrackers(
 }) {
   final buckets = <String, List<ExecutionEvent>>{};
   // Hoisted across bundles: tool-yield events accumulate here until the
-  // next normal bundle's first assistant message absorbs them.
+  // next normal bundle's first assistant message absorbs them. If no
+  // such bundle exists, the trailing handler below routes them under
+  // `noResponseMessageId(lastToolYieldRunId)`.
   final pending = <ExecutionEvent>[];
+  String? lastToolYieldRunId;
 
   ExecutionEvent? bridgeOrLog(BaseEvent raw) {
     try {
@@ -74,6 +83,7 @@ Map<String, ExecutionTracker> replayToTrackers(
           if (pending.isNotEmpty) {
             bucket.addAll(pending);
             pending.clear();
+            lastToolYieldRunId = null;
           }
         }
 
@@ -87,6 +97,7 @@ Map<String, ExecutionTracker> replayToTrackers(
         }
       }
     } else if (hasToolCall) {
+      lastToolYieldRunId = bundle.runId;
       for (final raw in bundle.events) {
         final execEvent = bridgeOrLog(raw);
         if (execEvent == null) continue;
@@ -98,6 +109,7 @@ Map<String, ExecutionTracker> replayToTrackers(
       if (pending.isNotEmpty) {
         bucket.addAll(pending);
         pending.clear();
+        lastToolYieldRunId = null;
       }
       for (final raw in bundle.events) {
         final execEvent = bridgeOrLog(raw);
@@ -107,13 +119,17 @@ Map<String, ExecutionTracker> replayToTrackers(
     }
   }
 
-  // A trailing tool-yield bundle's hoisted events have no follow-up
-  // assistant message to absorb them; the warning makes the drop
-  // observable instead of silent.
-  if (pending.isNotEmpty) {
+  // Trailing tool-yield: the chat-message side synthesizes a no-response
+  // tile under `noResponseMessageId(runId)` for the same run, so route
+  // the hoisted events there. Without this, the bubble disappears on
+  // reload even though it was visible while the run was live.
+  if (pending.isNotEmpty && lastToolYieldRunId != null) {
+    final synthesizedId = noResponseMessageId(lastToolYieldRunId);
+    buckets.putIfAbsent(synthesizedId, () => []).addAll(pending);
+    pending.clear();
+  } else if (pending.isNotEmpty) {
     _logger.warning(
-      'Dropping unattached events from a trailing tool-yield bundle '
-      '(no follow-up bundle).',
+      'Dropping unattached events with no tool-yield runId to anchor to.',
       attributes: {'pendingCount': pending.length},
     );
   }

--- a/packages/soliplex_agent/lib/src/orchestration/execution_event.dart
+++ b/packages/soliplex_agent/lib/src/orchestration/execution_event.dart
@@ -304,6 +304,54 @@ class ActivitySnapshot extends ExecutionEvent {
       );
 }
 
+/// A jsonpatch update for a sub-agent activity record.
+///
+/// Bridged from AG-UI `ACTIVITY_DELTA`. The [patch] is an RFC 6902
+/// operation list (e.g. `[{'op': 'replace', 'path': '/status', 'value':
+/// 'done'}]`). Trackers apply the patch to the [ActivitySnapshot]
+/// previously received under the same [messageId]; without a matching
+/// snapshot the delta is a no-op (a logged drop).
+class ActivityDelta extends ExecutionEvent {
+  const ActivityDelta({
+    required this.messageId,
+    required this.activityType,
+    required this.patch,
+    this.timestamp,
+  });
+
+  /// Identifier for the target `ActivityMessage`. Must match a prior
+  /// [ActivitySnapshot]'s `messageId` for the patch to apply.
+  final String messageId;
+
+  /// The kind of activity (e.g. `'skill_tool_call'`).
+  final String activityType;
+
+  /// RFC 6902 operation list. Stored as `List<dynamic>` to match the
+  /// underlying AG-UI event shape; trackers re-validate per-op.
+  final List<dynamic> patch;
+
+  /// Event timestamp in ms since epoch, or `null` if the backend did
+  /// not supply one.
+  final int? timestamp;
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is ActivityDelta &&
+          messageId == other.messageId &&
+          activityType == other.activityType &&
+          timestamp == other.timestamp &&
+          _deepEq.equals(patch, other.patch);
+
+  @override
+  int get hashCode => Object.hash(
+        messageId,
+        activityType,
+        timestamp,
+        _deepEq.hash(patch),
+      );
+}
+
 /// Extension point for third-party plugins to emit custom events.
 ///
 /// Use this when a `SessionExtension` needs to communicate

--- a/packages/soliplex_agent/lib/src/runtime/agent_session.dart
+++ b/packages/soliplex_agent/lib/src/runtime/agent_session.dart
@@ -632,6 +632,18 @@ ExecutionEvent? bridgeBaseEvent(BaseEvent event) {
         timestamp: timestamp,
         replace: replace,
       ),
+    ActivityDeltaEvent(
+      :final messageId,
+      :final activityType,
+      :final patch,
+      :final timestamp,
+    ) =>
+      ActivityDelta(
+        messageId: messageId,
+        activityType: activityType,
+        patch: patch,
+        timestamp: timestamp,
+      ),
     StepStartedEvent(:final stepName) => StepProgress(stepName: stepName),
 
     // Events that don't need ExecutionEvent bridging.
@@ -652,8 +664,7 @@ ExecutionEvent? bridgeBaseEvent(BaseEvent event) {
     CustomEvent() ||
     ReasoningStartEvent() ||
     ReasoningMessageChunkEvent() ||
-    ReasoningEncryptedValueEvent() ||
-    ActivityDeltaEvent() =>
+    ReasoningEncryptedValueEvent() =>
       null,
   };
 }

--- a/packages/soliplex_client/lib/src/application/application.dart
+++ b/packages/soliplex_client/lib/src/application/application.dart
@@ -1,6 +1,7 @@
 export 'agui_event_processor.dart';
 export 'citation_extractor.dart';
 export 'decode_outcome.dart';
+export 'json_patch.dart';
 export 'no_response_synthesis.dart';
 export 'rag_snapshot.dart';
 export 'state_bus.dart';

--- a/test/modules/room/agui_events_presentation_bugs_test.dart
+++ b/test/modules/room/agui_events_presentation_bugs_test.dart
@@ -1,23 +1,36 @@
-/// Reproduction harness for bugs in the "$N events" bubble rendered
-/// above assistant messages by [ExecutionTimeline].
+/// Reproduction harness for two known bugs in the "$N events" bubble
+/// rendered above assistant messages by [ExecutionTimeline].
 ///
 /// Each `test` documents the failure mode it reproduces and asserts the
-/// *correct* behavior — under the un-fixed code these assertions fail;
-/// after the fix lands they pass without other test changes.
+/// *correct* behavior. With the bugs present these assertions fail; once
+/// the underlying drops are fixed the assertions pass without other test
+/// changes.
 ///
 /// Bug 1 — Nested rows never get a checkmark
 /// -----------------------------------------
-/// Backend sends an `ACTIVITY_SNAPSHOT` for `skill_tool_call` with
-/// status `in_progress`, then an `ACTIVITY_DELTA` jsonpatch (`replace
-/// /status → done`) when the sub-skill completes. Before the fix the
-/// frontend dropped every `ActivityDeltaEvent` at two layers:
+/// Backend sends an ACTIVITY_SNAPSHOT for `skill_tool_call` with status
+/// `in_progress`, then an ACTIVITY_DELTA jsonpatch (`replace /status →
+/// done`) when the sub-skill completes. The frontend drops every
+/// `ActivityDeltaEvent` at two layers:
 ///
-/// * `bridgeBaseEvent` returned `null` for the variant.
-/// * `_processActivityDelta` in `agui_event_processor.dart` was a
-///   logged no-op.
+/// * [bridgeBaseEvent] returns `null` for the variant
+///   (agent_session.dart:656).
+/// * [_processActivityDelta] in agui_event_processor.dart is a logged
+///   no-op (line 807).
 ///
-/// Net effect: the nested row kept the in-progress status it had on
-/// first paint, so its trailing icon never flipped to a checkmark.
+/// Net effect: the nested row keeps the in-progress status it had on
+/// first paint, so its trailing icon never flips to a checkmark.
+///
+/// Bug 2 — Bubble disappears after reload
+/// --------------------------------------
+/// On thread reload, [replayToTrackers] keys events by assistant
+/// `TextMessageStart`. A run that ends with a `ToolCallStart` but no
+/// follow-up bundle (errored mid-tool, cancelled, server restart) hits
+/// the "trailing tool-yield" branch and silently drops its events; no
+/// tracker is produced for the run. If the chat-message processor
+/// synthesized a no-response tile for the same run via a different code
+/// path, that tile is rendered without a tracker — the "events bubble"
+/// vanishes on reload even though it was visible during the live run.
 library;
 
 import 'package:flutter_test/flutter_test.dart';
@@ -164,6 +177,106 @@ void main() {
           'done',
           reason: 'Bug 1: live tracker never sees the delta-driven '
               'status change; the trailing icon stays as a spinner.',
+        );
+      },
+    );
+  });
+
+  group('Bug 2: bubble disappears after thread reload', () {
+    test(
+      'a run that yielded to a tool and never produced an assistant '
+      'TextMessageStart (errored / cancelled mid-tool, trailing in '
+      'history) produces no tracker — the bubble vanishes on reload',
+      () {
+        // The chat-message side may still synthesize a no-response tile
+        // for this run (id = noResponseMessageId(runId)). The replay
+        // path *must* hand back a tracker keyed under the same id so the
+        // bubble keeps showing the thinking + tool-call timeline that
+        // was visible while the run was live.
+        final runs = [
+          RunEventBundle(
+            runId: 'run-stuck',
+            events: const [
+              RunStartedEvent(threadId: 't-1', runId: 'run-stuck'),
+              ThinkingTextMessageStartEvent(),
+              ThinkingTextMessageContentEvent(delta: 'reasoning'),
+              ThinkingTextMessageEndEvent(),
+              ToolCallStartEvent(
+                toolCallId: 'tc-1',
+                toolCallName: 'search',
+              ),
+              ToolCallEndEvent(toolCallId: 'tc-1'),
+              ToolCallResultEvent(
+                toolCallId: 'tc-1',
+                content: 'partial',
+                messageId: 'tool-1',
+              ),
+              // No assistant TextMessageStart, no follow-up bundle.
+            ],
+          ),
+        ];
+
+        final trackers = replayToTrackers(runs);
+        final expectedKey = noResponseMessageId('run-stuck');
+
+        expect(
+          trackers,
+          contains(expectedKey),
+          reason: 'Bug 2: trailing tool-yield drops its hoisted events; no '
+              'tracker is created for run-stuck so the bubble disappears '
+              'after a reload even though it was visible live.',
+        );
+        expect(
+          trackers[expectedKey]!.steps.value.map((s) => s.label),
+          containsAll(<String>['Thinking', 'search']),
+          reason: 'Bug 2: the recovered tracker must contain the same '
+              'steps the user saw live.',
+        );
+      },
+    );
+
+    test(
+      'multi-run thread where the LAST run is a trailing tool-yield: the '
+      'preceding assistant bubble is fine, but the last run loses its '
+      'tracker — confirms the bug is isolated to the trailing case',
+      () {
+        // Useful baseline: the bug-free preceding run rules out a regression
+        // in the normal-bundle code path so we can attribute the missing
+        // tracker entirely to the trailing tool-yield.
+        final runs = [
+          RunEventBundle(
+            runId: 'run-1',
+            events: const [
+              TextMessageStartEvent(messageId: 'asst-1'),
+              TextMessageContentEvent(messageId: 'asst-1', delta: 'hi'),
+              TextMessageEndEvent(messageId: 'asst-1'),
+            ],
+          ),
+          RunEventBundle(
+            runId: 'run-stuck',
+            events: const [
+              ThinkingTextMessageStartEvent(),
+              ThinkingTextMessageContentEvent(delta: 'mid'),
+              ThinkingTextMessageEndEvent(),
+              ToolCallStartEvent(toolCallId: 'tc-1', toolCallName: 'search'),
+              ToolCallEndEvent(toolCallId: 'tc-1'),
+              ToolCallResultEvent(
+                toolCallId: 'tc-1',
+                content: 'ok',
+                messageId: 'tool-1',
+              ),
+            ],
+          ),
+        ];
+
+        final trackers = replayToTrackers(runs);
+
+        expect(trackers.keys, contains('asst-1'));
+        expect(
+          trackers.keys,
+          contains(noResponseMessageId('run-stuck')),
+          reason: 'Bug 2: trailing tool-yield bundle silently drops its '
+              'events; the run loses its tracker on reload.',
         );
       },
     );

--- a/test/modules/room/agui_events_presentation_bugs_test.dart
+++ b/test/modules/room/agui_events_presentation_bugs_test.dart
@@ -1,0 +1,171 @@
+/// Reproduction harness for bugs in the "$N events" bubble rendered
+/// above assistant messages by [ExecutionTimeline].
+///
+/// Each `test` documents the failure mode it reproduces and asserts the
+/// *correct* behavior — under the un-fixed code these assertions fail;
+/// after the fix lands they pass without other test changes.
+///
+/// Bug 1 — Nested rows never get a checkmark
+/// -----------------------------------------
+/// Backend sends an `ACTIVITY_SNAPSHOT` for `skill_tool_call` with
+/// status `in_progress`, then an `ACTIVITY_DELTA` jsonpatch (`replace
+/// /status → done`) when the sub-skill completes. Before the fix the
+/// frontend dropped every `ActivityDeltaEvent` at two layers:
+///
+/// * `bridgeBaseEvent` returned `null` for the variant.
+/// * `_processActivityDelta` in `agui_event_processor.dart` was a
+///   logged no-op.
+///
+/// Net effect: the nested row kept the in-progress status it had on
+/// first paint, so its trailing icon never flipped to a checkmark.
+library;
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:soliplex_agent/soliplex_agent.dart';
+
+import 'package:soliplex_frontend/src/modules/room/execution_tracker.dart';
+import 'package:soliplex_frontend/src/modules/room/historical_replay.dart';
+import 'package:soliplex_frontend/src/modules/room/ui/execution/timeline_entry.dart';
+
+import '../../helpers/test_logger.dart';
+
+void main() {
+  group('Bug 1: ACTIVITY_DELTA status update is dropped', () {
+    test(
+      'bridgeBaseEvent drops ActivityDeltaEvent — nested rows never '
+      'receive the status change that drives the checkmark',
+      () {
+        final delta = ActivityDeltaEvent(
+          messageId: 'rag:call_1',
+          activityType: 'skill_tool_call',
+          patch: const [
+            {'op': 'replace', 'path': '/status', 'value': 'done'},
+          ],
+          timestamp: 200,
+        );
+
+        // Correct behavior: produce an ExecutionEvent the tracker can act
+        // on so the activity's status moves to "done". Currently null.
+        expect(
+          bridgeBaseEvent(delta),
+          isNotNull,
+          reason: 'Bug 1: ActivityDeltaEvent is dropped at the bridge; '
+              'the timeline never sees the status change.',
+        );
+      },
+    );
+
+    test(
+      'historical replay: snapshot(in_progress) + delta(status→done) '
+      'leaves the nested activity stuck at in_progress',
+      () {
+        final runs = [
+          RunEventBundle(
+            runId: 'run-1',
+            events: const [
+              TextMessageStartEvent(messageId: 'asst-1'),
+              ToolCallStartEvent(
+                toolCallId: 'tc-1',
+                toolCallName: 'execute_skill',
+              ),
+              ActivitySnapshotEvent(
+                messageId: 'rag:call_1',
+                activityType: 'skill_tool_call',
+                content: {
+                  'tool_name': 'ask',
+                  'args': '{"q":"hi"}',
+                  'status': 'in_progress',
+                },
+                timestamp: 100,
+              ),
+              ActivityDeltaEvent(
+                messageId: 'rag:call_1',
+                activityType: 'skill_tool_call',
+                patch: [
+                  {'op': 'replace', 'path': '/status', 'value': 'done'},
+                ],
+                timestamp: 150,
+              ),
+              ToolCallResultEvent(
+                toolCallId: 'tc-1',
+                content: 'ok',
+                messageId: 'result-1',
+              ),
+              TextMessageEndEvent(messageId: 'asst-1'),
+            ],
+          ),
+        ];
+
+        final trackers = replayToTrackers(runs);
+        final step = trackers['asst-1']!.timeline.value.single as TimelineStep;
+
+        expect(step.activities, hasLength(1));
+        expect(
+          step.activities.single.status,
+          'done',
+          reason: 'Bug 1: ACTIVITY_DELTA patches are dropped during replay; '
+              'the nested activity stays at its initial in_progress status.',
+        );
+      },
+    );
+
+    test(
+      'live tracker: ActivitySnapshot then ActivityDelta on the same '
+      'messageId does not advance the activity to done',
+      () {
+        final events = Signal<ExecutionEvent?>(null);
+        final tracker = ExecutionTracker(
+          executionEvents: events,
+          logger: testLogger(),
+        );
+        addTearDown(tracker.dispose);
+
+        // Bridge each AG-UI event through the production bridge, mirroring
+        // what AgentSession does at runtime. Anything the bridge drops
+        // never reaches the tracker — exactly the bug we're reproducing.
+        final ExecutionEvent? snapshot = bridgeBaseEvent(
+          const ActivitySnapshotEvent(
+            messageId: 'rag:call_1',
+            activityType: 'skill_tool_call',
+            content: {
+              'tool_name': 'ask',
+              'args': '{"q":"hi"}',
+              'status': 'in_progress',
+            },
+            timestamp: 100,
+          ),
+        );
+        expect(snapshot, isNotNull);
+        events.value = snapshot;
+
+        final ExecutionEvent? delta = bridgeBaseEvent(
+          ActivityDeltaEvent(
+            messageId: 'rag:call_1',
+            activityType: 'skill_tool_call',
+            patch: const [
+              {'op': 'replace', 'path': '/status', 'value': 'done'},
+            ],
+            timestamp: 200,
+          ),
+        );
+
+        expect(
+          delta,
+          isNotNull,
+          reason: 'Bug 1: the bridge drops the delta before it can reach '
+              'the live tracker.',
+        );
+        if (delta != null) events.value = delta;
+
+        final calls = tracker.skillToolCalls.value;
+        expect(calls, hasLength(1));
+        expect(
+          calls.single.status,
+          'done',
+          reason: 'Bug 1: live tracker never sees the delta-driven '
+              'status change; the trailing icon stays as a spinner.',
+        );
+      },
+    );
+  });
+}

--- a/test/modules/room/historical_replay_test.dart
+++ b/test/modules/room/historical_replay_test.dart
@@ -210,11 +210,13 @@ void main() {
     });
 
     test(
-        'trailing tool-yield bundle with no follow-up drops its hoisted '
-        'events without crashing or attaching them to a synthesized id', () {
-      // A tool-yield bundle with no normal-bundle follow-up has nowhere
-      // to attach its hoisted events. The replay must log the drop and
-      // return without crashing.
+        'trailing tool-yield bundle with no follow-up routes its hoisted '
+        'events under the synthesized no-response id for the same run', () {
+      // A tool-yield bundle with no normal-bundle follow-up still needs
+      // a tracker on reload: the chat-message side synthesizes a
+      // no-response tile under `noResponseMessageId(runId)` for the
+      // same run, and the bubble disappears if no tracker is keyed
+      // under that id.
       final runs = [
         RunEventBundle(
           runId: 'run-yield-only',
@@ -234,7 +236,15 @@ void main() {
 
       final trackers = replayToTrackers(runs);
 
-      expect(trackers, isEmpty);
+      expect(trackers.keys, ['no-response-run-yield-only']);
+      expect(
+        trackers['no-response-run-yield-only']!.steps.value.map((s) => s.label),
+        ['Thinking', 'search'],
+      );
+      expect(
+        trackers['no-response-run-yield-only']!.thinkingBlocks.value,
+        ['pre-tool'],
+      );
     });
 
     test(


### PR DESCRIPTION
## Summary

Two independent fixes to the "$N events" bubble rendered above assistant messages by `ExecutionTimeline`. Each lands as its own commit so they can bisect / revert independently.

### Bug 1 — Nested rows never get a checkmark (`8a189f6`)

`ACTIVITY_DELTA` events (the jsonpatch the backend sends to flip a sub-skill's status to `done`) were dropped at two layers: `bridgeBaseEvent` returned `null` and `_processActivityDelta` was a logged no-op. The execution tracker never saw the patch, so the second-level activity rows kept their initial `in_progress` status forever.

- New `ActivityDelta` `ExecutionEvent` variant carrying `messageId / activityType / patch / timestamp`.
- `bridgeBaseEvent` now bridges `ActivityDeltaEvent → ActivityDelta`.
- `ExecutionTracker` caches the raw `ActivityRecord` per `messageId` so a delta can apply its jsonpatch to the snapshotted content, re-decode `SkillToolCallActivity`, and upsert into `skillToolCalls` + `timeline`. A delta with no prior snapshot is logged and dropped.
- `applyJsonPatch` exported from `soliplex_client`'s `application` barrel.

### Bug 2 — Bubble disappears after reload (`b45330a`)

When the last bundle in a thread's history is a tool-yield (errored mid-tool, cancelled, server restart) with no follow-up assistant text, `replayToTrackers` hoisted its events into `pending` and dropped them. The chat-message side still synthesized a `NoResponseTile` under `noResponseMessageId(runId)` for the same run, but with no tracker bound to that key the `ExecutionTimeline` above it vanished — the bubble the user saw live disappeared on reload.

- Track `lastToolYieldRunId` during bundle iteration.
- On loop exit with non-empty `pending`, route the hoisted events under `noResponseMessageId(lastToolYieldRunId)` so the tracker keys match the synthesized tile.
- The existing `historical_replay_test` that codified the drop is flipped to assert the new (correct) bucketing.

### Bug harness — `test/modules/room/agui_events_presentation_bugs_test.dart`

The harness has 5 tests across the bridge, replay, and live-tracker layers — each one was written *before* the fix and was failing on the broken code, then passes after the corresponding fix lands. Useful for reproducing the bugs in isolation and pinpointing which drop layer is responsible for a regression.

**Open question for review:** worth keeping the harness as its own focused suite, or should I:
- (a) leave it as-is — bug-specific suite that stays alongside the codebase as documentation of *what these bugs were and how they fail*
- (b) inline its assertions into `execution_tracker_test.dart` / `historical_replay_test.dart` so the coverage stays but the bug framing disappears
- (c) delete it — the underlying coverage is implicit in (b) already (the existing tests cover snapshot upsert; deltas could be folded in)

I lean (a) for now since it's the only place that exercises the full bridge → tracker pipeline end-to-end for activity events, but happy to refactor if that's not the codebase convention.

## Test plan

- [x] `fvm flutter analyze` — zero warnings
- [x] `fvm flutter test test/modules/room/agui_events_presentation_bugs_test.dart` — 5/5 pass
- [x] `fvm flutter test test/modules/room/historical_replay_test.dart test/modules/room/execution_tracker_test.dart` — full pass
- [x] `fvm flutter test test/modules/room/` — 633 pass
- [x] Manual: run `analysis` room, send a query that triggers a sub-skill, verify second-level rows get checkmarks
- [ ] Manual: trigger a mid-tool error / cancel; reload thread; verify the events bubble remains visible

🤖 Generated with [Claude Code](https://claude.com/claude-code)