### PR TITLE
fix(auth): replace developer-jargon auth errors with user-actionable copy

### DIFF
--- a/lib/src/modules/auth/auth_failure_description.dart
+++ b/lib/src/modules/auth/auth_failure_description.dart
@@ -1,0 +1,50 @@
+import 'platform/auth_flow.dart';
+
+/// Maps an [AuthFailureKind] (plus optional context) to user-facing
+/// text. Centralised so UI never re-interpolates raw exception fields.
+///
+/// Never returns the raw [oauthError] string — unknown OAuth codes fall
+/// back to a generic retry message. RFC 6749 error codes are
+/// developer-jargon and not safe to display.
+String describeAuthFailure({
+  required AuthFailureKind kind,
+  String? oauthError,
+  String? serverUrl,
+}) {
+  switch (kind) {
+    case AuthFailureKind.cancelled:
+      return 'Sign-in was cancelled.';
+    case AuthFailureKind.discoveryUnreachable:
+      return serverUrl != null
+          ? "Couldn't reach the sign-in server at $serverUrl. "
+              'Check your connection and try again.'
+          : "Couldn't reach the sign-in server. "
+              'Check your connection and try again.';
+    case AuthFailureKind.network:
+      return 'Network problem during sign-in. Check your connection and try again.';
+    case AuthFailureKind.idpRejected:
+      return _describeIdpRejection(oauthError);
+    case AuthFailureKind.noBrowser:
+      return 'No browser is available for sign-in. Install a browser and try again.';
+    case AuthFailureKind.unknown:
+      return 'Sign-in failed. Please try again.';
+  }
+}
+
+String _describeIdpRejection(String? oauthError) {
+  switch (oauthError) {
+    case 'access_denied':
+      return 'The identity provider rejected the sign-in request.';
+    case 'invalid_grant':
+      return 'Your sign-in has expired. Please sign in again.';
+    case 'invalid_client':
+    case 'unauthorized_client':
+      return 'This app is not authorised to sign in with this server. '
+          'Contact your administrator.';
+    case 'invalid_scope':
+      return 'This app requested permissions the server does not allow. '
+          'Contact your administrator.';
+    default:
+      return 'Sign-in was rejected. Please try again.';
+  }
+}

--- a/lib/src/modules/auth/auth_failure_description.dart
+++ b/lib/src/modules/auth/auth_failure_description.dart
@@ -1,7 +1,7 @@
 import 'platform/auth_flow.dart';
 
 /// Maps an [AuthFailureKind] (plus optional context) to user-facing
-/// text. Centralised so UI never re-interpolates raw exception fields.
+/// text. Centralized so UI never re-interpolates raw exception fields.
 ///
 /// Never returns the raw [oauthError] string — unknown OAuth codes fall
 /// back to a generic retry message. RFC 6749 error codes are
@@ -39,7 +39,7 @@ String _describeIdpRejection(String? oauthError) {
       return 'Your sign-in has expired. Please sign in again.';
     case 'invalid_client':
     case 'unauthorized_client':
-      return 'This app is not authorised to sign in with this server. '
+      return 'This app is not authorized to sign in with this server. '
           'Contact your administrator.';
     case 'invalid_scope':
       return 'This app requested permissions the server does not allow. '

--- a/lib/src/modules/auth/connect_flow.dart
+++ b/lib/src/modules/auth/connect_flow.dart
@@ -16,9 +16,26 @@ sealed class ConnectState {
   const ConnectState();
 }
 
+/// A message to show on the URL-input screen.
+sealed class ConnectMessage {
+  const ConnectMessage(this.text);
+  final String text;
+}
+
+/// An alarming failure (network, server rejection, …) — rendered red.
+final class ConnectError extends ConnectMessage {
+  const ConnectError(super.text);
+}
+
+/// A neutral, non-alarming message (sign-in cancelled, session expired) —
+/// rendered without error styling.
+final class ConnectNotice extends ConnectMessage {
+  const ConnectNotice(super.text);
+}
+
 final class UrlInput extends ConnectState {
-  const UrlInput({this.error});
-  final String? error;
+  const UrlInput({this.message});
+  final ConnectMessage? message;
 }
 
 final class Probing extends ConnectState {
@@ -120,14 +137,18 @@ class ConnectFlow {
           }
           _proceedAfterProbe(result, result.providers);
         case ConnectionFailure(:final error, :final attemptedUrls):
-          state.value =
-              UrlInput(error: describeConnectionError(error, attemptedUrls));
+          state.value = UrlInput(
+            message: ConnectError(
+              describeConnectionError(error, attemptedUrls),
+            ),
+          );
       }
     } catch (e, st) {
       debugPrint('ConnectFlow.connect: $e\n$st');
       if (!_isCancelled(gen)) {
-        state.value =
-            UrlInput(error: 'Unexpected error connecting to $url: $e');
+        state.value = UrlInput(
+          message: ConnectError('Unexpected error connecting to $url: $e'),
+        );
       }
     }
   }
@@ -260,14 +281,18 @@ class ConnectFlow {
     } on AuthException catch (e) {
       await PreAuthStateStorage.clear();
       if (!_isCancelled(gen)) {
-        state.value = UrlInput(error: '${probeResult.serverUrl}: ${e.message}');
+        state.value = UrlInput(
+          message: ConnectError('${probeResult.serverUrl}: ${e.message}'),
+        );
       }
     } on Exception catch (e, st) {
       debugPrint('ConnectFlow._authenticate: $e\n$st');
       await PreAuthStateStorage.clear();
       if (!_isCancelled(gen)) {
         state.value = UrlInput(
-          error: 'Authentication with ${probeResult.serverUrl} failed: $e',
+          message: ConnectError(
+            'Authentication with ${probeResult.serverUrl} failed: $e',
+          ),
         );
       }
     }

