### PR TITLE
fix(room): complete AG-UI activity-event handling

### DIFF
--- a/lib/src/modules/room/execution_tracker.dart
+++ b/lib/src/modules/room/execution_tracker.dart
@@ -9,10 +9,17 @@ class ExecutionTracker {
     required ReadonlySignal<List<ActivityRecord>> activities,
     required Logger logger,
   })  : _logger = logger,
-        _activities = activities,
+        _activities = Signal<List<ActivityRecord>>(activities.value),
         _historical = false {
     _stopwatch.start();
     _unsub = executionEvents.subscribe(_onEvent);
+    // Mirror the session-owned activities into our local signal so the
+    // tracker stays self-contained when ThreadViewState absorbs it on
+    // detach: freeze() drops the subscription, and the captured list
+    // outlives the session's signal teardown.
+    _activitiesUnsub = activities.subscribe((value) {
+      _activities.value = value;
+    });
   }
 
   /// Builds a frozen tracker seeded from a list of already-emitted
@@ -31,7 +38,7 @@ class ExecutionTracker {
     required List<ActivityRecord> activities,
     required Logger logger,
   })  : _logger = logger,
-        _activities = Signal(activities),
+        _activities = Signal<List<ActivityRecord>>(activities),
         _historical = true {
     _stopwatch.start();
     for (final event in events) {
@@ -41,7 +48,7 @@ class ExecutionTracker {
   }
 
   final Logger _logger;
-  final ReadonlySignal<List<ActivityRecord>> _activities;
+  final Signal<List<ActivityRecord>> _activities;
 
   /// True when this tracker is replaying stored events on the reload
   /// path. Live-only side-effects (e.g. warning-level logs that mirror a
@@ -51,6 +58,7 @@ class ExecutionTracker {
 
   final Stopwatch _stopwatch = Stopwatch();
   void Function()? _unsub;
+  void Function()? _activitiesUnsub;
   bool _isFrozen = false;
   bool get isFrozen => _isFrozen;
 
@@ -93,6 +101,8 @@ class ExecutionTracker {
     _completeAllSteps(StepStatus.completed);
     _unsub?.call();
     _unsub = null;
+    _activitiesUnsub?.call();
+    _activitiesUnsub = null;
     _stopwatch.stop();
     _isFrozen = true;
   }
@@ -279,6 +289,8 @@ class ExecutionTracker {
   void dispose() {
     _unsub?.call();
     _unsub = null;
+    _activitiesUnsub?.call();
+    _activitiesUnsub = null;
     _stopwatch.stop();
   }
 }

--- a/lib/src/modules/room/execution_tracker.dart
+++ b/lib/src/modules/room/execution_tracker.dart
@@ -101,18 +101,20 @@ class ExecutionTracker {
     try {
       _dispatch(event);
     } on Object catch (e, st) {
-      // The tracker is a derived projection of the event stream; a throw
-      // here would propagate up through the signals subscription that
-      // pushed the event, destabilising any downstream observers. Log
-      // and skip the mutation instead — surrounding events keep flowing.
-      // The drop is deliberately UI-silent: chat-message boundaries mint
-      // the drop tile; double-minting from this projection would surface
-      // the same backend event as two tiles. Logged at error so Sentry
-      // still sees the schema/code drift.
+      // `_dispatch` operates on already-decoded `ExecutionEvent` variants
+      // and mutates local signals — a throw here is a frontend logic bug
+      // (bad cast, signals misuse, missing switch arm), not backend drift.
+      // Swallow in prod so downstream observers stay alive, but fail loud
+      // in dev/test via assert so the bug surfaces immediately.
       _logger.error(
         'ExecutionTracker dropped ${event.runtimeType}',
         error: e,
         stackTrace: st,
+        attributes: {'errorType': e.runtimeType.toString()},
+      );
+      assert(
+        false,
+        'ExecutionTracker._dispatch threw: $e\n$st',
       );
     }
   }

--- a/lib/src/modules/room/execution_tracker.dart
+++ b/lib/src/modules/room/execution_tracker.dart
@@ -6,8 +6,10 @@ import 'ui/execution/timeline_entry.dart';
 class ExecutionTracker {
   ExecutionTracker({
     required ReadonlySignal<ExecutionEvent?> executionEvents,
+    required ReadonlySignal<List<ActivityRecord>> activities,
     required Logger logger,
   })  : _logger = logger,
+        _activities = activities,
         _historical = false {
     _stopwatch.start();
     _unsub = executionEvents.subscribe(_onEvent);
@@ -19,11 +21,15 @@ class ExecutionTracker {
   ///
   /// The tracker opens no subscription; callers should not pass the
   /// returned instance to any signal. It is immutable from construction
-  /// ([isFrozen] returns `true`).
+  /// ([isFrozen] returns `true`). The activities signal is initialised
+  /// from the snapshot events found in [events] applying the AG-UI
+  /// `replace` semantics, so the historical projection matches what
+  /// `Conversation.activities` would hold after live replay.
   ExecutionTracker.historical({
     required List<ExecutionEvent> events,
     required Logger logger,
   })  : _logger = logger,
+        _activities = Signal(_reconstructActivities(events)),
         _historical = true {
     _stopwatch.start();
     for (final event in events) {
@@ -33,6 +39,7 @@ class ExecutionTracker {
   }
 
   final Logger _logger;
+  final ReadonlySignal<List<ActivityRecord>> _activities;
 
   /// True when this tracker is replaying stored events on the reload
   /// path. Live-only side-effects (e.g. warning-level logs that mirror a
@@ -55,28 +62,23 @@ class ExecutionTracker {
   final Signal<bool> _isThinkingStreaming = Signal<bool>(false);
   ReadonlySignal<bool> get isThinkingStreaming => _isThinkingStreaming;
 
-  /// Decoded `skill_tool_call` activities in arrival order, keyed by
-  /// `messageId`. Records that fail to decode as a skill_tool_call are
-  /// dropped from this signal (but their raw form is still emitted on
-  /// [executionEvents]). Mirrors the upsert semantics of
-  /// `Conversation.activities` in soliplex_client.
-  final Signal<List<SkillToolCallActivity>> _skillToolCalls =
-      Signal<List<SkillToolCallActivity>>(const []);
-  ReadonlySignal<List<SkillToolCallActivity>> get skillToolCalls =>
-      _skillToolCalls;
+  /// Decoded skill_tool activities, derived reactively from the source
+  /// activities signal. Records that fail to decode as a skill_tool_*
+  /// view are filtered out. The list mirrors the source order in
+  /// `Conversation.activities`.
+  late final ReadonlySignal<List<SkillToolCallActivity>> skillToolCalls =
+      computed(() {
+    return [
+      for (final record in _activities.value)
+        if (SkillToolCallActivity.fromRecord(record) case final view?) view,
+    ];
+  });
 
-  /// Last raw [ActivityRecord] seen for each `messageId`. [ActivityDelta]
-  /// applies a jsonpatch to the cached content here, re-decodes, and
-  /// upserts the result back into [_skillToolCalls] and the timeline.
-  /// The decoded `SkillToolCallActivity` can't be patched directly
-  /// because its constructor lossily transforms `args` from JSON string
-  /// to a map.
-  final Map<String, ActivityRecord> _activityRecords = {};
-
-  /// Timeline of steps with their nested activities, in arrival order.
-  /// Activities that arrive while a step is active are nested under that
-  /// step; activities arriving outside any active step are emitted as
-  /// [TimelineStandaloneActivity].
+  /// Timeline of steps with their nested activity ids, in arrival
+  /// order. Activities that arrive while a step is active are nested
+  /// under that step; activities arriving outside any active step are
+  /// emitted as [TimelineStandaloneActivity]. The renderer resolves
+  /// each id against [skillToolCalls] at paint time.
   final Signal<List<TimelineEntry>> _timeline =
       Signal<List<TimelineEntry>>(const []);
   ReadonlySignal<List<TimelineEntry>> get timeline => _timeline;
@@ -169,32 +171,8 @@ class ExecutionTracker {
       case RunCancelled():
         _completeAllSteps(StepStatus.failed);
         _isThinkingStreaming.value = false;
-      case ActivitySnapshot(
-          :final messageId,
-          :final activityType,
-          :final content,
-          :final timestamp,
-          :final replace,
-        ):
-        _upsertSkillToolCall(
-          messageId: messageId,
-          activityType: activityType,
-          content: content,
-          timestamp: timestamp,
-          replace: replace,
-        );
-      case ActivityDelta(
-          :final messageId,
-          :final activityType,
-          :final patch,
-          :final timestamp,
-        ):
-        _applyActivityDelta(
-          messageId: messageId,
-          activityType: activityType,
-          patch: patch,
-          timestamp: timestamp,
-        );
+      case ActivitySnapshot(:final messageId):
+        _placeActivityInTimeline(messageId);
       case TextDelta() ||
             StateUpdated() ||
             StepProgress() ||
@@ -204,100 +182,34 @@ class ExecutionTracker {
     }
   }
 
-  void _upsertSkillToolCall({
-    required String messageId,
-    required String activityType,
-    required Map<String, dynamic> content,
-    required int? timestamp,
-    required bool replace,
-  }) {
-    final current = _skillToolCalls.value;
-    final existingIndex = current.indexWhere((a) => a.messageId == messageId);
-
-    if (existingIndex >= 0 && !replace) {
-      return;
+  /// Records the structural position of [activityId] in the timeline.
+  /// Content is sourced from [skillToolCalls]; this only decides which
+  /// step the row nests under (or whether it stands alone). An id
+  /// already present in any entry is a no-op — the activity updates in
+  /// place via the computed signal.
+  void _placeActivityInTimeline(String activityId) {
+    final current = _timeline.value;
+    for (final entry in current) {
+      if (entry is TimelineStep && entry.activityIds.contains(activityId)) {
+        return;
+      }
+      if (entry is TimelineStandaloneActivity &&
+          entry.activityId == activityId) {
+        return;
+      }
     }
-
-    final record = ActivityRecord(
-      messageId: messageId,
-      activityType: activityType,
-      content: content,
-      timestamp: timestamp ?? DateTime.now().millisecondsSinceEpoch,
-    );
-    final decoded = SkillToolCallActivity.fromRecord(record);
-    if (decoded == null) {
-      _logger.warning(
-        'SkillToolCallActivity.fromRecord returned null; activity dropped',
-        attributes: {
-          'messageId': messageId,
-          'activityType': activityType,
-          'contentKeys': content.keys.toList().toString(),
-        },
-      );
-      return;
+    if (current.isNotEmpty && current.last is TimelineStep) {
+      final lastStep = current.last as TimelineStep;
+      if (lastStep.step.status == StepStatus.active) {
+        _timeline.value = [...current]..[current.length - 1] =
+            lastStep.withActivities([...lastStep.activityIds, activityId]);
+        return;
+      }
     }
-
-    _activityRecords[messageId] = record;
-    if (existingIndex >= 0) {
-      _skillToolCalls.value = [...current]..[existingIndex] = decoded;
-    } else {
-      _skillToolCalls.value = [...current, decoded];
-    }
-    _upsertActivityInTimeline(decoded);
-  }
-
-  void _applyActivityDelta({
-    required String messageId,
-    required String activityType,
-    required List<dynamic> patch,
-    required int? timestamp,
-  }) {
-    final existing = _activityRecords[messageId];
-    if (existing == null) {
-      // AG-UI spec: ACTIVITY_DELTA must follow a prior ACTIVITY_SNAPSHOT
-      // for the same messageId. An out-of-order delta has nothing to
-      // patch; log and drop so a backend ordering bug is observable
-      // instead of silently losing state.
-      _logger.warning(
-        'ActivityDelta with no prior snapshot; patch dropped',
-        attributes: {
-          'messageId': messageId,
-          'activityType': activityType,
-          'patchOps': patch.length,
-        },
-      );
-      return;
-    }
-
-    final patched = applyJsonPatch(existing.content, patch);
-    final updated = ActivityRecord(
-      messageId: messageId,
-      activityType: activityType,
-      content: patched,
-      timestamp: timestamp ?? existing.timestamp,
-    );
-    final decoded = SkillToolCallActivity.fromRecord(updated);
-    if (decoded == null) {
-      _logger.warning(
-        'ActivityDelta produced an undecodable record; patch dropped',
-        attributes: {
-          'messageId': messageId,
-          'activityType': activityType,
-          'contentKeys': patched.keys.toList().toString(),
-        },
-      );
-      return;
-    }
-
-    _activityRecords[messageId] = updated;
-    final calls = _skillToolCalls.value;
-    final idx = calls.indexWhere((a) => a.messageId == messageId);
-    if (idx >= 0) {
-      _skillToolCalls.value = [...calls]..[idx] = decoded;
-    } else {
-      _skillToolCalls.value = [...calls, decoded];
-    }
-    _upsertActivityInTimeline(decoded);
+    _timeline.value = [
+      ...current,
+      TimelineStandaloneActivity(activityId: activityId),
+    ];
   }
 
   void _addStep(String label, StepType type) {
@@ -354,37 +266,30 @@ class ExecutionTracker {
     }
   }
 
-  void _upsertActivityInTimeline(SkillToolCallActivity decoded) {
-    final current = _timeline.value;
-    for (var i = 0; i < current.length; i++) {
-      final entry = current[i];
-      if (entry is TimelineStep) {
-        final aIdx = entry.activities
-            .indexWhere((a) => a.messageId == decoded.messageId);
-        if (aIdx >= 0) {
-          final updated = [...entry.activities]..[aIdx] = decoded;
-          _timeline.value = [...current]..[i] = entry.withActivities(updated);
-          return;
-        }
-      } else if (entry is TimelineStandaloneActivity &&
-          entry.activity.messageId == decoded.messageId) {
-        _timeline.value = [...current]..[i] =
-            TimelineStandaloneActivity(activity: decoded);
-        return;
+  /// Replays the [ActivitySnapshot] events in [events] using AG-UI
+  /// `replace` semantics so the historical tracker's activities signal
+  /// holds the same list `Conversation.activities` would hold after a
+  /// live run with the same event stream.
+  static List<ActivityRecord> _reconstructActivities(
+    List<ExecutionEvent> events,
+  ) {
+    final list = <ActivityRecord>[];
+    for (final event in events) {
+      if (event is! ActivitySnapshot) continue;
+      final record = ActivityRecord(
+        messageId: event.messageId,
+        activityType: event.activityType,
+        content: event.content,
+        timestamp: event.timestamp ?? DateTime.now().millisecondsSinceEpoch,
+      );
+      final idx = list.indexWhere((a) => a.messageId == event.messageId);
+      if (idx >= 0) {
+        if (event.replace) list[idx] = record;
+      } else {
+        list.add(record);
       }
     }
-    if (current.isNotEmpty && current.last is TimelineStep) {
-      final lastStep = current.last as TimelineStep;
-      if (lastStep.step.status == StepStatus.active) {
-        _timeline.value = [...current]..[current.length - 1] =
-            lastStep.withActivities([...lastStep.activities, decoded]);
-        return;
-      }
-    }
-    _timeline.value = [
-      ...current,
-      TimelineStandaloneActivity(activity: decoded)
-    ];
+    return list;
   }
 
   void dispose() {

--- a/lib/src/modules/room/execution_tracker.dart
+++ b/lib/src/modules/room/execution_tracker.dart
@@ -246,7 +246,6 @@ class ExecutionTracker {
   }
 
   void _completeAllSteps(StepStatus status) {
-    assert(!_isFrozen, 'Cannot complete steps on a frozen ExecutionTracker');
     final now = _stopwatch.elapsed;
     _steps.value = [
       for (final step in _steps.value)

--- a/lib/src/modules/room/execution_tracker.dart
+++ b/lib/src/modules/room/execution_tracker.dart
@@ -21,15 +21,17 @@ class ExecutionTracker {
   ///
   /// The tracker opens no subscription; callers should not pass the
   /// returned instance to any signal. It is immutable from construction
-  /// ([isFrozen] returns `true`). The activities signal is initialised
-  /// from the snapshot events found in [events] applying the AG-UI
-  /// `replace` semantics, so the historical projection matches what
-  /// `Conversation.activities` would hold after live replay.
+  /// ([isFrozen] returns `true`). [activities] is the already-folded
+  /// activities list (see `applyActivityEvent`) — historical replay
+  /// folds the raw AG-UI events through the same function the live
+  /// processor uses, so snapshot + delta application produces the same
+  /// result as a live run with the same event stream.
   ExecutionTracker.historical({
     required List<ExecutionEvent> events,
+    required List<ActivityRecord> activities,
     required Logger logger,
   })  : _logger = logger,
-        _activities = Signal(_reconstructActivities(events)),
+        _activities = Signal(activities),
         _historical = true {
     _stopwatch.start();
     for (final event in events) {
@@ -179,8 +181,7 @@ class ExecutionTracker {
         // layer (so future consumers can read them), but they don't get a
         // timeline row — placing them would produce a phantom entry whose
         // _resolveActivity returns null on every render.
-        if (activityType == 'skill_tool_call' ||
-            activityType == 'skill_tool_result') {
+        if (kSkillToolCallActivityTypes.contains(activityType)) {
           _placeActivityInTimeline(messageId);
         }
       case TextDelta() ||
@@ -273,32 +274,6 @@ class ExecutionTracker {
         return;
       }
     }
-  }
-
-  /// Replays the [ActivitySnapshot] events in [events] using AG-UI
-  /// `replace` semantics so the historical tracker's activities signal
-  /// holds the same list `Conversation.activities` would hold after a
-  /// live run with the same event stream.
-  static List<ActivityRecord> _reconstructActivities(
-    List<ExecutionEvent> events,
-  ) {
-    final list = <ActivityRecord>[];
-    for (final event in events) {
-      if (event is! ActivitySnapshot) continue;
-      final record = ActivityRecord(
-        messageId: event.messageId,
-        activityType: event.activityType,
-        content: event.content,
-        timestamp: event.timestamp ?? DateTime.now().millisecondsSinceEpoch,
-      );
-      final idx = list.indexWhere((a) => a.messageId == event.messageId);
-      if (idx >= 0) {
-        if (event.replace) list[idx] = record;
-      } else {
-        list.add(record);
-      }
-    }
-    return list;
   }
 
   void dispose() {

--- a/lib/src/modules/room/execution_tracker.dart
+++ b/lib/src/modules/room/execution_tracker.dart
@@ -171,8 +171,16 @@ class ExecutionTracker {
       case RunCancelled():
         _completeAllSteps(StepStatus.failed);
         _isThinkingStreaming.value = false;
-      case ActivitySnapshot(:final messageId):
-        _placeActivityInTimeline(messageId);
+      case ActivitySnapshot(:final messageId, :final activityType):
+        // Only place ids whose activityType the decoder recognises. Other
+        // types still persist into Conversation.activities at the domain
+        // layer (so future consumers can read them), but they don't get a
+        // timeline row — placing them would produce a phantom entry whose
+        // _resolveActivity returns null on every render.
+        if (activityType == 'skill_tool_call' ||
+            activityType == 'skill_tool_result') {
+          _placeActivityInTimeline(messageId);
+        }
       case TextDelta() ||
             StateUpdated() ||
             StepProgress() ||

--- a/lib/src/modules/room/execution_tracker_extension.dart
+++ b/lib/src/modules/room/execution_tracker_extension.dart
@@ -79,7 +79,11 @@ class ExecutionTrackerExtension extends SessionExtension
     }
     switch (runState) {
       case RunningState(:final streaming):
-        _registry.onStreaming(streaming, session.lastExecutionEvent);
+        _registry.onStreaming(
+          streaming,
+          session.lastExecutionEvent,
+          session.conversationActivities,
+        );
         _sync();
       // Order is load-bearing across the three terminal arms: rekey must
       // run before `onRunTerminated`, because rekey moves the awaiting

--- a/lib/src/modules/room/historical_replay.dart
+++ b/lib/src/modules/room/historical_replay.dart
@@ -46,11 +46,18 @@ Map<String, ExecutionTracker> replayToTrackers(
   @visibleForTesting ExecutionBridge bridge = bridgeBaseEvent,
 }) {
   final buckets = <String, List<ExecutionEvent>>{};
+  // Parallel to `buckets`: the raw AG-UI events destined for each
+  // tracker, retained so we can fold them through `applyActivityEvent`
+  // at construction time. Bridging drops `ActivityDeltaEvent`, so the
+  // bridged `ExecutionEvent` stream is insufficient for activity
+  // reconstruction.
+  final rawBuckets = <String, List<BaseEvent>>{};
   // Hoisted across bundles: tool-yield events accumulate here until the
   // next normal bundle's first assistant message absorbs them. If no
   // such bundle exists, the trailing handler below routes them under
   // `noResponseMessageId(lastToolYieldRunId)`.
   final pending = <ExecutionEvent>[];
+  final pendingRaw = <BaseEvent>[];
   String? lastToolYieldRunId;
 
   ExecutionEvent? bridgeOrLog(BaseEvent raw) {
@@ -79,42 +86,50 @@ Map<String, ExecutionTracker> replayToTrackers(
             raw.role == TextMessageRole.assistant) {
           final messageId = raw.messageId;
           currentMessageId = messageId;
-          final bucket = buckets.putIfAbsent(messageId, () => []);
+          buckets.putIfAbsent(messageId, () => []);
+          final rawBucket = rawBuckets.putIfAbsent(messageId, () => []);
           if (pending.isNotEmpty) {
-            bucket.addAll(pending);
+            buckets[messageId]!.addAll(pending);
             pending.clear();
+            rawBucket.addAll(pendingRaw);
+            pendingRaw.clear();
             lastToolYieldRunId = null;
           }
         }
 
         final execEvent = bridgeOrLog(raw);
-        if (execEvent == null) continue;
-
         if (currentMessageId != null) {
-          buckets.putIfAbsent(currentMessageId, () => []).add(execEvent);
+          rawBuckets.putIfAbsent(currentMessageId, () => []).add(raw);
+          if (execEvent != null) {
+            buckets.putIfAbsent(currentMessageId, () => []).add(execEvent);
+          }
         } else {
-          pending.add(execEvent);
+          pendingRaw.add(raw);
+          if (execEvent != null) pending.add(execEvent);
         }
       }
     } else if (hasToolCall) {
       lastToolYieldRunId = bundle.runId;
       for (final raw in bundle.events) {
+        pendingRaw.add(raw);
         final execEvent = bridgeOrLog(raw);
-        if (execEvent == null) continue;
-        pending.add(execEvent);
+        if (execEvent != null) pending.add(execEvent);
       }
     } else {
       final synthesizedId = noResponseMessageId(bundle.runId);
       final bucket = buckets.putIfAbsent(synthesizedId, () => []);
+      final rawBucket = rawBuckets.putIfAbsent(synthesizedId, () => []);
       if (pending.isNotEmpty) {
         bucket.addAll(pending);
         pending.clear();
+        rawBucket.addAll(pendingRaw);
+        pendingRaw.clear();
         lastToolYieldRunId = null;
       }
       for (final raw in bundle.events) {
+        rawBucket.add(raw);
         final execEvent = bridgeOrLog(raw);
-        if (execEvent == null) continue;
-        bucket.add(execEvent);
+        if (execEvent != null) bucket.add(execEvent);
       }
     }
   }
@@ -126,17 +141,31 @@ Map<String, ExecutionTracker> replayToTrackers(
   if (pending.isNotEmpty && lastToolYieldRunId != null) {
     final synthesizedId = noResponseMessageId(lastToolYieldRunId);
     buckets.putIfAbsent(synthesizedId, () => []).addAll(pending);
+    rawBuckets.putIfAbsent(synthesizedId, () => []).addAll(pendingRaw);
     pending.clear();
+    pendingRaw.clear();
   } else if (pending.isNotEmpty) {
     _logger.warning(
       'Dropping unattached events with no tool-yield runId to anchor to.',
       attributes: {'pendingCount': pending.length},
     );
+    pendingRaw.clear();
   }
 
   return {
     for (final entry in buckets.entries)
-      entry.key:
-          ExecutionTracker.historical(events: entry.value, logger: _logger),
+      entry.key: ExecutionTracker.historical(
+        events: entry.value,
+        activities: _foldActivities(rawBuckets[entry.key] ?? const []),
+        logger: _logger,
+      ),
   };
+}
+
+List<ActivityRecord> _foldActivities(List<BaseEvent> events) {
+  var activities = const <ActivityRecord>[];
+  for (final event in events) {
+    activities = applyActivityEvent(activities, event, logger: _logger);
+  }
+  return activities;
 }

--- a/lib/src/modules/room/tracker_registry.dart
+++ b/lib/src/modules/room/tracker_registry.dart
@@ -21,11 +21,14 @@ class TrackerRegistry {
 
   /// Update tracker state based on the current streaming state.
   ///
-  /// [events] is the execution event signal to subscribe a new tracker to,
-  /// only used when a tracker needs to be created.
+  /// [events] is the execution event signal to subscribe a new tracker
+  /// to, only used when a tracker needs to be created. [activities] is
+  /// the live `Conversation.activities` signal the new tracker derives
+  /// its `skillToolCalls` from.
   void onStreaming(
     StreamingState streaming,
     ReadonlySignal<ExecutionEvent?> events,
+    ReadonlySignal<List<ActivityRecord>> activities,
   ) {
     switch (streaming) {
       case TextStreaming(:final messageId):
@@ -37,8 +40,11 @@ class TrackerRegistry {
           }
         } else {
           _freezeActive();
-          _trackers[messageId] =
-              ExecutionTracker(executionEvents: events, logger: _logger);
+          _trackers[messageId] = ExecutionTracker(
+            executionEvents: events,
+            activities: activities,
+            logger: _logger,
+          );
         }
         _activeId = messageId;
       case AwaitingText():
@@ -46,6 +52,7 @@ class TrackerRegistry {
         _activeId = awaitingTrackerKey;
         _trackers[awaitingTrackerKey] = ExecutionTracker(
           executionEvents: events,
+          activities: activities,
           logger: _logger,
         );
     }

--- a/lib/src/modules/room/ui/execution/execution_timeline.dart
+++ b/lib/src/modules/room/ui/execution/execution_timeline.dart
@@ -271,7 +271,7 @@ class _ExecutionTimelineState extends ConsumerState<ExecutionTimeline> {
                   ),
                 ),
                 Text(
-                  activity.status,
+                  activity.status.label,
                   style: theme.textTheme.bodySmall?.copyWith(
                     color: theme.colorScheme.outline,
                     fontSize: 11,
@@ -340,10 +340,9 @@ class _ExecutionTimelineState extends ConsumerState<ExecutionTimeline> {
     }
   }
 
-  Widget _activityStatusIcon(String status, ThemeData theme) {
+  Widget _activityStatusIcon(SkillToolCallStatus status, ThemeData theme) {
     switch (status) {
-      case 'in_progress':
-      case 'running':
+      case SkillToolCallStatus.inProgress:
         return SizedBox(
           width: 12,
           height: 12,
@@ -352,18 +351,15 @@ class _ExecutionTimelineState extends ConsumerState<ExecutionTimeline> {
             color: theme.colorScheme.primary,
           ),
         );
-      case 'failed':
-      case 'error':
+      case SkillToolCallStatus.error:
         return Icon(Icons.error, size: 12, color: theme.colorScheme.error);
-      case 'done':
-      case 'completed':
-      case 'success':
+      case SkillToolCallStatus.done:
         return Icon(
           Icons.check_circle,
           size: 12,
           color: theme.colorScheme.primary,
         );
-      default:
+      case SkillToolCallStatus.unknown:
         return Icon(
           Icons.circle_outlined,
           size: 12,

--- a/lib/src/modules/room/ui/execution/execution_timeline.dart
+++ b/lib/src/modules/room/ui/execution/execution_timeline.dart
@@ -92,11 +92,12 @@ class _ExecutionTimelineState extends ConsumerState<ExecutionTimeline> {
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
     final entries = widget.tracker.timeline.watch(context);
+    final calls = widget.tracker.skillToolCalls.watch(context);
     if (entries.isEmpty) return const SizedBox.shrink();
 
     final total = entries.fold<int>(
       0,
-      (sum, e) => sum + (e is TimelineStep ? 1 + e.activities.length : 1),
+      (sum, e) => sum + (e is TimelineStep ? 1 + e.activityIds.length : 1),
     );
 
     return Padding(
@@ -132,7 +133,7 @@ class _ExecutionTimelineState extends ConsumerState<ExecutionTimeline> {
             ),
             if (_expanded) ...[
               const SizedBox(height: 4),
-              for (final entry in entries) _buildEntry(entry, theme),
+              for (final entry in entries) _buildEntry(entry, theme, calls),
             ],
           ],
         ),
@@ -140,20 +141,42 @@ class _ExecutionTimelineState extends ConsumerState<ExecutionTimeline> {
     );
   }
 
-  Widget _buildEntry(TimelineEntry entry, ThemeData theme) {
+  Widget _buildEntry(
+    TimelineEntry entry,
+    ThemeData theme,
+    List<SkillToolCallActivity> calls,
+  ) {
     switch (entry) {
-      case TimelineStep(:final step, :final activities):
+      case TimelineStep(:final step, :final activityIds):
         return Column(
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
             _stepRow(step, theme),
-            for (final activity in activities)
-              _activityRow(activity, theme, indent: 20),
+            for (final id in activityIds)
+              if (_resolveActivity(id, calls) case final activity?)
+                _activityRow(activity, theme, indent: 20),
           ],
         );
-      case TimelineStandaloneActivity(:final activity):
+      case TimelineStandaloneActivity(:final activityId):
+        final activity = _resolveActivity(activityId, calls);
+        if (activity == null) return const SizedBox.shrink();
         return _activityRow(activity, theme, indent: 0);
     }
+  }
+
+  /// Looks up the decoded activity for [id] in the tracker's
+  /// `skillToolCalls`. Returns `null` for a dangling id (e.g. after a
+  /// future `MESSAGES_SNAPSHOT` that drops the record while the
+  /// timeline still references it) so the renderer falls through to
+  /// an empty row instead of throwing.
+  SkillToolCallActivity? _resolveActivity(
+    String id,
+    List<SkillToolCallActivity> calls,
+  ) {
+    for (final call in calls) {
+      if (call.messageId == id) return call;
+    }
+    return null;
   }
 
   Widget _stepRow(ExecutionStep step, ThemeData theme) {

--- a/lib/src/modules/room/ui/execution/execution_timeline.dart
+++ b/lib/src/modules/room/ui/execution/execution_timeline.dart
@@ -46,7 +46,7 @@ class _ExecutionTimelineState extends ConsumerState<ExecutionTimeline> {
   final Set<String> _loadingPhaseSources = <String>{};
 
   // Throttle: log each dangling-id at most once per widget lifetime so a
-  // sustained mismatch doesn't flood Sentry on every frame.
+  // sustained mismatch doesn't flood the logging backend on every frame.
   final Set<String> _loggedDanglingIds = <String>{};
 
   // Persistence handle — null during the AwaitingText phase, because
@@ -174,13 +174,13 @@ class _ExecutionTimelineState extends ConsumerState<ExecutionTimeline> {
 
   /// Looks up the decoded activity for [id] in the tracker's
   /// `skillToolCalls`. Returns `null` for a dangling id so the renderer
-  /// falls through to an empty row instead of throwing. The
-  /// tracker only places ids whose activityType the decoder recognises
-  /// (`skill_tool_call` / `skill_tool_result`), so a dangling id today
-  /// indicates a real divergence — a decode failure, a future
-  /// `MESSAGES_SNAPSHOT` that dropped the record, or a producer/consumer
-  /// mismatch. Logged at warning the first time each id fails to resolve
-  /// so the dropped row is observable instead of silent.
+  /// falls through to an empty row instead of throwing. The tracker
+  /// only places ids whose activityType the decoder recognises
+  /// (`skill_tool_call` / `skill_tool_result`), so a dangling id
+  /// indicates a real divergence — a decode failure, a
+  /// `MESSAGES_SNAPSHOT` that dropped the record, or a producer/
+  /// consumer mismatch. Logged at warning the first time each id fails
+  /// to resolve so the dropped row is observable instead of silent.
   SkillToolCallActivity? _resolveActivity(
     String id,
     List<SkillToolCallActivity> calls,

--- a/lib/src/modules/room/ui/execution/execution_timeline.dart
+++ b/lib/src/modules/room/ui/execution/execution_timeline.dart
@@ -4,6 +4,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:signals_flutter/signals_flutter.dart';
 import 'package:soliplex_agent/soliplex_agent.dart' hide State;
+import 'package:soliplex_logging/soliplex_logging.dart';
 
 import '../../compute_display_messages.dart' show loadingMessageId;
 import '../../execution_step.dart';
@@ -12,6 +13,9 @@ import '../../message_expansions.dart';
 import '../../room_providers.dart';
 import '../copy_button.dart';
 import 'timeline_entry.dart';
+
+final Logger _logger =
+    LogManager.instance.getLogger('soliplex_frontend.execution_timeline');
 
 /// Unified execution timeline — single collapsible that nests activities
 /// under their owning step. Activity rows with source (script/code/query
@@ -40,6 +44,10 @@ class _ExecutionTimelineState extends ConsumerState<ExecutionTimeline> {
   // response.
   bool _loadingPhaseTimeline = false;
   final Set<String> _loadingPhaseSources = <String>{};
+
+  // Throttle: log each dangling-id at most once per widget lifetime so a
+  // sustained mismatch doesn't flood Sentry on every frame.
+  final Set<String> _loggedDanglingIds = <String>{};
 
   // Persistence handle — null during the AwaitingText phase, because
   // loadingMessageId is reused across runs and persisting under it would
@@ -165,16 +173,32 @@ class _ExecutionTimelineState extends ConsumerState<ExecutionTimeline> {
   }
 
   /// Looks up the decoded activity for [id] in the tracker's
-  /// `skillToolCalls`. Returns `null` for a dangling id (e.g. after a
-  /// future `MESSAGES_SNAPSHOT` that drops the record while the
-  /// timeline still references it) so the renderer falls through to
-  /// an empty row instead of throwing.
+  /// `skillToolCalls`. Returns `null` for a dangling id so the renderer
+  /// falls through to an empty row instead of throwing. The
+  /// tracker only places ids whose activityType the decoder recognises
+  /// (`skill_tool_call` / `skill_tool_result`), so a dangling id today
+  /// indicates a real divergence — a decode failure, a future
+  /// `MESSAGES_SNAPSHOT` that dropped the record, or a producer/consumer
+  /// mismatch. Logged at warning the first time each id fails to resolve
+  /// so the dropped row is observable instead of silent.
   SkillToolCallActivity? _resolveActivity(
     String id,
     List<SkillToolCallActivity> calls,
   ) {
     for (final call in calls) {
       if (call.messageId == id) return call;
+    }
+    if (_loggedDanglingIds.add(id)) {
+      _logger.warning(
+        'ExecutionTimeline: timeline references an activity id with no '
+        'matching SkillToolCallActivity; row hidden',
+        attributes: {
+          'activityId': id,
+          'roomId': widget.roomId,
+          'messageId': widget.messageId,
+          'resolvableIdCount': calls.length,
+        },
+      );
     }
     return null;
   }

--- a/lib/src/modules/room/ui/execution/execution_timeline.dart
+++ b/lib/src/modules/room/ui/execution/execution_timeline.dart
@@ -223,14 +223,13 @@ class _ExecutionTimelineState extends ConsumerState<ExecutionTimeline> {
                     ),
                   ),
                 ),
-                if (activity.status != null)
-                  Text(
-                    activity.status!,
-                    style: theme.textTheme.bodySmall?.copyWith(
-                      color: theme.colorScheme.outline,
-                      fontSize: 11,
-                    ),
+                Text(
+                  activity.status,
+                  style: theme.textTheme.bodySmall?.copyWith(
+                    color: theme.colorScheme.outline,
+                    fontSize: 11,
                   ),
+                ),
               ],
             ),
           ),
@@ -294,7 +293,7 @@ class _ExecutionTimelineState extends ConsumerState<ExecutionTimeline> {
     }
   }
 
-  Widget _activityStatusIcon(String? status, ThemeData theme) {
+  Widget _activityStatusIcon(String status, ThemeData theme) {
     switch (status) {
       case 'in_progress':
       case 'running':

--- a/lib/src/modules/room/ui/execution/phase_indicator.dart
+++ b/lib/src/modules/room/ui/execution/phase_indicator.dart
@@ -1,9 +1,9 @@
 import 'package:flutter/material.dart';
 import 'package:soliplex_agent/soliplex_agent.dart' hide State;
 
-class ActivityIndicator extends StatelessWidget {
-  const ActivityIndicator({super.key, required this.activity});
-  final ActivityType activity;
+class PhaseIndicator extends StatelessWidget {
+  const PhaseIndicator({super.key, required this.phase});
+  final RunPhase phase;
 
   @override
   Widget build(BuildContext context) {
@@ -29,13 +29,13 @@ class ActivityIndicator extends StatelessWidget {
     );
   }
 
-  String get _label => switch (activity) {
-        ThinkingActivity() => 'Thinking...',
-        ToolCallActivity(:final allToolNames) when allToolNames.length > 1 =>
+  String get _label => switch (phase) {
+        ThinkingPhase() => 'Thinking...',
+        ToolCallPhase(:final allToolNames) when allToolNames.length > 1 =>
           'Calling ${allToolNames.length} tools...',
-        ToolCallActivity(:final allToolNames) =>
+        ToolCallPhase(:final allToolNames) =>
           'Calling ${allToolNames.first}...',
-        RespondingActivity() => 'Responding...',
-        ProcessingActivity() => 'Processing...',
+        RespondingPhase() => 'Responding...',
+        ProcessingPhase() => 'Processing...',
       };
 }

--- a/lib/src/modules/room/ui/execution/phase_indicator.dart
+++ b/lib/src/modules/room/ui/execution/phase_indicator.dart
@@ -31,10 +31,9 @@ class PhaseIndicator extends StatelessWidget {
 
   String get _label => switch (phase) {
         ThinkingPhase() => 'Thinking...',
-        ToolCallPhase(:final allToolNames) when allToolNames.length > 1 =>
-          'Calling ${allToolNames.length} tools...',
-        ToolCallPhase(:final allToolNames) =>
-          'Calling ${allToolNames.first}...',
+        ToolCallPhase(:final toolNames) when toolNames.length > 1 =>
+          'Calling ${toolNames.length} tools...',
+        ToolCallPhase(:final toolNames) => 'Calling ${toolNames.first}...',
         RespondingPhase() => 'Responding...',
         ProcessingPhase() => 'Processing...',
       };

--- a/lib/src/modules/room/ui/execution/timeline_entry.dart
+++ b/lib/src/modules/room/ui/execution/timeline_entry.dart
@@ -1,33 +1,42 @@
 import 'package:flutter/foundation.dart';
-import 'package:soliplex_agent/soliplex_agent.dart';
 
 import '../../execution_step.dart';
 
 /// A single row in the execution timeline. A [TimelineStep] groups a
-/// step with the activities that arrived while it was active; a
+/// step with the activity ids that arrived while it was active; a
 /// [TimelineStandaloneActivity] is an activity with no owning step
 /// (observed before the first step or after all steps completed).
+///
+/// An "activity id" is the AG-UI `ActivityMessage.messageId` of the
+/// referenced record — the same string carried by
+/// `SkillToolCallActivity.messageId` and `ActivityRecord.messageId`.
+/// The renderer resolves each id against the tracker's
+/// `skillToolCalls` computed signal, which is itself derived from
+/// `Conversation.activities`. Storing ids (not decoded objects) keeps
+/// activity content sourced from one place and lets a
+/// replace-in-place result snapshot update the rendered row without
+/// any tracker bookkeeping.
 sealed class TimelineEntry {
   const TimelineEntry();
 }
 
 @immutable
 final class TimelineStep extends TimelineEntry {
-  const TimelineStep({required this.step, this.activities = const []});
+  const TimelineStep({required this.step, this.activityIds = const []});
 
   final ExecutionStep step;
-  final List<SkillToolCallActivity> activities;
+  final List<String> activityIds;
 
   TimelineStep withStep(ExecutionStep step) =>
-      TimelineStep(step: step, activities: activities);
+      TimelineStep(step: step, activityIds: activityIds);
 
-  TimelineStep withActivities(List<SkillToolCallActivity> activities) =>
-      TimelineStep(step: step, activities: activities);
+  TimelineStep withActivities(List<String> activityIds) =>
+      TimelineStep(step: step, activityIds: activityIds);
 }
 
 @immutable
 final class TimelineStandaloneActivity extends TimelineEntry {
-  const TimelineStandaloneActivity({required this.activity});
+  const TimelineStandaloneActivity({required this.activityId});
 
-  final SkillToolCallActivity activity;
+  final String activityId;
 }

--- a/lib/src/modules/room/ui/loading_message_tile.dart
+++ b/lib/src/modules/room/ui/loading_message_tile.dart
@@ -2,7 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:soliplex_agent/soliplex_agent.dart' hide State;
 
 import '../execution_tracker.dart';
-import 'execution/activity_indicator.dart';
+import 'execution/phase_indicator.dart';
 import 'execution/execution_timeline.dart';
 import 'execution/thinking_block.dart';
 
@@ -12,13 +12,13 @@ class LoadingMessageTile extends StatelessWidget {
     required this.roomId,
     required this.messageId,
     this.executionTracker,
-    this.streamingActivity,
+    this.streamingPhase,
   });
 
   final String roomId;
   final String messageId;
   final ExecutionTracker? executionTracker;
-  final ActivityType? streamingActivity;
+  final RunPhase? streamingPhase;
 
   @override
   Widget build(BuildContext context) {
@@ -26,8 +26,7 @@ class LoadingMessageTile extends StatelessWidget {
       return Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
-          if (streamingActivity != null)
-            ActivityIndicator(activity: streamingActivity!),
+          if (streamingPhase != null) PhaseIndicator(phase: streamingPhase!),
           ExecutionTimeline(
             roomId: roomId,
             messageId: messageId,

--- a/lib/src/modules/room/ui/message_tile.dart
+++ b/lib/src/modules/room/ui/message_tile.dart
@@ -25,7 +25,7 @@ class MessageTile extends StatelessWidget {
     this.onDownloadWorkdirFile,
     this.onPreviewWorkdirFile,
     this.executionTracker,
-    this.streamingActivity,
+    this.streamingPhase,
   });
 
   final String roomId;
@@ -40,7 +40,7 @@ class MessageTile extends StatelessWidget {
   final DownloadWorkdirFile? onDownloadWorkdirFile;
   final FetchWorkdirFileBytes? onPreviewWorkdirFile;
   final ExecutionTracker? executionTracker;
-  final ActivityType? streamingActivity;
+  final RunPhase? streamingPhase;
 
   @override
   Widget build(BuildContext context) {
@@ -64,13 +64,13 @@ class MessageTile extends StatelessWidget {
             onDownloadWorkdirFile: onDownloadWorkdirFile,
             onPreviewWorkdirFile: onPreviewWorkdirFile,
             executionTracker: executionTracker,
-            streamingActivity: streamingActivity,
+            streamingPhase: streamingPhase,
           ),
         final NoResponseTile m => NoResponseTileWidget(
             roomId: roomId,
             message: m,
             executionTracker: executionTracker,
-            streamingActivity: streamingActivity,
+            streamingPhase: streamingPhase,
           ),
         final ToolCallMessage m => ToolCallTile(message: m),
         final ErrorMessage m => ErrorMessageTile(message: m),
@@ -79,7 +79,7 @@ class MessageTile extends StatelessWidget {
             roomId: roomId,
             messageId: m.id,
             executionTracker: executionTracker,
-            streamingActivity: streamingActivity,
+            streamingPhase: streamingPhase,
           ),
         final DroppedEventMessage m => DroppedEventMessageTile(message: m),
       },

--- a/lib/src/modules/room/ui/message_timeline.dart
+++ b/lib/src/modules/room/ui/message_timeline.dart
@@ -176,10 +176,10 @@ class _MessageTimelineState extends State<MessageTimeline> {
       _scrollToBottom();
     }
 
-    final streamingActivity = widget.streamingState != null
+    final streamingPhase = widget.streamingState != null
         ? switch (widget.streamingState!) {
-            AwaitingText(:final currentActivity) => currentActivity,
-            TextStreaming(:final currentActivity) => currentActivity,
+            AwaitingText(:final currentPhase) => currentPhase,
+            TextStreaming(:final currentPhase) => currentPhase,
           }
         : null;
 
@@ -225,7 +225,7 @@ class _MessageTimelineState extends State<MessageTimeline> {
                           (message is LoadingMessage
                               ? widget.executionTrackers[awaitingTrackerKey]
                               : null),
-                      streamingActivity: isLastItem ? streamingActivity : null,
+                      streamingPhase: isLastItem ? streamingPhase : null,
                     ),
                   );
                 },

--- a/lib/src/modules/room/ui/no_response_tile_widget.dart
+++ b/lib/src/modules/room/ui/no_response_tile_widget.dart
@@ -2,7 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:soliplex_agent/soliplex_agent.dart';
 
 import '../execution_tracker.dart';
-import 'execution/activity_indicator.dart';
+import 'execution/phase_indicator.dart';
 import 'execution/execution_timeline.dart';
 import 'execution/static_thinking_block.dart';
 import 'execution/thinking_block.dart';
@@ -13,13 +13,13 @@ class NoResponseTileWidget extends StatelessWidget {
     required this.roomId,
     required this.message,
     this.executionTracker,
-    this.streamingActivity,
+    this.streamingPhase,
   });
 
   final String roomId;
   final NoResponseTile message;
   final ExecutionTracker? executionTracker;
-  final ActivityType? streamingActivity;
+  final RunPhase? streamingPhase;
 
   @override
   Widget build(BuildContext context) {
@@ -29,8 +29,7 @@ class NoResponseTileWidget extends StatelessWidget {
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
-        if (streamingActivity != null)
-          ActivityIndicator(activity: streamingActivity!),
+        if (streamingPhase != null) PhaseIndicator(phase: streamingPhase!),
         if (hasTracker)
           ExecutionTimeline(
             roomId: roomId,

--- a/lib/src/modules/room/ui/text_message_tile.dart
+++ b/lib/src/modules/room/ui/text_message_tile.dart
@@ -4,7 +4,7 @@ import 'package:soliplex_agent/soliplex_agent.dart';
 import '../execution_tracker.dart';
 import 'citations_section.dart';
 import 'copy_button.dart';
-import 'execution/activity_indicator.dart';
+import 'execution/phase_indicator.dart';
 import 'execution/execution_timeline.dart';
 import 'execution/static_thinking_block.dart';
 import 'execution/thinking_block.dart';
@@ -26,7 +26,7 @@ class TextMessageTile extends StatelessWidget {
     this.onDownloadWorkdirFile,
     this.onPreviewWorkdirFile,
     this.executionTracker,
-    this.streamingActivity,
+    this.streamingPhase,
   });
 
   final String roomId;
@@ -40,7 +40,7 @@ class TextMessageTile extends StatelessWidget {
   final DownloadWorkdirFile? onDownloadWorkdirFile;
   final FetchWorkdirFileBytes? onPreviewWorkdirFile;
   final ExecutionTracker? executionTracker;
-  final ActivityType? streamingActivity;
+  final RunPhase? streamingPhase;
 
   @override
   Widget build(BuildContext context) {
@@ -52,8 +52,7 @@ class TextMessageTile extends StatelessWidget {
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
-        if (streamingActivity != null)
-          ActivityIndicator(activity: streamingActivity!),
+        if (streamingPhase != null) PhaseIndicator(phase: streamingPhase!),
         if (hasTracker)
           ExecutionTimeline(
             roomId: roomId,

--- a/packages/soliplex_agent/lib/src/orchestration/execution_event.dart
+++ b/packages/soliplex_agent/lib/src/orchestration/execution_event.dart
@@ -304,54 +304,6 @@ class ActivitySnapshot extends ExecutionEvent {
       );
 }
 
-/// A jsonpatch update for a sub-agent activity record.
-///
-/// Bridged from AG-UI `ACTIVITY_DELTA`. The [patch] is an RFC 6902
-/// operation list (e.g. `[{'op': 'replace', 'path': '/status', 'value':
-/// 'done'}]`). Trackers apply the patch to the [ActivitySnapshot]
-/// previously received under the same [messageId]; without a matching
-/// snapshot the delta is a no-op (a logged drop).
-class ActivityDelta extends ExecutionEvent {
-  const ActivityDelta({
-    required this.messageId,
-    required this.activityType,
-    required this.patch,
-    this.timestamp,
-  });
-
-  /// Identifier for the target `ActivityMessage`. Must match a prior
-  /// [ActivitySnapshot]'s `messageId` for the patch to apply.
-  final String messageId;
-
-  /// The kind of activity (e.g. `'skill_tool_call'`).
-  final String activityType;
-
-  /// RFC 6902 operation list. Stored as `List<dynamic>` to match the
-  /// underlying AG-UI event shape; trackers re-validate per-op.
-  final List<dynamic> patch;
-
-  /// Event timestamp in ms since epoch, or `null` if the backend did
-  /// not supply one.
-  final int? timestamp;
-
-  @override
-  bool operator ==(Object other) =>
-      identical(this, other) ||
-      other is ActivityDelta &&
-          messageId == other.messageId &&
-          activityType == other.activityType &&
-          timestamp == other.timestamp &&
-          _deepEq.equals(patch, other.patch);
-
-  @override
-  int get hashCode => Object.hash(
-        messageId,
-        activityType,
-        timestamp,
-        _deepEq.hash(patch),
-      );
-}
-
 /// Extension point for third-party plugins to emit custom events.
 ///
 /// Use this when a `SessionExtension` needs to communicate

--- a/packages/soliplex_agent/lib/src/runtime/agent_session.dart
+++ b/packages/soliplex_agent/lib/src/runtime/agent_session.dart
@@ -123,6 +123,26 @@ class AgentSession implements ToolExecutionContext {
   /// Reactive signal tracking the latest [RunState] from the orchestrator.
   ReadonlySignal<RunState> get runState => _runStateSignal.readonly();
 
+  /// Reactive signal exposing `Conversation.activities` for whichever
+  /// run-state variant currently carries a [Conversation]. Empty list
+  /// while idle or in a terminal state that didn't capture a
+  /// conversation. Used by `ExecutionTracker` to source decoded
+  /// [SkillToolCallActivity] views without maintaining a parallel
+  /// content cache.
+  late final ReadonlySignal<List<ActivityRecord>> conversationActivities =
+      computed(
+    () => switch (runState.value) {
+      RunningState(:final conversation) ||
+      ToolYieldingState(:final conversation) ||
+      CompletedState(:final conversation) =>
+        conversation.activities,
+      FailedState(:final conversation?) ||
+      CancelledState(:final conversation?) =>
+        conversation.activities,
+      _ => const <ActivityRecord>[],
+    },
+  );
+
   /// Reactive signal tracking the agent's `aguiState` map across the
   /// session lifetime.
   ///
@@ -632,21 +652,15 @@ ExecutionEvent? bridgeBaseEvent(BaseEvent event) {
         timestamp: timestamp,
         replace: replace,
       ),
-    ActivityDeltaEvent(
-      :final messageId,
-      :final activityType,
-      :final patch,
-      :final timestamp,
-    ) =>
-      ActivityDelta(
-        messageId: messageId,
-        activityType: activityType,
-        patch: patch,
-        timestamp: timestamp,
-      ),
     StepStartedEvent(:final stepName) => StepProgress(stepName: stepName),
 
     // Events that don't need ExecutionEvent bridging.
+    //
+    // `ActivityDeltaEvent` is intentionally dropped here: the domain
+    // layer (`agui_event_processor._processActivityDelta`) applies the
+    // patch to `Conversation.activities`, and the tracker observes
+    // activities reactively via the resulting signal. Bridging the
+    // delta into an `ExecutionEvent` would duplicate that work.
     RunStartedEvent() ||
     TextMessageStartEvent() ||
     TextMessageEndEvent() ||
@@ -660,6 +674,7 @@ ExecutionEvent? bridgeBaseEvent(BaseEvent event) {
     TextMessageChunkEvent() ||
     ToolCallChunkEvent() ||
     MessagesSnapshotEvent() ||
+    ActivityDeltaEvent() ||
     RawEvent() ||
     CustomEvent() ||
     ReasoningStartEvent() ||

--- a/packages/soliplex_agent/lib/src/runtime/agent_session.dart
+++ b/packages/soliplex_agent/lib/src/runtime/agent_session.dart
@@ -130,18 +130,7 @@ class AgentSession implements ToolExecutionContext {
   /// [SkillToolCallActivity] views without maintaining a parallel
   /// content cache.
   late final ReadonlySignal<List<ActivityRecord>> conversationActivities =
-      computed(
-    () => switch (runState.value) {
-      RunningState(:final conversation) ||
-      ToolYieldingState(:final conversation) ||
-      CompletedState(:final conversation) =>
-        conversation.activities,
-      FailedState(:final conversation?) ||
-      CancelledState(:final conversation?) =>
-        conversation.activities,
-      _ => const <ActivityRecord>[],
-    },
-  );
+      computed(() => conversationActivitiesOf(runState.value));
 
   /// Reactive signal tracking the agent's `aguiState` map across the
   /// session lifetime.
@@ -610,6 +599,23 @@ class AgentSession implements ToolExecutionContext {
       _state == AgentSessionState.failed ||
       _state == AgentSessionState.cancelled;
 }
+
+/// Extracts the activity list carried by [runState], or `const []` for
+/// variants that don't carry a [Conversation]. Backs
+/// [AgentSession.conversationActivities] — exposed as a top-level
+/// function so the switch can be exercised directly without
+/// orchestrator scaffolding.
+List<ActivityRecord> conversationActivitiesOf(RunState runState) =>
+    switch (runState) {
+      RunningState(:final conversation) ||
+      ToolYieldingState(:final conversation) ||
+      CompletedState(:final conversation) =>
+        conversation.activities,
+      FailedState(:final conversation?) ||
+      CancelledState(:final conversation?) =>
+        conversation.activities,
+      _ => const <ActivityRecord>[],
+    };
 
 /// Translates a raw AG-UI [BaseEvent] into the [ExecutionEvent] that
 /// consumers of [AgentSession.lastExecutionEvent] should observe, or

--- a/packages/soliplex_agent/lib/src/runtime/agent_session.dart
+++ b/packages/soliplex_agent/lib/src/runtime/agent_session.dart
@@ -614,7 +614,13 @@ List<ActivityRecord> conversationActivitiesOf(RunState runState) =>
       FailedState(:final conversation?) ||
       CancelledState(:final conversation?) =>
         conversation.activities,
-      _ => const <ActivityRecord>[],
+      // Exhaustive over the remaining sealed variants so adding a new
+      // RunState forces an explicit decision here rather than silently
+      // falling back to an empty list.
+      IdleState() ||
+      FailedState(conversation: null) ||
+      CancelledState(conversation: null) =>
+        const <ActivityRecord>[],
     };
 
 /// Translates a raw AG-UI [BaseEvent] into the [ExecutionEvent] that

--- a/packages/soliplex_agent/test/runtime/agent_session_test.dart
+++ b/packages/soliplex_agent/test/runtime/agent_session_test.dart
@@ -1017,4 +1017,77 @@ void main() {
       expect(steps.first.stepName, equals('planning'));
     });
   });
+
+  group('conversationActivitiesOf', () {
+    const activity = ActivityRecord(
+      messageId: 'rag:call_1',
+      activityType: 'skill_tool_call',
+      content: {'tool_name': 'ask'},
+      timestamp: 1,
+    );
+    final conversation = Conversation.empty(threadId: _key.threadId)
+        .copyWith(activities: const [activity]);
+
+    test('returns the conversation activities for states that carry one', () {
+      final states = <RunState>[
+        RunningState(
+          threadKey: _key,
+          runId: _runId,
+          conversation: conversation,
+          streaming: const AwaitingText(),
+        ),
+        ToolYieldingState(
+          threadKey: _key,
+          runId: _runId,
+          conversation: conversation,
+          pendingToolCalls: const [],
+          toolDepth: 0,
+        ),
+        CompletedState(
+          threadKey: _key,
+          runId: _runId,
+          conversation: conversation,
+        ),
+        FailedState.duringRun(
+          threadKey: _key,
+          runId: _runId,
+          reason: FailureReason.serverError,
+          error: 'boom',
+          conversation: conversation,
+        ),
+        CancelledState.duringRun(
+          threadKey: _key,
+          runId: _runId,
+          conversation: conversation,
+        ),
+      ];
+
+      for (final state in states) {
+        expect(
+          conversationActivitiesOf(state),
+          const [activity],
+          reason: '$state',
+        );
+      }
+    });
+
+    test(
+      'returns an empty list for states without a conversation',
+      () {
+        const states = <RunState>[
+          IdleState(),
+          FailedState.preRun(
+            threadKey: _key,
+            reason: FailureReason.networkLost,
+            error: 'offline',
+          ),
+          CancelledState.preRun(threadKey: _key),
+        ];
+
+        for (final state in states) {
+          expect(conversationActivitiesOf(state), isEmpty, reason: '$state');
+        }
+      },
+    );
+  });
 }

--- a/packages/soliplex_agent/test/runtime/bridge_base_event_test.dart
+++ b/packages/soliplex_agent/test/runtime/bridge_base_event_test.dart
@@ -43,5 +43,21 @@ void main() {
         expect(bridgeBaseEvent(e), const ThinkingEnded(), reason: '$e');
       }
     });
+
+    test('ActivityDeltaEvent returns null', () {
+      // The bridge intentionally drops ActivityDeltaEvent: the domain
+      // layer applies the patch to Conversation.activities, and the
+      // tracker observes activities reactively. Bridging the delta into
+      // an ExecutionEvent would duplicate that work.
+      const event = ActivityDeltaEvent(
+        messageId: 'rag:call_1',
+        activityType: 'skill_tool_call',
+        patch: [
+          {'op': 'replace', 'path': '/status', 'value': 'done'},
+        ],
+      );
+
+      expect(bridgeBaseEvent(event), isNull);
+    });
   });
 }

--- a/packages/soliplex_client/lib/src/application/activity_events.dart
+++ b/packages/soliplex_client/lib/src/application/activity_events.dart
@@ -42,17 +42,42 @@ List<ActivityRecord> _applySnapshot(
   final resolvedTimestamp =
       event.timestamp ?? DateTime.now().millisecondsSinceEpoch;
   final idx = current.indexWhere((a) => a.messageId == event.messageId);
-  final record = ActivityRecord(
-    messageId: event.messageId,
-    activityType: event.activityType,
-    content: event.content,
-    timestamp: resolvedTimestamp,
-  );
   if (idx >= 0) {
     if (!event.replace) return current;
-    return [...current]..[idx] = record;
+    final content = _mergeContentAcrossReplace(current[idx], event);
+    return [...current]..[idx] = ActivityRecord(
+        messageId: event.messageId,
+        activityType: event.activityType,
+        content: content,
+        timestamp: resolvedTimestamp,
+      );
   }
-  return [...current, record];
+  return [
+    ...current,
+    ActivityRecord(
+      messageId: event.messageId,
+      activityType: event.activityType,
+      content: event.content,
+      timestamp: resolvedTimestamp,
+    ),
+  ];
+}
+
+/// Carries the call phase's `args` onto a `skill_tool_result` snapshot
+/// that replaces it in place. Preserves the unified-row UI contract
+/// across AG-UI's call→result replace boundary: the result phase does
+/// not transmit `args`, but the same logical row continues to display
+/// the inputs that produced the result.
+Map<String, dynamic> _mergeContentAcrossReplace(
+  ActivityRecord prior,
+  ActivitySnapshotEvent event,
+) {
+  if (event.activityType != 'skill_tool_result') return event.content;
+  if (prior.activityType != 'skill_tool_call') return event.content;
+  if (event.content.containsKey('args')) return event.content;
+  final priorArgs = prior.content['args'];
+  if (priorArgs == null) return event.content;
+  return {...event.content, 'args': priorArgs};
 }
 
 List<ActivityRecord> _applyDelta(

--- a/packages/soliplex_client/lib/src/application/activity_events.dart
+++ b/packages/soliplex_client/lib/src/application/activity_events.dart
@@ -82,6 +82,15 @@ Map<String, dynamic> _mergeContentAcrossReplace(
   return {...event.content, 'args': priorArgs};
 }
 
+// AG-UI protocol violations on the delta path (missing prior snapshot,
+// activityType mismatch) are dropped silently from the UI's perspective:
+// the existing record stays at its prior state, no drop tile is minted.
+// This is intentionally asymmetric with `_processStateSnapshot`, which
+// throws on bad input and lets the orchestrator append a visible
+// `DroppedEventMessage`. The unified activity row remains usable across
+// a dropped delta (the row simply doesn't advance), so a drop tile
+// would be visual noise. The error-level log is the backend-escalation
+// channel; UI consumers see no change.
 List<ActivityRecord> _applyDelta(
   List<ActivityRecord> current,
   ActivityDeltaEvent event,

--- a/packages/soliplex_client/lib/src/application/activity_events.dart
+++ b/packages/soliplex_client/lib/src/application/activity_events.dart
@@ -1,6 +1,8 @@
 import 'package:ag_ui/ag_ui.dart';
 import 'package:soliplex_client/src/application/json_patch.dart';
 import 'package:soliplex_client/src/domain/activity_record.dart';
+import 'package:soliplex_client/src/domain/skill_tool_call_activity.dart'
+    show kSkillToolCallActivityType, kSkillToolResultActivityType;
 import 'package:soliplex_logging/soliplex_logging.dart';
 
 final Logger _defaultLogger =
@@ -72,8 +74,8 @@ Map<String, dynamic> _mergeContentAcrossReplace(
   ActivityRecord prior,
   ActivitySnapshotEvent event,
 ) {
-  if (event.activityType != 'skill_tool_result') return event.content;
-  if (prior.activityType != 'skill_tool_call') return event.content;
+  if (event.activityType != kSkillToolResultActivityType) return event.content;
+  if (prior.activityType != kSkillToolCallActivityType) return event.content;
   if (event.content.containsKey('args')) return event.content;
   final priorArgs = prior.content['args'];
   if (priorArgs == null) return event.content;

--- a/packages/soliplex_client/lib/src/application/activity_events.dart
+++ b/packages/soliplex_client/lib/src/application/activity_events.dart
@@ -1,0 +1,96 @@
+import 'package:ag_ui/ag_ui.dart';
+import 'package:soliplex_client/src/application/json_patch.dart';
+import 'package:soliplex_client/src/domain/activity_record.dart';
+import 'package:soliplex_logging/soliplex_logging.dart';
+
+final Logger _defaultLogger =
+    LogManager.instance.getLogger('soliplex_client.activity_events');
+
+/// Applies one AG-UI activity event to [current], returning the new
+/// activity list per AG-UI semantics:
+///
+/// - [ActivitySnapshotEvent] with `replace=true` overwrites a record at
+///   the matching `messageId`; with `replace=false` it is ignored when
+///   a record at that id already exists. A snapshot without a prior
+///   entry is appended.
+/// - [ActivityDeltaEvent] applies its RFC 6902 patch to the matching
+///   record's `content`. Drops the patch with an error log when no
+///   prior snapshot exists or when the delta's `activityType` does not
+///   match the existing record.
+/// - Any other event is returned unchanged.
+///
+/// Missing timestamps fall back to `DateTime.now().millisecondsSinceEpoch`
+/// so historical replay produces stable timestamps even when the
+/// backend omits them.
+List<ActivityRecord> applyActivityEvent(
+  List<ActivityRecord> current,
+  BaseEvent event, {
+  Logger? logger,
+}) {
+  final log = logger ?? _defaultLogger;
+  return switch (event) {
+    ActivitySnapshotEvent() => _applySnapshot(current, event),
+    ActivityDeltaEvent() => _applyDelta(current, event, log),
+    _ => current,
+  };
+}
+
+List<ActivityRecord> _applySnapshot(
+  List<ActivityRecord> current,
+  ActivitySnapshotEvent event,
+) {
+  final resolvedTimestamp =
+      event.timestamp ?? DateTime.now().millisecondsSinceEpoch;
+  final idx = current.indexWhere((a) => a.messageId == event.messageId);
+  final record = ActivityRecord(
+    messageId: event.messageId,
+    activityType: event.activityType,
+    content: event.content,
+    timestamp: resolvedTimestamp,
+  );
+  if (idx >= 0) {
+    if (!event.replace) return current;
+    return [...current]..[idx] = record;
+  }
+  return [...current, record];
+}
+
+List<ActivityRecord> _applyDelta(
+  List<ActivityRecord> current,
+  ActivityDeltaEvent event,
+  Logger log,
+) {
+  final idx = current.indexWhere((a) => a.messageId == event.messageId);
+  if (idx < 0) {
+    log.error(
+      'ActivityDeltaEvent dropped: no prior snapshot for messageId '
+      '(AG-UI protocol violation)',
+      attributes: {
+        'messageId': event.messageId,
+        'activityType': event.activityType,
+        'patchOps': event.patch.length,
+      },
+    );
+    return current;
+  }
+  final existing = current[idx];
+  if (existing.activityType != event.activityType) {
+    log.error(
+      'ActivityDeltaEvent dropped: activityType mismatch',
+      attributes: {
+        'messageId': event.messageId,
+        'expected': existing.activityType,
+        'received': event.activityType,
+        'patchOps': event.patch.length,
+      },
+    );
+    return current;
+  }
+  final patched = applyJsonPatch(existing.content, event.patch, logger: log);
+  return [...current]..[idx] = ActivityRecord(
+      messageId: event.messageId,
+      activityType: event.activityType,
+      content: patched,
+      timestamp: event.timestamp ?? existing.timestamp,
+    );
+}

--- a/packages/soliplex_client/lib/src/application/agui_event_processor.dart
+++ b/packages/soliplex_client/lib/src/application/agui_event_processor.dart
@@ -510,10 +510,13 @@ StreamingState _withToolCallPhase(
         latestToolCallId: latestToolCallId,
         timestamp: timestamp,
       ),
+    // Synthesize wall-clock when constructing a fresh ToolCallPhase
+    // and the backend omitted a timestamp. Mirrors the same fallback
+    // applied to ActivityRecord timestamps in `applyActivityEvent`.
     _ => ToolCallPhase.single(
         toolName: toolName,
         latestToolCallId: latestToolCallId,
-        timestamp: timestamp,
+        timestamp: timestamp ?? DateTime.now().millisecondsSinceEpoch,
       ),
   };
 

--- a/packages/soliplex_client/lib/src/application/agui_event_processor.dart
+++ b/packages/soliplex_client/lib/src/application/agui_event_processor.dart
@@ -2,6 +2,7 @@ import 'package:ag_ui/ag_ui.dart';
 import 'package:meta/meta.dart';
 import 'package:soliplex_client/src/application/json_patch.dart';
 import 'package:soliplex_client/src/application/no_response_synthesis.dart';
+import 'package:soliplex_client/src/application/run_phase.dart';
 import 'package:soliplex_client/src/application/streaming_state.dart';
 import 'package:soliplex_client/src/domain/activity_record.dart';
 import 'package:soliplex_client/src/domain/chat_message.dart';
@@ -111,7 +112,7 @@ EventProcessingResult processEvent(
             status: ToolCallStatus.streaming,
           ),
         ),
-        streaming: _withToolCallActivity(
+        streaming: _withToolCallPhase(
           streaming,
           toolCallName,
           latestToolCallId: toolCallId,
@@ -207,13 +208,13 @@ EventProcessingResult _processThinkingStart(
   Conversation conversation,
   StreamingState streaming,
 ) {
-  // Mark thinking as streaming and set activity
+  // Mark thinking as streaming and set phase
   if (streaming is AwaitingText) {
     return EventProcessingResult(
       conversation: conversation,
       streaming: streaming.copyWith(
         isThinkingStreaming: true,
-        currentActivity: const ThinkingActivity(),
+        currentPhase: const ThinkingPhase(),
       ),
     );
   }
@@ -222,7 +223,7 @@ EventProcessingResult _processThinkingStart(
       conversation: conversation,
       streaming: streaming.copyWith(
         isThinkingStreaming: true,
-        currentActivity: const ThinkingActivity(),
+        currentPhase: const ThinkingPhase(),
       ),
     );
   }
@@ -419,7 +420,7 @@ EventProcessingResult _processToolCallEnd(
 ) {
   // Only transition streaming → pending. Guard prevents downgrading tools
   // that are already executing/completed/failed (e.g. duplicate ToolCallEnd).
-  // Activity persists until the next activity starts — don't change it here.
+  // Phase persists until the next phase starts — don't change it here.
   if (!conversation.toolCalls.any((tc) => tc.id == toolCallId)) {
     _logger.warning(
       'ToolCallEndEvent for unknown toolCallId; ignored',
@@ -524,7 +525,7 @@ EventProcessingResult _processActivitySnapshot(
     }
     return EventProcessingResult(
       conversation: updatedConversation,
-      streaming: _withToolCallActivity(
+      streaming: _withToolCallPhase(
         streaming,
         toolName,
         timestamp: resolvedTimestamp,
@@ -542,27 +543,27 @@ EventProcessingResult _processActivitySnapshot(
   );
 }
 
-// Tool call activity helper
+// Tool call phase helper
 
-/// Returns [streaming] with [toolName] accumulated on its [ToolCallActivity].
-StreamingState _withToolCallActivity(
+/// Returns [streaming] with [toolName] accumulated on its [ToolCallPhase].
+StreamingState _withToolCallPhase(
   StreamingState streaming,
   String toolName, {
   String? latestToolCallId,
   int? timestamp,
 }) {
-  final currentActivity = switch (streaming) {
-    AwaitingText(:final currentActivity) => currentActivity,
-    TextStreaming(:final currentActivity) => currentActivity,
+  final currentPhase = switch (streaming) {
+    AwaitingText(:final currentPhase) => currentPhase,
+    TextStreaming(:final currentPhase) => currentPhase,
   };
 
-  final newActivity = switch (currentActivity) {
-    ToolCallActivity() => currentActivity.withToolName(
+  final newPhase = switch (currentPhase) {
+    ToolCallPhase() => currentPhase.withToolName(
         toolName,
         latestToolCallId: latestToolCallId,
         timestamp: timestamp,
       ),
-    _ => ToolCallActivity(
+    _ => ToolCallPhase(
         toolName: toolName,
         latestToolCallId: latestToolCallId,
         timestamp: timestamp,
@@ -570,8 +571,8 @@ StreamingState _withToolCallActivity(
   };
 
   return switch (streaming) {
-    AwaitingText() => streaming.copyWith(currentActivity: newActivity),
-    TextStreaming() => streaming.copyWith(currentActivity: newActivity),
+    AwaitingText() => streaming.copyWith(currentPhase: newPhase),
+    TextStreaming() => streaming.copyWith(currentPhase: newPhase),
   };
 }
 

--- a/packages/soliplex_client/lib/src/application/agui_event_processor.dart
+++ b/packages/soliplex_client/lib/src/application/agui_event_processor.dart
@@ -563,7 +563,7 @@ StreamingState _withToolCallPhase(
         latestToolCallId: latestToolCallId,
         timestamp: timestamp,
       ),
-    _ => ToolCallPhase(
+    _ => ToolCallPhase.single(
         toolName: toolName,
         latestToolCallId: latestToolCallId,
         timestamp: timestamp,

--- a/packages/soliplex_client/lib/src/application/agui_event_processor.dart
+++ b/packages/soliplex_client/lib/src/application/agui_event_processor.dart
@@ -166,10 +166,22 @@ EventProcessingResult processEvent(
     ReasoningEncryptedValueEvent(:final entityId) =>
       _processReasoningEncryptedValue(conversation, streaming, entityId),
 
-    // JSON Patch against an activity's state; requires a per-message
-    // activity store that does not exist in the domain.
-    ActivityDeltaEvent(:final messageId, :final activityType) =>
-      _processActivityDelta(conversation, streaming, messageId, activityType),
+    // JSON Patch against the prior ActivitySnapshot's content,
+    // mirroring how StateDeltaEvent patches aguiState.
+    ActivityDeltaEvent(
+      :final messageId,
+      :final activityType,
+      :final patch,
+      :final timestamp,
+    ) =>
+      _processActivityDelta(
+        conversation,
+        streaming,
+        messageId,
+        activityType,
+        patch,
+        timestamp,
+      ),
 
     // Unhandled event types — pass through unchanged.
     // Explicit cases ensure a compile error if ag_ui adds new event types.
@@ -809,13 +821,36 @@ EventProcessingResult _processActivityDelta(
   StreamingState streaming,
   String messageId,
   String activityType,
+  List<dynamic> patch,
+  int? timestamp,
 ) {
-  _logger.info(
-    'ActivityDeltaEvent dropped: no per-message activity store in the domain',
-    attributes: {'messageId': messageId, 'activityType': activityType},
-  );
+  final idx =
+      conversation.activities.indexWhere((a) => a.messageId == messageId);
+  if (idx < 0) {
+    _logger.warning(
+      'ActivityDeltaEvent dropped: no prior snapshot for messageId',
+      attributes: {
+        'messageId': messageId,
+        'activityType': activityType,
+        'patchOps': patch.length,
+      },
+    );
+    return EventProcessingResult(
+      conversation: conversation,
+      streaming: streaming,
+    );
+  }
+
+  final existing = conversation.activities[idx];
+  final patched = applyJsonPatch(existing.content, patch);
+  final updated = [...conversation.activities]..[idx] = ActivityRecord(
+      messageId: messageId,
+      activityType: activityType,
+      content: patched,
+      timestamp: timestamp ?? existing.timestamp,
+    );
   return EventProcessingResult(
-    conversation: conversation,
+    conversation: conversation.copyWith(activities: updated),
     streaming: streaming,
   );
 }

--- a/packages/soliplex_client/lib/src/application/agui_event_processor.dart
+++ b/packages/soliplex_client/lib/src/application/agui_event_processor.dart
@@ -778,7 +778,8 @@ EventProcessingResult _processStateSnapshot(
   // The cast throws on non-Map snapshots. The per-event-loop wrappers
   // in `RunOrchestrator._onEvent` and `SoliplexApi._replayEventsToHistory`
   // catch the throw and append a `DroppedEventMessage` at the failure
-  // position; surrounding events still process.
+  // position; surrounding events still process. Future callers of
+  // `processEvent` that don't wrap inherit this contract.
   return EventProcessingResult(
     conversation:
         conversation.copyWith(aguiState: snapshot as Map<String, dynamic>),
@@ -791,7 +792,8 @@ EventProcessingResult _processStateDelta(
   StreamingState streaming,
   List<dynamic> delta,
 ) {
-  final newState = applyJsonPatch(conversation.aguiState, delta);
+  final newState =
+      applyJsonPatch(conversation.aguiState, delta, logger: _logger);
   return EventProcessingResult(
     conversation: conversation.copyWith(aguiState: newState),
     streaming: streaming,
@@ -854,7 +856,26 @@ EventProcessingResult _processActivityDelta(
   }
 
   final existing = conversation.activities[idx];
-  final patched = applyJsonPatch(existing.content, patch);
+  if (existing.activityType != activityType) {
+    // Mismatch is a protocol violation: a delta tagged with one
+    // activityType cannot patch a record of another. Reject rather
+    // than half-applying, since the patch ops were authored against
+    // the wrong content shape and would corrupt the record.
+    _logger.error(
+      'ActivityDeltaEvent dropped: activityType mismatch',
+      attributes: {
+        'messageId': messageId,
+        'expected': existing.activityType,
+        'received': activityType,
+        'patchOps': patch.length,
+      },
+    );
+    return EventProcessingResult(
+      conversation: conversation,
+      streaming: streaming,
+    );
+  }
+  final patched = applyJsonPatch(existing.content, patch, logger: _logger);
   final updated = [...conversation.activities]..[idx] = ActivityRecord(
       messageId: messageId,
       activityType: activityType,

--- a/packages/soliplex_client/lib/src/application/agui_event_processor.dart
+++ b/packages/soliplex_client/lib/src/application/agui_event_processor.dart
@@ -476,9 +476,7 @@ EventProcessingResult _processActivitySnapshot(
     );
   }
   // skill_tool_result is recognized but intentionally leaves the
-  // streaming phase untouched (the call phase already set it). Genuinely
-  // unrecognized activityTypes still get persisted into the conversation
-  // and get a breadcrumb so future decoder additions are discoverable.
+  // streaming phase untouched (the call phase already set it).
   if (!kSkillToolCallActivityTypes.contains(event.activityType)) {
     _logger.info(
       'ActivitySnapshotEvent: activityType has no decoder; '
@@ -510,9 +508,13 @@ StreamingState _withToolCallPhase(
         latestToolCallId: latestToolCallId,
         timestamp: timestamp,
       ),
-    // Synthesize wall-clock when constructing a fresh ToolCallPhase
-    // and the backend omitted a timestamp. Mirrors the same fallback
-    // applied to ActivityRecord timestamps in `applyActivityEvent`.
+    // Fresh-construction branch only: synthesize wall-clock when the
+    // backend omitted a timestamp. The accumulation branch above
+    // deliberately inherits the prior phase's timestamp via
+    // `withToolName`'s `timestamp ?? this.timestamp` — re-synthesizing
+    // there would bump the phase's hashCode on every tool event and
+    // break `identical()` short-circuits downstream. Mirrors the
+    // same fresh-record fallback in `applyActivityEvent`.
     _ => ToolCallPhase.single(
         toolName: toolName,
         latestToolCallId: latestToolCallId,

--- a/packages/soliplex_client/lib/src/application/agui_event_processor.dart
+++ b/packages/soliplex_client/lib/src/application/agui_event_processor.dart
@@ -1,10 +1,10 @@
 import 'package:ag_ui/ag_ui.dart';
 import 'package:meta/meta.dart';
+import 'package:soliplex_client/src/application/activity_events.dart';
 import 'package:soliplex_client/src/application/json_patch.dart';
 import 'package:soliplex_client/src/application/no_response_synthesis.dart';
 import 'package:soliplex_client/src/application/run_phase.dart';
 import 'package:soliplex_client/src/application/streaming_state.dart';
-import 'package:soliplex_client/src/domain/activity_record.dart';
 import 'package:soliplex_client/src/domain/chat_message.dart';
 import 'package:soliplex_client/src/domain/conversation.dart';
 import 'package:soliplex_logging/soliplex_logging.dart';
@@ -143,22 +143,8 @@ EventProcessingResult processEvent(
       ),
 
     // Activity snapshot events
-    ActivitySnapshotEvent(
-      :final messageId,
-      :final activityType,
-      :final content,
-      :final replace,
-      :final timestamp,
-    ) =>
-      _processActivitySnapshot(
-        conversation,
-        streaming,
-        messageId,
-        activityType,
-        content,
-        replace,
-        timestamp,
-      ),
+    ActivitySnapshotEvent() =>
+      _processActivitySnapshot(conversation, streaming, event),
 
     // Opaque provider-signed blob anchoring a reasoning message to the LLM
     // provider on follow-up turns. Round-trip preservation requires an
@@ -169,20 +155,8 @@ EventProcessingResult processEvent(
 
     // JSON Patch against the prior ActivitySnapshot's content,
     // mirroring how StateDeltaEvent patches aguiState.
-    ActivityDeltaEvent(
-      :final messageId,
-      :final activityType,
-      :final patch,
-      :final timestamp,
-    ) =>
-      _processActivityDelta(
-        conversation,
-        streaming,
-        messageId,
-        activityType,
-        patch,
-        timestamp,
-      ),
+    ActivityDeltaEvent() =>
+      _processActivityDelta(conversation, streaming, event),
 
     // Unhandled event types — pass through unchanged.
     // Explicit cases ensure a compile error if ag_ui adds new event types.
@@ -466,51 +440,20 @@ EventProcessingResult _processToolCallResult(
 EventProcessingResult _processActivitySnapshot(
   Conversation conversation,
   StreamingState streaming,
-  String messageId,
-  String activityType,
-  Map<String, dynamic> content,
-  bool replace,
-  int? timestamp,
+  ActivitySnapshotEvent event,
 ) {
-  final resolvedTimestamp = timestamp ?? DateTime.now().millisecondsSinceEpoch;
-
-  // Persist the snapshot in conversation.activities per ag-ui spec:
-  //   replace=true  → overwrite the record with the same messageId
-  //   replace=false → ignore if a record with that messageId already exists
-  final existingIndex = conversation.activities.indexWhere(
-    (a) => a.messageId == messageId,
+  final updatedActivities = applyActivityEvent(
+    conversation.activities,
+    event,
+    logger: _logger,
   );
-  final List<ActivityRecord> updatedActivities;
-  if (existingIndex >= 0) {
-    if (replace) {
-      updatedActivities = [...conversation.activities]..[existingIndex] =
-            ActivityRecord(
-          messageId: messageId,
-          activityType: activityType,
-          content: content,
-          timestamp: resolvedTimestamp,
-        );
-    } else {
-      updatedActivities = conversation.activities;
-    }
-  } else {
-    updatedActivities = [
-      ...conversation.activities,
-      ActivityRecord(
-        messageId: messageId,
-        activityType: activityType,
-        content: content,
-        timestamp: resolvedTimestamp,
-      ),
-    ];
-  }
   final updatedConversation =
       identical(updatedActivities, conversation.activities)
           ? conversation
           : conversation.copyWith(activities: updatedActivities);
 
-  if (activityType == 'skill_tool_call') {
-    final toolName = content['tool_name'];
+  if (event.activityType == 'skill_tool_call') {
+    final toolName = event.content['tool_name'];
     // Pass through if tool_name is missing or not a String — the backend
     // contract requires it, so this guards against schema drift.
     if (toolName is! String) {
@@ -528,14 +471,14 @@ EventProcessingResult _processActivitySnapshot(
       streaming: _withToolCallPhase(
         streaming,
         toolName,
-        timestamp: resolvedTimestamp,
+        timestamp: event.timestamp,
       ),
     );
   }
   // Unknown activity types pass through unchanged.
   _logger.info(
     'Unhandled activityType',
-    attributes: {'activityType': activityType},
+    attributes: {'activityType': event.activityType},
   );
   return EventProcessingResult(
     conversation: updatedConversation,
@@ -819,69 +762,26 @@ EventProcessingResult _processReasoningEncryptedValue(
   );
 }
 
-/// Applies an RFC 6902 JSON Patch to the [ActivityRecord] previously
-/// received under [messageId]. Mirrors `_processStateDelta` against
-/// `aguiState`: the patch replaces the activity record's content in
-/// place, preserving the timestamp from the event (or the existing
-/// record's timestamp when the event omits one).
-///
-/// Drops the patch with an error when no prior snapshot exists. The
-/// AG-UI spec requires `ACTIVITY_DELTA` to follow an `ACTIVITY_SNAPSHOT`
-/// for the same `messageId`; a delta without a snapshot is a backend
-/// protocol violation that loses state we'd otherwise represent.
+/// Applies an [ActivityDeltaEvent] to [Conversation.activities],
+/// preserving streaming state. Drop semantics (no prior snapshot,
+/// activityType mismatch, malformed patch ops) live in
+/// [applyActivityEvent]; this wrapper only forwards the result.
 EventProcessingResult _processActivityDelta(
   Conversation conversation,
   StreamingState streaming,
-  String messageId,
-  String activityType,
-  List<dynamic> patch,
-  int? timestamp,
+  ActivityDeltaEvent event,
 ) {
-  final idx =
-      conversation.activities.indexWhere((a) => a.messageId == messageId);
-  if (idx < 0) {
-    _logger.error(
-      'ActivityDeltaEvent dropped: no prior snapshot for messageId '
-      '(AG-UI protocol violation)',
-      attributes: {
-        'messageId': messageId,
-        'activityType': activityType,
-        'patchOps': patch.length,
-      },
-    );
+  final updated = applyActivityEvent(
+    conversation.activities,
+    event,
+    logger: _logger,
+  );
+  if (identical(updated, conversation.activities)) {
     return EventProcessingResult(
       conversation: conversation,
       streaming: streaming,
     );
   }
-
-  final existing = conversation.activities[idx];
-  if (existing.activityType != activityType) {
-    // Mismatch is a protocol violation: a delta tagged with one
-    // activityType cannot patch a record of another. Reject rather
-    // than half-applying, since the patch ops were authored against
-    // the wrong content shape and would corrupt the record.
-    _logger.error(
-      'ActivityDeltaEvent dropped: activityType mismatch',
-      attributes: {
-        'messageId': messageId,
-        'expected': existing.activityType,
-        'received': activityType,
-        'patchOps': patch.length,
-      },
-    );
-    return EventProcessingResult(
-      conversation: conversation,
-      streaming: streaming,
-    );
-  }
-  final patched = applyJsonPatch(existing.content, patch, logger: _logger);
-  final updated = [...conversation.activities]..[idx] = ActivityRecord(
-      messageId: messageId,
-      activityType: activityType,
-      content: patched,
-      timestamp: timestamp ?? existing.timestamp,
-    );
   return EventProcessingResult(
     conversation: conversation.copyWith(activities: updated),
     streaming: streaming,

--- a/packages/soliplex_client/lib/src/application/agui_event_processor.dart
+++ b/packages/soliplex_client/lib/src/application/agui_event_processor.dart
@@ -7,6 +7,8 @@ import 'package:soliplex_client/src/application/run_phase.dart';
 import 'package:soliplex_client/src/application/streaming_state.dart';
 import 'package:soliplex_client/src/domain/chat_message.dart';
 import 'package:soliplex_client/src/domain/conversation.dart';
+import 'package:soliplex_client/src/domain/skill_tool_call_activity.dart'
+    show kSkillToolCallActivityType, kSkillToolCallActivityTypes;
 import 'package:soliplex_logging/soliplex_logging.dart';
 
 final Logger _logger =
@@ -450,7 +452,7 @@ EventProcessingResult _processActivitySnapshot(
           ? conversation
           : conversation.copyWith(activities: updatedActivities);
 
-  if (event.activityType == 'skill_tool_call') {
+  if (event.activityType == kSkillToolCallActivityType) {
     final toolName = event.content['tool_name'];
     // Pass through if tool_name is missing or not a String — the backend
     // contract requires it, so this guards against schema drift.
@@ -473,11 +475,17 @@ EventProcessingResult _processActivitySnapshot(
       ),
     );
   }
-  // Unknown activity types pass through unchanged.
-  _logger.info(
-    'Unhandled activityType',
-    attributes: {'activityType': event.activityType},
-  );
+  // skill_tool_result is recognized but intentionally leaves the
+  // streaming phase untouched (the call phase already set it). Genuinely
+  // unrecognized activityTypes still get persisted into the conversation
+  // and get a breadcrumb so future decoder additions are discoverable.
+  if (!kSkillToolCallActivityTypes.contains(event.activityType)) {
+    _logger.info(
+      'ActivitySnapshotEvent: activityType has no decoder; '
+      'persisted to conversation.activities only',
+      attributes: {'activityType': event.activityType},
+    );
+  }
   return EventProcessingResult(
     conversation: updatedConversation,
     streaming: streaming,

--- a/packages/soliplex_client/lib/src/application/agui_event_processor.dart
+++ b/packages/soliplex_client/lib/src/application/agui_event_processor.dart
@@ -176,13 +176,10 @@ EventProcessingResult processEvent(
   };
 }
 
-// Thinking events - buffer thinking text in AwaitingText state
-
 EventProcessingResult _processThinkingStart(
   Conversation conversation,
   StreamingState streaming,
 ) {
-  // Mark thinking as streaming and set phase
   if (streaming is AwaitingText) {
     return EventProcessingResult(
       conversation: conversation,
@@ -394,7 +391,8 @@ EventProcessingResult _processToolCallEnd(
 ) {
   // Only transition streaming → pending. Guard prevents downgrading tools
   // that are already executing/completed/failed (e.g. duplicate ToolCallEnd).
-  // Phase persists until the next phase starts — don't change it here.
+  // Streaming phase is owned by phase-start handlers; ToolCallEnd leaves
+  // it untouched so the current phase persists until the next one starts.
   if (!conversation.toolCalls.any((tc) => tc.id == toolCallId)) {
     _logger.warning(
       'ToolCallEndEvent for unknown toolCallId; ignored',
@@ -485,8 +483,6 @@ EventProcessingResult _processActivitySnapshot(
     streaming: streaming,
   );
 }
-
-// Tool call phase helper
 
 /// Returns [streaming] with [toolName] accumulated on its [ToolCallPhase].
 StreamingState _withToolCallPhase(
@@ -675,9 +671,9 @@ EventProcessingResult _processRunError(
   };
   if (conversation.status is Idle) {
     // RunErrorEvent without a preceding RunStartedEvent is a backend
-    // protocol violation. Log at error so Sentry sees it, then append
-    // an ErrorMessage so the user gets a visible failure row instead of
-    // a silent status-only flip.
+    // protocol violation. Log at error level for backend escalation,
+    // then append an ErrorMessage so the user gets a visible failure
+    // row instead of a silent status-only flip.
     _logger.error(
       'RunErrorEvent on Idle: pre-run failure (backend protocol violation)',
       attributes: logAttributes,

--- a/packages/soliplex_client/lib/src/application/agui_event_processor.dart
+++ b/packages/soliplex_client/lib/src/application/agui_event_processor.dart
@@ -817,6 +817,16 @@ EventProcessingResult _processReasoningEncryptedValue(
   );
 }
 
+/// Applies an RFC 6902 JSON Patch to the [ActivityRecord] previously
+/// received under [messageId]. Mirrors `_processStateDelta` against
+/// `aguiState`: the patch replaces the activity record's content in
+/// place, preserving the timestamp from the event (or the existing
+/// record's timestamp when the event omits one).
+///
+/// Drops the patch with an error when no prior snapshot exists. The
+/// AG-UI spec requires `ACTIVITY_DELTA` to follow an `ACTIVITY_SNAPSHOT`
+/// for the same `messageId`; a delta without a snapshot is a backend
+/// protocol violation that loses state we'd otherwise represent.
 EventProcessingResult _processActivityDelta(
   Conversation conversation,
   StreamingState streaming,
@@ -828,8 +838,9 @@ EventProcessingResult _processActivityDelta(
   final idx =
       conversation.activities.indexWhere((a) => a.messageId == messageId);
   if (idx < 0) {
-    _logger.warning(
-      'ActivityDeltaEvent dropped: no prior snapshot for messageId',
+    _logger.error(
+      'ActivityDeltaEvent dropped: no prior snapshot for messageId '
+      '(AG-UI protocol violation)',
       attributes: {
         'messageId': messageId,
         'activityType': activityType,

--- a/packages/soliplex_client/lib/src/application/application.dart
+++ b/packages/soliplex_client/lib/src/application/application.dart
@@ -4,5 +4,6 @@ export 'decode_outcome.dart';
 export 'json_patch.dart';
 export 'no_response_synthesis.dart';
 export 'rag_snapshot.dart';
+export 'run_phase.dart';
 export 'state_bus.dart';
 export 'streaming_state.dart';

--- a/packages/soliplex_client/lib/src/application/application.dart
+++ b/packages/soliplex_client/lib/src/application/application.dart
@@ -1,3 +1,4 @@
+export 'activity_events.dart';
 export 'agui_event_processor.dart';
 export 'citation_extractor.dart';
 export 'decode_outcome.dart';

--- a/packages/soliplex_client/lib/src/application/json_patch.dart
+++ b/packages/soliplex_client/lib/src/application/json_patch.dart
@@ -1,30 +1,26 @@
-import 'dart:developer' as developer;
+import 'package:soliplex_logging/soliplex_logging.dart';
+
+final Logger _defaultLogger =
+    LogManager.instance.getLogger('soliplex_client.json_patch');
 
 /// Applies RFC 6902 JSON Patch operations to a state map.
 ///
-/// Returns a new map with the patches applied. Logs and skips invalid
-/// operations rather than failing entirely. Supports add, replace, and remove
-/// operations.
-///
-/// Example:
-/// ```dart
-/// final state = {'count': 0};
-/// final operations = [
-///   {'op': 'replace', 'path': '/count', 'value': 1},
-///   {'op': 'add', 'path': '/name', 'value': 'test'},
-/// ];
-/// final result = applyJsonPatch(state, operations);
-/// // result == {'count': 1, 'name': 'test'}
-/// ```
+/// Returns a new map with the patches applied. Failed operations are
+/// logged via [logger] (defaults to a `LogManager` logger that flows
+/// through configured sinks) and skipped so the rest of the patch can
+/// land. Supports `add`, `replace`, and `remove`; `move`, `copy`, and
+/// `test` are not implemented and produce a warning log.
 Map<String, dynamic> applyJsonPatch(
   Map<String, dynamic> state,
-  List<dynamic> operations,
-) {
+  List<dynamic> operations, {
+  Logger? logger,
+}) {
+  final log = logger ?? _defaultLogger;
   var result = Map<String, dynamic>.from(state);
 
   for (final op in operations) {
     if (op is! Map<String, dynamic>) {
-      _logPatchError('Operation is not a map', op);
+      _logPatchWarning(log, 'Operation is not a map', op);
       continue;
     }
 
@@ -33,19 +29,27 @@ Map<String, dynamic> applyJsonPatch(
     final value = op['value'];
 
     if (operation == null || path == null) {
-      _logPatchError('Missing op or path', op);
+      _logPatchWarning(log, 'Missing op or path', op);
       continue;
     }
 
     try {
       result = switch (operation) {
-        'add' => _setAtPath(result, path, value, insert: true),
-        'replace' => _setAtPath(result, path, value),
+        'add' => _setAtPath(result, path, value, insert: true, logger: log),
+        'replace' => _setAtPath(result, path, value, logger: log),
         'remove' => _removeAtPath(result, path),
-        _ => result, // Skip unsupported operations (move, copy, test)
+        _ => () {
+            _logPatchWarning(log, 'Unsupported operation', op);
+            return result;
+          }(),
       };
-    } catch (e) {
-      _logPatchError('Failed to apply $operation at $path: $e', op);
+    } catch (e, st) {
+      _logPatchWarning(
+        log,
+        'Failed to apply $operation at $path: $e',
+        op,
+        stackTrace: st,
+      );
     }
   }
 
@@ -56,6 +60,7 @@ Map<String, dynamic> _setAtPath(
   Map<String, dynamic> state,
   String path,
   dynamic value, {
+  required Logger logger,
   bool insert = false,
 }) {
   final segments = _parsePath(path);
@@ -106,7 +111,8 @@ Map<String, dynamic> _setAtPath(
         } else if (!insert && index >= 0 && index < current.length) {
           current[index] = value;
         } else {
-          _logPatchError(
+          _logPatchWarning(
+            logger,
             'Array index $index out of bounds '
             '(length=${current.length}) at $path',
             {'op': insert ? 'add' : 'replace', 'path': path, 'value': value},
@@ -182,10 +188,15 @@ List<dynamic> _deepCopyList(List<dynamic> list) {
   }).toList();
 }
 
-void _logPatchError(String message, dynamic operation) {
-  developer.log(
+void _logPatchWarning(
+  Logger logger,
+  String message,
+  dynamic operation, {
+  StackTrace? stackTrace,
+}) {
+  logger.warning(
     '$message: $operation',
-    name: 'JsonPatch',
-    level: 900, // Warning level
+    stackTrace: stackTrace,
+    attributes: {'operation': operation.toString()},
   );
 }

--- a/packages/soliplex_client/lib/src/application/run_phase.dart
+++ b/packages/soliplex_client/lib/src/application/run_phase.dart
@@ -1,0 +1,138 @@
+import 'package:meta/meta.dart';
+
+/// Current phase of a run.
+///
+/// Represents what the backend is currently doing. Persists until the next
+/// phase starts (not when the current one ends), ensuring the UI can
+/// display the phase even for rapid events.
+@immutable
+sealed class RunPhase {
+  const RunPhase();
+}
+
+/// No specific phase - initial state or processing.
+@immutable
+class ProcessingPhase extends RunPhase {
+  /// Creates a processing phase.
+  const ProcessingPhase();
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) || other is ProcessingPhase;
+
+  @override
+  int get hashCode => runtimeType.hashCode;
+
+  @override
+  String toString() => 'ProcessingPhase()';
+}
+
+/// Model is thinking/reasoning.
+@immutable
+class ThinkingPhase extends RunPhase {
+  /// Creates a thinking phase.
+  const ThinkingPhase();
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) || other is ThinkingPhase;
+
+  @override
+  int get hashCode => runtimeType.hashCode;
+
+  @override
+  String toString() => 'ThinkingPhase()';
+}
+
+/// One or more tools are being called.
+@immutable
+class ToolCallPhase extends RunPhase {
+  /// Creates a tool call phase with a single tool name.
+  const ToolCallPhase({
+    required String toolName,
+    this.latestToolCallId,
+    this.timestamp,
+  })  : toolNames = const {},
+        _singleToolName = toolName;
+
+  /// Creates a tool call phase with multiple tool names.
+  const ToolCallPhase.multiple({
+    required this.toolNames,
+    this.latestToolCallId,
+    this.timestamp,
+  }) : _singleToolName = null;
+
+  /// Names of tools being/have been called in this phase.
+  final Set<String> toolNames;
+
+  /// Single tool name for backward compatibility constructor.
+  final String? _singleToolName;
+
+  /// ID of the most recent tool call that updated this phase.
+  final String? latestToolCallId;
+
+  /// Timestamp of the most recent event that updated this phase.
+  final int? timestamp;
+
+  /// All tool names (handles both constructors).
+  Set<String> get allToolNames =>
+      _singleToolName != null ? {_singleToolName} : toolNames;
+
+  /// Creates a new phase with an additional tool name.
+  ToolCallPhase withToolName(
+    String name, {
+    String? latestToolCallId,
+    int? timestamp,
+  }) {
+    return ToolCallPhase.multiple(
+      toolNames: {...allToolNames, name},
+      latestToolCallId: latestToolCallId ?? this.latestToolCallId,
+      timestamp: timestamp ?? this.timestamp,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is ToolCallPhase &&
+          _setEquals(allToolNames, other.allToolNames) &&
+          latestToolCallId == other.latestToolCallId &&
+          timestamp == other.timestamp;
+
+  @override
+  int get hashCode => Object.hash(
+        runtimeType,
+        Object.hashAll(allToolNames.toList()..sort()),
+        latestToolCallId,
+        timestamp,
+      );
+
+  @override
+  String toString() => 'ToolCallPhase(toolNames: $allToolNames, '
+      'latestToolCallId: $latestToolCallId, timestamp: $timestamp)';
+
+  static bool _setEquals(Set<String> a, Set<String> b) {
+    if (a.length != b.length) return false;
+    for (final item in a) {
+      if (!b.contains(item)) return false;
+    }
+    return true;
+  }
+}
+
+/// Model is responding with text.
+@immutable
+class RespondingPhase extends RunPhase {
+  /// Creates a responding phase.
+  const RespondingPhase();
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) || other is RespondingPhase;
+
+  @override
+  int get hashCode => runtimeType.hashCode;
+
+  @override
+  String toString() => 'RespondingPhase()';
+}

--- a/packages/soliplex_client/lib/src/application/run_phase.dart
+++ b/packages/soliplex_client/lib/src/application/run_phase.dart
@@ -47,28 +47,27 @@ class ThinkingPhase extends RunPhase {
 /// One or more tools are being called.
 @immutable
 class ToolCallPhase extends RunPhase {
-  /// Creates a tool call phase with a single tool name.
+  /// Creates a tool call phase covering [toolNames].
   const ToolCallPhase({
-    required String toolName,
-    this.latestToolCallId,
-    this.timestamp,
-  })  : toolNames = const {},
-        _singleToolName = toolName;
-
-  /// Creates a tool call phase with multiple tool names.
-  const ToolCallPhase.multiple({
     required this.toolNames,
     this.latestToolCallId,
     this.timestamp,
-  }) : _singleToolName = null;
+  });
+
+  /// Convenience constructor for a single tool name.
+  factory ToolCallPhase.single({
+    required String toolName,
+    String? latestToolCallId,
+    int? timestamp,
+  }) =>
+      ToolCallPhase(
+        toolNames: {toolName},
+        latestToolCallId: latestToolCallId,
+        timestamp: timestamp,
+      );
 
   /// Names of tools being/have been called in this phase.
   final Set<String> toolNames;
-
-  /// Storage for the single-tool constructor; `null` when constructed
-  /// via [ToolCallPhase.multiple]. Reading the canonical tool-name set
-  /// must go through [allToolNames] to handle both representations.
-  final String? _singleToolName;
 
   /// ID of the most recent tool call that updated this phase.
   final String? latestToolCallId;
@@ -76,18 +75,14 @@ class ToolCallPhase extends RunPhase {
   /// Timestamp of the most recent event that updated this phase.
   final int? timestamp;
 
-  /// All tool names (handles both constructors).
-  Set<String> get allToolNames =>
-      _singleToolName != null ? {_singleToolName} : toolNames;
-
   /// Creates a new phase with an additional tool name.
   ToolCallPhase withToolName(
     String name, {
     String? latestToolCallId,
     int? timestamp,
   }) {
-    return ToolCallPhase.multiple(
-      toolNames: {...allToolNames, name},
+    return ToolCallPhase(
+      toolNames: {...toolNames, name},
       latestToolCallId: latestToolCallId ?? this.latestToolCallId,
       timestamp: timestamp ?? this.timestamp,
     );
@@ -97,20 +92,20 @@ class ToolCallPhase extends RunPhase {
   bool operator ==(Object other) =>
       identical(this, other) ||
       other is ToolCallPhase &&
-          _setEquals(allToolNames, other.allToolNames) &&
+          _setEquals(toolNames, other.toolNames) &&
           latestToolCallId == other.latestToolCallId &&
           timestamp == other.timestamp;
 
   @override
   int get hashCode => Object.hash(
         runtimeType,
-        Object.hashAll(allToolNames.toList()..sort()),
+        Object.hashAll(toolNames.toList()..sort()),
         latestToolCallId,
         timestamp,
       );
 
   @override
-  String toString() => 'ToolCallPhase(toolNames: $allToolNames, '
+  String toString() => 'ToolCallPhase(toolNames: $toolNames, '
       'latestToolCallId: $latestToolCallId, timestamp: $timestamp)';
 
   static bool _setEquals(Set<String> a, Set<String> b) {

--- a/packages/soliplex_client/lib/src/application/run_phase.dart
+++ b/packages/soliplex_client/lib/src/application/run_phase.dart
@@ -65,7 +65,9 @@ class ToolCallPhase extends RunPhase {
   /// Names of tools being/have been called in this phase.
   final Set<String> toolNames;
 
-  /// Single tool name for backward compatibility constructor.
+  /// Storage for the single-tool constructor; `null` when constructed
+  /// via [ToolCallPhase.multiple]. Reading the canonical tool-name set
+  /// must go through [allToolNames] to handle both representations.
   final String? _singleToolName;
 
   /// ID of the most recent tool call that updated this phase.

--- a/packages/soliplex_client/lib/src/application/streaming_state.dart
+++ b/packages/soliplex_client/lib/src/application/streaming_state.dart
@@ -1,142 +1,6 @@
 import 'package:meta/meta.dart';
+import 'package:soliplex_client/src/application/run_phase.dart';
 import 'package:soliplex_client/src/domain/chat_message.dart';
-
-/// Current activity type during a run.
-///
-/// Represents what the backend is currently doing. Persists until the next
-/// activity starts (not when the current one ends), ensuring the UI can
-/// display activity even for rapid events.
-@immutable
-sealed class ActivityType {
-  const ActivityType();
-}
-
-/// No specific activity - initial state or processing.
-@immutable
-class ProcessingActivity extends ActivityType {
-  /// Creates a processing activity.
-  const ProcessingActivity();
-
-  @override
-  bool operator ==(Object other) =>
-      identical(this, other) || other is ProcessingActivity;
-
-  @override
-  int get hashCode => runtimeType.hashCode;
-
-  @override
-  String toString() => 'ProcessingActivity()';
-}
-
-/// Model is thinking/reasoning.
-@immutable
-class ThinkingActivity extends ActivityType {
-  /// Creates a thinking activity.
-  const ThinkingActivity();
-
-  @override
-  bool operator ==(Object other) =>
-      identical(this, other) || other is ThinkingActivity;
-
-  @override
-  int get hashCode => runtimeType.hashCode;
-
-  @override
-  String toString() => 'ThinkingActivity()';
-}
-
-/// One or more tools are being called.
-@immutable
-class ToolCallActivity extends ActivityType {
-  /// Creates a tool call activity with a single tool name.
-  const ToolCallActivity({
-    required String toolName,
-    this.latestToolCallId,
-    this.timestamp,
-  })  : toolNames = const {},
-        _singleToolName = toolName;
-
-  /// Creates a tool call activity with multiple tool names.
-  const ToolCallActivity.multiple({
-    required this.toolNames,
-    this.latestToolCallId,
-    this.timestamp,
-  }) : _singleToolName = null;
-
-  /// Names of tools being/have been called in this phase.
-  final Set<String> toolNames;
-
-  /// Single tool name for backward compatibility constructor.
-  final String? _singleToolName;
-
-  /// ID of the most recent tool call that updated this activity.
-  final String? latestToolCallId;
-
-  /// Timestamp of the most recent event that updated this activity.
-  final int? timestamp;
-
-  /// All tool names (handles both constructors).
-  Set<String> get allToolNames =>
-      _singleToolName != null ? {_singleToolName} : toolNames;
-
-  /// Creates a new activity with an additional tool name.
-  ToolCallActivity withToolName(
-    String name, {
-    String? latestToolCallId,
-    int? timestamp,
-  }) {
-    return ToolCallActivity.multiple(
-      toolNames: {...allToolNames, name},
-      latestToolCallId: latestToolCallId ?? this.latestToolCallId,
-      timestamp: timestamp ?? this.timestamp,
-    );
-  }
-
-  @override
-  bool operator ==(Object other) =>
-      identical(this, other) ||
-      other is ToolCallActivity &&
-          _setEquals(allToolNames, other.allToolNames) &&
-          latestToolCallId == other.latestToolCallId &&
-          timestamp == other.timestamp;
-
-  @override
-  int get hashCode => Object.hash(
-        runtimeType,
-        Object.hashAll(allToolNames.toList()..sort()),
-        latestToolCallId,
-        timestamp,
-      );
-
-  @override
-  String toString() => 'ToolCallActivity(toolNames: $allToolNames, '
-      'latestToolCallId: $latestToolCallId, timestamp: $timestamp)';
-
-  static bool _setEquals(Set<String> a, Set<String> b) {
-    if (a.length != b.length) return false;
-    for (final item in a) {
-      if (!b.contains(item)) return false;
-    }
-    return true;
-  }
-}
-
-/// Model is responding with text.
-@immutable
-class RespondingActivity extends ActivityType {
-  /// Creates a responding activity.
-  const RespondingActivity();
-
-  @override
-  bool operator ==(Object other) =>
-      identical(this, other) || other is RespondingActivity;
-
-  @override
-  int get hashCode => runtimeType.hashCode;
-
-  @override
-  String toString() => 'RespondingActivity()';
-}
 
 /// Ephemeral streaming state (application layer, not domain).
 ///
@@ -167,7 +31,7 @@ class AwaitingText extends StreamingState {
   const AwaitingText({
     this.bufferedThinkingText = '',
     this.isThinkingStreaming = false,
-    this.currentActivity = const ProcessingActivity(),
+    this.currentPhase = const ProcessingPhase(),
   });
 
   /// Thinking text buffered before text message started.
@@ -176,8 +40,8 @@ class AwaitingText extends StreamingState {
   /// Whether thinking is currently streaming.
   final bool isThinkingStreaming;
 
-  /// Current activity type (persists until next activity starts).
-  final ActivityType currentActivity;
+  /// Current run phase (persists until next phase starts).
+  final RunPhase currentPhase;
 
   /// Whether there is any thinking content to display.
   bool get hasThinkingContent =>
@@ -187,12 +51,12 @@ class AwaitingText extends StreamingState {
   AwaitingText copyWith({
     String? bufferedThinkingText,
     bool? isThinkingStreaming,
-    ActivityType? currentActivity,
+    RunPhase? currentPhase,
   }) {
     return AwaitingText(
       bufferedThinkingText: bufferedThinkingText ?? this.bufferedThinkingText,
       isThinkingStreaming: isThinkingStreaming ?? this.isThinkingStreaming,
-      currentActivity: currentActivity ?? this.currentActivity,
+      currentPhase: currentPhase ?? this.currentPhase,
     );
   }
 
@@ -203,21 +67,21 @@ class AwaitingText extends StreamingState {
           runtimeType == other.runtimeType &&
           bufferedThinkingText == other.bufferedThinkingText &&
           isThinkingStreaming == other.isThinkingStreaming &&
-          currentActivity == other.currentActivity;
+          currentPhase == other.currentPhase;
 
   @override
   int get hashCode => Object.hash(
         runtimeType,
         bufferedThinkingText,
         isThinkingStreaming,
-        currentActivity,
+        currentPhase,
       );
 
   @override
   String toString() => 'AwaitingText('
       'thinkingText: ${bufferedThinkingText.length} chars, '
       'isThinkingStreaming: $isThinkingStreaming, '
-      'activity: $currentActivity)';
+      'phase: $currentPhase)';
 }
 
 /// Text is currently streaming.
@@ -231,7 +95,7 @@ class TextStreaming extends StreamingState {
     required this.text,
     this.thinkingText = '',
     this.isThinkingStreaming = false,
-    this.currentActivity = const RespondingActivity(),
+    this.currentPhase = const RespondingPhase(),
   });
 
   /// The ID of the message being streamed.
@@ -249,8 +113,8 @@ class TextStreaming extends StreamingState {
   /// Whether thinking is currently streaming.
   final bool isThinkingStreaming;
 
-  /// Current activity type (persists until next activity starts).
-  final ActivityType currentActivity;
+  /// Current run phase (persists until next phase starts).
+  final RunPhase currentPhase;
 
   /// Creates a copy with the delta appended to text.
   TextStreaming appendDelta(String delta) {
@@ -260,7 +124,7 @@ class TextStreaming extends StreamingState {
       text: text + delta,
       thinkingText: thinkingText,
       isThinkingStreaming: isThinkingStreaming,
-      currentActivity: currentActivity,
+      currentPhase: currentPhase,
     );
   }
 
@@ -272,7 +136,7 @@ class TextStreaming extends StreamingState {
       text: text,
       thinkingText: thinkingText + delta,
       isThinkingStreaming: isThinkingStreaming,
-      currentActivity: currentActivity,
+      currentPhase: currentPhase,
     );
   }
 
@@ -283,7 +147,7 @@ class TextStreaming extends StreamingState {
     String? text,
     String? thinkingText,
     bool? isThinkingStreaming,
-    ActivityType? currentActivity,
+    RunPhase? currentPhase,
   }) {
     return TextStreaming(
       messageId: messageId ?? this.messageId,
@@ -291,7 +155,7 @@ class TextStreaming extends StreamingState {
       text: text ?? this.text,
       thinkingText: thinkingText ?? this.thinkingText,
       isThinkingStreaming: isThinkingStreaming ?? this.isThinkingStreaming,
-      currentActivity: currentActivity ?? this.currentActivity,
+      currentPhase: currentPhase ?? this.currentPhase,
     );
   }
 
@@ -305,7 +169,7 @@ class TextStreaming extends StreamingState {
           text == other.text &&
           thinkingText == other.thinkingText &&
           isThinkingStreaming == other.isThinkingStreaming &&
-          currentActivity == other.currentActivity;
+          currentPhase == other.currentPhase;
 
   @override
   int get hashCode => Object.hash(
@@ -315,12 +179,12 @@ class TextStreaming extends StreamingState {
         text,
         thinkingText,
         isThinkingStreaming,
-        currentActivity,
+        currentPhase,
       );
 
   @override
   String toString() => 'TextStreaming('
       'messageId: $messageId, user: $user, '
       'text: ${text.length} chars, thinkingText: ${thinkingText.length} chars, '
-      'activity: $currentActivity)';
+      'phase: $currentPhase)';
 }

--- a/packages/soliplex_client/lib/src/domain/skill_tool_call_activity.dart
+++ b/packages/soliplex_client/lib/src/domain/skill_tool_call_activity.dart
@@ -10,6 +10,52 @@ import 'package:soliplex_logging/soliplex_logging.dart';
 final Logger _logger =
     LogManager.instance.getLogger('soliplex_client.skill_tool_call_activity');
 
+/// Lifecycle status of a [SkillToolCallActivity].
+///
+/// Decoded from `content['status']` when the backend supplies a value;
+/// otherwise synthesized from the activityType
+/// (`skill_tool_call → inProgress`, `skill_tool_result → done`).
+/// [parse] coalesces alternate string spellings the backend may emit.
+enum SkillToolCallStatus {
+  /// Tool invocation in flight; result not yet available.
+  inProgress('in_progress'),
+
+  /// Tool invocation completed successfully.
+  done('done'),
+
+  /// Tool invocation failed.
+  error('error'),
+
+  /// Status was unrecognised — preserved so the renderer can fall back.
+  unknown('unknown');
+
+  const SkillToolCallStatus(this.label);
+
+  /// Canonical lowercase label for telemetry and UI display.
+  final String label;
+
+  /// Coalesces a backend status token onto the canonical set. Returns
+  /// [unknown] when [raw] is `null` or not one of the recognised
+  /// spellings.
+  static SkillToolCallStatus parse(String? raw) {
+    switch (raw) {
+      case 'in_progress':
+      case 'running':
+        return SkillToolCallStatus.inProgress;
+      case 'done':
+      case 'completed':
+      case 'success':
+        return SkillToolCallStatus.done;
+      case 'failed':
+      case 'error':
+        return SkillToolCallStatus.error;
+      case null:
+      default:
+        return SkillToolCallStatus.unknown;
+    }
+  }
+}
+
 /// Typed view of a `skill_tool_call` or `skill_tool_result` activity
 /// record.
 ///
@@ -20,11 +66,10 @@ final Logger _logger =
 /// view decodes either phase so the timeline row can render
 /// continuously across the transition.
 ///
-/// `status` is sourced from `content['status']` when explicitly
+/// [status] is sourced from `content['status']` when explicitly
 /// provided as a `String`; otherwise it is synthesized from the
-/// activityType (`skill_tool_call → 'in_progress'`, `skill_tool_result
-/// → 'done'`) so the renderer's icon table picks the right glyph
-/// without a backend-side status field.
+/// activityType (`skill_tool_call → inProgress`, `skill_tool_result
+/// → done`) so the renderer can switch exhaustively on the enum.
 ///
 /// Construct via [SkillToolCallActivity.fromRecord], which returns
 /// `null` when the record is not a well-formed skill tool activity.
@@ -78,7 +123,7 @@ class SkillToolCallActivity {
       toolName: toolName,
       args: args,
       result: null,
-      status: _readStatus(record) ?? 'in_progress',
+      status: _decodeStatus(record, fallback: SkillToolCallStatus.inProgress),
       timestamp: record.timestamp,
     );
   }
@@ -108,7 +153,7 @@ class SkillToolCallActivity {
       toolName: toolName,
       args: const {},
       result: result,
-      status: _readStatus(record) ?? 'done',
+      status: _decodeStatus(record, fallback: SkillToolCallStatus.done),
       timestamp: record.timestamp,
     );
   }
@@ -152,9 +197,13 @@ class SkillToolCallActivity {
     }
   }
 
-  static String? _readStatus(ActivityRecord record) {
+  static SkillToolCallStatus _decodeStatus(
+    ActivityRecord record, {
+    required SkillToolCallStatus fallback,
+  }) {
     final raw = record.content['status'];
-    return raw is String ? raw : null;
+    if (raw is! String) return fallback;
+    return SkillToolCallStatus.parse(raw);
   }
 
   /// Identifier for the target `ActivityMessage`.
@@ -173,11 +222,10 @@ class SkillToolCallActivity {
   /// did not include a `result` field.
   final String? result;
 
-  /// Status token. Always `'in_progress'` for a `skill_tool_call`
-  /// record and `'done'` for a `skill_tool_result` record unless the
-  /// backend supplies an explicit `content['status']` String, in
-  /// which case that value passes through.
-  final String status;
+  /// Lifecycle status. Synthesized from the activityType when
+  /// `content['status']` is absent or unparseable; otherwise reflects
+  /// the backend's value parsed through [SkillToolCallStatus.parse].
+  final SkillToolCallStatus status;
 
   /// Event timestamp for the underlying snapshot.
   final int timestamp;

--- a/packages/soliplex_client/lib/src/domain/skill_tool_call_activity.dart
+++ b/packages/soliplex_client/lib/src/domain/skill_tool_call_activity.dart
@@ -141,6 +141,9 @@ class SkillToolCallActivity {
     final toolName = _readToolName(record);
     if (toolName == null) return null;
 
+    final args = _decodeArgs(record);
+    if (args == null) return null;
+
     final rawResult = record.content['result'];
     final String? result;
     if (rawResult == null || rawResult is String) {
@@ -160,7 +163,7 @@ class SkillToolCallActivity {
     return SkillToolCallActivity(
       messageId: record.messageId,
       toolName: toolName,
-      args: const {},
+      args: args,
       result: result,
       status: _decodeStatus(record, fallback: SkillToolCallStatus.done),
       timestamp: record.timestamp,
@@ -221,9 +224,10 @@ class SkillToolCallActivity {
   /// Tool being invoked (e.g. `"ask"`).
   final String toolName;
 
-  /// Decoded arguments for the tool call. Empty when the record is a
-  /// `skill_tool_result` (the result snapshot does not carry args per
-  /// the AG-UI replace-in-place contract) or when args are absent.
+  /// Decoded arguments for the tool call. The result-phase record
+  /// carries args forward from the call phase so the unified row keeps
+  /// rendering the inputs across AG-UI's replace boundary; empty when
+  /// args were absent on both phases.
   final Map<String, dynamic> args;
 
   /// Decoded result from a `skill_tool_result` record. `null` while the

--- a/packages/soliplex_client/lib/src/domain/skill_tool_call_activity.dart
+++ b/packages/soliplex_client/lib/src/domain/skill_tool_call_activity.dart
@@ -10,6 +10,15 @@ import 'package:soliplex_logging/soliplex_logging.dart';
 final Logger _logger =
     LogManager.instance.getLogger('soliplex_client.skill_tool_call_activity');
 
+/// `activityType` strings that [SkillToolCallActivity.fromRecord]
+/// recognises. Consumers that filter by activityType (e.g. the
+/// execution tracker's timeline placement) reference this set so the
+/// recognised types stay in lockstep with the decoder.
+const Set<String> kSkillToolCallActivityTypes = {
+  'skill_tool_call',
+  'skill_tool_result',
+};
+
 /// Lifecycle status of a [SkillToolCallActivity].
 ///
 /// Decoded from `content['status']` when the backend supplies a value;

--- a/packages/soliplex_client/lib/src/domain/skill_tool_call_activity.dart
+++ b/packages/soliplex_client/lib/src/domain/skill_tool_call_activity.dart
@@ -10,13 +10,21 @@ import 'package:soliplex_logging/soliplex_logging.dart';
 final Logger _logger =
     LogManager.instance.getLogger('soliplex_client.skill_tool_call_activity');
 
+/// `activityType` string identifying the call phase of a skill tool
+/// invocation.
+const String kSkillToolCallActivityType = 'skill_tool_call';
+
+/// `activityType` string identifying the result phase of a skill tool
+/// invocation.
+const String kSkillToolResultActivityType = 'skill_tool_result';
+
 /// `activityType` strings that [SkillToolCallActivity.fromRecord]
 /// recognises. Consumers that filter by activityType (e.g. the
 /// execution tracker's timeline placement) reference this set so the
 /// recognised types stay in lockstep with the decoder.
 const Set<String> kSkillToolCallActivityTypes = {
-  'skill_tool_call',
-  'skill_tool_result',
+  kSkillToolCallActivityType,
+  kSkillToolResultActivityType,
 };
 
 /// Lifecycle status of a [SkillToolCallActivity].
@@ -111,9 +119,9 @@ class SkillToolCallActivity {
   /// matching the processor's posture in `_processActivitySnapshot`.
   static SkillToolCallActivity? fromRecord(ActivityRecord record) {
     switch (record.activityType) {
-      case 'skill_tool_call':
+      case kSkillToolCallActivityType:
         return _decodeCall(record);
-      case 'skill_tool_result':
+      case kSkillToolResultActivityType:
         return _decodeResult(record);
       default:
         return null;
@@ -190,7 +198,6 @@ class SkillToolCallActivity {
     final rawArgs = record.content['args'];
     switch (rawArgs) {
       case null:
-        return const {};
       case final String s when s.isEmpty:
         return const {};
       case final String s:

--- a/packages/soliplex_client/lib/src/domain/skill_tool_call_activity.dart
+++ b/packages/soliplex_client/lib/src/domain/skill_tool_call_activity.dart
@@ -7,17 +7,26 @@ import 'package:meta/meta.dart';
 import 'package:soliplex_client/src/domain/activity_record.dart';
 import 'package:soliplex_client/src/domain/conversation.dart';
 
-/// Typed view of a `skill_tool_call` activity record.
+/// Typed view of a `skill_tool_call` or `skill_tool_result` activity
+/// record.
 ///
-/// Decodes the raw [ActivityRecord.content] bag for the
-/// `skill_tool_call` [ActivityRecord.activityType]. The `args` field in
-/// the raw content is a double-encoded JSON string per the backend
-/// contract; this class decodes it into a plain map.
+/// One logical tool invocation arrives as two snapshots sharing a
+/// `messageId`: the call phase (`activity_type='skill_tool_call'`,
+/// carrying `args`) and the result phase (`activity_type=
+/// 'skill_tool_result'`, carrying `result`, with `replace=true`). This
+/// view decodes either phase so the timeline row can render
+/// continuously across the transition.
+///
+/// `status` is sourced from `content['status']` when explicitly
+/// provided as a `String`; otherwise it is synthesized from the
+/// activityType (`skill_tool_call → 'in_progress'`, `skill_tool_result
+/// → 'done'`) so the renderer's icon table picks the right glyph
+/// without a backend-side status field.
 ///
 /// Construct via [SkillToolCallActivity.fromRecord], which returns
-/// `null` when the record is not a well-formed skill_tool_call. The
-/// underlying [ActivityRecord] stays authoritative — this is a read
-/// view for UI consumers, not a replacement.
+/// `null` when the record is not a well-formed skill tool activity.
+/// The underlying [ActivityRecord] stays authoritative — this is a
+/// read view for UI consumers, not a replacement.
 @immutable
 class SkillToolCallActivity {
   /// Creates a [SkillToolCallActivity]. Prefer [fromRecord].
@@ -25,51 +34,96 @@ class SkillToolCallActivity {
     required this.messageId,
     required this.toolName,
     required this.args,
+    required this.result,
     required this.status,
     required this.timestamp,
   });
 
   /// Attempts to decode [record] as a [SkillToolCallActivity].
   ///
-  /// Returns `null` when:
-  /// - [ActivityRecord.activityType] is not `"skill_tool_call"`
-  /// - `content['tool_name']` is missing or not a [String]
-  /// - `content['args']` is present but not decodable as a JSON object
+  /// Dispatches on [ActivityRecord.activityType]:
+  /// - `skill_tool_call` → decodes args, synthesizes status
+  ///   `'in_progress'` when [ActivityRecord.content] does not carry
+  ///   an explicit `status` String.
+  /// - `skill_tool_result` → decodes the optional `result` String,
+  ///   synthesizes status `'done'` when no explicit `status` is set.
+  /// - any other activityType → returns `null`.
   ///
-  /// Missing `args` yields an empty map; missing `status` yields `null`.
-  /// Schema drift is logged (warning) rather than thrown, matching the
-  /// processor's posture in `_processActivitySnapshot`.
+  /// Both phases require `content['tool_name']` to be a `String`.
+  /// Schema drift is logged (level 900) rather than thrown, matching
+  /// the processor's posture in `_processActivitySnapshot`.
   static SkillToolCallActivity? fromRecord(ActivityRecord record) {
-    if (record.activityType != 'skill_tool_call') {
-      return null;
+    switch (record.activityType) {
+      case 'skill_tool_call':
+        return _decodeCall(record);
+      case 'skill_tool_result':
+        return _decodeResult(record);
+      default:
+        return null;
     }
-    final toolName = record.content['tool_name'];
-    if (toolName is! String) {
-      developer.log(
-        'SkillToolCallActivity.fromRecord: missing or invalid tool_name '
-        '(runtimeType=${toolName.runtimeType}) for messageId '
-        '${record.messageId}',
-        name: 'soliplex_client.skill_tool_call_activity',
-        level: 900,
-      );
-      return null;
-    }
+  }
 
+  static SkillToolCallActivity? _decodeCall(ActivityRecord record) {
+    final toolName = _readToolName(record);
+    if (toolName == null) return null;
+
+    final args = _decodeArgs(record);
+    if (args == null) return null;
+
+    return SkillToolCallActivity(
+      messageId: record.messageId,
+      toolName: toolName,
+      args: args,
+      result: null,
+      status: _readStatus(record) ?? 'in_progress',
+      timestamp: record.timestamp,
+    );
+  }
+
+  static SkillToolCallActivity? _decodeResult(ActivityRecord record) {
+    final toolName = _readToolName(record);
+    if (toolName == null) return null;
+
+    final rawResult = record.content['result'];
+    final result = rawResult is String ? rawResult : null;
+
+    return SkillToolCallActivity(
+      messageId: record.messageId,
+      toolName: toolName,
+      args: const {},
+      result: result,
+      status: _readStatus(record) ?? 'done',
+      timestamp: record.timestamp,
+    );
+  }
+
+  static String? _readToolName(ActivityRecord record) {
+    final toolName = record.content['tool_name'];
+    if (toolName is String) return toolName;
+    developer.log(
+      'SkillToolCallActivity.fromRecord: missing or invalid tool_name '
+      '(runtimeType=${toolName.runtimeType}) for messageId '
+      '${record.messageId}',
+      name: 'soliplex_client.skill_tool_call_activity',
+      level: 900,
+    );
+    return null;
+  }
+
+  /// Returns `null` when the args field is structurally invalid (the
+  /// decoder should abandon the record). Returns an empty map when
+  /// args are simply absent.
+  static Map<String, dynamic>? _decodeArgs(ActivityRecord record) {
     final rawArgs = record.content['args'];
-    final Map<String, dynamic> decodedArgs;
     switch (rawArgs) {
       case null:
-        decodedArgs = const {};
+        return const {};
       case final String s when s.isEmpty:
-        decodedArgs = const {};
+        return const {};
       case final String s:
-        final parsed = _tryDecodeJsonObject(s, record.messageId);
-        if (parsed == null) {
-          return null;
-        }
-        decodedArgs = parsed;
+        return _tryDecodeJsonObject(s, record.messageId);
       case final Map<String, dynamic> m:
-        decodedArgs = m;
+        return m;
       default:
         developer.log(
           'SkillToolCallActivity.fromRecord: unexpected args '
@@ -80,17 +134,11 @@ class SkillToolCallActivity {
         );
         return null;
     }
+  }
 
-    final rawStatus = record.content['status'];
-    final status = rawStatus is String ? rawStatus : null;
-
-    return SkillToolCallActivity(
-      messageId: record.messageId,
-      toolName: toolName,
-      args: decodedArgs,
-      status: status,
-      timestamp: record.timestamp,
-    );
+  static String? _readStatus(ActivityRecord record) {
+    final raw = record.content['status'];
+    return raw is String ? raw : null;
   }
 
   /// Identifier for the target `ActivityMessage`.
@@ -99,11 +147,21 @@ class SkillToolCallActivity {
   /// Tool being invoked (e.g. `"ask"`).
   final String toolName;
 
-  /// Decoded arguments for the tool call. Empty when absent.
+  /// Decoded arguments for the tool call. Empty when the record is a
+  /// `skill_tool_result` (the result snapshot does not carry args per
+  /// the AG-UI replace-in-place contract) or when args are absent.
   final Map<String, dynamic> args;
 
-  /// Optional status token (e.g. `"in_progress"`, `"done"`).
-  final String? status;
+  /// Decoded result from a `skill_tool_result` record. `null` while the
+  /// record is still a `skill_tool_call`, or when the result snapshot
+  /// did not include a `result` field.
+  final String? result;
+
+  /// Status token. Always `'in_progress'` for a `skill_tool_call`
+  /// record and `'done'` for a `skill_tool_result` record unless the
+  /// backend supplies an explicit `content['status']` String, in
+  /// which case that value passes through.
+  final String status;
 
   /// Event timestamp for the underlying snapshot.
   final int timestamp;
@@ -115,6 +173,7 @@ class SkillToolCallActivity {
     const mapEquals = DeepCollectionEquality();
     return messageId == other.messageId &&
         toolName == other.toolName &&
+        result == other.result &&
         status == other.status &&
         timestamp == other.timestamp &&
         mapEquals.equals(args, other.args);
@@ -124,6 +183,7 @@ class SkillToolCallActivity {
   int get hashCode => Object.hash(
         messageId,
         toolName,
+        result,
         status,
         timestamp,
         const DeepCollectionEquality().hash(args),
@@ -161,8 +221,8 @@ Map<String, dynamic>? _tryDecodeJsonObject(String raw, String messageId) {
 
 /// Typed accessors for [Conversation.activities].
 extension ConversationSkillToolCalls on Conversation {
-  /// All `skill_tool_call` activities in [activities], decoded to the
-  /// typed view. Malformed records are skipped (see
+  /// All skill tool activities in [activities], decoded to the typed
+  /// view. Malformed records are skipped (see
   /// [SkillToolCallActivity.fromRecord]).
   List<SkillToolCallActivity> get skillToolCalls => [
         for (final record in activities)

--- a/packages/soliplex_client/lib/src/domain/skill_tool_call_activity.dart
+++ b/packages/soliplex_client/lib/src/domain/skill_tool_call_activity.dart
@@ -10,12 +10,12 @@ import 'package:soliplex_logging/soliplex_logging.dart';
 final Logger _logger =
     LogManager.instance.getLogger('soliplex_client.skill_tool_call_activity');
 
-/// `activityType` string identifying the call phase of a skill tool
-/// invocation.
+/// Backend wire string for the call phase. Coordinate any change with
+/// the backend before renaming.
 const String kSkillToolCallActivityType = 'skill_tool_call';
 
-/// `activityType` string identifying the result phase of a skill tool
-/// invocation.
+/// Backend wire string for the result phase. Coordinate any change
+/// with the backend before renaming.
 const String kSkillToolResultActivityType = 'skill_tool_result';
 
 /// `activityType` strings that [SkillToolCallActivity.fromRecord]

--- a/packages/soliplex_client/lib/src/domain/skill_tool_call_activity.dart
+++ b/packages/soliplex_client/lib/src/domain/skill_tool_call_activity.dart
@@ -107,8 +107,8 @@ class SkillToolCallActivity {
   /// - any other activityType → returns `null`.
   ///
   /// Both phases require `content['tool_name']` to be a `String`.
-  /// Schema drift is logged (level 900) rather than thrown, matching
-  /// the processor's posture in `_processActivitySnapshot`.
+  /// Schema drift is logged at warning level rather than thrown,
+  /// matching the processor's posture in `_processActivitySnapshot`.
   static SkillToolCallActivity? fromRecord(ActivityRecord record) {
     switch (record.activityType) {
       case 'skill_tool_call':

--- a/packages/soliplex_client/lib/src/domain/skill_tool_call_activity.dart
+++ b/packages/soliplex_client/lib/src/domain/skill_tool_call_activity.dart
@@ -1,11 +1,14 @@
 import 'dart:convert';
-import 'dart:developer' as developer;
 
 import 'package:collection/collection.dart';
 import 'package:meta/meta.dart';
 
 import 'package:soliplex_client/src/domain/activity_record.dart';
 import 'package:soliplex_client/src/domain/conversation.dart';
+import 'package:soliplex_logging/soliplex_logging.dart';
+
+final Logger _logger =
+    LogManager.instance.getLogger('soliplex_client.skill_tool_call_activity');
 
 /// Typed view of a `skill_tool_call` or `skill_tool_result` activity
 /// record.
@@ -85,7 +88,20 @@ class SkillToolCallActivity {
     if (toolName == null) return null;
 
     final rawResult = record.content['result'];
-    final result = rawResult is String ? rawResult : null;
+    final String? result;
+    if (rawResult == null || rawResult is String) {
+      result = rawResult as String?;
+    } else {
+      _logger.warning(
+        'SkillToolCallActivity: skill_tool_result `result` field has '
+        'unexpected type; coerced to null',
+        attributes: {
+          'messageId': record.messageId,
+          'resultType': rawResult.runtimeType.toString(),
+        },
+      );
+      result = null;
+    }
 
     return SkillToolCallActivity(
       messageId: record.messageId,
@@ -100,12 +116,12 @@ class SkillToolCallActivity {
   static String? _readToolName(ActivityRecord record) {
     final toolName = record.content['tool_name'];
     if (toolName is String) return toolName;
-    developer.log(
-      'SkillToolCallActivity.fromRecord: missing or invalid tool_name '
-      '(runtimeType=${toolName.runtimeType}) for messageId '
-      '${record.messageId}',
-      name: 'soliplex_client.skill_tool_call_activity',
-      level: 900,
+    _logger.warning(
+      'SkillToolCallActivity.fromRecord: missing or invalid tool_name',
+      attributes: {
+        'messageId': record.messageId,
+        'toolNameType': toolName.runtimeType.toString(),
+      },
     );
     return null;
   }
@@ -125,12 +141,12 @@ class SkillToolCallActivity {
       case final Map<String, dynamic> m:
         return m;
       default:
-        developer.log(
-          'SkillToolCallActivity.fromRecord: unexpected args '
-          'runtimeType=${rawArgs.runtimeType} for messageId '
-          '${record.messageId}',
-          name: 'soliplex_client.skill_tool_call_activity',
-          level: 900,
+        _logger.warning(
+          'SkillToolCallActivity.fromRecord: unexpected args runtimeType',
+          attributes: {
+            'messageId': record.messageId,
+            'argsType': rawArgs.runtimeType.toString(),
+          },
         );
         return null;
     }
@@ -200,20 +216,18 @@ Map<String, dynamic>? _tryDecodeJsonObject(String raw, String messageId) {
     if (decoded is Map<String, dynamic>) {
       return decoded;
     }
-    developer.log(
-      'SkillToolCallActivity.fromRecord: args decoded to '
-      '${decoded.runtimeType}, not a JSON object, for messageId '
-      '$messageId',
-      name: 'soliplex_client.skill_tool_call_activity',
-      level: 900,
+    _logger.warning(
+      'SkillToolCallActivity.fromRecord: args decoded to non-object JSON',
+      attributes: {
+        'messageId': messageId,
+        'decodedType': decoded.runtimeType.toString(),
+      },
     );
     return null;
   } on FormatException catch (e) {
-    developer.log(
-      'SkillToolCallActivity.fromRecord: args JSON parse failed for '
-      'messageId $messageId: $e',
-      name: 'soliplex_client.skill_tool_call_activity',
-      level: 900,
+    _logger.warning(
+      'SkillToolCallActivity.fromRecord: args JSON parse failed',
+      attributes: {'messageId': messageId, 'error': e.toString()},
     );
     return null;
   }

--- a/packages/soliplex_client/test/application/activity_events_test.dart
+++ b/packages/soliplex_client/test/application/activity_events_test.dart
@@ -43,6 +43,68 @@ void main() {
       expect(result.single.timestamp, 200);
     });
 
+    test('skill_tool_result snapshot merges args from prior call record', () {
+      // Unified-row UI contract: AG-UI replaces the call snapshot with a
+      // result snapshot at the same messageId. The result phase does not
+      // carry args, so storage drops them unless the application layer
+      // bridges across the replace boundary.
+      const call = ActivityRecord(
+        messageId: 'rag:call_1',
+        activityType: 'skill_tool_call',
+        content: {
+          'tool_name': 'ask',
+          'args': '{"q":"hi"}',
+        },
+        timestamp: 100,
+      );
+      const result = ActivitySnapshotEvent(
+        messageId: 'rag:call_1',
+        activityType: 'skill_tool_result',
+        content: {
+          'tool_name': 'ask',
+          'result': 'answer',
+        },
+        timestamp: 200,
+      );
+
+      final after = applyActivityEvent([call], result, logger: logger);
+
+      expect(after, hasLength(1));
+      expect(after.single.activityType, 'skill_tool_result');
+      expect(after.single.content['result'], 'answer');
+      expect(after.single.content['args'], '{"q":"hi"}');
+    });
+
+    test(
+        'skill_tool_result snapshot does not overwrite args carried by '
+        'the event', () {
+      // Defensive: if a future backend ships args on the result phase,
+      // its value wins over the call-phase carry-over.
+      const call = ActivityRecord(
+        messageId: 'rag:call_1',
+        activityType: 'skill_tool_call',
+        content: {
+          'tool_name': 'ask',
+          'args': '{"q":"old"}',
+        },
+        timestamp: 100,
+      );
+      const result = ActivitySnapshotEvent(
+        messageId: 'rag:call_1',
+        activityType: 'skill_tool_result',
+        content: {
+          'tool_name': 'ask',
+          'args': '{"q":"new"}',
+          'result': 'answer',
+        },
+        timestamp: 200,
+      );
+
+      final after = applyActivityEvent([call], result, logger: logger);
+
+      expect(after.single.content['args'], '{"q":"new"}');
+    });
+
     test('preserves prior record when replace=false and id collides', () {
       // Live and historical paths must agree on AG-UI's replace=false
       // semantic: a duplicate-id snapshot without replace is ignored.

--- a/packages/soliplex_client/test/application/activity_events_test.dart
+++ b/packages/soliplex_client/test/application/activity_events_test.dart
@@ -2,6 +2,19 @@ import 'package:soliplex_client/soliplex_client.dart';
 import 'package:soliplex_logging/soliplex_logging.dart';
 import 'package:test/test.dart';
 
+class _RecordingSink implements LogSink {
+  final List<LogRecord> records = [];
+
+  @override
+  void write(LogRecord record) => records.add(record);
+
+  @override
+  Future<void> flush() async {}
+
+  @override
+  Future<void> close() async {}
+}
+
 void main() {
   final logger = LogManager.instance.getLogger('test.activity_events');
 
@@ -189,6 +202,60 @@ void main() {
       expect(result.single.activityType, 'skill_tool_call');
       expect(result.single.content['status'], 'in_progress');
       expect(result.single.timestamp, 100);
+    });
+
+    test('logs error with structured attrs when no prior snapshot exists', () {
+      // Backend escalation contract: every delta-drop branch must log at
+      // error level with messageId / activityType / patchOps attributes
+      // so backend triage can reconstruct the dropped patch.
+      final sink = _RecordingSink();
+      LogManager.instance.addSink(sink);
+      addTearDown(() => LogManager.instance.removeSink(sink));
+
+      const event = ActivityDeltaEvent(
+        messageId: 'rag:orphan',
+        activityType: 'skill_tool_call',
+        patch: [
+          {'op': 'replace', 'path': '/status', 'value': 'done'},
+          {'op': 'add', 'path': '/progress', 'value': 0.5},
+        ],
+      );
+
+      applyActivityEvent(const [], event, logger: logger);
+
+      final error = sink.records.singleWhere((r) => r.level == LogLevel.error);
+      expect(error.attributes['messageId'], 'rag:orphan');
+      expect(error.attributes['activityType'], 'skill_tool_call');
+      expect(error.attributes['patchOps'], 2);
+    });
+
+    test('logs error with structured attrs when activityType disagrees', () {
+      final sink = _RecordingSink();
+      LogManager.instance.addSink(sink);
+      addTearDown(() => LogManager.instance.removeSink(sink));
+
+      const initial = ActivityRecord(
+        messageId: 'rag:call_1',
+        activityType: 'skill_tool_call',
+        content: {'tool_name': 'ask', 'status': 'in_progress'},
+        timestamp: 100,
+      );
+      const event = ActivityDeltaEvent(
+        messageId: 'rag:call_1',
+        activityType: 'skill_tool_result',
+        patch: [
+          {'op': 'replace', 'path': '/status', 'value': 'done'},
+        ],
+        timestamp: 200,
+      );
+
+      applyActivityEvent([initial], event, logger: logger);
+
+      final error = sink.records.singleWhere((r) => r.level == LogLevel.error);
+      expect(error.attributes['messageId'], 'rag:call_1');
+      expect(error.attributes['expected'], 'skill_tool_call');
+      expect(error.attributes['received'], 'skill_tool_result');
+      expect(error.attributes['patchOps'], 1);
     });
 
     test('inherits prior timestamp when event omits one', () {

--- a/packages/soliplex_client/test/application/activity_events_test.dart
+++ b/packages/soliplex_client/test/application/activity_events_test.dart
@@ -1,0 +1,170 @@
+import 'package:soliplex_client/soliplex_client.dart';
+import 'package:soliplex_logging/soliplex_logging.dart';
+import 'package:test/test.dart';
+
+void main() {
+  final logger = LogManager.instance.getLogger('test.activity_events');
+
+  group('applyActivityEvent — snapshot', () {
+    test('appends a new record when no prior entry exists', () {
+      const event = ActivitySnapshotEvent(
+        messageId: 'rag:call_1',
+        activityType: 'skill_tool_call',
+        content: {'tool_name': 'ask', 'args': '{"q":"hi"}'},
+        timestamp: 100,
+      );
+
+      final result = applyActivityEvent(const [], event, logger: logger);
+
+      expect(result, hasLength(1));
+      expect(result.single.messageId, 'rag:call_1');
+      expect(result.single.timestamp, 100);
+    });
+
+    test('replaces in place when replace=true', () {
+      const initial = ActivityRecord(
+        messageId: 'rag:call_1',
+        activityType: 'skill_tool_call',
+        content: {'tool_name': 'ask'},
+        timestamp: 100,
+      );
+      const event = ActivitySnapshotEvent(
+        messageId: 'rag:call_1',
+        activityType: 'skill_tool_result',
+        content: {'tool_name': 'ask', 'result': 'answer'},
+        timestamp: 200,
+      );
+
+      final result = applyActivityEvent([initial], event, logger: logger);
+
+      expect(result, hasLength(1));
+      expect(result.single.activityType, 'skill_tool_result');
+      expect(result.single.content['result'], 'answer');
+      expect(result.single.timestamp, 200);
+    });
+
+    test('preserves prior record when replace=false and id collides', () {
+      // Live and historical paths must agree on AG-UI's replace=false
+      // semantic: a duplicate-id snapshot without replace is ignored.
+      const initial = ActivityRecord(
+        messageId: 'rag:call_1',
+        activityType: 'skill_tool_call',
+        content: {'tool_name': 'first', 'args': '{"q":"first"}'},
+        timestamp: 100,
+      );
+      const event = ActivitySnapshotEvent(
+        messageId: 'rag:call_1',
+        activityType: 'skill_tool_call',
+        content: {'tool_name': 'second', 'args': '{"q":"second"}'},
+        replace: false,
+        timestamp: 200,
+      );
+
+      final result = applyActivityEvent([initial], event, logger: logger);
+
+      expect(result, hasLength(1));
+      expect(result.single.content['tool_name'], 'first');
+      expect(result.single.timestamp, 100);
+    });
+  });
+
+  group('applyActivityEvent — delta', () {
+    test('applies JSON Patch to the matching record', () {
+      const initial = ActivityRecord(
+        messageId: 'rag:call_1',
+        activityType: 'skill_tool_call',
+        content: {'tool_name': 'ask', 'status': 'in_progress'},
+        timestamp: 100,
+      );
+      const event = ActivityDeltaEvent(
+        messageId: 'rag:call_1',
+        activityType: 'skill_tool_call',
+        patch: [
+          {'op': 'replace', 'path': '/status', 'value': 'done'},
+        ],
+        timestamp: 200,
+      );
+
+      final result = applyActivityEvent([initial], event, logger: logger);
+
+      expect(result.single.content['status'], 'done');
+      expect(result.single.timestamp, 200);
+    });
+
+    test('drops when no prior snapshot exists', () {
+      const event = ActivityDeltaEvent(
+        messageId: 'rag:orphan',
+        activityType: 'skill_tool_call',
+        patch: [
+          {'op': 'replace', 'path': '/status', 'value': 'done'},
+        ],
+      );
+
+      final result = applyActivityEvent(const [], event, logger: logger);
+
+      expect(result, isEmpty);
+    });
+
+    test('drops when activityType disagrees with prior record', () {
+      const initial = ActivityRecord(
+        messageId: 'rag:call_1',
+        activityType: 'skill_tool_call',
+        content: {'tool_name': 'ask', 'status': 'in_progress'},
+        timestamp: 100,
+      );
+      const event = ActivityDeltaEvent(
+        messageId: 'rag:call_1',
+        activityType: 'skill_tool_result',
+        patch: [
+          {'op': 'replace', 'path': '/status', 'value': 'done'},
+        ],
+        timestamp: 200,
+      );
+
+      final result = applyActivityEvent([initial], event, logger: logger);
+
+      // Existing record is preserved unchanged.
+      expect(result.single.activityType, 'skill_tool_call');
+      expect(result.single.content['status'], 'in_progress');
+      expect(result.single.timestamp, 100);
+    });
+
+    test('inherits prior timestamp when event omits one', () {
+      const initial = ActivityRecord(
+        messageId: 'rag:call_1',
+        activityType: 'skill_tool_call',
+        content: {'tool_name': 'ask', 'status': 'in_progress'},
+        timestamp: 500,
+      );
+      const event = ActivityDeltaEvent(
+        messageId: 'rag:call_1',
+        activityType: 'skill_tool_call',
+        patch: [
+          {'op': 'add', 'path': '/progress', 'value': 0.5},
+        ],
+      );
+
+      final result = applyActivityEvent([initial], event, logger: logger);
+
+      expect(result.single.timestamp, 500);
+    });
+  });
+
+  test('returns the input list unchanged for non-activity events', () {
+    const initial = ActivityRecord(
+      messageId: 'rag:call_1',
+      activityType: 'skill_tool_call',
+      content: {'tool_name': 'ask'},
+      timestamp: 100,
+    );
+
+    final result = applyActivityEvent(
+      [initial],
+      const TextMessageStartEvent(messageId: 'asst-1'),
+      logger: logger,
+    );
+
+    expect(identical(result, [initial]) || result.length == 1, isTrue);
+    expect(result.single.messageId, 'rag:call_1');
+  });
+}

--- a/packages/soliplex_client/test/application/activity_events_test.dart
+++ b/packages/soliplex_client/test/application/activity_events_test.dart
@@ -3,10 +3,18 @@ import 'package:soliplex_logging/soliplex_logging.dart';
 import 'package:test/test.dart';
 
 class _RecordingSink implements LogSink {
+  _RecordingSink({required this.forLoggerName});
+
+  /// Only records from this logger are captured; everything else the
+  /// singleton sees during the test is ignored. Keeps assertions strict
+  /// without coupling to the rest of the codebase's log traffic.
+  final String forLoggerName;
   final List<LogRecord> records = [];
 
   @override
-  void write(LogRecord record) => records.add(record);
+  void write(LogRecord record) {
+    if (record.loggerName == forLoggerName) records.add(record);
+  }
 
   @override
   Future<void> flush() async {}
@@ -205,10 +213,12 @@ void main() {
     });
 
     test('logs error with structured attrs when no prior snapshot exists', () {
-      // Backend escalation contract: every delta-drop branch must log at
-      // error level with messageId / activityType / patchOps attributes
-      // so backend triage can reconstruct the dropped patch.
-      final sink = _RecordingSink();
+      // Backend escalation contract: every delta-drop branch must log
+      // exactly one record, at error level, with messageId / activityType
+      // / patchOps attributes so backend triage can reconstruct the
+      // dropped patch. Sink filtering keeps the assertion strict against
+      // noise additions on the same path.
+      final sink = _RecordingSink(forLoggerName: 'test.activity_events');
       LogManager.instance.addSink(sink);
       addTearDown(() => LogManager.instance.removeSink(sink));
 
@@ -223,14 +233,16 @@ void main() {
 
       applyActivityEvent(const [], event, logger: logger);
 
-      final error = sink.records.singleWhere((r) => r.level == LogLevel.error);
-      expect(error.attributes['messageId'], 'rag:orphan');
-      expect(error.attributes['activityType'], 'skill_tool_call');
-      expect(error.attributes['patchOps'], 2);
+      expect(sink.records, hasLength(1));
+      final record = sink.records.single;
+      expect(record.level, LogLevel.error);
+      expect(record.attributes['messageId'], 'rag:orphan');
+      expect(record.attributes['activityType'], 'skill_tool_call');
+      expect(record.attributes['patchOps'], 2);
     });
 
     test('logs error with structured attrs when activityType disagrees', () {
-      final sink = _RecordingSink();
+      final sink = _RecordingSink(forLoggerName: 'test.activity_events');
       LogManager.instance.addSink(sink);
       addTearDown(() => LogManager.instance.removeSink(sink));
 
@@ -251,11 +263,13 @@ void main() {
 
       applyActivityEvent([initial], event, logger: logger);
 
-      final error = sink.records.singleWhere((r) => r.level == LogLevel.error);
-      expect(error.attributes['messageId'], 'rag:call_1');
-      expect(error.attributes['expected'], 'skill_tool_call');
-      expect(error.attributes['received'], 'skill_tool_result');
-      expect(error.attributes['patchOps'], 1);
+      expect(sink.records, hasLength(1));
+      final record = sink.records.single;
+      expect(record.level, LogLevel.error);
+      expect(record.attributes['messageId'], 'rag:call_1');
+      expect(record.attributes['expected'], 'skill_tool_call');
+      expect(record.attributes['received'], 'skill_tool_result');
+      expect(record.attributes['patchOps'], 1);
     });
 
     test('inherits prior timestamp when event omits one', () {

--- a/packages/soliplex_client/test/application/agui_event_processor_test.dart
+++ b/packages/soliplex_client/test/application/agui_event_processor_test.dart
@@ -3,6 +3,7 @@ import 'package:soliplex_client/src/application/agui_event_processor.dart';
 import 'package:soliplex_client/src/application/no_response_synthesis.dart';
 import 'package:soliplex_client/src/application/streaming_state.dart'
     as app_streaming;
+import 'package:soliplex_client/src/domain/activity_record.dart';
 import 'package:soliplex_client/src/domain/chat_message.dart';
 import 'package:soliplex_client/src/domain/conversation.dart';
 import 'package:test/test.dart';
@@ -1372,6 +1373,80 @@ void main() {
 
         expect(result.conversation.activities, hasLength(1));
         expect(result.conversation.activities.first.messageId, 'rag:call_x');
+      });
+    });
+
+    group('activity delta events', () {
+      test('applies JSON Patch to the matching record content', () {
+        final seeded = conversation.copyWith(
+          activities: [
+            const ActivityRecord(
+              messageId: 'rag:call_1',
+              activityType: 'skill_tool_call',
+              content: {
+                'tool_name': 'ask',
+                'args': '{"q":"hi"}',
+                'status': 'in_progress',
+              },
+              timestamp: 100,
+            ),
+          ],
+        );
+        const event = ActivityDeltaEvent(
+          messageId: 'rag:call_1',
+          activityType: 'skill_tool_call',
+          patch: [
+            {'op': 'replace', 'path': '/status', 'value': 'done'},
+          ],
+          timestamp: 200,
+        );
+
+        final result = processEvent(seeded, streaming, event);
+
+        expect(result.conversation.activities, hasLength(1));
+        final patched = result.conversation.activities.single;
+        expect(patched.content['status'], 'done');
+        expect(patched.content['tool_name'], 'ask');
+        expect(patched.timestamp, 200);
+      });
+
+      test('with no prior snapshot drops the patch and warns', () {
+        const event = ActivityDeltaEvent(
+          messageId: 'rag:orphan',
+          activityType: 'skill_tool_call',
+          patch: [
+            {'op': 'replace', 'path': '/status', 'value': 'done'},
+          ],
+        );
+
+        final result = processEvent(conversation, streaming, event);
+
+        expect(result.conversation.activities, isEmpty);
+        expect(result.streaming, equals(streaming));
+      });
+
+      test('without timestamp preserves the prior record timestamp', () {
+        final seeded = conversation.copyWith(
+          activities: [
+            const ActivityRecord(
+              messageId: 'rag:call_2',
+              activityType: 'skill_tool_call',
+              content: {'tool_name': 'ask', 'status': 'in_progress'},
+              timestamp: 500,
+            ),
+          ],
+        );
+        const event = ActivityDeltaEvent(
+          messageId: 'rag:call_2',
+          activityType: 'skill_tool_call',
+          patch: [
+            {'op': 'add', 'path': '/progress', 'value': 0.5},
+          ],
+        );
+
+        final result = processEvent(seeded, streaming, event);
+
+        expect(result.conversation.activities.single.timestamp, 500);
       });
     });
 

--- a/packages/soliplex_client/test/application/agui_event_processor_test.dart
+++ b/packages/soliplex_client/test/application/agui_event_processor_test.dart
@@ -570,7 +570,7 @@ void main() {
           final awaitingText = result2.streaming as app_streaming.AwaitingText;
           final phase =
               awaitingText.currentPhase as app_streaming.ToolCallPhase;
-          expect(phase.allToolNames, equals({'search', 'summarize'}));
+          expect(phase.toolNames, equals({'search', 'summarize'}));
         });
       });
 
@@ -762,8 +762,9 @@ void main() {
         });
 
         test('does not change phase', () {
-          const awaitingWithTool = app_streaming.AwaitingText(
-            currentPhase: app_streaming.ToolCallPhase(toolName: 'search'),
+          final awaitingWithTool = app_streaming.AwaitingText(
+            currentPhase:
+                app_streaming.ToolCallPhase.single(toolName: 'search'),
           );
           final conversationWithTool = conversation.withToolCall(
             const ToolCallInfo(
@@ -1053,7 +1054,7 @@ void main() {
           final awaitingText = result.streaming as app_streaming.AwaitingText;
           final phase =
               awaitingText.currentPhase as app_streaming.ToolCallPhase;
-          expect(phase.allToolNames, contains('search'));
+          expect(phase.toolNames, contains('search'));
         });
 
         test('ToolCallStartEvent during TextStreaming sets phase', () {
@@ -1076,7 +1077,7 @@ void main() {
           final textStreaming = result.streaming as app_streaming.TextStreaming;
           final phase =
               textStreaming.currentPhase as app_streaming.ToolCallPhase;
-          expect(phase.allToolNames, contains('search'));
+          expect(phase.toolNames, contains('search'));
           expect(phase.latestToolCallId, equals('tc-1'));
         });
 
@@ -1147,12 +1148,12 @@ void main() {
 
         final awaitingText = result.streaming as app_streaming.AwaitingText;
         final phase = awaitingText.currentPhase as app_streaming.ToolCallPhase;
-        expect(phase.allToolNames, contains('search'));
+        expect(phase.toolNames, contains('search'));
       });
 
       test('skill_tool_call accumulates on existing ToolCallPhase', () {
-        const firstTool = app_streaming.AwaitingText(
-          currentPhase: app_streaming.ToolCallPhase(toolName: 'ask'),
+        final firstTool = app_streaming.AwaitingText(
+          currentPhase: app_streaming.ToolCallPhase.single(toolName: 'ask'),
         );
         const event = ActivitySnapshotEvent(
           messageId: 'msg-1',
@@ -1164,7 +1165,7 @@ void main() {
 
         final awaitingText = result.streaming as app_streaming.AwaitingText;
         final phase = awaitingText.currentPhase as app_streaming.ToolCallPhase;
-        expect(phase.allToolNames, equals({'ask', 'search'}));
+        expect(phase.toolNames, equals({'ask', 'search'}));
       });
 
       test('skill_tool_call with missing tool_name passes through', () {

--- a/packages/soliplex_client/test/application/agui_event_processor_test.dart
+++ b/packages/soliplex_client/test/application/agui_event_processor_test.dart
@@ -1,6 +1,8 @@
 import 'package:ag_ui/ag_ui.dart';
 import 'package:soliplex_client/src/application/agui_event_processor.dart';
 import 'package:soliplex_client/src/application/no_response_synthesis.dart';
+import 'package:soliplex_client/src/application/run_phase.dart'
+    as app_streaming;
 import 'package:soliplex_client/src/application/streaming_state.dart'
     as app_streaming;
 import 'package:soliplex_client/src/domain/activity_record.dart';
@@ -548,7 +550,7 @@ void main() {
           expect(tc.status, equals(ToolCallStatus.streaming));
         });
 
-        test('accumulates tool names in activity across multiple starts', () {
+        test('accumulates tool names in phase across multiple starts', () {
           const event1 = ToolCallStartEvent(
             toolCallId: 'tc-1',
             toolCallName: 'search',
@@ -566,9 +568,9 @@ void main() {
           );
 
           final awaitingText = result2.streaming as app_streaming.AwaitingText;
-          final activity =
-              awaitingText.currentActivity as app_streaming.ToolCallActivity;
-          expect(activity.allToolNames, equals({'search', 'summarize'}));
+          final phase =
+              awaitingText.currentPhase as app_streaming.ToolCallPhase;
+          expect(phase.allToolNames, equals({'search', 'summarize'}));
         });
       });
 
@@ -759,9 +761,9 @@ void main() {
           expect(result.conversation.toolCalls.first.id, equals('tc-1'));
         });
 
-        test('does not change activity', () {
+        test('does not change phase', () {
           const awaitingWithTool = app_streaming.AwaitingText(
-            currentActivity: app_streaming.ToolCallActivity(toolName: 'search'),
+            currentPhase: app_streaming.ToolCallPhase(toolName: 'search'),
           );
           final conversationWithTool = conversation.withToolCall(
             const ToolCallInfo(
@@ -779,8 +781,8 @@ void main() {
           );
 
           expect(
-            (result.streaming as app_streaming.AwaitingText).currentActivity,
-            isA<app_streaming.ToolCallActivity>(),
+            (result.streaming as app_streaming.AwaitingText).currentPhase,
+            isA<app_streaming.ToolCallPhase>(),
           );
         });
 
@@ -984,7 +986,7 @@ void main() {
         });
       });
 
-      group('ToolCallActivity equality', () {
+      group('ToolCallPhase equality', () {
         test(
             'consecutive starts of same tool produce unequal activities '
             '(different toolCallId)', () {
@@ -1004,14 +1006,14 @@ void main() {
             event2,
           );
 
-          final activity1 =
-              (result1.streaming as app_streaming.AwaitingText).currentActivity;
-          final activity2 =
-              (result2.streaming as app_streaming.AwaitingText).currentActivity;
-          expect(activity1, isNot(equals(activity2)));
+          final phase1 =
+              (result1.streaming as app_streaming.AwaitingText).currentPhase;
+          final phase2 =
+              (result2.streaming as app_streaming.AwaitingText).currentPhase;
+          expect(phase1, isNot(equals(phase2)));
         });
 
-        test('ToolCallStartEvent sets latestToolCallId on activity', () {
+        test('ToolCallStartEvent sets latestToolCallId on phase', () {
           const event = ToolCallStartEvent(
             toolCallId: 'tc-1',
             toolCallName: 'search',
@@ -1019,12 +1021,12 @@ void main() {
 
           final result = processEvent(conversation, streaming, event);
 
-          final activity = (result.streaming as app_streaming.AwaitingText)
-              .currentActivity as app_streaming.ToolCallActivity;
-          expect(activity.latestToolCallId, equals('tc-1'));
+          final phase = (result.streaming as app_streaming.AwaitingText)
+              .currentPhase as app_streaming.ToolCallPhase;
+          expect(phase.latestToolCallId, equals('tc-1'));
         });
 
-        test('ToolCallStartEvent sets timestamp on activity', () {
+        test('ToolCallStartEvent sets timestamp on phase', () {
           const event = ToolCallStartEvent(
             toolCallId: 'tc-1',
             toolCallName: 'search',
@@ -1033,14 +1035,14 @@ void main() {
 
           final result = processEvent(conversation, streaming, event);
 
-          final activity = (result.streaming as app_streaming.AwaitingText)
-              .currentActivity as app_streaming.ToolCallActivity;
-          expect(activity.timestamp, equals(1000));
+          final phase = (result.streaming as app_streaming.AwaitingText)
+              .currentPhase as app_streaming.ToolCallPhase;
+          expect(phase.timestamp, equals(1000));
         });
       });
 
       group('regression — existing behavior preserved', () {
-        test('ToolCallActivity still tracks tool names', () {
+        test('ToolCallPhase still tracks tool names', () {
           const event = ToolCallStartEvent(
             toolCallId: 'tc-1',
             toolCallName: 'search',
@@ -1049,12 +1051,12 @@ void main() {
           final result = processEvent(conversation, streaming, event);
 
           final awaitingText = result.streaming as app_streaming.AwaitingText;
-          final activity =
-              awaitingText.currentActivity as app_streaming.ToolCallActivity;
-          expect(activity.allToolNames, contains('search'));
+          final phase =
+              awaitingText.currentPhase as app_streaming.ToolCallPhase;
+          expect(phase.allToolNames, contains('search'));
         });
 
-        test('ToolCallStartEvent during TextStreaming sets activity', () {
+        test('ToolCallStartEvent during TextStreaming sets phase', () {
           // Start streaming text
           const textStart = TextMessageStartEvent(messageId: 'msg-1');
           var result = processEvent(conversation, streaming, textStart);
@@ -1072,10 +1074,10 @@ void main() {
           );
 
           final textStreaming = result.streaming as app_streaming.TextStreaming;
-          final activity =
-              textStreaming.currentActivity as app_streaming.ToolCallActivity;
-          expect(activity.allToolNames, contains('search'));
-          expect(activity.latestToolCallId, equals('tc-1'));
+          final phase =
+              textStreaming.currentPhase as app_streaming.ToolCallPhase;
+          expect(phase.allToolNames, contains('search'));
+          expect(phase.latestToolCallId, equals('tc-1'));
         });
 
         test('text and tool calls coexist', () {
@@ -1134,7 +1136,7 @@ void main() {
     });
 
     group('activity snapshot events', () {
-      test('skill_tool_call sets ToolCallActivity with tool name', () {
+      test('skill_tool_call sets ToolCallPhase with tool name', () {
         const event = ActivitySnapshotEvent(
           messageId: 'msg-1',
           activityType: 'skill_tool_call',
@@ -1144,14 +1146,13 @@ void main() {
         final result = processEvent(conversation, streaming, event);
 
         final awaitingText = result.streaming as app_streaming.AwaitingText;
-        final activity =
-            awaitingText.currentActivity as app_streaming.ToolCallActivity;
-        expect(activity.allToolNames, contains('search'));
+        final phase = awaitingText.currentPhase as app_streaming.ToolCallPhase;
+        expect(phase.allToolNames, contains('search'));
       });
 
-      test('skill_tool_call accumulates on existing ToolCallActivity', () {
+      test('skill_tool_call accumulates on existing ToolCallPhase', () {
         const firstTool = app_streaming.AwaitingText(
-          currentActivity: app_streaming.ToolCallActivity(toolName: 'ask'),
+          currentPhase: app_streaming.ToolCallPhase(toolName: 'ask'),
         );
         const event = ActivitySnapshotEvent(
           messageId: 'msg-1',
@@ -1162,9 +1163,8 @@ void main() {
         final result = processEvent(conversation, firstTool, event);
 
         final awaitingText = result.streaming as app_streaming.AwaitingText;
-        final activity =
-            awaitingText.currentActivity as app_streaming.ToolCallActivity;
-        expect(activity.allToolNames, equals({'ask', 'search'}));
+        final phase = awaitingText.currentPhase as app_streaming.ToolCallPhase;
+        expect(phase.allToolNames, equals({'ask', 'search'}));
       });
 
       test('skill_tool_call with missing tool_name passes through', () {
@@ -1178,8 +1178,8 @@ void main() {
 
         final awaitingText = result.streaming as app_streaming.AwaitingText;
         expect(
-          awaitingText.currentActivity,
-          isA<app_streaming.ProcessingActivity>(),
+          awaitingText.currentPhase,
+          isA<app_streaming.ProcessingPhase>(),
         );
       });
 
@@ -1194,8 +1194,8 @@ void main() {
 
         final awaitingText = result.streaming as app_streaming.AwaitingText;
         expect(
-          awaitingText.currentActivity,
-          isA<app_streaming.ProcessingActivity>(),
+          awaitingText.currentPhase,
+          isA<app_streaming.ProcessingPhase>(),
         );
       });
 
@@ -1210,9 +1210,8 @@ void main() {
         final result = processEvent(conversation, streaming, event);
 
         final awaitingText = result.streaming as app_streaming.AwaitingText;
-        final activity =
-            awaitingText.currentActivity as app_streaming.ToolCallActivity;
-        expect(activity.timestamp, equals(2000));
+        final phase = awaitingText.currentPhase as app_streaming.ToolCallPhase;
+        expect(phase.timestamp, equals(2000));
       });
 
       test(
@@ -1228,10 +1227,10 @@ void main() {
           final result = processEvent(conversation, streaming, event);
           final after = DateTime.now().millisecondsSinceEpoch;
 
-          final activity = (result.streaming as app_streaming.AwaitingText)
-              .currentActivity as app_streaming.ToolCallActivity;
-          expect(activity.timestamp, greaterThanOrEqualTo(before));
-          expect(activity.timestamp, lessThanOrEqualTo(after));
+          final phase = (result.streaming as app_streaming.AwaitingText)
+              .currentPhase as app_streaming.ToolCallPhase;
+          expect(phase.timestamp, greaterThanOrEqualTo(before));
+          expect(phase.timestamp, lessThanOrEqualTo(after));
         },
       );
 
@@ -1451,7 +1450,7 @@ void main() {
     });
 
     group('thinking events', () {
-      test('ThinkingStartEvent sets isThinkingStreaming and activity', () {
+      test('ThinkingStartEvent sets isThinkingStreaming and phase', () {
         const event = ThinkingStartEvent();
 
         final result = processEvent(conversation, streaming, event);
@@ -1459,15 +1458,15 @@ void main() {
         final awaitingText = result.streaming as app_streaming.AwaitingText;
         expect(awaitingText.isThinkingStreaming, isTrue);
         expect(
-          awaitingText.currentActivity,
-          isA<app_streaming.ThinkingActivity>(),
+          awaitingText.currentPhase,
+          isA<app_streaming.ThinkingPhase>(),
         );
       });
 
       test('ThinkingEndEvent sets isThinkingStreaming to false', () {
         const thinkingStreaming = app_streaming.AwaitingText(
           isThinkingStreaming: true,
-          currentActivity: app_streaming.ThinkingActivity(),
+          currentPhase: app_streaming.ThinkingPhase(),
         );
         const event = ThinkingEndEvent();
 
@@ -1478,7 +1477,7 @@ void main() {
       });
 
       test(
-        'ThinkingTextMessageStartEvent sets isThinkingStreaming and activity',
+        'ThinkingTextMessageStartEvent sets isThinkingStreaming and phase',
         () {
           const event = ThinkingTextMessageStartEvent();
 
@@ -1487,8 +1486,8 @@ void main() {
           final awaitingText = result.streaming as app_streaming.AwaitingText;
           expect(awaitingText.isThinkingStreaming, isTrue);
           expect(
-            awaitingText.currentActivity,
-            isA<app_streaming.ThinkingActivity>(),
+            awaitingText.currentPhase,
+            isA<app_streaming.ThinkingPhase>(),
           );
         },
       );
@@ -1597,7 +1596,7 @@ void main() {
     });
 
     group('reasoning events', () {
-      test('ReasoningStartEvent sets isThinkingStreaming and activity', () {
+      test('ReasoningStartEvent sets isThinkingStreaming and phase', () {
         const event = ReasoningStartEvent(messageId: 'reas-1');
 
         final result = processEvent(conversation, streaming, event);
@@ -1605,15 +1604,15 @@ void main() {
         final awaitingText = result.streaming as app_streaming.AwaitingText;
         expect(awaitingText.isThinkingStreaming, isTrue);
         expect(
-          awaitingText.currentActivity,
-          isA<app_streaming.ThinkingActivity>(),
+          awaitingText.currentPhase,
+          isA<app_streaming.ThinkingPhase>(),
         );
       });
 
       test('ReasoningEndEvent sets isThinkingStreaming to false', () {
         const reasoningState = app_streaming.AwaitingText(
           isThinkingStreaming: true,
-          currentActivity: app_streaming.ThinkingActivity(),
+          currentPhase: app_streaming.ThinkingPhase(),
         );
         const event = ReasoningEndEvent(messageId: 'reas-1');
 

--- a/packages/soliplex_client/test/application/agui_event_processor_test.dart
+++ b/packages/soliplex_client/test/application/agui_event_processor_test.dart
@@ -1040,6 +1040,26 @@ void main() {
               .currentPhase as app_streaming.ToolCallPhase;
           expect(phase.timestamp, equals(1000));
         });
+
+        test('ToolCallStartEvent without timestamp synthesizes wall-clock', () {
+          // Sibling to the skill_tool_call synthesis test: both code paths
+          // construct a fresh ToolCallPhase via `_withToolCallPhase`; both
+          // must guarantee a non-null timestamp so equality and any future
+          // UI consumer can rely on the field.
+          final before = DateTime.now().millisecondsSinceEpoch;
+          const event = ToolCallStartEvent(
+            toolCallId: 'tc-1',
+            toolCallName: 'search',
+          );
+
+          final result = processEvent(conversation, streaming, event);
+          final after = DateTime.now().millisecondsSinceEpoch;
+
+          final phase = (result.streaming as app_streaming.AwaitingText)
+              .currentPhase as app_streaming.ToolCallPhase;
+          expect(phase.timestamp, greaterThanOrEqualTo(before));
+          expect(phase.timestamp, lessThanOrEqualTo(after));
+        });
       });
 
       group('regression — existing behavior preserved', () {

--- a/packages/soliplex_client/test/application/agui_event_processor_test.dart
+++ b/packages/soliplex_client/test/application/agui_event_processor_test.dart
@@ -1184,22 +1184,6 @@ void main() {
         );
       });
 
-      test('unknown activityType passes through unchanged', () {
-        const event = ActivitySnapshotEvent(
-          messageId: 'msg-1',
-          activityType: 'unknown_activity',
-          content: {'data': 'value'},
-        );
-
-        final result = processEvent(conversation, streaming, event);
-
-        final awaitingText = result.streaming as app_streaming.AwaitingText;
-        expect(
-          awaitingText.currentPhase,
-          isA<app_streaming.ProcessingPhase>(),
-        );
-      });
-
       test('skill_tool_call sets timestamp from event', () {
         const event = ActivitySnapshotEvent(
           messageId: 'msg-1',
@@ -1254,7 +1238,11 @@ void main() {
         expect(record.timestamp, 1234);
       });
 
-      test('unknown activityType is persisted', () {
+      test('unknown activityType is persisted and leaves streaming intact', () {
+        // Two invariants exercised together: unknown activityTypes flow
+        // into Conversation.activities (so future consumers can read
+        // them) AND don't disturb the streaming phase (no spurious
+        // ToolCallPhase transition).
         const event = ActivitySnapshotEvent(
           messageId: 'plan:1',
           activityType: 'plan',
@@ -1266,6 +1254,10 @@ void main() {
 
         expect(result.conversation.activities, hasLength(1));
         expect(result.conversation.activities.first.activityType, 'plan');
+        expect(
+          (result.streaming as app_streaming.AwaitingText).currentPhase,
+          isA<app_streaming.ProcessingPhase>(),
+        );
       });
 
       test('replace:true overwrites record with same messageId in place', () {
@@ -1747,6 +1739,11 @@ void main() {
     });
 
     group('passthrough events', () {
+      // Representative pin: one structural event (TextMessageChunkEvent)
+      // and one wildcard event (CustomEvent) — both must leave
+      // conversation and streaming state untouched. Adding more entries
+      // here doesn't increase coverage; events that need custom
+      // handling have their own targeted tests above.
       final passthroughEvents = <String, BaseEvent>{
         'CustomEvent': const CustomEvent(name: 'custom', value: {'data': 123}),
         'TextMessageChunkEvent': const TextMessageChunkEvent(
@@ -1754,16 +1751,6 @@ void main() {
           role: TextMessageRole.assistant,
           delta: 'Hello',
         ),
-        'ToolCallChunkEvent': const ToolCallChunkEvent(
-          toolCallId: 'tc-1',
-          toolCallName: 'search',
-          delta: '{"q":"test"}',
-        ),
-        'MessagesSnapshotEvent': const MessagesSnapshotEvent(messages: []),
-        'StepStartedEvent': const StepStartedEvent(stepName: 'step-1'),
-        'StepFinishedEvent': const StepFinishedEvent(stepName: 'step-1'),
-        'RawEvent': const RawEvent(event: 'raw-data'),
-        'ThinkingContentEvent': const ThinkingContentEvent(delta: 'hmm'),
       };
 
       for (final entry in passthroughEvents.entries) {

--- a/packages/soliplex_client/test/application/agui_event_processor_test.dart
+++ b/packages/soliplex_client/test/application/agui_event_processor_test.dart
@@ -1425,6 +1425,42 @@ void main() {
         expect(result.streaming, equals(streaming));
       });
 
+      test('with mismatched activityType drops the patch and warns', () {
+        final seeded = conversation.copyWith(
+          activities: [
+            const ActivityRecord(
+              messageId: 'rag:call_3',
+              activityType: 'skill_tool_call',
+              content: {'tool_name': 'ask', 'status': 'in_progress'},
+              timestamp: 100,
+            ),
+          ],
+        );
+        const event = ActivityDeltaEvent(
+          messageId: 'rag:call_3',
+          activityType: 'skill_tool_result',
+          patch: [
+            {'op': 'replace', 'path': '/status', 'value': 'done'},
+          ],
+          timestamp: 200,
+        );
+
+        final result = processEvent(seeded, streaming, event);
+
+        // Existing record is preserved unchanged; the mismatched delta
+        // cannot be safely applied because patch ops are authored
+        // against the call-side content shape.
+        expect(
+          result.conversation.activities.single.activityType,
+          'skill_tool_call',
+        );
+        expect(
+          result.conversation.activities.single.content['status'],
+          'in_progress',
+        );
+        expect(result.conversation.activities.single.timestamp, 100);
+      });
+
       test('without timestamp preserves the prior record timestamp', () {
         final seeded = conversation.copyWith(
           activities: [

--- a/packages/soliplex_client/test/application/run_phase_test.dart
+++ b/packages/soliplex_client/test/application/run_phase_test.dart
@@ -33,13 +33,6 @@ void main() {
       expect(updated.toolNames, equals({'search'}));
     });
 
-    test('equality works across constructor variants', () {
-      final single = ToolCallPhase.single(toolName: 'search');
-      const multiple = ToolCallPhase(toolNames: {'search'});
-
-      expect(single, equals(multiple));
-    });
-
     test('equality works across constructors with all fields populated', () {
       final single = ToolCallPhase.single(
         toolName: 'search',

--- a/packages/soliplex_client/test/application/run_phase_test.dart
+++ b/packages/soliplex_client/test/application/run_phase_test.dart
@@ -6,47 +6,47 @@ void main() {
     test(
       'withToolName accumulates tool names from single-tool constructor',
       () {
-        const phase = ToolCallPhase(toolName: 'search');
+        final phase = ToolCallPhase.single(toolName: 'search');
 
         final updated = phase.withToolName('summarize');
 
-        expect(updated.allToolNames, equals({'search', 'summarize'}));
+        expect(updated.toolNames, equals({'search', 'summarize'}));
       },
     );
 
     test(
       'withToolName accumulates tool names from multiple-tool constructor',
       () {
-        const phase = ToolCallPhase.multiple(toolNames: {'a', 'b'});
+        const phase = ToolCallPhase(toolNames: {'a', 'b'});
 
         final updated = phase.withToolName('c');
 
-        expect(updated.allToolNames, equals({'a', 'b', 'c'}));
+        expect(updated.toolNames, equals({'a', 'b', 'c'}));
       },
     );
 
     test('withToolName is idempotent for duplicate names', () {
-      const phase = ToolCallPhase(toolName: 'search');
+      final phase = ToolCallPhase.single(toolName: 'search');
 
       final updated = phase.withToolName('search');
 
-      expect(updated.allToolNames, equals({'search'}));
+      expect(updated.toolNames, equals({'search'}));
     });
 
     test('equality works across constructor variants', () {
-      const single = ToolCallPhase(toolName: 'search');
-      const multiple = ToolCallPhase.multiple(toolNames: {'search'});
+      final single = ToolCallPhase.single(toolName: 'search');
+      const multiple = ToolCallPhase(toolNames: {'search'});
 
       expect(single, equals(multiple));
     });
 
     test('equality works across constructors with all fields populated', () {
-      const single = ToolCallPhase(
+      final single = ToolCallPhase.single(
         toolName: 'search',
         latestToolCallId: 'tc-1',
         timestamp: 100,
       );
-      const multiple = ToolCallPhase.multiple(
+      const multiple = ToolCallPhase(
         toolNames: {'search'},
         latestToolCallId: 'tc-1',
         timestamp: 100,
@@ -57,8 +57,8 @@ void main() {
     });
 
     test('hashCode is order-independent for tool names', () {
-      const ab = ToolCallPhase.multiple(toolNames: {'a', 'b'});
-      const ba = ToolCallPhase.multiple(toolNames: {'b', 'a'});
+      const ab = ToolCallPhase(toolNames: {'a', 'b'});
+      const ba = ToolCallPhase(toolNames: {'b', 'a'});
 
       expect(ab, equals(ba));
       expect(ab.hashCode, equals(ba.hashCode));

--- a/packages/soliplex_client/test/application/run_phase_test.dart
+++ b/packages/soliplex_client/test/application/run_phase_test.dart
@@ -1,0 +1,67 @@
+import 'package:soliplex_client/src/application/run_phase.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('ToolCallPhase', () {
+    test(
+      'withToolName accumulates tool names from single-tool constructor',
+      () {
+        const phase = ToolCallPhase(toolName: 'search');
+
+        final updated = phase.withToolName('summarize');
+
+        expect(updated.allToolNames, equals({'search', 'summarize'}));
+      },
+    );
+
+    test(
+      'withToolName accumulates tool names from multiple-tool constructor',
+      () {
+        const phase = ToolCallPhase.multiple(toolNames: {'a', 'b'});
+
+        final updated = phase.withToolName('c');
+
+        expect(updated.allToolNames, equals({'a', 'b', 'c'}));
+      },
+    );
+
+    test('withToolName is idempotent for duplicate names', () {
+      const phase = ToolCallPhase(toolName: 'search');
+
+      final updated = phase.withToolName('search');
+
+      expect(updated.allToolNames, equals({'search'}));
+    });
+
+    test('equality works across constructor variants', () {
+      const single = ToolCallPhase(toolName: 'search');
+      const multiple = ToolCallPhase.multiple(toolNames: {'search'});
+
+      expect(single, equals(multiple));
+    });
+
+    test('equality works across constructors with all fields populated', () {
+      const single = ToolCallPhase(
+        toolName: 'search',
+        latestToolCallId: 'tc-1',
+        timestamp: 100,
+      );
+      const multiple = ToolCallPhase.multiple(
+        toolNames: {'search'},
+        latestToolCallId: 'tc-1',
+        timestamp: 100,
+      );
+
+      expect(single, equals(multiple));
+      expect(single.hashCode, equals(multiple.hashCode));
+    });
+
+    test('hashCode is order-independent for tool names', () {
+      const ab = ToolCallPhase.multiple(toolNames: {'a', 'b'});
+      const ba = ToolCallPhase.multiple(toolNames: {'b', 'a'});
+
+      expect(ab, equals(ba));
+      expect(ab.hashCode, equals(ba.hashCode));
+    });
+  });
+}

--- a/packages/soliplex_client/test/application/streaming_state_test.dart
+++ b/packages/soliplex_client/test/application/streaming_state_test.dart
@@ -2,69 +2,6 @@ import 'package:soliplex_client/src/application/streaming_state.dart';
 import 'package:test/test.dart';
 
 void main() {
-  group('ToolCallActivity', () {
-    test(
-      'withToolName accumulates tool names from single-tool constructor',
-      () {
-        const activity = ToolCallActivity(toolName: 'search');
-
-        final updated = activity.withToolName('summarize');
-
-        expect(updated.allToolNames, equals({'search', 'summarize'}));
-      },
-    );
-
-    test(
-      'withToolName accumulates tool names from multiple-tool constructor',
-      () {
-        const activity = ToolCallActivity.multiple(toolNames: {'a', 'b'});
-
-        final updated = activity.withToolName('c');
-
-        expect(updated.allToolNames, equals({'a', 'b', 'c'}));
-      },
-    );
-
-    test('withToolName is idempotent for duplicate names', () {
-      const activity = ToolCallActivity(toolName: 'search');
-
-      final updated = activity.withToolName('search');
-
-      expect(updated.allToolNames, equals({'search'}));
-    });
-
-    test('equality works across constructor variants', () {
-      const single = ToolCallActivity(toolName: 'search');
-      const multiple = ToolCallActivity.multiple(toolNames: {'search'});
-
-      expect(single, equals(multiple));
-    });
-
-    test('equality works across constructors with all fields populated', () {
-      const single = ToolCallActivity(
-        toolName: 'search',
-        latestToolCallId: 'tc-1',
-        timestamp: 100,
-      );
-      const multiple = ToolCallActivity.multiple(
-        toolNames: {'search'},
-        latestToolCallId: 'tc-1',
-        timestamp: 100,
-      );
-
-      expect(single, equals(multiple));
-      expect(single.hashCode, equals(multiple.hashCode));
-    });
-
-    test('hashCode is order-independent for tool names', () {
-      const ab = ToolCallActivity.multiple(toolNames: {'a', 'b'});
-      const ba = ToolCallActivity.multiple(toolNames: {'b', 'a'});
-
-      expect(ab, equals(ba));
-      expect(ab.hashCode, equals(ba.hashCode));
-    });
-  });
-
   group('AwaitingText', () {
     test(
       'hasThinkingContent is true when bufferedThinkingText is non-empty',

--- a/packages/soliplex_client/test/canary/activity_pipeline_canary_test.dart
+++ b/packages/soliplex_client/test/canary/activity_pipeline_canary_test.dart
@@ -45,7 +45,7 @@ void main() {
         expect(calls.single.messageId, 'rag:call_1');
         expect(calls.single.toolName, 'ask');
         expect(calls.single.args, {'q': 'what is AG-UI?', 'top_k': 3});
-        expect(calls.single.status, 'in_progress');
+        expect(calls.single.status, SkillToolCallStatus.inProgress);
         expect(calls.single.timestamp, 100);
       },
     );
@@ -85,7 +85,7 @@ void main() {
         final calls = afterFinish.conversation.skillToolCalls;
         expect(calls, hasLength(1));
         expect(calls.single.messageId, 'rag:call_1');
-        expect(calls.single.status, 'done');
+        expect(calls.single.status, SkillToolCallStatus.done);
         expect(calls.single.timestamp, 2);
       },
     );
@@ -201,7 +201,7 @@ void main() {
         final calls = afterShadow.conversation.skillToolCalls;
         expect(calls, hasLength(1));
         expect(calls.single.toolName, 'ask');
-        expect(calls.single.status, 'in_progress');
+        expect(calls.single.status, SkillToolCallStatus.inProgress);
         expect(calls.single.args, {'q': 'first'});
       },
     );

--- a/packages/soliplex_client/test/domain/skill_tool_call_activity_test.dart
+++ b/packages/soliplex_client/test/domain/skill_tool_call_activity_test.dart
@@ -361,21 +361,5 @@ void main() {
 
       expect(a, isNot(equals(b)));
     });
-
-    test('toString includes identifying fields', () {
-      const a = SkillToolCallActivity(
-        messageId: 'rag:call_1',
-        toolName: 'ask',
-        args: {},
-        result: null,
-        status: SkillToolCallStatus.done,
-        timestamp: 7,
-      );
-      final s = a.toString();
-      expect(s, contains('rag:call_1'));
-      expect(s, contains('ask'));
-      expect(s, contains('done'));
-      expect(s, contains('7'));
-    });
   });
 }

--- a/packages/soliplex_client/test/domain/skill_tool_call_activity_test.dart
+++ b/packages/soliplex_client/test/domain/skill_tool_call_activity_test.dart
@@ -20,7 +20,7 @@ void main() {
       expect(call, isNotNull);
       expect(call!.messageId, 'rag:call_1');
       expect(call.toolName, 'ask');
-      expect(call.status, 'in_progress');
+      expect(call.status, SkillToolCallStatus.inProgress);
       expect(call.timestamp, 1234);
       expect(call.args, {'q': 'hello', 'top_k': 3});
     });
@@ -37,7 +37,7 @@ void main() {
 
       expect(call, isNotNull);
       expect(call!.args, isEmpty);
-      expect(call.status, 'in_progress');
+      expect(call.status, SkillToolCallStatus.inProgress);
     });
 
     test('empty args string decodes to an empty map', () {
@@ -137,7 +137,7 @@ void main() {
       expect(SkillToolCallActivity.fromRecord(record), isNull);
     });
 
-    test('non-string status falls back to synthesized in_progress', () {
+    test('non-string status falls back to synthesized inProgress', () {
       const record = ActivityRecord(
         messageId: 'rag:call_5',
         activityType: 'skill_tool_call',
@@ -148,10 +148,10 @@ void main() {
       final call = SkillToolCallActivity.fromRecord(record);
 
       expect(call, isNotNull);
-      expect(call!.status, 'in_progress');
+      expect(call!.status, SkillToolCallStatus.inProgress);
     });
 
-    test('skill_tool_call without status synthesizes in_progress', () {
+    test('skill_tool_call without status synthesizes inProgress', () {
       const record = ActivityRecord(
         messageId: 'rag:call_no_status',
         activityType: 'skill_tool_call',
@@ -162,10 +162,10 @@ void main() {
       final call = SkillToolCallActivity.fromRecord(record);
 
       expect(call, isNotNull);
-      expect(call!.status, 'in_progress');
+      expect(call!.status, SkillToolCallStatus.inProgress);
     });
 
-    test('skill_tool_call with explicit status preserves it', () {
+    test('skill_tool_call with explicit status maps to enum', () {
       const record = ActivityRecord(
         messageId: 'rag:custom_status',
         activityType: 'skill_tool_call',
@@ -180,7 +180,7 @@ void main() {
       final call = SkillToolCallActivity.fromRecord(record);
 
       expect(call, isNotNull);
-      expect(call!.status, 'failed');
+      expect(call!.status, SkillToolCallStatus.error);
     });
 
     test('decodes a well-formed skill_tool_result', () {
@@ -199,13 +199,13 @@ void main() {
       expect(call, isNotNull);
       expect(call!.messageId, 'rag:call_1');
       expect(call.toolName, 'ask');
-      expect(call.status, 'done');
+      expect(call.status, SkillToolCallStatus.done);
       expect(call.result, 'answer text');
       expect(call.args, isEmpty);
       expect(call.timestamp, 1500);
     });
 
-    test('skill_tool_result with explicit status preserves it', () {
+    test('skill_tool_result with unrecognised status decodes as unknown', () {
       const record = ActivityRecord(
         messageId: 'rag:explicit_done',
         activityType: 'skill_tool_result',
@@ -220,7 +220,7 @@ void main() {
       final call = SkillToolCallActivity.fromRecord(record);
 
       expect(call, isNotNull);
-      expect(call!.status, 'partial');
+      expect(call!.status, SkillToolCallStatus.unknown);
       expect(call.result, 'answer');
     });
 
@@ -235,7 +235,7 @@ void main() {
       final call = SkillToolCallActivity.fromRecord(record);
 
       expect(call, isNotNull);
-      expect(call!.status, 'done');
+      expect(call!.status, SkillToolCallStatus.done);
       expect(call.result, isNull);
     });
 
@@ -279,7 +279,7 @@ void main() {
           'top_k': 3,
         },
         result: null,
-        status: 'done',
+        status: SkillToolCallStatus.done,
         timestamp: 1,
       );
       const b = SkillToolCallActivity(
@@ -290,7 +290,7 @@ void main() {
           'top_k': 3,
         },
         result: null,
-        status: 'done',
+        status: SkillToolCallStatus.done,
         timestamp: 1,
       );
 
@@ -304,7 +304,7 @@ void main() {
         toolName: 'ask',
         args: {'q': 'hi'},
         result: null,
-        status: 'in_progress',
+        status: SkillToolCallStatus.inProgress,
         timestamp: 1,
       );
       const b = SkillToolCallActivity(
@@ -312,7 +312,7 @@ void main() {
         toolName: 'ask',
         args: {'q': 'bye'},
         result: null,
-        status: 'in_progress',
+        status: SkillToolCallStatus.inProgress,
         timestamp: 1,
       );
 
@@ -325,7 +325,7 @@ void main() {
         toolName: 'ask',
         args: {},
         result: 'first answer',
-        status: 'done',
+        status: SkillToolCallStatus.done,
         timestamp: 1,
       );
       const b = SkillToolCallActivity(
@@ -333,7 +333,7 @@ void main() {
         toolName: 'ask',
         args: {},
         result: 'second answer',
-        status: 'done',
+        status: SkillToolCallStatus.done,
         timestamp: 1,
       );
 
@@ -346,7 +346,7 @@ void main() {
         toolName: 'ask',
         args: {},
         result: null,
-        status: 'done',
+        status: SkillToolCallStatus.done,
         timestamp: 7,
       );
       final s = a.toString();

--- a/packages/soliplex_client/test/domain/skill_tool_call_activity_test.dart
+++ b/packages/soliplex_client/test/domain/skill_tool_call_activity_test.dart
@@ -205,6 +205,28 @@ void main() {
       expect(call.timestamp, 1500);
     });
 
+    test('skill_tool_result with args in content decodes them', () {
+      // Counterpart to the merge done in _applySnapshot: once args are
+      // carried onto the result-phase record, the typed view must
+      // surface them so the unified row keeps showing the inputs.
+      const record = ActivityRecord(
+        messageId: 'rag:call_1',
+        activityType: 'skill_tool_result',
+        content: {
+          'tool_name': 'ask',
+          'args': '{"q":"hi","top_k":3}',
+          'result': 'answer',
+        },
+        timestamp: 1500,
+      );
+
+      final call = SkillToolCallActivity.fromRecord(record);
+
+      expect(call, isNotNull);
+      expect(call!.args, {'q': 'hi', 'top_k': 3});
+      expect(call.result, 'answer');
+    });
+
     test('skill_tool_result with unrecognised status decodes as unknown', () {
       const record = ActivityRecord(
         messageId: 'rag:explicit_done',

--- a/packages/soliplex_client/test/domain/skill_tool_call_activity_test.dart
+++ b/packages/soliplex_client/test/domain/skill_tool_call_activity_test.dart
@@ -37,7 +37,7 @@ void main() {
 
       expect(call, isNotNull);
       expect(call!.args, isEmpty);
-      expect(call.status, isNull);
+      expect(call.status, 'in_progress');
     });
 
     test('empty args string decodes to an empty map', () {
@@ -137,7 +137,7 @@ void main() {
       expect(SkillToolCallActivity.fromRecord(record), isNull);
     });
 
-    test('non-string status is coerced to null', () {
+    test('non-string status falls back to synthesized in_progress', () {
       const record = ActivityRecord(
         messageId: 'rag:call_5',
         activityType: 'skill_tool_call',
@@ -148,7 +148,124 @@ void main() {
       final call = SkillToolCallActivity.fromRecord(record);
 
       expect(call, isNotNull);
-      expect(call!.status, isNull);
+      expect(call!.status, 'in_progress');
+    });
+
+    test('skill_tool_call without status synthesizes in_progress', () {
+      const record = ActivityRecord(
+        messageId: 'rag:call_no_status',
+        activityType: 'skill_tool_call',
+        content: {'tool_name': 'ask', 'args': '{"q":"hi"}'},
+        timestamp: 1,
+      );
+
+      final call = SkillToolCallActivity.fromRecord(record);
+
+      expect(call, isNotNull);
+      expect(call!.status, 'in_progress');
+    });
+
+    test('skill_tool_call with explicit status preserves it', () {
+      const record = ActivityRecord(
+        messageId: 'rag:custom_status',
+        activityType: 'skill_tool_call',
+        content: {
+          'tool_name': 'ask',
+          'args': '{}',
+          'status': 'failed',
+        },
+        timestamp: 1,
+      );
+
+      final call = SkillToolCallActivity.fromRecord(record);
+
+      expect(call, isNotNull);
+      expect(call!.status, 'failed');
+    });
+
+    test('decodes a well-formed skill_tool_result', () {
+      const record = ActivityRecord(
+        messageId: 'rag:call_1',
+        activityType: 'skill_tool_result',
+        content: {
+          'tool_name': 'ask',
+          'result': 'answer text',
+        },
+        timestamp: 1500,
+      );
+
+      final call = SkillToolCallActivity.fromRecord(record);
+
+      expect(call, isNotNull);
+      expect(call!.messageId, 'rag:call_1');
+      expect(call.toolName, 'ask');
+      expect(call.status, 'done');
+      expect(call.result, 'answer text');
+      expect(call.args, isEmpty);
+      expect(call.timestamp, 1500);
+    });
+
+    test('skill_tool_result with explicit status preserves it', () {
+      const record = ActivityRecord(
+        messageId: 'rag:explicit_done',
+        activityType: 'skill_tool_result',
+        content: {
+          'tool_name': 'ask',
+          'result': 'answer',
+          'status': 'partial',
+        },
+        timestamp: 1,
+      );
+
+      final call = SkillToolCallActivity.fromRecord(record);
+
+      expect(call, isNotNull);
+      expect(call!.status, 'partial');
+      expect(call.result, 'answer');
+    });
+
+    test('skill_tool_result without result yields null result field', () {
+      const record = ActivityRecord(
+        messageId: 'rag:no_result',
+        activityType: 'skill_tool_result',
+        content: {'tool_name': 'ask'},
+        timestamp: 1,
+      );
+
+      final call = SkillToolCallActivity.fromRecord(record);
+
+      expect(call, isNotNull);
+      expect(call!.status, 'done');
+      expect(call.result, isNull);
+    });
+
+    test('skill_tool_result without tool_name returns null', () {
+      // Regression guard: if a future backend ever omits tool_name from
+      // the result snapshot, fromRecord must return null so the failure
+      // is loud (row stays at spinner) rather than silently dropping
+      // the completion.
+      const record = ActivityRecord(
+        messageId: 'rag:bad_result',
+        activityType: 'skill_tool_result',
+        content: {'result': 'orphan'},
+        timestamp: 1,
+      );
+
+      expect(SkillToolCallActivity.fromRecord(record), isNull);
+    });
+
+    test('non-string result is coerced to null', () {
+      const record = ActivityRecord(
+        messageId: 'rag:bad_result_type',
+        activityType: 'skill_tool_result',
+        content: {'tool_name': 'ask', 'result': 42},
+        timestamp: 1,
+      );
+
+      final call = SkillToolCallActivity.fromRecord(record);
+
+      expect(call, isNotNull);
+      expect(call!.result, isNull);
     });
   });
 
@@ -161,6 +278,7 @@ void main() {
           'q': 'hi',
           'top_k': 3,
         },
+        result: null,
         status: 'done',
         timestamp: 1,
       );
@@ -171,6 +289,7 @@ void main() {
           'q': 'hi',
           'top_k': 3,
         },
+        result: null,
         status: 'done',
         timestamp: 1,
       );
@@ -184,14 +303,37 @@ void main() {
         messageId: 'm1',
         toolName: 'ask',
         args: {'q': 'hi'},
-        status: null,
+        result: null,
+        status: 'in_progress',
         timestamp: 1,
       );
       const b = SkillToolCallActivity(
         messageId: 'm1',
         toolName: 'ask',
         args: {'q': 'bye'},
-        status: null,
+        result: null,
+        status: 'in_progress',
+        timestamp: 1,
+      );
+
+      expect(a, isNot(equals(b)));
+    });
+
+    test('not equal when result differs', () {
+      const a = SkillToolCallActivity(
+        messageId: 'm1',
+        toolName: 'ask',
+        args: {},
+        result: 'first answer',
+        status: 'done',
+        timestamp: 1,
+      );
+      const b = SkillToolCallActivity(
+        messageId: 'm1',
+        toolName: 'ask',
+        args: {},
+        result: 'second answer',
+        status: 'done',
         timestamp: 1,
       );
 
@@ -203,6 +345,7 @@ void main() {
         messageId: 'rag:call_1',
         toolName: 'ask',
         args: {},
+        result: null,
         status: 'done',
         timestamp: 7,
       );

--- a/test/modules/room/agui_events_presentation_bugs_test.dart
+++ b/test/modules/room/agui_events_presentation_bugs_test.dart
@@ -99,10 +99,10 @@ void main() {
         expect(activity.result, 'answer text');
         expect(
           activity.args,
-          isEmpty,
-          reason: 'replace=true means the result snapshot overwrites the '
-              "call record; args are not present in the result phase's "
-              'content per AG-UI spec.',
+          {'q': 'hi'},
+          reason: 'The application layer carries args from the call phase '
+              'onto the result-phase record so the unified row keeps '
+              'rendering the inputs across AG-UI replace-in-place.',
         );
       },
     );

--- a/test/modules/room/agui_events_presentation_bugs_test.dart
+++ b/test/modules/room/agui_events_presentation_bugs_test.dart
@@ -92,7 +92,7 @@ void main() {
         final activity = tracker.skillToolCalls.value.single;
         expect(
           activity.status,
-          'done',
+          SkillToolCallStatus.done,
           reason: 'Result snapshot must flip the row to done; otherwise '
               'the nested icon stays at the in-progress spinner.',
         );
@@ -153,9 +153,9 @@ void main() {
         expect(calls, hasLength(1));
         expect(
           calls.single.status,
-          'in_progress',
+          SkillToolCallStatus.inProgress,
           reason: 'The call phase carries no explicit status; the decoder '
-              'must synthesize in_progress so the spinner renders.',
+              'must synthesize inProgress so the spinner renders.',
         );
 
         const resultContent = {
@@ -185,7 +185,7 @@ void main() {
         expect(updated, hasLength(1));
         expect(
           updated.single.status,
-          'done',
+          SkillToolCallStatus.done,
           reason: 'The result snapshot must replace the call record so '
               'the trailing icon flips to the checkmark.',
         );

--- a/test/modules/room/agui_events_presentation_bugs_test.dart
+++ b/test/modules/room/agui_events_presentation_bugs_test.dart
@@ -85,10 +85,11 @@ void main() {
         ];
 
         final trackers = replayToTrackers(runs);
-        final step = trackers['asst-1']!.timeline.value.single as TimelineStep;
+        final tracker = trackers['asst-1']!;
+        final step = tracker.timeline.value.single as TimelineStep;
 
-        expect(step.activities, hasLength(1));
-        final activity = step.activities.single;
+        expect(step.activityIds, ['rag:call_1']);
+        final activity = tracker.skillToolCalls.value.single;
         expect(
           activity.status,
           'done',
@@ -111,27 +112,41 @@ void main() {
       'on the same messageId advances the activity to done',
       () {
         final events = Signal<ExecutionEvent?>(null);
+        final activities = Signal<List<ActivityRecord>>(const []);
         final tracker = ExecutionTracker(
           executionEvents: events,
+          activities: activities,
           logger: testLogger(),
         );
         addTearDown(tracker.dispose);
 
         // Bridge each AG-UI event through the production bridge, mirroring
-        // what AgentSession does at runtime.
+        // what AgentSession does at runtime. Push the same content into
+        // the activities signal so the tracker's computed skillToolCalls
+        // sees the decoded view, matching what _processActivitySnapshot
+        // does in production.
+        const callContent = {
+          'tool_name': 'ask',
+          'args': '{"q":"hi"}',
+        };
         final ExecutionEvent? callSnapshot = bridgeBaseEvent(
           const ActivitySnapshotEvent(
             messageId: 'rag:call_1',
             activityType: 'skill_tool_call',
-            content: {
-              'tool_name': 'ask',
-              'args': '{"q":"hi"}',
-            },
+            content: callContent,
             replace: false,
             timestamp: 100,
           ),
         );
         expect(callSnapshot, isNotNull);
+        activities.value = const [
+          ActivityRecord(
+            messageId: 'rag:call_1',
+            activityType: 'skill_tool_call',
+            content: callContent,
+            timestamp: 100,
+          ),
+        ];
         events.value = callSnapshot;
 
         final calls = tracker.skillToolCalls.value;
@@ -143,18 +158,27 @@ void main() {
               'must synthesize in_progress so the spinner renders.',
         );
 
+        const resultContent = {
+          'tool_name': 'ask',
+          'result': 'answer text',
+        };
         final ExecutionEvent? resultSnapshot = bridgeBaseEvent(
           const ActivitySnapshotEvent(
             messageId: 'rag:call_1',
             activityType: 'skill_tool_result',
-            content: {
-              'tool_name': 'ask',
-              'result': 'answer text',
-            },
+            content: resultContent,
             timestamp: 150,
           ),
         );
         expect(resultSnapshot, isNotNull);
+        activities.value = const [
+          ActivityRecord(
+            messageId: 'rag:call_1',
+            activityType: 'skill_tool_result',
+            content: resultContent,
+            timestamp: 150,
+          ),
+        ];
         events.value = resultSnapshot;
 
         final updated = tracker.skillToolCalls.value;

--- a/test/modules/room/agui_events_presentation_bugs_test.dart
+++ b/test/modules/room/agui_events_presentation_bugs_test.dart
@@ -1,30 +1,27 @@
-/// Regression harness for two known bugs in the "$N events" bubble
-/// rendered above assistant messages by [ExecutionTimeline].
+/// Invariants for the "$N events" bubble rendered above assistant
+/// messages by [ExecutionTimeline].
 ///
-/// Bug 1 — Nested rows never get a checkmark
-/// -----------------------------------------
-/// haiku.skills emits one logical sub-skill invocation as two
-/// `ActivitySnapshotEvent`s sharing a `messageId`: a call phase
+/// Nested-row completion
+/// ---------------------
+/// A logical sub-skill invocation arrives as two `ActivitySnapshotEvent`s
+/// sharing a `messageId`: a call phase
 /// (`activity_type='skill_tool_call'`, carrying `args`) and a result
 /// phase (`activity_type='skill_tool_result'`, carrying `result`,
-/// `replace=true`). The original frontend decoder bailed on any
-/// activityType other than `skill_tool_call`, so the result snapshot
-/// was logged and dropped; the nested row stayed at its in-progress
-/// spinner for the rest of the run. The decoder now dispatches on
-/// activityType and routes `skill_tool_result` through a result-phase
-/// decoder that synthesizes `status='done'` and exposes the
-/// `content['result']` text.
+/// `replace=true`). The decoder dispatches on activityType so the
+/// result phase synthesizes `status='done'` and exposes
+/// `content['result']`, flipping the nested row out of its
+/// in-progress spinner.
 ///
-/// Bug 2 — Bubble disappears after reload
-/// --------------------------------------
+/// Bubble survives reload after a tool-yield
+/// -----------------------------------------
 /// On thread reload, [replayToTrackers] keys events by assistant
 /// `TextMessageStart`. A run that ends with a `ToolCallStart` but no
 /// follow-up bundle (errored mid-tool, cancelled, server restart) hits
-/// the "trailing tool-yield" branch and silently drops its events; no
-/// tracker is produced for the run. If the chat-message processor
-/// synthesized a no-response tile for the same run via a different code
-/// path, that tile is rendered without a tracker — the "events bubble"
-/// vanishes on reload even though it was visible during the live run.
+/// the "trailing tool-yield" branch. If the chat-message processor
+/// synthesizes a no-response tile for the same run via a different
+/// code path, the replay must still produce a tracker keyed under the
+/// synthesized id so the bubble keeps rendering the thinking and
+/// tool-call timeline that was visible during the live run.
 library;
 
 import 'package:flutter_test/flutter_test.dart';
@@ -51,7 +48,7 @@ void main() {
                 toolCallId: 'tc-1',
                 toolCallName: 'execute_skill',
               ),
-              // Phase 1: call. haiku.skills emits replace=false so the
+              // Phase 1: call. The producer emits replace=false so the
               // initial snapshot lands as a new record.
               ActivitySnapshotEvent(
                 messageId: 'rag:call_1',

--- a/test/modules/room/agui_events_presentation_bugs_test.dart
+++ b/test/modules/room/agui_events_presentation_bugs_test.dart
@@ -34,7 +34,7 @@ import 'package:soliplex_frontend/src/modules/room/ui/execution/timeline_entry.d
 import '../../helpers/test_logger.dart';
 
 void main() {
-  group('Bug 1: skill_tool_result snapshot completes the nested row', () {
+  group('skill_tool_result snapshot completes the nested row', () {
     test(
       'historical replay: call snapshot + result snapshot leaves the '
       'nested activity at status=done with the result text exposed',
@@ -191,7 +191,7 @@ void main() {
     );
   });
 
-  group('Bug 2: bubble disappears after thread reload', () {
+  group('bubble survives reload after a tool-yield', () {
     test(
       'a run that yielded to a tool and never produced an assistant '
       'TextMessageStart (errored / cancelled mid-tool, trailing in '
@@ -231,27 +231,27 @@ void main() {
         expect(
           trackers,
           contains(expectedKey),
-          reason: 'Bug 2: trailing tool-yield drops its hoisted events; no '
-              'tracker is created for run-stuck so the bubble disappears '
-              'after a reload even though it was visible live.',
+          reason: 'A trailing tool-yield must still produce a tracker '
+              'keyed under the synthesized no-response id so the bubble '
+              'keeps rendering across the reload boundary.',
         );
         expect(
           trackers[expectedKey]!.steps.value.map((s) => s.label),
           containsAll(<String>['Thinking', 'search']),
-          reason: 'Bug 2: the recovered tracker must contain the same '
-              'steps the user saw live.',
+          reason: 'The recovered tracker must contain the same steps the '
+              'user saw live.',
         );
       },
     );
 
     test(
-      'multi-run thread where the LAST run is a trailing tool-yield: the '
-      'preceding assistant bubble is fine, but the last run loses its '
-      'tracker — confirms the bug is isolated to the trailing case',
+      'multi-run thread: a normal-bundle run followed by a trailing '
+      'tool-yield run — both must produce trackers',
       () {
-        // Useful baseline: the bug-free preceding run rules out a regression
-        // in the normal-bundle code path so we can attribute the missing
-        // tracker entirely to the trailing tool-yield.
+        // The first run exercises the normal-bundle code path; the second
+        // exercises the trailing tool-yield branch. Keeping both in one
+        // test pins that the recovery is scoped to the trailing case
+        // without disturbing the surrounding bundles.
         final runs = [
           RunEventBundle(
             runId: 'run-1',
@@ -284,8 +284,8 @@ void main() {
         expect(
           trackers.keys,
           contains(noResponseMessageId('run-stuck')),
-          reason: 'Bug 2: trailing tool-yield bundle silently drops its '
-              'events; the run loses its tracker on reload.',
+          reason: 'A trailing tool-yield bundle must still produce a '
+              'tracker; the second run must not lose it on reload.',
         );
       },
     );

--- a/test/modules/room/agui_events_presentation_bugs_test.dart
+++ b/test/modules/room/agui_events_presentation_bugs_test.dart
@@ -1,25 +1,19 @@
-/// Reproduction harness for two known bugs in the "$N events" bubble
+/// Regression harness for two known bugs in the "$N events" bubble
 /// rendered above assistant messages by [ExecutionTimeline].
-///
-/// Each `test` documents the failure mode it reproduces and asserts the
-/// *correct* behavior. With the bugs present these assertions fail; once
-/// the underlying drops are fixed the assertions pass without other test
-/// changes.
 ///
 /// Bug 1 — Nested rows never get a checkmark
 /// -----------------------------------------
-/// Backend sends an ACTIVITY_SNAPSHOT for `skill_tool_call` with status
-/// `in_progress`, then an ACTIVITY_DELTA jsonpatch (`replace /status →
-/// done`) when the sub-skill completes. The frontend drops every
-/// `ActivityDeltaEvent` at two layers:
-///
-/// * [bridgeBaseEvent] returns `null` for the variant
-///   (agent_session.dart:656).
-/// * [_processActivityDelta] in agui_event_processor.dart is a logged
-///   no-op (line 807).
-///
-/// Net effect: the nested row keeps the in-progress status it had on
-/// first paint, so its trailing icon never flips to a checkmark.
+/// haiku.skills emits one logical sub-skill invocation as two
+/// `ActivitySnapshotEvent`s sharing a `messageId`: a call phase
+/// (`activity_type='skill_tool_call'`, carrying `args`) and a result
+/// phase (`activity_type='skill_tool_result'`, carrying `result`,
+/// `replace=true`). The original frontend decoder bailed on any
+/// activityType other than `skill_tool_call`, so the result snapshot
+/// was logged and dropped; the nested row stayed at its in-progress
+/// spinner for the rest of the run. The decoder now dispatches on
+/// activityType and routes `skill_tool_result` through a result-phase
+/// decoder that synthesizes `status='done'` and exposes the
+/// `content['result']` text.
 ///
 /// Bug 2 — Bubble disappears after reload
 /// --------------------------------------
@@ -43,34 +37,10 @@ import 'package:soliplex_frontend/src/modules/room/ui/execution/timeline_entry.d
 import '../../helpers/test_logger.dart';
 
 void main() {
-  group('Bug 1: ACTIVITY_DELTA status update is dropped', () {
+  group('Bug 1: skill_tool_result snapshot completes the nested row', () {
     test(
-      'bridgeBaseEvent drops ActivityDeltaEvent — nested rows never '
-      'receive the status change that drives the checkmark',
-      () {
-        final delta = ActivityDeltaEvent(
-          messageId: 'rag:call_1',
-          activityType: 'skill_tool_call',
-          patch: const [
-            {'op': 'replace', 'path': '/status', 'value': 'done'},
-          ],
-          timestamp: 200,
-        );
-
-        // Correct behavior: produce an ExecutionEvent the tracker can act
-        // on so the activity's status moves to "done". Currently null.
-        expect(
-          bridgeBaseEvent(delta),
-          isNotNull,
-          reason: 'Bug 1: ActivityDeltaEvent is dropped at the bridge; '
-              'the timeline never sees the status change.',
-        );
-      },
-    );
-
-    test(
-      'historical replay: snapshot(in_progress) + delta(status→done) '
-      'leaves the nested activity stuck at in_progress',
+      'historical replay: call snapshot + result snapshot leaves the '
+      'nested activity at status=done with the result text exposed',
       () {
         final runs = [
           RunEventBundle(
@@ -81,22 +51,27 @@ void main() {
                 toolCallId: 'tc-1',
                 toolCallName: 'execute_skill',
               ),
+              // Phase 1: call. haiku.skills emits replace=false so the
+              // initial snapshot lands as a new record.
               ActivitySnapshotEvent(
                 messageId: 'rag:call_1',
                 activityType: 'skill_tool_call',
                 content: {
                   'tool_name': 'ask',
                   'args': '{"q":"hi"}',
-                  'status': 'in_progress',
                 },
+                replace: false,
                 timestamp: 100,
               ),
-              ActivityDeltaEvent(
+              // Phase 2: result. Different activity_type, same messageId,
+              // replace=true so the call record is overwritten in place.
+              ActivitySnapshotEvent(
                 messageId: 'rag:call_1',
-                activityType: 'skill_tool_call',
-                patch: [
-                  {'op': 'replace', 'path': '/status', 'value': 'done'},
-                ],
+                activityType: 'skill_tool_result',
+                content: {
+                  'tool_name': 'ask',
+                  'result': 'answer text',
+                },
                 timestamp: 150,
               ),
               ToolCallResultEvent(
@@ -113,18 +88,27 @@ void main() {
         final step = trackers['asst-1']!.timeline.value.single as TimelineStep;
 
         expect(step.activities, hasLength(1));
+        final activity = step.activities.single;
         expect(
-          step.activities.single.status,
+          activity.status,
           'done',
-          reason: 'Bug 1: ACTIVITY_DELTA patches are dropped during replay; '
-              'the nested activity stays at its initial in_progress status.',
+          reason: 'Result snapshot must flip the row to done; otherwise '
+              'the nested icon stays at the in-progress spinner.',
+        );
+        expect(activity.result, 'answer text');
+        expect(
+          activity.args,
+          isEmpty,
+          reason: 'replace=true means the result snapshot overwrites the '
+              "call record; args are not present in the result phase's "
+              'content per AG-UI spec.',
         );
       },
     );
 
     test(
-      'live tracker: ActivitySnapshot then ActivityDelta on the same '
-      'messageId does not advance the activity to done',
+      'live tracker: call ActivitySnapshot then result ActivitySnapshot '
+      'on the same messageId advances the activity to done',
       () {
         final events = Signal<ExecutionEvent?>(null);
         final tracker = ExecutionTracker(
@@ -134,50 +118,54 @@ void main() {
         addTearDown(tracker.dispose);
 
         // Bridge each AG-UI event through the production bridge, mirroring
-        // what AgentSession does at runtime. Anything the bridge drops
-        // never reaches the tracker — exactly the bug we're reproducing.
-        final ExecutionEvent? snapshot = bridgeBaseEvent(
+        // what AgentSession does at runtime.
+        final ExecutionEvent? callSnapshot = bridgeBaseEvent(
           const ActivitySnapshotEvent(
             messageId: 'rag:call_1',
             activityType: 'skill_tool_call',
             content: {
               'tool_name': 'ask',
               'args': '{"q":"hi"}',
-              'status': 'in_progress',
             },
+            replace: false,
             timestamp: 100,
           ),
         );
-        expect(snapshot, isNotNull);
-        events.value = snapshot;
-
-        final ExecutionEvent? delta = bridgeBaseEvent(
-          ActivityDeltaEvent(
-            messageId: 'rag:call_1',
-            activityType: 'skill_tool_call',
-            patch: const [
-              {'op': 'replace', 'path': '/status', 'value': 'done'},
-            ],
-            timestamp: 200,
-          ),
-        );
-
-        expect(
-          delta,
-          isNotNull,
-          reason: 'Bug 1: the bridge drops the delta before it can reach '
-              'the live tracker.',
-        );
-        if (delta != null) events.value = delta;
+        expect(callSnapshot, isNotNull);
+        events.value = callSnapshot;
 
         final calls = tracker.skillToolCalls.value;
         expect(calls, hasLength(1));
         expect(
           calls.single.status,
-          'done',
-          reason: 'Bug 1: live tracker never sees the delta-driven '
-              'status change; the trailing icon stays as a spinner.',
+          'in_progress',
+          reason: 'The call phase carries no explicit status; the decoder '
+              'must synthesize in_progress so the spinner renders.',
         );
+
+        final ExecutionEvent? resultSnapshot = bridgeBaseEvent(
+          const ActivitySnapshotEvent(
+            messageId: 'rag:call_1',
+            activityType: 'skill_tool_result',
+            content: {
+              'tool_name': 'ask',
+              'result': 'answer text',
+            },
+            timestamp: 150,
+          ),
+        );
+        expect(resultSnapshot, isNotNull);
+        events.value = resultSnapshot;
+
+        final updated = tracker.skillToolCalls.value;
+        expect(updated, hasLength(1));
+        expect(
+          updated.single.status,
+          'done',
+          reason: 'The result snapshot must replace the call record so '
+              'the trailing icon flips to the checkmark.',
+        );
+        expect(updated.single.result, 'answer text');
       },
     );
   });

--- a/test/modules/room/compute_display_messages_test.dart
+++ b/test/modules/room/compute_display_messages_test.dart
@@ -30,7 +30,7 @@ void main() {
 
     final result = computeDisplayMessages(
       messages,
-      const AwaitingText(currentActivity: ThinkingActivity()),
+      const AwaitingText(currentPhase: ThinkingPhase()),
     );
 
     expect(result.length, 2);

--- a/test/modules/room/execution_tracker_extension_test.dart
+++ b/test/modules/room/execution_tracker_extension_test.dart
@@ -12,12 +12,18 @@ const _runId = 'run-1';
 class _FakeSession implements AgentSession {
   final Signal<RunState> _runState = Signal<RunState>(const IdleState());
   final Signal<ExecutionEvent?> _events = Signal<ExecutionEvent?>(null);
+  final Signal<List<ActivityRecord>> _activities =
+      Signal<List<ActivityRecord>>(const []);
 
   @override
   ReadonlySignal<RunState> get runState => _runState.readonly();
 
   @override
   ReadonlySignal<ExecutionEvent?> get lastExecutionEvent => _events.readonly();
+
+  @override
+  ReadonlySignal<List<ActivityRecord>> get conversationActivities =>
+      _activities.readonly();
 
   void emitRunState(RunState state) => _runState.value = state;
 

--- a/test/modules/room/execution_tracker_test.dart
+++ b/test/modules/room/execution_tracker_test.dart
@@ -161,9 +161,6 @@ void main() {
   });
 
   test('freeze called twice is a no-op (idempotent)', () {
-    // freeze() mutates state (clears spinner, completes steps) before
-    // flipping _isFrozen = true. _completeAllSteps asserts non-frozen, so
-    // a second call must short-circuit before re-running it.
     events.value = const ThinkingStarted();
     tracker.freeze();
     expect(tracker.isFrozen, isTrue);
@@ -423,7 +420,8 @@ void main() {
 
       final step = tracker.timeline.value.single as TimelineStep;
       expect(step.activityIds, ['bwrap:call_1']);
-      expect(tracker.skillToolCalls.value.single.status, 'done');
+      expect(
+          tracker.skillToolCalls.value.single.status, SkillToolCallStatus.done);
     });
 
     test('step completion updates status in timeline entry', () {

--- a/test/modules/room/execution_tracker_test.dart
+++ b/test/modules/room/execution_tracker_test.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter_test/flutter_test.dart';
 import 'package:soliplex_agent/soliplex_agent.dart';
 
@@ -246,6 +248,74 @@ void main() {
       ];
 
       expect(tracker.skillToolCalls.value, isEmpty);
+    });
+
+    test('freeze decouples the tracker from the source activities signal', () {
+      // ThreadViewState._detachSession absorbs the live tracker into its
+      // historical map and then lets the session — owner of the source
+      // `conversationActivities` — auto-dispose. The absorbed tracker
+      // must capture the activity list at freeze time and stop tracking
+      // the source: later session-side mutations cannot reach the
+      // historical view, and later session disposal cannot pollute reads
+      // with "signal read after disposed" warnings.
+      activities.value = const [
+        ActivityRecord(
+          messageId: 'rag:call_1',
+          activityType: 'skill_tool_call',
+          content: {'tool_name': 'ask', 'args': '{"q":"hi"}'},
+          timestamp: 1,
+        ),
+      ];
+      expect(tracker.skillToolCalls.value.single.toolName, 'ask');
+
+      tracker.freeze();
+
+      // Post-absorption, the session is free to mutate or dispose its
+      // signals; the absorbed tracker must stay pinned to what it had at
+      // freeze time.
+      activities.value = const [
+        ActivityRecord(
+          messageId: 'rag:call_1',
+          activityType: 'skill_tool_call',
+          content: {'tool_name': 'ask', 'args': '{"q":"hi"}'},
+          timestamp: 1,
+        ),
+        ActivityRecord(
+          messageId: 'rag:call_2',
+          activityType: 'skill_tool_call',
+          content: {'tool_name': 'search', 'args': '{}'},
+          timestamp: 2,
+        ),
+      ];
+      expect(
+        tracker.skillToolCalls.value.map((c) => c.messageId),
+        ['rag:call_1'],
+        reason: 'Frozen tracker must not pick up late mutations from the '
+            'session-owned source signal.',
+      );
+
+      // Disposing the source is the final step of session teardown.
+      // Reading the frozen tracker after disposal must not warn nor throw.
+      final captured = <String>[];
+      runZoned(
+        () {
+          activities.dispose();
+          // Force read; signals_core warns via `print` if a disposed
+          // signal is reached on this code path.
+          expect(
+            tracker.skillToolCalls.value.single.toolName,
+            'ask',
+          );
+        },
+        zoneSpecification: ZoneSpecification(
+          print: (_, __, ___, line) => captured.add(line),
+        ),
+      );
+      expect(
+        captured.where((l) => l.contains('read after disposed')),
+        isEmpty,
+        reason: 'Frozen tracker must not read the disposed source.',
+      );
     });
   });
 

--- a/test/modules/room/execution_tracker_test.dart
+++ b/test/modules/room/execution_tracker_test.dart
@@ -9,11 +9,17 @@ import '../../helpers/test_logger.dart';
 
 void main() {
   late Signal<ExecutionEvent?> events;
+  late Signal<List<ActivityRecord>> activities;
   late ExecutionTracker tracker;
 
   setUp(() {
     events = Signal<ExecutionEvent?>(null);
-    tracker = ExecutionTracker(executionEvents: events, logger: testLogger());
+    activities = Signal<List<ActivityRecord>>(const []);
+    tracker = ExecutionTracker(
+      executionEvents: events,
+      activities: activities,
+      logger: testLogger(),
+    );
   });
 
   tearDown(() => tracker.dispose());
@@ -209,142 +215,41 @@ void main() {
       expect(tracker.skillToolCalls.value, isEmpty);
     });
 
-    test('decodes a single skill_tool_call snapshot', () {
-      events.value = const ActivitySnapshot(
-        messageId: 'rag:call_1',
-        activityType: 'skill_tool_call',
-        content: {
-          'tool_name': 'ask',
-          'args': '{"q":"hi"}',
-          'status': 'in_progress',
-        },
-        timestamp: 100,
-      );
-
-      final calls = tracker.skillToolCalls.value;
-      expect(calls, hasLength(1));
-      expect(calls.single.messageId, 'rag:call_1');
-      expect(calls.single.toolName, 'ask');
-      expect(calls.single.args, {'q': 'hi'});
-      expect(calls.single.status, 'in_progress');
-      expect(calls.single.timestamp, 100);
-    });
-
-    test('replace:true overwrites record with same messageId in place', () {
-      events.value = const ActivitySnapshot(
-        messageId: 'rag:call_1',
-        activityType: 'skill_tool_call',
-        content: {
-          'tool_name': 'ask',
-          'args': '{"q":"hi"}',
-          'status': 'in_progress',
-        },
-        timestamp: 1,
-      );
-      events.value = const ActivitySnapshot(
-        messageId: 'rag:call_1',
-        activityType: 'skill_tool_call',
-        content: {
-          'tool_name': 'ask',
-          'args': '{"q":"hi"}',
-          'status': 'done',
-        },
-        timestamp: 2,
-      );
-
-      final calls = tracker.skillToolCalls.value;
-      expect(calls, hasLength(1));
-      expect(calls.single.status, 'done');
-      expect(calls.single.timestamp, 2);
-    });
-
-    test('replace:false on existing messageId is ignored', () {
-      events.value = const ActivitySnapshot(
-        messageId: 'rag:call_1',
-        activityType: 'skill_tool_call',
-        content: {
-          'tool_name': 'ask',
-          'args': '{"q":"first"}',
-          'status': 'in_progress',
-        },
-        timestamp: 1,
-      );
-      events.value = const ActivitySnapshot(
-        messageId: 'rag:call_1',
-        activityType: 'skill_tool_call',
-        content: {
-          'tool_name': 'search',
-          'args': '{"q":"second"}',
-          'status': 'done',
-        },
-        replace: false,
-        timestamp: 2,
-      );
-
-      final calls = tracker.skillToolCalls.value;
-      expect(calls, hasLength(1));
-      expect(calls.single.toolName, 'ask');
-      expect(calls.single.args, {'q': 'first'});
-    });
-
-    test('two concurrent messageIds stay independent', () {
-      events.value = const ActivitySnapshot(
-        messageId: 'rag:call_a',
-        activityType: 'skill_tool_call',
-        content: {'tool_name': 'ask', 'args': '{"q":"a"}'},
-        timestamp: 1,
-      );
-      events.value = const ActivitySnapshot(
-        messageId: 'rag:call_b',
-        activityType: 'skill_tool_call',
-        content: {'tool_name': 'search', 'args': '{"q":"b"}'},
-        timestamp: 2,
-      );
-
-      final calls = tracker.skillToolCalls.value;
-      expect(calls, hasLength(2));
-      final byId = {for (final c in calls) c.messageId: c};
-      expect(byId['rag:call_a']!.toolName, 'ask');
-      expect(byId['rag:call_b']!.toolName, 'search');
-    });
-
-    test('non-skill_tool_call activityType is dropped', () {
-      events.value = const ActivitySnapshot(
-        messageId: 'plan:1',
-        activityType: 'plan',
-        content: {'steps': 3},
-        timestamp: 1,
-      );
-
-      expect(tracker.skillToolCalls.value, isEmpty);
-    });
-
-    test('malformed skill_tool_call is dropped', () {
-      events.value = const ActivitySnapshot(
-        messageId: 'rag:bad',
-        activityType: 'skill_tool_call',
-        content: {'tool_name': 'ask', 'args': 'not json {'},
-        timestamp: 1,
-      );
-
-      expect(tracker.skillToolCalls.value, isEmpty);
-    });
-
-    test(
-      'missing timestamp is filled with wall-clock (non-zero) so the '
-      'decoded activity still appears',
-      () {
-        events.value = const ActivitySnapshot(
-          messageId: 'rag:call_1',
+    test('reflects the source activities signal in order', () {
+      activities.value = const [
+        ActivityRecord(
+          messageId: 'rag:call_a',
           activityType: 'skill_tool_call',
-          content: {'tool_name': 'ask', 'args': '{}'},
-        );
+          content: {'tool_name': 'ask', 'args': '{"q":"a"}'},
+          timestamp: 1,
+        ),
+        ActivityRecord(
+          messageId: 'rag:call_b',
+          activityType: 'skill_tool_call',
+          content: {'tool_name': 'search', 'args': '{"q":"b"}'},
+          timestamp: 2,
+        ),
+      ];
 
-        final calls = tracker.skillToolCalls.value;
-        expect(calls, hasLength(1));
-        expect(calls.single.timestamp, greaterThan(0));
-      },
-    );
+      final calls = tracker.skillToolCalls.value;
+      expect(calls.map((c) => c.toolName), ['ask', 'search']);
+    });
+
+    test('filters records that fail to decode as a skill_tool_* view', () {
+      // Records that aren't skill_tool_call or skill_tool_result are
+      // skipped — the tracker's `skillToolCalls` is a typed view, not
+      // a passthrough.
+      activities.value = const [
+        ActivityRecord(
+          messageId: 'plan:1',
+          activityType: 'plan',
+          content: {'steps': 3},
+          timestamp: 1,
+        ),
+      ];
+
+      expect(tracker.skillToolCalls.value, isEmpty);
+    });
   });
 
   group('timeline', () {
@@ -360,7 +265,7 @@ void main() {
       expect(entry, isA<TimelineStep>());
       final step = entry as TimelineStep;
       expect(step.step.label, 'Thinking');
-      expect(step.activities, isEmpty);
+      expect(step.activityIds, isEmpty);
     });
 
     test('activity during active step nests under it', () {
@@ -368,6 +273,14 @@ void main() {
         toolName: 'execute_skill',
         toolCallId: 'tc-1',
       );
+      activities.value = const [
+        ActivityRecord(
+          messageId: 'bwrap:call_1',
+          activityType: 'skill_tool_call',
+          content: {'tool_name': 'execute_script', 'args': '{}'},
+          timestamp: 100,
+        ),
+      ];
       events.value = const ActivitySnapshot(
         messageId: 'bwrap:call_1',
         activityType: 'skill_tool_call',
@@ -377,8 +290,8 @@ void main() {
 
       expect(tracker.timeline.value, hasLength(1));
       final step = tracker.timeline.value.single as TimelineStep;
-      expect(step.activities, hasLength(1));
-      expect(step.activities.single.toolName, 'execute_script');
+      expect(step.activityIds, ['bwrap:call_1']);
+      expect(tracker.skillToolCalls.value.single.toolName, 'execute_script');
     });
 
     test('activity arriving with no active step is standalone', () {
@@ -451,8 +364,11 @@ void main() {
 
       final tl = tracker.timeline.value;
       expect(tl, hasLength(2));
-      expect((tl[0] as TimelineStep).activities, hasLength(1));
-      expect((tl[1] as TimelineStep).activities, hasLength(2));
+      expect((tl[0] as TimelineStep).activityIds, ['bwrap:call_1']);
+      expect(
+        (tl[1] as TimelineStep).activityIds,
+        ['bwrap:call_2', 'bwrap:call_3'],
+      );
     });
 
     test('replace updates nested activity in place', () {
@@ -460,6 +376,18 @@ void main() {
         toolName: 'execute_skill',
         toolCallId: 'tc-1',
       );
+      activities.value = const [
+        ActivityRecord(
+          messageId: 'bwrap:call_1',
+          activityType: 'skill_tool_call',
+          content: {
+            'tool_name': 'execute_script',
+            'args': '{}',
+            'status': 'in_progress',
+          },
+          timestamp: 100,
+        ),
+      ];
       events.value = const ActivitySnapshot(
         messageId: 'bwrap:call_1',
         activityType: 'skill_tool_call',
@@ -470,6 +398,18 @@ void main() {
         },
         timestamp: 100,
       );
+      activities.value = const [
+        ActivityRecord(
+          messageId: 'bwrap:call_1',
+          activityType: 'skill_tool_call',
+          content: {
+            'tool_name': 'execute_script',
+            'args': '{}',
+            'status': 'done',
+          },
+          timestamp: 150,
+        ),
+      ];
       events.value = const ActivitySnapshot(
         messageId: 'bwrap:call_1',
         activityType: 'skill_tool_call',
@@ -482,8 +422,8 @@ void main() {
       );
 
       final step = tracker.timeline.value.single as TimelineStep;
-      expect(step.activities, hasLength(1));
-      expect(step.activities.single.status, 'done');
+      expect(step.activityIds, ['bwrap:call_1']);
+      expect(tracker.skillToolCalls.value.single.status, 'done');
     });
 
     test('step completion updates status in timeline entry', () {
@@ -543,8 +483,8 @@ void main() {
       );
 
       final step = tracker.timeline.value.single as TimelineStep;
-      expect(step.activities, hasLength(1));
-      expect(step.activities.single.toolName, 'execute_script');
+      expect(step.activityIds, ['bwrap:call_1']);
+      expect(tracker.skillToolCalls.value.single.toolName, 'execute_script');
       tracker.dispose();
     });
 

--- a/test/modules/room/execution_tracker_test.dart
+++ b/test/modules/room/execution_tracker_test.dart
@@ -442,8 +442,11 @@ void main() {
 
   group('ExecutionTracker.historical', () {
     test('returns frozen tracker', () {
-      final tracker =
-          ExecutionTracker.historical(events: const [], logger: testLogger());
+      final tracker = ExecutionTracker.historical(
+        events: const [],
+        activities: const [],
+        logger: testLogger(),
+      );
       expect(tracker.isFrozen, isTrue);
       tracker.dispose();
     });
@@ -457,6 +460,7 @@ void main() {
           ServerToolCallCompleted(toolCallId: 'tc-1', result: 'ok'),
           RunCompleted(),
         ],
+        activities: const [],
         logger: testLogger(),
       );
 
@@ -477,6 +481,14 @@ void main() {
             timestamp: 100,
           ),
         ],
+        activities: const [
+          ActivityRecord(
+            messageId: 'bwrap:call_1',
+            activityType: 'skill_tool_call',
+            content: {'tool_name': 'execute_script', 'args': '{}'},
+            timestamp: 100,
+          ),
+        ],
         logger: testLogger(),
       );
 
@@ -487,56 +499,15 @@ void main() {
     });
 
     test('empty events list yields empty timeline', () {
-      final tracker =
-          ExecutionTracker.historical(events: const [], logger: testLogger());
+      final tracker = ExecutionTracker.historical(
+        events: const [],
+        activities: const [],
+        logger: testLogger(),
+      );
       expect(tracker.steps.value, isEmpty);
       expect(tracker.timeline.value, isEmpty);
       tracker.dispose();
     });
-
-    test(
-      'replace=false against an existing messageId is ignored on replay '
-      '(matches the live _processActivitySnapshot semantics)',
-      () {
-        // Two snapshots share the same messageId. The second declares
-        // replace=false, so AG-UI says: ignore it. _reconstructActivities
-        // must preserve the FIRST snapshot's content; a regression that
-        // overwrote on replace=false would diverge from the live domain
-        // path silently and only on reload.
-        final tracker = ExecutionTracker.historical(
-          events: const [
-            ClientToolExecuting(toolName: 'execute_skill', toolCallId: 'tc-1'),
-            ActivitySnapshot(
-              messageId: 'rag:call_1',
-              activityType: 'skill_tool_call',
-              content: {
-                'tool_name': 'first',
-                'args': '{"q":"first"}',
-              },
-              timestamp: 100,
-            ),
-            ActivitySnapshot(
-              messageId: 'rag:call_1',
-              activityType: 'skill_tool_call',
-              content: {
-                'tool_name': 'second',
-                'args': '{"q":"second"}',
-              },
-              replace: false,
-              timestamp: 200,
-            ),
-          ],
-          logger: testLogger(),
-        );
-
-        final calls = tracker.skillToolCalls.value;
-        expect(calls, hasLength(1));
-        expect(calls.single.toolName, 'first');
-        expect(calls.single.args, {'q': 'first'});
-        expect(calls.single.timestamp, 100);
-        tracker.dispose();
-      },
-    );
 
     test(
         'events ending mid-thinking are finalized: no spinner, no '
@@ -546,6 +517,7 @@ void main() {
           ThinkingStarted(),
           ThinkingContent(delta: 'reasoning'),
         ],
+        activities: const [],
         logger: testLogger(),
       );
 

--- a/test/modules/room/execution_tracker_test.dart
+++ b/test/modules/room/execution_tracker_test.dart
@@ -497,6 +497,50 @@ void main() {
     });
 
     test(
+      'replace=false against an existing messageId is ignored on replay '
+      '(matches the live _processActivitySnapshot semantics)',
+      () {
+        // Two snapshots share the same messageId. The second declares
+        // replace=false, so AG-UI says: ignore it. _reconstructActivities
+        // must preserve the FIRST snapshot's content; a regression that
+        // overwrote on replace=false would diverge from the live domain
+        // path silently and only on reload.
+        final tracker = ExecutionTracker.historical(
+          events: const [
+            ClientToolExecuting(toolName: 'execute_skill', toolCallId: 'tc-1'),
+            ActivitySnapshot(
+              messageId: 'rag:call_1',
+              activityType: 'skill_tool_call',
+              content: {
+                'tool_name': 'first',
+                'args': '{"q":"first"}',
+              },
+              timestamp: 100,
+            ),
+            ActivitySnapshot(
+              messageId: 'rag:call_1',
+              activityType: 'skill_tool_call',
+              content: {
+                'tool_name': 'second',
+                'args': '{"q":"second"}',
+              },
+              replace: false,
+              timestamp: 200,
+            ),
+          ],
+          logger: testLogger(),
+        );
+
+        final calls = tracker.skillToolCalls.value;
+        expect(calls, hasLength(1));
+        expect(calls.single.toolName, 'first');
+        expect(calls.single.args, {'q': 'first'});
+        expect(calls.single.timestamp, 100);
+        tracker.dispose();
+      },
+    );
+
+    test(
         'events ending mid-thinking are finalized: no spinner, no '
         'active step', () {
       final tracker = ExecutionTracker.historical(
@@ -525,41 +569,6 @@ void main() {
     expect(tracker.isThinkingStreaming.value, isFalse);
     expect(tracker.steps.value.single.status, StepStatus.completed);
   });
-
-  test(
-    'a throw inside a switch arm is caught; subsequent events still process',
-    () {
-      // ActivitySnapshot with an unrecognized activityType makes
-      // `SkillToolCallActivity.fromRecord` return null. The warning that
-      // fires next reads `content.keys.toList().toString()` while
-      // building its attributes — a Map whose `keys` getter throws makes
-      // that argument-evaluation throw, propagating into the switch arm.
-      // The wrap catches it; the tracker keeps responding to events.
-      events.value = ActivitySnapshot(
-        messageId: 'msg-1',
-        activityType: 'unknown_activity',
-        content: _ThrowingMap(),
-        timestamp: 1,
-        replace: false,
-      );
-
-      // The tracker survives and still bridges later events.
-      events.value = const ThinkingStarted();
-      expect(tracker.steps.value, hasLength(1));
-      expect(tracker.steps.value.single.label, 'Thinking');
-      expect(tracker.isThinkingStreaming.value, isTrue);
-    },
-  );
-}
-
-/// A `Map<String, dynamic>` whose `keys` getter throws. Used to drive the
-/// argument-evaluation throw in `_upsertSkillToolCall`'s warning call.
-class _ThrowingMap implements Map<String, dynamic> {
-  @override
-  Iterable<String> get keys => throw StateError('keys access blew up');
-
-  @override
-  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
 }
 
 extension on StepStatus {

--- a/test/modules/room/execution_tracker_test.dart
+++ b/test/modules/room/execution_tracker_test.dart
@@ -314,7 +314,10 @@ void main() {
       expect(
         captured.where((l) => l.contains('read after disposed')),
         isEmpty,
-        reason: 'Frozen tracker must not read the disposed source.',
+        reason: 'Frozen tracker must not read the disposed source. The '
+            'matched substring is signals_core 6.2.1\'s verbatim warning; '
+            'a signals_core upgrade that rewords it would silently pass '
+            'this test — revisit the matcher on signals upgrades.',
       );
     });
   });

--- a/test/modules/room/historical_replay_test.dart
+++ b/test/modules/room/historical_replay_test.dart
@@ -134,8 +134,8 @@ void main() {
       expect(entries, hasLength(1));
       final step = entries.single as TimelineStep;
       expect(step.step.label, 'execute_skill');
-      expect(step.activities, hasLength(1));
-      expect(step.activities.single.toolName, 'execute_script');
+      expect(step.activityIds, hasLength(1));
+      expect(tracker.skillToolCalls.value.single.toolName, 'execute_script');
     });
 
     test(

--- a/test/modules/room/thread_view_state_test.dart
+++ b/test/modules/room/thread_view_state_test.dart
@@ -23,11 +23,13 @@ class _FakeAgentSession implements AgentSession {
       : _runState = Signal<RunState>(const IdleState()),
         _lastExecutionEvent = Signal<ExecutionEvent?>(null),
         _reconnectStatus = Signal<ReconnectStatus?>(null),
+        _activities = Signal<List<ActivityRecord>>(const []),
         _extensions = extensions;
 
   final Signal<RunState> _runState;
   final Signal<ExecutionEvent?> _lastExecutionEvent;
   final Signal<ReconnectStatus?> _reconnectStatus;
+  final Signal<List<ActivityRecord>> _activities;
   final Completer<AgentResult> _resultCompleter = Completer<AgentResult>();
   final List<SessionExtension> _extensions;
   bool cancelCalled = false;
@@ -40,6 +42,10 @@ class _FakeAgentSession implements AgentSession {
 
   @override
   ReadonlySignal<ExecutionEvent?> get lastExecutionEvent => _lastExecutionEvent;
+
+  @override
+  ReadonlySignal<List<ActivityRecord>> get conversationActivities =>
+      _activities;
 
   @override
   ReadonlySignal<ReconnectStatus?> get reconnectStatus => _reconnectStatus;

--- a/test/modules/room/tracker_registry_test.dart
+++ b/test/modules/room/tracker_registry_test.dart
@@ -8,10 +8,12 @@ import '../../helpers/test_logger.dart';
 
 void main() {
   late Signal<ExecutionEvent?> events;
+  late Signal<List<ActivityRecord>> activities;
   late TrackerRegistry registry;
 
   setUp(() {
     events = Signal<ExecutionEvent?>(null);
+    activities = Signal<List<ActivityRecord>>(const []);
     registry = TrackerRegistry(logger: testLogger());
   });
 
@@ -25,6 +27,7 @@ void main() {
     registry.onStreaming(
       const AwaitingText(currentPhase: ThinkingPhase()),
       events,
+      activities,
     );
 
     expect(registry.trackers, hasLength(1));
@@ -35,6 +38,7 @@ void main() {
     registry.onStreaming(
       const AwaitingText(currentPhase: ThinkingPhase()),
       events,
+      activities,
     );
 
     registry.onStreaming(
@@ -44,6 +48,7 @@ void main() {
         text: '',
       ),
       events,
+      activities,
     );
 
     expect(registry.trackers.containsKey(awaitingTrackerKey), isFalse);
@@ -60,6 +65,7 @@ void main() {
         text: '',
       ),
       events,
+      activities,
     );
 
     expect(registry.trackers, hasLength(1));
@@ -77,6 +83,7 @@ void main() {
         text: '',
       ),
       events1,
+      activities,
     );
 
     registry.onStreaming(
@@ -86,6 +93,7 @@ void main() {
         text: '',
       ),
       events2,
+      activities,
     );
 
     expect(registry.trackers, hasLength(2));
@@ -101,6 +109,7 @@ void main() {
         text: '',
       ),
       events,
+      activities,
     );
 
     final tracker = registry.trackers['msg-1'];
@@ -112,6 +121,7 @@ void main() {
         text: 'more text',
       ),
       events,
+      activities,
     );
 
     expect(registry.trackers, hasLength(1));
@@ -127,6 +137,7 @@ void main() {
         text: '',
       ),
       events,
+      activities,
     );
 
     registry.onRunTerminated();
@@ -147,6 +158,7 @@ void main() {
         text: '',
       ),
       events,
+      activities,
     );
 
     registry.onRunTerminated();
@@ -158,6 +170,7 @@ void main() {
         text: '',
       ),
       events,
+      activities,
     );
 
     registry.dispose();
@@ -187,6 +200,7 @@ void main() {
           text: '',
         ),
         events,
+        activities,
       );
       final live = registry.trackers['asst-1'];
 
@@ -205,6 +219,7 @@ void main() {
       registry.onStreaming(
         const AwaitingText(currentPhase: ThinkingPhase()),
         events,
+        activities,
       );
       final awaitingTracker = registry.trackers[awaitingTrackerKey];
 
@@ -221,6 +236,7 @@ void main() {
       registry.onStreaming(
         const AwaitingText(currentPhase: ThinkingPhase()),
         events,
+        activities,
       );
       registry.renameAwaitingTo('no-response-run-1');
 
@@ -233,6 +249,7 @@ void main() {
       registry.onStreaming(
         const AwaitingText(currentPhase: ThinkingPhase()),
         events,
+        activities,
       );
       final before = registry.trackers[awaitingTrackerKey];
 
@@ -259,6 +276,7 @@ void main() {
       final historicalEvents = Signal<ExecutionEvent?>(null);
       final historicalTracker = ExecutionTracker(
         executionEvents: historicalEvents,
+        activities: activities,
         logger: testLogger(),
       );
       registry.seedHistorical({'no-response-run-1': historicalTracker});
@@ -266,6 +284,7 @@ void main() {
       registry.onStreaming(
         const AwaitingText(currentPhase: ThinkingPhase()),
         events,
+        activities,
       );
       final awaitingTracker = registry.trackers[awaitingTrackerKey];
 
@@ -294,11 +313,13 @@ void main() {
         text: '',
       ),
       events,
+      activities,
     );
 
     registry.onStreaming(
       const AwaitingText(currentPhase: ThinkingPhase()),
       events,
+      activities,
     );
 
     // Should not create an awaiting tracker — msg-1 is still active

--- a/test/modules/room/tracker_registry_test.dart
+++ b/test/modules/room/tracker_registry_test.dart
@@ -23,7 +23,7 @@ void main() {
 
   test('creates tracker on AwaitingText when idle', () {
     registry.onStreaming(
-      const AwaitingText(currentActivity: ThinkingActivity()),
+      const AwaitingText(currentPhase: ThinkingPhase()),
       events,
     );
 
@@ -33,7 +33,7 @@ void main() {
 
   test('re-keys awaiting tracker to message ID on TextStreaming', () {
     registry.onStreaming(
-      const AwaitingText(currentActivity: ThinkingActivity()),
+      const AwaitingText(currentPhase: ThinkingPhase()),
       events,
     );
 
@@ -203,7 +203,7 @@ void main() {
   group('renameAwaitingTo', () {
     test('moves the awaiting tracker to the new key', () {
       registry.onStreaming(
-        const AwaitingText(currentActivity: ThinkingActivity()),
+        const AwaitingText(currentPhase: ThinkingPhase()),
         events,
       );
       final awaitingTracker = registry.trackers[awaitingTrackerKey];
@@ -219,7 +219,7 @@ void main() {
       // synthesized id; otherwise _freezeActive would no-op (the awaiting
       // entry no longer exists under that key).
       registry.onStreaming(
-        const AwaitingText(currentActivity: ThinkingActivity()),
+        const AwaitingText(currentPhase: ThinkingPhase()),
         events,
       );
       registry.renameAwaitingTo('no-response-run-1');
@@ -231,7 +231,7 @@ void main() {
 
     test('no-ops when the new key equals the awaiting sentinel', () {
       registry.onStreaming(
-        const AwaitingText(currentActivity: ThinkingActivity()),
+        const AwaitingText(currentPhase: ThinkingPhase()),
         events,
       );
       final before = registry.trackers[awaitingTrackerKey];
@@ -264,7 +264,7 @@ void main() {
       registry.seedHistorical({'no-response-run-1': historicalTracker});
 
       registry.onStreaming(
-        const AwaitingText(currentActivity: ThinkingActivity()),
+        const AwaitingText(currentPhase: ThinkingPhase()),
         events,
       );
       final awaitingTracker = registry.trackers[awaitingTrackerKey];
@@ -297,7 +297,7 @@ void main() {
     );
 
     registry.onStreaming(
-      const AwaitingText(currentActivity: ThinkingActivity()),
+      const AwaitingText(currentPhase: ThinkingPhase()),
       events,
     );
 

--- a/test/modules/room/tracker_registry_test.dart
+++ b/test/modules/room/tracker_registry_test.dart
@@ -180,10 +180,16 @@ void main() {
   group('seedHistorical', () {
     test('adds frozen trackers under their message ids', () {
       final historical = {
-        'asst-1':
-            ExecutionTracker.historical(events: const [], logger: testLogger()),
-        'asst-2':
-            ExecutionTracker.historical(events: const [], logger: testLogger()),
+        'asst-1': ExecutionTracker.historical(
+          events: const [],
+          activities: const [],
+          logger: testLogger(),
+        ),
+        'asst-2': ExecutionTracker.historical(
+          events: const [],
+          activities: const [],
+          logger: testLogger(),
+        ),
       };
 
       registry.seedHistorical(historical);
@@ -205,8 +211,11 @@ void main() {
       final live = registry.trackers['asst-1'];
 
       final historical = {
-        'asst-1':
-            ExecutionTracker.historical(events: const [], logger: testLogger()),
+        'asst-1': ExecutionTracker.historical(
+          events: const [],
+          activities: const [],
+          logger: testLogger(),
+        ),
       };
       registry.seedHistorical(historical);
 

--- a/test/modules/room/ui/execution/execution_timeline_test.dart
+++ b/test/modules/room/ui/execution/execution_timeline_test.dart
@@ -17,14 +17,53 @@ const _messageId = 'm1';
 
 void main() {
   late Signal<ExecutionEvent?> events;
+  late Signal<List<ActivityRecord>> activities;
   late ExecutionTracker tracker;
   late MessageExpansions store;
 
   setUp(() {
     events = Signal<ExecutionEvent?>(null);
-    tracker = ExecutionTracker(executionEvents: events, logger: testLogger());
+    activities = Signal<List<ActivityRecord>>(const []);
+    tracker = ExecutionTracker(
+      executionEvents: events,
+      activities: activities,
+      logger: testLogger(),
+    );
     store = MessageExpansions();
   });
+
+  // Helper: push an ActivitySnapshot event AND the corresponding
+  // ActivityRecord into the activities signal, mirroring what
+  // `_processActivitySnapshot` + the bridge do in production.
+  void pushSnapshot({
+    required String messageId,
+    required String activityType,
+    required Map<String, dynamic> content,
+    required int timestamp,
+    bool replace = true,
+  }) {
+    final record = ActivityRecord(
+      messageId: messageId,
+      activityType: activityType,
+      content: content,
+      timestamp: timestamp,
+    );
+    final idx = activities.value.indexWhere((a) => a.messageId == messageId);
+    if (idx >= 0) {
+      if (replace) {
+        activities.value = [...activities.value]..[idx] = record;
+      }
+    } else {
+      activities.value = [...activities.value, record];
+    }
+    events.value = ActivitySnapshot(
+      messageId: messageId,
+      activityType: activityType,
+      content: content,
+      timestamp: timestamp,
+      replace: replace,
+    );
+  }
 
   tearDown(() => tracker.dispose());
 
@@ -59,13 +98,13 @@ void main() {
       toolName: 'execute_skill',
       toolCallId: 'tc-1',
     );
-    events.value = const ActivitySnapshot(
+    pushSnapshot(
       messageId: 'bwrap:call_1',
       activityType: 'skill_tool_call',
       content: {'tool_name': 'execute_script', 'args': '{}'},
       timestamp: 100,
     );
-    events.value = const ActivitySnapshot(
+    pushSnapshot(
       messageId: 'bwrap:call_2',
       activityType: 'skill_tool_call',
       content: {'tool_name': 'list_environments', 'args': '{}'},
@@ -92,7 +131,7 @@ void main() {
       toolName: 'execute_skill',
       toolCallId: 'tc-1',
     );
-    events.value = const ActivitySnapshot(
+    pushSnapshot(
       messageId: 'bwrap:call_1',
       activityType: 'skill_tool_call',
       content: {'tool_name': 'execute_script', 'args': '{}'},
@@ -117,7 +156,7 @@ void main() {
       toolName: 'execute_skill',
       toolCallId: 'tc-1',
     );
-    events.value = const ActivitySnapshot(
+    pushSnapshot(
       messageId: 'bwrap:call_1',
       activityType: 'skill_tool_call',
       content: {
@@ -141,7 +180,7 @@ void main() {
   });
 
   testWidgets('activity with no args has no source chevron', (tester) async {
-    events.value = const ActivitySnapshot(
+    pushSnapshot(
       messageId: 'bwrap:call_1',
       activityType: 'skill_tool_call',
       content: {'tool_name': 'noop', 'args': '{}'},
@@ -159,7 +198,7 @@ void main() {
   });
 
   testWidgets('generic args fall back to JSON preview', (tester) async {
-    events.value = const ActivitySnapshot(
+    pushSnapshot(
       messageId: 'rag:call_1',
       activityType: 'skill_tool_call',
       content: {
@@ -199,7 +238,7 @@ void main() {
 
   testWidgets('standalone activity rendered when no active step',
       (tester) async {
-    events.value = const ActivitySnapshot(
+    pushSnapshot(
       messageId: 'bwrap:call_1',
       activityType: 'skill_tool_call',
       content: {
@@ -245,7 +284,7 @@ void main() {
         toolName: 'execute_skill',
         toolCallId: 'tc-1',
       );
-      events.value = const ActivitySnapshot(
+      pushSnapshot(
         messageId: 'bwrap:call_1',
         activityType: 'skill_tool_call',
         content: {
@@ -276,14 +315,20 @@ void main() {
       events.value = const ThinkingStarted();
 
       final events2 = Signal<ExecutionEvent?>(null);
-      final tracker2 =
-          ExecutionTracker(executionEvents: events2, logger: testLogger());
+      final tracker2 = ExecutionTracker(
+        executionEvents: events2,
+        activities: Signal<List<ActivityRecord>>(const []),
+        logger: testLogger(),
+      );
       addTearDown(tracker2.dispose);
       events2.value = const ThinkingStarted();
 
       final events3 = Signal<ExecutionEvent?>(null);
-      final tracker3 =
-          ExecutionTracker(executionEvents: events3, logger: testLogger());
+      final tracker3 = ExecutionTracker(
+        executionEvents: events3,
+        activities: Signal<List<ActivityRecord>>(const []),
+        logger: testLogger(),
+      );
       addTearDown(tracker3.dispose);
       events3.value = const ThinkingStarted();
 
@@ -351,7 +396,7 @@ void main() {
         toolName: 'execute_skill',
         toolCallId: 'tc-1',
       );
-      events.value = const ActivitySnapshot(
+      pushSnapshot(
         messageId: 'bwrap:call_1',
         activityType: 'skill_tool_call',
         content: {

--- a/test/modules/room/ui/execution/execution_timeline_test.dart
+++ b/test/modules/room/ui/execution/execution_timeline_test.dart
@@ -101,9 +101,8 @@ void main() {
       // ActivitySnapshot event, then clear the activities signal so
       // skillToolCalls becomes empty. The renderer must fall through to
       // SizedBox.shrink() for the dangling id, not throw on missing
-      // lookup. Today there is no production path that produces this
-      // state — the test pins the defensive fallback for future
-      // MESSAGES_SNAPSHOT or producer/consumer drift.
+      // lookup — pinning the defensive fallback for MESSAGES_SNAPSHOT
+      // or producer/consumer drift.
       events.value = const ClientToolExecuting(
         toolName: 'execute_skill',
         toolCallId: 'tc-1',

--- a/test/modules/room/ui/execution/execution_timeline_test.dart
+++ b/test/modules/room/ui/execution/execution_timeline_test.dart
@@ -93,6 +93,43 @@ void main() {
     expect(find.byType(GestureDetector), findsNothing);
   });
 
+  testWidgets(
+    'dangling activity id (in timeline but not in skillToolCalls) renders '
+    'as an empty row instead of throwing',
+    (tester) async {
+      // Place the activity on the timeline by firing a recognized
+      // ActivitySnapshot event, then clear the activities signal so
+      // skillToolCalls becomes empty. The renderer must fall through to
+      // SizedBox.shrink() for the dangling id, not throw on missing
+      // lookup. Today there is no production path that produces this
+      // state — the test pins the defensive fallback for future
+      // MESSAGES_SNAPSHOT or producer/consumer drift.
+      events.value = const ClientToolExecuting(
+        toolName: 'execute_skill',
+        toolCallId: 'tc-1',
+      );
+      pushSnapshot(
+        messageId: 'rag:call_1',
+        activityType: 'skill_tool_call',
+        content: {'tool_name': 'lookup', 'args': '{}'},
+        timestamp: 100,
+      );
+      // Drop the activity record while the timeline retains the id.
+      activities.value = const [];
+
+      await tester.pumpWidget(wrap(build()));
+      await tester.pump();
+      // Expand the timeline so the row is built.
+      await tester.tap(find.text('2 events'));
+      await tester.pump();
+
+      // The step row renders (it's a structural entry, not content-keyed).
+      expect(find.text('execute_skill'), findsOneWidget);
+      // The activity row does not render — no `lookup` text, no throw.
+      expect(find.text('lookup'), findsNothing);
+    },
+  );
+
   testWidgets('header counts step + nested activities', (tester) async {
     events.value = const ClientToolExecuting(
       toolName: 'execute_skill',

--- a/test/modules/room/ui/execution/thinking_block_test.dart
+++ b/test/modules/room/ui/execution/thinking_block_test.dart
@@ -23,7 +23,11 @@ void main() {
 
     setUp(() {
       events = Signal<ExecutionEvent?>(null);
-      tracker = ExecutionTracker(executionEvents: events, logger: testLogger());
+      tracker = ExecutionTracker(
+        executionEvents: events,
+        activities: Signal<List<ActivityRecord>>(const []),
+        logger: testLogger(),
+      );
       store = MessageExpansions();
     });
 

--- a/test/modules/room/ui/execution_widgets_test.dart
+++ b/test/modules/room/ui/execution_widgets_test.dart
@@ -65,8 +65,11 @@ void main() {
 
   testWidgets('ExecutionTimeline shows event count', (tester) async {
     final events = Signal<ExecutionEvent?>(null);
-    final tracker =
-        ExecutionTracker(executionEvents: events, logger: testLogger());
+    final tracker = ExecutionTracker(
+      executionEvents: events,
+      activities: Signal<List<ActivityRecord>>(const []),
+      logger: testLogger(),
+    );
 
     events.value = const ThinkingStarted();
     events.value = const ServerToolCallStarted(
@@ -91,8 +94,11 @@ void main() {
 
   testWidgets('ExecutionThinkingBlock shows thinking label', (tester) async {
     final events = Signal<ExecutionEvent?>(null);
-    final tracker =
-        ExecutionTracker(executionEvents: events, logger: testLogger());
+    final tracker = ExecutionTracker(
+      executionEvents: events,
+      activities: Signal<List<ActivityRecord>>(const []),
+      logger: testLogger(),
+    );
 
     events.value = const ThinkingStarted();
     events.value = const ThinkingContent(delta: 'Let me think about this');

--- a/test/modules/room/ui/execution_widgets_test.dart
+++ b/test/modules/room/ui/execution_widgets_test.dart
@@ -32,10 +32,10 @@ void main() {
   });
 
   testWidgets('PhaseIndicator shows tool call label', (tester) async {
-    await tester.pumpWidget(const MaterialApp(
+    await tester.pumpWidget(MaterialApp(
       home: Scaffold(
         body: PhaseIndicator(
-          phase: ToolCallPhase(toolName: 'search_docs'),
+          phase: ToolCallPhase.single(toolName: 'search_docs'),
         ),
       ),
     ));

--- a/test/modules/room/ui/execution_widgets_test.dart
+++ b/test/modules/room/ui/execution_widgets_test.dart
@@ -8,7 +8,7 @@ import '../../../helpers/test_logger.dart';
 import 'package:soliplex_frontend/src/modules/room/execution_tracker.dart';
 import 'package:soliplex_frontend/src/modules/room/message_expansions.dart';
 import 'package:soliplex_frontend/src/modules/room/room_providers.dart';
-import 'package:soliplex_frontend/src/modules/room/ui/execution/activity_indicator.dart';
+import 'package:soliplex_frontend/src/modules/room/ui/execution/phase_indicator.dart';
 import 'package:soliplex_frontend/src/modules/room/ui/execution/execution_timeline.dart';
 import 'package:soliplex_frontend/src/modules/room/ui/execution/thinking_block.dart';
 
@@ -20,10 +20,10 @@ Widget _withStore(Widget child) => ProviderScope(
     );
 
 void main() {
-  testWidgets('ActivityIndicator shows Processing label', (tester) async {
+  testWidgets('PhaseIndicator shows Processing label', (tester) async {
     await tester.pumpWidget(const MaterialApp(
       home: Scaffold(
-        body: ActivityIndicator(activity: ProcessingActivity()),
+        body: PhaseIndicator(phase: ProcessingPhase()),
       ),
     ));
 
@@ -31,11 +31,11 @@ void main() {
     expect(find.byType(CircularProgressIndicator), findsWidgets);
   });
 
-  testWidgets('ActivityIndicator shows tool call label', (tester) async {
+  testWidgets('PhaseIndicator shows tool call label', (tester) async {
     await tester.pumpWidget(const MaterialApp(
       home: Scaffold(
-        body: ActivityIndicator(
-          activity: ToolCallActivity(toolName: 'search_docs'),
+        body: PhaseIndicator(
+          phase: ToolCallPhase(toolName: 'search_docs'),
         ),
       ),
     ));
@@ -43,20 +43,20 @@ void main() {
     expect(find.text('Calling search_docs...'), findsOneWidget);
   });
 
-  testWidgets('ActivityIndicator shows Thinking label', (tester) async {
+  testWidgets('PhaseIndicator shows Thinking label', (tester) async {
     await tester.pumpWidget(const MaterialApp(
       home: Scaffold(
-        body: ActivityIndicator(activity: ThinkingActivity()),
+        body: PhaseIndicator(phase: ThinkingPhase()),
       ),
     ));
 
     expect(find.text('Thinking...'), findsOneWidget);
   });
 
-  testWidgets('ActivityIndicator shows Responding label', (tester) async {
+  testWidgets('PhaseIndicator shows Responding label', (tester) async {
     await tester.pumpWidget(const MaterialApp(
       home: Scaffold(
-        body: ActivityIndicator(activity: RespondingActivity()),
+        body: PhaseIndicator(phase: RespondingPhase()),
       ),
     ));
 

--- a/test/modules/room/ui/message_tile_test.dart
+++ b/test/modules/room/ui/message_tile_test.dart
@@ -66,8 +66,11 @@ void main() {
         'renders ExecutionTimeline and ThinkingBlock when tracker provided',
         (tester) async {
       final events = Signal<ExecutionEvent?>(null);
-      final tracker =
-          ExecutionTracker(executionEvents: events, logger: testLogger());
+      final tracker = ExecutionTracker(
+        executionEvents: events,
+        activities: Signal<List<ActivityRecord>>(const []),
+        logger: testLogger(),
+      );
 
       events.value = const ThinkingStarted();
       events.value = const ThinkingContent(delta: 'reasoning...');
@@ -132,8 +135,11 @@ void main() {
     testWidgets('prefers ExecutionThinkingBlock over message thinkingText',
         (tester) async {
       final events = Signal<ExecutionEvent?>(null);
-      final tracker =
-          ExecutionTracker(executionEvents: events, logger: testLogger());
+      final tracker = ExecutionTracker(
+        executionEvents: events,
+        activities: Signal<List<ActivityRecord>>(const []),
+        logger: testLogger(),
+      );
 
       events.value = const ThinkingStarted();
       events.value = const ThinkingContent(delta: 'live thinking');
@@ -174,8 +180,11 @@ void main() {
 
     testWidgets('renders execution widgets with tracker', (tester) async {
       final events = Signal<ExecutionEvent?>(null);
-      final tracker =
-          ExecutionTracker(executionEvents: events, logger: testLogger());
+      final tracker = ExecutionTracker(
+        executionEvents: events,
+        activities: Signal<List<ActivityRecord>>(const []),
+        logger: testLogger(),
+      );
 
       events.value = const ThinkingStarted();
       events.value = const ThinkingContent(delta: 'working...');

--- a/test/modules/room/ui/message_tile_test.dart
+++ b/test/modules/room/ui/message_tile_test.dart
@@ -8,7 +8,7 @@ import '../../../helpers/test_logger.dart';
 import 'package:soliplex_frontend/src/modules/room/execution_tracker.dart';
 import 'package:soliplex_frontend/src/modules/room/message_expansions.dart';
 import 'package:soliplex_frontend/src/modules/room/room_providers.dart';
-import 'package:soliplex_frontend/src/modules/room/ui/execution/activity_indicator.dart';
+import 'package:soliplex_frontend/src/modules/room/ui/execution/phase_indicator.dart';
 import 'package:soliplex_frontend/src/modules/room/ui/execution/execution_timeline.dart';
 import 'package:soliplex_frontend/src/modules/room/ui/execution/thinking_block.dart';
 import 'package:soliplex_frontend/src/modules/room/ui/loading_message_tile.dart';
@@ -95,7 +95,7 @@ void main() {
       tracker.dispose();
     });
 
-    testWidgets('renders ActivityIndicator when streamingActivity provided',
+    testWidgets('renders PhaseIndicator when streamingPhase provided',
         (tester) async {
       final msg = TextMessage(
         id: 'msg-1',
@@ -107,10 +107,10 @@ void main() {
       await tester.pumpWidget(_wrap(TextMessageTile(
         roomId: 'r',
         message: msg,
-        streamingActivity: const RespondingActivity(),
+        streamingPhase: const RespondingPhase(),
       )));
 
-      expect(find.byType(ActivityIndicator), findsOneWidget);
+      expect(find.byType(PhaseIndicator), findsOneWidget);
       expect(find.text('Responding...'), findsOneWidget);
     });
 
@@ -184,10 +184,10 @@ void main() {
         roomId: 'r',
         messageId: '_loading',
         executionTracker: tracker,
-        streamingActivity: const ThinkingActivity(),
+        streamingPhase: const ThinkingPhase(),
       )));
 
-      expect(find.byType(ActivityIndicator), findsOneWidget);
+      expect(find.byType(PhaseIndicator), findsOneWidget);
       expect(find.byType(ExecutionTimeline), findsOneWidget);
       expect(find.byType(ExecutionThinkingBlock), findsOneWidget);
 


### PR DESCRIPTION
## Summary

Completes the AG-UI activity-event refactor started in PR 3, fixing the user-visible bugs where nested skill-tool-call rows stayed on an empty circle and rows briefly rendered as phantom \`SizedBox.shrink()\` placeholders.

The five Changes from \`activity-handling-fundamental-fix.md\` all landed:

1. Domain handles \`ACTIVITY_DELTA\` — \`_processActivityDelta\` patches \`Conversation.activities\` via \`applyJsonPatch\`.
2. Decoder recognises \`skill_tool_result\` — \`SkillToolCallActivity.fromRecord\` switches on \`activityType\`.
3. Tracker stops caching activity content — \`_activityRecords\` deleted; \`TimelineStep.activityIds: List<String>\` references domain records via a new \`AgentSession.conversationActivities\` computed signal.
4. \`ActivityType\` → \`RunPhase\` rename, split into its own file.
5. Tests use the real backend emission pattern (call snapshot \`replace=false\` → result snapshot \`replace=true\`, same \`messageId\`).

Other resolved items:

- Tool-call args carry across the AG-UI replace boundary.
- Absorbed \`ExecutionTracker\` isolates from the session-owned activities signal.
- Phantom-row regression from PR 3.
- Trailing tool-yield reload bubble.
- \`applyJsonPatch\` routes through \`LogManager\`; activity-event validation tightened.
- Comment hygiene sweep (one cluster missed — tracked in todo).

The remaining dual-pipeline smell is filed as #238.

## Test plan

- [x] \`mcp__dart__analyze_files\` zero warnings
- [x] \`mcp__dart__run_tests\` passes
- [x] Manual: skill-tool-call rows flip spinner → checkmark when result snapshot arrives; reload preserves the checkmark
- [ ] Manual: trailing tool-yield reload shows execution bubble under the synthesized NoResponseTile