### PR TITLE
refactor(diagnostics): adopt design system + cap large bodies

### DIFF
--- a/lib/src/modules/diagnostics/ui/request_detail_view.dart
+++ b/lib/src/modules/diagnostics/ui/request_detail_view.dart
@@ -171,33 +171,28 @@ class _RequestDetailViewState extends State<RequestDetailView>
       child: Row(
         children: [
           Expanded(
-            child: TextField(
+            child: SoliplexInput(
               controller: _searchController,
-              decoration: InputDecoration(
-                hintText: 'Search…',
-                prefixIcon: const Icon(Icons.search, size: 18),
-                suffixIcon: _searchController.text.isNotEmpty
-                    ? IconButton(
-                        icon: const Icon(Icons.clear, size: 18),
-                        onPressed: () => _searchController.clear(),
-                        tooltip: 'Clear search',
-                      )
-                    : null,
-                isDense: true,
-                contentPadding:
-                    const EdgeInsets.symmetric(vertical: SoliplexSpacing.s2),
-                border: OutlineInputBorder(
-                  borderRadius: BorderRadius.circular(soliplexRadii.sm),
-                ),
-              ),
+              hintText: 'Search…',
+              leadingIcon: const Icon(Icons.search, size: 18),
+              trailingIcon: _searchController.text.isNotEmpty
+                  ? IconButton(
+                      icon: const Icon(Icons.clear, size: 18),
+                      onPressed: () => _searchController.clear(),
+                      tooltip: 'Clear search',
+                    )
+                  : null,
             ),
           ),
           const SizedBox(width: SoliplexSpacing.s2),
-          DropdownButton<SearchScope>(
-            value: _scope,
-            underline: const SizedBox.shrink(),
-            isDense: true,
-            onChanged: (v) {
+          SoliplexDropdown<SearchScope>(
+            initialValue: _scope,
+            width: 160,
+            entries: [
+              for (final scope in SearchScope.values)
+                SoliplexDropdownEntry(value: scope, label: scope.label),
+            ],
+            onSelected: (v) {
               if (v != null) {
                 setState(() {
                   _scope = v;
@@ -205,13 +200,6 @@ class _RequestDetailViewState extends State<RequestDetailView>
                 });
               }
             },
-            items: [
-              for (final scope in SearchScope.values)
-                DropdownMenuItem(
-                  value: scope,
-                  child: Text(scope.label),
-                ),
-            ],
           ),
           if (_searchController.text.isNotEmpty && _totalMatches > 0) ...[
             const SizedBox(width: SoliplexSpacing.s2),

--- a/test/modules/diagnostics/ui/network_inspector_screen_test.dart
+++ b/test/modules/diagnostics/ui/network_inspector_screen_test.dart
@@ -50,7 +50,8 @@ void main() {
       await tester.pumpWidget(
         MaterialApp(home: NetworkInspectorScreen(inspector: inspector)),
       );
-      final button = tester.widget<IconButton>(find.byType(IconButton));
+      final button = tester.widget<IconButton>(
+          find.widgetWithIcon(IconButton, Icons.delete_outline));
       expect(button.onPressed, isNull);
     });
 
@@ -59,7 +60,8 @@ void main() {
       await tester.pumpWidget(
         MaterialApp(home: NetworkInspectorScreen(inspector: inspector)),
       );
-      final button = tester.widget<IconButton>(find.byType(IconButton));
+      final button = tester.widget<IconButton>(
+          find.widgetWithIcon(IconButton, Icons.delete_outline));
       expect(button.onPressed, isNotNull);
     });
 
@@ -75,7 +77,7 @@ void main() {
         MaterialApp(home: NetworkInspectorScreen(inspector: inspector)),
       );
 
-      await tester.tap(find.byType(IconButton));
+      await tester.tap(find.widgetWithIcon(IconButton, Icons.delete_outline));
       await tester.pump();
 
       expect(find.text('No HTTP requests yet'), findsOneWidget);
@@ -89,7 +91,8 @@ void main() {
         MaterialApp(home: NetworkInspectorScreen(inspector: inspector)),
       );
 
-      final button = tester.widget<IconButton>(find.byType(IconButton));
+      final button = tester.widget<IconButton>(
+          find.widgetWithIcon(IconButton, Icons.delete_outline));
       expect(
         button.onPressed,
         isNotNull,
@@ -118,7 +121,7 @@ void main() {
       // Panel is visible when concurrency events exist.
       expect(find.byIcon(Icons.hourglass_empty), findsOneWidget);
 
-      await tester.tap(find.byType(IconButton));
+      await tester.tap(find.widgetWithIcon(IconButton, Icons.delete_outline));
       await tester.pump();
 
       // Panel hides itself when the list is empty.

--- a/test/modules/diagnostics/ui/request_detail_view_test.dart
+++ b/test/modules/diagnostics/ui/request_detail_view_test.dart
@@ -1,10 +1,19 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:soliplex_agent/soliplex_agent.dart' hide State;
+import 'package:soliplex_design/soliplex_design.dart';
 import 'package:soliplex_frontend/src/modules/diagnostics/models/http_event_group.dart';
 import 'package:soliplex_frontend/src/modules/diagnostics/ui/request_detail_view.dart';
 
 import '../../../helpers/http_event_factories.dart';
+
+// The scope dropdown (SoliplexDropdown/DropdownMenu) keeps its entry labels
+// in the tree, and some scopes ("Request", "Response", "curl", "Overview")
+// share text with the tabs. Scope tab finders to the TabBar to disambiguate.
+Finder _tab(String label) => find.descendant(
+      of: find.byType(TabBar),
+      matching: find.text(label),
+    );
 
 void main() {
   group('RequestDetailView', () {
@@ -17,13 +26,14 @@ void main() {
       await tester.pumpWidget(
         MaterialApp(home: Scaffold(body: RequestDetailView(group: group))),
       );
-      expect(find.text('Request'), findsOneWidget);
-      expect(find.text('Response'), findsOneWidget);
-      expect(find.text('curl'), findsOneWidget);
-      expect(find.text('Overview'), findsOneWidget);
+      expect(_tab('Request'), findsOneWidget);
+      expect(_tab('Response'), findsOneWidget);
+      expect(_tab('curl'), findsOneWidget);
+      expect(_tab('Overview'), findsOneWidget);
     });
 
-    testWidgets('shows search bar with text field', (tester) async {
+    testWidgets('shows search bar with branded input and scope dropdown',
+        (tester) async {
       final group = HttpEventGroup(
         requestId: 'req-1',
         request: createRequestEvent(),
@@ -32,8 +42,9 @@ void main() {
       await tester.pumpWidget(
         MaterialApp(home: Scaffold(body: RequestDetailView(group: group))),
       );
-      expect(find.byType(TextField), findsOneWidget);
-      expect(find.widgetWithText(TextField, ''), findsOneWidget);
+      expect(find.byType(SoliplexInput), findsOneWidget);
+      expect(find.text('Search…'), findsOneWidget);
+      expect(find.byType(SoliplexDropdown<SearchScope>), findsOneWidget);
     });
 
     testWidgets('request tab shows headers and body when present',
@@ -76,7 +87,7 @@ void main() {
         MaterialApp(home: Scaffold(body: RequestDetailView(group: group))),
       );
       // Navigate to Response tab
-      await tester.tap(find.text('Response'));
+      await tester.tap(_tab('Response'));
       await tester.pump();
       await tester.pump(const Duration(milliseconds: 300));
       expect(find.text('Waiting for response...'), findsOneWidget);
@@ -93,7 +104,7 @@ void main() {
       await tester.pumpWidget(
         MaterialApp(home: Scaffold(body: RequestDetailView(group: group))),
       );
-      await tester.tap(find.text('Response'));
+      await tester.tap(_tab('Response'));
       await tester.pumpAndSettle();
       expect(find.text('Connection refused'), findsOneWidget);
     });
@@ -106,7 +117,7 @@ void main() {
       await tester.pumpWidget(
         MaterialApp(home: Scaffold(body: RequestDetailView(group: group))),
       );
-      await tester.tap(find.text('Response'));
+      await tester.tap(_tab('Response'));
       await tester.pump();
       await tester.pump(const Duration(milliseconds: 300));
       expect(find.text('Stream in progress...'), findsOneWidget);
@@ -125,7 +136,7 @@ void main() {
       await tester.pumpWidget(
         MaterialApp(home: Scaffold(body: RequestDetailView(group: group))),
       );
-      await tester.tap(find.text('curl'));
+      await tester.tap(_tab('curl'));
       await tester.pumpAndSettle();
       expect(find.text('curl command'), findsOneWidget);
       expect(find.textContaining('curl'), findsWidgets);
@@ -142,7 +153,7 @@ void main() {
       await tester.pumpWidget(
         MaterialApp(home: Scaffold(body: RequestDetailView(group: group))),
       );
-      await tester.tap(find.text('curl'));
+      await tester.tap(_tab('curl'));
       await tester.pump();
       await tester.pump(const Duration(milliseconds: 300));
       expect(


### PR DESCRIPTION
## Summary

Design-system adoption for the diagnostics (network inspector) module, plus a performance fix for large bodies spotted during manual testing. Independent of the lobby stack (touches only `diagnostics/**`) — branches off `main`.

Two commits:

### 1. `refactor(diagnostics)`: adopt SoliplexInput + SoliplexDropdown
- Request-detail **search field** `TextField` → `SoliplexInput`.
- Search-**scope** selector `DropdownButton<SearchScope>` → `SoliplexDropdown<SearchScope>` (per design call: full brand consistency over the compact inline control).

### 2. `perf(diagnostics)`: cap large text bodies
Large bodies janked the inspector — each tab rendered the whole payload as a single `SelectableText`, and the Overview JSON tree built eagerly (thousands of widgets at once).
- New `CappedText` helper renders the first 100 KB with a truncation notice.
- The Overview JSON tree is gated on payload size; oversized payloads fall back to a capped preview.
- Full content stays reachable via the existing Copy buttons.
- A lazily **virtualized** view (no cap) is tracked as a follow-up: #292.

## Test adjustments (review note)

`DropdownMenu` (what `SoliplexDropdown` wraps) behaves differently from the old `DropdownButton`:
1. It keeps entry labels mounted; several scope labels collide with tab labels, so tab finders are now scoped to `TabBar` (`_tab()` helper).
2. It adds a trailing chevron `IconButton`, so the screen's clear button is now found by `find.widgetWithIcon(IconButton, Icons.delete_outline)`.

## Test plan

- [x] `dart analyze` clean (lib + tests)
- [x] Diagnostics suite green (212 tests, incl. new cap tests)
- [x] Full suite green (1512)
- [x] Manual: search + scope select work; large bodies no longer jank (verified by reporter)

Follow-up: #292 (virtualize instead of cap).

🤖 Generated with [Claude Code](https://claude.com/claude-code)