### PR TITLE
refactor(quiz): adopt SoliplexButton + SoliplexInput

### DIFF
--- a/lib/src/modules/quiz/ui/quiz_answer_input.dart
+++ b/lib/src/modules/quiz/ui/quiz_answer_input.dart
@@ -138,16 +138,13 @@ class QuizTextInput extends StatelessWidget {
   Widget build(BuildContext context) {
     final isDisabled = questionState is Answered || questionState is Submitting;
 
-    return TextField(
+    return SoliplexInput(
       controller: controller,
       enabled: !isDisabled,
       textInputAction: TextInputAction.done,
       onSubmitted: isDisabled ? null : (_) => onSubmitted(),
       onChanged: onChanged,
-      decoration: const InputDecoration(
-        hintText: 'Type your answer...',
-        border: OutlineInputBorder(),
-      ),
+      hintText: 'Type your answer...',
     );
   }
 }

--- a/lib/src/modules/quiz/ui/quiz_feedback.dart
+++ b/lib/src/modules/quiz/ui/quiz_feedback.dart
@@ -89,7 +89,7 @@ class QuizErrorFeedback extends StatelessWidget {
               ),
             ),
           ),
-          TextButton(onPressed: onRetry, child: const Text('Retry')),
+          SoliplexButton.text(onPressed: onRetry, child: const Text('Retry')),
         ],
       ),
     );

--- a/lib/src/modules/quiz/ui/quiz_question.dart
+++ b/lib/src/modules/quiz/ui/quiz_question.dart
@@ -117,23 +117,20 @@ class QuizQuestionView extends StatelessWidget {
 
   Widget _buildActionButton(QuestionState questionState) {
     return switch (questionState) {
-      AwaitingInput() => const FilledButton(
+      AwaitingInput() => const SoliplexButton.filled(
           onPressed: null,
           child: Text('Submit Answer'),
         ),
-      Composing(:final canSubmit) => FilledButton(
+      Composing(:final canSubmit) => SoliplexButton.filled(
           onPressed: canSubmit ? onSubmit : null,
           child: const Text('Submit Answer'),
         ),
-      Submitting() => const FilledButton(
+      Submitting() => const SoliplexButton.filled(
           onPressed: null,
-          child: SizedBox(
-            width: 20,
-            height: 20,
-            child: CircularProgressIndicator(strokeWidth: 2),
-          ),
+          isLoading: true,
+          child: Text('Submit Answer'),
         ),
-      Answered() => FilledButton(
+      Answered() => SoliplexButton.filled(
           onPressed: onNext,
           child: Text(
             session.isLastQuestion ? 'See Results' : 'Next Question',

--- a/lib/src/modules/quiz/ui/quiz_results.dart
+++ b/lib/src/modules/quiz/ui/quiz_results.dart
@@ -58,11 +58,11 @@ class QuizResultsView extends StatelessWidget {
                 spacing: 8,
                 runSpacing: 8,
                 children: [
-                  OutlinedButton(
+                  SoliplexButton.outlined(
                     onPressed: onBack,
                     child: const Text('Back to Room'),
                   ),
-                  FilledButton(
+                  SoliplexButton.filled(
                     onPressed: onRetake,
                     child: const Text('Retake Quiz'),
                   ),

--- a/lib/src/modules/quiz/ui/quiz_screen.dart
+++ b/lib/src/modules/quiz/ui/quiz_screen.dart
@@ -136,7 +136,7 @@ class _QuizScreenState extends State<QuizScreen> {
                     children: [
                       Text(message),
                       const SizedBox(height: SoliplexSpacing.s4),
-                      FilledButton(
+                      SoliplexButton.filled(
                         onPressed: action,
                         child: Text(label),
                       ),
@@ -220,11 +220,11 @@ class _QuizScreenState extends State<QuizScreen> {
           title: const Text('Leave Quiz?'),
           content: const Text('Your progress will be lost.'),
           actions: [
-            TextButton(
+            SoliplexButton.text(
               onPressed: () => Navigator.pop(context, false),
               child: const Text('Cancel'),
             ),
-            FilledButton(
+            SoliplexButton.filled(
               onPressed: () => Navigator.pop(context, true),
               child: const Text('Leave'),
             ),

--- a/lib/src/modules/quiz/ui/quiz_start.dart
+++ b/lib/src/modules/quiz/ui/quiz_start.dart
@@ -40,10 +40,10 @@ class QuizStartView extends StatelessWidget {
                 ),
               ),
               const SizedBox(height: SoliplexSpacing.s6),
-              FilledButton.icon(
+              SoliplexButton.filled(
                 onPressed: onStart,
                 icon: const Icon(Icons.play_arrow),
-                label: const Text('Start Quiz'),
+                child: const Text('Start Quiz'),
               ),
             ],
           ),


### PR DESCRIPTION
## Summary

Design-system adoption for the quiz module. Independent of the other stacks (touches only `quiz/**`) — branches off `main`.

- **Buttons** → `SoliplexButton`:
  - `quiz_start`: Start Quiz (`filled` + leading icon)
  - `quiz_question`: the action button across all four states (`AwaitingInput` / `Composing` / `Submitting` / `Answered`) — the **Submitting** state now uses the `isLoading` axis instead of a hand-rolled `SizedBox` + `CircularProgressIndicator`
  - `quiz_results`: Back to Room (`outlined`), Retake Quiz (`filled`)
  - `quiz_screen`: error-retry CTA (`filled`), and the Leave-Quiz dialog (Cancel `text`, Leave `filled`)
  - `quiz_feedback`: Retry (`text`)
- **Free-text answer field** (`quiz_answer_input`) `TextField` → `SoliplexInput`.

No behavior change beyond the Submitting loading-state polish (spinner now sits over a faded label so the button keeps its size). Intents left as primary throughout — no destructive coloring added (incl. "Leave", which matches its prior plain-filled styling).

## Test plan

- [x] `dart analyze` clean
- [x] Quiz suite green (99 tests, unmodified — all finders survive the wrapper delegation)
- [x] Full suite green (1510)
- [x] Manual smoke: full quiz flow (start → answer → submit spinner → next → results → retake), free-text + multiple-choice, leave-dialog, light & dark

🤖 Generated with [Claude Code](https://claude.com/claude-code)