### PR TITLE
refactor(auth): convert Go to Lobby button to SoliplexButton

### DIFF
--- a/lib/src/modules/auth/ui/home_screen.dart
+++ b/lib/src/modules/auth/ui/home_screen.dart
@@ -401,11 +401,11 @@ class _HomeScreenState extends ConsumerState<HomeScreen> {
       if (connectedCount > 0)
         Align(
           alignment: Alignment.centerRight,
-          child: TextButton.icon(
+          child: SoliplexButton.text(
             onPressed: () => context.go(AppRoutes.lobby),
             iconAlignment: IconAlignment.end,
             icon: const Icon(Icons.arrow_forward),
-            label: const Text('Go to Lobby'),
+            child: const Text('Go to Lobby'),
           ),
         ),
       Align(


### PR DESCRIPTION
## Summary

Follow-up to #282 and #283. The "Go to Lobby →" button on the home screen was the one documented exception from the auth adoption sweep — it stayed on raw Material `TextButton.icon` because `SoliplexButton` only supported leading icons. Now that #283 added the `iconAlignment` axis, it converts cleanly to `SoliplexButton.text(..., iconAlignment: IconAlignment.end)`.

With this, the **auth module is 100% on the branded button** — no raw `FilledButton`/`OutlinedButton`/`TextButton` remain.

## Test plan

- [x] `grep` confirms zero Material buttons left in `lib/src/modules/auth/`
- [x] `dart analyze` clean
- [x] `home_screen_test.dart` green (39 tests) — the trailing arrow + label still render and navigate

🤖 Generated with [Claude Code](https://claude.com/claude-code)