### PR TITLE
feat(lobby): hide/show servers' rooms via sidebar eye toggle

### DIFF
--- a/lib/src/modules/lobby/hidden_servers_storage.dart
+++ b/lib/src/modules/lobby/hidden_servers_storage.dart
@@ -1,0 +1,21 @@
+import 'package:shared_preferences/shared_preferences.dart';
+
+/// Persists the set of server IDs whose rooms are hidden from the lobby
+/// content, so the choice survives launches.
+///
+/// Backed by `shared_preferences` (a non-sensitive UI preference). The
+/// hidden state is per-server visibility only — it does not sign the user
+/// out or remove the server.
+abstract final class HiddenServersStorage {
+  static const _key = 'soliplex_lobby_hidden_servers';
+
+  static Future<Set<String>> load() async {
+    final prefs = await SharedPreferences.getInstance();
+    return prefs.getStringList(_key)?.toSet() ?? <String>{};
+  }
+
+  static Future<void> save(Set<String> serverIds) async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setStringList(_key, serverIds.toList());
+  }
+}

--- a/lib/src/modules/lobby/lobby_state.dart
+++ b/lib/src/modules/lobby/lobby_state.dart
@@ -9,6 +9,7 @@ import 'package:soliplex_client/soliplex_client.dart'
 import '../auth/auth_tokens.dart';
 import '../auth/server_entry.dart';
 import '../auth/server_manager.dart';
+import 'hidden_servers_storage.dart';
 import 'lobby_view_mode.dart';
 
 typedef ApiResolver = SoliplexApi Function(ServerEntry entry);
