### PR TITLE
Preserve session on auth failure: ExpiredSession, returnTo, draft persistence

### DIFF
--- a/lib/src/core/routes.dart
+++ b/lib/src/core/routes.dart
@@ -12,7 +12,11 @@ class AppRoutes {
   static const networkInspector = '/diagnostics/network';
   static const authCallback = '/auth/callback';
 
-  static String homeWithUrl(String url) => '/?url=${Uri.encodeComponent(url)}';
+  static String homeWithUrl(String url, {String? returnTo}) {
+    final base = '/?url=${Uri.encodeComponent(url)}';
+    if (returnTo == null) return base;
+    return '$base&returnTo=${Uri.encodeComponent(returnTo)}';
+  }
 
   static String versionsForServer(String serverAlias) =>
       '/versions/server/$serverAlias';

--- a/lib/src/modules/auth/auth_module.dart
+++ b/lib/src/modules/auth/auth_module.dart
@@ -40,7 +40,7 @@ class AuthAppModule extends AppModule {
         _consentNotice = consentNotice,
         _logo = logo,
         _defaultBackendUrl = defaultBackendUrl,
-        _refreshListenable = SignalListenable(serverManager.authState);
+        _refreshListenable = SignalListenable(serverManager.connectionRevision);
 
   final ServerManager _serverManager;
   final SoliplexHttpClient _probeClient;
@@ -101,10 +101,25 @@ class AuthAppModule extends AppModule {
           ),
         ],
         redirect: (_, state) {
+          final isPublic = _publicPaths.contains(state.matchedLocation);
+          if (isPublic) return null;
+
+          // Per-server guard: if the route names a specific server and
+          // that server isn't connected (signed out or expired),
+          // redirect to its sign-in entry.
+          final alias = state.pathParameters['serverAlias'];
+          if (alias != null) {
+            final entry = _serverManager.entryByAlias(alias);
+            if (entry != null && !entry.isConnected) {
+              return AppRoutes.homeWithUrl(entry.serverUrl.toString());
+            }
+          }
+
+          // Global guard: if no server is connected at all, fall back
+          // to the home screen / server list.
           final isAuthenticated =
               _serverManager.authState.value is Authenticated;
-          final isPublic = _publicPaths.contains(state.matchedLocation);
-          if (!isAuthenticated && !isPublic) return AppRoutes.home;
+          if (!isAuthenticated) return AppRoutes.home;
           return null;
         },
       );

