### PR TITLE
feat(lobby): list/grid view toggle

### DIFF
--- a/lib/src/modules/lobby/lobby_state.dart
+++ b/lib/src/modules/lobby/lobby_state.dart
@@ -8,6 +8,7 @@ import 'package:soliplex_client/soliplex_client.dart'
 import '../auth/auth_tokens.dart';
 import '../auth/server_entry.dart';
 import '../auth/server_manager.dart';
+import 'lobby_view_mode.dart';
 
 typedef ApiResolver = SoliplexApi Function(ServerEntry entry);
 
@@ -59,6 +60,7 @@ class LobbyState {
   })  : _serverManager = serverManager,
         _apiResolver = apiResolver ?? _defaultResolver {
     _unsubscribe = _serverManager.servers.subscribe(_onServersChanged);
+    _loadViewMode();
   }
 
   final ServerManager _serverManager;
@@ -72,6 +74,22 @@ class LobbyState {
   final Signal<Map<String, UserProfile?>> _userProfiles =
       Signal<Map<String, UserProfile?>>({});
   ReadonlySignal<Map<String, UserProfile?>> get userProfiles => _userProfiles;
+
+  /// Preferred room layout. Starts at [LobbyViewMode.list] and flips to
+  /// the persisted value once [_loadViewMode] resolves.
+  final Signal<LobbyViewMode> _viewMode = Signal(LobbyViewMode.list);
+  ReadonlySignal<LobbyViewMode> get viewMode => _viewMode;
+
+  Future<void> _loadViewMode() async {
+    _viewMode.value = await LobbyViewModeStorage.load();
+  }
+
+  /// Updates the room layout and persists the choice for next launch.
+  void setViewMode(LobbyViewMode mode) {
+    if (mode == _viewMode.value) return;
+    _viewMode.value = mode;
+    LobbyViewModeStorage.save(mode);
+  }
 
   /// Cancel tokens keyed by serverId, one per in-flight fetch.
   final Map<String, CancelToken> _cancelTokens = {};

--- a/lib/src/modules/lobby/lobby_state.dart
+++ b/lib/src/modules/lobby/lobby_state.dart
@@ -76,20 +76,44 @@ class LobbyState {
       Signal<Map<String, UserProfile?>>({});
   ReadonlySignal<Map<String, UserProfile?>> get userProfiles => _userProfiles;
 
-  /// Preferred room layout. Starts at [LobbyViewMode.list] and flips to
-  /// the persisted value once [_loadViewMode] resolves.
+  /// Preferred room layout. Starts at [LobbyViewMode.list]; replaced by the
+  /// persisted preference (or its [LobbyViewMode.list] fallback) once
+  /// [_loadViewMode] resolves.
   final Signal<LobbyViewMode> _viewMode = Signal(LobbyViewMode.list);
   ReadonlySignal<LobbyViewMode> get viewMode => _viewMode;
 
   Future<void> _loadViewMode() async {
-    _viewMode.value = await LobbyViewModeStorage.load();
+    try {
+      _viewMode.value = await LobbyViewModeStorage.load();
+    } catch (error, st) {
+      // Keep the default; a missing preference is not worth blocking on, but
+      // a systematic storage failure should still leave a trace.
+      dev.log(
+        'Failed to load lobby view mode',
+        error: error,
+        stackTrace: st,
+        level: 900,
+      );
+    }
   }
 
   /// Updates the room layout and persists the choice for next launch.
   void setViewMode(LobbyViewMode mode) {
     if (mode == _viewMode.value) return;
     _viewMode.value = mode;
-    unawaited(LobbyViewModeStorage.save(mode));
+    unawaited(
+      LobbyViewModeStorage.save(mode).catchError((Object error, StackTrace st) {
+        // The in-memory choice already took effect; only persistence failed.
+        // The next launch falls back to the default, which the user can
+        // re-select — but log so a silent storage failure is debuggable.
+        dev.log(
+          'Failed to persist lobby view mode',
+          error: error,
+          stackTrace: st,
+          level: 900,
+        );
+      }),
+    );
   }
 
   /// Cancel tokens keyed by serverId, one per in-flight fetch.

--- a/lib/src/modules/lobby/lobby_state.dart
+++ b/lib/src/modules/lobby/lobby_state.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:convert';
 import 'dart:developer' as dev;
 
@@ -60,7 +61,7 @@ class LobbyState {
   })  : _serverManager = serverManager,
         _apiResolver = apiResolver ?? _defaultResolver {
     _unsubscribe = _serverManager.servers.subscribe(_onServersChanged);
-    _loadViewMode();
+    unawaited(_loadViewMode());
   }
 
   final ServerManager _serverManager;
@@ -88,7 +89,7 @@ class LobbyState {
   void setViewMode(LobbyViewMode mode) {
     if (mode == _viewMode.value) return;
     _viewMode.value = mode;
-    LobbyViewModeStorage.save(mode);
+    unawaited(LobbyViewModeStorage.save(mode));
   }
 
   /// Cancel tokens keyed by serverId, one per in-flight fetch.

--- a/lib/src/modules/lobby/lobby_view_mode.dart
+++ b/lib/src/modules/lobby/lobby_view_mode.dart
@@ -1,0 +1,25 @@
+import 'package:shared_preferences/shared_preferences.dart';
+
+/// How the lobby lays out each server's rooms.
+enum LobbyViewMode { list, grid }
+
+/// Persists the user's preferred [LobbyViewMode] across launches.
+///
+/// Backed by `shared_preferences` (the choice is a non-sensitive UI
+/// preference). An unset or unrecognized value falls back to
+/// [LobbyViewMode.list].
+abstract final class LobbyViewModeStorage {
+  static const _key = 'soliplex_lobby_view_mode';
+
+  static Future<LobbyViewMode> load() async {
+    final prefs = await SharedPreferences.getInstance();
+    final raw = prefs.getString(_key);
+    return LobbyViewMode.values.where((mode) => mode.name == raw).firstOrNull ??
+        LobbyViewMode.list;
+  }
+
+  static Future<void> save(LobbyViewMode mode) async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setString(_key, mode.name);
+  }
+}

--- a/lib/src/modules/lobby/ui/lobby_screen.dart
+++ b/lib/src/modules/lobby/ui/lobby_screen.dart
@@ -12,6 +12,7 @@ import '../lobby_state.dart';
 import '../lobby_view_mode.dart';
 import 'room_card.dart';
 import 'room_grid_card.dart';
+import 'room_grid_layout.dart';
 import 'server_sidebar.dart';
 import 'package:soliplex_design/soliplex_design.dart';
 
@@ -459,8 +460,7 @@ class _ServerSection extends StatelessWidget {
 ///
 /// Lives inside the outer room `ListView`, so it lays out with a [Wrap]
 /// (fixed-width cells, intrinsic height) rather than a nested scrollable
-/// grid. Column count steps with the available width via
-/// [SoliplexBreakpoints].
+/// grid. Column count and cell width come from [roomGridLayout].
 class _RoomGrid extends StatelessWidget {
   const _RoomGrid({
     required this.serverId,
@@ -480,21 +480,15 @@ class _RoomGrid extends StatelessWidget {
       padding: const EdgeInsets.symmetric(horizontal: SoliplexSpacing.s4),
       child: LayoutBuilder(
         builder: (context, constraints) {
-          final width = constraints.maxWidth;
-          final columns = width >= SoliplexBreakpoints.desktop
-              ? 3
-              : width >= SoliplexBreakpoints.mobile
-                  ? 2
-                  : 1;
           const spacing = SoliplexSpacing.s3;
-          final cellWidth = (width - spacing * (columns - 1)) / columns;
+          final layout = roomGridLayout(constraints.maxWidth, spacing: spacing);
           return Wrap(
             spacing: spacing,
             runSpacing: spacing,
             children: [
               for (final room in rooms)
                 SizedBox(
-                  width: cellWidth,
+                  width: layout.cellWidth,
                   child: RoomGridCard(
                     room: room,
                     onTap: () => onRoomTap(serverId, room.id),

--- a/lib/src/modules/lobby/ui/lobby_screen.dart
+++ b/lib/src/modules/lobby/ui/lobby_screen.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
 import 'package:signals_flutter/signals_flutter.dart';
+import 'package:soliplex_agent/soliplex_agent.dart' show Room;
 import 'package:soliplex_client/soliplex_client.dart'
     show PermissionDeniedException;
 
@@ -8,7 +9,9 @@ import '../../../core/routes.dart';
 import '../../auth/server_entry.dart';
 import '../../auth/server_manager.dart';
 import '../lobby_state.dart';
+import '../lobby_view_mode.dart';
 import 'room_card.dart';
+import 'room_grid_card.dart';
 import 'server_sidebar.dart';
 import 'package:soliplex_design/soliplex_design.dart';
 
@@ -16,9 +19,18 @@ const double _sidebarWidth = 240;
 const double _wideBreakpoint = 600;
 
 class LobbyScreen extends StatefulWidget {
-  const LobbyScreen({super.key, required this.serverManager});
+  const LobbyScreen({
+    super.key,
+    required this.serverManager,
+    this.apiResolver,
+  });
 
   final ServerManager serverManager;
+
+  /// Test seam forwarded to [LobbyState]; production uses the default
+  /// per-entry API resolver.
+  @visibleForTesting
+  final ApiResolver? apiResolver;
 
   @override
   State<LobbyScreen> createState() => _LobbyScreenState();
@@ -30,7 +42,10 @@ class _LobbyScreenState extends State<LobbyScreen> {
   @override
   void initState() {
     super.initState();
-    _state = LobbyState(serverManager: widget.serverManager);
+    _state = LobbyState(
+      serverManager: widget.serverManager,
+      apiResolver: widget.apiResolver,
+    );
   }
 
   @override
@@ -78,6 +93,7 @@ class _LobbyScreenState extends State<LobbyScreen> {
     final servers = widget.serverManager.servers.watch(context);
     final profiles = _state.userProfiles.watch(context);
     final roomsByServer = _state.roomsByServer.watch(context);
+    final viewMode = _state.viewMode.watch(context);
     return LayoutBuilder(
       builder: (context, constraints) {
         final isWide = constraints.maxWidth >= _wideBreakpoint;
@@ -86,6 +102,8 @@ class _LobbyScreenState extends State<LobbyScreen> {
                 servers: servers,
                 profiles: profiles,
                 roomsByServer: roomsByServer,
+                viewMode: viewMode,
+                onViewModeChanged: _state.setViewMode,
                 onServerTap: _onServerTap,
                 onAddServer: _onAddServer,
                 onNetworkInspector: _onNetworkInspector,
@@ -98,6 +116,8 @@ class _LobbyScreenState extends State<LobbyScreen> {
                 servers: servers,
                 profiles: profiles,
                 roomsByServer: roomsByServer,
+                viewMode: viewMode,
+                onViewModeChanged: _state.setViewMode,
                 onServerTap: _onServerTap,
                 onAddServer: _onAddServer,
                 onNetworkInspector: _onNetworkInspector,
@@ -116,6 +136,8 @@ class _WideLayout extends StatelessWidget {
     required this.servers,
     required this.profiles,
     required this.roomsByServer,
+    required this.viewMode,
+    required this.onViewModeChanged,
     required this.onServerTap,
     required this.onAddServer,
     required this.onNetworkInspector,
@@ -128,6 +150,8 @@ class _WideLayout extends StatelessWidget {
   final Map<String, ServerEntry> servers;
   final Map<String, UserProfile?> profiles;
   final Map<String, ServerRooms> roomsByServer;
+  final LobbyViewMode viewMode;
+  final void Function(LobbyViewMode) onViewModeChanged;
   final VoidCallback onServerTap;
   final VoidCallback onAddServer;
   final VoidCallback onNetworkInspector;
@@ -157,6 +181,8 @@ class _WideLayout extends StatelessWidget {
             child: _RoomContent(
               roomsByServer: roomsByServer,
               servers: servers,
+              viewMode: viewMode,
+              onViewModeChanged: onViewModeChanged,
               onRoomTap: onRoomTap,
               onInfoTap: onInfoTap,
               onAddServer: onAddServer,
@@ -174,6 +200,8 @@ class _NarrowLayout extends StatelessWidget {
     required this.servers,
     required this.profiles,
     required this.roomsByServer,
+    required this.viewMode,
+    required this.onViewModeChanged,
     required this.onServerTap,
     required this.onAddServer,
     required this.onNetworkInspector,
@@ -186,6 +214,8 @@ class _NarrowLayout extends StatelessWidget {
   final Map<String, ServerEntry> servers;
   final Map<String, UserProfile?> profiles;
   final Map<String, ServerRooms> roomsByServer;
+  final LobbyViewMode viewMode;
+  final void Function(LobbyViewMode) onViewModeChanged;
   final VoidCallback onServerTap;
   final VoidCallback onAddServer;
   final VoidCallback onNetworkInspector;
@@ -218,6 +248,8 @@ class _NarrowLayout extends StatelessWidget {
       body: _RoomContent(
         roomsByServer: roomsByServer,
         servers: servers,
+        viewMode: viewMode,
+        onViewModeChanged: onViewModeChanged,
         onRoomTap: onRoomTap,
         onInfoTap: onInfoTap,
         onAddServer: onAddServer,
@@ -231,6 +263,8 @@ class _RoomContent extends StatelessWidget {
   const _RoomContent({
     required this.roomsByServer,
     required this.servers,
+    required this.viewMode,
+    required this.onViewModeChanged,
     required this.onRoomTap,
     required this.onInfoTap,
     required this.onAddServer,
@@ -239,6 +273,8 @@ class _RoomContent extends StatelessWidget {
 
   final Map<String, ServerRooms> roomsByServer;
   final Map<String, ServerEntry> servers;
+  final LobbyViewMode viewMode;
+  final void Function(LobbyViewMode) onViewModeChanged;
   final void Function(String serverId, String roomId) onRoomTap;
   final void Function(String serverId, String roomId) onInfoTap;
   final VoidCallback onAddServer;
@@ -262,18 +298,64 @@ class _RoomContent extends StatelessWidget {
       );
     }
 
-    return ListView(
+    return Column(
       children: [
-        for (final entry in roomsByServer.entries)
-          _ServerSection(
-            serverId: entry.key,
-            serverUrl: servers[entry.key]?.serverUrl,
-            serverRooms: entry.value,
-            onRoomTap: onRoomTap,
-            onInfoTap: onInfoTap,
-            onSignIn: onSignIn,
+        Padding(
+          padding: const EdgeInsets.fromLTRB(
+              SoliplexSpacing.s4, SoliplexSpacing.s2, SoliplexSpacing.s4, 0),
+          child: Align(
+            alignment: Alignment.centerRight,
+            child: _ViewModeToggle(
+              viewMode: viewMode,
+              onChanged: onViewModeChanged,
+            ),
           ),
+        ),
+        Expanded(
+          child: ListView(
+            children: [
+              for (final entry in roomsByServer.entries)
+                _ServerSection(
+                  serverId: entry.key,
+                  serverUrl: servers[entry.key]?.serverUrl,
+                  serverRooms: entry.value,
+                  viewMode: viewMode,
+                  onRoomTap: onRoomTap,
+                  onInfoTap: onInfoTap,
+                  onSignIn: onSignIn,
+                ),
+            ],
+          ),
+        ),
       ],
+    );
+  }
+}
+
+class _ViewModeToggle extends StatelessWidget {
+  const _ViewModeToggle({required this.viewMode, required this.onChanged});
+
+  final LobbyViewMode viewMode;
+  final void Function(LobbyViewMode) onChanged;
+
+  @override
+  Widget build(BuildContext context) {
+    return SegmentedButton<LobbyViewMode>(
+      showSelectedIcon: false,
+      segments: const [
+        ButtonSegment(
+          value: LobbyViewMode.list,
+          icon: Icon(Icons.view_list),
+          tooltip: 'List view',
+        ),
+        ButtonSegment(
+          value: LobbyViewMode.grid,
+          icon: Icon(Icons.grid_view),
+          tooltip: 'Grid view',
+        ),
+      ],
+      selected: {viewMode},
+      onSelectionChanged: (selection) => onChanged(selection.first),
     );
   }
 }
@@ -283,6 +365,7 @@ class _ServerSection extends StatelessWidget {
     required this.serverId,
     required this.serverUrl,
     required this.serverRooms,
+    required this.viewMode,
     required this.onRoomTap,
     required this.onInfoTap,
     required this.onSignIn,
@@ -291,6 +374,7 @@ class _ServerSection extends StatelessWidget {
   final String serverId;
   final Uri? serverUrl;
   final ServerRooms serverRooms;
+  final LobbyViewMode viewMode;
   final void Function(String serverId, String roomId) onRoomTap;
   final void Function(String serverId, String roomId) onInfoTap;
   final void Function(String serverId) onSignIn;
@@ -324,16 +408,24 @@ class _ServerSection extends StatelessWidget {
                 _ => 'Failed to load rooms: $error',
               }),
             ),
-          RoomsLoaded(:final rooms) => Column(
-              children: [
-                for (final room in rooms)
-                  RoomCard(
-                    room: room,
-                    onTap: () => onRoomTap(serverId, room.id),
-                    onInfoTap: () => onInfoTap(serverId, room.id),
-                  ),
-              ],
-            ),
+          RoomsLoaded(:final rooms) => switch (viewMode) {
+              LobbyViewMode.list => Column(
+                  children: [
+                    for (final room in rooms)
+                      RoomCard(
+                        room: room,
+                        onTap: () => onRoomTap(serverId, room.id),
+                        onInfoTap: () => onInfoTap(serverId, room.id),
+                      ),
+                  ],
+                ),
+              LobbyViewMode.grid => _RoomGrid(
+                  serverId: serverId,
+                  rooms: rooms,
+                  onRoomTap: onRoomTap,
+                  onInfoTap: onInfoTap,
+                ),
+            },
           RoomsExpired() => Padding(
               padding:
                   const EdgeInsets.symmetric(horizontal: SoliplexSpacing.s4),
@@ -359,6 +451,60 @@ class _ServerSection extends StatelessWidget {
             ),
         },
       ],
+    );
+  }
+}
+
+/// Responsive grid of [RoomGridCard]s for a single server's rooms.
+///
+/// Lives inside the outer room `ListView`, so it lays out with a [Wrap]
+/// (fixed-width cells, intrinsic height) rather than a nested scrollable
+/// grid. Column count steps with the available width via
+/// [SoliplexBreakpoints].
+class _RoomGrid extends StatelessWidget {
+  const _RoomGrid({
+    required this.serverId,
+    required this.rooms,
+    required this.onRoomTap,
+    required this.onInfoTap,
+  });
+
+  final String serverId;
+  final List<Room> rooms;
+  final void Function(String serverId, String roomId) onRoomTap;
+  final void Function(String serverId, String roomId) onInfoTap;
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: SoliplexSpacing.s4),
+      child: LayoutBuilder(
+        builder: (context, constraints) {
+          final width = constraints.maxWidth;
+          final columns = width >= SoliplexBreakpoints.desktop
+              ? 3
+              : width >= SoliplexBreakpoints.mobile
+                  ? 2
+                  : 1;
+          const spacing = SoliplexSpacing.s3;
+          final cellWidth = (width - spacing * (columns - 1)) / columns;
+          return Wrap(
+            spacing: spacing,
+            runSpacing: spacing,
+            children: [
+              for (final room in rooms)
+                SizedBox(
+                  width: cellWidth,
+                  child: RoomGridCard(
+                    room: room,
+                    onTap: () => onRoomTap(serverId, room.id),
+                    onInfoTap: () => onInfoTap(serverId, room.id),
+                  ),
+                ),
+            ],
+          );
+        },
+      ),
     );
   }
 }

--- a/lib/src/modules/lobby/ui/room_grid_card.dart
+++ b/lib/src/modules/lobby/ui/room_grid_card.dart
@@ -1,0 +1,81 @@
+import 'package:flutter/material.dart';
+import 'package:soliplex_agent/soliplex_agent.dart';
+import 'package:soliplex_design/soliplex_design.dart';
+
+/// Vertical card used for the lobby's grid layout. Carries the same
+/// affordances as the list-row [RoomCard] (open on tap, info button,
+/// quiz indicator) in a shape that tiles cleanly into a grid cell.
+class RoomGridCard extends StatelessWidget {
+  const RoomGridCard({
+    super.key,
+    required this.room,
+    required this.onTap,
+    required this.onInfoTap,
+  });
+
+  final Room room;
+  final VoidCallback onTap;
+  final VoidCallback onInfoTap;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final radius = BorderRadius.circular(soliplexRadii.md);
+    return Card(
+      child: InkWell(
+        onTap: onTap,
+        borderRadius: radius,
+        child: Padding(
+          padding: const EdgeInsets.all(SoliplexSpacing.s3),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              Row(
+                children: [
+                  Expanded(
+                    child: Text(
+                      room.name,
+                      style: theme.textTheme.titleMedium,
+                      maxLines: 1,
+                      overflow: TextOverflow.ellipsis,
+                    ),
+                  ),
+                  if (room.hasQuizzes)
+                    Tooltip(
+                      message: 'Has quizzes',
+                      child: Icon(
+                        Icons.quiz,
+                        size: 20,
+                        color: theme.colorScheme.primary,
+                      ),
+                    ),
+                ],
+              ),
+              if (room.description.isNotEmpty) ...[
+                const SizedBox(height: SoliplexSpacing.s2),
+                Text(
+                  room.description,
+                  style: theme.textTheme.bodySmall?.copyWith(
+                    color: theme.colorScheme.onSurfaceVariant,
+                  ),
+                  maxLines: 2,
+                  overflow: TextOverflow.ellipsis,
+                ),
+              ],
+              const SizedBox(height: SoliplexSpacing.s2),
+              Align(
+                alignment: Alignment.centerRight,
+                child: IconButton(
+                  icon: const Icon(Icons.info_outline),
+                  tooltip: 'Room info',
+                  onPressed: onInfoTap,
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/src/modules/lobby/ui/room_grid_card.dart
+++ b/lib/src/modules/lobby/ui/room_grid_card.dart
@@ -2,9 +2,9 @@ import 'package:flutter/material.dart';
 import 'package:soliplex_agent/soliplex_agent.dart';
 import 'package:soliplex_design/soliplex_design.dart';
 
-/// Vertical card used for the lobby's grid layout. Carries the same
-/// affordances as the list-row [RoomCard] (open on tap, info button,
-/// quiz indicator) in a shape that tiles cleanly into a grid cell.
+/// Vertical card used for the lobby's grid layout: open on tap, info
+/// button, and a quiz indicator, in a shape that tiles cleanly into a
+/// grid cell. The list-row counterpart is [RoomCard].
 class RoomGridCard extends StatelessWidget {
   const RoomGridCard({
     super.key,

--- a/lib/src/modules/lobby/ui/room_grid_layout.dart
+++ b/lib/src/modules/lobby/ui/room_grid_layout.dart
@@ -1,0 +1,21 @@
+import 'package:soliplex_design/soliplex_design.dart';
+
+/// Column count and cell width for the lobby room grid at a given [width],
+/// laid out with [spacing] between cells.
+///
+/// Three columns at [SoliplexBreakpoints.desktop] and wider, two at
+/// [SoliplexBreakpoints.mobile] and wider, one below that. The cell width
+/// removes the inter-cell gaps (`columns - 1` of them) before dividing the
+/// remaining width evenly.
+({int columns, double cellWidth}) roomGridLayout(
+  double width, {
+  double spacing = SoliplexSpacing.s3,
+}) {
+  final columns = width >= SoliplexBreakpoints.desktop
+      ? 3
+      : width >= SoliplexBreakpoints.mobile
+          ? 2
+          : 1;
+  final cellWidth = (width - spacing * (columns - 1)) / columns;
+  return (columns: columns, cellWidth: cellWidth);
+}

--- a/test/modules/lobby/lobby_state_test.dart
+++ b/test/modules/lobby/lobby_state_test.dart
@@ -3,6 +3,7 @@ import 'dart:convert';
 import 'dart:typed_data';
 
 import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
 import 'package:soliplex_agent/soliplex_agent.dart';
 import 'package:soliplex_frontend/src/modules/auth/auth_session.dart';
 import 'package:soliplex_frontend/src/modules/auth/auth_tokens.dart';
@@ -18,6 +19,9 @@ ServerManager _createManager() => ServerManager(
     );
 
 void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+  setUp(() => SharedPreferences.setMockInitialValues({}));
+
   group('LobbyState', () {
     group('room fetching on init', () {
       test('fetches rooms from all connected servers', () async {

--- a/test/modules/lobby/lobby_view_mode_test.dart
+++ b/test/modules/lobby/lobby_view_mode_test.dart
@@ -1,0 +1,69 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:soliplex_frontend/src/modules/auth/auth_session.dart';
+import 'package:soliplex_frontend/src/modules/auth/server_manager.dart';
+import 'package:soliplex_frontend/src/modules/lobby/lobby_state.dart';
+import 'package:soliplex_frontend/src/modules/lobby/lobby_view_mode.dart';
+
+import '../../helpers/fakes.dart';
+
+ServerManager _createManager() => ServerManager(
+      authFactory: () => AuthSession(refreshService: FakeTokenRefreshService()),
+      clientFactory: ({getToken, tokenRefresher}) => FakeHttpClient(),
+      storage: InMemoryServerStorage(),
+    );
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  group('LobbyViewModeStorage', () {
+    test('defaults to list when nothing is persisted', () async {
+      SharedPreferences.setMockInitialValues({});
+      expect(await LobbyViewModeStorage.load(), LobbyViewMode.list);
+    });
+
+    test('round-trips the saved mode', () async {
+      SharedPreferences.setMockInitialValues({});
+      await LobbyViewModeStorage.save(LobbyViewMode.grid);
+      expect(await LobbyViewModeStorage.load(), LobbyViewMode.grid);
+    });
+
+    test('falls back to list on an unrecognized stored value', () async {
+      SharedPreferences.setMockInitialValues(
+        {'soliplex_lobby_view_mode': 'bogus'},
+      );
+      expect(await LobbyViewModeStorage.load(), LobbyViewMode.list);
+    });
+  });
+
+  group('LobbyState.viewMode', () {
+    test('starts at list', () {
+      SharedPreferences.setMockInitialValues({});
+      final state = LobbyState(serverManager: _createManager());
+      expect(state.viewMode.value, LobbyViewMode.list);
+      state.dispose();
+    });
+
+    test('adopts the persisted mode after async load', () async {
+      SharedPreferences.setMockInitialValues(
+        {'soliplex_lobby_view_mode': 'grid'},
+      );
+      final state = LobbyState(serverManager: _createManager());
+      await Future<void>.delayed(Duration.zero);
+      expect(state.viewMode.value, LobbyViewMode.grid);
+      state.dispose();
+    });
+
+    test('setViewMode updates the signal and persists the choice', () async {
+      SharedPreferences.setMockInitialValues({});
+      final state = LobbyState(serverManager: _createManager());
+      await Future<void>.delayed(Duration.zero);
+
+      state.setViewMode(LobbyViewMode.grid);
+
+      expect(state.viewMode.value, LobbyViewMode.grid);
+      expect(await LobbyViewModeStorage.load(), LobbyViewMode.grid);
+      state.dispose();
+    });
+  });
+}

--- a/test/modules/lobby/ui/lobby_screen_test.dart
+++ b/test/modules/lobby/ui/lobby_screen_test.dart
@@ -1,10 +1,15 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:go_router/go_router.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:soliplex_agent/soliplex_agent.dart' show Room;
 import 'package:soliplex_frontend/src/modules/auth/auth_session.dart';
 import 'package:soliplex_frontend/src/modules/auth/auth_tokens.dart';
 import 'package:soliplex_frontend/src/modules/auth/server_manager.dart';
+import 'package:soliplex_frontend/src/modules/lobby/lobby_state.dart';
 import 'package:soliplex_frontend/src/modules/lobby/ui/lobby_screen.dart';
+import 'package:soliplex_frontend/src/modules/lobby/ui/room_card.dart';
+import 'package:soliplex_frontend/src/modules/lobby/ui/room_grid_card.dart';
 
 import '../../../helpers/fakes.dart';
 
@@ -17,13 +22,17 @@ ServerManager _createManager() => ServerManager(
 Widget _buildApp(
   ServerManager manager, {
   void Function(Uri location)? onHomeRoute,
+  ApiResolver? apiResolver,
 }) {
   final router = GoRouter(
     initialLocation: '/lobby',
     routes: [
       GoRoute(
         path: '/lobby',
-        builder: (_, __) => LobbyScreen(serverManager: manager),
+        builder: (_, __) => LobbyScreen(
+          serverManager: manager,
+          apiResolver: apiResolver,
+        ),
       ),
       GoRoute(
         path: '/servers',
@@ -42,6 +51,8 @@ Widget _buildApp(
 }
 
 void main() {
+  setUp(() => SharedPreferences.setMockInitialValues({}));
+
   group('LobbyScreen', () {
     testWidgets('shows sidebar on wide viewport with Add Server visible',
         (tester) async {
@@ -163,5 +174,59 @@ void main() {
         expect(homeLocation!.queryParameters['returnTo'], '/lobby');
       },
     );
+
+    testWidgets('toggle switches loaded rooms from list to grid cards',
+        (tester) async {
+      tester.view.physicalSize = const Size(800, 600);
+      tester.view.devicePixelRatio = 1.0;
+      addTearDown(tester.view.resetPhysicalSize);
+
+      final manager = _createManager();
+      manager.addServer(
+        serverId: 'local',
+        serverUrl: Uri.parse('http://localhost:8000'),
+        requiresAuth: false,
+      );
+      final fakeApi = FakeSoliplexApi()
+        ..nextRooms = const [Room(id: 'room-1', name: 'General')];
+
+      await tester.pumpWidget(_buildApp(manager, apiResolver: (_) => fakeApi));
+      await tester.pumpAndSettle();
+
+      // List mode (default): list-row card, no grid card.
+      expect(find.byType(RoomCard), findsOneWidget);
+      expect(find.byType(RoomGridCard), findsNothing);
+
+      // Switch to grid.
+      await tester.tap(find.byIcon(Icons.grid_view));
+      await tester.pumpAndSettle();
+
+      expect(find.byType(RoomGridCard), findsOneWidget);
+      expect(find.byType(RoomCard), findsNothing);
+    });
+
+    testWidgets('honors the persisted grid mode on load', (tester) async {
+      SharedPreferences.setMockInitialValues(
+        {'soliplex_lobby_view_mode': 'grid'},
+      );
+      tester.view.physicalSize = const Size(800, 600);
+      tester.view.devicePixelRatio = 1.0;
+      addTearDown(tester.view.resetPhysicalSize);
+
+      final manager = _createManager();
+      manager.addServer(
+        serverId: 'local',
+        serverUrl: Uri.parse('http://localhost:8000'),
+        requiresAuth: false,
+      );
+      final fakeApi = FakeSoliplexApi()
+        ..nextRooms = const [Room(id: 'room-1', name: 'General')];
+
+      await tester.pumpWidget(_buildApp(manager, apiResolver: (_) => fakeApi));
+      await tester.pumpAndSettle();
+
+      expect(find.byType(RoomGridCard), findsOneWidget);
+      expect(find.byType(RoomCard), findsNothing);
+    });
   });
 }

--- a/test/modules/lobby/ui/lobby_screen_test.dart
+++ b/test/modules/lobby/ui/lobby_screen_test.dart
@@ -197,7 +197,6 @@ void main() {
       expect(find.byType(RoomCard), findsOneWidget);
       expect(find.byType(RoomGridCard), findsNothing);
 
-      // Switch to grid.
       await tester.tap(find.byIcon(Icons.grid_view));
       await tester.pumpAndSettle();
 

--- a/test/modules/lobby/ui/room_grid_card_test.dart
+++ b/test/modules/lobby/ui/room_grid_card_test.dart
@@ -25,6 +25,20 @@ void main() {
       expect(find.text('Team-wide chat'), findsOneWidget);
     });
 
+    testWidgets('omits the description when empty', (tester) async {
+      await tester.pumpWidget(_harness(
+        RoomGridCard(
+          room: const Room(id: 'r1', name: 'General'),
+          onTap: () {},
+          onInfoTap: () {},
+        ),
+      ));
+
+      // Only the name renders; the description block is skipped entirely.
+      expect(find.text('General'), findsOneWidget);
+      expect(find.byType(Text), findsOneWidget);
+    });
+
     testWidgets('shows the quiz badge only when the room has quizzes',
         (tester) async {
       await tester.pumpWidget(_harness(

--- a/test/modules/lobby/ui/room_grid_card_test.dart
+++ b/test/modules/lobby/ui/room_grid_card_test.dart
@@ -1,0 +1,72 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:soliplex_agent/soliplex_agent.dart';
+import 'package:soliplex_frontend/src/modules/lobby/ui/room_grid_card.dart';
+
+Widget _harness(Widget child) =>
+    MaterialApp(home: Scaffold(body: Center(child: child)));
+
+void main() {
+  group('RoomGridCard', () {
+    testWidgets('renders name and description', (tester) async {
+      await tester.pumpWidget(_harness(
+        RoomGridCard(
+          room: const Room(
+            id: 'r1',
+            name: 'General',
+            description: 'Team-wide chat',
+          ),
+          onTap: () {},
+          onInfoTap: () {},
+        ),
+      ));
+
+      expect(find.text('General'), findsOneWidget);
+      expect(find.text('Team-wide chat'), findsOneWidget);
+    });
+
+    testWidgets('shows the quiz badge only when the room has quizzes',
+        (tester) async {
+      await tester.pumpWidget(_harness(
+        RoomGridCard(
+          room: const Room(id: 'r1', name: 'No quiz'),
+          onTap: () {},
+          onInfoTap: () {},
+        ),
+      ));
+      expect(find.byIcon(Icons.quiz), findsNothing);
+
+      await tester.pumpWidget(_harness(
+        RoomGridCard(
+          room: const Room(
+            id: 'r2',
+            name: 'Has quiz',
+            quizzes: {'q1': 'Quiz One'},
+          ),
+          onTap: () {},
+          onInfoTap: () {},
+        ),
+      ));
+      expect(find.byIcon(Icons.quiz), findsOneWidget);
+    });
+
+    testWidgets('fires onTap and onInfoTap', (tester) async {
+      var tapped = 0;
+      var infoTapped = 0;
+      await tester.pumpWidget(_harness(
+        RoomGridCard(
+          room: const Room(id: 'r1', name: 'General'),
+          onTap: () => tapped++,
+          onInfoTap: () => infoTapped++,
+        ),
+      ));
+
+      await tester.tap(find.byIcon(Icons.info_outline));
+      expect(infoTapped, 1);
+      expect(tapped, 0);
+
+      await tester.tap(find.text('General'));
+      expect(tapped, 1);
+    });
+  });
+}

--- a/test/modules/lobby/ui/room_grid_layout_test.dart
+++ b/test/modules/lobby/ui/room_grid_layout_test.dart
@@ -1,0 +1,34 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:soliplex_design/soliplex_design.dart';
+import 'package:soliplex_frontend/src/modules/lobby/ui/room_grid_layout.dart';
+
+void main() {
+  group('roomGridLayout columns', () {
+    test('one column below the mobile breakpoint', () {
+      expect(roomGridLayout(SoliplexBreakpoints.mobile - 1).columns, 1);
+    });
+
+    test('two columns from the mobile breakpoint up to desktop', () {
+      expect(roomGridLayout(SoliplexBreakpoints.mobile).columns, 2);
+      expect(roomGridLayout(SoliplexBreakpoints.desktop - 1).columns, 2);
+    });
+
+    test('three columns at the desktop breakpoint and wider', () {
+      expect(roomGridLayout(SoliplexBreakpoints.desktop).columns, 3);
+      expect(roomGridLayout(SoliplexBreakpoints.desktop + 200).columns, 3);
+    });
+  });
+
+  group('roomGridLayout cellWidth', () {
+    test('fills the full width in a single column', () {
+      expect(roomGridLayout(300, spacing: 12).cellWidth, 300);
+    });
+
+    test('subtracts the inter-cell gaps before dividing', () {
+      // Two columns: one gap. (600 - 12) / 2.
+      expect(roomGridLayout(600, spacing: 12).cellWidth, 294);
+      // Three columns: two gaps. (840 - 24) / 3.
+      expect(roomGridLayout(840, spacing: 12).cellWidth, 272);
+    });
+  });
+}


### PR DESCRIPTION
## Summary

The customer-requested lobby **list/grid view switch**. Stacked on the lobby adoption PR (#288) — base is `refactor/lobby-button-adoption`; retarget to `main` once #288 merges.

- A `SegmentedButton` (list / grid icons) sits at the top of the room content area, shown in both wide and narrow layouts.
- Each server's `RoomsLoaded` rooms render either the existing list-row `RoomCard` (list) or a new vertical `RoomGridCard` in a responsive `Wrap` (grid). Column count steps with width via `SoliplexBreakpoints` (1 / 2 / 3).
- View mode is a `signal` on `LobbyState`, **persisted across launches** via `LobbyViewModeStorage` (SharedPreferences), mirroring the existing `ReturnToStorage` pattern. UI starts in list and flips to the persisted mode once the async load resolves.
- Loading / failed / expired / empty states are untouched.

## Notable choices

- **Tonal → filled** carried over from #288; no view-state changes there.
- `LobbyScreen` gains a `@visibleForTesting` `apiResolver` seam (mirrors the one `LobbyState` already exposes) so the toggle can be tested against loaded rooms.
- `RoomGridCard` uses the top-level `soliplexRadii` const rather than `SoliplexTheme.of(context)` so it renders correctly under a bare `MaterialApp` in widget tests (matches `preview_icon_button.dart`).

## Test plan

- [x] `dart analyze` clean (lib + tests)
- [x] Storage round-trip + unrecognized-value fallback
- [x] `LobbyState`: default list, adopts persisted mode, `setViewMode` updates signal + persists
- [x] `RoomGridCard`: name/description render, quiz badge gating, tap + info callbacks
- [x] `LobbyScreen`: toggle swaps `RoomCard` ⇄ `RoomGridCard`; persisted grid mode honored on load
- [x] Full suite green (1521 tests)
- [x] Manual smoke: toggle in wide + narrow, persistence across relaunch, both light & dark

🤖 Generated with [Claude Code](https://claude.com/claude-code)