### PR TITLE
refactor(diagnostics): adopt design tokens

### DIFF
--- a/lib/src/design/tokens/typography_x.dart
+++ b/lib/src/design/tokens/typography_x.dart
@@ -2,22 +2,29 @@ import 'package:flutter/material.dart';
 
 import '../../shared/platform_resolver.dart';
 
-TextStyle appMonospaceTextStyle(BuildContext context) {
-  final base = Theme.of(context).textTheme.bodyMedium;
+TextStyle appMonospaceTextStyle(BuildContext context, {TextStyle? base}) {
+  final effectiveBase = base ?? Theme.of(context).textTheme.bodyMedium;
 
   if (isCupertino(context)) {
-    return base!.copyWith(
+    return effectiveBase!.copyWith(
       fontFamily: 'SF Mono',
       fontFamilyFallback: const ['Menlo', 'monospace'],
     );
   }
 
-  return base!.copyWith(
+  return effectiveBase!.copyWith(
     fontFamily: 'Roboto Mono',
     fontFamilyFallback: const ['monospace'],
   );
 }
 
 extension TypographyX on BuildContext {
+  /// Monospace using `bodyMedium` (16pt) as the base.
   TextStyle get monospace => appMonospaceTextStyle(this);
+
+  /// Monospace built on top of a specific text theme entry, e.g.
+  /// `context.monospaceOn(Theme.of(context).textTheme.labelSmall)` for a
+  /// 12pt monospace badge.
+  TextStyle monospaceOn(TextStyle? base) =>
+      appMonospaceTextStyle(this, base: base);
 }

--- a/lib/src/modules/diagnostics/ui/concurrency_summary_panel.dart
+++ b/lib/src/modules/diagnostics/ui/concurrency_summary_panel.dart
@@ -3,6 +3,8 @@ import 'dart:math' as math;
 import 'package:flutter/material.dart';
 import 'package:soliplex_agent/soliplex_agent.dart';
 
+import '../../../design/design.dart';
+
 /// Compact header strip showing aggregate queue health from the HTTP
 /// concurrency limiter.
 ///
@@ -25,7 +27,10 @@ class ConcurrencySummaryPanel extends StatelessWidget {
 
     return Container(
       width: double.infinity,
-      padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+      padding: const EdgeInsets.symmetric(
+        horizontal: SoliplexSpacing.s3,
+        vertical: SoliplexSpacing.s2,
+      ),
       color: theme.colorScheme.surfaceContainerHighest,
       child: Row(
         children: [
@@ -34,11 +39,11 @@ class ConcurrencySummaryPanel extends StatelessWidget {
             size: 16,
             color: theme.colorScheme.onSurfaceVariant,
           ),
-          const SizedBox(width: 8),
+          const SizedBox(width: SoliplexSpacing.s2),
           Expanded(
             child: Wrap(
-              spacing: 12,
-              runSpacing: 4,
+              spacing: SoliplexSpacing.s3,
+              runSpacing: SoliplexSpacing.s1,
               children: [
                 Text(
                   'queued ${stats.queuedCount} of ${stats.total}',

--- a/lib/src/modules/diagnostics/ui/http_event_tile.dart
+++ b/lib/src/modules/diagnostics/ui/http_event_tile.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 
+import '../../../design/design.dart';
 import '../models/format_utils.dart';
 import '../models/http_event_group.dart';
 import 'http_status_display.dart';
@@ -26,15 +27,15 @@ class HttpEventTile extends StatelessWidget {
       label: group.semanticLabel,
       child: Padding(
         padding: EdgeInsets.symmetric(
-          horizontal: dense ? 8 : 12,
-          vertical: dense ? 6 : 8,
+          horizontal: dense ? SoliplexSpacing.s2 : SoliplexSpacing.s3,
+          vertical: SoliplexSpacing.s2,
         ),
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.start,
           mainAxisSize: MainAxisSize.min,
           children: [
             _buildRequestLine(theme),
-            SizedBox(height: dense ? 2 : 4),
+            const SizedBox(height: SoliplexSpacing.s1),
             _buildResultLine(theme),
           ],
         ),
@@ -63,7 +64,7 @@ class HttpEventTile extends StatelessWidget {
     return Row(
       children: [
         Text(group.methodLabel, style: methodStyle),
-        const SizedBox(width: 6),
+        const SizedBox(width: SoliplexSpacing.s2),
         Expanded(
           child: Text(
             group.pathWithQuery,
@@ -78,20 +79,21 @@ class HttpEventTile extends StatelessWidget {
 
   Widget _buildResultLine(ThemeData theme) {
     final colorScheme = theme.colorScheme;
-    final metaStyle = theme.textTheme.bodySmall?.copyWith(
+    final metaStyle =
+        (dense ? theme.textTheme.labelSmall : theme.textTheme.bodySmall)
+            ?.copyWith(
       color: isSelected
           ? colorScheme.onPrimaryContainer
           : colorScheme.onSurfaceVariant,
-      fontSize: dense ? 11 : null,
     );
 
     return Row(
       children: [
         if (!dense) ...[
           Text(group.timestamp.toHttpTimeString(), style: metaStyle),
-          const SizedBox(width: 4),
+          const SizedBox(width: SoliplexSpacing.s1),
           Text('→', style: metaStyle),
-          const SizedBox(width: 4),
+          const SizedBox(width: SoliplexSpacing.s1),
         ],
         Expanded(
           child: HttpStatusDisplay(group: group, isSelected: isSelected),

--- a/lib/src/modules/diagnostics/ui/http_status_display.dart
+++ b/lib/src/modules/diagnostics/ui/http_status_display.dart
@@ -1,6 +1,6 @@
 import 'package:flutter/material.dart';
 
-import '../../../design/color/color_scheme_extensions.dart';
+import '../../../design/design.dart';
 import '../models/format_utils.dart';
 import '../models/http_event_group.dart';
 
@@ -89,7 +89,7 @@ class HttpStatusDisplay extends StatelessWidget {
             color: color,
           ),
         ),
-        const SizedBox(width: 8),
+        const SizedBox(width: SoliplexSpacing.s2),
         Text(
           text,
           style: theme.textTheme.bodySmall?.copyWith(

--- a/lib/src/modules/diagnostics/ui/json_tree_view.dart
+++ b/lib/src/modules/diagnostics/ui/json_tree_view.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 
+import '../../../design/design.dart';
 import '../models/json_tree_model.dart';
 
 /// Renders a [List<JsonNode>] as an expandable tree with syntax coloring.
@@ -11,12 +12,12 @@ class JsonTreeView extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     if (nodes.isEmpty) {
+      final theme = Theme.of(context);
       return Text(
         '(empty)',
-        style: Theme.of(context).textTheme.bodySmall?.copyWith(
-              fontFamily: 'monospace',
+        style: context.monospaceOn(theme.textTheme.bodySmall).copyWith(
               fontStyle: FontStyle.italic,
-              color: Theme.of(context).colorScheme.onSurfaceVariant,
+              color: theme.colorScheme.onSurfaceVariant,
             ),
       );
     }
@@ -57,7 +58,7 @@ class _JsonNodeTileState extends State<_JsonNodeTile> {
   @override
   Widget build(BuildContext context) {
     final node = widget.node;
-    final indent = widget.depth * 16.0;
+    final indent = widget.depth * SoliplexSpacing.s4;
 
     return switch (node) {
       ValueNode() => _buildValueRow(context, node, indent),
@@ -99,9 +100,7 @@ class _JsonNodeTileState extends State<_JsonNodeTile> {
       if (asDouble != null) valueColor = colorScheme.primary;
     }
 
-    final baseStyle = theme.textTheme.bodySmall?.copyWith(
-      fontFamily: 'monospace',
-    );
+    final baseStyle = context.monospaceOn(theme.textTheme.bodySmall);
 
     return Padding(
       padding: EdgeInsets.only(left: indent),
@@ -111,13 +110,13 @@ class _JsonNodeTileState extends State<_JsonNodeTile> {
             if (node.key.isNotEmpty)
               TextSpan(
                 text: '${node.key}: ',
-                style: baseStyle?.copyWith(
+                style: baseStyle.copyWith(
                   color: colorScheme.onSurface,
                 ),
               ),
             TextSpan(
               text: node.value,
-              style: baseStyle?.copyWith(color: valueColor),
+              style: baseStyle.copyWith(color: valueColor),
             ),
           ],
         ),
@@ -136,9 +135,7 @@ class _JsonNodeTileState extends State<_JsonNodeTile> {
   }) {
     final theme = Theme.of(context);
     final colorScheme = theme.colorScheme;
-    final baseStyle = theme.textTheme.bodySmall?.copyWith(
-      fontFamily: 'monospace',
-    );
+    final baseStyle = context.monospaceOn(theme.textTheme.bodySmall);
 
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
@@ -155,7 +152,7 @@ class _JsonNodeTileState extends State<_JsonNodeTile> {
                   size: 16,
                   color: colorScheme.onSurfaceVariant,
                 ),
-                const SizedBox(width: 2),
+                const SizedBox(width: SoliplexSpacing.s1),
                 SelectableText(
                   _expanded ? expandedLabel : label,
                   style: baseStyle,

--- a/lib/src/modules/diagnostics/ui/network_inspector_screen.dart
+++ b/lib/src/modules/diagnostics/ui/network_inspector_screen.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 
+import '../../../design/design.dart';
 import '../models/http_event_group.dart';
 import '../models/http_event_grouper.dart';
 import '../network_inspector.dart';
@@ -55,7 +56,8 @@ class _NetworkInspectorScreenState extends State<NetworkInspectorScreen> {
                     if (sortedGroups.isEmpty) {
                       return _buildEmptyState(context);
                     }
-                    final isWide = constraints.maxWidth >= 600;
+                    final isWide =
+                        constraints.maxWidth >= SoliplexBreakpoints.tablet;
                     if (isWide) {
                       return _buildMasterDetailLayout(context, sortedGroups);
                     }
@@ -81,14 +83,14 @@ class _NetworkInspectorScreenState extends State<NetworkInspectorScreen> {
             size: 64,
             color: theme.colorScheme.onSurfaceVariant.withValues(alpha: 0.5),
           ),
-          const SizedBox(height: 16),
+          const SizedBox(height: SoliplexSpacing.s4),
           Text(
             'No HTTP requests yet',
             style: theme.textTheme.titleMedium?.copyWith(
               color: theme.colorScheme.onSurfaceVariant,
             ),
           ),
-          const SizedBox(height: 8),
+          const SizedBox(height: SoliplexSpacing.s2),
           Text(
             'Requests will appear here as you use the app',
             style: theme.textTheme.bodyMedium?.copyWith(
@@ -102,7 +104,7 @@ class _NetworkInspectorScreenState extends State<NetworkInspectorScreen> {
 
   Widget _buildListLayout(BuildContext context, List<HttpEventGroup> groups) {
     return ListView.separated(
-      padding: const EdgeInsets.symmetric(vertical: 8),
+      padding: const EdgeInsets.symmetric(vertical: SoliplexSpacing.s2),
       itemCount: groups.length,
       separatorBuilder: (_, __) => const Divider(height: 1),
       itemBuilder: (context, index) {
@@ -137,7 +139,7 @@ class _NetworkInspectorScreenState extends State<NetworkInspectorScreen> {
               ),
             ),
             child: ListView.separated(
-              padding: const EdgeInsets.symmetric(vertical: 8),
+              padding: const EdgeInsets.symmetric(vertical: SoliplexSpacing.s2),
               itemCount: groups.length,
               separatorBuilder: (_, __) => const Divider(height: 1),
               itemBuilder: (context, index) {

--- a/lib/src/modules/diagnostics/ui/overview_tab.dart
+++ b/lib/src/modules/diagnostics/ui/overview_tab.dart
@@ -2,6 +2,7 @@ import 'dart:convert';
 
 import 'package:flutter/material.dart';
 
+import '../../../design/design.dart';
 import '../models/event_accumulator.dart';
 import '../models/http_event_group.dart';
 import '../models/json_tree_model.dart';
@@ -51,11 +52,11 @@ class _OverviewTabState extends State<OverviewTab> {
     }
 
     return ListView(
-      padding: const EdgeInsets.all(16),
+      padding: const EdgeInsets.all(SoliplexSpacing.s4),
       children: [
         if (hasRequestBody) ...[
           _JsonSection(title: 'Request Body', body: body),
-          const SizedBox(height: 16),
+          const SizedBox(height: SoliplexSpacing.s4),
         ],
         if (group.isStream)
           _StreamSection(
@@ -129,7 +130,7 @@ class _StreamSection extends StatelessWidget {
             ),
           ],
         ),
-        const SizedBox(height: 8),
+        const SizedBox(height: SoliplexSpacing.s2),
         if (parseResult.wasTruncated) _TruncationBanner(),
         if (view == _StreamView.conversation)
           _ConversationView(run: accumulatedRun)
@@ -143,14 +144,18 @@ class _StreamSection extends StatelessWidget {
 class _TruncationBanner extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
-    final colorScheme = Theme.of(context).colorScheme;
+    final theme = Theme.of(context);
+    final colorScheme = theme.colorScheme;
     return Container(
       width: double.infinity,
-      margin: const EdgeInsets.only(bottom: 8),
-      padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+      margin: const EdgeInsets.only(bottom: SoliplexSpacing.s2),
+      padding: const EdgeInsets.symmetric(
+        horizontal: SoliplexSpacing.s3,
+        vertical: SoliplexSpacing.s2,
+      ),
       decoration: BoxDecoration(
         color: colorScheme.tertiaryContainer,
-        borderRadius: BorderRadius.circular(4),
+        borderRadius: BorderRadius.circular(soliplexRadii.sm),
       ),
       child: Row(
         children: [
@@ -159,11 +164,10 @@ class _TruncationBanner extends StatelessWidget {
             size: 16,
             color: colorScheme.onTertiaryContainer,
           ),
-          const SizedBox(width: 8),
+          const SizedBox(width: SoliplexSpacing.s2),
           Text(
             'Earlier stream content was truncated',
-            style: TextStyle(
-              fontSize: 12,
+            style: theme.textTheme.labelSmall?.copyWith(
               color: colorScheme.onTertiaryContainer,
             ),
           ),
@@ -258,16 +262,16 @@ class _RunEntryCard extends StatelessWidget {
     };
 
     return Card(
-      margin: const EdgeInsets.only(bottom: 8),
+      margin: const EdgeInsets.only(bottom: SoliplexSpacing.s2),
       child: Padding(
-        padding: const EdgeInsets.all(12),
+        padding: const EdgeInsets.all(SoliplexSpacing.s3),
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
             _RoleBadge(
                 label: label, color: badgeColor, textColor: badgeTextColor),
             if (content.isNotEmpty) ...[
-              const SizedBox(height: 8),
+              const SizedBox(height: SoliplexSpacing.s2),
               SelectableText(
                 content,
                 style: theme.textTheme.bodySmall,
@@ -293,16 +297,19 @@ class _RoleBadge extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final theme = Theme.of(context);
     return Container(
-      padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 2),
+      padding: const EdgeInsets.symmetric(
+        horizontal: SoliplexSpacing.s2,
+        vertical: SoliplexSpacing.s1,
+      ),
       decoration: BoxDecoration(
         color: color,
-        borderRadius: BorderRadius.circular(4),
+        borderRadius: BorderRadius.circular(soliplexRadii.sm),
       ),
       child: Text(
         label,
-        style: TextStyle(
-          fontSize: 10,
+        style: theme.textTheme.labelSmall?.copyWith(
           fontWeight: FontWeight.bold,
           color: textColor,
         ),
@@ -358,26 +365,28 @@ class _SseEventCardState extends State<_SseEventCard> {
     final nodes = buildJsonTree(widget.event.payload);
 
     return Card(
-      margin: const EdgeInsets.only(bottom: 6),
+      margin: const EdgeInsets.only(bottom: SoliplexSpacing.s2),
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
           InkWell(
             onTap: () => setState(() => _expanded = !_expanded),
             child: Padding(
-              padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+              padding: const EdgeInsets.symmetric(
+                horizontal: SoliplexSpacing.s3,
+                vertical: SoliplexSpacing.s2,
+              ),
               child: Row(
                 children: [
                   _EventTypeBadge(type: widget.event.type),
-                  const SizedBox(width: 8),
+                  const SizedBox(width: SoliplexSpacing.s2),
                   if (summary.isNotEmpty)
                     Expanded(
                       child: Text(
                         summary,
-                        style: theme.textTheme.bodySmall?.copyWith(
-                          color: colorScheme.onSurfaceVariant,
-                          fontFamily: 'monospace',
-                        ),
+                        style: context
+                            .monospaceOn(theme.textTheme.bodySmall)
+                            .copyWith(color: colorScheme.onSurfaceVariant),
                         maxLines: 1,
                         overflow: TextOverflow.ellipsis,
                       ),
@@ -393,7 +402,12 @@ class _SseEventCardState extends State<_SseEventCard> {
           ),
           if (_expanded)
             Padding(
-              padding: const EdgeInsets.fromLTRB(12, 0, 12, 12),
+              padding: const EdgeInsets.fromLTRB(
+                SoliplexSpacing.s3,
+                0,
+                SoliplexSpacing.s3,
+                SoliplexSpacing.s3,
+              ),
               child: JsonTreeView(nodes: nodes),
             ),
         ],
@@ -409,20 +423,22 @@ class _EventTypeBadge extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final colorScheme = Theme.of(context).colorScheme;
+    final theme = Theme.of(context);
+    final colorScheme = theme.colorScheme;
     return Container(
-      padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 2),
+      padding: const EdgeInsets.symmetric(
+        horizontal: SoliplexSpacing.s2,
+        vertical: SoliplexSpacing.s1,
+      ),
       decoration: BoxDecoration(
         color: colorScheme.surfaceContainerHighest,
-        borderRadius: BorderRadius.circular(4),
+        borderRadius: BorderRadius.circular(soliplexRadii.sm),
       ),
       child: Text(
         type,
-        style: TextStyle(
-          fontSize: 10,
-          fontFamily: 'monospace',
-          color: colorScheme.onSurfaceVariant,
-        ),
+        style: context
+            .monospaceOn(theme.textTheme.labelSmall)
+            .copyWith(color: colorScheme.onSurfaceVariant),
       ),
     );
   }
@@ -456,20 +472,18 @@ class _JsonSection extends StatelessWidget {
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
         Text(title, style: theme.textTheme.titleSmall),
-        const SizedBox(height: 8),
+        const SizedBox(height: SoliplexSpacing.s2),
         Container(
           width: double.infinity,
-          padding: const EdgeInsets.all(12),
+          padding: const EdgeInsets.all(SoliplexSpacing.s3),
           decoration: BoxDecoration(
             color: theme.colorScheme.surfaceContainerHighest,
-            borderRadius: BorderRadius.circular(4),
+            borderRadius: BorderRadius.circular(soliplexRadii.sm),
           ),
           child: plainText != null
               ? SelectableText(
                   plainText,
-                  style: theme.textTheme.bodySmall?.copyWith(
-                    fontFamily: 'monospace',
-                  ),
+                  style: context.monospaceOn(theme.textTheme.bodySmall),
                 )
               : JsonTreeView(nodes: buildJsonTree(parsed)),
         ),

--- a/lib/src/modules/diagnostics/ui/request_detail_view.dart
+++ b/lib/src/modules/diagnostics/ui/request_detail_view.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:soliplex_agent/soliplex_agent.dart' hide State;
 
+import '../../../design/design.dart';
 import '../../../shared/copy_button.dart';
 import '../models/format_utils.dart';
 import '../models/http_event_group.dart';
@@ -147,7 +148,7 @@ class _RequestDetailViewState extends State<RequestDetailView>
         mainAxisSize: MainAxisSize.min,
         children: [
           Text(label),
-          const SizedBox(width: 4),
+          const SizedBox(width: SoliplexSpacing.s1),
           _MatchBadge(count: count),
         ],
       ),
@@ -157,7 +158,10 @@ class _RequestDetailViewState extends State<RequestDetailView>
   Widget _buildSearchBar(BuildContext context) {
     final colorScheme = Theme.of(context).colorScheme;
     return Container(
-      padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
+      padding: const EdgeInsets.symmetric(
+        horizontal: SoliplexSpacing.s3,
+        vertical: SoliplexSpacing.s2,
+      ),
       decoration: BoxDecoration(
         color: colorScheme.surfaceContainerLow,
         border: Border(
@@ -180,14 +184,15 @@ class _RequestDetailViewState extends State<RequestDetailView>
                       )
                     : null,
                 isDense: true,
-                contentPadding: const EdgeInsets.symmetric(vertical: 8),
+                contentPadding:
+                    const EdgeInsets.symmetric(vertical: SoliplexSpacing.s2),
                 border: OutlineInputBorder(
-                  borderRadius: BorderRadius.circular(6),
+                  borderRadius: BorderRadius.circular(soliplexRadii.sm),
                 ),
               ),
             ),
           ),
-          const SizedBox(width: 8),
+          const SizedBox(width: SoliplexSpacing.s2),
           DropdownButton<SearchScope>(
             value: _scope,
             underline: const SizedBox.shrink(),
@@ -209,7 +214,7 @@ class _RequestDetailViewState extends State<RequestDetailView>
             ],
           ),
           if (_searchController.text.isNotEmpty && _totalMatches > 0) ...[
-            const SizedBox(width: 8),
+            const SizedBox(width: SoliplexSpacing.s2),
             Text(
               '${_currentMatchIndex + 1}/$_totalMatches',
               style: Theme.of(context).textTheme.bodySmall,
@@ -241,7 +246,7 @@ class _RequestDetailViewState extends State<RequestDetailView>
     final colorScheme = theme.colorScheme;
 
     return Container(
-      padding: const EdgeInsets.all(16),
+      padding: const EdgeInsets.all(SoliplexSpacing.s4),
       decoration: BoxDecoration(
         color: colorScheme.surfaceContainerLow,
         border: Border(
@@ -257,7 +262,7 @@ class _RequestDetailViewState extends State<RequestDetailView>
                 method: group.methodLabel,
                 isStream: group.isStream,
               ),
-              const SizedBox(width: 8),
+              const SizedBox(width: SoliplexSpacing.s2),
               Expanded(child: HttpStatusDisplay(group: group)),
               Text(
                 group.timestamp.toHttpTimeString(),
@@ -267,12 +272,10 @@ class _RequestDetailViewState extends State<RequestDetailView>
               ),
             ],
           ),
-          const SizedBox(height: 8),
+          const SizedBox(height: SoliplexSpacing.s2),
           SelectableText(
             group.uri.toString(),
-            style: theme.textTheme.bodyMedium?.copyWith(
-              fontFamily: 'monospace',
-            ),
+            style: context.monospace,
           ),
         ],
       ),
@@ -317,17 +320,20 @@ class _MatchBadge extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final colorScheme = Theme.of(context).colorScheme;
+    final theme = Theme.of(context);
+    final colorScheme = theme.colorScheme;
     return Container(
-      padding: const EdgeInsets.symmetric(horizontal: 5, vertical: 1),
+      padding: const EdgeInsets.symmetric(
+        horizontal: SoliplexSpacing.s1,
+        vertical: SoliplexSpacing.s1,
+      ),
       decoration: BoxDecoration(
         color: colorScheme.primaryContainer,
-        borderRadius: BorderRadius.circular(8),
+        borderRadius: BorderRadius.circular(soliplexRadii.sm),
       ),
       child: Text(
         '$count',
-        style: TextStyle(
-          fontSize: 10,
+        style: theme.textTheme.labelSmall?.copyWith(
           fontWeight: FontWeight.bold,
           color: colorScheme.onPrimaryContainer,
         ),
@@ -344,7 +350,8 @@ class _MethodBadge extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final colorScheme = Theme.of(context).colorScheme;
+    final theme = Theme.of(context);
+    final colorScheme = theme.colorScheme;
     final backgroundColor = isStream
         ? colorScheme.secondaryContainer
         : colorScheme.primaryContainer;
@@ -353,16 +360,18 @@ class _MethodBadge extends StatelessWidget {
         : colorScheme.onPrimaryContainer;
 
     return Container(
-      padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+      padding: const EdgeInsets.symmetric(
+        horizontal: SoliplexSpacing.s2,
+        vertical: SoliplexSpacing.s1,
+      ),
       decoration: BoxDecoration(
         color: backgroundColor,
-        borderRadius: BorderRadius.circular(4),
+        borderRadius: BorderRadius.circular(soliplexRadii.sm),
       ),
       child: Text(
         method,
-        style: TextStyle(
+        style: theme.textTheme.labelSmall?.copyWith(
           fontWeight: FontWeight.bold,
-          fontSize: 12,
           color: textColor,
         ),
       ),
@@ -385,7 +394,7 @@ class _RequestTab extends StatelessWidget {
     }
 
     return ListView(
-      padding: const EdgeInsets.all(16),
+      padding: const EdgeInsets.all(SoliplexSpacing.s4),
       children: [
         if (headers.isNotEmpty) ...[
           _SectionHeader(
@@ -398,7 +407,7 @@ class _RequestTab extends StatelessWidget {
             ),
           ),
           _HeadersTable(headers: headers),
-          const SizedBox(height: 16),
+          const SizedBox(height: SoliplexSpacing.s4),
         ],
         if (body != null) ...[
           _SectionHeader(
@@ -456,7 +465,7 @@ class _ResponseTab extends StatelessWidget {
     }
 
     return ListView(
-      padding: const EdgeInsets.all(16),
+      padding: const EdgeInsets.all(SoliplexSpacing.s4),
       children: [
         _MetadataRow(
           label: 'Duration',
@@ -467,7 +476,7 @@ class _ResponseTab extends StatelessWidget {
           value: streamEnd.bytesReceived.toHttpBytesString(),
         ),
         if (streamEnd.body != null) ...[
-          const SizedBox(height: 16),
+          const SizedBox(height: SoliplexSpacing.s4),
           _SectionHeader(
             title: 'Stream Content',
             copyButton: CopyButton(
@@ -492,7 +501,7 @@ class _ResponseTab extends StatelessWidget {
 
   Widget _buildNormalResponse(HttpResponseEvent resp) {
     return ListView(
-      padding: const EdgeInsets.all(16),
+      padding: const EdgeInsets.all(SoliplexSpacing.s4),
       children: [
         _MetadataRow(label: 'Status', value: '${resp.statusCode}'),
         if (resp.reasonPhrase != null)
@@ -506,7 +515,7 @@ class _ResponseTab extends StatelessWidget {
           value: resp.bodySize.toHttpBytesString(),
         ),
         if (resp.headers != null && resp.headers!.isNotEmpty) ...[
-          const SizedBox(height: 16),
+          const SizedBox(height: SoliplexSpacing.s4),
           _SectionHeader(
             title: 'Headers',
             copyButton: CopyButton(
@@ -520,7 +529,7 @@ class _ResponseTab extends StatelessWidget {
           _HeadersTable(headers: resp.headers!),
         ],
         if (resp.body != null) ...[
-          const SizedBox(height: 16),
+          const SizedBox(height: SoliplexSpacing.s4),
           _SectionHeader(
             title: 'Body',
             copyButton: CopyButton(
@@ -553,7 +562,7 @@ class _CurlTab extends StatelessWidget {
     final theme = Theme.of(context);
 
     return Padding(
-      padding: const EdgeInsets.all(16),
+      padding: const EdgeInsets.all(SoliplexSpacing.s4),
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
@@ -568,20 +577,18 @@ class _CurlTab extends StatelessWidget {
                   iconSize: 18, text: curl, tooltip: 'Copy to clipboard'),
             ],
           ),
-          const SizedBox(height: 8),
+          const SizedBox(height: SoliplexSpacing.s2),
           Expanded(
             child: Container(
               width: double.infinity,
-              padding: const EdgeInsets.all(12),
+              padding: const EdgeInsets.all(SoliplexSpacing.s3),
               decoration: BoxDecoration(
                 color: theme.colorScheme.surfaceContainerHighest,
-                borderRadius: BorderRadius.circular(8),
+                borderRadius: BorderRadius.circular(soliplexRadii.sm),
               ),
               child: SelectableText(
                 curl,
-                style: theme.textTheme.bodySmall?.copyWith(
-                  fontFamily: 'monospace',
-                ),
+                style: context.monospaceOn(theme.textTheme.bodySmall),
               ),
             ),
           ),
@@ -601,7 +608,7 @@ class _SectionHeader extends StatelessWidget {
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
     return Padding(
-      padding: const EdgeInsets.only(bottom: 8),
+      padding: const EdgeInsets.only(bottom: SoliplexSpacing.s2),
       child: Row(
         children: [
           Text(title, style: theme.textTheme.titleSmall),
@@ -623,18 +630,20 @@ class _HeadersTable extends StatelessWidget {
     final theme = Theme.of(context);
     final colorScheme = theme.colorScheme;
 
+    final monoSmall = context.monospaceOn(theme.textTheme.bodySmall);
+
     return Container(
       decoration: BoxDecoration(
         border: Border.all(color: colorScheme.outlineVariant),
-        borderRadius: BorderRadius.circular(4),
+        borderRadius: BorderRadius.circular(soliplexRadii.sm),
       ),
       child: Column(
         children: [
           for (final (index, entry) in headers.entries.indexed)
             Container(
               padding: const EdgeInsets.symmetric(
-                horizontal: 12,
-                vertical: 8,
+                horizontal: SoliplexSpacing.s3,
+                vertical: SoliplexSpacing.s2,
               ),
               decoration: BoxDecoration(
                 color: index.isEven
@@ -653,19 +662,14 @@ class _HeadersTable extends StatelessWidget {
                     width: 140,
                     child: SelectableText(
                       entry.key,
-                      style: theme.textTheme.bodySmall?.copyWith(
-                        fontWeight: FontWeight.w600,
-                        fontFamily: 'monospace',
-                      ),
+                      style: monoSmall.copyWith(fontWeight: FontWeight.w600),
                     ),
                   ),
-                  const SizedBox(width: 8),
+                  const SizedBox(width: SoliplexSpacing.s2),
                   Expanded(
                     child: SelectableText(
                       entry.value,
-                      style: theme.textTheme.bodySmall?.copyWith(
-                        fontFamily: 'monospace',
-                      ),
+                      style: monoSmall,
                     ),
                   ),
                 ],
@@ -689,16 +693,14 @@ class _BodyDisplay extends StatelessWidget {
 
     return Container(
       width: double.infinity,
-      padding: const EdgeInsets.all(12),
+      padding: const EdgeInsets.all(SoliplexSpacing.s3),
       decoration: BoxDecoration(
         color: theme.colorScheme.surfaceContainerHighest,
-        borderRadius: BorderRadius.circular(4),
+        borderRadius: BorderRadius.circular(soliplexRadii.sm),
       ),
       child: SelectableText(
         formattedBody,
-        style: theme.textTheme.bodySmall?.copyWith(
-          fontFamily: 'monospace',
-        ),
+        style: context.monospaceOn(theme.textTheme.bodySmall),
       ),
     );
   }
@@ -714,7 +716,7 @@ class _MetadataRow extends StatelessWidget {
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
     return Padding(
-      padding: const EdgeInsets.symmetric(vertical: 4),
+      padding: const EdgeInsets.symmetric(vertical: SoliplexSpacing.s1),
       child: Row(
         children: [
           SizedBox(
@@ -769,12 +771,12 @@ class _ErrorDisplay extends StatelessWidget {
     final colorScheme = theme.colorScheme;
 
     return Padding(
-      padding: const EdgeInsets.all(16),
+      padding: const EdgeInsets.all(SoliplexSpacing.s4),
       child: Column(
         mainAxisAlignment: MainAxisAlignment.center,
         children: [
           Icon(Icons.error_outline, size: 48, color: colorScheme.error),
-          const SizedBox(height: 12),
+          const SizedBox(height: SoliplexSpacing.s3),
           Text(
             message,
             style: theme.textTheme.bodyLarge?.copyWith(
@@ -783,7 +785,7 @@ class _ErrorDisplay extends StatelessWidget {
             textAlign: TextAlign.center,
           ),
           if (details != null) ...[
-            const SizedBox(height: 8),
+            const SizedBox(height: SoliplexSpacing.s2),
             Text(
               details!,
               style: theme.textTheme.bodySmall?.copyWith(

--- a/lib/src/modules/diagnostics/ui/run_http_detail_page.dart
+++ b/lib/src/modules/diagnostics/ui/run_http_detail_page.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 
+import '../../../design/design.dart';
 import '../models/http_event_group.dart';
 import 'http_event_tile.dart';
 import 'request_detail_view.dart';
@@ -42,7 +43,7 @@ class RunHttpDetailPage extends StatelessWidget {
             size: 48,
             color: theme.colorScheme.onSurfaceVariant.withValues(alpha: 0.5),
           ),
-          const SizedBox(height: 12),
+          const SizedBox(height: SoliplexSpacing.s3),
           Text(
             'No HTTP traffic found for this run',
             style: theme.textTheme.bodyMedium?.copyWith(
@@ -65,7 +66,7 @@ class _MultiGroupView extends StatelessWidget {
     return Scaffold(
       appBar: AppBar(title: Text('HTTP Traffic (${groups.length})')),
       body: ListView.separated(
-        padding: const EdgeInsets.symmetric(vertical: 8),
+        padding: const EdgeInsets.symmetric(vertical: SoliplexSpacing.s2),
         itemCount: groups.length,
         separatorBuilder: (_, __) => const Divider(height: 1),
         itemBuilder: (context, index) {


### PR DESCRIPTION
## Summary
- Migrates `lib/src/modules/diagnostics/ui/` (9 files) off hardcoded spacing, radii, font sizes, and monospace family literals onto the documented design system tokens.
- All `EdgeInsets`/`SizedBox` literals → `SoliplexSpacing.{s1,s2,s3,s4,s6}`. Sub-token values (2, 5, 6) rounded to the nearest token per the migration policy.
- All `BorderRadius.circular(4|8)` → `soliplexRadii.sm` (6 px). Uses the top-level const directly instead of `SoliplexTheme.of(context).radii.sm` so widget tests don't have to inject the theme extension.
- `fontSize: 10|11|12` literals → `theme.textTheme.labelSmall` (12 px).
- `maxWidth >= 600` → `SoliplexBreakpoints.tablet`.
- `fontFamily: 'monospace'` literals → `context.monospace` or the new `context.monospaceOn(baseStyle)` helper for smaller monospace styles.
- Adds `appMonospaceTextStyle({TextStyle? base})` + `TypographyX.monospaceOn` extension in `lib/src/design/tokens/typography_x.dart` so monospace can sit on any text-theme entry without re-introducing `fontFamily` literals at call sites.

## Context
**Stacks on #250** (`docs/design-system-guardrails`). Third in the migration series; cleans up the diagnostics module first (highest violation density per the audit). All 1285 tests pass.

The dense diagnostics rows lose ~2 px of vertical compression where sub-token spacings (2, 6) rounded up to s1/s2 — accepted per the rounding policy. If dense mode matters more than uniformity, we can re-open by adding sub-tokens (requires user approval per CLAUDE.md).

## Test plan
- [ ] `fvm flutter analyze` — zero warnings
- [ ] `fvm flutter test` — 1285 pass
- [ ] Open the diagnostics route in dev (`flutter run`) and exercise the network inspector, request detail, JSON tree, and overview tab in both light and dark, at tablet + mobile widths
- [ ] Eyeball against `design_handoff/handoff/Soliplex Design System.html`

🤖 Generated with [Claude Code](https://claude.com/claude-code)