--- a/lib/src/modules/auth/auth_module.dart
+++ b/lib/src/modules/auth/auth_module.dart
@@ -75,6 +75,7 @@ class AuthAppModule extends AppModule {
             path: AppRoutes.home,
             pageBuilder: (_, state) {
               final autoConnectUrl = state.uri.queryParameters['url'];
+              final returnTo = state.uri.queryParameters['returnTo'];
               return NoTransitionPage(
                 key: autoConnectUrl != null ? UniqueKey() : state.pageKey,
                 child: HomeScreen(
@@ -83,6 +84,7 @@ class AuthAppModule extends AppModule {
                   logo: _logo,
                   defaultBackendUrl: _defaultBackendUrl,
                   autoConnectUrl: autoConnectUrl,
+                  autoConnectReturnTo: returnTo,
                 ),
               );
             },
@@ -106,12 +108,16 @@ class AuthAppModule extends AppModule {
 
           // Per-server guard: if the route names a specific server and
           // that server isn't connected (signed out or expired),
-          // redirect to its sign-in entry.
+          // redirect to its sign-in entry. Carry the original location
+          // through so the callback can return the user back here.
           final alias = state.pathParameters['serverAlias'];
           if (alias != null) {
             final entry = _serverManager.entryByAlias(alias);
             if (entry != null && !entry.isConnected) {
-              return AppRoutes.homeWithUrl(entry.serverUrl.toString());
+              return AppRoutes.homeWithUrl(
+                entry.serverUrl.toString(),
+                returnTo: state.matchedLocation,
+              );
             }
           }
 

--- a/lib/src/modules/auth/auth_session.dart
+++ b/lib/src/modules/auth/auth_session.dart
@@ -1,3 +1,5 @@
+import 'dart:developer' as dev;
+
 import 'package:soliplex_agent/soliplex_agent.dart';
 
 import 'auth_tokens.dart';
@@ -95,7 +97,13 @@ class AuthSession implements TokenRefresher {
         refreshToken: tokens.refreshToken,
         clientId: provider.clientId,
       );
-    } catch (_) {
+    } catch (e, st) {
+      dev.log(
+        'Token refresh threw before producing a result',
+        error: e,
+        stackTrace: st,
+        level: 1000,
+      );
       return false;
     }
 
@@ -124,7 +132,11 @@ class AuthSession implements TokenRefresher {
         markSessionExpired();
         return false;
 
-      case TokenRefreshFailure():
+      case TokenRefreshFailure(:final reason):
+        dev.log(
+          'Token refresh failed: $reason',
+          level: 1000,
+        );
         return false;
     }
   }

--- a/lib/src/modules/auth/auth_session.dart
+++ b/lib/src/modules/auth/auth_session.dart
@@ -133,9 +133,12 @@ class AuthSession implements TokenRefresher {
         return false;
 
       case TokenRefreshFailure(:final reason):
+        // networkError is recoverable on retry; unknownError is the
+        // anomaly worth a SEVERE entry. invalidGrant and noRefreshToken
+        // are filtered earlier and reach markSessionExpired.
         dev.log(
-          'Token refresh failed: $reason',
-          level: 1000,
+          'Token refresh failed: ${reason.name}',
+          level: reason == TokenRefreshFailureReason.networkError ? 900 : 1000,
         );
         return false;
     }

--- a/lib/src/modules/auth/auth_session.dart
+++ b/lib/src/modules/auth/auth_session.dart
@@ -17,8 +17,19 @@ class AuthSession implements TokenRefresher {
   ReadonlySignal<SessionState> get session => _session;
 
   /// Sync read for the HTTP client's getToken callback.
+  ///
+  /// Returns null for [ExpiredSession] — the access token is known dead
+  /// and sending it as a header would just round-trip a guaranteed 401.
   String? get accessToken => switch (_session.value) {
         ActiveSession(:final tokens) => tokens.accessToken,
+        ExpiredSession() => null,
+        NoSession() => null,
+      };
+
+  /// Refresh token available for both active and expired sessions.
+  String? get refreshToken => switch (_session.value) {
+        ActiveSession(:final tokens) => tokens.refreshToken,
+        ExpiredSession(:final tokens) => tokens.refreshToken,
         NoSession() => null,
       };
 
@@ -30,6 +41,20 @@ class AuthSession implements TokenRefresher {
 
   void logout() {
     _session.value = const NoSession();
+  }
+
+  /// Flip an active or expired session to [ExpiredSession], preserving
+  /// the tokens so a later refresh attempt can revive the session
+  /// silently. No-op if the session is already expired or has been
+  /// signed out.
+  void markSessionExpired() {
+    switch (_session.value) {
+      case ActiveSession(:final provider, :final tokens):
+        _session.value = ExpiredSession(provider: provider, tokens: tokens);
+      case ExpiredSession():
+      case NoSession():
+        return;
+    }
   }
 
   // ── TokenRefresher interface ──
@@ -56,38 +81,47 @@ class AuthSession implements TokenRefresher {
   }
 
   Future<bool> _doRefresh() async {
-    final current = _session.value;
-    if (current is! ActiveSession) return false;
+    final (provider, tokens) = switch (_session.value) {
+      ActiveSession(:final provider, :final tokens) => (provider, tokens),
+      ExpiredSession(:final provider, :final tokens) => (provider, tokens),
+      NoSession() => (null, null),
+    };
+    if (provider == null || tokens == null) return false;
 
     final TokenRefreshResult result;
     try {
       result = await _refreshService.refresh(
-        discoveryUrl: current.provider.discoveryUrl,
-        refreshToken: current.tokens.refreshToken,
-        clientId: current.provider.clientId,
+        discoveryUrl: provider.discoveryUrl,
+        refreshToken: tokens.refreshToken,
+        clientId: provider.clientId,
       );
     } catch (_) {
       return false;
     }
 
-    // Guard: session may have changed (logout or re-login) during the await.
-    if (!identical(_session.value, current)) return false;
+    // User-initiated sign-out during the await wins; everything else
+    // (including a concurrent flip to ExpiredSession) accepts the new
+    // tokens.
+    if (_session.value is NoSession) return false;
 
     switch (result) {
       case TokenRefreshSuccess():
         _session.value = ActiveSession(
-          provider: current.provider,
+          provider: provider,
           tokens: AuthTokens(
             accessToken: result.accessToken,
             refreshToken: result.refreshToken,
             expiresAt: result.expiresAt,
-            idToken: result.idToken ?? current.tokens.idToken,
+            idToken: result.idToken ?? tokens.idToken,
           ),
         );
         return true;
 
       case TokenRefreshFailure(reason: TokenRefreshFailureReason.invalidGrant):
-        logout();
+      case TokenRefreshFailure(
+          reason: TokenRefreshFailureReason.noRefreshToken
+        ):
+        markSessionExpired();
         return false;
 
       case TokenRefreshFailure():

--- a/lib/src/modules/auth/auth_session.dart
+++ b/lib/src/modules/auth/auth_session.dart
@@ -28,13 +28,6 @@ class AuthSession implements TokenRefresher {
         NoSession() => null,
       };
 
-  /// Refresh token available for both active and expired sessions.
-  String? get refreshToken => switch (_session.value) {
-        ActiveSession(:final tokens) => tokens.refreshToken,
-        ExpiredSession(:final tokens) => tokens.refreshToken,
-        NoSession() => null,
-      };
-
   bool get isAuthenticated => _session.value is ActiveSession;
 
   void login({required OidcProvider provider, required AuthTokens tokens}) {
@@ -45,10 +38,9 @@ class AuthSession implements TokenRefresher {
     _session.value = const NoSession();
   }
 
-  /// Flip an active or expired session to [ExpiredSession], preserving
-  /// the tokens so a later refresh attempt can revive the session
-  /// silently. No-op if the session is already expired or has been
-  /// signed out.
+  /// Flip an active session to [ExpiredSession], preserving the tokens
+  /// so a later refresh attempt can revive the session silently. No-op
+  /// when the session is already expired or has been signed out.
   void markSessionExpired() {
     switch (_session.value) {
       case ActiveSession(:final provider, :final tokens):
@@ -126,18 +118,32 @@ class AuthSession implements TokenRefresher {
         return true;
 
       case TokenRefreshFailure(reason: TokenRefreshFailureReason.invalidGrant):
+        dev.log(
+          'Token refresh rejected (invalid_grant) for ${provider.discoveryUrl}',
+          level: 900,
+        );
+        markSessionExpired();
+        return false;
+
       case TokenRefreshFailure(
           reason: TokenRefreshFailureReason.noRefreshToken
         ):
+        // A refresh attempt without a refresh token is a frontend
+        // invariant violation: the session should never have been
+        // marked refreshable in the first place.
+        dev.log(
+          'Token refresh requested without a refresh token '
+          'for ${provider.discoveryUrl}',
+          level: 1000,
+        );
         markSessionExpired();
         return false;
 
       case TokenRefreshFailure(:final reason):
         // networkError is recoverable on retry; unknownError is the
-        // anomaly worth a SEVERE entry. invalidGrant and noRefreshToken
-        // are filtered earlier and reach markSessionExpired.
+        // anomaly worth a SEVERE entry.
         dev.log(
-          'Token refresh failed: ${reason.name}',
+          'Token refresh failed (${reason.name}) for ${provider.discoveryUrl}',
           level: reason == TokenRefreshFailureReason.networkError ? 900 : 1000,
         );
         return false;

--- a/lib/src/modules/auth/auth_tokens.dart
+++ b/lib/src/modules/auth/auth_tokens.dart
@@ -74,3 +74,16 @@ final class ActiveSession extends SessionState {
   final OidcProvider provider;
   final AuthTokens tokens;
 }
+
+/// In-memory transient state after an auth attempt has failed and a
+/// silent refresh could not recover. Tokens are preserved so the next
+/// user interaction can attempt another refresh.
+final class ExpiredSession extends SessionState {
+  const ExpiredSession({
+    required this.provider,
+    required this.tokens,
+  });
+
+  final OidcProvider provider;
+  final AuthTokens tokens;
+}

--- a/lib/src/modules/auth/connect_flow.dart
+++ b/lib/src/modules/auth/connect_flow.dart
@@ -80,11 +80,18 @@ class ConnectFlow {
   bool _disposed = false;
   int _generation = 0;
 
+  /// Held between the start of [connect] and the eventual save of
+  /// `PreAuthState` so the user lands back where they came from after
+  /// a successful re-auth. Carried across consent / provider-selection
+  /// pauses since those don't reset the flow.
+  String? _pendingReturnTo;
+
   bool _isCancelled(int gen) => _disposed || gen != _generation;
 
-  Future<void> connect(String url) async {
+  Future<void> connect(String url, {String? returnTo}) async {
     if (state.value is! UrlInput) return;
     final gen = ++_generation;
+    _pendingReturnTo = returnTo;
     state.value = const Probing();
 
     try {
@@ -146,6 +153,7 @@ class ConnectFlow {
 
   void reset() {
     _generation++;
+    _pendingReturnTo = null;
     state.value = const UrlInput();
   }
 
@@ -211,6 +219,7 @@ class ConnectFlow {
       discoveryUrl: discoveryUrl,
       clientId: provider.clientId,
       createdAt: DateTime.timestamp(),
+      frontendReturnTo: _pendingReturnTo,
     ));
 
     if (_isCancelled(gen)) return;

--- a/lib/src/modules/auth/pre_auth_state.dart
+++ b/lib/src/modules/auth/pre_auth_state.dart
@@ -22,6 +22,7 @@ class PreAuthState {
     required this.discoveryUrl,
     required this.clientId,
     required this.createdAt,
+    this.frontendReturnTo,
   });
 
   factory PreAuthState.fromJson(Map<String, dynamic> json) {
@@ -31,6 +32,7 @@ class PreAuthState {
       discoveryUrl: json['discoveryUrl'] as String,
       clientId: json['clientId'] as String,
       createdAt: DateTime.parse(json['createdAt'] as String).toUtc(),
+      frontendReturnTo: json['frontendReturnTo'] as String?,
     );
   }
 
@@ -40,7 +42,17 @@ class PreAuthState {
   final String clientId;
   final DateTime createdAt;
 
-  static const maxAge = Duration(minutes: 5);
+  /// In-app route the user should be returned to after a successful
+  /// re-auth (e.g. `/room/<alias>/<roomId>`). Null when there's no
+  /// specific return target; the callback falls back to the lobby.
+  ///
+  /// Must be a relative route — absolute URLs are rejected at the
+  /// callback boundary to prevent open-redirect attacks.
+  final String? frontendReturnTo;
+
+  /// 30-minute window covers typical OIDC roundtrips: password reset,
+  /// MFA prompts, email magic links. Five minutes is too short.
+  static const maxAge = Duration(minutes: 30);
 
   bool isExpired({DateTime? now}) {
     final currentTime = now ?? DateTime.timestamp();
@@ -53,6 +65,7 @@ class PreAuthState {
         'discoveryUrl': discoveryUrl,
         'clientId': clientId,
         'createdAt': createdAt.toUtc().toIso8601String(),
+        if (frontendReturnTo != null) 'frontendReturnTo': frontendReturnTo,
       };
 
   @override
@@ -62,11 +75,18 @@ class PreAuthState {
       other.providerId == providerId &&
       other.discoveryUrl == discoveryUrl &&
       other.clientId == clientId &&
-      other.createdAt == createdAt;
+      other.createdAt == createdAt &&
+      other.frontendReturnTo == frontendReturnTo;
 
   @override
-  int get hashCode =>
-      Object.hash(serverUrl, providerId, discoveryUrl, clientId, createdAt);
+  int get hashCode => Object.hash(
+        serverUrl,
+        providerId,
+        discoveryUrl,
+        clientId,
+        createdAt,
+        frontendReturnTo,
+      );
 
   @override
   String toString() =>

--- a/lib/src/modules/auth/pre_auth_state.dart
+++ b/lib/src/modules/auth/pre_auth_state.dart
@@ -16,14 +16,22 @@ import 'package:shared_preferences/shared_preferences.dart';
 /// Includes [createdAt] for expiry — states older than [maxAge] are rejected.
 @immutable
 class PreAuthState {
-  const PreAuthState({
+  PreAuthState({
     required this.serverUrl,
     required this.providerId,
     required this.discoveryUrl,
     required this.clientId,
     required this.createdAt,
     this.frontendReturnTo,
-  });
+  }) {
+    if (frontendReturnTo != null && !_isSafeReturnTo(frontendReturnTo!)) {
+      throw ArgumentError.value(
+        frontendReturnTo,
+        'frontendReturnTo',
+        'must be an in-app path starting with "/" and not "//"',
+      );
+    }
+  }
 
   factory PreAuthState.fromJson(Map<String, dynamic> json) {
     return PreAuthState(
@@ -36,6 +44,12 @@ class PreAuthState {
     );
   }
 
+  static bool _isSafeReturnTo(String value) {
+    if (value.isEmpty) return false;
+    if (value.startsWith('//')) return false;
+    return value.startsWith('/');
+  }
+
   final Uri serverUrl;
   final String providerId;
   final String discoveryUrl;
@@ -46,12 +60,13 @@ class PreAuthState {
   /// re-auth (e.g. `/room/<alias>/<roomId>`). Null when there's no
   /// specific return target; the callback falls back to the lobby.
   ///
-  /// Must be a relative route — absolute URLs are rejected at the
-  /// callback boundary to prevent open-redirect attacks.
+  /// The constructor rejects anything that isn't a relative in-app
+  /// path (open-redirect defense): absolute URLs and `//host/...`
+  /// values throw [ArgumentError] before they can be persisted.
   final String? frontendReturnTo;
 
-  /// 30-minute window covers typical OIDC roundtrips: password reset,
-  /// MFA prompts, email magic links. Five minutes is too short.
+  /// Covers typical OIDC roundtrips: password reset, MFA prompts,
+  /// email magic links.
   static const maxAge = Duration(minutes: 30);
 
   bool isExpired({DateTime? now}) {

--- a/lib/src/modules/auth/return_to_storage.dart
+++ b/lib/src/modules/auth/return_to_storage.dart
@@ -10,13 +10,9 @@ import 'package:shared_preferences/shared_preferences.dart';
 /// because none of the persisted state is sensitive — tokens go
 /// through the secure store.
 ///
-/// Entries expire after 24 hours. Drafts are user content, so the TTL
-/// is generous: a 5-minute TTL would silently delete a composer draft
-/// if the user took six minutes to sign back in, which is hostile.
-/// 24 hours bounds the staleness window without surprising the user.
+/// Entries expire after 24 hours so drafts survive multi-minute OIDC
+/// roundtrips with retries while still bounding staleness.
 abstract final class ReturnToStorage {
-  /// Prefix for every key written by this store. Lets us namespace
-  /// cleanly and grep for it during debugging.
   static const _prefix = 'soliplex_return_to';
 
   /// Entries older than this are treated as missing and lazily cleared

--- a/lib/src/modules/auth/return_to_storage.dart
+++ b/lib/src/modules/auth/return_to_storage.dart
@@ -1,0 +1,91 @@
+import 'dart:convert';
+import 'dart:developer' as dev;
+
+import 'package:shared_preferences/shared_preferences.dart';
+
+/// Per-screen snapshot store for state that needs to survive an
+/// auth-failure round-trip (composer drafts, quiz progress).
+///
+/// Backed by `shared_preferences` rather than `flutter_secure_storage`
+/// because none of the persisted state is sensitive — tokens go
+/// through the secure store.
+///
+/// Entries expire after 24 hours. Drafts are user content, so the TTL
+/// is generous: a 5-minute TTL would silently delete a composer draft
+/// if the user took six minutes to sign back in, which is hostile.
+/// 24 hours bounds the staleness window without surprising the user.
+abstract final class ReturnToStorage {
+  /// Prefix for every key written by this store. Lets us namespace
+  /// cleanly and grep for it during debugging.
+  static const _prefix = 'soliplex_return_to';
+
+  /// Entries older than this are treated as missing and lazily cleared
+  /// on the next read.
+  static const maxAge = Duration(hours: 24);
+
+  static String _composerKey(String serverId, String roomId) =>
+      '$_prefix:composer:$serverId:$roomId';
+
+  /// Stores the unsent composer text for a `(serverId, roomId)` pair.
+  ///
+  /// Empty / whitespace-only text is treated as "no draft" and clears
+  /// any existing entry — there's nothing meaningful to restore.
+  static Future<void> saveComposer({
+    required String serverId,
+    required String roomId,
+    required String unsentText,
+    DateTime? now,
+  }) async {
+    final trimmed = unsentText.trim();
+    if (trimmed.isEmpty) {
+      await clearComposer(serverId: serverId, roomId: roomId);
+      return;
+    }
+    final prefs = await SharedPreferences.getInstance();
+    final entry = {
+      'unsentText': unsentText,
+      'createdAt': (now ?? DateTime.timestamp()).toUtc().toIso8601String(),
+    };
+    await prefs.setString(_composerKey(serverId, roomId), jsonEncode(entry));
+  }
+
+  /// Returns the previously persisted composer text for the pair, or
+  /// `null` when missing, expired, or corrupted. Expired or corrupted
+  /// entries are removed from storage as a side effect.
+  static Future<String?> loadComposer({
+    required String serverId,
+    required String roomId,
+    DateTime? now,
+  }) async {
+    final prefs = await SharedPreferences.getInstance();
+    final raw = prefs.getString(_composerKey(serverId, roomId));
+    if (raw == null) return null;
+
+    try {
+      final json = jsonDecode(raw) as Map<String, dynamic>;
+      final createdAt = DateTime.parse(json['createdAt'] as String).toUtc();
+      final currentTime = now ?? DateTime.timestamp();
+      if (currentTime.difference(createdAt) > maxAge) {
+        await clearComposer(serverId: serverId, roomId: roomId);
+        return null;
+      }
+      return json['unsentText'] as String?;
+    } catch (e, st) {
+      dev.log(
+        'ReturnToStorage: corrupted composer entry; clearing',
+        error: e,
+        stackTrace: st,
+      );
+      await clearComposer(serverId: serverId, roomId: roomId);
+      return null;
+    }
+  }
+
+  static Future<void> clearComposer({
+    required String serverId,
+    required String roomId,
+  }) async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.remove(_composerKey(serverId, roomId));
+  }
+}

--- a/lib/src/modules/auth/server_manager.dart
+++ b/lib/src/modules/auth/server_manager.dart
@@ -197,6 +197,7 @@ class ServerManager {
     Future<void> persist() async {
       switch (entry.auth.session.value) {
         case ActiveSession(:final provider, :final tokens):
+        case ExpiredSession(:final provider, :final tokens):
           await _storage.save(
             serverId,
             AuthenticatedServer(

--- a/lib/src/modules/auth/server_manager.dart
+++ b/lib/src/modules/auth/server_manager.dart
@@ -55,6 +55,17 @@ class ServerManager {
         : const Unauthenticated();
   });
 
+  /// A revision marker that bumps on any per-server session-state
+  /// change, including transitions that leave the aggregate
+  /// [authState] unchanged (e.g. one of several servers flipping to
+  /// expired while others stay active). Wire GoRouter's
+  /// `refreshListenable` here so per-server route guards re-evaluate
+  /// on every transition.
+  late final ReadonlySignal<List<SessionState>> connectionRevision =
+      computed(() => [
+            for (final entry in _servers.value.values) entry.auth.session.value,
+          ]);
+
   String _uniqueAlias(Uri serverUrl) {
     final base = aliasFromUrl(serverUrl);
     if (_aliases.add(base)) return base;

--- a/lib/src/modules/auth/server_manager.dart
+++ b/lib/src/modules/auth/server_manager.dart
@@ -58,9 +58,9 @@ class ServerManager {
   /// A revision marker that bumps on any per-server session-state
   /// change, including transitions that leave the aggregate
   /// [authState] unchanged (e.g. one of several servers flipping to
-  /// expired while others stay active). Wire GoRouter's
-  /// `refreshListenable` here so per-server route guards re-evaluate
-  /// on every transition.
+  /// expired while others stay active). Consumed by GoRouter as a
+  /// `refreshListenable` so per-server route guards re-evaluate on
+  /// every transition.
   late final ReadonlySignal<List<SessionState>> connectionRevision =
       computed(() => [
             for (final entry in _servers.value.values) entry.auth.session.value,

--- a/lib/src/modules/auth/ui/auth_callback_screen.dart
+++ b/lib/src/modules/auth/ui/auth_callback_screen.dart
@@ -80,11 +80,30 @@ class _AuthCallbackScreenState extends ConsumerState<AuthCallbackScreen> {
         ),
       );
 
-      if (mounted) context.go(AppRoutes.lobby);
+      if (mounted) context.go(_safeReturnTo(preAuth.frontendReturnTo));
     } catch (e, st) {
       dev.log('Auth callback failed', error: e, stackTrace: st);
       _fail('Something went wrong. Please try again.');
     }
+  }
+
+  /// Returns [returnTo] if it's a safe relative in-app path, else
+  /// falls back to the lobby.
+  ///
+  /// Rejects absolute URLs (`http://`, `https://`) and
+  /// protocol-relative URLs (`//host/...`) — these could otherwise be
+  /// used as open-redirect targets when the callback honors a value
+  /// crafted by a third party. The PreAuthState cookie is short-lived
+  /// and same-origin-stored, but defense in depth.
+  String _safeReturnTo(String? returnTo) {
+    if (returnTo == null || returnTo.isEmpty) return AppRoutes.lobby;
+    if (returnTo.startsWith('//') ||
+        returnTo.startsWith('http://') ||
+        returnTo.startsWith('https://')) {
+      return AppRoutes.lobby;
+    }
+    if (!returnTo.startsWith('/')) return AppRoutes.lobby;
+    return returnTo;
   }
 
   void _fail(String message) {

--- a/lib/src/modules/auth/ui/auth_callback_screen.dart
+++ b/lib/src/modules/auth/ui/auth_callback_screen.dart
@@ -99,11 +99,17 @@ class _AuthCallbackScreenState extends ConsumerState<AuthCallbackScreen> {
     if (returnTo == null || returnTo.isEmpty) return AppRoutes.lobby;
     if (returnTo.startsWith('//') ||
         returnTo.startsWith('http://') ||
-        returnTo.startsWith('https://') ||
-        !returnTo.startsWith('/')) {
+        returnTo.startsWith('https://')) {
       dev.log(
-        'Rejected unsafe returnTo: $returnTo',
+        'Rejected returnTo (open-redirect target): $returnTo',
         level: 900,
+      );
+      return AppRoutes.lobby;
+    }
+    if (!returnTo.startsWith('/')) {
+      dev.log(
+        'Rejected returnTo (not an absolute path): $returnTo',
+        level: 800,
       );
       return AppRoutes.lobby;
     }

--- a/lib/src/modules/auth/ui/auth_callback_screen.dart
+++ b/lib/src/modules/auth/ui/auth_callback_screen.dart
@@ -82,7 +82,12 @@ class _AuthCallbackScreenState extends ConsumerState<AuthCallbackScreen> {
 
       if (mounted) context.go(_safeReturnTo(preAuth.frontendReturnTo));
     } catch (e, st) {
-      dev.log('Auth callback failed', error: e, stackTrace: st);
+      dev.log(
+        'Auth callback failed',
+        error: e,
+        stackTrace: st,
+        level: 1000,
+      );
       _fail('Something went wrong. Please try again.');
     }
   }
@@ -90,11 +95,11 @@ class _AuthCallbackScreenState extends ConsumerState<AuthCallbackScreen> {
   /// Returns [returnTo] if it's a safe relative in-app path, else
   /// falls back to the lobby.
   ///
-  /// Rejects absolute URLs (`http://`, `https://`) and
-  /// protocol-relative URLs (`//host/...`) — these could otherwise be
-  /// used as open-redirect targets when the callback honors a value
-  /// crafted by a third party. The PreAuthState cookie is short-lived
-  /// and same-origin-stored, but defense in depth.
+  /// Defense in depth on top of [PreAuthState]'s constructor
+  /// validation: rejects absolute URLs (`http://`, `https://`) and
+  /// protocol-relative URLs (`//host/...`) so a tampered storage entry
+  /// cannot open-redirect the user even if it bypassed the type
+  /// invariant.
   String _safeReturnTo(String? returnTo) {
     if (returnTo == null || returnTo.isEmpty) return AppRoutes.lobby;
     if (returnTo.startsWith('//') ||

--- a/lib/src/modules/auth/ui/auth_callback_screen.dart
+++ b/lib/src/modules/auth/ui/auth_callback_screen.dart
@@ -99,10 +99,14 @@ class _AuthCallbackScreenState extends ConsumerState<AuthCallbackScreen> {
     if (returnTo == null || returnTo.isEmpty) return AppRoutes.lobby;
     if (returnTo.startsWith('//') ||
         returnTo.startsWith('http://') ||
-        returnTo.startsWith('https://')) {
+        returnTo.startsWith('https://') ||
+        !returnTo.startsWith('/')) {
+      dev.log(
+        'Rejected unsafe returnTo: $returnTo',
+        level: 900,
+      );
       return AppRoutes.lobby;
     }
-    if (!returnTo.startsWith('/')) return AppRoutes.lobby;
     return returnTo;
   }
 

--- a/lib/src/modules/auth/ui/home_screen.dart
+++ b/lib/src/modules/auth/ui/home_screen.dart
@@ -21,6 +21,7 @@ class HomeScreen extends ConsumerStatefulWidget {
     this.logo,
     this.defaultBackendUrl,
     this.autoConnectUrl,
+    this.autoConnectReturnTo,
   });
 
   final ServerManager serverManager;
@@ -28,6 +29,12 @@ class HomeScreen extends ConsumerStatefulWidget {
   final Widget? logo;
   final String? defaultBackendUrl;
   final String? autoConnectUrl;
+
+  /// In-app route to return the user to after a successful re-auth
+  /// triggered by this auto-connect. Forwarded to
+  /// [ConnectFlow.connect] which stashes it in `PreAuthState` for the
+  /// callback to honor.
+  final String? autoConnectReturnTo;
 
   @override
   ConsumerState<HomeScreen> createState() => _HomeScreenState();
@@ -475,7 +482,10 @@ class _HomeScreenState extends ConsumerState<HomeScreen> {
 
   void _connect() {
     if (!_formKey.currentState!.validate()) return;
-    _flow.connect(_urlController.text.trim());
+    _flow.connect(
+      _urlController.text.trim(),
+      returnTo: widget.autoConnectReturnTo,
+    );
   }
 }
 

--- a/lib/src/modules/diagnostics/models/http_event_group.dart
+++ b/lib/src/modules/diagnostics/models/http_event_group.dart
@@ -83,6 +83,16 @@ class HttpEventGroup {
     return null;
   }
 
+  /// Whether [timestamp] would return a value rather than throw.
+  ///
+  /// False for orphan groups whose only event is a [response] or
+  /// [streamEnd]. Orphans appear when the inspector's bounded FIFO
+  /// buffer evicts a [request] / [streamStart] while its later-arriving
+  /// counterpart remains. Callers that need a sortable timestamp should
+  /// skip these groups.
+  bool get hasTimestamp =>
+      request != null || streamStart != null || error != null;
+
   DateTime get timestamp {
     if (request case HttpRequestEvent(:final timestamp)) return timestamp;
     if (streamStart case HttpStreamStartEvent(:final timestamp)) {

--- a/lib/src/modules/diagnostics/models/http_event_grouper.dart
+++ b/lib/src/modules/diagnostics/models/http_event_grouper.dart
@@ -19,7 +19,11 @@ List<HttpEventGroup> groupHttpEvents(List<HttpEvent> events) {
     };
   }
 
-  final sorted = groups.values.toList()
+  // Orphan groups (response or streamEnd whose request/streamStart was
+  // evicted from the inspector's bounded buffer) have no sortable
+  // timestamp and would throw from [HttpEventGroup.timestamp]. They sit
+  // invisibly in the buffer until FIFO eviction removes them too.
+  final sorted = groups.values.where((g) => g.hasTimestamp).toList()
     ..sort((a, b) => a.timestamp.compareTo(b.timestamp));
   return sorted;
 }

--- a/lib/src/modules/lobby/lobby_state.dart
+++ b/lib/src/modules/lobby/lobby_state.dart
@@ -135,7 +135,7 @@ class LobbyState {
         };
         _userProfiles.value = {..._userProfiles.value, serverId: null};
       case NoSession():
-        // Logout or never authenticated: prune the row.
+        // Signed out: prune the row.
         final updatedRooms = Map<String, ServerRooms>.from(_roomsByServer.value)
           ..remove(serverId);
         final updatedProfiles =
@@ -144,8 +144,6 @@ class LobbyState {
         _roomsByServer.value = updatedRooms;
         _userProfiles.value = updatedProfiles;
       case ActiveSession():
-        // Unreachable: isConnected is true when the session is
-        // ActiveSession, so the early return above would have fired.
         assert(false, 'ActiveSession reached the !isConnected branch');
     }
   }

--- a/lib/src/modules/lobby/lobby_state.dart
+++ b/lib/src/modules/lobby/lobby_state.dart
@@ -123,26 +123,31 @@ class LobbyState {
       return;
     }
     _cancelTokens.remove(serverId)?.cancel('disconnected');
-    final session = entry.auth.session.value;
-    if (session is ExpiredSession) {
-      // Keep the row visible with an inline "sign in again" affordance.
-      // The previously-known profile is dropped so a re-auth as a
-      // different identity does not briefly show the previous user's
-      // name; one frame of no-name placeholder is honest.
-      _roomsByServer.value = {
-        ..._roomsByServer.value,
-        serverId: RoomsExpired(),
-      };
-      _userProfiles.value = {..._userProfiles.value, serverId: null};
-      return;
+    switch (entry.auth.session.value) {
+      case ExpiredSession():
+        // Keep the row visible with an inline "sign in again" affordance.
+        // The previously-known profile is dropped so a re-auth as a
+        // different identity does not briefly render the prior user's
+        // name.
+        _roomsByServer.value = {
+          ..._roomsByServer.value,
+          serverId: RoomsExpired(),
+        };
+        _userProfiles.value = {..._userProfiles.value, serverId: null};
+      case NoSession():
+        // Logout or never authenticated: prune the row.
+        final updatedRooms = Map<String, ServerRooms>.from(_roomsByServer.value)
+          ..remove(serverId);
+        final updatedProfiles =
+            Map<String, UserProfile?>.from(_userProfiles.value)
+              ..remove(serverId);
+        _roomsByServer.value = updatedRooms;
+        _userProfiles.value = updatedProfiles;
+      case ActiveSession():
+        // Unreachable: isConnected is true when the session is
+        // ActiveSession, so the early return above would have fired.
+        assert(false, 'ActiveSession reached the !isConnected branch');
     }
-    // NoSession (logout or never authenticated): prune the row.
-    final updatedRooms = Map<String, ServerRooms>.from(_roomsByServer.value)
-      ..remove(serverId);
-    final updatedProfiles = Map<String, UserProfile?>.from(_userProfiles.value)
-      ..remove(serverId);
-    _roomsByServer.value = updatedRooms;
-    _userProfiles.value = updatedProfiles;
   }
 
   void _fetchRooms(String serverId, ServerEntry entry) {

--- a/lib/src/modules/lobby/lobby_state.dart
+++ b/lib/src/modules/lobby/lobby_state.dart
@@ -1,8 +1,9 @@
 import 'dart:convert';
+import 'dart:developer' as dev;
 
 import 'package:soliplex_agent/soliplex_agent.dart' hide AuthException;
 import 'package:soliplex_client/soliplex_client.dart'
-    show AuthException, SoliplexApi;
+    show AuthException, PermissionDeniedException, SoliplexApi;
 
 import '../auth/server_entry.dart';
 import '../auth/server_manager.dart';
@@ -144,7 +145,7 @@ class LobbyState {
         ..._roomsByServer.value,
         serverId: RoomsLoaded(rooms),
       };
-    }).catchError((Object error) {
+    }).catchError((Object error, StackTrace st) {
       if (token.isCancelled) return;
       _cancelTokens.remove(serverId);
       if (error is AuthException) {
@@ -154,9 +155,18 @@ class LobbyState {
         entry.auth.markSessionExpired();
         return;
       }
-      // PermissionDeniedException flows through to RoomsFailed; re-auth
-      // wouldn't help, so the UI renders a permission-specific message
-      // instead of triggering the auth funnel.
+      if (error is! PermissionDeniedException) {
+        // PermissionDeniedException is rendered inline by the lobby
+        // section; everything else (network, 5xx, decode, programmer
+        // errors) would otherwise be stringified into the UI with no
+        // backing log.
+        dev.log(
+          'Failed to fetch rooms for $serverId',
+          error: error,
+          stackTrace: st,
+          level: 1000,
+        );
+      }
       _roomsByServer.value = {
         ..._roomsByServer.value,
         serverId: RoomsFailed(error),
@@ -176,15 +186,24 @@ class LobbyState {
         profile = null;
       }
       _userProfiles.value = {..._userProfiles.value, serverId: profile};
-    }).catchError((Object error) {
+    }).catchError((Object error, StackTrace st) {
       if (!_authSubscriptions.containsKey(serverId)) return;
       if (error is AuthException) {
         entry.auth.markSessionExpired();
         return;
       }
       // Profile is optional sidebar metadata; silent null is the correct
-      // disposition for PermissionDeniedException and other failures —
-      // there is no UI affordance to surface or recover from.
+      // UI disposition for PermissionDeniedException and other failures.
+      // Log everything else so 5xx / decode / programmer errors stay
+      // debuggable — there is no surface in the UI for them otherwise.
+      if (error is! PermissionDeniedException) {
+        dev.log(
+          'Failed to fetch user profile for $serverId',
+          error: error,
+          stackTrace: st,
+          level: 900,
+        );
+      }
       _userProfiles.value = {..._userProfiles.value, serverId: null};
     });
   }

--- a/lib/src/modules/lobby/lobby_state.dart
+++ b/lib/src/modules/lobby/lobby_state.dart
@@ -154,6 +154,9 @@ class LobbyState {
         entry.auth.markSessionExpired();
         return;
       }
+      // PermissionDeniedException flows through to RoomsFailed; re-auth
+      // wouldn't help, so the UI renders a permission-specific message
+      // instead of triggering the auth funnel.
       _roomsByServer.value = {
         ..._roomsByServer.value,
         serverId: RoomsFailed(error),
@@ -179,6 +182,9 @@ class LobbyState {
         entry.auth.markSessionExpired();
         return;
       }
+      // Profile is optional sidebar metadata; silent null is the correct
+      // disposition for PermissionDeniedException and other failures —
+      // there is no UI affordance to surface or recover from.
       _userProfiles.value = {..._userProfiles.value, serverId: null};
     });
   }

--- a/lib/src/modules/lobby/lobby_state.dart
+++ b/lib/src/modules/lobby/lobby_state.dart
@@ -5,6 +5,7 @@ import 'package:soliplex_agent/soliplex_agent.dart' hide AuthException;
 import 'package:soliplex_client/soliplex_client.dart'
     show AuthException, PermissionDeniedException, SoliplexApi;
 
+import '../auth/auth_tokens.dart';
 import '../auth/server_entry.dart';
 import '../auth/server_manager.dart';
 
@@ -44,6 +45,11 @@ class RoomsFailed extends ServerRooms {
   RoomsFailed(this.error);
   final Object error;
 }
+
+/// The server's session has expired. Tokens are preserved (for a silent
+/// refresh attempt later), but the user must re-authenticate to see
+/// rooms. The lobby renders an inline "sign in again" affordance.
+class RoomsExpired extends ServerRooms {}
 
 /// Manages per-server room lists, fetching from all connected servers.
 class LobbyState {
@@ -114,15 +120,29 @@ class LobbyState {
     if (entry.isConnected) {
       _fetchRooms(serverId, entry);
       _fetchUserProfile(serverId, entry);
-    } else {
-      final updatedRooms = Map<String, ServerRooms>.from(_roomsByServer.value)
-        ..remove(serverId);
-      final updatedProfiles =
-          Map<String, UserProfile?>.from(_userProfiles.value)..remove(serverId);
-      _cancelTokens.remove(serverId)?.cancel('disconnected');
-      _roomsByServer.value = updatedRooms;
-      _userProfiles.value = updatedProfiles;
+      return;
     }
+    _cancelTokens.remove(serverId)?.cancel('disconnected');
+    final session = entry.auth.session.value;
+    if (session is ExpiredSession) {
+      // Keep the row visible with an inline "sign in again" affordance.
+      // The previously-known profile is dropped so a re-auth as a
+      // different identity does not briefly show the previous user's
+      // name; one frame of no-name placeholder is honest.
+      _roomsByServer.value = {
+        ..._roomsByServer.value,
+        serverId: RoomsExpired(),
+      };
+      _userProfiles.value = {..._userProfiles.value, serverId: null};
+      return;
+    }
+    // NoSession (logout or never authenticated): prune the row.
+    final updatedRooms = Map<String, ServerRooms>.from(_roomsByServer.value)
+      ..remove(serverId);
+    final updatedProfiles = Map<String, UserProfile?>.from(_userProfiles.value)
+      ..remove(serverId);
+    _roomsByServer.value = updatedRooms;
+    _userProfiles.value = updatedProfiles;
   }
 
   void _fetchRooms(String serverId, ServerEntry entry) {
@@ -149,9 +169,9 @@ class LobbyState {
       if (token.isCancelled) return;
       _cancelTokens.remove(serverId);
       if (error is AuthException) {
-        // Funnel to the per-server auth funnel. _onAuthChanged will
-        // drop the section from the lobby on the isConnected→false
-        // transition; no need to set RoomsFailed.
+        // Funnel to the per-server auth funnel. _onAuthChanged observes
+        // the ExpiredSession transition and writes RoomsExpired so the
+        // lobby keeps the row with an inline "sign in again" affordance.
         entry.auth.markSessionExpired();
         return;
       }

--- a/lib/src/modules/lobby/lobby_state.dart
+++ b/lib/src/modules/lobby/lobby_state.dart
@@ -1,7 +1,8 @@
 import 'dart:convert';
 
-import 'package:soliplex_agent/soliplex_agent.dart';
-import 'package:soliplex_client/soliplex_client.dart' show SoliplexApi;
+import 'package:soliplex_agent/soliplex_agent.dart' hide AuthException;
+import 'package:soliplex_client/soliplex_client.dart'
+    show AuthException, SoliplexApi;
 
 import '../auth/server_entry.dart';
 import '../auth/server_manager.dart';
@@ -146,6 +147,13 @@ class LobbyState {
     }).catchError((Object error) {
       if (token.isCancelled) return;
       _cancelTokens.remove(serverId);
+      if (error is AuthException) {
+        // Funnel to the per-server auth funnel. _onAuthChanged will
+        // drop the section from the lobby on the isConnected→false
+        // transition; no need to set RoomsFailed.
+        entry.auth.markSessionExpired();
+        return;
+      }
       _roomsByServer.value = {
         ..._roomsByServer.value,
         serverId: RoomsFailed(error),
@@ -165,8 +173,12 @@ class LobbyState {
         profile = null;
       }
       _userProfiles.value = {..._userProfiles.value, serverId: profile};
-    }).catchError((Object _) {
+    }).catchError((Object error) {
       if (!_authSubscriptions.containsKey(serverId)) return;
+      if (error is AuthException) {
+        entry.auth.markSessionExpired();
+        return;
+      }
       _userProfiles.value = {..._userProfiles.value, serverId: null};
     });
   }

--- a/lib/src/modules/lobby/ui/lobby_screen.dart
+++ b/lib/src/modules/lobby/ui/lobby_screen.dart
@@ -1,6 +1,8 @@
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
 import 'package:signals_flutter/signals_flutter.dart';
+import 'package:soliplex_client/soliplex_client.dart'
+    show PermissionDeniedException;
 
 import '../../../core/routes.dart';
 import '../../auth/server_entry.dart';
@@ -291,7 +293,11 @@ class _ServerSection extends StatelessWidget {
           RoomsFailed(:final error) => Padding(
               padding:
                   const EdgeInsets.symmetric(horizontal: SoliplexSpacing.s4),
-              child: Text('Failed to load rooms: $error'),
+              child: Text(switch (error) {
+                PermissionDeniedException() =>
+                  "You don't have permission to view rooms on this server.",
+                _ => 'Failed to load rooms: $error',
+              }),
             ),
           RoomsLoaded(:final rooms) => Column(
               children: [

--- a/lib/src/modules/lobby/ui/lobby_screen.dart
+++ b/lib/src/modules/lobby/ui/lobby_screen.dart
@@ -61,6 +61,18 @@ class _LobbyScreenState extends State<LobbyScreen> {
     context.push(AppRoutes.roomInfo(entry.alias, roomId));
   }
 
+  void _onSignIn(String serverId) {
+    final entry = widget.serverManager.servers.value[serverId];
+    assert(entry != null, 'Sign-in tap for unknown serverId: $serverId');
+    if (entry == null) return;
+    context.go(
+      AppRoutes.homeWithUrl(
+        entry.serverUrl.toString(),
+        returnTo: AppRoutes.lobby,
+      ),
+    );
+  }
+
   @override
   Widget build(BuildContext context) {
     final servers = widget.serverManager.servers.watch(context);
@@ -80,6 +92,7 @@ class _LobbyScreenState extends State<LobbyScreen> {
                 onVersions: _onVersions,
                 onRoomTap: _onRoomTap,
                 onInfoTap: _onInfoTap,
+                onSignIn: _onSignIn,
               )
             : _NarrowLayout(
                 servers: servers,
@@ -91,6 +104,7 @@ class _LobbyScreenState extends State<LobbyScreen> {
                 onVersions: _onVersions,
                 onRoomTap: _onRoomTap,
                 onInfoTap: _onInfoTap,
+                onSignIn: _onSignIn,
               );
       },
     );
@@ -108,6 +122,7 @@ class _WideLayout extends StatelessWidget {
     required this.onVersions,
     required this.onRoomTap,
     required this.onInfoTap,
+    required this.onSignIn,
   });
 
   final Map<String, ServerEntry> servers;
@@ -119,6 +134,7 @@ class _WideLayout extends StatelessWidget {
   final VoidCallback onVersions;
   final void Function(String serverId, String roomId) onRoomTap;
   final void Function(String serverId, String roomId) onInfoTap;
+  final void Function(String serverId) onSignIn;
 
   @override
   Widget build(BuildContext context) {
@@ -144,6 +160,7 @@ class _WideLayout extends StatelessWidget {
               onRoomTap: onRoomTap,
               onInfoTap: onInfoTap,
               onAddServer: onAddServer,
+              onSignIn: onSignIn,
             ),
           ),
         ],
@@ -163,6 +180,7 @@ class _NarrowLayout extends StatelessWidget {
     required this.onVersions,
     required this.onRoomTap,
     required this.onInfoTap,
+    required this.onSignIn,
   });
 
   final Map<String, ServerEntry> servers;
@@ -174,6 +192,7 @@ class _NarrowLayout extends StatelessWidget {
   final VoidCallback onVersions;
   final void Function(String serverId, String roomId) onRoomTap;
   final void Function(String serverId, String roomId) onInfoTap;
+  final void Function(String serverId) onSignIn;
 
   @override
   Widget build(BuildContext context) {
@@ -202,6 +221,7 @@ class _NarrowLayout extends StatelessWidget {
         onRoomTap: onRoomTap,
         onInfoTap: onInfoTap,
         onAddServer: onAddServer,
+        onSignIn: onSignIn,
       ),
     );
   }
@@ -214,6 +234,7 @@ class _RoomContent extends StatelessWidget {
     required this.onRoomTap,
     required this.onInfoTap,
     required this.onAddServer,
+    required this.onSignIn,
   });
 
   final Map<String, ServerRooms> roomsByServer;
@@ -221,6 +242,7 @@ class _RoomContent extends StatelessWidget {
   final void Function(String serverId, String roomId) onRoomTap;
   final void Function(String serverId, String roomId) onInfoTap;
   final VoidCallback onAddServer;
+  final void Function(String serverId) onSignIn;
 
   @override
   Widget build(BuildContext context) {
@@ -249,6 +271,7 @@ class _RoomContent extends StatelessWidget {
             serverRooms: entry.value,
             onRoomTap: onRoomTap,
             onInfoTap: onInfoTap,
+            onSignIn: onSignIn,
           ),
       ],
     );
@@ -262,6 +285,7 @@ class _ServerSection extends StatelessWidget {
     required this.serverRooms,
     required this.onRoomTap,
     required this.onInfoTap,
+    required this.onSignIn,
   });
 
   final String serverId;
@@ -269,6 +293,7 @@ class _ServerSection extends StatelessWidget {
   final ServerRooms serverRooms;
   final void Function(String serverId, String roomId) onRoomTap;
   final void Function(String serverId, String roomId) onInfoTap;
+  final void Function(String serverId) onSignIn;
 
   @override
   Widget build(BuildContext context) {
@@ -308,6 +333,29 @@ class _ServerSection extends StatelessWidget {
                     onInfoTap: () => onInfoTap(serverId, room.id),
                   ),
               ],
+            ),
+          RoomsExpired() => Padding(
+              padding:
+                  const EdgeInsets.symmetric(horizontal: SoliplexSpacing.s4),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(
+                    'Session expired',
+                    style: Theme.of(context).textTheme.titleSmall,
+                  ),
+                  const SizedBox(height: SoliplexSpacing.s1),
+                  Text(
+                    'Sign in again to view rooms on this server.',
+                    style: Theme.of(context).textTheme.bodyMedium,
+                  ),
+                  const SizedBox(height: SoliplexSpacing.s3),
+                  FilledButton.tonal(
+                    onPressed: () => onSignIn(serverId),
+                    child: const Text('Sign in'),
+                  ),
+                ],
+              ),
             ),
         },
       ],

--- a/lib/src/modules/lobby/ui/server_sidebar.dart
+++ b/lib/src/modules/lobby/ui/server_sidebar.dart
@@ -121,8 +121,14 @@ class _ServerTile extends StatelessWidget {
 
   String _identityLabel(SessionState session) {
     if (!entry.requiresAuth) return 'No authentication required';
-    if (session is ExpiredSession) return 'Session expired';
-    if (session is NoSession) return 'Not signed in';
+    return switch (session) {
+      ExpiredSession() => 'Session expired',
+      NoSession() => 'Not signed in',
+      ActiveSession() => _activeIdentityLabel(),
+    };
+  }
+
+  String _activeIdentityLabel() {
     if (profile == null) return 'Signed in';
     final name = '${profile!.givenName} ${profile!.familyName}'.trim();
     if (name.isNotEmpty) return name;

--- a/lib/src/modules/lobby/ui/server_sidebar.dart
+++ b/lib/src/modules/lobby/ui/server_sidebar.dart
@@ -1,5 +1,7 @@
 import 'package:flutter/material.dart';
+import 'package:signals_flutter/signals_flutter.dart';
 
+import '../../auth/auth_tokens.dart';
 import '../../auth/server_entry.dart';
 import '../lobby_state.dart';
 import '../../../design/design.dart';
@@ -107,15 +109,20 @@ class _ServerTile extends StatelessWidget {
   Widget build(BuildContext context) {
     return ListTile(
       title: Text(formatServerUrl(entry.serverUrl)),
-      subtitle: Text(_identityLabel),
+      // The label depends on entry.auth.session, which the parent does
+      // not watch — Watch rebuilds the subtitle on session flips.
+      subtitle: Watch(
+        (context) => Text(_identityLabel(entry.auth.session.value)),
+      ),
       dense: true,
       onTap: onTap,
     );
   }
 
-  String get _identityLabel {
+  String _identityLabel(SessionState session) {
     if (!entry.requiresAuth) return 'No authentication required';
-    if (!entry.isConnected) return 'Not signed in';
+    if (session is ExpiredSession) return 'Session expired';
+    if (session is NoSession) return 'Not signed in';
     if (profile == null) return 'Signed in';
     final name = '${profile!.givenName} ${profile!.familyName}'.trim();
     if (name.isNotEmpty) return name;

--- a/lib/src/modules/quiz/quiz_session_controller.dart
+++ b/lib/src/modules/quiz/quiz_session_controller.dart
@@ -1,18 +1,22 @@
 import 'package:soliplex_agent/soliplex_agent.dart' hide State;
 import 'package:soliplex_client/soliplex_client.dart';
 
+import '../auth/auth_session.dart';
 import 'quiz_session.dart';
 
 class QuizSessionController {
   QuizSessionController({
     required SoliplexApi api,
+    required AuthSession auth,
     required String roomId,
     required Logger logger,
   })  : _api = api,
+        _auth = auth,
         _roomId = roomId,
         _logger = logger;
 
   final SoliplexApi _api;
+  final AuthSession _auth;
   final String _roomId;
   final Logger _logger;
 
@@ -102,10 +106,15 @@ class QuizSessionController {
         error: e,
         stackTrace: stackTrace,
       );
+      if (e is AuthException) {
+        _auth.markSessionExpired();
+      }
       _recoverFromSubmitError(
         input,
         switch (e) {
           AuthException() => 'Your session has expired. Please sign in again.',
+          PermissionDeniedException() =>
+            "You don't have permission to submit answers in this quiz.",
           NotFoundException() => 'This question is no longer available.',
           NetworkException() =>
             'Could not reach the server. Check your connection and try again.',

--- a/lib/src/modules/quiz/ui/quiz_screen.dart
+++ b/lib/src/modules/quiz/ui/quiz_screen.dart
@@ -107,6 +107,11 @@ class _QuizScreenState extends State<QuizScreen> {
                     _handleBack,
                     'Back to Room',
                   ),
+                PermissionDeniedException() => (
+                    "You don't have permission to view this quiz.",
+                    _handleBack,
+                    'Back to Room',
+                  ),
                 NotFoundException() => (
                     'This quiz is no longer available.',
                     _handleBack,

--- a/lib/src/modules/quiz/ui/quiz_screen.dart
+++ b/lib/src/modules/quiz/ui/quiz_screen.dart
@@ -45,6 +45,7 @@ class _QuizScreenState extends State<QuizScreen> {
     _quizFuture = _fetchQuiz();
     _controller = QuizSessionController(
       api: api,
+      auth: widget.serverEntry.auth,
       roomId: widget.roomId,
       logger: _logger,
     );

--- a/lib/src/modules/room/room_state.dart
+++ b/lib/src/modules/room/room_state.dart
@@ -2,6 +2,7 @@ import 'dart:async' show unawaited;
 
 import 'package:soliplex_agent/soliplex_agent.dart';
 
+import '../auth/auth_session.dart';
 import '../auth/server_entry.dart';
 import 'agent_runtime_manager.dart';
 import 'run_registry.dart';
@@ -36,6 +37,7 @@ class RoomState {
     required UploadTrackerRegistry uploadRegistry,
     this.onNavigateToThread,
   })  : _connection = serverEntry.connection,
+        _auth = serverEntry.auth,
         _roomId = roomId,
         _runtimeManager = runtimeManager,
         _registry = registry,
@@ -53,6 +55,7 @@ class RoomState {
   }
 
   final ServerConnection _connection;
+  final AuthSession _auth;
   final String _roomId;
   final AgentRuntimeManager _runtimeManager;
   final RunRegistry _registry;
@@ -113,6 +116,7 @@ class RoomState {
     _activeThreadView?.dispose();
     _activeThreadView = ThreadViewState(
       connection: _connection,
+      auth: _auth,
       roomId: _roomId,
       threadId: threadId,
       registry: _registry,

--- a/lib/src/modules/room/thread_view_state.dart
+++ b/lib/src/modules/room/thread_view_state.dart
@@ -4,6 +4,7 @@ import 'package:flutter/foundation.dart' show debugPrint;
 import 'package:soliplex_agent/soliplex_agent.dart';
 
 import '../auth/auth_session.dart';
+import '../auth/auth_tokens.dart';
 import 'execution_tracker.dart';
 import 'execution_tracker_extension.dart';
 import 'historical_replay.dart';
@@ -69,6 +70,7 @@ class ThreadViewState {
         _auth = auth,
         _roomId = roomId,
         _registry = registry {
+    _authUnsub = _auth.session.subscribe(_onAuthChanged);
     if (!_restoreFromRegistry()) _fetch();
   }
 
@@ -89,6 +91,7 @@ class ThreadViewState {
   final Signal<AgentSession?> _activeSession = Signal<AgentSession?>(null);
   void Function()? _runStateUnsub;
   void Function()? _reconnectStatusUnsub;
+  void Function()? _authUnsub;
   bool _isDisposed = false;
 
   final SessionSpawner _spawner = SessionSpawner();
@@ -415,11 +418,24 @@ class ThreadViewState {
 
   void dispose() {
     _isDisposed = true;
+    _authUnsub?.call();
+    _authUnsub = null;
     _cancelToken?.cancel('disposed');
     _detachSession();
     _sessionState.dispose();
     _reconnectStatus.dispose();
     isCancellable.dispose();
     pendingApproval.dispose();
+  }
+
+  /// Cancels the active run and pending history fetch when the auth
+  /// session leaves [ActiveSession] (expired or signed out). The
+  /// route guard handles navigation; this just stops in-flight work
+  /// so the SSE client doesn't reconnect-loop with a dead token.
+  void _onAuthChanged(SessionState state) {
+    if (_isDisposed) return;
+    if (state is ActiveSession) return;
+    _cancelToken?.cancel('auth expired');
+    _activeSession.value?.cancel();
   }
 }

--- a/lib/src/modules/room/thread_view_state.dart
+++ b/lib/src/modules/room/thread_view_state.dart
@@ -452,6 +452,9 @@ class ThreadViewState {
   /// stays mounted and the in-memory [SendError.unsentText] +
   /// `_restoreUnsentText` path handles restoration without touching
   /// storage.
+  ///
+  /// Storage failures are logged at SEVERE and swallowed; the user's
+  /// draft is lost but the redirect still proceeds.
   void _onSendError(SendError? err) {
     if (_isDisposed) return;
     if (err == null) return;

--- a/lib/src/modules/room/thread_view_state.dart
+++ b/lib/src/modules/room/thread_view_state.dart
@@ -292,6 +292,18 @@ class ThreadViewState {
           // banner so the user sees what happened before the redirect.
           _auth.markSessionExpired();
         }
+        if (reason == FailureReason.internalError ||
+            reason == FailureReason.serverError) {
+          // Both reasons surface to the user only as a friendly string.
+          // Without this log, the underlying error and stack are
+          // unrecoverable for diagnosis.
+          dev.log(
+            'Thread run failed: ${reason.name}',
+            error: error,
+            name: 'ThreadViewState',
+            level: 1000,
+          );
+        }
         _lastSendError.value = SendError(_friendlyMessage(reason, error));
         if (conversation != null) {
           _messages.value = _messagesLoaded(conversation);

--- a/lib/src/modules/room/thread_view_state.dart
+++ b/lib/src/modules/room/thread_view_state.dart
@@ -5,6 +5,7 @@ import 'package:soliplex_agent/soliplex_agent.dart';
 
 import '../auth/auth_session.dart';
 import '../auth/auth_tokens.dart';
+import '../auth/return_to_storage.dart';
 import 'execution_tracker.dart';
 import 'execution_tracker_extension.dart';
 import 'historical_replay.dart';
@@ -71,6 +72,7 @@ class ThreadViewState {
         _roomId = roomId,
         _registry = registry {
     _authUnsub = _auth.session.subscribe(_onAuthChanged);
+    _sendErrorUnsub = _lastSendError.subscribe(_onSendError);
     if (!_restoreFromRegistry()) _fetch();
   }
 
@@ -92,6 +94,7 @@ class ThreadViewState {
   void Function()? _runStateUnsub;
   void Function()? _reconnectStatusUnsub;
   void Function()? _authUnsub;
+  void Function()? _sendErrorUnsub;
   bool _isDisposed = false;
 
   final SessionSpawner _spawner = SessionSpawner();
@@ -420,6 +423,8 @@ class ThreadViewState {
     _isDisposed = true;
     _authUnsub?.call();
     _authUnsub = null;
+    _sendErrorUnsub?.call();
+    _sendErrorUnsub = null;
     _cancelToken?.cancel('disposed');
     _detachSession();
     _sessionState.dispose();
@@ -437,5 +442,27 @@ class ThreadViewState {
     if (state is ActiveSession) return;
     _cancelToken?.cancel('auth expired');
     _activeSession.value?.cancel();
+  }
+
+  /// Persists composer text when a spawn-failure SendError lands with
+  /// the original prompt attached AND the underlying error is an
+  /// auth failure. The auth path is the only one where the user gets
+  /// navigated away (route guard) — for non-auth errors the screen
+  /// stays mounted and the in-memory [SendError.unsentText] +
+  /// `_restoreUnsentText` path handles restoration without touching
+  /// storage.
+  void _onSendError(SendError? err) {
+    if (_isDisposed) return;
+    if (err == null) return;
+    final text = err.unsentText;
+    if (text == null || text.trim().isEmpty) return;
+    if (err.error is! AuthException) return;
+    unawaited(
+      ReturnToStorage.saveComposer(
+        serverId: _connection.serverId,
+        roomId: _roomId,
+        unsentText: text,
+      ),
+    );
   }
 }

--- a/lib/src/modules/room/thread_view_state.dart
+++ b/lib/src/modules/room/thread_view_state.dart
@@ -3,6 +3,7 @@ import 'dart:async' show unawaited;
 import 'package:flutter/foundation.dart' show debugPrint;
 import 'package:soliplex_agent/soliplex_agent.dart';
 
+import '../auth/auth_session.dart';
 import 'execution_tracker.dart';
 import 'execution_tracker_extension.dart';
 import 'historical_replay.dart';
@@ -59,17 +60,20 @@ typedef HistoryLoadedCallback = void Function(
 class ThreadViewState {
   ThreadViewState({
     required ServerConnection connection,
+    required AuthSession auth,
     required String roomId,
     required this.threadId,
     required RunRegistry registry,
     this.onHistoryLoaded,
   })  : _connection = connection,
+        _auth = auth,
         _roomId = roomId,
         _registry = registry {
     if (!_restoreFromRegistry()) _fetch();
   }
 
   final ServerConnection _connection;
+  final AuthSession _auth;
   final String _roomId;
   final String threadId;
   final HistoryLoadedCallback? onHistoryLoaded;
@@ -275,6 +279,12 @@ class ThreadViewState {
         _messages.value = _messagesLoaded(conversation);
       case FailedState(:final conversation, :final reason, :final error):
         _detachSession();
+        if (reason == FailureReason.authExpired) {
+          // Funnel to the per-server auth funnel so the route guard
+          // (and any lobby UX) can react. The screen also surfaces a
+          // banner so the user sees what happened before the redirect.
+          _auth.markSessionExpired();
+        }
         _lastSendError.value = SendError(_friendlyMessage(reason, error));
         if (conversation != null) {
           _messages.value = _messagesLoaded(conversation);

--- a/lib/src/modules/room/thread_view_state.dart
+++ b/lib/src/modules/room/thread_view_state.dart
@@ -1,4 +1,5 @@
 import 'dart:async' show unawaited;
+import 'dart:developer' as dev;
 
 import 'package:flutter/foundation.dart' show debugPrint;
 import 'package:soliplex_agent/soliplex_agent.dart';
@@ -462,7 +463,14 @@ class ThreadViewState {
         serverId: _connection.serverId,
         roomId: _roomId,
         unsentText: text,
-      ),
+      ).catchError((Object e, StackTrace st) {
+        dev.log(
+          'Failed to persist composer draft for auth roundtrip',
+          error: e,
+          stackTrace: st,
+          level: 1000,
+        );
+      }),
     );
   }
 }

--- a/lib/src/modules/room/ui/room_screen.dart
+++ b/lib/src/modules/room/ui/room_screen.dart
@@ -160,21 +160,30 @@ class _RoomScreenState extends State<RoomScreen> {
   /// the controller already has text (user typed something since
   /// mount, or another restoration path already populated it).
   Future<void> _restorePersistedComposer() async {
-    final text = await ReturnToStorage.loadComposer(
-      serverId: widget.serverEntry.serverId,
-      roomId: widget.roomId,
-    );
-    if (!mounted || text == null) return;
-    if (_chatController.text.isNotEmpty) return;
-    _chatController.text = text;
-    _chatController.selection =
-        TextSelection.collapsed(offset: _chatController.text.length);
-    // One-shot: clear once restored so subsequent mounts of the same
-    // room don't re-pre-fill the box with stale content.
-    await ReturnToStorage.clearComposer(
-      serverId: widget.serverEntry.serverId,
-      roomId: widget.roomId,
-    );
+    try {
+      final text = await ReturnToStorage.loadComposer(
+        serverId: widget.serverEntry.serverId,
+        roomId: widget.roomId,
+      );
+      if (!mounted || text == null) return;
+      if (_chatController.text.isNotEmpty) return;
+      _chatController.text = text;
+      _chatController.selection =
+          TextSelection.collapsed(offset: _chatController.text.length);
+      // One-shot: clear once restored so subsequent mounts of the same
+      // room don't re-pre-fill the box with stale content.
+      await ReturnToStorage.clearComposer(
+        serverId: widget.serverEntry.serverId,
+        roomId: widget.roomId,
+      );
+    } catch (e, st) {
+      dev.log(
+        'Failed to restore persisted composer draft',
+        error: e,
+        stackTrace: st,
+        level: 1000,
+      );
+    }
   }
 
   @override

--- a/lib/src/modules/room/ui/room_screen.dart
+++ b/lib/src/modules/room/ui/room_screen.dart
@@ -18,6 +18,7 @@ import 'package:soliplex_client/soliplex_client.dart'
         SourceReferenceFormatting,
         buildDocumentFilter;
 import '../../../core/routes.dart';
+import '../../auth/return_to_storage.dart';
 import '../../auth/server_entry.dart';
 import '../document_selections.dart';
 import '../pick_file.dart';
@@ -151,6 +152,29 @@ class _RoomScreenState extends State<RoomScreen> {
     } else {
       _autoSelectFirstThread();
     }
+    unawaited(_restorePersistedComposer());
+  }
+
+  /// Restores a composer draft that was persisted across an
+  /// auth-failure redirect for this `(serverId, roomId)`. No-op if
+  /// the controller already has text (user typed something since
+  /// mount, or another restoration path already populated it).
+  Future<void> _restorePersistedComposer() async {
+    final text = await ReturnToStorage.loadComposer(
+      serverId: widget.serverEntry.serverId,
+      roomId: widget.roomId,
+    );
+    if (!mounted || text == null) return;
+    if (_chatController.text.isNotEmpty) return;
+    _chatController.text = text;
+    _chatController.selection =
+        TextSelection.collapsed(offset: _chatController.text.length);
+    // One-shot: clear once restored so subsequent mounts of the same
+    // room don't re-pre-fill the box with stale content.
+    await ReturnToStorage.clearComposer(
+      serverId: widget.serverEntry.serverId,
+      roomId: widget.roomId,
+    );
   }
 
   @override

--- a/lib/src/modules/room/ui/room_screen.dart
+++ b/lib/src/modules/room/ui/room_screen.dart
@@ -159,6 +159,9 @@ class _RoomScreenState extends State<RoomScreen> {
   /// auth-failure redirect for this `(serverId, roomId)`. No-op if
   /// the controller already has text (user typed something since
   /// mount, or another restoration path already populated it).
+  ///
+  /// Storage failures are logged at SEVERE and swallowed; an empty
+  /// composer is the safe fallback.
   Future<void> _restorePersistedComposer() async {
     try {
       final text = await ReturnToStorage.loadComposer(

--- a/lib/src/modules/room/upload_tracker.dart
+++ b/lib/src/modules/room/upload_tracker.dart
@@ -7,6 +7,7 @@ import 'package:signals_flutter/signals_flutter.dart';
 import 'package:soliplex_client/soliplex_client.dart';
 
 import '../auth/auth_session.dart';
+import '../auth/auth_tokens.dart';
 
 /// Sealed status for a single upload scope (a room or a thread).
 ///
@@ -240,10 +241,13 @@ class _QueuedJob {
 class UploadTracker {
   UploadTracker({required SoliplexApi api, required AuthSession auth})
       : _api = api,
-        _auth = auth;
+        _auth = auth {
+    _authUnsub = _auth.session.subscribe(_onAuthChanged);
+  }
 
   final SoliplexApi _api;
   final AuthSession _auth;
+  void Function()? _authUnsub;
   final Map<String, _ScopeState> _scopes = {};
   final Queue<_QueuedJob> _queue = Queue<_QueuedJob>();
   bool _draining = false;
@@ -807,6 +811,8 @@ class UploadTracker {
   void dispose() {
     if (_isDisposed) return;
     _isDisposed = true;
+    _authUnsub?.call();
+    _authUnsub = null;
     for (final scope in _scopes.values) {
       // Cancel both in-flight POSTs and queued-but-not-started jobs.
       // Each queued job's token is the same CancelToken instance stored
@@ -822,5 +828,21 @@ class UploadTracker {
     }
     _queue.clear();
     _scopes.clear();
+  }
+
+  /// Cancels all in-flight and queued uploads when the auth session
+  /// leaves [ActiveSession]. The route guard navigates the user away;
+  /// this stops the upload's HTTP work so it doesn't reconnect-loop
+  /// against a dead token.
+  void _onAuthChanged(SessionState state) {
+    if (_isDisposed) return;
+    if (state is ActiveSession) return;
+    for (final scope in _scopes.values) {
+      for (final record in scope.pending) {
+        if (record is _Pending) {
+          record.cancelToken.cancel('auth expired');
+        }
+      }
+    }
   }
 }

--- a/lib/src/modules/room/upload_tracker.dart
+++ b/lib/src/modules/room/upload_tracker.dart
@@ -834,6 +834,11 @@ class UploadTracker {
   /// leaves [ActiveSession]. The route guard navigates the user away;
   /// this stops the upload's HTTP work so it doesn't reconnect-loop
   /// against a dead token.
+  ///
+  /// Walking `scope.pending` covers both states because each queued
+  /// job's [_QueuedJob.token] is the same [CancelToken] instance as the
+  /// matching `_Pending.cancelToken`. The drain loop skips queued jobs
+  /// whose token is cancelled (`_drain`'s `isCancelled` check).
   void _onAuthChanged(SessionState state) {
     if (_isDisposed) return;
     if (state is ActiveSession) return;

--- a/lib/src/modules/room/upload_tracker.dart
+++ b/lib/src/modules/room/upload_tracker.dart
@@ -6,6 +6,8 @@ import 'dart:io' show FileSystemException, SocketException;
 import 'package:signals_flutter/signals_flutter.dart';
 import 'package:soliplex_client/soliplex_client.dart';
 
+import '../auth/auth_session.dart';
+
 /// Sealed status for a single upload scope (a room or a thread).
 ///
 /// A refresh failure from a `Loaded` state is logged but not surfaced
@@ -236,9 +238,12 @@ class _QueuedJob {
 /// for every enqueued upload immediately, regardless of where it sits
 /// in the queue.
 class UploadTracker {
-  UploadTracker({required SoliplexApi api}) : _api = api;
+  UploadTracker({required SoliplexApi api, required AuthSession auth})
+      : _api = api,
+        _auth = auth;
 
   final SoliplexApi _api;
+  final AuthSession _auth;
   final Map<String, _ScopeState> _scopes = {};
   final Queue<_QueuedJob> _queue = Queue<_QueuedJob>();
   bool _draining = false;
@@ -618,7 +623,13 @@ class UploadTracker {
           );
           continue;
         }
+        // Retries exhausted: commit the failed row first so the
+        // tracker state is consistent, then funnel through the auth
+        // funnel. The route guard / lobby UX react asynchronously
+        // (next microtask) and pick up the new auth state — the user
+        // returns to find the failed row already recorded.
         _markFailed(scope, id, error);
+        _auth.markSessionExpired();
         return;
       } on Object catch (error, stackTrace) {
         if (_isDisposed) return;

--- a/lib/src/modules/room/upload_tracker.dart
+++ b/lib/src/modules/room/upload_tracker.dart
@@ -628,10 +628,8 @@ class UploadTracker {
           continue;
         }
         // Retries exhausted: commit the failed row first so the
-        // tracker state is consistent, then funnel through the auth
-        // funnel. The route guard / lobby UX react asynchronously
-        // (next microtask) and pick up the new auth state — the user
-        // returns to find the failed row already recorded.
+        // tracker state is consistent before any auth-change listener
+        // observes the flip and reacts.
         _markFailed(scope, id, error);
         _auth.markSessionExpired();
         return;

--- a/lib/src/modules/room/upload_tracker_registry.dart
+++ b/lib/src/modules/room/upload_tracker_registry.dart
@@ -58,7 +58,7 @@ class UploadTrackerRegistry {
     final key = (entry.serverId, roomId);
     return _trackers.putIfAbsent(
       key,
-      () => UploadTracker(api: entry.connection.api),
+      () => UploadTracker(api: entry.connection.api, auth: entry.auth),
     );
   }
 

--- a/packages/soliplex_agent/lib/src/models/failure_reason.dart
+++ b/packages/soliplex_agent/lib/src/models/failure_reason.dart
@@ -7,8 +7,12 @@ enum FailureReason {
   /// Server returned an error event in the AG-UI stream.
   serverError,
 
-  /// Auth token expired or was rejected (401/403).
+  /// Auth token expired or was rejected (401).
   authExpired,
+
+  /// Server returned 403: the user is authenticated but lacks
+  /// permission for this resource. Re-authenticating won't help.
+  permissionDenied,
 
   /// Network lost — SSE stream ended without a terminal event.
   networkLost,

--- a/packages/soliplex_agent/lib/src/orchestration/error_classifier.dart
+++ b/packages/soliplex_agent/lib/src/orchestration/error_classifier.dart
@@ -17,6 +17,9 @@ FailureReason classifyError(Object error) {
     return classifyError(error.originalError!);
   }
   if (error is AuthException) return FailureReason.authExpired;
+  if (error is PermissionDeniedException) {
+    return FailureReason.permissionDenied;
+  }
   if (error is NetworkException) return FailureReason.networkLost;
   if (error is TransportError) return _classifyTransportError(error);
   return FailureReason.internalError;
@@ -25,7 +28,8 @@ FailureReason classifyError(Object error) {
 FailureReason _classifyTransportError(TransportError error) {
   final status = error.statusCode;
   if (status == null) return FailureReason.serverError;
-  if (status == 401 || status == 403) return FailureReason.authExpired;
+  if (status == 401) return FailureReason.authExpired;
+  if (status == 403) return FailureReason.permissionDenied;
   if (status == 429) return FailureReason.rateLimited;
   return FailureReason.serverError;
 }

--- a/packages/soliplex_agent/test/models/failure_reason_test.dart
+++ b/packages/soliplex_agent/test/models/failure_reason_test.dart
@@ -3,8 +3,8 @@ import 'package:test/test.dart';
 
 void main() {
   group('FailureReason', () {
-    test('has exactly 8 values', () {
-      expect(FailureReason.values, hasLength(8));
+    test('has exactly 9 values', () {
+      expect(FailureReason.values, hasLength(9));
     });
 
     test('contains all expected values', () {
@@ -13,6 +13,7 @@ void main() {
         containsAll([
           FailureReason.serverError,
           FailureReason.authExpired,
+          FailureReason.permissionDenied,
           FailureReason.networkLost,
           FailureReason.streamResumeFailed,
           FailureReason.rateLimited,

--- a/packages/soliplex_agent/test/orchestration/error_classifier_test.dart
+++ b/packages/soliplex_agent/test/orchestration/error_classifier_test.dart
@@ -10,6 +10,11 @@ void main() {
         expect(classifyError(error), equals(FailureReason.authExpired));
       });
 
+      test('PermissionDeniedException maps to permissionDenied', () {
+        const error = PermissionDeniedException(message: 'Forbidden');
+        expect(classifyError(error), equals(FailureReason.permissionDenied));
+      });
+
       test('NetworkException maps to networkLost', () {
         const error = NetworkException(message: 'No internet');
         expect(classifyError(error), equals(FailureReason.networkLost));
@@ -22,9 +27,9 @@ void main() {
         expect(classifyError(error), equals(FailureReason.authExpired));
       });
 
-      test('403 maps to authExpired', () {
+      test('403 maps to permissionDenied', () {
         const error = TransportError('Forbidden', statusCode: 403);
-        expect(classifyError(error), equals(FailureReason.authExpired));
+        expect(classifyError(error), equals(FailureReason.permissionDenied));
       });
 
       test('429 maps to rateLimited', () {

--- a/packages/soliplex_client/lib/src/auth/token_refresh_service.dart
+++ b/packages/soliplex_client/lib/src/auth/token_refresh_service.dart
@@ -99,7 +99,12 @@ class TokenRefreshService {
   static const fallbackTokenLifetime = Duration(minutes: 30);
 
   /// How long before expiry to trigger proactive refresh.
-  static const refreshThreshold = Duration(minutes: 1);
+  ///
+  /// Five minutes gives long-running streams (LLM generations, uploads)
+  /// headroom to refresh proactively before their access token expires
+  /// mid-stream. Mid-stream refresh on the SSE client itself would be a
+  /// stricter fix; this threshold is the cheap version.
+  static const refreshThreshold = Duration(minutes: 5);
 
   /// Attempt to refresh tokens.
   ///

--- a/packages/soliplex_client/lib/src/errors/exceptions.dart
+++ b/packages/soliplex_client/lib/src/errors/exceptions.dart
@@ -20,9 +20,11 @@ abstract class SoliplexException implements Exception {
   String toString() => '$runtimeType: $message';
 }
 
-/// Exception thrown when authentication fails (401, 403).
+/// Exception thrown when authentication is missing or expired (401).
 ///
-/// UI should redirect to login.
+/// The bearer token is absent, malformed, or no longer accepted by the
+/// server. Callers should attempt a token refresh and, if that fails,
+/// drive the user to re-authenticate.
 class AuthException extends SoliplexException {
   /// Creates an auth exception.
   const AuthException({
@@ -47,6 +49,37 @@ class AuthException extends SoliplexException {
       return 'AuthException($statusCode): $message';
     }
     return 'AuthException: $message';
+  }
+}
+
+/// Exception thrown when the user is authenticated but lacks permission
+/// for the requested resource (403).
+///
+/// Re-authenticating with the same identity does not resolve this — the
+/// server has explicitly denied access. UI should surface an inline
+/// "no permission" message rather than driving a re-auth flow.
+class PermissionDeniedException extends SoliplexException {
+  /// Creates a permission-denied exception.
+  const PermissionDeniedException({
+    required super.message,
+    this.statusCode,
+    this.serverMessage,
+    super.originalError,
+    super.stackTrace,
+  });
+
+  /// The HTTP status code that triggered this exception (typically 403).
+  final int? statusCode;
+
+  /// The error message from the server, if any.
+  final String? serverMessage;
+
+  @override
+  String toString() {
+    if (statusCode != null) {
+      return 'PermissionDeniedException($statusCode): $message';
+    }
+    return 'PermissionDeniedException: $message';
   }
 }
 

--- a/packages/soliplex_client/lib/src/http/agui_stream_client.dart
+++ b/packages/soliplex_client/lib/src/http/agui_stream_client.dart
@@ -204,7 +204,10 @@ class AgUiStreamClient {
 
   bool _retryable(Object e) => switch (e) {
         CancelledException() => false,
-        AuthException() || NotFoundException() => false,
+        AuthException() ||
+        PermissionDeniedException() ||
+        NotFoundException() =>
+          false,
         ApiException(:final statusCode) =>
           statusCode >= 500 && statusCode < 600,
         NetworkException() => true,

--- a/packages/soliplex_client/lib/src/http/http_transport.dart
+++ b/packages/soliplex_client/lib/src/http/http_transport.dart
@@ -75,7 +75,8 @@ class HttpTransport {
   ///
   /// Throws:
   /// - [CancelledException] if the request was cancelled via [cancelToken]
-  /// - [AuthException] for 401 and 403 responses
+  /// - [AuthException] for 401 responses
+  /// - [PermissionDeniedException] for 403 responses
   /// - [NotFoundException] for 404 responses
   /// - [ApiException] for other 4xx and 5xx responses
   /// - [NetworkException] for connection failures (from client)
@@ -137,7 +138,8 @@ class HttpTransport {
   ///
   /// Throws:
   /// - [CancelledException] if the request was cancelled via [cancelToken]
-  /// - [AuthException] for 401 and 403 responses
+  /// - [AuthException] for 401 responses
+  /// - [PermissionDeniedException] for 403 responses
   /// - [NotFoundException] for 404 responses
   /// - [ApiException] for other 4xx and 5xx responses
   /// - [NetworkException] for connection failures (from client)
@@ -181,7 +183,8 @@ class HttpTransport {
   /// Throws:
   /// - [CancelledException] if cancelled before the stream starts
   /// - [NetworkException] for connection failures (from client)
-  /// - [AuthException] for 401/403 on stream setup
+  /// - [AuthException] for 401 on stream setup
+  /// - [PermissionDeniedException] for 403 on stream setup
   /// - [ApiException] for other 4xx/5xx on stream setup
   Future<StreamedHttpResponse> requestStream(
     String method,

--- a/packages/soliplex_client/lib/src/http/http_transport.dart
+++ b/packages/soliplex_client/lib/src/http/http_transport.dart
@@ -302,8 +302,15 @@ class HttpTransport {
     final message = 'HTTP $statusCode'
         '${response.reasonPhrase != null ? ': ${response.reasonPhrase}' : ''}';
 
-    if (statusCode == 401 || statusCode == 403) {
+    if (statusCode == 401) {
       throw AuthException(message: message, statusCode: statusCode);
+    }
+
+    if (statusCode == 403) {
+      throw PermissionDeniedException(
+        message: message,
+        statusCode: statusCode,
+      );
     }
 
     if (statusCode == 404) {
@@ -325,8 +332,16 @@ class HttpTransport {
     final serverMessage = _extractErrorMessage(body);
     final message = serverMessage ?? 'HTTP $statusCode';
 
-    if (statusCode == 401 || statusCode == 403) {
+    if (statusCode == 401) {
       throw AuthException(
+        message: message,
+        statusCode: statusCode,
+        serverMessage: serverMessage,
+      );
+    }
+
+    if (statusCode == 403) {
+      throw PermissionDeniedException(
         message: message,
         statusCode: statusCode,
         serverMessage: serverMessage,

--- a/packages/soliplex_client/test/http/agui_stream_client_test.dart
+++ b/packages/soliplex_client/test/http/agui_stream_client_test.dart
@@ -247,6 +247,29 @@ void main() {
         );
       });
 
+      test('propagates PermissionDeniedException from transport on 403',
+          () async {
+        when(
+          () => mockTransport.requestStream(
+            any(),
+            any(),
+            headers: any(named: 'headers'),
+            body: any(named: 'body'),
+            cancelToken: any(named: 'cancelToken'),
+          ),
+        ).thenThrow(
+          const PermissionDeniedException(
+            message: 'Forbidden',
+            statusCode: 403,
+          ),
+        );
+
+        expect(
+          () => client.runAgent(endpoint, input).toList(),
+          throwsA(isA<PermissionDeniedException>()),
+        );
+      });
+
       test('propagates ApiException from transport on 500', () async {
         when(
           () => mockTransport.requestStream(

--- a/packages/soliplex_client/test/http/http_transport_test.dart
+++ b/packages/soliplex_client/test/http/http_transport_test.dart
@@ -556,7 +556,7 @@ void main() {
         );
       });
 
-      test('throws AuthException for 403 response', () async {
+      test('throws PermissionDeniedException for 403 response', () async {
         when(
           () => mockClient.request(
             any(),
@@ -572,11 +572,30 @@ void main() {
         await expectLater(
           transport.request<void>('GET', Uri.parse('https://api.example.com')),
           throwsA(
-            isA<AuthException>()
+            isA<PermissionDeniedException>()
                 .having((e) => e.statusCode, 'statusCode', 403)
                 .having((e) => e.message, 'message', 'Forbidden')
                 .having((e) => e.serverMessage, 'serverMessage', 'Forbidden'),
           ),
+        );
+      });
+
+      test('403 is not caught as AuthException', () async {
+        when(
+          () => mockClient.request(
+            any(),
+            any(),
+            headers: any(named: 'headers'),
+            body: any(named: 'body'),
+            timeout: any(named: 'timeout'),
+          ),
+        ).thenAnswer(
+          (_) async => jsonResponse(403, body: {'error': 'Forbidden'}),
+        );
+
+        await expectLater(
+          transport.request<void>('GET', Uri.parse('https://api.example.com')),
+          throwsA(isNot(isA<AuthException>())),
         );
       });
 

--- a/test/modules/auth/auth_module_test.dart
+++ b/test/modules/auth/auth_module_test.dart
@@ -222,7 +222,10 @@ void main() {
 
         expect(
           currentLocation(),
-          AppRoutes.homeWithUrl(a.serverUrl.toString()),
+          AppRoutes.homeWithUrl(
+            a.serverUrl.toString(),
+            returnTo: '/room/${a.alias}/r1',
+          ),
         );
       },
     );
@@ -256,7 +259,10 @@ void main() {
 
         expect(
           currentLocation(),
-          AppRoutes.homeWithUrl(a.serverUrl.toString()),
+          AppRoutes.homeWithUrl(
+            a.serverUrl.toString(),
+            returnTo: '/room/${a.alias}/r1',
+          ),
         );
       },
     );

--- a/test/modules/auth/auth_module_test.dart
+++ b/test/modules/auth/auth_module_test.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:go_router/go_router.dart';
+import 'package:soliplex_frontend/src/core/routes.dart';
 import 'package:soliplex_frontend/src/modules/auth/auth_module.dart';
 import 'package:soliplex_frontend/src/modules/auth/auth_session.dart';
 import 'package:soliplex_frontend/src/modules/auth/auth_tokens.dart';
@@ -141,5 +142,123 @@ void main() {
 
       expect(find.text('Chat'), findsOneWidget);
     });
+  });
+
+  group('per-server route guard', () {
+    late ServerManager serverManager;
+    late AuthAppModule module;
+    late GoRouter router;
+
+    const provider = OidcProvider(
+      discoveryUrl: 'https://sso.example.com/.well-known/openid-configuration',
+      clientId: 'soliplex',
+    );
+
+    AuthTokens tokens() => AuthTokens(
+          accessToken: 'access',
+          refreshToken: 'refresh',
+          expiresAt: DateTime.now().add(const Duration(hours: 1)),
+        );
+
+    Widget buildAppWithRoomRoute() {
+      final contribution = module.build();
+      router = GoRouter(
+        initialLocation: '/',
+        refreshListenable: module.refreshListenable,
+        routes: [
+          ...contribution.routes,
+          GoRoute(
+            path: '/room/:serverAlias/:roomId',
+            builder: (_, state) => Text(
+              'Room ${state.pathParameters['serverAlias']}/${state.pathParameters['roomId']}',
+            ),
+          ),
+        ],
+        redirect: contribution.redirect,
+      );
+      return ProviderScope(
+        overrides: contribution.overrides,
+        child: MaterialApp.router(routerConfig: router),
+      );
+    }
+
+    setUp(() {
+      serverManager = _createServerManager();
+      module = _createModule(serverManager: serverManager);
+    });
+
+    tearDown(() async => module.onDispose());
+
+    String currentLocation() =>
+        router.routerDelegate.currentConfiguration.uri.toString();
+
+    testWidgets(
+      'redirects /room/A/x to homeWithUrl when server A is not connected',
+      (tester) async {
+        // Two servers: A signed out, B authenticated. Aggregate authState
+        // stays Authenticated (B keeps us logged in), so the global guard
+        // does nothing. The per-server guard must kick in.
+        final a = serverManager.addServer(
+          serverId: 'a',
+          serverUrl: Uri.parse('https://a.example.com'),
+        );
+        final b = serverManager.addServer(
+          serverId: 'b',
+          serverUrl: Uri.parse('https://b.example.com'),
+        );
+        b.auth.login(provider: provider, tokens: tokens());
+
+        await tester.pumpWidget(buildAppWithRoomRoute());
+        await tester.pumpAndSettle();
+
+        router.go('/room/${b.alias}/r1');
+        await tester.pumpAndSettle();
+        expect(currentLocation(), '/room/${b.alias}/r1');
+
+        router.go('/room/${a.alias}/r1');
+        // Don't pumpAndSettle — auto-connect on HomeScreen would hit
+        // the fake HTTP client. We only care about the redirect target.
+        await tester.pump();
+
+        expect(
+          currentLocation(),
+          AppRoutes.homeWithUrl(a.serverUrl.toString()),
+        );
+      },
+    );
+
+    testWidgets(
+      'redirect re-evaluates when an active server flips to expired '
+      'mid-session',
+      (tester) async {
+        final a = serverManager.addServer(
+          serverId: 'a',
+          serverUrl: Uri.parse('https://a.example.com'),
+        );
+        final b = serverManager.addServer(
+          serverId: 'b',
+          serverUrl: Uri.parse('https://b.example.com'),
+        );
+        a.auth.login(provider: provider, tokens: tokens());
+        b.auth.login(provider: provider, tokens: tokens());
+
+        await tester.pumpWidget(buildAppWithRoomRoute());
+        await tester.pumpAndSettle();
+
+        router.go('/room/${a.alias}/r1');
+        await tester.pumpAndSettle();
+        expect(currentLocation(), '/room/${a.alias}/r1');
+
+        a.auth.markSessionExpired();
+        // refreshListenable should fire on the per-server transition even
+        // though B keeps the aggregate authenticated.
+        await tester.pump();
+
+        expect(
+          currentLocation(),
+          AppRoutes.homeWithUrl(a.serverUrl.toString()),
+        );
+      },
+    );
   });
 }

--- a/test/modules/auth/auth_session_test.dart
+++ b/test/modules/auth/auth_session_test.dart
@@ -90,18 +90,6 @@ void main() {
       expect(session.accessToken, isNull);
     });
 
-    test('refreshToken returns token for Active and Expired', () {
-      session.login(provider: _provider, tokens: _tokens());
-      expect(session.refreshToken, 'refresh');
-
-      session.markSessionExpired();
-      expect(session.refreshToken, 'refresh');
-    });
-
-    test('refreshToken returns null for NoSession', () {
-      expect(session.refreshToken, isNull);
-    });
-
     test('isAuthenticated is false for ExpiredSession', () {
       session.login(provider: _provider, tokens: _tokens());
       session.markSessionExpired();

--- a/test/modules/auth/auth_session_test.dart
+++ b/test/modules/auth/auth_session_test.dart
@@ -72,6 +72,72 @@ void main() {
     });
   });
 
+  group('ExpiredSession', () {
+    test('can be constructed with provider and tokens', () {
+      final tokens = _tokens();
+      final expired = ExpiredSession(provider: _provider, tokens: tokens);
+
+      expect(expired.provider, same(_provider));
+      expect(expired.tokens, same(tokens));
+    });
+
+    test('accessToken returns null when state is ExpiredSession', () {
+      final tokens = _tokens();
+      session.login(provider: _provider, tokens: tokens);
+      session.markSessionExpired();
+
+      expect(session.session.value, isA<ExpiredSession>());
+      expect(session.accessToken, isNull);
+    });
+
+    test('refreshToken returns token for Active and Expired', () {
+      session.login(provider: _provider, tokens: _tokens());
+      expect(session.refreshToken, 'refresh');
+
+      session.markSessionExpired();
+      expect(session.refreshToken, 'refresh');
+    });
+
+    test('refreshToken returns null for NoSession', () {
+      expect(session.refreshToken, isNull);
+    });
+
+    test('isAuthenticated is false for ExpiredSession', () {
+      session.login(provider: _provider, tokens: _tokens());
+      session.markSessionExpired();
+
+      expect(session.isAuthenticated, isFalse);
+    });
+  });
+
+  group('markSessionExpired', () {
+    test('flips ActiveSession to ExpiredSession preserving tokens', () {
+      final tokens = _tokens();
+      session.login(provider: _provider, tokens: tokens);
+
+      session.markSessionExpired();
+
+      final expired = session.session.value as ExpiredSession;
+      expect(expired.provider, same(_provider));
+      expect(expired.tokens, same(tokens));
+    });
+
+    test('is a no-op when state is already ExpiredSession', () {
+      session.login(provider: _provider, tokens: _tokens());
+      session.markSessionExpired();
+      final firstExpired = session.session.value;
+
+      session.markSessionExpired();
+
+      expect(session.session.value, same(firstExpired));
+    });
+
+    test('is a no-op when state is NoSession', () {
+      session.markSessionExpired();
+      expect(session.session.value, isA<NoSession>());
+    });
+  });
+
   group('needsRefresh', () {
     test('false when not authenticated', () {
       expect(session.needsRefresh, isFalse);
@@ -112,11 +178,9 @@ void main() {
       expect(active.tokens.refreshToken, 'new-refresh');
     });
 
-    test('invalidGrant logs out', () async {
-      session.login(
-        provider: _provider,
-        tokens: _tokens(expiresIn: const Duration(seconds: 30)),
-      );
+    test('invalidGrant flips to ExpiredSession preserving tokens', () async {
+      final tokens = _tokens(expiresIn: const Duration(seconds: 30));
+      session.login(provider: _provider, tokens: tokens);
 
       refreshService.nextResult = const TokenRefreshFailure(
         TokenRefreshFailureReason.invalidGrant,
@@ -126,6 +190,69 @@ void main() {
 
       expect(result, isFalse);
       expect(session.isAuthenticated, isFalse);
+      final expired = session.session.value as ExpiredSession;
+      expect(expired.tokens, same(tokens));
+    });
+
+    test('noRefreshToken flips to ExpiredSession', () async {
+      final tokens = _tokens(expiresIn: const Duration(seconds: 30));
+      session.login(provider: _provider, tokens: tokens);
+
+      refreshService.nextResult = const TokenRefreshFailure(
+        TokenRefreshFailureReason.noRefreshToken,
+      );
+
+      final result = await session.tryRefresh();
+
+      expect(result, isFalse);
+      expect(session.session.value, isA<ExpiredSession>());
+    });
+
+    test('refresh succeeds from ExpiredSession and promotes to Active',
+        () async {
+      session.login(provider: _provider, tokens: _tokens());
+      session.markSessionExpired();
+      expect(session.session.value, isA<ExpiredSession>());
+
+      refreshService.nextResult = TokenRefreshSuccess(
+        accessToken: 'revived',
+        refreshToken: 'new-refresh',
+        expiresAt: DateTime.now().add(const Duration(hours: 1)),
+      );
+
+      final result = await session.tryRefresh();
+
+      expect(result, isTrue);
+      expect(session.session.value, isA<ActiveSession>());
+      expect(session.accessToken, 'revived');
+    });
+
+    test('race: markSessionExpired during await does not drop new tokens',
+        () async {
+      final completer = Completer<TokenRefreshResult>();
+      final slowRefreshService = _DelayedRefreshService(completer.future);
+      final slowSession = AuthSession(refreshService: slowRefreshService);
+      slowSession.login(
+        provider: _provider,
+        tokens: _tokens(expiresIn: const Duration(seconds: 30)),
+      );
+
+      final refreshFuture = slowSession.tryRefresh();
+
+      slowSession.markSessionExpired();
+      expect(slowSession.session.value, isA<ExpiredSession>());
+
+      completer.complete(TokenRefreshSuccess(
+        accessToken: 'revived',
+        refreshToken: 'new-refresh',
+        expiresAt: DateTime.now().add(const Duration(hours: 1)),
+      ));
+
+      final result = await refreshFuture;
+
+      expect(result, isTrue);
+      expect(slowSession.session.value, isA<ActiveSession>());
+      expect(slowSession.accessToken, 'revived');
     });
 
     test('other failure keeps session', () async {

--- a/test/modules/auth/auth_session_test.dart
+++ b/test/modules/auth/auth_session_test.dart
@@ -155,6 +155,17 @@ void main() {
       );
       expect(session.needsRefresh, isTrue);
     });
+
+    test('true when tokens are within the 5-minute refresh window', () {
+      // The 5-minute threshold gives long-running streams (LLM
+      // generations, uploads) headroom to refresh proactively before
+      // their access token expires mid-stream.
+      session.login(
+        provider: _provider,
+        tokens: _tokens(expiresIn: const Duration(minutes: 4)),
+      );
+      expect(session.needsRefresh, isTrue);
+    });
   });
 
   group('tryRefresh', () {

--- a/test/modules/auth/connect_flow_test.dart
+++ b/test/modules/auth/connect_flow_test.dart
@@ -1,0 +1,78 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:soliplex_agent/soliplex_agent.dart';
+
+import 'package:soliplex_frontend/src/modules/auth/auth_session.dart';
+import 'package:soliplex_frontend/src/modules/auth/connect_flow.dart';
+import 'package:soliplex_frontend/src/modules/auth/pre_auth_state.dart';
+import 'package:soliplex_frontend/src/modules/auth/server_manager.dart';
+
+import '../../helpers/fakes.dart';
+
+const _provider = AuthProviderConfig(
+  id: 'idp-1',
+  name: 'Test IdP',
+  serverUrl: 'https://auth.example.com',
+  clientId: 'test-client',
+  scope: 'openid email profile',
+);
+
+ServerManager _createManager() => ServerManager(
+      authFactory: () => AuthSession(refreshService: FakeTokenRefreshService()),
+      clientFactory: ({getToken, tokenRefresher}) => FakeHttpClient(),
+      storage: InMemoryServerStorage(),
+    );
+
+ConnectFlow _createFlow({required FakeAuthFlow authFlow}) => ConnectFlow(
+      serverManager: _createManager(),
+      probeClient: FakeHttpClient(),
+      discover: (_, __) async => [_provider],
+      authFlow: authFlow,
+    );
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  group('ConnectFlow.connect — returnTo plumbing', () {
+    setUp(() {
+      SharedPreferences.setMockInitialValues({});
+    });
+
+    test(
+      'writes returnTo passed to connect() into PreAuthState',
+      () async {
+        final flow = _createFlow(
+          authFlow: FakeAuthFlow()..throwRedirectInitiated = true,
+        );
+
+        await flow.connect(
+          'https://server.example.com',
+          returnTo: '/r/alias/room/thread/t1',
+        );
+        // _authenticate is invoked without await; pump the event queue so
+        // its PreAuthStateStorage.save and AuthRedirectInitiated branch run.
+        await pumpEventQueue();
+
+        final saved = await PreAuthStateStorage.load();
+        expect(saved, isNotNull);
+        expect(saved!.frontendReturnTo, '/r/alias/room/thread/t1');
+      },
+    );
+
+    test(
+      'writes null frontendReturnTo when connect() is called without returnTo',
+      () async {
+        final flow = _createFlow(
+          authFlow: FakeAuthFlow()..throwRedirectInitiated = true,
+        );
+
+        await flow.connect('https://server.example.com');
+        await pumpEventQueue();
+
+        final saved = await PreAuthStateStorage.load();
+        expect(saved, isNotNull);
+        expect(saved!.frontendReturnTo, isNull);
+      },
+    );
+  });
+}

--- a/test/modules/auth/pre_auth_state_test.dart
+++ b/test/modules/auth/pre_auth_state_test.dart
@@ -4,12 +4,14 @@ import 'package:soliplex_frontend/src/modules/auth/pre_auth_state.dart';
 
 final _baseTime = DateTime.utc(2026, 3, 19, 12, 0);
 
-PreAuthState _makeState({DateTime? createdAt}) => PreAuthState(
+PreAuthState _makeState({DateTime? createdAt, String? frontendReturnTo}) =>
+    PreAuthState(
       serverUrl: Uri.parse('https://api.example.com'),
       providerId: 'keycloak',
       discoveryUrl: 'https://sso.example.com/.well-known/openid-configuration',
       clientId: 'soliplex',
       createdAt: createdAt ?? _baseTime,
+      frontendReturnTo: frontendReturnTo,
     );
 
 void main() {
@@ -35,18 +37,37 @@ void main() {
       expect(restored.createdAt.isUtc, isTrue);
     });
 
-    test('isExpired returns false within maxAge', () {
+    test('isExpired returns false within 30-minute maxAge', () {
+      // 30 minutes covers typical OIDC roundtrips that involve a
+      // password reset, MFA prompt, or email magic link.
       final state = _makeState();
-      final now = _baseTime.add(const Duration(minutes: 4, seconds: 59));
+      final now = _baseTime.add(const Duration(minutes: 29, seconds: 59));
 
       expect(state.isExpired(now: now), isFalse);
     });
 
-    test('isExpired returns true after maxAge', () {
+    test('isExpired returns true after 30-minute maxAge', () {
       final state = _makeState();
-      final now = _baseTime.add(const Duration(minutes: 5, seconds: 1));
+      final now = _baseTime.add(const Duration(minutes: 30, seconds: 1));
 
       expect(state.isExpired(now: now), isTrue);
+    });
+
+    test('frontendReturnTo round-trips through JSON', () {
+      final state = _makeState(frontendReturnTo: '/room/server-a/r1');
+
+      final restored = PreAuthState.fromJson(state.toJson());
+
+      expect(restored.frontendReturnTo, '/room/server-a/r1');
+    });
+
+    test('frontendReturnTo defaults to null and round-trips as null', () {
+      final state = _makeState();
+
+      final restored = PreAuthState.fromJson(state.toJson());
+
+      expect(state.frontendReturnTo, isNull);
+      expect(restored.frontendReturnTo, isNull);
     });
 
     test('equality', () {
@@ -85,7 +106,7 @@ void main() {
       final state = _makeState();
       await PreAuthStateStorage.save(state);
 
-      final expiredNow = _baseTime.add(const Duration(minutes: 6));
+      final expiredNow = _baseTime.add(const Duration(minutes: 31));
       final loaded = await PreAuthStateStorage.load(now: expiredNow);
       expect(loaded, isNull);
 

--- a/test/modules/auth/pre_auth_state_test.dart
+++ b/test/modules/auth/pre_auth_state_test.dart
@@ -70,6 +70,42 @@ void main() {
       expect(restored.frontendReturnTo, isNull);
     });
 
+    test('constructor rejects open-redirect candidates for frontendReturnTo',
+        () {
+      // The constructor is the type-level open-redirect guard: any
+      // value that isn't an in-app path starting with a single `/`
+      // must throw before it can be persisted or honored by the
+      // callback.
+      for (final unsafe in [
+        'https://evil.com/x',
+        'http://evil.com/x',
+        '//evil.com/x',
+        'lobby',
+        '../admin',
+        '',
+      ]) {
+        expect(
+          () => _makeState(frontendReturnTo: unsafe),
+          throwsA(isA<ArgumentError>()),
+          reason: 'unsafe=$unsafe should be rejected by the constructor',
+        );
+      }
+    });
+
+    test('constructor accepts safe relative paths for frontendReturnTo', () {
+      for (final safe in [
+        '/lobby',
+        '/room/server-a/r1',
+        '/room/server-a/r1?focus=last',
+      ]) {
+        expect(
+          () => _makeState(frontendReturnTo: safe),
+          returnsNormally,
+          reason: 'safe=$safe should be accepted',
+        );
+      }
+    });
+
     test('equality', () {
       final a = _makeState();
       final b = _makeState();

--- a/test/modules/auth/return_to_storage_test.dart
+++ b/test/modules/auth/return_to_storage_test.dart
@@ -1,0 +1,155 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:soliplex_frontend/src/modules/auth/return_to_storage.dart';
+
+final _baseTime = DateTime.utc(2026, 5, 20, 12);
+
+void main() {
+  group('ReturnToStorage composer', () {
+    setUp(() {
+      SharedPreferences.setMockInitialValues({});
+    });
+
+    test('save and load round-trip', () async {
+      await ReturnToStorage.saveComposer(
+        serverId: 'server-a',
+        roomId: 'room-1',
+        unsentText: 'half-written message',
+        now: _baseTime,
+      );
+
+      final loaded = await ReturnToStorage.loadComposer(
+        serverId: 'server-a',
+        roomId: 'room-1',
+        now: _baseTime,
+      );
+
+      expect(loaded, 'half-written message');
+    });
+
+    test('load returns null when nothing saved', () async {
+      final loaded = await ReturnToStorage.loadComposer(
+        serverId: 'server-a',
+        roomId: 'room-1',
+      );
+      expect(loaded, isNull);
+    });
+
+    test('saving empty / whitespace-only text clears any existing entry',
+        () async {
+      await ReturnToStorage.saveComposer(
+        serverId: 'a',
+        roomId: 'r',
+        unsentText: 'previous draft',
+      );
+
+      await ReturnToStorage.saveComposer(
+        serverId: 'a',
+        roomId: 'r',
+        unsentText: '   ',
+      );
+
+      expect(
+        await ReturnToStorage.loadComposer(serverId: 'a', roomId: 'r'),
+        isNull,
+      );
+    });
+
+    test('per-(serverId, roomId) isolation', () async {
+      await ReturnToStorage.saveComposer(
+        serverId: 'a',
+        roomId: 'r1',
+        unsentText: 'A/r1 draft',
+        now: _baseTime,
+      );
+      await ReturnToStorage.saveComposer(
+        serverId: 'b',
+        roomId: 'r1',
+        unsentText: 'B/r1 draft',
+        now: _baseTime,
+      );
+      await ReturnToStorage.saveComposer(
+        serverId: 'a',
+        roomId: 'r2',
+        unsentText: 'A/r2 draft',
+        now: _baseTime,
+      );
+
+      expect(
+        await ReturnToStorage.loadComposer(
+          serverId: 'a',
+          roomId: 'r1',
+          now: _baseTime,
+        ),
+        'A/r1 draft',
+      );
+      expect(
+        await ReturnToStorage.loadComposer(
+          serverId: 'b',
+          roomId: 'r1',
+          now: _baseTime,
+        ),
+        'B/r1 draft',
+      );
+      expect(
+        await ReturnToStorage.loadComposer(
+          serverId: 'a',
+          roomId: 'r2',
+          now: _baseTime,
+        ),
+        'A/r2 draft',
+      );
+    });
+
+    test('load returns null and clears entry past the 24h TTL', () async {
+      await ReturnToStorage.saveComposer(
+        serverId: 'a',
+        roomId: 'r',
+        unsentText: 'old draft',
+        now: _baseTime,
+      );
+
+      // One second past 24h.
+      final later = _baseTime.add(const Duration(hours: 24, seconds: 1));
+      final loaded = await ReturnToStorage.loadComposer(
+        serverId: 'a',
+        roomId: 'r',
+        now: later,
+      );
+      expect(loaded, isNull);
+
+      // Verify the expired entry was actually cleared.
+      final prefs = await SharedPreferences.getInstance();
+      expect(prefs.getKeys(), isEmpty);
+    });
+
+    test('load returns null and clears corrupted entry', () async {
+      final prefs = await SharedPreferences.getInstance();
+      await prefs.setString(
+        'soliplex_return_to:composer:a:r',
+        '{not valid json',
+      );
+
+      final loaded = await ReturnToStorage.loadComposer(
+        serverId: 'a',
+        roomId: 'r',
+      );
+      expect(loaded, isNull);
+      expect(prefs.getKeys(), isEmpty);
+    });
+
+    test('clearComposer removes a stored entry', () async {
+      await ReturnToStorage.saveComposer(
+        serverId: 'a',
+        roomId: 'r',
+        unsentText: 'draft',
+      );
+      await ReturnToStorage.clearComposer(serverId: 'a', roomId: 'r');
+
+      expect(
+        await ReturnToStorage.loadComposer(serverId: 'a', roomId: 'r'),
+        isNull,
+      );
+    });
+  });
+}

--- a/test/modules/auth/server_manager_test.dart
+++ b/test/modules/auth/server_manager_test.dart
@@ -267,21 +267,6 @@ void main() {
         isNot(equals(revisionBefore)),
       );
     });
-
-    test('fires when a server is added or removed', () {
-      final manager = _createManager();
-      final before = manager.connectionRevision.value;
-
-      manager.addServer(
-        serverId: 'a',
-        serverUrl: Uri.parse('https://a.example.com'),
-      );
-
-      expect(
-        manager.connectionRevision.value,
-        isNot(equals(before)),
-      );
-    });
   });
 
   group('requiresAuth', () {

--- a/test/modules/auth/server_manager_test.dart
+++ b/test/modules/auth/server_manager_test.dart
@@ -363,6 +363,31 @@ void main() {
       expect(stored['test']!.serverUrl, Uri.parse('https://api.example.com'));
     });
 
+    test('markSessionExpired persists tokens as AuthenticatedServer', () async {
+      // Refresh tokens must survive app restart through an expired
+      // session — that's what keeps a silent refresh possible after
+      // relaunching the app. A regression that maps the expired arm
+      // back to KnownServer would silently lose refresh tokens.
+      final storage = InMemoryServerStorage();
+      final manager = _createManager(storage: storage);
+
+      final entry = manager.addServer(
+        serverId: 'test',
+        serverUrl: Uri.parse('https://api.example.com'),
+      );
+      final tokens = _tokens();
+      entry.auth.login(provider: _provider, tokens: tokens);
+      entry.auth.markSessionExpired();
+
+      await Future<void>.delayed(Duration.zero);
+      final stored = await storage.loadAll();
+      expect(stored, hasLength(1));
+      final persisted = stored['test'];
+      expect(persisted, isA<AuthenticatedServer>());
+      expect((persisted! as AuthenticatedServer).tokens.refreshToken,
+          tokens.refreshToken);
+    });
+
     test('logout persists server without tokens', () async {
       final storage = InMemoryServerStorage();
       final manager = _createManager(storage: storage);

--- a/test/modules/auth/server_manager_test.dart
+++ b/test/modules/auth/server_manager_test.dart
@@ -233,6 +233,57 @@ void main() {
     });
   });
 
+  group('connectionRevision', () {
+    test('fires when any single server flips between active and expired', () {
+      // The aggregate authState stays Authenticated when only one of
+      // several servers' sessions changes, so the route guard cannot
+      // listen to it alone. connectionRevision must fire on every
+      // per-server transition.
+      final manager = _createManager();
+
+      final a = manager.addServer(
+        serverId: 'a',
+        serverUrl: Uri.parse('https://a.example.com'),
+      );
+      final b = manager.addServer(
+        serverId: 'b',
+        serverUrl: Uri.parse('https://b.example.com'),
+      );
+
+      a.auth.login(provider: _provider, tokens: _tokens());
+      b.auth.login(provider: _provider, tokens: _tokens());
+
+      final aggregateBefore = manager.authState.value;
+      final revisionBefore = manager.connectionRevision.value;
+
+      // Flip A only.
+      a.auth.markSessionExpired();
+
+      // authState aggregate stays Authenticated (B is still active).
+      expect(manager.authState.value, equals(aggregateBefore));
+      // But connectionRevision must observe the per-server change.
+      expect(
+        manager.connectionRevision.value,
+        isNot(equals(revisionBefore)),
+      );
+    });
+
+    test('fires when a server is added or removed', () {
+      final manager = _createManager();
+      final before = manager.connectionRevision.value;
+
+      manager.addServer(
+        serverId: 'a',
+        serverUrl: Uri.parse('https://a.example.com'),
+      );
+
+      expect(
+        manager.connectionRevision.value,
+        isNot(equals(before)),
+      );
+    });
+  });
+
   group('requiresAuth', () {
     test('defaults to true', () {
       final manager = _createManager();

--- a/test/modules/auth/ui/auth_callback_screen_test.dart
+++ b/test/modules/auth/ui/auth_callback_screen_test.dart
@@ -40,6 +40,17 @@ Widget _buildApp({
         ),
       ),
       GoRoute(
+        path: '/room/:serverAlias/:roomId',
+        builder: (_, state) => Scaffold(
+          body: Center(
+            child: Text(
+              'Room ${state.pathParameters['serverAlias']}/'
+              '${state.pathParameters['roomId']}',
+            ),
+          ),
+        ),
+      ),
+      GoRoute(
         path: '/auth/callback',
         builder: (_, __) => AuthCallbackScreen(serverManager: serverManager),
       ),
@@ -128,6 +139,73 @@ void main() {
 
       expect(serverManager.servers.value, isNotEmpty);
       expect(find.text('Lobby Screen'), findsOneWidget);
+    });
+
+    testWidgets('navigates to frontendReturnTo when set', (tester) async {
+      final serverManager = _createServerManager();
+      final state = PreAuthState(
+        serverUrl: Uri.parse('https://api.example.com'),
+        providerId: 'keycloak',
+        discoveryUrl:
+            'https://sso.example.com/.well-known/openid-configuration',
+        clientId: 'soliplex',
+        createdAt: DateTime.timestamp(),
+        frontendReturnTo: '/room/server-a/r1',
+      );
+      await PreAuthStateStorage.save(state);
+
+      await tester.pumpWidget(_buildApp(
+        serverManager: serverManager,
+        callbackParams: const WebCallbackSuccess(
+          accessToken: 'access',
+          refreshToken: 'refresh',
+          expiresIn: 3600,
+        ),
+      ));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Room server-a/r1'), findsOneWidget);
+      expect(find.text('Lobby Screen'), findsNothing);
+    });
+
+    testWidgets('falls back to lobby on absolute frontendReturnTo',
+        (tester) async {
+      // Open-redirect guard: crafted absolute URLs must be rejected
+      // and the user lands on the safe default.
+      for (final crafted in [
+        'https://evil.com/x',
+        'http://evil.com/x',
+        '//evil.com/x',
+      ]) {
+        SharedPreferences.setMockInitialValues({});
+        final serverManager = _createServerManager();
+        final state = PreAuthState(
+          serverUrl: Uri.parse('https://api.example.com'),
+          providerId: 'keycloak',
+          discoveryUrl:
+              'https://sso.example.com/.well-known/openid-configuration',
+          clientId: 'soliplex',
+          createdAt: DateTime.timestamp(),
+          frontendReturnTo: crafted,
+        );
+        await PreAuthStateStorage.save(state);
+
+        await tester.pumpWidget(_buildApp(
+          serverManager: serverManager,
+          callbackParams: const WebCallbackSuccess(
+            accessToken: 'access',
+            refreshToken: 'refresh',
+            expiresIn: 3600,
+          ),
+        ));
+        await tester.pumpAndSettle();
+
+        expect(
+          find.text('Lobby Screen'),
+          findsOneWidget,
+          reason: 'crafted=$crafted should be rejected',
+        );
+      }
     });
 
     testWidgets('shows error when pre-auth state is expired', (tester) async {

--- a/test/modules/auth/ui/auth_callback_screen_test.dart
+++ b/test/modules/auth/ui/auth_callback_screen_test.dart
@@ -1,3 +1,5 @@
+import 'dart:convert';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -11,6 +13,16 @@ import 'package:soliplex_frontend/src/modules/auth/server_manager.dart';
 import 'package:soliplex_frontend/src/modules/auth/ui/auth_callback_screen.dart';
 
 import '../../../helpers/fakes.dart';
+
+String _rawPreAuthJson({required String frontendReturnTo}) => jsonEncode({
+      'serverUrl': 'https://api.example.com',
+      'providerId': 'keycloak',
+      'discoveryUrl':
+          'https://sso.example.com/.well-known/openid-configuration',
+      'clientId': 'soliplex',
+      'createdAt': DateTime.timestamp().toUtc().toIso8601String(),
+      'frontendReturnTo': frontendReturnTo,
+    });
 
 ServerManager _createServerManager() => ServerManager(
       authFactory: () => AuthSession(
@@ -168,27 +180,23 @@ void main() {
       expect(find.text('Lobby Screen'), findsNothing);
     });
 
-    testWidgets('falls back to lobby on absolute frontendReturnTo',
+    testWidgets('tampered storage with absolute frontendReturnTo is rejected',
         (tester) async {
-      // Open-redirect guard: crafted absolute URLs must be rejected
-      // and the user lands on the safe default.
+      // Defense in depth: even if shared_preferences is tampered with
+      // externally (the constructor would otherwise reject these),
+      // load() must not propagate a value that could open-redirect
+      // the user.
       for (final crafted in [
         'https://evil.com/x',
         'http://evil.com/x',
         '//evil.com/x',
       ]) {
-        SharedPreferences.setMockInitialValues({});
+        SharedPreferences.setMockInitialValues({
+          PreAuthStateStorage.storageKey: _rawPreAuthJson(
+            frontendReturnTo: crafted,
+          ),
+        });
         final serverManager = _createServerManager();
-        final state = PreAuthState(
-          serverUrl: Uri.parse('https://api.example.com'),
-          providerId: 'keycloak',
-          discoveryUrl:
-              'https://sso.example.com/.well-known/openid-configuration',
-          clientId: 'soliplex',
-          createdAt: DateTime.timestamp(),
-          frontendReturnTo: crafted,
-        );
-        await PreAuthStateStorage.save(state);
 
         await tester.pumpWidget(_buildApp(
           serverManager: serverManager,
@@ -201,9 +209,15 @@ void main() {
         await tester.pumpAndSettle();
 
         expect(
+          find.text('Room ${crafted.replaceAll('/', '')}'),
+          findsNothing,
+          reason: 'crafted=$crafted must not navigate to the attacker target',
+        );
+        expect(
           find.text('Lobby Screen'),
-          findsOneWidget,
-          reason: 'crafted=$crafted should be rejected',
+          findsNothing,
+          reason: 'crafted=$crafted should surface the error, not silently '
+              'land on the lobby',
         );
       }
     });

--- a/test/modules/auth/ui/auth_callback_screen_test.dart
+++ b/test/modules/auth/ui/auth_callback_screen_test.dart
@@ -138,7 +138,7 @@ void main() {
         discoveryUrl:
             'https://sso.example.com/.well-known/openid-configuration',
         clientId: 'soliplex',
-        createdAt: DateTime.timestamp().subtract(const Duration(minutes: 10)),
+        createdAt: DateTime.timestamp().subtract(const Duration(minutes: 31)),
       );
       await PreAuthStateStorage.save(state);
 

--- a/test/modules/diagnostics/models/http_event_grouper_test.dart
+++ b/test/modules/diagnostics/models/http_event_grouper_test.dart
@@ -60,15 +60,41 @@ void main() {
       expect(groups[0].status, HttpEventStatus.streamComplete);
     });
 
-    test('handles response with no matching request', () {
-      final events = [
-        createResponseEvent(requestId: 'unmatched', statusCode: 200),
-      ];
-      final groups = groupHttpEvents(events);
-      expect(groups, hasLength(1));
-      expect(groups[0].request, isNull);
-      expect(groups[0].response, isNotNull);
-    });
+    test(
+      'drops orphan response (whose request was evicted from the buffer)',
+      () {
+        // The inspector's ring buffer can evict an HttpRequestEvent while
+        // its later-arriving HttpResponseEvent remains. The grouper sorts
+        // by timestamp, which the orphan has no way to produce, so the
+        // grouper filters orphans out rather than letting [timestamp]
+        // throw mid-sort.
+        final events = [
+          createResponseEvent(requestId: 'unmatched', statusCode: 200),
+        ];
+        expect(groupHttpEvents(events), isEmpty);
+      },
+    );
+
+    test(
+      'orphan response alongside a real group does not crash the sort',
+      () {
+        // The actual regression: with two or more groups in the result,
+        // Dart's sort runs the comparator, which calls [timestamp] on
+        // every group. Before the filter, the orphan threw a StateError
+        // and the Network Inspector UI red-screened.
+        final events = [
+          createRequestEvent(
+            requestId: 'req-1',
+            timestamp: DateTime.utc(2026, 1, 1, 12),
+          ),
+          createResponseEvent(requestId: 'req-1'),
+          createResponseEvent(requestId: 'orphan', statusCode: 500),
+        ];
+        final groups = groupHttpEvents(events);
+        expect(groups, hasLength(1));
+        expect(groups[0].requestId, 'req-1');
+      },
+    );
 
     test('groups interleaved requests from multiple runs', () {
       final events = [

--- a/test/modules/lobby/lobby_state_test.dart
+++ b/test/modules/lobby/lobby_state_test.dart
@@ -180,8 +180,13 @@ void main() {
 
       test(
         'AuthException on rooms fetch funnels to markSessionExpired '
-        'and section is removed (not RoomsFailed)',
+        'and section becomes RoomsExpired (kept visible for sign-in)',
         () async {
+          // The lobby keeps an expired server's row visible with an
+          // inline "sign in again" affordance so the user can recover
+          // without leaving the lobby. The profile is dropped so a
+          // re-auth as a different identity doesn't briefly show the
+          // previous user's name.
           final manager = _createManager();
           final entry = manager.addServer(
             serverId: 'auth-server',
@@ -212,11 +217,118 @@ void main() {
 
           await Future<void>.delayed(Duration.zero);
 
-          // Session should flip to ExpiredSession (tokens preserved).
+          // Session flips to ExpiredSession; tokens preserved for a
+          // future silent refresh attempt.
           expect(entry.auth.session.value, isA<ExpiredSession>());
-          // Lobby section is removed by _onAuthChanged on the
-          // isConnected→false transition.
+          // Section is kept visible with the RoomsExpired marker.
+          expect(state.roomsByServer.value['auth-server'], isA<RoomsExpired>());
+          // Profile is cleared (null) — see test rationale above.
+          expect(
+            state.userProfiles.value.containsKey('auth-server'),
+            isTrue,
+          );
+          expect(state.userProfiles.value['auth-server'], isNull);
+
+          state.dispose();
+        },
+      );
+
+      test(
+        'ExpiredSession → ActiveSession refetches rooms and profile',
+        () async {
+          // The user clicks "Sign in" on the expired card, the new
+          // ActiveSession arrives, and the lobby must transition the
+          // section out of RoomsExpired back into RoomsLoaded.
+          final manager = _createManager();
+          final entry = manager.addServer(
+            serverId: 'auth-server',
+            serverUrl: Uri.parse('https://api.example.com'),
+          );
+          const provider = OidcProvider(
+            discoveryUrl: 'https://sso/.well-known/openid-configuration',
+            clientId: 'c',
+          );
+          entry.auth.login(
+            provider: provider,
+            tokens: AuthTokens(
+              accessToken: 'a',
+              refreshToken: 'r',
+              expiresAt: DateTime.now().add(const Duration(hours: 1)),
+            ),
+          );
+
+          final fakeApi = FakeSoliplexApi();
+          // First fetch on initial login fails with 401.
+          fakeApi.nextError = const AuthException(
+            message: 'Unauthorized',
+            statusCode: 401,
+          );
+
+          final state = LobbyState(
+            serverManager: manager,
+            apiResolver: (_) => fakeApi,
+          );
+          await Future<void>.delayed(Duration.zero);
+          expect(state.roomsByServer.value['auth-server'], isA<RoomsExpired>());
+
+          // Re-sign-in: clear the error, queue a successful rooms list,
+          // and flip the session back to ActiveSession.
+          fakeApi.nextError = null;
+          fakeApi.nextRooms = const <Room>[];
+          entry.auth.login(
+            provider: provider,
+            tokens: AuthTokens(
+              accessToken: 'a2',
+              refreshToken: 'r2',
+              expiresAt: DateTime.now().add(const Duration(hours: 1)),
+            ),
+          );
+          await Future<void>.delayed(Duration.zero);
+
+          expect(state.roomsByServer.value['auth-server'], isA<RoomsLoaded>());
+
+          state.dispose();
+        },
+      );
+
+      test(
+        'NoSession (logout) prunes the section',
+        () async {
+          // A true sign-out should not leave a stale "session expired"
+          // row in the lobby. Pruning the section is the right disposition
+          // because there are no tokens to recover from.
+          final manager = _createManager();
+          final entry = manager.addServer(
+            serverId: 'auth-server',
+            serverUrl: Uri.parse('https://api.example.com'),
+          );
+          entry.auth.login(
+            provider: const OidcProvider(
+              discoveryUrl: 'https://sso/.well-known/openid-configuration',
+              clientId: 'c',
+            ),
+            tokens: AuthTokens(
+              accessToken: 'a',
+              refreshToken: 'r',
+              expiresAt: DateTime.now().add(const Duration(hours: 1)),
+            ),
+          );
+
+          final fakeApi = FakeSoliplexApi();
+          fakeApi.nextRooms = const <Room>[];
+
+          final state = LobbyState(
+            serverManager: manager,
+            apiResolver: (_) => fakeApi,
+          );
+          await Future<void>.delayed(Duration.zero);
+          expect(state.roomsByServer.value['auth-server'], isA<RoomsLoaded>());
+
+          entry.auth.logout();
+          await Future<void>.delayed(Duration.zero);
+
           expect(state.roomsByServer.value.containsKey('auth-server'), isFalse);
+          expect(state.userProfiles.value.containsKey('auth-server'), isFalse);
 
           state.dispose();
         },

--- a/test/modules/lobby/lobby_state_test.dart
+++ b/test/modules/lobby/lobby_state_test.dart
@@ -124,6 +124,50 @@ void main() {
 
         state.dispose();
       });
+
+      test(
+        'AuthException on rooms fetch funnels to markSessionExpired '
+        'and section is removed (not RoomsFailed)',
+        () async {
+          final manager = _createManager();
+          final entry = manager.addServer(
+            serverId: 'auth-server',
+            serverUrl: Uri.parse('https://api.example.com'),
+          );
+          entry.auth.login(
+            provider: const OidcProvider(
+              discoveryUrl: 'https://sso/.well-known/openid-configuration',
+              clientId: 'c',
+            ),
+            tokens: AuthTokens(
+              accessToken: 'a',
+              refreshToken: 'r',
+              expiresAt: DateTime.now().add(const Duration(hours: 1)),
+            ),
+          );
+
+          final fakeApi = FakeSoliplexApi();
+          fakeApi.nextError = const AuthException(
+            message: 'Unauthorized',
+            statusCode: 401,
+          );
+
+          final state = LobbyState(
+            serverManager: manager,
+            apiResolver: (_) => fakeApi,
+          );
+
+          await Future<void>.delayed(Duration.zero);
+
+          // Session should flip to ExpiredSession (tokens preserved).
+          expect(entry.auth.session.value, isA<ExpiredSession>());
+          // Lobby section is removed by _onAuthChanged on the
+          // isConnected→false transition.
+          expect(state.roomsByServer.value.containsKey('auth-server'), isFalse);
+
+          state.dispose();
+        },
+      );
     });
 
     group('server removal', () {

--- a/test/modules/lobby/lobby_state_test.dart
+++ b/test/modules/lobby/lobby_state_test.dart
@@ -126,6 +126,59 @@ void main() {
       });
 
       test(
+        'PermissionDeniedException on rooms fetch produces RoomsFailed '
+        'and does NOT funnel to markSessionExpired',
+        () async {
+          // A 403 means the user is authenticated but lacks access;
+          // re-auth wouldn't help, so the lobby renders an inline
+          // permission message instead of flipping the session to
+          // ExpiredSession. A future refactor that lumps
+          // PermissionDeniedException under AuthException (or routes
+          // it through the auth funnel) would silently break this
+          // contract — this test pins it.
+          final manager = _createManager();
+          final entry = manager.addServer(
+            serverId: 'auth-server',
+            serverUrl: Uri.parse('https://api.example.com'),
+          );
+          entry.auth.login(
+            provider: const OidcProvider(
+              discoveryUrl: 'https://sso/.well-known/openid-configuration',
+              clientId: 'c',
+            ),
+            tokens: AuthTokens(
+              accessToken: 'a',
+              refreshToken: 'r',
+              expiresAt: DateTime.now().add(const Duration(hours: 1)),
+            ),
+          );
+
+          final fakeApi = FakeSoliplexApi();
+          final error = const PermissionDeniedException(
+            message: 'Forbidden',
+            statusCode: 403,
+          );
+          fakeApi.nextError = error;
+
+          final state = LobbyState(
+            serverManager: manager,
+            apiResolver: (_) => fakeApi,
+          );
+
+          await Future<void>.delayed(Duration.zero);
+
+          // Session must stay ActiveSession; 403 is not an auth failure.
+          expect(entry.auth.session.value, isA<ActiveSession>());
+          // Section is preserved and surfaces the 403 inline.
+          final rooms = state.roomsByServer.value;
+          expect(rooms['auth-server'], isA<RoomsFailed>());
+          expect((rooms['auth-server']! as RoomsFailed).error, same(error));
+
+          state.dispose();
+        },
+      );
+
+      test(
         'AuthException on rooms fetch funnels to markSessionExpired '
         'and section is removed (not RoomsFailed)',
         () async {

--- a/test/modules/lobby/lobby_state_test.dart
+++ b/test/modules/lobby/lobby_state_test.dart
@@ -222,7 +222,9 @@ void main() {
           expect(entry.auth.session.value, isA<ExpiredSession>());
           // Section is kept visible with the RoomsExpired marker.
           expect(state.roomsByServer.value['auth-server'], isA<RoomsExpired>());
-          // Profile is cleared (null) — see test rationale above.
+          // Profile entry is present but null: the key is preserved so
+          // the sidebar still iterates it, but stale identity data is
+          // cleared.
           expect(
             state.userProfiles.value.containsKey('auth-server'),
             isTrue,

--- a/test/modules/lobby/ui/lobby_screen_test.dart
+++ b/test/modules/lobby/ui/lobby_screen_test.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:go_router/go_router.dart';
 import 'package:soliplex_frontend/src/modules/auth/auth_session.dart';
+import 'package:soliplex_frontend/src/modules/auth/auth_tokens.dart';
 import 'package:soliplex_frontend/src/modules/auth/server_manager.dart';
 import 'package:soliplex_frontend/src/modules/lobby/ui/lobby_screen.dart';
 
@@ -13,7 +14,10 @@ ServerManager _createManager() => ServerManager(
       storage: InMemoryServerStorage(),
     );
 
-Widget _buildApp(ServerManager manager) {
+Widget _buildApp(
+  ServerManager manager, {
+  void Function(Uri location)? onHomeRoute,
+}) {
   final router = GoRouter(
     initialLocation: '/lobby',
     routes: [
@@ -24,6 +28,13 @@ Widget _buildApp(ServerManager manager) {
       GoRoute(
         path: '/servers',
         builder: (_, __) => const Scaffold(body: Text('Servers')),
+      ),
+      GoRoute(
+        path: '/',
+        builder: (_, state) {
+          onHomeRoute?.call(state.uri);
+          return const Scaffold(body: Text('Home'));
+        },
       ),
     ],
   );
@@ -95,5 +106,62 @@ void main() {
       // Empty state: prominent Add Server CTA in the room content area
       expect(find.text('No servers connected'), findsOneWidget);
     });
+
+    testWidgets(
+      'expired-session row renders Sign in button that routes to '
+      'homeWithUrl with returnTo=lobby',
+      (tester) async {
+        // The whole purpose of keeping the expired row visible is to
+        // give the user a way to recover. A regression that removed
+        // the button or mis-wired its onPressed would re-introduce
+        // the "invisible expired server" bug this commit fixes.
+        tester.view.physicalSize = const Size(800, 600);
+        tester.view.devicePixelRatio = 1.0;
+        addTearDown(tester.view.resetPhysicalSize);
+
+        final manager = _createManager();
+        final entry = manager.addServer(
+          serverId: 'auth-server',
+          serverUrl: Uri.parse('https://api.example.com'),
+        );
+        entry.auth.login(
+          provider: const OidcProvider(
+            discoveryUrl: 'https://sso/.well-known/openid-configuration',
+            clientId: 'c',
+          ),
+          tokens: AuthTokens(
+            accessToken: 'a',
+            refreshToken: 'r',
+            expiresAt: DateTime.now().add(const Duration(hours: 1)),
+          ),
+        );
+        entry.auth.markSessionExpired();
+
+        Uri? homeLocation;
+        await tester.pumpWidget(
+          _buildApp(manager, onHomeRoute: (uri) => homeLocation = uri),
+        );
+        await tester.pump();
+
+        // The panel description is unique to the RoomsExpired arm
+        // (the sidebar tile also renders "Session expired", but only
+        // as a subtitle), so it pins the panel without ambiguity.
+        expect(
+          find.text('Sign in again to view rooms on this server.'),
+          findsOneWidget,
+        );
+        expect(find.text('Sign in'), findsOneWidget);
+
+        await tester.tap(find.text('Sign in'));
+        await tester.pumpAndSettle();
+
+        expect(homeLocation, isNotNull);
+        expect(
+          homeLocation!.queryParameters['url'],
+          'https://api.example.com',
+        );
+        expect(homeLocation!.queryParameters['returnTo'], '/lobby');
+      },
+    );
   });
 }

--- a/test/modules/lobby/ui/server_sidebar_test.dart
+++ b/test/modules/lobby/ui/server_sidebar_test.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:soliplex_frontend/src/modules/auth/auth_session.dart';
+import 'package:soliplex_frontend/src/modules/auth/auth_tokens.dart';
 import 'package:soliplex_frontend/src/modules/auth/server_entry.dart';
 import 'package:soliplex_frontend/src/modules/auth/server_manager.dart';
 import 'package:soliplex_frontend/src/modules/lobby/lobby_state.dart';
@@ -98,5 +99,48 @@ void main() {
       await tester.tap(find.text('Network Inspector'));
       expect(inspectorTapped, isTrue);
     });
+
+    testWidgets(
+      'subtitle reacts to session flipping to ExpiredSession '
+      'without any server-map mutation',
+      (tester) async {
+        // The ServerSidebar receives a `servers` map snapshot from its
+        // parent. The parent only rebuilds when the map mutates (server
+        // added/removed). A pure session-state flip on an existing entry
+        // does not change the map. The subtitle reactivity therefore
+        // must come from the tile itself watching the per-entry session
+        // signal — without that, the subtitle would stale-display the
+        // pre-flip label until something else triggered a rebuild.
+        final manager = _createManager();
+        final entry = manager.addServer(
+          serverId: 'auth-server',
+          serverUrl: Uri.parse('https://api.example.com'),
+        );
+        entry.auth.login(
+          provider: const OidcProvider(
+            discoveryUrl: 'https://sso/.well-known/openid-configuration',
+            clientId: 'c',
+          ),
+          tokens: AuthTokens(
+            accessToken: 'a',
+            refreshToken: 'r',
+            expiresAt: DateTime.now().add(const Duration(hours: 1)),
+          ),
+        );
+
+        // Snapshot the map once; we intentionally never refresh it.
+        final servers = manager.servers.value;
+
+        await tester.pumpWidget(_buildSidebar(servers: servers));
+        expect(find.text('Signed in'), findsOneWidget);
+        expect(find.text('Session expired'), findsNothing);
+
+        entry.auth.markSessionExpired();
+        await tester.pump();
+
+        expect(find.text('Session expired'), findsOneWidget);
+        expect(find.text('Signed in'), findsNothing);
+      },
+    );
   });
 }

--- a/test/modules/quiz/quiz_session_controller_test.dart
+++ b/test/modules/quiz/quiz_session_controller_test.dart
@@ -3,6 +3,8 @@ import 'dart:async';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:soliplex_client/soliplex_client.dart';
 
+import 'package:soliplex_frontend/src/modules/auth/auth_session.dart';
+import 'package:soliplex_frontend/src/modules/auth/auth_tokens.dart';
 import 'package:soliplex_frontend/src/modules/quiz/quiz_session.dart';
 import 'package:soliplex_frontend/src/modules/quiz/quiz_session_controller.dart';
 
@@ -10,12 +12,15 @@ import '../../helpers/fakes.dart';
 
 void main() {
   late FakeSoliplexApi api;
+  late AuthSession auth;
   late QuizSessionController controller;
 
   setUp(() {
     api = FakeSoliplexApi();
+    auth = AuthSession(refreshService: FakeTokenRefreshService());
     controller = QuizSessionController(
       api: api,
+      auth: auth,
       roomId: 'room-1',
       logger: testLogger(),
     );
@@ -291,7 +296,19 @@ void main() {
     );
   });
 
-  test('AuthException shows session-expired message', () async {
+  test('AuthException shows session-expired message and funnels auth',
+      () async {
+    auth.login(
+      provider: const OidcProvider(
+        discoveryUrl: 'https://sso/.well-known/openid-configuration',
+        clientId: 'c',
+      ),
+      tokens: AuthTokens(
+        accessToken: 'a',
+        refreshToken: 'r',
+        expiresAt: DateTime.now().add(const Duration(hours: 1)),
+      ),
+    );
     api.nextQuizAnswerError = const AuthException(message: 'session expired');
     controller.start(_quiz());
     controller.updateInput(const TextInput('answer'));
@@ -300,6 +317,33 @@ void main() {
       controller.submissionError.value,
       'Your session has expired. Please sign in again.',
     );
+    expect(auth.session.value, isA<ExpiredSession>());
+  });
+
+  test('PermissionDeniedException shows no-permission message, no funnel',
+      () async {
+    auth.login(
+      provider: const OidcProvider(
+        discoveryUrl: 'https://sso/.well-known/openid-configuration',
+        clientId: 'c',
+      ),
+      tokens: AuthTokens(
+        accessToken: 'a',
+        refreshToken: 'r',
+        expiresAt: DateTime.now().add(const Duration(hours: 1)),
+      ),
+    );
+    api.nextQuizAnswerError =
+        const PermissionDeniedException(message: 'forbidden');
+    controller.start(_quiz());
+    controller.updateInput(const TextInput('answer'));
+    await controller.submitAnswer();
+    expect(
+      controller.submissionError.value,
+      "You don't have permission to submit answers in this quiz.",
+    );
+    // Session is not flipped — 403 doesn't mean we should re-auth.
+    expect(auth.session.value, isA<ActiveSession>());
   });
 
   test('non-Exception error preserves input and sets error message', () async {

--- a/test/modules/room/room_state_test.dart
+++ b/test/modules/room/room_state_test.dart
@@ -11,8 +11,6 @@ import 'package:soliplex_frontend/src/modules/room/upload_tracker_registry.dart'
 
 import '../../helpers/fakes.dart';
 
-class _FakeAuthSession extends Fake implements AuthSession {}
-
 ServerConnection _fakeConnection(FakeSoliplexApi api) => ServerConnection(
       serverId: 'test-server',
       api: api,
@@ -23,7 +21,7 @@ ServerEntry _fakeServerEntry(ServerConnection connection) => ServerEntry(
       serverId: connection.serverId,
       alias: connection.serverId,
       serverUrl: Uri.parse('https://${connection.serverId}.example.com'),
-      auth: _FakeAuthSession(),
+      auth: AuthSession(refreshService: FakeTokenRefreshService()),
       httpClient: FakeHttpClient(),
       connection: connection,
     );

--- a/test/modules/room/thread_view_state_test.dart
+++ b/test/modules/room/thread_view_state_test.dart
@@ -1,10 +1,12 @@
 import 'dart:async';
 
 import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
 import 'package:soliplex_agent/soliplex_agent.dart';
 
 import 'package:soliplex_frontend/src/modules/auth/auth_session.dart';
 import 'package:soliplex_frontend/src/modules/auth/auth_tokens.dart';
+import 'package:soliplex_frontend/src/modules/auth/return_to_storage.dart';
 import 'package:soliplex_frontend/src/modules/room/agent_runtime_manager.dart';
 import 'package:soliplex_frontend/src/modules/room/execution_tracker_extension.dart';
 import 'package:soliplex_frontend/src/modules/room/human_approval_extension.dart';
@@ -89,6 +91,7 @@ void main() {
   late RunRegistry registry;
 
   setUp(() {
+    SharedPreferences.setMockInitialValues({});
     api = FakeSoliplexApi();
     connection = _fakeConnection(api);
     auth = AuthSession(refreshService: FakeTokenRefreshService());
@@ -1025,6 +1028,76 @@ void main() {
         auth.markSessionExpired();
 
         expect(session.cancelCalled, isTrue);
+
+        state.dispose();
+      },
+    );
+
+    test(
+      'AuthException SendError persists composer text via ReturnToStorage',
+      () async {
+        api.nextThreadHistory = ThreadHistory(messages: const []);
+
+        final state = ThreadViewState(
+          connection: connection,
+          auth: auth,
+          roomId: 'room-1',
+          threadId: 'thread-1',
+          registry: registry,
+        );
+        await Future<void>.delayed(Duration.zero);
+
+        // Simulate the spawn-failure path: SessionSpawner writes a
+        // SendError with the original prompt and an AuthException.
+        state.lastSendError; // ensure signal is materialized
+        // ignore: invalid_use_of_protected_member
+        (state.lastSendError as Signal<SendError?>).value = const SendError(
+          AuthException(message: 'Unauthorized', statusCode: 401),
+          unsentText: 'half-written question',
+        );
+
+        await Future<void>.delayed(Duration.zero);
+
+        final restored = await ReturnToStorage.loadComposer(
+          serverId: 'test-server',
+          roomId: 'room-1',
+        );
+        expect(restored, 'half-written question');
+
+        state.dispose();
+      },
+    );
+
+    test(
+      'non-auth SendError does not persist composer text',
+      () async {
+        api.nextThreadHistory = ThreadHistory(messages: const []);
+
+        final state = ThreadViewState(
+          connection: connection,
+          auth: auth,
+          roomId: 'room-1',
+          threadId: 'thread-1',
+          registry: registry,
+        );
+        await Future<void>.delayed(Duration.zero);
+
+        // ignore: invalid_use_of_protected_member
+        (state.lastSendError as Signal<SendError?>).value = const SendError(
+          NetworkException(message: 'offline'),
+          unsentText: 'half-written question',
+        );
+
+        await Future<void>.delayed(Duration.zero);
+
+        // Only auth errors trigger persistence — for transient
+        // failures, the in-memory SendError.unsentText path handles
+        // restoration without touching storage.
+        final restored = await ReturnToStorage.loadComposer(
+          serverId: 'test-server',
+          roomId: 'room-1',
+        );
+        expect(restored, isNull);
 
         state.dispose();
       },

--- a/test/modules/room/thread_view_state_test.dart
+++ b/test/modules/room/thread_view_state_test.dart
@@ -992,6 +992,44 @@ void main() {
       },
     );
 
+    test(
+      'auth flip to ExpiredSession cancels the active AgentSession',
+      () async {
+        api.nextThreadHistory = ThreadHistory(messages: const []);
+        auth.login(
+          provider: const OidcProvider(
+            discoveryUrl: 'https://sso/.well-known/openid-configuration',
+            clientId: 'c',
+          ),
+          tokens: AuthTokens(
+            accessToken: 'a',
+            refreshToken: 'r',
+            expiresAt: DateTime.now().add(const Duration(hours: 1)),
+          ),
+        );
+
+        final state = ThreadViewState(
+          connection: connection,
+          auth: auth,
+          roomId: 'room-1',
+          threadId: 'thread-1',
+          registry: registry,
+        );
+        await Future<void>.delayed(Duration.zero);
+
+        final session = _FakeAgentSession();
+        state.attachSession(session);
+        expect(session.cancelCalled, isFalse);
+
+        // A 401 on an unrelated surface flips the session.
+        auth.markSessionExpired();
+
+        expect(session.cancelCalled, isTrue);
+
+        state.dispose();
+      },
+    );
+
     test('FailedState(authExpired) funnels through markSessionExpired',
         () async {
       api.nextThreadHistory = ThreadHistory(messages: const []);

--- a/test/modules/room/thread_view_state_test.dart
+++ b/test/modules/room/thread_view_state_test.dart
@@ -21,6 +21,29 @@ ServerConnection _fakeConnection(FakeSoliplexApi api) => ServerConnection(
       agUiStreamClient: FakeAgUiStreamClient(),
     );
 
+/// FakeSoliplexApi variant that holds getThreadHistory open until the
+/// test resolves it. Used to assert observable behavior on an in-flight
+/// request (notably cancel-token cancellation on auth flip).
+class _PendingHistoryApi extends FakeSoliplexApi {
+  Completer<ThreadHistory>? _pending;
+  CancelToken? capturedToken;
+
+  @override
+  Future<ThreadHistory> getThreadHistory(
+    String roomId,
+    String threadId, {
+    CancelToken? cancelToken,
+  }) {
+    capturedToken = cancelToken;
+    _pending ??= Completer<ThreadHistory>();
+    return _pending!.future;
+  }
+
+  void completeWith(ThreadHistory history) {
+    _pending?.complete(history);
+  }
+}
+
 /// Minimal session fake for testing [ThreadViewState] signal behavior.
 class _FakeAgentSession implements AgentSession {
   _FakeAgentSession({List<SessionExtension> extensions = const []})
@@ -990,6 +1013,48 @@ void main() {
         );
 
         expect(state.lastSendError.value?.error, 'Some other failure');
+
+        state.dispose();
+      },
+    );
+
+    test(
+      'auth flip to ExpiredSession cancels an in-flight history fetch',
+      () async {
+        final pendingApi = _PendingHistoryApi();
+        final pendingConnection = _fakeConnection(pendingApi);
+        auth.login(
+          provider: const OidcProvider(
+            discoveryUrl: 'https://sso/.well-known/openid-configuration',
+            clientId: 'c',
+          ),
+          tokens: AuthTokens(
+            accessToken: 'a',
+            refreshToken: 'r',
+            expiresAt: DateTime.now().add(const Duration(hours: 1)),
+          ),
+        );
+
+        final state = ThreadViewState(
+          connection: pendingConnection,
+          auth: auth,
+          roomId: 'room-1',
+          threadId: 'thread-1',
+          registry: registry,
+        );
+        await Future<void>.delayed(Duration.zero);
+
+        final inFlightToken = pendingApi.capturedToken;
+        expect(inFlightToken, isNotNull);
+        expect(inFlightToken!.isCancelled, isFalse);
+
+        auth.markSessionExpired();
+
+        expect(inFlightToken.isCancelled, isTrue);
+        expect(inFlightToken.reason, 'auth expired');
+
+        pendingApi.completeWith(ThreadHistory(messages: const []));
+        await Future<void>.delayed(Duration.zero);
 
         state.dispose();
       },

--- a/test/modules/room/thread_view_state_test.dart
+++ b/test/modules/room/thread_view_state_test.dart
@@ -3,6 +3,8 @@ import 'dart:async';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:soliplex_agent/soliplex_agent.dart';
 
+import 'package:soliplex_frontend/src/modules/auth/auth_session.dart';
+import 'package:soliplex_frontend/src/modules/auth/auth_tokens.dart';
 import 'package:soliplex_frontend/src/modules/room/agent_runtime_manager.dart';
 import 'package:soliplex_frontend/src/modules/room/execution_tracker_extension.dart';
 import 'package:soliplex_frontend/src/modules/room/human_approval_extension.dart';
@@ -83,11 +85,13 @@ class _FakeAgentSession implements AgentSession {
 void main() {
   late FakeSoliplexApi api;
   late ServerConnection connection;
+  late AuthSession auth;
   late RunRegistry registry;
 
   setUp(() {
     api = FakeSoliplexApi();
     connection = _fakeConnection(api);
+    auth = AuthSession(refreshService: FakeTokenRefreshService());
     registry = RunRegistry();
   });
 
@@ -106,6 +110,7 @@ void main() {
 
     final state = ThreadViewState(
       connection: connection,
+      auth: auth,
       roomId: 'room-1',
       threadId: 'thread-1',
       registry: registry,
@@ -143,6 +148,7 @@ void main() {
     ThreadHistory? capturedHistory;
     final state = ThreadViewState(
       connection: connection,
+      auth: auth,
       roomId: 'room-1',
       threadId: 'thread-1',
       registry: registry,
@@ -165,6 +171,7 @@ void main() {
 
     final state = ThreadViewState(
       connection: connection,
+      auth: auth,
       roomId: 'room-1',
       threadId: 'thread-1',
       registry: registry,
@@ -189,6 +196,7 @@ void main() {
 
     final state = ThreadViewState(
       connection: connection,
+      auth: auth,
       roomId: 'room-1',
       threadId: 'thread-1',
       registry: registry,
@@ -217,6 +225,7 @@ void main() {
 
     final state = ThreadViewState(
       connection: connection,
+      auth: auth,
       roomId: 'room-1',
       threadId: 'thread-1',
       registry: registry,
@@ -236,6 +245,7 @@ void main() {
 
     final state = ThreadViewState(
       connection: connection,
+      auth: auth,
       roomId: 'room-1',
       threadId: 'thread-1',
       registry: registry,
@@ -352,6 +362,7 @@ void main() {
     // Now create a new ThreadViewState (simulates navigating back).
     final state = ThreadViewState(
       connection: connection,
+      auth: auth,
       roomId: 'room-1',
       threadId: 'thread-1',
       registry: registry,
@@ -396,6 +407,7 @@ void main() {
 
       final state = ThreadViewState(
         connection: connection,
+        auth: auth,
         roomId: 'room-1',
         threadId: 'thread-1',
         registry: registry,
@@ -433,6 +445,7 @@ void main() {
       // to call createThread, which we make fail.
       final state = ThreadViewState(
         connection: connection,
+        auth: auth,
         roomId: 'room-1',
         threadId: 'thread-1',
         registry: registry,
@@ -468,6 +481,7 @@ void main() {
 
       final state = ThreadViewState(
         connection: connection,
+        auth: auth,
         roomId: 'room-1',
         threadId: 'thread-1',
         registry: registry,
@@ -504,6 +518,7 @@ void main() {
 
       final state = ThreadViewState(
         connection: connection,
+        auth: auth,
         roomId: 'room-1',
         threadId: 'thread-1',
         registry: registry,
@@ -538,6 +553,7 @@ void main() {
 
       final state = ThreadViewState(
         connection: connection,
+        auth: auth,
         roomId: 'room-1',
         threadId: 'thread-1',
         registry: registry,
@@ -559,6 +575,7 @@ void main() {
 
       final state = ThreadViewState(
         connection: connection,
+        auth: auth,
         roomId: 'room-1',
         threadId: 'thread-1',
         registry: registry,
@@ -583,6 +600,7 @@ void main() {
 
       final state = ThreadViewState(
         connection: connection,
+        auth: auth,
         roomId: 'room-1',
         threadId: 'thread-1',
         registry: registry,
@@ -612,6 +630,7 @@ void main() {
 
       final state = ThreadViewState(
         connection: connection,
+        auth: auth,
         roomId: 'room-1',
         threadId: 'thread-1',
         registry: registry,
@@ -640,6 +659,7 @@ void main() {
 
       final state = ThreadViewState(
         connection: connection,
+        auth: auth,
         roomId: 'room-1',
         threadId: 'thread-1',
         registry: registry,
@@ -656,6 +676,7 @@ void main() {
 
       final state = ThreadViewState(
         connection: connection,
+        auth: auth,
         roomId: 'room-1',
         threadId: 'thread-1',
         registry: registry,
@@ -709,6 +730,7 @@ void main() {
 
       final state = ThreadViewState(
         connection: connection,
+        auth: auth,
         roomId: 'room-1',
         threadId: 'thread-1',
         registry: registry,
@@ -761,6 +783,7 @@ void main() {
 
       final state = ThreadViewState(
         connection: connection,
+        auth: auth,
         roomId: 'room-1',
         threadId: 'thread-1',
         registry: registry,
@@ -785,6 +808,7 @@ void main() {
       api.nextThreadHistory = ThreadHistory(messages: const []);
       final state = ThreadViewState(
         connection: connection,
+        auth: auth,
         roomId: 'room-1',
         threadId: 'thread-1',
         registry: registry,
@@ -800,6 +824,7 @@ void main() {
       api.nextThreadHistory = ThreadHistory(messages: const []);
       final state = ThreadViewState(
         connection: connection,
+        auth: auth,
         roomId: 'room-1',
         threadId: 'thread-1',
         registry: registry,
@@ -825,6 +850,7 @@ void main() {
         api.nextThreadHistory = ThreadHistory(messages: const []);
         final state = ThreadViewState(
           connection: connection,
+          auth: auth,
           roomId: 'room-1',
           threadId: 'thread-1',
           registry: registry,
@@ -862,6 +888,7 @@ void main() {
         api.nextThreadHistory = ThreadHistory(messages: const []);
         final state = ThreadViewState(
           connection: connection,
+          auth: auth,
           roomId: 'room-1',
           threadId: 'thread-1',
           registry: registry,
@@ -899,6 +926,7 @@ void main() {
 
         final state = ThreadViewState(
           connection: connection,
+          auth: auth,
           roomId: 'room-1',
           threadId: 'thread-1',
           registry: registry,
@@ -936,6 +964,7 @@ void main() {
 
         final state = ThreadViewState(
           connection: connection,
+          auth: auth,
           roomId: 'room-1',
           threadId: 'thread-1',
           registry: registry,
@@ -963,12 +992,58 @@ void main() {
       },
     );
 
+    test('FailedState(authExpired) funnels through markSessionExpired',
+        () async {
+      api.nextThreadHistory = ThreadHistory(messages: const []);
+      auth.login(
+        provider: const OidcProvider(
+          discoveryUrl: 'https://sso/.well-known/openid-configuration',
+          clientId: 'c',
+        ),
+        tokens: AuthTokens(
+          accessToken: 'a',
+          refreshToken: 'r',
+          expiresAt: DateTime.now().add(const Duration(hours: 1)),
+        ),
+      );
+
+      final state = ThreadViewState(
+        connection: connection,
+        auth: auth,
+        roomId: 'room-1',
+        threadId: 'thread-1',
+        registry: registry,
+      );
+      await Future<void>.delayed(Duration.zero);
+
+      final session = _FakeAgentSession();
+      state.attachSession(session);
+
+      session.emit(
+        FailedState.preRun(
+          threadKey: (
+            serverId: 'test-server',
+            roomId: 'room-1',
+            threadId: 'thread-1',
+          ),
+          reason: FailureReason.authExpired,
+          error: 'Session expired',
+        ),
+      );
+
+      expect(auth.session.value, isA<ExpiredSession>());
+      expect(state.lastSendError.value?.error, 'Session expired');
+
+      state.dispose();
+    });
+
     test('mirrors session.reconnectStatus into reconnectStatus signal',
         () async {
       api.nextThreadHistory = ThreadHistory(messages: const []);
 
       final state = ThreadViewState(
         connection: connection,
+        auth: auth,
         roomId: 'room-1',
         threadId: 'thread-1',
         registry: registry,
@@ -1000,6 +1075,7 @@ void main() {
 
         final state = ThreadViewState(
           connection: connection,
+          auth: auth,
           roomId: 'room-1',
           threadId: 'thread-1',
           registry: registry,
@@ -1028,6 +1104,7 @@ void main() {
 
         final state = ThreadViewState(
           connection: connection,
+          auth: auth,
           roomId: 'room-1',
           threadId: 'thread-1',
           registry: registry,
@@ -1070,6 +1147,7 @@ void main() {
       api.nextThreadHistory = ThreadHistory(messages: const []);
       final state = ThreadViewState(
         connection: connection,
+        auth: auth,
         roomId: 'room-1',
         threadId: 'thread-1',
         registry: registry,
@@ -1092,6 +1170,7 @@ void main() {
       api.nextThreadHistory = ThreadHistory(messages: const []);
       final state = ThreadViewState(
         connection: connection,
+        auth: auth,
         roomId: 'room-1',
         threadId: 'thread-1',
         registry: registry,
@@ -1128,6 +1207,7 @@ void main() {
       api.nextThreadHistory = ThreadHistory(messages: const []);
       final state = ThreadViewState(
         connection: connection,
+        auth: auth,
         roomId: 'room-1',
         threadId: 'thread-1',
         registry: registry,

--- a/test/modules/room/ui/upload_event_banner_test.dart
+++ b/test/modules/room/ui/upload_event_banner_test.dart
@@ -5,8 +5,11 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:soliplex_client/soliplex_client.dart';
 import 'package:soliplex_frontend/src/design/design.dart';
+import 'package:soliplex_frontend/src/modules/auth/auth_session.dart';
 import 'package:soliplex_frontend/src/modules/room/ui/upload_event_banner.dart';
 import 'package:soliplex_frontend/src/modules/room/upload_tracker.dart';
+
+import '../../../helpers/fakes.dart';
 
 class _MockApi extends Mock implements SoliplexApi {}
 
@@ -27,7 +30,10 @@ void main() {
 
   setUp(() {
     api = _MockApi();
-    tracker = UploadTracker(api: api);
+    tracker = UploadTracker(
+      api: api,
+      auth: AuthSession(refreshService: FakeTokenRefreshService()),
+    );
 
     // Defaults: empty server lists, uploads succeed. Individual tests
     // override as needed.

--- a/test/modules/room/upload_tracker_registry_test.dart
+++ b/test/modules/room/upload_tracker_registry_test.dart
@@ -6,9 +6,9 @@ import 'package:soliplex_frontend/src/modules/auth/auth_session.dart';
 import 'package:soliplex_frontend/src/modules/auth/server_entry.dart';
 import 'package:soliplex_frontend/src/modules/room/upload_tracker_registry.dart';
 
-class _FakeHttpClient extends Fake implements SoliplexHttpClient {}
+import '../../helpers/fakes.dart' show FakeTokenRefreshService;
 
-class _FakeAuthSession extends Fake implements AuthSession {}
+class _FakeHttpClient extends Fake implements SoliplexHttpClient {}
 
 class _FakeServerConnection extends Fake implements ServerConnection {
   _FakeServerConnection(this.api);
@@ -24,7 +24,7 @@ ServerEntry _entry(String serverId, {SoliplexApi? api}) {
     serverId: serverId,
     alias: serverId,
     serverUrl: Uri.parse('https://$serverId.example.com'),
-    auth: _FakeAuthSession(),
+    auth: AuthSession(refreshService: FakeTokenRefreshService()),
     httpClient: _FakeHttpClient(),
     connection: _FakeServerConnection(api ?? _MockSoliplexApi()),
   );

--- a/test/modules/room/upload_tracker_test.dart
+++ b/test/modules/room/upload_tracker_test.dart
@@ -1145,6 +1145,66 @@ void main() {
     });
 
     test(
+      'auth flip to ExpiredSession cancels pending uploads',
+      () async {
+        stubGetRoomUploads([]);
+        unawaited(tracker.refreshRoom('room-1'));
+        await _pump();
+
+        auth.login(
+          provider: const OidcProvider(
+            discoveryUrl: 'https://sso/.well-known/openid-configuration',
+            clientId: 'c',
+          ),
+          tokens: AuthTokens(
+            accessToken: 'a',
+            refreshToken: 'r',
+            expiresAt: DateTime.now().add(const Duration(hours: 1)),
+          ),
+        );
+
+        // Stage an upload whose POST blocks until we tell it to.
+        final postCompleter = Completer<void>();
+        late CancelToken capturedToken;
+        when(() => mockApi.uploadFileToRoom(
+              any(),
+              filename: any(named: 'filename'),
+              openStream: any(named: 'openStream'),
+              contentLength: any(named: 'contentLength'),
+              mimeType: any(named: 'mimeType'),
+              webFileBlob: any(named: 'webFileBlob'),
+              onProgress: any(named: 'onProgress'),
+              cancelToken: any(named: 'cancelToken'),
+            )).thenAnswer((invocation) async {
+          capturedToken = invocation.namedArguments[const Symbol('cancelToken')]
+              as CancelToken;
+          await postCompleter.future;
+          if (capturedToken.isCancelled) throw const CancelledException();
+        });
+
+        tracker.uploadToRoom(
+          roomId: 'room-1',
+          filename: 'slow.pdf',
+          openStream: () => Stream<List<int>>.value(const [1]),
+          contentLength: 1,
+        );
+        await _pump();
+
+        // Sanity: the upload's token is alive while POST is in flight.
+        expect(capturedToken.isCancelled, isFalse);
+
+        // Flip auth on this server (could be triggered from anywhere).
+        auth.markSessionExpired();
+
+        expect(capturedToken.isCancelled, isTrue);
+
+        // Let the staged POST observe the cancel and unblock.
+        postCompleter.complete();
+        await _pump();
+      },
+    );
+
+    test(
       'progress emissions update PendingUpload.sentBytes as chunks flow',
       () async {
         stubGetRoomUploads([]);

--- a/test/modules/room/upload_tracker_test.dart
+++ b/test/modules/room/upload_tracker_test.dart
@@ -4,7 +4,11 @@ import 'dart:io' show FileSystemException, SocketException;
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:soliplex_client/soliplex_client.dart';
+import 'package:soliplex_frontend/src/modules/auth/auth_session.dart';
+import 'package:soliplex_frontend/src/modules/auth/auth_tokens.dart';
 import 'package:soliplex_frontend/src/modules/room/upload_tracker.dart';
+
+import '../../helpers/fakes.dart';
 
 class MockSoliplexApi extends Mock implements SoliplexApi {}
 
@@ -27,9 +31,12 @@ void main() {
     registerFallbackValue(CancelToken());
   });
 
+  late AuthSession auth;
+
   setUp(() {
     mockApi = MockSoliplexApi();
-    tracker = UploadTracker(api: mockApi);
+    auth = AuthSession(refreshService: FakeTokenRefreshService());
+    tracker = UploadTracker(api: mockApi, auth: auth);
   });
 
   tearDown(() {
@@ -1086,6 +1093,18 @@ void main() {
       unawaited(tracker.refreshRoom('room-1'));
       await _pump();
 
+      auth.login(
+        provider: const OidcProvider(
+          discoveryUrl: 'https://sso/.well-known/openid-configuration',
+          clientId: 'c',
+        ),
+        tokens: AuthTokens(
+          accessToken: 'a',
+          refreshToken: 'r',
+          expiresAt: DateTime.now().add(const Duration(hours: 1)),
+        ),
+      );
+
       var callCount = 0;
       when(() => mockApi.uploadFileToRoom(
             any(),
@@ -1119,6 +1138,10 @@ void main() {
       final failed = status.uploads.whereType<FailedUpload>().single;
       expect(failed.filename, 'fail.pdf');
       expect(failed.message, 'Session expired. Please sign in again.');
+
+      // Session funneled through markSessionExpired so route guard
+      // and lobby UX can react. Tokens preserved.
+      expect(auth.session.value, isA<ExpiredSession>());
     });
 
     test(


### PR DESCRIPTION
## Summary

- Introduce **ExpiredSession** — tokens are preserved across auth failures so a silent refresh can revive the session; the lobby keeps the row visible with an inline "sign in again" affordance instead of pruning it.
- Split **401 vs 403** in the HTTP layer: a new `PermissionDeniedException` for 403 (renders inline, never funnels through `markSessionExpired`), while 401 funnels through the per-server auth funnel.
- Wire a **per-server route guard** via `connectionRevision` so individual server flips re-evaluate routing even when the aggregate `authState` stays Authenticated.
- Add **`PreAuthState.frontendReturnTo`** (30-min TTL, constructor-enforced relative-path guard) plumbed end-to-end from the route guard through `ConnectFlow` to the OIDC callback.
- Persist **composer drafts** across the auth round-trip via `ReturnToStorage` (24h TTL, shared_preferences); restored on remount post-reauth.
- Sharpen failure logging across the auth and refresh paths (SEVERE for invariant violations; WARNING for recoverable / explicit-rejection cases); include `discoveryUrl` in refresh-failure messages.
- Lobby UI uses sealed switches throughout; new `RoomsExpired` panel widget test.

## Test plan

- [x] `flutter analyze` — zero warnings
- [x] `flutter test` — 1453 tests pass
- [x] Auth callback rejects open-redirect targets (constructor + `_safeReturnTo` defense-in-depth)
- [x] Composer drafts persist across an auth round-trip and restore on remount
- [x] Lobby shows `RoomsExpired` panel for a flipped server while other rows stay loaded
- [x] In-flight history fetch is cancelled with reason `'auth expired'` on auth flip
- [x] `PermissionDeniedException` (403) does not funnel through `markSessionExpired`
- [ ] Manual smoke: sign in, force a 401 via token revoke at the IdP, confirm inline re-auth then draft restoration
- [ ] Manual smoke: open two servers, expire one, confirm the other stays usable while the flipped row shows the inline sign-in affordance

🤖 Generated with [Claude Code](https://claude.com/claude-code)