### PR TITLE
chore: resolve dependencies (ag_ui upstream, signals/secure_storage bumps, CI Flutter pin)

### DIFF
--- a/.github/actions/setup-dart-env/action.yaml
+++ b/.github/actions/setup-dart-env/action.yaml
@@ -28,4 +28,10 @@ runs:
     - name: Install dependencies
       working-directory: ${{ inputs.working-directory }}
       shell: bash
+      # The ag_ui git dependency lives in a repo that LFS-tracks binary
+      # assets we don't use; one of its LFS objects is missing upstream,
+      # which aborts the clone during pub get. We consume only the pure
+      # Dart sources (not LFS-tracked), so skip the LFS smudge filter.
+      env:
+        GIT_LFS_SKIP_SMUDGE: "1"
       run: ${{ inputs.runner }} pub get

--- a/.github/actions/setup-dart-env/action.yaml
+++ b/.github/actions/setup-dart-env/action.yaml
@@ -13,6 +13,7 @@ runs:
     - name: Setup Flutter
       uses: subosito/flutter-action@v2
       with:
+        flutter-version: 3.38.7
         channel: stable
         cache: true
 

--- a/docs/developer-setup.md
+++ b/docs/developer-setup.md
@@ -4,7 +4,7 @@ Platform-specific setup instructions for building and running Soliplex.
 
 ## Prerequisites
 
-- Flutter SDK (stable channel, >=3.27.0)
+- Flutter SDK (stable channel, >=3.38.4; CI builds with 3.38.7)
 - Xcode (for iOS/macOS)
 - CocoaPods (`gem install cocoapods`)
 - Android Studio (for Android)
@@ -12,12 +12,22 @@ Platform-specific setup instructions for building and running Soliplex.
 ## Quick Start
 
 ```bash
+# The ag_ui dependency is fetched from a Git LFS-enabled repo whose
+# binary assets we don't use, and one of its LFS objects is missing
+# upstream — which aborts the clone during pub get. We need only its
+# pure Dart sources (not LFS-tracked), so skip the LFS smudge filter:
+export GIT_LFS_SKIP_SMUDGE=1
+
 # Install dependencies
 flutter pub get
 
 # Run the app
 flutter run -d macos   # or: -d ios, -d chrome, -d android
 ```
+
+Add `export GIT_LFS_SKIP_SMUDGE=1` to your shell profile (`~/.zshrc`,
+`~/.bashrc`) so it persists. CI sets this automatically for its
+`pub get` step.
 
 ## Platform Setup
 

--- a/packages/soliplex_agent/CLAUDE.md
+++ b/packages/soliplex_agent/CLAUDE.md
@@ -57,9 +57,12 @@ lib/src/
 
 ## Dependencies
 
-- `soliplex_client` -- REST API, AG-UI client, domain models
-- `ag_ui` -- AG-UI protocol types (events, tool definitions)
+- `soliplex_client` -- REST API, AG-UI client, domain models, and the
+  AG-UI protocol types (events, tool definitions) re-exported from its
+  barrel
 - `soliplex_logging` -- structured logging
+- `signals_core` -- reactive signals for session and run state
+- `collection` -- collection utilities
 - `meta` -- annotations
 
 ## Rules

--- a/packages/soliplex_agent/pubspec.yaml
+++ b/packages/soliplex_agent/pubspec.yaml
@@ -10,7 +10,7 @@ environment:
 dependencies:
   collection: ^1.18.0
   meta: ^1.9.0
-  signals_core: ^6.2.0
+  signals_core: ^6.3.1
   soliplex_client:
     path: ../soliplex_client
   soliplex_logging:

--- a/packages/soliplex_agent/pubspec.yaml
+++ b/packages/soliplex_agent/pubspec.yaml
@@ -8,10 +8,6 @@ environment:
   sdk: ^3.6.0
 
 dependencies:
-  ag_ui:
-    git:
-      url: https://github.com/soliplex/ag-ui.git
-      path: sdks/community/dart
   collection: ^1.18.0
   meta: ^1.9.0
   signals_core: ^6.2.0

--- a/packages/soliplex_agent/test/runtime/bridge_base_event_test.dart
+++ b/packages/soliplex_agent/test/runtime/bridge_base_event_test.dart
@@ -1,6 +1,6 @@
-import 'package:ag_ui/ag_ui.dart';
 import 'package:soliplex_agent/src/orchestration/execution_event.dart';
 import 'package:soliplex_agent/src/runtime/agent_session.dart';
