### PR TITLE
feat(lobby): filter rooms by name

### DIFF
--- a/lib/src/modules/lobby/lobby_state.dart
+++ b/lib/src/modules/lobby/lobby_state.dart
@@ -91,6 +91,13 @@ class LobbyState {
     LobbyViewModeStorage.save(mode);
   }
 
+  /// Free-text room-name filter. Ephemeral — intentionally not persisted,
+  /// so each lobby visit starts unfiltered.
+  final Signal<String> _searchQuery = Signal('');
+  ReadonlySignal<String> get searchQuery => _searchQuery;
+
+  void setSearchQuery(String query) => _searchQuery.value = query;
+
   /// Cancel tokens keyed by serverId, one per in-flight fetch.
   final Map<String, CancelToken> _cancelTokens = {};
 

--- a/lib/src/modules/lobby/ui/lobby_screen.dart
+++ b/lib/src/modules/lobby/ui/lobby_screen.dart
@@ -94,6 +94,7 @@ class _LobbyScreenState extends State<LobbyScreen> {
     final profiles = _state.userProfiles.watch(context);
     final roomsByServer = _state.roomsByServer.watch(context);
     final viewMode = _state.viewMode.watch(context);
+    final searchQuery = _state.searchQuery.watch(context);
     return LayoutBuilder(
       builder: (context, constraints) {
         final isWide = constraints.maxWidth >= _wideBreakpoint;
@@ -104,6 +105,8 @@ class _LobbyScreenState extends State<LobbyScreen> {
                 roomsByServer: roomsByServer,
                 viewMode: viewMode,
                 onViewModeChanged: _state.setViewMode,
+                searchQuery: searchQuery,
+                onSearchChanged: _state.setSearchQuery,
                 onServerTap: _onServerTap,
                 onAddServer: _onAddServer,
                 onNetworkInspector: _onNetworkInspector,
@@ -118,6 +121,8 @@ class _LobbyScreenState extends State<LobbyScreen> {
                 roomsByServer: roomsByServer,
                 viewMode: viewMode,
                 onViewModeChanged: _state.setViewMode,
+                searchQuery: searchQuery,
+                onSearchChanged: _state.setSearchQuery,
                 onServerTap: _onServerTap,
                 onAddServer: _onAddServer,
                 onNetworkInspector: _onNetworkInspector,
@@ -138,6 +143,8 @@ class _WideLayout extends StatelessWidget {
     required this.roomsByServer,
     required this.viewMode,
     required this.onViewModeChanged,
+    required this.searchQuery,
+    required this.onSearchChanged,
     required this.onServerTap,
     required this.onAddServer,
     required this.onNetworkInspector,
@@ -152,6 +159,8 @@ class _WideLayout extends StatelessWidget {
   final Map<String, ServerRooms> roomsByServer;
   final LobbyViewMode viewMode;
   final void Function(LobbyViewMode) onViewModeChanged;
+  final String searchQuery;
+  final void Function(String) onSearchChanged;
   final VoidCallback onServerTap;
   final VoidCallback onAddServer;
   final VoidCallback onNetworkInspector;
@@ -183,6 +192,8 @@ class _WideLayout extends StatelessWidget {
               servers: servers,
               viewMode: viewMode,
               onViewModeChanged: onViewModeChanged,
+              searchQuery: searchQuery,
+              onSearchChanged: onSearchChanged,
               onRoomTap: onRoomTap,
               onInfoTap: onInfoTap,
               onAddServer: onAddServer,
@@ -202,6 +213,8 @@ class _NarrowLayout extends StatelessWidget {
     required this.roomsByServer,
     required this.viewMode,
     required this.onViewModeChanged,
+    required this.searchQuery,
+    required this.onSearchChanged,
     required this.onServerTap,
     required this.onAddServer,
     required this.onNetworkInspector,
@@ -216,6 +229,8 @@ class _NarrowLayout extends StatelessWidget {
   final Map<String, ServerRooms> roomsByServer;
   final LobbyViewMode viewMode;
   final void Function(LobbyViewMode) onViewModeChanged;
+  final String searchQuery;
+  final void Function(String) onSearchChanged;
   final VoidCallback onServerTap;
   final VoidCallback onAddServer;
   final VoidCallback onNetworkInspector;
@@ -250,6 +265,8 @@ class _NarrowLayout extends StatelessWidget {
         servers: servers,
         viewMode: viewMode,
         onViewModeChanged: onViewModeChanged,
+        searchQuery: searchQuery,
+        onSearchChanged: onSearchChanged,
         onRoomTap: onRoomTap,
         onInfoTap: onInfoTap,
         onAddServer: onAddServer,
@@ -265,6 +282,8 @@ class _RoomContent extends StatelessWidget {
     required this.servers,
     required this.viewMode,
     required this.onViewModeChanged,
+    required this.searchQuery,
+    required this.onSearchChanged,
     required this.onRoomTap,
     required this.onInfoTap,
     required this.onAddServer,
@@ -275,6 +294,8 @@ class _RoomContent extends StatelessWidget {
   final Map<String, ServerEntry> servers;
   final LobbyViewMode viewMode;
   final void Function(LobbyViewMode) onViewModeChanged;
+  final String searchQuery;
+  final void Function(String) onSearchChanged;
   final void Function(String serverId, String roomId) onRoomTap;
   final void Function(String serverId, String roomId) onInfoTap;
   final VoidCallback onAddServer;
@@ -303,12 +324,11 @@ class _RoomContent extends StatelessWidget {
         Padding(
           padding: const EdgeInsets.fromLTRB(
               SoliplexSpacing.s4, SoliplexSpacing.s2, SoliplexSpacing.s4, 0),
-          child: Align(
-            alignment: Alignment.centerRight,
-            child: _ViewModeToggle(
-              viewMode: viewMode,
-              onChanged: onViewModeChanged,
-            ),
+          child: _LobbyControls(
+            viewMode: viewMode,
+            onViewModeChanged: onViewModeChanged,
+            searchQuery: searchQuery,
+            onSearchChanged: onSearchChanged,
           ),
         ),
         Expanded(
@@ -320,6 +340,7 @@ class _RoomContent extends StatelessWidget {
                   serverUrl: servers[entry.key]?.serverUrl,
                   serverRooms: entry.value,
                   viewMode: viewMode,
+                  searchQuery: searchQuery,
                   onRoomTap: onRoomTap,
                   onInfoTap: onInfoTap,
                   onSignIn: onSignIn,
@@ -328,6 +349,96 @@ class _RoomContent extends StatelessWidget {
           ),
         ),
       ],
+    );
+  }
+}
+
+/// The lobby's control row: a room-name filter and the view-mode toggle.
+///
+/// Stateful so the search field's [TextEditingController] survives the
+/// signal-driven rebuilds (every keystroke updates the query signal) and
+/// the wide/narrow layout switch. On narrow widths the search field takes
+/// the full width and the toggle drops below it.
+class _LobbyControls extends StatefulWidget {
+  const _LobbyControls({
+    required this.viewMode,
+    required this.onViewModeChanged,
+    required this.searchQuery,
+    required this.onSearchChanged,
+  });
+
+  final LobbyViewMode viewMode;
+  final void Function(LobbyViewMode) onViewModeChanged;
+  final String searchQuery;
+  final void Function(String) onSearchChanged;
+
+  @override
+  State<_LobbyControls> createState() => _LobbyControlsState();
+}
+
+class _LobbyControlsState extends State<_LobbyControls> {
+  late final TextEditingController _controller;
+
+  @override
+  void initState() {
+    super.initState();
+    _controller = TextEditingController(text: widget.searchQuery)
+      ..addListener(_handleChanged);
+  }
+
+  void _handleChanged() {
+    widget.onSearchChanged(_controller.text);
+    // Refresh the clear-button affordance as the field empties/fills.
+    setState(() {});
+  }
+
+  @override
+  void dispose() {
+    _controller.removeListener(_handleChanged);
+    _controller.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final search = SoliplexInput(
+      controller: _controller,
+      hintText: 'Filter rooms',
+      leadingIcon: const Icon(Icons.search),
+      textInputAction: TextInputAction.search,
+      trailingIcon: _controller.text.isEmpty
+          ? null
+          : IconButton(
+              icon: const Icon(Icons.clear),
+              tooltip: 'Clear filter',
+              onPressed: _controller.clear,
+            ),
+    );
+    final toggle = _ViewModeToggle(
+      viewMode: widget.viewMode,
+      onChanged: widget.onViewModeChanged,
+    );
+
+    return LayoutBuilder(
+      builder: (context, constraints) {
+        if (constraints.maxWidth >= SoliplexBreakpoints.tablet) {
+          return Row(
+            children: [
+              Expanded(child: search),
+              const SizedBox(width: SoliplexSpacing.s3),
+              toggle,
+            ],
+          );
+        }
+        return Column(
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            search,
+            const SizedBox(height: SoliplexSpacing.s2),
+            Align(alignment: Alignment.centerRight, child: toggle),
+          ],
+        );
+      },
     );
   }
 }
@@ -366,6 +477,7 @@ class _ServerSection extends StatelessWidget {
     required this.serverUrl,
     required this.serverRooms,
     required this.viewMode,
+    required this.searchQuery,
     required this.onRoomTap,
     required this.onInfoTap,
     required this.onSignIn,
@@ -375,6 +487,7 @@ class _ServerSection extends StatelessWidget {
   final Uri? serverUrl;
   final ServerRooms serverRooms;
   final LobbyViewMode viewMode;
+  final String searchQuery;
   final void Function(String serverId, String roomId) onRoomTap;
   final void Function(String serverId, String roomId) onInfoTap;
   final void Function(String serverId) onSignIn;
@@ -408,24 +521,7 @@ class _ServerSection extends StatelessWidget {
                 _ => 'Failed to load rooms: $error',
               }),
             ),
-          RoomsLoaded(:final rooms) => switch (viewMode) {
-              LobbyViewMode.list => Column(
-                  children: [
-                    for (final room in rooms)
-                      RoomCard(
-                        room: room,
-                        onTap: () => onRoomTap(serverId, room.id),
-                        onInfoTap: () => onInfoTap(serverId, room.id),
-                      ),
-                  ],
-                ),
-              LobbyViewMode.grid => _RoomGrid(
-                  serverId: serverId,
-                  rooms: rooms,
-                  onRoomTap: onRoomTap,
-                  onInfoTap: onInfoTap,
-                ),
-            },
+          RoomsLoaded(:final rooms) => _buildRooms(context, rooms),
           RoomsExpired() => Padding(
               padding:
                   const EdgeInsets.symmetric(horizontal: SoliplexSpacing.s4),
@@ -452,6 +548,50 @@ class _ServerSection extends StatelessWidget {
         },
       ],
     );
+  }
+
+  Widget _buildRooms(BuildContext context, List<Room> rooms) {
+    final query = searchQuery.trim().toLowerCase();
+    final matches = query.isEmpty
+        ? rooms
+        : rooms
+            .where((room) => room.name.toLowerCase().contains(query))
+            .toList();
+
+    if (matches.isEmpty) {
+      // A server with no rooms and no active filter renders nothing, as
+      // before. The "no matches" copy is reserved for an active filter.
+      if (query.isEmpty) return const SizedBox.shrink();
+      return Padding(
+        padding: const EdgeInsets.fromLTRB(
+            SoliplexSpacing.s4, 0, SoliplexSpacing.s4, SoliplexSpacing.s2),
+        child: Text(
+          'No rooms match "${searchQuery.trim()}".',
+          style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                color: Theme.of(context).colorScheme.onSurfaceVariant,
+              ),
+        ),
+      );
+    }
+
+    return switch (viewMode) {
+      LobbyViewMode.list => Column(
+          children: [
+            for (final room in matches)
+              RoomCard(
+                room: room,
+                onTap: () => onRoomTap(serverId, room.id),
+                onInfoTap: () => onInfoTap(serverId, room.id),
+              ),
+          ],
+        ),
+      LobbyViewMode.grid => _RoomGrid(
+          serverId: serverId,
+          rooms: matches,
+          onRoomTap: onRoomTap,
+          onInfoTap: onInfoTap,
+        ),
+    };
   }
 }
 

--- a/test/modules/lobby/lobby_state_test.dart
+++ b/test/modules/lobby/lobby_state_test.dart
@@ -922,6 +922,18 @@ void main() {
         // No exception means cancellation was handled gracefully
       });
     });
+
+    group('searchQuery', () {
+      test('defaults to empty and is updated by setSearchQuery', () {
+        final state = LobbyState(serverManager: _createManager());
+        expect(state.searchQuery.value, '');
+
+        state.setSearchQuery('design');
+        expect(state.searchQuery.value, 'design');
+
+        state.dispose();
+      });
+    });
   });
 }
 

--- a/test/modules/lobby/ui/lobby_screen_test.dart
+++ b/test/modules/lobby/ui/lobby_screen_test.dart
@@ -228,5 +228,90 @@ void main() {
       expect(find.byType(RoomGridCard), findsOneWidget);
       expect(find.byType(RoomCard), findsNothing);
     });