@@ -62,6 +63,7 @@ class LobbyState {
         _apiResolver = apiResolver ?? _defaultResolver {
     _unsubscribe = _serverManager.servers.subscribe(_onServersChanged);
     unawaited(_loadViewMode());
+    unawaited(_loadHiddenServers());
   }
 
   final ServerManager _serverManager;
@@ -122,6 +124,24 @@ class LobbyState {
   ReadonlySignal<String> get searchQuery => _searchQuery;
 
   void setSearchQuery(String query) => _searchQuery.value = query;
+
+  /// Server IDs whose rooms are hidden from the lobby content. Persisted
+  /// across launches; the servers stay in the sidebar so visibility can be
+  /// toggled back on.
+  final Signal<Set<String>> _hiddenServerIds = Signal(const {});
+  ReadonlySignal<Set<String>> get hiddenServerIds => _hiddenServerIds;
+
+  Future<void> _loadHiddenServers() async {
+    _hiddenServerIds.value = await HiddenServersStorage.load();
+  }
+
+  /// Toggles whether [serverId]'s rooms are shown, persisting the change.
+  void toggleServerHidden(String serverId) {
+    final next = Set<String>.from(_hiddenServerIds.value);
+    if (!next.add(serverId)) next.remove(serverId);
+    _hiddenServerIds.value = next;
+    HiddenServersStorage.save(next);
+  }
 
   /// Cancel tokens keyed by serverId, one per in-flight fetch.
   final Map<String, CancelToken> _cancelTokens = {};

--- a/lib/src/modules/lobby/ui/lobby_screen.dart
+++ b/lib/src/modules/lobby/ui/lobby_screen.dart
@@ -96,6 +96,7 @@ class _LobbyScreenState extends State<LobbyScreen> {
     final roomsByServer = _state.roomsByServer.watch(context);
     final viewMode = _state.viewMode.watch(context);
     final searchQuery = _state.searchQuery.watch(context);
+    final hiddenServerIds = _state.hiddenServerIds.watch(context);
     return LayoutBuilder(
       builder: (context, constraints) {
         final isWide = constraints.maxWidth >= _wideBreakpoint;
@@ -108,6 +109,8 @@ class _LobbyScreenState extends State<LobbyScreen> {
                 onViewModeChanged: _state.setViewMode,
                 searchQuery: searchQuery,
                 onSearchChanged: _state.setSearchQuery,
+                hiddenServerIds: hiddenServerIds,
+                onToggleHidden: _state.toggleServerHidden,
                 onServerTap: _onServerTap,
                 onAddServer: _onAddServer,
                 onNetworkInspector: _onNetworkInspector,
@@ -124,6 +127,8 @@ class _LobbyScreenState extends State<LobbyScreen> {
                 onViewModeChanged: _state.setViewMode,
                 searchQuery: searchQuery,
                 onSearchChanged: _state.setSearchQuery,
+                hiddenServerIds: hiddenServerIds,
+                onToggleHidden: _state.toggleServerHidden,
                 onServerTap: _onServerTap,
                 onAddServer: _onAddServer,
                 onNetworkInspector: _onNetworkInspector,
@@ -146,6 +151,8 @@ class _WideLayout extends StatelessWidget {
     required this.onViewModeChanged,
     required this.searchQuery,
     required this.onSearchChanged,
+    required this.hiddenServerIds,
+    required this.onToggleHidden,
     required this.onServerTap,
     required this.onAddServer,
     required this.onNetworkInspector,
@@ -162,6 +169,8 @@ class _WideLayout extends StatelessWidget {
   final void Function(LobbyViewMode) onViewModeChanged;
   final String searchQuery;
   final void Function(String) onSearchChanged;
+  final Set<String> hiddenServerIds;
+  final void Function(String serverId) onToggleHidden;
   final VoidCallback onServerTap;
   final VoidCallback onAddServer;
   final VoidCallback onNetworkInspector;
@@ -180,6 +189,8 @@ class _WideLayout extends StatelessWidget {
             child: ServerSidebar(
               servers: servers,
               profiles: profiles,
+              hiddenServerIds: hiddenServerIds,
+              onToggleHidden: onToggleHidden,
               onServerTap: onServerTap,
               onAddServer: onAddServer,
               onNetworkInspector: onNetworkInspector,
@@ -195,6 +206,7 @@ class _WideLayout extends StatelessWidget {
               onViewModeChanged: onViewModeChanged,
               searchQuery: searchQuery,
               onSearchChanged: onSearchChanged,
+              hiddenServerIds: hiddenServerIds,
               onRoomTap: onRoomTap,
               onInfoTap: onInfoTap,
               onAddServer: onAddServer,
@@ -216,6 +228,8 @@ class _NarrowLayout extends StatelessWidget {
     required this.onViewModeChanged,
     required this.searchQuery,
     required this.onSearchChanged,
+    required this.hiddenServerIds,
+    required this.onToggleHidden,
     required this.onServerTap,
     required this.onAddServer,
     required this.onNetworkInspector,
@@ -232,6 +246,8 @@ class _NarrowLayout extends StatelessWidget {
   final void Function(LobbyViewMode) onViewModeChanged;
   final String searchQuery;
   final void Function(String) onSearchChanged;
+  final Set<String> hiddenServerIds;
+  final void Function(String serverId) onToggleHidden;
   final VoidCallback onServerTap;
   final VoidCallback onAddServer;
   final VoidCallback onNetworkInspector;
@@ -255,6 +271,8 @@ class _NarrowLayout extends StatelessWidget {
         child: ServerSidebar(
           servers: servers,
           profiles: profiles,
+          hiddenServerIds: hiddenServerIds,
+          onToggleHidden: onToggleHidden,
           onServerTap: onServerTap,
           onAddServer: onAddServer,
           onNetworkInspector: onNetworkInspector,
@@ -268,6 +286,7 @@ class _NarrowLayout extends StatelessWidget {
         onViewModeChanged: onViewModeChanged,
         searchQuery: searchQuery,
         onSearchChanged: onSearchChanged,
+        hiddenServerIds: hiddenServerIds,
         onRoomTap: onRoomTap,
         onInfoTap: onInfoTap,
         onAddServer: onAddServer,
@@ -285,6 +304,7 @@ class _RoomContent extends StatelessWidget {
     required this.onViewModeChanged,
     required this.searchQuery,
     required this.onSearchChanged,
+    required this.hiddenServerIds,
     required this.onRoomTap,
     required this.onInfoTap,
     required this.onAddServer,
@@ -297,6 +317,7 @@ class _RoomContent extends StatelessWidget {
   final void Function(LobbyViewMode) onViewModeChanged;
   final String searchQuery;
   final void Function(String) onSearchChanged;
+  final Set<String> hiddenServerIds;
   final void Function(String serverId, String roomId) onRoomTap;
   final void Function(String serverId, String roomId) onInfoTap;
   final VoidCallback onAddServer;
@@ -332,23 +353,47 @@ class _RoomContent extends StatelessWidget {
             onSearchChanged: onSearchChanged,
           ),
         ),
-        Expanded(
-          child: ListView(
-            children: [
-              for (final entry in roomsByServer.entries)
-                _ServerSection(
-                  serverId: entry.key,
-                  serverUrl: servers[entry.key]?.serverUrl,
-                  serverRooms: entry.value,
-                  viewMode: viewMode,
-                  searchQuery: searchQuery,
-                  onRoomTap: onRoomTap,
-                  onInfoTap: onInfoTap,
-                  onSignIn: onSignIn,
+        Expanded(child: _buildSections(context)),
+      ],
+    );
+  }
+
+  Widget _buildSections(BuildContext context) {
+    final visible = roomsByServer.entries
+        .where((entry) => !hiddenServerIds.contains(entry.key))
+        .toList();
+
+    // Distinguish "everything is hidden" from "no room data yet" — only the
+    // former gets the explanatory copy; the latter renders blank as before.
+    if (visible.isEmpty && roomsByServer.isNotEmpty) {
+      return Center(
+        child: Padding(
+          padding: const EdgeInsets.all(SoliplexSpacing.s6),
+          child: Text(
+            'All servers are hidden. Use the eye icon next to a server to '
+            'show its rooms.',
+            textAlign: TextAlign.center,
+            style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                  color: Theme.of(context).colorScheme.onSurfaceVariant,
                 ),
-            ],
           ),
         ),
+      );
+    }
+
+    return ListView(
+      children: [
+        for (final entry in visible)
+          _ServerSection(
+            serverId: entry.key,
+            serverUrl: servers[entry.key]?.serverUrl,
+            serverRooms: entry.value,
+            viewMode: viewMode,
+            searchQuery: searchQuery,
+            onRoomTap: onRoomTap,
+            onInfoTap: onInfoTap,
+            onSignIn: onSignIn,
+          ),
       ],
     );
   }

--- a/lib/src/modules/lobby/ui/server_sidebar.dart
+++ b/lib/src/modules/lobby/ui/server_sidebar.dart
@@ -11,6 +11,8 @@ class ServerSidebar extends StatelessWidget {
     super.key,
     required this.servers,
     required this.profiles,
+    required this.hiddenServerIds,
+    required this.onToggleHidden,
     required this.onServerTap,
     required this.onAddServer,
     required this.onNetworkInspector,
@@ -19,6 +21,8 @@ class ServerSidebar extends StatelessWidget {
 
   final Map<String, ServerEntry> servers;
   final Map<String, UserProfile?> profiles;
+  final Set<String> hiddenServerIds;
+  final void Function(String serverId) onToggleHidden;
   final VoidCallback onServerTap;
   final VoidCallback onAddServer;
   final VoidCallback onNetworkInspector;
@@ -33,6 +37,8 @@ class ServerSidebar extends StatelessWidget {
           child: _ServerList(
             servers: servers,
             profiles: profiles,
+            hiddenServerIds: hiddenServerIds,
+            onToggleHidden: onToggleHidden,
             onServerTap: onServerTap,
             onAddServer: onAddServer,
           ),
@@ -52,12 +58,16 @@ class _ServerList extends StatelessWidget {
   const _ServerList({
     required this.servers,
     required this.profiles,
+    required this.hiddenServerIds,
+    required this.onToggleHidden,
     required this.onServerTap,
     required this.onAddServer,
   });
 
   final Map<String, ServerEntry> servers;
   final Map<String, UserProfile?> profiles;
+  final Set<String> hiddenServerIds;
+  final void Function(String serverId) onToggleHidden;
   final VoidCallback onServerTap;
   final VoidCallback onAddServer;
 
@@ -79,6 +89,8 @@ class _ServerList extends StatelessWidget {
           _ServerTile(
             entry: entry.value,
             profile: profiles[entry.key],
+            hidden: hiddenServerIds.contains(entry.key),
+            onToggleHidden: () => onToggleHidden(entry.key),
             onTap: onServerTap,
           ),
         Padding(
@@ -98,21 +110,39 @@ class _ServerTile extends StatelessWidget {
   const _ServerTile({
     required this.entry,
     required this.profile,
+    required this.hidden,
+    required this.onToggleHidden,
     required this.onTap,
   });
 
   final ServerEntry entry;
   final UserProfile? profile;
+  final bool hidden;
+  final VoidCallback onToggleHidden;
   final VoidCallback onTap;
 
   @override
   Widget build(BuildContext context) {
     return ListTile(
-      title: Text(formatServerUrl(entry.serverUrl)),
+      // Dim the title/subtitle when hidden to signal the server's rooms
+      // are excluded from the lobby; the eye button stays full-strength so
+      // it's still an obvious affordance to toggle back.
+      title: Opacity(
+        opacity: hidden ? 0.5 : 1.0,
+        child: Text(formatServerUrl(entry.serverUrl)),
+      ),
       // The label depends on entry.auth.session, which the parent does
       // not watch — Watch rebuilds the subtitle on session flips.
-      subtitle: Watch(
-        (context) => Text(_identityLabel(entry.auth.session.value)),
+      subtitle: Opacity(
+        opacity: hidden ? 0.5 : 1.0,
+        child: Watch(
+          (context) => Text(_identityLabel(entry.auth.session.value)),
+        ),
+      ),
+      trailing: IconButton(
+        icon: Icon(hidden ? Icons.visibility_off : Icons.visibility),
+        tooltip: hidden ? 'Show rooms' : 'Hide rooms',
+        onPressed: onToggleHidden,
       ),
       dense: true,
       onTap: onTap,

--- a/test/modules/lobby/lobby_state_test.dart
+++ b/test/modules/lobby/lobby_state_test.dart
@@ -8,6 +8,7 @@ import 'package:soliplex_agent/soliplex_agent.dart';
 import 'package:soliplex_frontend/src/modules/auth/auth_session.dart';
 import 'package:soliplex_frontend/src/modules/auth/auth_tokens.dart';
 import 'package:soliplex_frontend/src/modules/auth/server_manager.dart';
+import 'package:soliplex_frontend/src/modules/lobby/hidden_servers_storage.dart';
 import 'package:soliplex_frontend/src/modules/lobby/lobby_state.dart';
 
 import '../../helpers/fakes.dart';
@@ -931,6 +932,35 @@ void main() {
         state.setSearchQuery('design');
         expect(state.searchQuery.value, 'design');
 
+        state.dispose();
+      });
+    });
+
+    group('hiddenServerIds', () {
+      test('defaults to empty; toggle adds then removes and persists',
+          () async {
+        final state = LobbyState(serverManager: _createManager());
+        await Future<void>.delayed(Duration.zero);
+        expect(state.hiddenServerIds.value, isEmpty);
+
+        state.toggleServerHidden('srv-1');
+        expect(state.hiddenServerIds.value, {'srv-1'});
+        expect(await HiddenServersStorage.load(), {'srv-1'});
+
+        state.toggleServerHidden('srv-1');
+        expect(state.hiddenServerIds.value, isEmpty);
+        expect(await HiddenServersStorage.load(), isEmpty);
+
+        state.dispose();
+      });
+
+      test('adopts the persisted hidden set after async load', () async {
+        SharedPreferences.setMockInitialValues({
+          'soliplex_lobby_hidden_servers': ['srv-1', 'srv-2'],
+        });
+        final state = LobbyState(serverManager: _createManager());
+        await Future<void>.delayed(Duration.zero);
+        expect(state.hiddenServerIds.value, {'srv-1', 'srv-2'});
         state.dispose();
       });
     });

--- a/test/modules/lobby/ui/lobby_screen_test.dart
+++ b/test/modules/lobby/ui/lobby_screen_test.dart
@@ -312,5 +312,55 @@ void main() {
 
       expect(find.byType(RoomCard), findsNWidgets(2));
     });
+
+    testWidgets('hiding a server removes its rooms section', (tester) async {
+      tester.view.physicalSize = const Size(800, 600);
+      tester.view.devicePixelRatio = 1.0;
+      addTearDown(tester.view.resetPhysicalSize);
+
+      final manager = _createManager();
+      manager.addServer(
+        serverId: 'local',
+        serverUrl: Uri.parse('http://localhost:8000'),
+        requiresAuth: false,
+      );
+      final fakeApi = FakeSoliplexApi()
+        ..nextRooms = const [Room(id: 'r1', name: 'General')];
+
+      await tester.pumpWidget(_buildApp(manager, apiResolver: (_) => fakeApi));
+      await tester.pumpAndSettle();
+      expect(find.byType(RoomCard), findsOneWidget);
+
+      // Toggle the server off via its sidebar eye button.
+      await tester.tap(find.byIcon(Icons.visibility));
+      await tester.pumpAndSettle();
+
+      expect(find.byType(RoomCard), findsNothing);
+      expect(find.textContaining('All servers are hidden'), findsOneWidget);
+    });
+
+    testWidgets('honors a persisted hidden server on load', (tester) async {
+      SharedPreferences.setMockInitialValues({
+        'soliplex_lobby_hidden_servers': ['local'],
+      });
+      tester.view.physicalSize = const Size(800, 600);
+      tester.view.devicePixelRatio = 1.0;
+      addTearDown(tester.view.resetPhysicalSize);
+
+      final manager = _createManager();
+      manager.addServer(
+        serverId: 'local',
+        serverUrl: Uri.parse('http://localhost:8000'),
+        requiresAuth: false,
+      );
+      final fakeApi = FakeSoliplexApi()
+        ..nextRooms = const [Room(id: 'r1', name: 'General')];
+
+      await tester.pumpWidget(_buildApp(manager, apiResolver: (_) => fakeApi));
+      await tester.pumpAndSettle();
+
+      expect(find.byType(RoomCard), findsNothing);
+      expect(find.byIcon(Icons.visibility_off), findsOneWidget);
+    });
   });
 }

--- a/test/modules/lobby/ui/server_sidebar_test.dart
+++ b/test/modules/lobby/ui/server_sidebar_test.dart
@@ -18,6 +18,8 @@ ServerManager _createManager() => ServerManager(
 Widget _buildSidebar({
   required Map<String, ServerEntry> servers,
   Map<String, UserProfile?> profiles = const {},
+  Set<String> hiddenServerIds = const {},
+  void Function(String serverId)? onToggleHidden,
   VoidCallback? onServerTap,
   VoidCallback? onAddServer,
   VoidCallback? onNetworkInspector,
@@ -28,6 +30,8 @@ Widget _buildSidebar({
       body: ServerSidebar(
         servers: servers,
         profiles: profiles,
+        hiddenServerIds: hiddenServerIds,
+        onToggleHidden: onToggleHidden ?? (_) {},
         onServerTap: onServerTap ?? () {},
         onAddServer: onAddServer ?? () {},
         onNetworkInspector: onNetworkInspector ?? () {},
@@ -142,5 +146,44 @@ void main() {
         expect(find.text('Signed in'), findsNothing);
       },
     );
+
+    testWidgets('eye button fires onToggleHidden with the server id',
+        (tester) async {
+      final manager = _createManager();
+      manager.addServer(
+        serverId: 'http://srv1.test',
+        serverUrl: Uri.parse('http://srv1.test'),
+        requiresAuth: false,
+      );
+
+      String? toggled;
+      await tester.pumpWidget(_buildSidebar(
+        servers: manager.servers.value,
+        onToggleHidden: (id) => toggled = id,
+      ));
+
+      // Visible server shows the "visibility" (eye) icon.
+      expect(find.byIcon(Icons.visibility), findsOneWidget);
+      await tester.tap(find.byIcon(Icons.visibility));
+      expect(toggled, 'http://srv1.test');
+    });
+
+    testWidgets('hidden server renders the visibility_off icon',
+        (tester) async {
+      final manager = _createManager();
+      manager.addServer(
+        serverId: 'http://srv1.test',
+        serverUrl: Uri.parse('http://srv1.test'),
+        requiresAuth: false,
+      );
+
+      await tester.pumpWidget(_buildSidebar(
+        servers: manager.servers.value,
+        hiddenServerIds: const {'http://srv1.test'},
+      ));
+
+      expect(find.byIcon(Icons.visibility_off), findsOneWidget);
+      expect(find.byIcon(Icons.visibility), findsNothing);
+    });
   });
 }


### PR DESCRIPTION
## Summary

Final piece of the "lobby controls" bundle (after view toggle #289 and name filter #290). Adds **per-server visibility**. Stacked on `feat/lobby-room-filter` (#290).

- Each sidebar `_ServerTile` gains a visibility eye button (`visibility` / `visibility_off`). Toggling it hides that server's rooms section from the lobby content; the tile stays (dimmed) so visibility can be toggled back — no sign-out, no removal.
- The hidden set is a **persisted** `signal` on `LobbyState` (`HiddenServersStorage` → SharedPreferences `setStringList`), mirroring the view-mode/`ReturnToStorage` pattern.
- When **every** server is hidden, the content area shows explanatory copy pointing at the eye icon. "No room data yet" still renders blank (not confused with all-hidden).
- Composes with the name filter: hidden servers drop out *before* filtering runs.

## Why an eye-on-tile (vs a dropdown)

Per the team + Erik: a multi-select dropdown of servers would get long and clunky; an eye toggle on the sidebar tile is discoverable and lives where servers already are.

## Test plan

- [x] `dart analyze` clean (lib + tests)
- [x] `HiddenServersStorage` round-trip; `LobbyState` hidden default/toggle/persist + adopts persisted set on load
- [x] `ServerSidebar`: eye fires `onToggleHidden` with the id; hidden tile shows `visibility_off`
- [x] `LobbyScreen`: hiding a server drops its section + shows all-hidden copy; persisted hidden server honored on load
- [x] Full suite green (1531 tests)
- [x] Manual smoke: toggle visibility wide + narrow (drawer), persistence across relaunch, interaction with filter + grid, light & dark

## Stack

#289 (toggle) → #290 (name filter) → **this**. Retarget each to `main` as the stack lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)