+import 'package:soliplex_client/soliplex_client.dart';
 import 'package:test/test.dart';
 
 void main() {

--- a/packages/soliplex_client/pubspec.yaml
+++ b/packages/soliplex_client/pubspec.yaml
@@ -15,7 +15,7 @@ dependencies:
   collection: ^1.19.1
   http: ^1.2.0
   meta: ^1.9.0
-  signals_core: ^6.2.0
+  signals_core: ^6.3.1
   soliplex_logging:
     path: ../soliplex_logging
 

--- a/packages/soliplex_client/pubspec.yaml
+++ b/packages/soliplex_client/pubspec.yaml
@@ -10,7 +10,7 @@ environment:
 dependencies:
   ag_ui:
     git:
-      url: https://github.com/soliplex/ag-ui.git
+      url: https://github.com/ag-ui-protocol/ag-ui.git
       path: sdks/community/dart
   collection: ^1.19.1
   http: ^1.2.0

--- a/packages/soliplex_client_native/pubspec.yaml
+++ b/packages/soliplex_client_native/pubspec.yaml
@@ -6,7 +6,7 @@ resolution: workspace
 
 environment:
   sdk: ^3.6.0
-  flutter: '>=3.10.0'
+  flutter: '>=3.38.4'
 
 dependencies:
   cupertino_http: ^2.0.0

--- a/packages/soliplex_design/pubspec.yaml
+++ b/packages/soliplex_design/pubspec.yaml
@@ -6,7 +6,7 @@ resolution: workspace
 
 environment:
   sdk: ^3.6.0
-  flutter: '>=3.27.0'
+  flutter: '>=3.38.4'
 
 dependencies:
   flutter:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -14,8 +14,8 @@ packages:
     description:
       path: "sdks/community/dart"
       ref: HEAD
-      resolved-ref: "29ae5b90c763ef4df3117b8e6f3b863755f41e7e"
-      url: "https://github.com/soliplex/ag-ui.git"
+      resolved-ref: "282291ea436a3d7d77b09fe690cb8309b9cd3a7b"
+      url: "https://github.com/ag-ui-protocol/ag-ui.git"
     source: git
     version: "0.1.0"
   analyzer:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -307,26 +307,26 @@ packages:
     dependency: "direct main"
     description:
       name: flutter_secure_storage
-      sha256: "6848263f9744072d0977347c383fb8b57d9780319a6bf5238b5a2866a029de62"
+      sha256: "7686b1d6a29985dcbb808c59518226e603e3bfa7c0ddfd1a0d00e4cda77c868e"
       url: "https://pub.dev"
     source: hosted
-    version: "10.2.0"
+    version: "10.3.1"
   flutter_secure_storage_darwin:
     dependency: transitive
     description:
       name: flutter_secure_storage_darwin
-      sha256: "67cd1ff671add31dc13e45194398187a04bb63804b37fa47866afae296d73fcb"
+      sha256: "82329fa5cdf343773b1b6897dea959105a29f092454259edff92f9f6637e8149"
       url: "https://pub.dev"
     source: hosted
-    version: "0.3.1"
+    version: "0.3.2"
   flutter_secure_storage_linux:
     dependency: transitive
     description:
       name: flutter_secure_storage_linux
-      sha256: "2b5c76dce569ab752d55a1cee6a2242bcc11fdba927078fb88c503f150767cda"
+      sha256: a5f35ddab43cf5c8215d2feb4ce1957851f28c5c37e6f04335066a0602087bf5
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.0"
+    version: "3.0.1"
   flutter_secure_storage_platform_interface:
     dependency: transitive
     description:
@@ -749,10 +749,10 @@ packages:
     dependency: transitive
     description:
       name: preact_signals
-      sha256: ad45313c86b2228536a16d3dfc86da8263705d4acb4136c42907378de6910d8c
+      sha256: "0cd9262527732f1d9760e3fed1e407630e893c49e48229ff3f007daf357dbb1e"
       url: "https://pub.dev"
     source: hosted
-    version: "1.9.4"
+    version: "6.3.1"
   provider:
     dependency: transitive
     description:
@@ -877,18 +877,18 @@ packages:
     dependency: transitive
     description:
       name: signals_core
-      sha256: ea427bd53619e69e6f6cf244177e3b72870e433065c807600fb496fd80611c9f
+      sha256: abed6049b557da5b4e9c41715fd67bcc1a032dcc1ec147a9f228c2acf34ee151
       url: "https://pub.dev"
     source: hosted
-    version: "6.2.1"
+    version: "6.3.1"
   signals_flutter:
     dependency: "direct main"
     description:
       name: signals_flutter
-      sha256: "7c83418f47e3538685217e583f0fbd17a29716fa1a9ce2247e2455786e8ea81a"
+      sha256: "018625c022925fd1b586ae9f4aec670cdc94ba4fe117ec73cd6a945359529113"
       url: "https://pub.dev"
     source: hosted
-    version: "6.3.0"
+    version: "6.3.1"
   sky_engine:
     dependency: transitive
     description: flutter

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -7,7 +7,7 @@ version: 0.87.0+55
 
 environment:
   sdk: ^3.6.0
-  flutter: ">=3.27.0"
+  flutter: ">=3.38.4"
 
 workspace:
   - packages/soliplex_agent
@@ -25,13 +25,13 @@ dependencies:
   flutter_markdown_plus: ^1.0.7
   flutter_markdown_plus_latex: ^1.0.5
   flutter_riverpod: ^3.1.0
-  flutter_secure_storage: ^10.1.0
+  flutter_secure_storage: ^10.3.0
   flutter_svg: ^2.3.0
   go_router: ^17.2.3
   markdown: ^7.0.0
   package_info_plus: ^9.0.1
   shared_preferences: ^2.5.5
-  signals_flutter: ^6.3.0
+  signals_flutter: ^6.3.1
   file_picker: ^11.0.0
   mime: ^2.0.0
   url_launcher: ^6.3.1


### PR DESCRIPTION
## Summary

Dependency and CI-configuration hygiene. No application logic changes.

- **Source `ag_ui` from upstream, pinned in one place.** Switch the `ag_ui` git dependency from the `soliplex/ag-ui` fork to upstream `ag-ui-protocol/ag-ui` (the fork's Dart `lib/` was byte-identical to upstream). Drop the now-redundant direct `ag_ui` dep from `soliplex_agent` — it consumes ag_ui types via `soliplex_client`'s barrel re-export, so `soliplex_client` is now the single pin site. The one direct ag_ui import (in a test) is rerouted through the barrel.
- **Pin CI Flutter to 3.38.7.** `setup-dart-env` previously tracked the floating `stable` channel; pin it to the SDK the committed lockfile is generated on (and that devs run) to eliminate CI-vs-local lockfile churn.
- **Bump dependencies:** `signals_core`/`signals_flutter` → 6.3.1, `flutter_secure_storage` → 10.3.0 (resolves 10.3.1; darwin 0.3.2, linux 3.0.1). All minor/patch.
- **Correct the declared Flutter floor** to `>=3.38.4` across the app and Flutter packages, matching the minimum the resolved lock already requires (the prior `>=3.27.0` / `>=3.10.0` floors were stale/unsatisfiable).
- **Docs:** correct `soliplex_agent`'s dependency list.

## Notes for reviewers

- **`preact_signals` jumps 1.9.4 → 6.3.1 in the lock.** This is not a real major bump — the signals ecosystem realigned `preact_signals` versioning to track `signals_core` 6.x, and `signals_core 6.3.1` requires `preact_signals ^6.3.1`. It's purely transitive; we import it nowhere.
- **`flutter_secure_storage` 10.3.0 keychain change is a no-op for us.** The `kSecUseDataProtectionKeychain` change is macOS-only and behaves identically for the default options we use (`const FlutterSecureStorage()`), so no token loss / forced re-login.
- **Deferred:** the Dart `sdk` floor stays `^3.6.0` even though the lock requires `>=3.10.3`. Bumping it raises the language version to 3.10, which triggers a whole-repo tall-style reformat + new lints under `--fatal-infos`. That Dart-3.10 migration is intentionally left to its own PR.

## Supersedes

Replaces dependabot PRs #270, #271, #272 (their bumps are included here, with a lockfile generated on the pinned Flutter so there's no SDK-pinned-package churn).

## Verification

- `flutter analyze --fatal-infos` — clean
- `dart format --set-exit-if-changed .` — 0 changed
- App tests 1510 pass; `soliplex_client` 1483 pass (only backend-dependent integration tests fail with connection-refused); `soliplex_agent` non-integration 477 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)