+
+    testWidgets('search filters rooms by name within the section',
+        (tester) async {
+      tester.view.physicalSize = const Size(800, 600);
+      tester.view.devicePixelRatio = 1.0;
+      addTearDown(tester.view.resetPhysicalSize);
+
+      final manager = _createManager();
+      manager.addServer(
+        serverId: 'local',
+        serverUrl: Uri.parse('http://localhost:8000'),
+        requiresAuth: false,
+      );
+      final fakeApi = FakeSoliplexApi()
+        ..nextRooms = const [
+          Room(id: 'r1', name: 'General'),
+          Room(id: 'r2', name: 'Random'),
+        ];
+
+      await tester.pumpWidget(_buildApp(manager, apiResolver: (_) => fakeApi));
+      await tester.pumpAndSettle();
+      expect(find.byType(RoomCard), findsNWidgets(2));
+
+      await tester.enterText(find.byType(TextField), 'gen');
+      await tester.pumpAndSettle();
+
+      expect(find.byType(RoomCard), findsOneWidget);
+      expect(find.text('General'), findsOneWidget);
+      expect(find.text('Random'), findsNothing);
+    });
+
+    testWidgets('shows no-match copy when the filter excludes everything',
+        (tester) async {
+      tester.view.physicalSize = const Size(800, 600);
+      tester.view.devicePixelRatio = 1.0;
+      addTearDown(tester.view.resetPhysicalSize);
+
+      final manager = _createManager();
+      manager.addServer(
+        serverId: 'local',
+        serverUrl: Uri.parse('http://localhost:8000'),
+        requiresAuth: false,
+      );
+      final fakeApi = FakeSoliplexApi()
+        ..nextRooms = const [Room(id: 'r1', name: 'General')];
+
+      await tester.pumpWidget(_buildApp(manager, apiResolver: (_) => fakeApi));
+      await tester.pumpAndSettle();
+
+      await tester.enterText(find.byType(TextField), 'zzz');
+      await tester.pumpAndSettle();
+
+      expect(find.byType(RoomCard), findsNothing);
+      expect(find.textContaining('No rooms match'), findsOneWidget);
+    });
+
+    testWidgets('clear button resets the filter', (tester) async {
+      tester.view.physicalSize = const Size(800, 600);
+      tester.view.devicePixelRatio = 1.0;
+      addTearDown(tester.view.resetPhysicalSize);
+
+      final manager = _createManager();
+      manager.addServer(
+        serverId: 'local',
+        serverUrl: Uri.parse('http://localhost:8000'),
+        requiresAuth: false,
+      );
+      final fakeApi = FakeSoliplexApi()
+        ..nextRooms = const [
+          Room(id: 'r1', name: 'General'),
+          Room(id: 'r2', name: 'Random'),
+        ];
+
+      await tester.pumpWidget(_buildApp(manager, apiResolver: (_) => fakeApi));
+      await tester.pumpAndSettle();
+
+      await tester.enterText(find.byType(TextField), 'gen');
+      await tester.pumpAndSettle();
+      expect(find.byType(RoomCard), findsOneWidget);
+
+      await tester.tap(find.byIcon(Icons.clear));
+      await tester.pumpAndSettle();
+
+      expect(find.byType(RoomCard), findsNWidgets(2));
+    });
   });
 }


