### PR TITLE
refactor(quiz/auth/lobby): adopt design tokens

### DIFF
--- a/lib/src/modules/auth/ui/auth_callback_screen.dart
+++ b/lib/src/modules/auth/ui/auth_callback_screen.dart
@@ -11,6 +11,7 @@ import '../platform/callback_params.dart';
 import '../pre_auth_state.dart';
 import '../server_entry.dart';
 import '../server_manager.dart';
+import '../../../design/design.dart';
 
 class AuthCallbackScreen extends ConsumerStatefulWidget {
   const AuthCallbackScreen({super.key, required this.serverManager});
@@ -105,14 +106,18 @@ class _AuthCallbackScreenState extends ConsumerState<AuthCallbackScreen> {
     return Scaffold(
       body: Center(
         child: Padding(
-          padding: const EdgeInsets.all(16),
+          padding: const EdgeInsets.all(SoliplexSpacing.s4),
           child: Column(
             mainAxisSize: MainAxisSize.min,
             children: [
-              const Icon(Icons.error_outline, size: 48, color: Colors.red),
-              const SizedBox(height: 16),
+              Icon(
+                Icons.error_outline,
+                size: 48,
+                color: Theme.of(context).colorScheme.error,
+              ),
+              const SizedBox(height: SoliplexSpacing.s4),
               Text(_error ?? 'An error occurred'),
-              const SizedBox(height: 16),
+              const SizedBox(height: SoliplexSpacing.s4),
               FilledButton(
                 onPressed: () => context.go(AppRoutes.home),
                 child: const Text('Back to home'),

--- a/lib/src/modules/auth/ui/home_screen.dart
+++ b/lib/src/modules/auth/ui/home_screen.dart
@@ -11,6 +11,7 @@ import '../consent_notice.dart';
 import '../connection_probe.dart';
 import '../server_entry.dart';
 import '../server_manager.dart';
+import '../../../design/design.dart';
 
 class HomeScreen extends ConsumerStatefulWidget {
   const HomeScreen({
@@ -141,7 +142,7 @@ class _HomeScreenState extends ConsumerState<HomeScreen> {
 
     return Center(
       child: SingleChildScrollView(
-        padding: const EdgeInsets.all(24),
+        padding: const EdgeInsets.all(SoliplexSpacing.s6),
         child: ConstrainedBox(
           constraints: const BoxConstraints(maxWidth: 400),
           child: Column(
@@ -183,13 +184,13 @@ class _HomeScreenState extends ConsumerState<HomeScreen> {
           size: _logoSize,
           color: theme.colorScheme.primary,
         ),
-      const SizedBox(height: 16),
+      const SizedBox(height: SoliplexSpacing.s4),
       Text(
         widget.appName,
         style: theme.textTheme.headlineMedium,
         textAlign: TextAlign.center,
       ),
-      const SizedBox(height: 8),
+      const SizedBox(height: SoliplexSpacing.s2),
       Text(
         subtitle,
         style: theme.textTheme.bodyMedium?.copyWith(
@@ -197,7 +198,7 @@ class _HomeScreenState extends ConsumerState<HomeScreen> {
         ),
         textAlign: TextAlign.center,
       ),
-      const SizedBox(height: 32),
+      const SizedBox(height: SoliplexSpacing.s6),
     ];
   }
 
@@ -234,13 +235,13 @@ class _HomeScreenState extends ConsumerState<HomeScreen> {
           onFieldSubmitted: (_) => _connect(),
         ),
       ),
-      const SizedBox(height: 16),
+      const SizedBox(height: SoliplexSpacing.s4),
       if (error != null) ...[
         Container(
-          padding: const EdgeInsets.all(12),
+          padding: const EdgeInsets.all(SoliplexSpacing.s3),
           decoration: BoxDecoration(
             color: theme.colorScheme.errorContainer,
-            borderRadius: BorderRadius.circular(8),
+            borderRadius: BorderRadius.circular(soliplexRadii.sm),
           ),
           child: Row(
             children: [
@@ -249,7 +250,7 @@ class _HomeScreenState extends ConsumerState<HomeScreen> {
                 color: theme.colorScheme.onErrorContainer,
                 size: 20,
               ),
-              const SizedBox(width: 8),
+              const SizedBox(width: SoliplexSpacing.s2),
               Expanded(
                 child: Text(
                   error,
@@ -261,7 +262,7 @@ class _HomeScreenState extends ConsumerState<HomeScreen> {
             ],
           ),
         ),
-        const SizedBox(height: 16),
+        const SizedBox(height: SoliplexSpacing.s4),
       ],
       FilledButton.icon(
         onPressed: _connect,
@@ -287,14 +288,14 @@ class _HomeScreenState extends ConsumerState<HomeScreen> {
     return [
       ..._buildHeader(context, 'Insecure Connection'),
       Icon(Icons.warning_amber, size: 48, color: theme.colorScheme.error),
-      const SizedBox(height: 16),
+      const SizedBox(height: SoliplexSpacing.s4),
       Text(
         'This connection to ${formatServerUrl(probeResult.serverUrl)} is not '
         'encrypted. Your data, including credentials, may be visible to '
         'others on the network.',
         textAlign: TextAlign.center,
       ),
-      const SizedBox(height: 24),
+      const SizedBox(height: SoliplexSpacing.s6),
       Row(
         mainAxisAlignment: MainAxisAlignment.center,
         children: [
@@ -302,7 +303,7 @@ class _HomeScreenState extends ConsumerState<HomeScreen> {
             onPressed: _flow.reset,
             child: const Text('Cancel'),
           ),
-          const SizedBox(width: 16),
+          const SizedBox(width: SoliplexSpacing.s4),
           FilledButton(
             onPressed: _flow.acceptInsecure,
             child: const Text('Connect anyway'),
@@ -321,9 +322,9 @@ class _HomeScreenState extends ConsumerState<HomeScreen> {
     return [
       ..._buildHeader(context, 'Sign in to continue'),
       Text(notice.title, style: Theme.of(context).textTheme.titleLarge),
-      const SizedBox(height: 16),
+      const SizedBox(height: SoliplexSpacing.s4),
       Text(notice.body),
-      const SizedBox(height: 16),
+      const SizedBox(height: SoliplexSpacing.s4),
       Row(
         mainAxisAlignment: MainAxisAlignment.center,
         children: [
@@ -331,7 +332,7 @@ class _HomeScreenState extends ConsumerState<HomeScreen> {
             onPressed: _flow.reset,
             child: const Text('Cancel'),
           ),
-          const SizedBox(width: 16),
+          const SizedBox(width: SoliplexSpacing.s4),
           FilledButton(
             onPressed: _flow.acknowledgeConsent,
             child: Text(notice.acknowledgmentLabel),
@@ -351,16 +352,16 @@ class _HomeScreenState extends ConsumerState<HomeScreen> {
         'Choose authentication provider',
         style: Theme.of(context).textTheme.titleMedium,
       ),
-      const SizedBox(height: 16),
+      const SizedBox(height: SoliplexSpacing.s4),
       for (final provider in providers)
         Padding(
-          padding: const EdgeInsets.only(bottom: 8),
+          padding: const EdgeInsets.only(bottom: SoliplexSpacing.s2),
           child: FilledButton(
             onPressed: () => _flow.selectProvider(provider),
             child: Text(provider.name),
           ),
         ),
-      const SizedBox(height: 8),
+      const SizedBox(height: SoliplexSpacing.s2),
       TextButton(
         onPressed: _flow.reset,
         child: const Text('Change server'),
@@ -390,12 +391,12 @@ class _HomeScreenState extends ConsumerState<HomeScreen> {
     final hiddenCount = loggedOut.length - visibleServers.length;
 
     return [
-      const SizedBox(height: 32),
+      const SizedBox(height: SoliplexSpacing.s6),
       Row(
         children: [
           const Expanded(child: Divider()),
           Padding(
-            padding: const EdgeInsets.symmetric(horizontal: 12),
+            padding: const EdgeInsets.symmetric(horizontal: SoliplexSpacing.s3),
             child: Text(
               'Your servers',
               style: Theme.of(context).textTheme.bodySmall?.copyWith(

--- a/lib/src/modules/auth/ui/server_list_screen.dart
+++ b/lib/src/modules/auth/ui/server_list_screen.dart
@@ -11,6 +11,7 @@ import '../auth_providers.dart';
 import '../auth_tokens.dart';
 import '../server_entry.dart';
 import '../server_manager.dart';
+import '../../../design/design.dart';
 
 class ServerListScreen extends ConsumerStatefulWidget {
   const ServerListScreen({super.key, required this.serverManager});
@@ -78,7 +79,8 @@ class _ServerListScreenState extends ConsumerState<ServerListScreen> {
 
   Widget _sectionHeader(ThemeData theme, String label) {
     return Padding(
-      padding: const EdgeInsets.fromLTRB(16, 16, 16, 4),
+      padding: const EdgeInsets.fromLTRB(SoliplexSpacing.s4, SoliplexSpacing.s4,
+          SoliplexSpacing.s4, SoliplexSpacing.s1),
       child: Text(
         label,
         style: theme.textTheme.titleSmall?.copyWith(

--- a/lib/src/modules/lobby/ui/lobby_screen.dart
+++ b/lib/src/modules/lobby/ui/lobby_screen.dart
@@ -8,6 +8,7 @@ import '../../auth/server_manager.dart';
 import '../lobby_state.dart';
 import 'room_card.dart';
 import 'server_sidebar.dart';
+import '../../../design/design.dart';
 
 const double _sidebarWidth = 240;
 const double _wideBreakpoint = 600;
@@ -227,7 +228,7 @@ class _RoomContent extends StatelessWidget {
           mainAxisSize: MainAxisSize.min,
           children: [
             const Text('No servers connected'),
-            const SizedBox(height: 16),
+            const SizedBox(height: SoliplexSpacing.s4),
             FilledButton(
               onPressed: onAddServer,
               child: const Text('Add Server'),
@@ -275,7 +276,8 @@ class _ServerSection extends StatelessWidget {
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
         Padding(
-          padding: const EdgeInsets.fromLTRB(16, 16, 16, 8),
+          padding: const EdgeInsets.fromLTRB(SoliplexSpacing.s4,
+              SoliplexSpacing.s4, SoliplexSpacing.s4, SoliplexSpacing.s2),
           child: Text(
             heading,
             style: Theme.of(context).textTheme.titleMedium,
@@ -283,11 +285,12 @@ class _ServerSection extends StatelessWidget {
         ),
         switch (serverRooms) {
           RoomsLoading() => const Padding(
-              padding: EdgeInsets.symmetric(horizontal: 16),
+              padding: EdgeInsets.symmetric(horizontal: SoliplexSpacing.s4),
               child: LinearProgressIndicator(),
             ),
           RoomsFailed(:final error) => Padding(
-              padding: const EdgeInsets.symmetric(horizontal: 16),
+              padding:
+                  const EdgeInsets.symmetric(horizontal: SoliplexSpacing.s4),
               child: Text('Failed to load rooms: $error'),
             ),
           RoomsLoaded(:final rooms) => Column(

--- a/lib/src/modules/lobby/ui/server_sidebar.dart
+++ b/lib/src/modules/lobby/ui/server_sidebar.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 
 import '../../auth/server_entry.dart';
 import '../lobby_state.dart';
+import '../../../design/design.dart';
 
 class ServerSidebar extends StatelessWidget {
   const ServerSidebar({
@@ -63,7 +64,8 @@ class _ServerList extends StatelessWidget {
     return ListView(
       children: [
         Padding(
-          padding: const EdgeInsets.fromLTRB(16, 16, 16, 8),
+          padding: const EdgeInsets.fromLTRB(SoliplexSpacing.s4,
+              SoliplexSpacing.s4, SoliplexSpacing.s4, SoliplexSpacing.s2),
           child: Text(
             'Servers (${servers.length})',
             style: Theme.of(context).textTheme.titleSmall?.copyWith(
@@ -78,7 +80,7 @@ class _ServerList extends StatelessWidget {
             onTap: onServerTap,
           ),
         Padding(
-          padding: const EdgeInsets.symmetric(horizontal: 8),
+          padding: const EdgeInsets.symmetric(horizontal: SoliplexSpacing.s2),
           child: OutlinedButton.icon(
             onPressed: onAddServer,
             icon: const Icon(Icons.add, size: 18),

--- a/lib/src/modules/quiz/ui/quiz_answer_input.dart
+++ b/lib/src/modules/quiz/ui/quiz_answer_input.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:soliplex_client/soliplex_client.dart';
 
 import '../quiz_session.dart';
+import '../../../design/design.dart';
 
 class QuizMultipleChoiceInput extends StatelessWidget {
   const QuizMultipleChoiceInput({
@@ -78,21 +79,21 @@ class _OptionTile extends StatelessWidget {
     };
 
     return Padding(
-      padding: const EdgeInsets.only(bottom: 8),
+      padding: const EdgeInsets.only(bottom: SoliplexSpacing.s2),
       child: Material(
         color: backgroundColor,
-        borderRadius: BorderRadius.circular(8),
+        borderRadius: BorderRadius.circular(soliplexRadii.sm),
         child: InkWell(
           onTap: onTap,
-          borderRadius: BorderRadius.circular(8),
+          borderRadius: BorderRadius.circular(soliplexRadii.sm),
           child: Container(
-            padding: const EdgeInsets.all(16),
+            padding: const EdgeInsets.all(SoliplexSpacing.s4),
             decoration: BoxDecoration(
               border: Border.all(
                 color: isSelected ? colorScheme.primary : colorScheme.outline,
                 width: isSelected ? 2 : 1,
               ),
-              borderRadius: BorderRadius.circular(8),
+              borderRadius: BorderRadius.circular(soliplexRadii.sm),
             ),
             child: Row(
               children: [

--- a/lib/src/modules/quiz/ui/quiz_feedback.dart
+++ b/lib/src/modules/quiz/ui/quiz_feedback.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:soliplex_client/soliplex_client.dart';
+import '../../../design/design.dart';
 
 class QuizAnswerFeedback extends StatelessWidget {
   const QuizAnswerFeedback({super.key, required this.result});
@@ -12,12 +13,12 @@ class QuizAnswerFeedback extends StatelessWidget {
     final isCorrect = result.isCorrect;
 
     return Container(
-      padding: const EdgeInsets.all(16),
+      padding: const EdgeInsets.all(SoliplexSpacing.s4),
       decoration: BoxDecoration(
         color: isCorrect
             ? colorScheme.primaryContainer
             : colorScheme.errorContainer,
-        borderRadius: BorderRadius.circular(8),
+        borderRadius: BorderRadius.circular(soliplexRadii.sm),
       ),
       child: Row(
         children: [
@@ -25,7 +26,7 @@ class QuizAnswerFeedback extends StatelessWidget {
             isCorrect ? Icons.check_circle : Icons.cancel,
             color: isCorrect ? colorScheme.primary : colorScheme.error,
           ),
-          const SizedBox(width: 8),
+          const SizedBox(width: SoliplexSpacing.s2),
           Expanded(
             child: Column(
               crossAxisAlignment: CrossAxisAlignment.start,
@@ -39,7 +40,7 @@ class QuizAnswerFeedback extends StatelessWidget {
                   ),
                 ),
                 if (result case IncorrectAnswer(:final expectedAnswer)) ...[
-                  const SizedBox(height: 4),
+                  const SizedBox(height: SoliplexSpacing.s1),
                   Text(
                     'Expected: $expectedAnswer',
                     style: textTheme.bodyMedium?.copyWith(
@@ -71,15 +72,15 @@ class QuizErrorFeedback extends StatelessWidget {
     final textTheme = Theme.of(context).textTheme;
 
     return Container(
-      padding: const EdgeInsets.all(16),
+      padding: const EdgeInsets.all(SoliplexSpacing.s4),
       decoration: BoxDecoration(
         color: colorScheme.errorContainer,
-        borderRadius: BorderRadius.circular(8),
+        borderRadius: BorderRadius.circular(soliplexRadii.sm),
       ),
       child: Row(
         children: [
           Icon(Icons.error_outline, color: colorScheme.error),
-          const SizedBox(width: 8),
+          const SizedBox(width: SoliplexSpacing.s2),
           Expanded(
             child: Text(
               message,

--- a/lib/src/modules/quiz/ui/quiz_question.dart
+++ b/lib/src/modules/quiz/ui/quiz_question.dart
@@ -4,6 +4,7 @@ import 'package:soliplex_client/soliplex_client.dart';
 import '../quiz_session.dart';
 import 'quiz_answer_input.dart';
 import 'quiz_feedback.dart';
+import '../../../design/design.dart';
 
 class QuizQuestionView extends StatelessWidget {
   const QuizQuestionView({
@@ -51,10 +52,11 @@ class QuizQuestionView extends StatelessWidget {
         ),
         Expanded(
           child: SingleChildScrollView(
-            padding: const EdgeInsets.all(16),
+            padding: const EdgeInsets.all(SoliplexSpacing.s4),
             child: Center(
               child: ConstrainedBox(
-                constraints: const BoxConstraints(maxWidth: 600),
+                constraints:
+                    const BoxConstraints(maxWidth: SoliplexBreakpoints.tablet),
                 child: Column(
                   crossAxisAlignment: CrossAxisAlignment.stretch,
                   children: [
@@ -65,22 +67,22 @@ class QuizQuestionView extends StatelessWidget {
                         color: theme.colorScheme.onSurfaceVariant,
                       ),
                     ),
-                    const SizedBox(height: 8),
+                    const SizedBox(height: SoliplexSpacing.s2),
                     Text(question.text, style: theme.textTheme.titleLarge),
-                    const SizedBox(height: 16),
+                    const SizedBox(height: SoliplexSpacing.s4),
                     _buildInput(question, questionState, selectedOption),
                     if (submissionError != null) ...[
-                      const SizedBox(height: 16),
+                      const SizedBox(height: SoliplexSpacing.s4),
                       QuizErrorFeedback(
                         message: submissionError!,
                         onRetry: onRetry,
                       ),
                     ],
                     if (questionState case Answered(:final result)) ...[
-                      const SizedBox(height: 16),
+                      const SizedBox(height: SoliplexSpacing.s4),
                       QuizAnswerFeedback(result: result),
                     ],
-                    const SizedBox(height: 16),
+                    const SizedBox(height: SoliplexSpacing.s4),
                     _buildActionButton(questionState),
                   ],
                 ),

--- a/lib/src/modules/quiz/ui/quiz_results.dart
+++ b/lib/src/modules/quiz/ui/quiz_results.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 
 import '../quiz_session.dart';
+import '../../../design/design.dart';
 
 class QuizResultsView extends StatelessWidget {
   const QuizResultsView({
@@ -29,14 +30,14 @@ class QuizResultsView extends StatelessWidget {
       child: ConstrainedBox(
         constraints: const BoxConstraints(maxWidth: 400),
         child: Padding(
-          padding: const EdgeInsets.all(16),
+          padding: const EdgeInsets.all(SoliplexSpacing.s4),
           child: Column(
             mainAxisAlignment: MainAxisAlignment.center,
             children: [
               Icon(scoreIcon, size: 64, color: scoreColor),
-              const SizedBox(height: 16),
+              const SizedBox(height: SoliplexSpacing.s4),
               Text('Quiz Complete!', style: theme.textTheme.headlineMedium),
-              const SizedBox(height: 8),
+              const SizedBox(height: SoliplexSpacing.s2),
               Text(
                 '${session.scorePercent}%',
                 style: theme.textTheme.displayLarge?.copyWith(
@@ -44,14 +45,14 @@ class QuizResultsView extends StatelessWidget {
                   fontWeight: FontWeight.bold,
                 ),
               ),
-              const SizedBox(height: 8),
+              const SizedBox(height: SoliplexSpacing.s2),
               Text(
                 '${session.correctCount} of ${session.totalAnswered} correct',
                 style: theme.textTheme.bodyLarge?.copyWith(
                   color: theme.colorScheme.onSurfaceVariant,
                 ),
               ),
-              const SizedBox(height: 24),
+              const SizedBox(height: SoliplexSpacing.s6),
               Wrap(
                 alignment: WrapAlignment.center,
                 spacing: 8,

--- a/lib/src/modules/quiz/ui/quiz_screen.dart
+++ b/lib/src/modules/quiz/ui/quiz_screen.dart
@@ -11,6 +11,7 @@ import '../quiz_session_controller.dart';
 import 'quiz_question.dart';
 import 'quiz_results.dart';
 import 'quiz_start.dart';
+import '../../../design/design.dart';
 
 class QuizScreen extends StatefulWidget {
   const QuizScreen({
@@ -123,12 +124,12 @@ class _QuizScreenState extends State<QuizScreen> {
               };
               return Center(
                 child: Padding(
-                  padding: const EdgeInsets.all(16),
+                  padding: const EdgeInsets.all(SoliplexSpacing.s4),
                   child: Column(
                     mainAxisSize: MainAxisSize.min,
                     children: [
                       Text(message),
-                      const SizedBox(height: 16),
+                      const SizedBox(height: SoliplexSpacing.s4),
                       FilledButton(
                         onPressed: action,
                         child: Text(label),

--- a/lib/src/modules/quiz/ui/quiz_start.dart
+++ b/lib/src/modules/quiz/ui/quiz_start.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:soliplex_client/soliplex_client.dart';
+import '../../../design/design.dart';
 
 class QuizStartView extends StatelessWidget {
   const QuizStartView({
@@ -18,18 +19,18 @@ class QuizStartView extends StatelessWidget {
       child: ConstrainedBox(
         constraints: const BoxConstraints(maxWidth: 400),
         child: Padding(
-          padding: const EdgeInsets.all(16),
+          padding: const EdgeInsets.all(SoliplexSpacing.s4),
           child: Column(
             mainAxisAlignment: MainAxisAlignment.center,
             children: [
               Icon(Icons.quiz, size: 64, color: theme.colorScheme.primary),
-              const SizedBox(height: 16),
+              const SizedBox(height: SoliplexSpacing.s4),
               Text(
                 quiz.title,
                 style: theme.textTheme.headlineMedium,
                 textAlign: TextAlign.center,
               ),
-              const SizedBox(height: 8),
+              const SizedBox(height: SoliplexSpacing.s2),
               Text(
                 quiz.questionCount == 1
                     ? '1 question'
@@ -38,7 +39,7 @@ class QuizStartView extends StatelessWidget {
                   color: theme.colorScheme.onSurfaceVariant,
                 ),
               ),
-              const SizedBox(height: 24),
+              const SizedBox(height: SoliplexSpacing.s6),
               FilledButton.icon(
                 onPressed: onStart,
                 icon: const Icon(Icons.play_arrow),


### PR DESCRIPTION
## Summary
- Migrates `lib/src/modules/{quiz,auth,lobby}/ui/` (11 files) onto the design tokens via the same mechanical sweep as #251 (diagnostics) and #252 (room).
- `EdgeInsets` / `SizedBox` literals → `SoliplexSpacing.{s1..s6}`.
- `BorderRadius.circular(N)` → `soliplexRadii.{sm,md,lg,xl}`.
- `BoxConstraints(maxWidth: 600)` → `SoliplexBreakpoints.tablet`.
- `auth_callback_screen` `Colors.red` error icon → `colorScheme.error`.

## Context
**Stacks on #252** (`refactor/design-adoption-room`). Fifth in the migration series. Density much lower than diagnostics or room — `auth_callback_screen` was the only Material status color, no monospace literals, no chat-bubble exceptions. All 1285 tests pass.

Next: #6 — `chore/design-adoption-packages-audit` — confirm workspace packages stay token-free.

## Test plan
- [ ] `fvm flutter analyze` — zero warnings
- [ ] `fvm flutter test` — 1285 pass
- [ ] Exercise the quiz flow (start → question → results), auth callback (success and error paths), and lobby (server list + room cards) in dev (`flutter run`). Light + dark.

🤖 Generated with [Claude Code](https://claude.com/claude-code)