--- a/lib/src/modules/auth/connect_flow.dart
+++ b/lib/src/modules/auth/connect_flow.dart
@@ -2,6 +2,7 @@ import 'package:flutter/foundation.dart' show debugPrint;
 import 'package:soliplex_agent/soliplex_agent.dart' hide AuthException;
 import 'package:soliplex_agent/soliplex_agent.dart' as agent show AuthException;
 
+import 'auth_failure_description.dart';
 import 'auth_tokens.dart';
 import 'connection_probe.dart';
 import 'consent_notice.dart';
@@ -281,8 +282,15 @@ class ConnectFlow {
     } on AuthException catch (e) {
       await PreAuthStateStorage.clear();
       if (!_isCancelled(gen)) {
+        final description = describeAuthFailure(
+          kind: e.kind,
+          oauthError: e.oauthError,
+          serverUrl: probeResult.serverUrl.toString(),
+        );
         state.value = UrlInput(
-          message: ConnectError('${probeResult.serverUrl}: ${e.message}'),
+          message: e.kind == AuthFailureKind.cancelled
+              ? ConnectNotice(description)
+              : ConnectError(description),
         );
       }
     } on Exception catch (e, st) {
@@ -291,7 +299,7 @@ class ConnectFlow {
       if (!_isCancelled(gen)) {
         state.value = UrlInput(
           message: ConnectError(
-            'Authentication with ${probeResult.serverUrl} failed: $e',
+            describeAuthFailure(kind: AuthFailureKind.unknown),
           ),
         );
       }

--- a/lib/src/modules/auth/platform/auth_flow.dart
+++ b/lib/src/modules/auth/platform/auth_flow.dart
@@ -51,7 +51,7 @@ enum AuthFailureKind {
 class AuthException implements Exception {
   const AuthException(
     this.message, {
-    this.kind = AuthFailureKind.unknown,
+    required this.kind,
     this.oauthError,
   });
 

--- a/lib/src/modules/auth/platform/auth_flow.dart
+++ b/lib/src/modules/auth/platform/auth_flow.dart
@@ -18,14 +18,53 @@ class AuthResult {
   final DateTime? expiresAt;
 }
 
-/// Authentication failure.
+/// Why an OIDC authentication attempt failed.
+///
+/// Distinct from HTTP-level auth errors (those use
+/// `package:soliplex_agent`'s `AuthException`). This taxonomy captures
+/// causes specific to the platform-level OIDC flow — discovery, the
+/// browser handoff, and the token exchange.
+enum AuthFailureKind {
+  /// User dismissed the OAuth browser sheet. Not an error; UI should
+  /// render this as a neutral notice, not a red banner.
+  cancelled,
+
+  /// Discovery doc fetch failed or returned non-JSON.
+  discoveryUnreachable,
+
+  /// Network failure during the auth flow (TLS, DNS, timeout, offline).
+  network,
+
+  /// IdP returned an OAuth error on `/authorize` or `/token`. The
+  /// specific RFC 6749 code is in [AuthException.oauthError].
+  idpRejected,
+
+  /// No installed browser available (Android only).
+  noBrowser,
+
+  /// IdP returned success but no access token, or PKCE/state mismatch,
+  /// or anything we can't classify.
+  unknown,
+}
+
+/// Authentication failure from the platform OIDC flow.
 class AuthException implements Exception {
-  const AuthException(this.message);
+  const AuthException(
+    this.message, {
+    this.kind = AuthFailureKind.unknown,
+    this.oauthError,
+  });
 
   final String message;
+  final AuthFailureKind kind;
+
+  /// Populated when [kind] is [AuthFailureKind.idpRejected]; carries
+  /// the RFC 6749 `error` string (`access_denied`, `invalid_grant`, …).
+  final String? oauthError;
 
   @override
-  String toString() => 'AuthException: $message';
+  String toString() =>
+      'AuthException($kind${oauthError != null ? ', oauthError: $oauthError' : ''}): $message';
 }
 
 /// Thrown when web auth triggers a browser redirect to the IdP.

--- a/lib/src/modules/auth/platform/auth_flow_native.dart
+++ b/lib/src/modules/auth/platform/auth_flow_native.dart
@@ -1,5 +1,6 @@
 import 'dart:developer' as dev;
 
+import 'package:flutter/services.dart';
 import 'package:flutter_appauth/flutter_appauth.dart';
 import 'package:soliplex_agent/soliplex_agent.dart' hide AuthException;
 
@@ -52,7 +53,10 @@ class NativeAuthFlow implements AuthFlow {
 
       final accessToken = result.accessToken;
       if (accessToken == null) {
-        throw const AuthException('IdP returned success but no access token');
+        throw const AuthException(
+          'IdP returned success but no access token',
+          kind: AuthFailureKind.unknown,
+        );
       }
 
       return AuthResult(
@@ -63,12 +67,71 @@ class NativeAuthFlow implements AuthFlow {
       );
     } on AuthException {
       rethrow;
-    } on Exception catch (e, st) {
-      dev.log('NativeAuthFlow.authenticate', error: e, stackTrace: st);
+    } on FlutterAppAuthUserCancelledException catch (e, st) {
+      dev.log('NativeAuthFlow: user cancelled', error: e, stackTrace: st);
+      throw const AuthException(
+        'User cancelled sign-in',
+        kind: AuthFailureKind.cancelled,
+      );
+    } on FlutterAppAuthPlatformException catch (e, st) {
+      dev.log('NativeAuthFlow: platform exception', error: e, stackTrace: st);
+      throw _classifyAppAuth(e);
+    } on PlatformException catch (e, st) {
+      dev.log('NativeAuthFlow: channel exception', error: e, stackTrace: st);
       throw AuthException(
-        'Authentication failed (${e.runtimeType}). Please try again.',
+        'Sign-in channel error: ${e.code}',
+        kind: AuthFailureKind.unknown,
+      );
+    } on Exception catch (e, st) {
+      dev.log('NativeAuthFlow: unexpected', error: e, stackTrace: st);
+      throw const AuthException(
+        'Unexpected sign-in failure',
+        kind: AuthFailureKind.unknown,
       );
     }
+  }
+
+  AuthException _classifyAppAuth(FlutterAppAuthPlatformException e) {
+    final oauthError = e.platformErrorDetails.error;
+    if (oauthError != null && oauthError.isNotEmpty) {
+      return AuthException(
+        'IdP rejected sign-in: $oauthError',
+        kind: AuthFailureKind.idpRejected,
+        oauthError: oauthError,
+      );
+    }
+
+    switch (e.code) {
+      case 'no_browser_available':
+        return const AuthException(
+          'No browser available',
+          kind: AuthFailureKind.noBrowser,
+        );
+      case 'discovery_failed':
+        return const AuthException(
+          'Discovery doc unreachable',
+          kind: AuthFailureKind.discoveryUnreachable,
+        );
+    }
+
+    final domain = e.platformErrorDetails.domain;
+    if (domain != null) {
+      if (domain.startsWith('org.openid.appauth.discovery')) {
+        return const AuthException(
+          'Discovery doc unreachable',
+          kind: AuthFailureKind.discoveryUnreachable,
+        );
+      }
+      if (domain == 'NSURLErrorDomain' ||
+          domain.startsWith('org.openid.appauth.network')) {
+        return const AuthException(
+          'Network failure during sign-in',
+          kind: AuthFailureKind.network,
+        );
+      }
+    }
+
+    return const AuthException('Sign-in failed', kind: AuthFailureKind.unknown);
   }
 
   /// Propagates any [FlutterAppAuth] failure (user cancel, network,

--- a/lib/src/modules/auth/platform/auth_flow_native.dart
+++ b/lib/src/modules/auth/platform/auth_flow_native.dart
@@ -53,6 +53,10 @@ class NativeAuthFlow implements AuthFlow {
 
       final accessToken = result.accessToken;
       if (accessToken == null) {
+        dev.log(
+          'NativeAuthFlow: token exchange succeeded but access token was null',
+          level: 1000,
+        );
         throw const AuthException(
           'IdP returned success but no access token',
           kind: AuthFailureKind.unknown,
@@ -91,6 +95,12 @@ class NativeAuthFlow implements AuthFlow {
     }
   }
 
+  /// Maps a [FlutterAppAuthPlatformException] to an [AuthFailureKind].
+  ///
+  /// Priority order is deliberate: an IdP-returned RFC 6749 `error` is the
+  /// most specific signal (the server told us exactly what was wrong), so it
+  /// wins over the plugin's generic `code` and the iOS-only `domain`. When
+  /// nothing classifies, falls back to [AuthFailureKind.unknown].
   AuthException _classifyAppAuth(FlutterAppAuthPlatformException e) {
     final oauthError = e.platformErrorDetails.error;
     if (oauthError != null && oauthError.isNotEmpty) {

--- a/lib/src/modules/auth/ui/auth_callback_screen.dart
+++ b/lib/src/modules/auth/ui/auth_callback_screen.dart
@@ -43,6 +43,7 @@ class _AuthCallbackScreenState extends ConsumerState<AuthCallbackScreen> {
           _fail('No callback parameters received.');
           return;
         case WebCallbackError(:final error):
+          dev.log('Auth callback returned OAuth error', error: error);
           _fail(describeAuthFailure(
             kind: AuthFailureKind.idpRejected,
             oauthError: error,

--- a/lib/src/modules/auth/ui/auth_callback_screen.dart
+++ b/lib/src/modules/auth/ui/auth_callback_screen.dart
@@ -5,8 +5,10 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 
 import '../../../core/routes.dart';
+import '../auth_failure_description.dart';
 import '../auth_providers.dart';
 import '../auth_tokens.dart';
+import '../platform/auth_flow.dart';
 import '../platform/callback_params.dart';
 import '../pre_auth_state.dart';
 import '../server_entry.dart';
@@ -41,7 +43,10 @@ class _AuthCallbackScreenState extends ConsumerState<AuthCallbackScreen> {
           _fail('No callback parameters received.');
           return;
         case WebCallbackError(:final error):
-          _fail('Authentication failed: $error');
+          _fail(describeAuthFailure(
+            kind: AuthFailureKind.idpRejected,
+            oauthError: error,
+          ));
           return;
         case WebCallbackSuccess():
           break;

--- a/lib/src/modules/auth/ui/home_screen.dart
+++ b/lib/src/modules/auth/ui/home_screen.dart
@@ -221,8 +221,7 @@ class _HomeScreenState extends ConsumerState<HomeScreen> {
   // -- State UIs --
 
   List<Widget> _buildUrlInput(BuildContext context) {
-    final theme = Theme.of(context);
-    final error = (_flow.state.value as UrlInput).error;
+    final message = (_flow.state.value as UrlInput).message;
 
     return [
       ..._buildHeader(context, 'Enter the URL of your backend server'),
@@ -252,32 +251,8 @@ class _HomeScreenState extends ConsumerState<HomeScreen> {
         ),
       ),
       const SizedBox(height: SoliplexSpacing.s4),
-      if (error != null) ...[
-        Container(
-          padding: const EdgeInsets.all(SoliplexSpacing.s3),
-          decoration: BoxDecoration(
-            color: theme.colorScheme.errorContainer,
-            borderRadius: BorderRadius.circular(soliplexRadii.sm),
-          ),
-          child: Row(
-            children: [
-              Icon(
-                Icons.error_outline,
-                color: theme.colorScheme.onErrorContainer,
-                size: 20,
-              ),
-              const SizedBox(width: SoliplexSpacing.s2),
-              Expanded(
-                child: Text(
-                  error,
-                  style: TextStyle(
-                    color: theme.colorScheme.onErrorContainer,
-                  ),
-                ),
-              ),
-            ],
-          ),
-        ),
+      if (message != null) ...[
+        UrlMessageBanner(message: message),
         const SizedBox(height: SoliplexSpacing.s4),
       ],
       FilledButton.icon(
@@ -509,5 +484,53 @@ class _VersionFooter extends StatelessWidget {
         child: const Text('Versions'),
       ),
     );
+  }
+}
+
+/// Renders a [ConnectMessage] on the URL-input screen.
+///
+/// [ConnectError] renders a red error banner with an icon.
+/// [ConnectNotice] renders a quiet neutral message with no container.
+class UrlMessageBanner extends StatelessWidget {
+  const UrlMessageBanner({super.key, required this.message});
+
+  final ConnectMessage message;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return switch (message) {
+      ConnectError(:final text) => Container(
+          padding: const EdgeInsets.all(SoliplexSpacing.s3),
+          decoration: BoxDecoration(
+            color: theme.colorScheme.errorContainer,
+            borderRadius: BorderRadius.circular(soliplexRadii.sm),
+          ),
+          child: Row(
+            children: [
+              Icon(
+                Icons.error_outline,
+                color: theme.colorScheme.onErrorContainer,
+                size: 20,
+              ),
+              const SizedBox(width: SoliplexSpacing.s2),
+              Expanded(
+                child: Text(
+                  text,
+                  style: TextStyle(
+                    color: theme.colorScheme.onErrorContainer,
+                  ),
+                ),
+              ),
+            ],
+          ),
+        ),
+      ConnectNotice(:final text) => Text(
+          text,
+          style: theme.textTheme.bodyMedium?.copyWith(
+            color: theme.colorScheme.onSurfaceVariant,
+          ),
+        ),
+    };
   }
 }

--- a/lib/src/modules/auth/ui/server_list_screen.dart
+++ b/lib/src/modules/auth/ui/server_list_screen.dart
@@ -228,7 +228,7 @@ class _ServerListScreenState extends ConsumerState<ServerListScreen> {
       // Unknown throwable (e.g. a stray Error from a programmer bug).
       // Render a generic one-liner rather than risk dumping a raw
       // toString into the inline error slot.
-      raw = 'Unexpected error (${e.runtimeType})';
+      raw = 'Sign-out failed. Please try again.';
     }
     const limit = 200;
     return raw.length > limit ? '${raw.substring(0, limit - 1)}…' : raw;

--- a/test/modules/auth/auth_failure_description_test.dart
+++ b/test/modules/auth/auth_failure_description_test.dart
@@ -4,7 +4,7 @@ import 'package:soliplex_frontend/src/modules/auth/platform/auth_flow.dart';
 
 void main() {
   group('describeAuthFailure', () {
-    test('cancelled returns neutral copy', () {
+    test('cancelled returns neutral text', () {
       expect(
         describeAuthFailure(kind: AuthFailureKind.cancelled),
         'Sign-in was cancelled.',
@@ -42,7 +42,7 @@ void main() {
       );
     });
 
-    test('idpRejected invalid_grant maps to re-login copy', () {
+    test('idpRejected invalid_grant maps to re-login text', () {
       expect(
         describeAuthFailure(
           kind: AuthFailureKind.idpRejected,
@@ -87,11 +87,12 @@ void main() {
         'output never contains the literal word "Exception" or runtimeType junk',
         () {
       for (final kind in AuthFailureKind.values) {
-        final copy = describeAuthFailure(kind: kind);
-        expect(copy, isNot(contains('Exception')));
-        expect(copy, isNot(contains('runtimeType')));
-        expect(copy, isNot(matches(RegExp(r'\(\w{3,4}\)\.'))),
-            reason: 'Avoid leaking minified type names like "(Nra).": $copy');
+        final description = describeAuthFailure(kind: kind);
+        expect(description, isNot(contains('Exception')));
+        expect(description, isNot(contains('runtimeType')));
+        expect(description, isNot(matches(RegExp(r'\(\w{3,4}\)\.'))),
+            reason:
+                'Avoid leaking minified type names like "(Nra).": $description');
       }
     });
   });

--- a/test/modules/auth/auth_failure_description_test.dart
+++ b/test/modules/auth/auth_failure_description_test.dart
@@ -1,0 +1,98 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:soliplex_frontend/src/modules/auth/auth_failure_description.dart';
+import 'package:soliplex_frontend/src/modules/auth/platform/auth_flow.dart';
+
+void main() {
+  group('describeAuthFailure', () {
+    test('cancelled returns neutral copy', () {
+      expect(
+        describeAuthFailure(kind: AuthFailureKind.cancelled),
+        'Sign-in was cancelled.',
+      );
+    });
+
+    test('discoveryUnreachable includes server URL when provided', () {
+      expect(
+        describeAuthFailure(
+          kind: AuthFailureKind.discoveryUnreachable,
+          serverUrl: 'https://rag.example.net',
+        ),
+        contains('https://rag.example.net'),
+      );
+      expect(
+        describeAuthFailure(kind: AuthFailureKind.discoveryUnreachable),
+        contains('sign-in server'),
+      );
+    });
+
+    test('network is actionable', () {
+      expect(
+        describeAuthFailure(kind: AuthFailureKind.network),
+        contains('connection'),
+      );
+    });
+
+    test('idpRejected access_denied has a friendly message', () {
+      expect(
+        describeAuthFailure(
+          kind: AuthFailureKind.idpRejected,
+          oauthError: 'access_denied',
+        ),
+        'The identity provider rejected the sign-in request.',
+      );
+    });
+
+    test('idpRejected invalid_grant maps to re-login copy', () {
+      expect(
+        describeAuthFailure(
+          kind: AuthFailureKind.idpRejected,
+          oauthError: 'invalid_grant',
+        ),
+        contains('expired'),
+      );
+    });
+
+    test('idpRejected unknown oauthError falls back gracefully', () {
+      expect(
+        describeAuthFailure(
+          kind: AuthFailureKind.idpRejected,
+          oauthError: 'some_future_code',
+        ),
+        'Sign-in was rejected. Please try again.',
+      );
+      expect(
+        describeAuthFailure(
+          kind: AuthFailureKind.idpRejected,
+          oauthError: 'some_future_code',
+        ),
+        isNot(contains('some_future_code')),
+      );
+    });
+
+    test('noBrowser tells user to install a browser', () {
+      expect(
+        describeAuthFailure(kind: AuthFailureKind.noBrowser),
+        contains('browser'),
+      );
+    });
+
+    test('unknown falls back to a clean retry message', () {
+      expect(
+        describeAuthFailure(kind: AuthFailureKind.unknown),
+        'Sign-in failed. Please try again.',
+      );
+    });
+
+    test(
+        'output never contains the literal word "Exception" or runtimeType junk',
+        () {
+      for (final kind in AuthFailureKind.values) {
+        final copy = describeAuthFailure(kind: kind);
+        expect(copy, isNot(contains('Exception')));
+        expect(copy, isNot(contains('runtimeType')));
+        expect(copy, isNot(matches(RegExp(r'\(\w{3,4}\)\.'))),
+            reason: 'Avoid leaking minified type names like "(Nra).": $copy');
+      }
+    });
+  });
+}

--- a/test/modules/auth/connect_flow_cancel_test.dart
+++ b/test/modules/auth/connect_flow_cancel_test.dart
@@ -1,0 +1,111 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:soliplex_agent/soliplex_agent.dart' show AuthProviderConfig;
+
+import 'package:soliplex_frontend/src/modules/auth/auth_session.dart';
+import 'package:soliplex_frontend/src/modules/auth/connect_flow.dart';
+import 'package:soliplex_frontend/src/modules/auth/platform/auth_flow.dart';
+import 'package:soliplex_frontend/src/modules/auth/server_manager.dart';
+
+import '../../helpers/fakes.dart';
+
+const _provider = AuthProviderConfig(
+  id: 'idp-1',
+  name: 'Test IdP',
+  serverUrl: 'https://auth.example.com',
+  clientId: 'test-client',
+  scope: 'openid email profile',
+);
+
+ServerManager _createManager() => ServerManager(
+      authFactory: () => AuthSession(refreshService: FakeTokenRefreshService()),
+      clientFactory: ({getToken, tokenRefresher}) => FakeHttpClient(),
+      storage: InMemoryServerStorage(),
+    );
+
+ConnectFlow _createFlow({required FakeAuthFlow authFlow}) => ConnectFlow(
+      serverManager: _createManager(),
+      probeClient: FakeHttpClient(),
+      discover: (_, __) async => [_provider],
+      authFlow: authFlow,
+    );
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  group('ConnectFlow._authenticate — AuthException routing', () {
+    setUp(() {
+      SharedPreferences.setMockInitialValues({});
+    });
+
+    test(
+      'cancelled → ConnectNotice (not ConnectError), text is cancel copy',
+      () async {
+        final flow = _createFlow(
+          authFlow: FakeAuthFlow()
+            ..nextError = const AuthException(
+              'User cancelled',
+              kind: AuthFailureKind.cancelled,
+            ),
+        );
+
+        await flow.connect('https://server.example.com');
+        await pumpEventQueue();
+
+        final s = flow.state.value as UrlInput;
+        final m = s.message;
+        expect(m, isA<ConnectNotice>());
+        expect((m as ConnectNotice).text, 'Sign-in was cancelled.');
+      },
+    );
+
+    test(
+      'idpRejected with access_denied → ConnectError, copy says rejected, '
+      'raw oauthError not exposed',
+      () async {
+        final flow = _createFlow(
+          authFlow: FakeAuthFlow()
+            ..nextError = const AuthException(
+              'IdP rejected: access_denied',
+              kind: AuthFailureKind.idpRejected,
+              oauthError: 'access_denied',
+            ),
+        );
+
+        await flow.connect('https://server.example.com');
+        await pumpEventQueue();
+
+        final s = flow.state.value as UrlInput;
+        final m = s.message;
+        expect(m, isA<ConnectError>());
+        final text = (m as ConnectError).text;
+        expect(text, contains('rejected the sign-in'));
+        expect(text, isNot(contains('access_denied')));
+      },
+    );
+
+    test(
+      'unknown (generic Exception) → ConnectError, no Exception interpolation '
+      'or raw error code leak',
+      () async {
+        final flow = _createFlow(
+          authFlow: FakeAuthFlow()
+            ..nextError = const AuthException(
+              'Something unexpected (Nra).',
+              kind: AuthFailureKind.unknown,
+            ),
+        );
+
+        await flow.connect('https://server.example.com');
+        await pumpEventQueue();
+
+        final s = flow.state.value as UrlInput;
+        final m = s.message;
+        expect(m, isA<ConnectError>());
+        final text = (m as ConnectError).text;
+        expect(text, isNot(matches(RegExp(r'\(\w{3,4}\)\.'))));
+        expect(text, isNot(contains('Exception')));
+      },
+    );
+  });
+}

--- a/test/modules/auth/connect_flow_cancel_test.dart
+++ b/test/modules/auth/connect_flow_cancel_test.dart
@@ -39,7 +39,7 @@ void main() {
     });
 
     test(
-      'cancelled → ConnectNotice (not ConnectError), text is cancel copy',
+      'cancelled → ConnectNotice (not ConnectError), text is cancel message',
       () async {
         final flow = _createFlow(
           authFlow: FakeAuthFlow()
@@ -60,7 +60,7 @@ void main() {
     );
 
     test(
-      'idpRejected with access_denied → ConnectError, copy says rejected, '
+      'idpRejected with access_denied → ConnectError, text says rejected, '
       'raw oauthError not exposed',
       () async {
         final flow = _createFlow(

--- a/test/modules/auth/connect_flow_cancel_test.dart
+++ b/test/modules/auth/connect_flow_cancel_test.dart
@@ -107,5 +107,26 @@ void main() {
         expect(text, isNot(contains('Exception')));
       },
     );
+
+    test(
+      'discoveryUnreachable → ConnectError mentioning the probed server URL',
+      () async {
+        final flow = _createFlow(
+          authFlow: FakeAuthFlow()
+            ..nextError = const AuthException(
+              'Discovery doc unreachable',
+              kind: AuthFailureKind.discoveryUnreachable,
+            ),
+        );
+
+        await flow.connect('https://server.example.com');
+        await pumpEventQueue();
+
+        final s = flow.state.value as UrlInput;
+        final m = s.message;
+        expect(m, isA<ConnectError>());
+        expect((m as ConnectError).text, contains('server.example.com'));
+      },
+    );
   });
 }

--- a/test/modules/auth/platform/auth_flow_native_mapping_test.dart
+++ b/test/modules/auth/platform/auth_flow_native_mapping_test.dart
@@ -1,0 +1,191 @@
+import 'package:flutter/services.dart';
+import 'package:flutter_appauth/flutter_appauth.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:soliplex_agent/soliplex_agent.dart' hide AuthException;
+import 'package:soliplex_frontend/src/modules/auth/platform/auth_flow.dart';
+import 'package:soliplex_frontend/src/modules/auth/platform/auth_flow_native.dart';
+
+class _MockAppAuth extends Mock implements FlutterAppAuth {}
+
+void main() {
+  late _MockAppAuth appAuth;
+  late NativeAuthFlow flow;
+  const provider = AuthProviderConfig(
+    id: 'idp',
+    name: 'IdP',
+    serverUrl: 'https://idp.example.com',
+    clientId: 'cid',
+    scope: 'openid profile',
+  );
+
+  setUpAll(() {
+    registerFallbackValue(
+      AuthorizationTokenRequest(
+        'id',
+        'app://callback',
+        discoveryUrl: 'https://example.com/.well-known/openid-configuration',
+      ),
+    );
+  });
+
+  setUp(() {
+    appAuth = _MockAppAuth();
+    flow = NativeAuthFlow(appAuth: appAuth, redirectScheme: 'app');
+  });
+
+  Future<AuthException> capture() async {
+    try {
+      await flow.authenticate(provider);
+      fail('expected throw');
+    } on AuthException catch (e) {
+      return e;
+    }
+  }
+
+  group('NativeAuthFlow exception mapping', () {
+    test('FlutterAppAuthUserCancelledException → cancelled', () async {
+      when(() => appAuth.authorizeAndExchangeCode(any())).thenThrow(
+        FlutterAppAuthUserCancelledException(
+          code: 'user_cancelled',
+          message: 'cancelled',
+          platformErrorDetails: FlutterAppAuthPlatformErrorDetails(),
+        ),
+      );
+      final e = await capture();
+      expect(e.kind, AuthFailureKind.cancelled);
+    });
+
+    test('FlutterAppAuthPlatformException no_browser_available → noBrowser',
+        () async {
+      when(() => appAuth.authorizeAndExchangeCode(any())).thenThrow(
+        FlutterAppAuthPlatformException(
+          code: 'no_browser_available',
+          message: 'no browser',
+          platformErrorDetails: FlutterAppAuthPlatformErrorDetails(),
+        ),
+      );
+      final e = await capture();
+      expect(e.kind, AuthFailureKind.noBrowser);
+    });
+
+    test(
+        'FlutterAppAuthPlatformException discovery_failed → discoveryUnreachable',
+        () async {
+      when(() => appAuth.authorizeAndExchangeCode(any())).thenThrow(
+        FlutterAppAuthPlatformException(
+          code: 'discovery_failed',
+          message: 'failed',
+          platformErrorDetails: FlutterAppAuthPlatformErrorDetails(),
+        ),
+      );
+      final e = await capture();
+      expect(e.kind, AuthFailureKind.discoveryUnreachable);
+    });
+
+    test(
+        'authorize_and_exchange_code_failed + discovery domain → discoveryUnreachable',
+        () async {
+      when(() => appAuth.authorizeAndExchangeCode(any())).thenThrow(
+        FlutterAppAuthPlatformException(
+          code: 'authorize_and_exchange_code_failed',
+          platformErrorDetails: FlutterAppAuthPlatformErrorDetails(
+            domain: 'org.openid.appauth.discovery',
+            code: '0',
+          ),
+        ),
+      );
+      final e = await capture();
+      expect(e.kind, AuthFailureKind.discoveryUnreachable);
+    });
+
+    test('authorize_and_exchange_code_failed + NSURLErrorDomain → network',
+        () async {
+      when(() => appAuth.authorizeAndExchangeCode(any())).thenThrow(
+        FlutterAppAuthPlatformException(
+          code: 'authorize_and_exchange_code_failed',
+          platformErrorDetails: FlutterAppAuthPlatformErrorDetails(
+            domain: 'NSURLErrorDomain',
+            code: '-1009',
+          ),
+        ),
+      );
+      final e = await capture();
+      expect(e.kind, AuthFailureKind.network);
+    });
+
+    test('authorize_failed + OAuth error → idpRejected with oauthError',
+        () async {
+      when(() => appAuth.authorizeAndExchangeCode(any())).thenThrow(
+        FlutterAppAuthPlatformException(
+          code: 'authorize_failed',
+          platformErrorDetails: FlutterAppAuthPlatformErrorDetails(
+            error: 'access_denied',
+            errorDescription: 'user denied',
+          ),
+        ),
+      );
+      final e = await capture();
+      expect(e.kind, AuthFailureKind.idpRejected);
+      expect(e.oauthError, 'access_denied');
+    });
+
+    test('token_failed + OAuth error → idpRejected with oauthError', () async {
+      when(() => appAuth.authorizeAndExchangeCode(any())).thenThrow(
+        FlutterAppAuthPlatformException(
+          code: 'token_failed',
+          platformErrorDetails: FlutterAppAuthPlatformErrorDetails(
+            error: 'invalid_grant',
+          ),
+        ),
+      );
+      final e = await capture();
+      expect(e.kind, AuthFailureKind.idpRejected);
+      expect(e.oauthError, 'invalid_grant');
+    });
+
+    test('PlatformException (channel error) → unknown', () async {
+      when(() => appAuth.authorizeAndExchangeCode(any())).thenThrow(
+        PlatformException(code: 'channel_error'),
+      );
+      final e = await capture();
+      expect(e.kind, AuthFailureKind.unknown);
+    });
+
+    test('FormatException → unknown', () async {
+      when(() => appAuth.authorizeAndExchangeCode(any())).thenThrow(
+        const FormatException('unexpected'),
+      );
+      final e = await capture();
+      expect(e.kind, AuthFailureKind.unknown);
+    });
+
+    test('message does not contain runtimeType pattern', () async {
+      when(() => appAuth.authorizeAndExchangeCode(any())).thenThrow(
+        const FormatException('boom'),
+      );
+      final e = await capture();
+      expect(e.message, isNot(contains('runtimeType')));
+      expect(e.message, isNot(matches(RegExp(r'\(\w{3,4}\)\.'))));
+    });
+
+    test('null access token → unknown with "no access token" in message',
+        () async {
+      when(() => appAuth.authorizeAndExchangeCode(any())).thenAnswer(
+        (_) async => AuthorizationTokenResponse(
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+        ),
+      );
+      final e = await capture();
+      expect(e.kind, AuthFailureKind.unknown);
+      expect(e.message, contains('no access token'));
+    });
+  });
+}

--- a/test/modules/auth/platform/auth_flow_test.dart
+++ b/test/modules/auth/platform/auth_flow_test.dart
@@ -4,7 +4,10 @@ import 'package:soliplex_frontend/src/modules/auth/platform/auth_flow.dart';
 void main() {
   group('AuthException', () {
     test('toString includes kind and message', () {
-      const error = AuthException('something failed');
+      const error = AuthException(
+        'something failed',
+        kind: AuthFailureKind.unknown,
+      );
       expect(
         error.toString(),
         'AuthException(AuthFailureKind.unknown): something failed',

--- a/test/modules/auth/platform/auth_flow_test.dart
+++ b/test/modules/auth/platform/auth_flow_test.dart
@@ -3,9 +3,24 @@ import 'package:soliplex_frontend/src/modules/auth/platform/auth_flow.dart';
 
 void main() {
   group('AuthException', () {
-    test('toString includes message', () {
+    test('toString includes kind and message', () {
       const error = AuthException('something failed');
-      expect(error.toString(), 'AuthException: something failed');
+      expect(
+        error.toString(),
+        'AuthException(AuthFailureKind.unknown): something failed',
+      );
+    });
+
+    test('toString includes oauthError when present', () {
+      const error = AuthException(
+        'IdP rejected',
+        kind: AuthFailureKind.idpRejected,
+        oauthError: 'access_denied',
+      );
+      expect(
+        error.toString(),
+        'AuthException(AuthFailureKind.idpRejected, oauthError: access_denied): IdP rejected',
+      );
     });
   });
 

--- a/test/modules/auth/ui/auth_callback_screen_test.dart
+++ b/test/modules/auth/ui/auth_callback_screen_test.dart
@@ -115,7 +115,40 @@ void main() {
       ));
       await tester.pumpAndSettle();
 
-      expect(find.textContaining('access_denied'), findsOneWidget);
+      expect(
+        find.text('The identity provider rejected the sign-in request.'),
+        findsOneWidget,
+      );
+      expect(find.textContaining('access_denied'), findsNothing);
+    });
+
+    testWidgets('shows friendly message for invalid_grant error',
+        (tester) async {
+      final serverManager = _createServerManager();
+      await tester.pumpWidget(_buildApp(
+        serverManager: serverManager,
+        callbackParams: const WebCallbackError(error: 'invalid_grant'),
+      ));
+      await tester.pumpAndSettle();
+
+      expect(find.textContaining('expired'), findsOneWidget);
+      expect(find.textContaining('invalid_grant'), findsNothing);
+    });
+
+    testWidgets('shows generic message for unknown OAuth error code',
+        (tester) async {
+      final serverManager = _createServerManager();
+      await tester.pumpWidget(_buildApp(
+        serverManager: serverManager,
+        callbackParams: const WebCallbackError(error: 'some_unknown_code'),
+      ));
+      await tester.pumpAndSettle();
+
+      expect(
+        find.text('Sign-in was rejected. Please try again.'),
+        findsOneWidget,
+      );
+      expect(find.textContaining('some_unknown_code'), findsNothing);
     });
 
     testWidgets('shows error when no pre-auth state saved', (tester) async {

--- a/test/modules/auth/ui/server_list_screen_test.dart
+++ b/test/modules/auth/ui/server_list_screen_test.dart
@@ -17,6 +17,10 @@ import 'package:soliplex_frontend/src/modules/auth/ui/server_list_screen.dart';
 
 import '../../../helpers/fakes.dart';
 
+/// A bare [Error] (not an [Exception]) used to exercise the else-branch of
+/// [_friendlyLogoutError] without leaking a runtime type name.
+class _LogoutBoom extends Error {}
+
 ServerManager _createServerManager() => ServerManager(
       authFactory: () => AuthSession(
         refreshService: FakeTokenRefreshService(),
@@ -575,6 +579,53 @@ void main() {
       await tester.pumpAndSettle();
 
       expect(entry.auth.isAuthenticated, isFalse);
+    });
+
+    testWidgets(
+        'logout Error (non-Exception) shows generic message without type name',
+        (tester) async {
+      final serverManager = _createServerManager();
+      final entry = serverManager.addServer(
+        serverId: 'test',
+        serverUrl: Uri.parse('https://api.example.com'),
+      );
+      _loginEntry(entry);
+
+      final discoveryJson = jsonEncode({
+        'token_endpoint': 'https://sso.example.com/token',
+        'end_session_endpoint': 'https://sso.example.com/logout',
+      });
+      final probeClient = FakeHttpClient()
+        ..onRequest = (method, uri) async {
+          return HttpResponse(
+            statusCode: 200,
+            bodyBytes: Uint8List.fromList(utf8.encode(discoveryJson)),
+          );
+        };
+
+      final authFlow = RecordingAuthFlow(
+        onEndSession: () => throw _LogoutBoom(),
+      );
+
+      await tester.pumpWidget(_buildApp(
+        serverManager: serverManager,
+        authFlow: authFlow,
+        probeClient: probeClient,
+      ));
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.text('Log out'));
+      await tester.pumpAndSettle();
+
+      expect(entry.auth.isAuthenticated, isTrue);
+      expect(find.textContaining('Log out failed:'), findsOneWidget);
+      expect(
+        find.text('Log out failed: Sign-out failed. Please try again.'),
+        findsOneWidget,
+      );
+      // Ensure no minified/raw runtime type name leaks (e.g. "(Nra)" or
+      // "(_LogoutBoom)").
+      expect(find.textContaining(RegExp(r'\(\w{3,}\)')), findsNothing);
     });
 
     testWidgets('logout on non-active session skips IdP round-trip',

--- a/test/modules/auth/ui/url_message_banner_test.dart
+++ b/test/modules/auth/ui/url_message_banner_test.dart
@@ -1,0 +1,46 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:soliplex_frontend/src/modules/auth/connect_flow.dart';
+import 'package:soliplex_frontend/src/modules/auth/ui/home_screen.dart';
+
+Widget _wrap(Widget child) => MaterialApp(
+      home: Scaffold(body: child),
+    );
+
+void main() {
+  group('UrlMessageBanner', () {
+    testWidgets('ConnectError shows text, error icon, and error container',
+        (tester) async {
+      late ThemeData theme;
+
+      await tester.pumpWidget(
+        _wrap(
+          Builder(
+            builder: (context) {
+              theme = Theme.of(context);
+              return UrlMessageBanner(message: const ConnectError('Boom'));
+            },
+          ),
+        ),
+      );
+
+      expect(find.text('Boom'), findsOneWidget);
+      expect(find.byIcon(Icons.error_outline), findsOneWidget);
+
+      final container = tester.widget<Container>(find.byType(Container).first);
+      final decoration = container.decoration! as BoxDecoration;
+      expect(decoration.color, equals(theme.colorScheme.errorContainer));
+    });
+
+    testWidgets('ConnectNotice shows text, no icon, no error container',
+        (tester) async {
+      await tester.pumpWidget(
+        _wrap(UrlMessageBanner(message: const ConnectNotice('Heads up'))),
+      );
+
+      expect(find.text('Heads up'), findsOneWidget);
+      expect(find.byIcon(Icons.error_outline), findsNothing);
+      expect(find.byType(Container), findsNothing);
+    });
+  });
+}


### PR DESCRIPTION
## Summary

Replaces auth error messages that leaked developer detail — most visibly the release-mode `Authentication failed (Nra). Please try again.` from a minified `e.runtimeType` — with user-actionable copy across every auth surface, and treats user-cancel as a neutral notice rather than a red error.

**Architecture:** an `AuthFailureKind` taxonomy on the platform-layer `AuthException`. Raw failures are classified into that taxonomy *at the boundary where they originate* (native `flutter_appauth` exceptions; web OAuth `error` codes); the UI selects copy by kind via one centralized helper (`describeAuthFailure`) and never re-interpolates exception fields.

### What changed, by surface

- **Native flow** (`auth_flow_native.dart`): replaced `Authentication failed (${e.runtimeType})` with a classifier mapping `flutter_appauth` exceptions (user-cancel, no-browser, discovery, network, IdP-returned OAuth error) into `AuthFailureKind`.
- **Copy** (`auth_failure_description.dart`): single `describeAuthFailure({kind, oauthError, serverUrl})` — never echoes the raw RFC 6749 code; unknown codes fall back to a clean retry message.
- **Connect flow** (`connect_flow.dart`): routes `AuthException` through the helper; user-cancel now renders as a neutral `ConnectNotice` instead of a red banner.
- **UrlInput model**: `UrlInput` now carries a sealed `ConnectMessage` (`ConnectError | ConnectNotice`) instead of two mutually-exclusive nullable fields + a runtime assert; rendering extracted into a testable `UrlMessageBanner` widget.
- **Web callback** (`auth_callback_screen.dart`): maps OAuth error codes to friendly copy via the same helper instead of showing the raw code.
- **Logout** (`server_list_screen.dart`): removed the `Unexpected error (${e.runtimeType})` leak in the unknown-throwable fallback (full detail is still logged at the catch site).

### Notes

- **Session-expired UX (original Task 7) intentionally not included.** The route guard already redirects an expired server to its sign-in screen, which auto-reconnects — a seamless re-auth that makes a separate "session expired" banner redundant. Dropped after review.
- Manual on-device verification on a **release** build is still recommended before merge, since the original bug only reproduced under release tree-shaking.

## Test plan

- [x] `flutter analyze` — zero warnings
- [x] Full suite green (1537 tests), incl. new coverage:
  - `auth_flow_native_mapping_test.dart` — every classifier branch + regression guards (no `runtimeType`, no `(Nra).` pattern)
  - `auth_failure_description_test.dart` — copy per kind + never leaks raw codes
  - `connect_flow_cancel_test.dart` — cancel→notice, idpRejected→error, no leak
  - `url_message_banner_test.dart` — error vs notice rendering
  - `auth_callback_screen_test.dart` — web OAuth codes → friendly copy (flipped a test that previously asserted the raw code was shown)
  - `server_list_screen_test.dart` — logout `Error` shows generic copy, no type-name leak
- [ ] Manual device verification on a release IPA: cancel sheet → neutral notice; discovery 404 → reachability error; airplane mode → network error; IdP `access_denied` → friendly rejection copy

🤖 Generated with [Claude Code](https://claude.com/claude-code)