### PR DESCRIPTION
## Summary

Second of the "lobby controls" bundle (after the view toggle, #289). Adds a **room name filter**. Stacked on `feat/lobby-grid-view` (#289) — base will retarget up the stack as PRs merge.

- A `SoliplexInput` search field joins the controls row. On wide widths it shares a row with the view-mode toggle (search expands, toggle right); on narrow widths the search takes the full width and the toggle drops below it (`LayoutBuilder`, `SoliplexBreakpoints.tablet`).
- Typing filters **within each server section** — headings stay; a per-section "No rooms match …" message shows when a filter empties a section. A server with genuinely zero rooms still renders nothing (unchanged).
- Query is an **ephemeral** `signal` on `LobbyState` — intentionally *not* persisted (unlike view mode), so each visit starts unfiltered.
- A clear (✕) button appears in the field once non-empty.

## Notable choices

- `_LobbyControls` is a `StatefulWidget` owning the field's `TextEditingController`, so the text survives the signal-driven rebuilds (every keystroke updates the query signal) and the wide↔narrow layout switch.
- Sectioned (not flattened) filtering, per the agreed design — keeps the per-server context.

## Test plan

- [x] `dart analyze` clean (lib + tests)
- [x] `LobbyState`: searchQuery defaults empty, `setSearchQuery` updates it
- [x] `LobbyScreen`: filter narrows a section to matches; "no match" copy when excluded; clear button resets
- [x] Full suite green (1525 tests)
- [x] Manual smoke: filter in wide + narrow, clear button, interaction with grid mode, light & dark

## Stack

#289 (view toggle) → **this** → server-visibility PR to follow. Retarget to `main` as the stack lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)