### PR TITLE
refactor(auth): adopt SoliplexButton across auth UI and async dialog

### DIFF
--- a/lib/src/modules/auth/ui/auth_callback_screen.dart
+++ b/lib/src/modules/auth/ui/auth_callback_screen.dart
@@ -158,7 +158,7 @@ class _AuthCallbackScreenState extends ConsumerState<AuthCallbackScreen> {
               const SizedBox(height: SoliplexSpacing.s4),
               Text(_error ?? 'An error occurred'),
               const SizedBox(height: SoliplexSpacing.s4),
-              FilledButton(
+              SoliplexButton.filled(
                 onPressed: () => context.go(AppRoutes.home),
                 child: const Text('Back to home'),
               ),

--- a/lib/src/modules/auth/ui/home_screen.dart
+++ b/lib/src/modules/auth/ui/home_screen.dart
@@ -255,10 +255,10 @@ class _HomeScreenState extends ConsumerState<HomeScreen> {
         UrlMessageBanner(message: message),
         const SizedBox(height: SoliplexSpacing.s4),
       ],
-      FilledButton.icon(
+      SoliplexButton.filled(
         onPressed: _connect,
         icon: const Icon(Icons.login),
-        label: const Text('Connect'),
+        child: const Text('Connect'),
       ),
     ];
   }
@@ -290,12 +290,12 @@ class _HomeScreenState extends ConsumerState<HomeScreen> {
       Row(
         mainAxisAlignment: MainAxisAlignment.center,
         children: [
-          OutlinedButton(
+          SoliplexButton.outlined(
             onPressed: _flow.reset,
             child: const Text('Cancel'),
           ),
           const SizedBox(width: SoliplexSpacing.s4),
-          FilledButton(
+          SoliplexButton.filled(
             onPressed: _flow.acceptInsecure,
             child: const Text('Connect anyway'),
           ),
@@ -319,12 +319,12 @@ class _HomeScreenState extends ConsumerState<HomeScreen> {
       Row(
         mainAxisAlignment: MainAxisAlignment.center,
         children: [
-          OutlinedButton(
+          SoliplexButton.outlined(
             onPressed: _flow.reset,
             child: const Text('Cancel'),
           ),
           const SizedBox(width: SoliplexSpacing.s4),
-          FilledButton(
+          SoliplexButton.filled(
             onPressed: _flow.acknowledgeConsent,
             child: Text(notice.acknowledgmentLabel),
           ),
@@ -347,13 +347,13 @@ class _HomeScreenState extends ConsumerState<HomeScreen> {
       for (final provider in providers)
         Padding(
           padding: const EdgeInsets.only(bottom: SoliplexSpacing.s2),
-          child: FilledButton(
+          child: SoliplexButton.filled(
             onPressed: () => _flow.selectProvider(provider),
             child: Text(provider.name),
           ),
         ),
       const SizedBox(height: SoliplexSpacing.s2),
-      TextButton(
+      SoliplexButton.text(
         onPressed: _flow.reset,
         child: const Text('Change server'),
       ),
@@ -410,7 +410,7 @@ class _HomeScreenState extends ConsumerState<HomeScreen> {
         ),
       Align(
         alignment: Alignment.centerRight,
-        child: TextButton(
+        child: SoliplexButton.text(
           onPressed: () => context.push(AppRoutes.servers),
           child: Text('All servers ($connectedCount connected)'),
         ),
@@ -432,7 +432,7 @@ class _HomeScreenState extends ConsumerState<HomeScreen> {
         ),
       if (hiddenCount > 0)
         Center(
-          child: TextButton(
+          child: SoliplexButton.text(
             onPressed: () => setState(() => _showAllServers = true),
             child: Text('Show $hiddenCount more'),
           ),
@@ -479,7 +479,7 @@ class _VersionFooter extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Center(
-      child: TextButton(
+      child: SoliplexButton.text(
         onPressed: () => context.push(AppRoutes.versions),
         child: const Text('Versions'),
       ),

--- a/lib/src/modules/auth/ui/server_list_screen.dart
+++ b/lib/src/modules/auth/ui/server_list_screen.dart
@@ -62,12 +62,12 @@ class _ServerListScreenState extends ConsumerState<ServerListScreen> {
         title: const Text('Servers'),
         automaticallyImplyLeading: false,
         actions: [
-          TextButton(
+          SoliplexButton.text(
             onPressed: () => context.go(AppRoutes.home),
             child: const Text('Home'),
           ),
           if (connected.isNotEmpty)
-            TextButton(
+            SoliplexButton.text(
               onPressed: () => context.go(AppRoutes.lobby),
               child: const Text('Lobby'),
             ),
@@ -113,17 +113,10 @@ class _ServerListScreenState extends ConsumerState<ServerListScreen> {
             mainAxisSize: MainAxisSize.min,
             children: [
               if (entry.requiresAuth)
-                TextButton(
-                  onPressed: inFlight
-                      ? null
-                      : () => _runLogout(entry, removeAfter: false),
-                  child: inFlight
-                      ? const SizedBox(
-                          width: SoliplexSpacing.s4,
-                          height: SoliplexSpacing.s4,
-                          child: CircularProgressIndicator(strokeWidth: 2),
-                        )
-                      : const Text('Log out'),
+                SoliplexButton.text(
+                  onPressed: () => _runLogout(entry, removeAfter: false),
+                  isLoading: inFlight,
+                  child: const Text('Log out'),
                 ),
               IconButton(
                 icon: Icon(
@@ -163,7 +156,7 @@ class _ServerListScreenState extends ConsumerState<ServerListScreen> {
       trailing: Row(
         mainAxisSize: MainAxisSize.min,
         children: [
-          TextButton(
+          SoliplexButton.text(
             onPressed: () => context.go(
               AppRoutes.homeWithUrl(entry.serverUrl.toString()),
             ),

--- a/lib/src/modules/room/ui/async_action_dialog.dart
+++ b/lib/src/modules/room/ui/async_action_dialog.dart
@@ -95,29 +95,17 @@ class _AsyncActionDialogState extends State<AsyncActionDialog> {
         ],
       ),
       actions: [
-        TextButton(
+        SoliplexButton.text(
           onPressed: _busy ? null : () => Navigator.pop(context),
           child: const Text('Cancel'),
         ),
-        if (_busy)
-          const Padding(
-            padding: EdgeInsets.symmetric(horizontal: SoliplexSpacing.s4),
-            child: SizedBox(
-              width: 16,
-              height: 16,
-              child: CircularProgressIndicator(strokeWidth: 2),
-            ),
-          )
-        else
-          TextButton(
-            onPressed: widget.canSubmit ? _run : null,
-            style: widget.isDestructive
-                ? TextButton.styleFrom(
-                    foregroundColor: theme.colorScheme.error,
-                  )
-                : null,
-            child: Text(widget.actionLabel),
-          ),
+        SoliplexButton.text(
+          onPressed: widget.canSubmit ? _run : null,
+          isLoading: _busy,
+          intent:
+              widget.isDestructive ? ButtonIntent.danger : ButtonIntent.primary,
+          child: Text(widget.actionLabel),
+        ),
       ],
     );
   }

--- a/test/modules/room/ui/async_action_dialog_test.dart
+++ b/test/modules/room/ui/async_action_dialog_test.dart
@@ -64,7 +64,12 @@ void main() {
       await tester.pump();
 
       expect(find.byType(CircularProgressIndicator), findsOneWidget);
-      expect(find.text('Go'), findsNothing);
+      // SoliplexButton keeps the label mounted (faded) while loading so the
+      // button's width stays stable; the action is disabled instead of removed.
+      final actionButton = tester.widget<TextButton>(
+        find.widgetWithText(TextButton, 'Go'),
+      );
+      expect(actionButton.onPressed, isNull);
 
       completer.complete();
       await tester.pumpAndSettle();


### PR DESCRIPTION
## Summary

First adoption PR for the branded component library (shipped in #275). Converts the auth module's buttons — and the shared `AsyncActionDialog` — from raw Material `FilledButton`/`OutlinedButton`/`TextButton` to `SoliplexButton`.

- **`server_list_screen.dart`** — Home / Lobby / Sign in → `SoliplexButton.text`; the connected-server "Log out" button now uses the `isLoading` axis instead of a hand-rolled `SizedBox` + `CircularProgressIndicator` swap.
- **`home_screen.dart`** — Connect, Cancel ×2, Connect anyway, acknowledge-consent, provider-select, Change server, All servers, Show more, Versions → branded equivalents.
- **`auth_callback_screen.dart`** — "Back to home" → `SoliplexButton.filled`.
- **`async_action_dialog.dart`** — Cancel + action → `SoliplexButton.text`; destructive action uses `ButtonIntent.danger`; the `_busy` spinner branch collapses into the button's `isLoading` axis (the button now stays put and shows a spinner over a faded label rather than being swapped for a bare spinner).

No behavior changes beyond the intended loading-state polish — all sites keep the same colors (danger → `colorScheme.error`, matching the prior `styleFrom(foregroundColor:)`).

## Known API gap

The "Go to Lobby" affordance in `home_screen.dart` (~L404) keeps its Material `TextButton.icon` because it relies on `iconAlignment: IconAlignment.end` (trailing icon), and `SoliplexButton` currently only supports **leading** icons. Left as-is rather than degrade the UX. Worth a follow-up to add a trailing-icon option to `SoliplexButton` before the rest of the adoption sweep hits other trailing-icon sites.

## Test plan

- [x] `dart analyze` clean on all touched files
- [x] Full test suite green (1510 passed), including the auth + dialog suites
- [x] Updated one assertion in `async_action_dialog_test.dart`: during loading the label now stays mounted (faded) for stable button width, so the test asserts the action is *disabled* rather than *removed*
- [x] Manual smoke: sign-in flow, server list logout spinner, rename/delete dialogs in both light & dark

🤖 Generated with [Claude Code](https://claude.com/claude-code)