### PR TITLE
feat: inactivity logout with re-auth prompt

### DIFF
--- a/lib/soliplex_frontend.dart
+++ b/lib/soliplex_frontend.dart
@@ -3,11 +3,15 @@ library;
 
 export 'src/core/app_module.dart' show AppModule, ModuleRoutes;
 export 'src/core/branding.dart' show BrandLogo, SoliplexBranding;
+export 'src/core/inactivity/inactivity_config.dart' show InactivityConfig;
 export 'src/core/shell.dart' show runSoliplexShell;
 export 'src/core/shell_config.dart' show ShellConfig;
 export 'src/interfaces/auth_state.dart'
     show AuthState, Authenticated, Unauthenticated;
-export 'src/modules/auth/auth_providers.dart' show serverManagerProvider;
+export 'src/modules/auth/auth_providers.dart'
+    show inactivityLogoutFlagsProvider, serverManagerProvider;
+export 'src/modules/auth/inactivity_logout_storage.dart'
+    show InactivityLogoutFlagStorage, SharedPrefsInactivityLogoutFlagStorage;
 export 'src/modules/auth/platform/callback_service.dart'
     show CallbackParamsCapture, clearCallbackUrl;
 export 'src/modules/auth/consent_notice.dart' show ConsentNotice;

--- a/lib/soliplex_frontend.dart
+++ b/lib/soliplex_frontend.dart
@@ -11,7 +11,7 @@ export 'src/interfaces/auth_state.dart'
 export 'src/modules/auth/auth_providers.dart'
     show inactivityLogoutFlagsProvider, serverManagerProvider;
 export 'src/modules/auth/inactivity_logout_storage.dart'
-    show InactivityLogoutFlagStorage, SharedPrefsInactivityLogoutFlagStorage;
+    show InactivityLogoutFlagStorage, LocalInactivityLogoutFlagStorage;
 export 'src/modules/auth/platform/callback_service.dart'
     show CallbackParamsCapture, clearCallbackUrl;
 export 'src/modules/auth/consent_notice.dart' show ConsentNotice;

--- a/lib/src/core/inactivity/inactivity_config.dart
+++ b/lib/src/core/inactivity/inactivity_config.dart
@@ -1,0 +1,29 @@
+/// Compile-time configuration for the inactivity-logout feature.
+///
+/// `warningDuration` is the idle interval before the "stay signed in?"
+/// dialog appears. `graceDuration` is the additional interval the dialog
+/// stays open before the app performs a local logout. Defaults match
+/// issue #284: 10 minutes of inactivity, then a 5-minute grace.
+///
+/// Pass [InactivityConfig.disabled] (or any zero duration) to opt out;
+/// the monitor checks [isEnabled] and never schedules timers when off.
+class InactivityConfig {
+  const InactivityConfig({
+    this.warningDuration = defaultWarningDuration,
+    this.graceDuration = defaultGraceDuration,
+  });
+
+  static const Duration defaultWarningDuration = Duration(minutes: 10);
+  static const Duration defaultGraceDuration = Duration(minutes: 5);
+
+  static const InactivityConfig disabled = InactivityConfig(
+    warningDuration: Duration.zero,
+    graceDuration: Duration.zero,
+  );
+
+  final Duration warningDuration;
+  final Duration graceDuration;
+
+  bool get isEnabled =>
+      warningDuration > Duration.zero && graceDuration > Duration.zero;
+}

--- a/lib/src/core/inactivity/inactivity_config.dart
+++ b/lib/src/core/inactivity/inactivity_config.dart
@@ -2,8 +2,8 @@
 ///
 /// `warningDuration` is the idle interval before the "stay signed in?"
 /// dialog appears. `graceDuration` is the additional interval the dialog
-/// stays open before the app performs a local logout. Defaults match
-/// issue #284: 10 minutes of inactivity, then a 5-minute grace.
+/// stays open before the app performs a local logout. Defaults: 10
+/// minutes of inactivity, then a 5-minute grace.
 ///
 /// Pass [InactivityConfig.disabled] (or any zero duration) to opt out;
 /// the monitor checks [isEnabled] and never schedules timers when off.

--- a/lib/src/core/inactivity/inactivity_dialog.dart
+++ b/lib/src/core/inactivity/inactivity_dialog.dart
@@ -1,0 +1,111 @@
+import 'dart:async';
+
+import 'package:clock/clock.dart';
+import 'package:flutter/material.dart';
+import 'package:soliplex_agent/soliplex_agent.dart' show ReadonlySignal;
+import 'package:soliplex_design/soliplex_design.dart';
+
+/// The "are you still there?" modal shown when inactivity is detected.
+///
+/// The countdown is driven by the `graceDeadline` signal exposed by
+/// `InactivityMonitor`. Tapping "Stay signed in" calls [onExtend];
+/// tapping "Sign out now" calls [onLogout]. The shell drives showing
+/// and dismissing the dialog via `InactivityMonitor.warningVisible`,
+/// so the dialog itself never pops its own route.
+class InactivityDialog extends StatefulWidget {
+  const InactivityDialog({
+    super.key,
+    required this.graceDeadline,
+    required this.onExtend,
+    required this.onLogout,
+  });
+
+  final ReadonlySignal<DateTime?> graceDeadline;
+  final VoidCallback onExtend;
+  final VoidCallback onLogout;
+
+  @override
+  State<InactivityDialog> createState() => _InactivityDialogState();
+}
+
+class _InactivityDialogState extends State<InactivityDialog> {
+  Timer? _ticker;
+
+  @override
+  void initState() {
+    super.initState();
+    _ticker = Timer.periodic(const Duration(seconds: 1), (_) {
+      if (mounted) setState(() {});
+    });
+  }
+
+  @override
+  void dispose() {
+    _ticker?.cancel();
+    super.dispose();
+  }
+
+  Duration _remainingFor(DateTime? deadline) {
+    if (deadline == null) return Duration.zero;
+    final diff = deadline.difference(clock.now());
+    return diff.isNegative ? Duration.zero : diff;
+  }
+
+  String _formatRemaining(Duration remaining) {
+    final minutes = remaining.inMinutes;
+    final seconds = remaining.inSeconds % 60;
+    return '${minutes.toString().padLeft(2, '0')}:'
+        '${seconds.toString().padLeft(2, '0')}';
+  }
+
+  String _semanticsLabelFor(Duration remaining) {
+    final minutes = remaining.inMinutes;
+    final seconds = remaining.inSeconds % 60;
+    return 'Time remaining: $minutes minutes $seconds seconds';
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final remaining = _remainingFor(widget.graceDeadline.value);
+
+    return PopScope(
+      canPop: false,
+      child: AlertDialog(
+        title: const Text('Still there?'),
+        content: Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(
+              "You've been inactive for a while. You'll be signed out in:",
+              style: theme.textTheme.bodyMedium,
+            ),
+            const SizedBox(height: SoliplexSpacing.s2),
+            Semantics(
+              label: _semanticsLabelFor(remaining),
+              excludeSemantics: true,
+              child: Text(
+                _formatRemaining(remaining),
+                style: theme.textTheme.headlineMedium?.copyWith(
+                  fontFeatures: const [FontFeature.tabularFigures()],
+                ),
+              ),
+            ),
+          ],
+        ),
+        actions: [
+          SoliplexButton.text(
+            onPressed: widget.onLogout,
+            intent: ButtonIntent.danger,
+            child: const Text('Sign out now'),
+          ),
+          SoliplexButton.filled(
+            onPressed: widget.onExtend,
+            child: const Text('Stay signed in'),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/src/core/inactivity/inactivity_dialog.dart
+++ b/lib/src/core/inactivity/inactivity_dialog.dart
@@ -7,8 +7,9 @@ import 'package:soliplex_design/soliplex_design.dart';
 
 /// The "are you still there?" modal shown when inactivity is detected.
 ///
-/// The countdown is driven by the `graceDeadline` signal exposed by
-/// `InactivityMonitor`. Tapping "Stay signed in" calls [onExtend];
+/// The remaining time is computed from the `graceDeadline` signal
+/// exposed by `InactivityMonitor` and repainted once per second by a
+/// periodic timer. Tapping "Stay signed in" calls [onExtend];
 /// tapping "Sign out now" calls [onLogout]. The shell drives showing
 /// and dismissing the dialog via `InactivityMonitor.warningVisible`,
 /// so the dialog itself never pops its own route.

--- a/lib/src/core/inactivity/inactivity_dialog.dart
+++ b/lib/src/core/inactivity/inactivity_dialog.dart
@@ -7,9 +7,10 @@ import 'package:soliplex_design/soliplex_design.dart';
 
 /// The "are you still there?" modal shown when inactivity is detected.
 ///
-/// The remaining time is computed from the `graceDeadline` signal
-/// exposed by `InactivityMonitor` and repainted once per second by a
-/// periodic timer. Tapping "Stay signed in" calls [onExtend];
+/// A periodic timer triggers a rebuild every second, recomputing the
+/// remaining time from the current `graceDeadline` value (exposed by
+/// `InactivityMonitor`) against the wall clock; the dialog does not
+/// subscribe to the signal. Tapping "Stay signed in" calls [onExtend];
 /// tapping "Sign out now" calls [onLogout]. The shell drives showing
 /// and dismissing the dialog via `InactivityMonitor.warningVisible`,
 /// so the dialog itself never pops its own route.

--- a/lib/src/core/inactivity/inactivity_dialog_host.dart
+++ b/lib/src/core/inactivity/inactivity_dialog_host.dart
@@ -1,0 +1,78 @@
+import 'package:flutter/material.dart';
+
+import 'inactivity_dialog.dart';
+import 'inactivity_monitor.dart';
+
+/// Renders [child] and pushes / removes [InactivityDialog] in response
+/// to [InactivityMonitor.warningVisible].
+///
+/// Mounted from `MaterialApp.router`'s builder so the host's
+/// [BuildContext] sits inside the root navigator. Reacting via signal
+/// subscription (instead of [Watch] in build) keeps the imperative
+/// [Navigator] calls outside the build phase.
+class InactivityDialogHost extends StatefulWidget {
+  const InactivityDialogHost({
+    super.key,
+    required this.monitor,
+    required this.child,
+  });
+
+  final InactivityMonitor monitor;
+  final Widget child;
+
+  @override
+  State<InactivityDialogHost> createState() => _InactivityDialogHostState();
+}
+
+class _InactivityDialogHostState extends State<InactivityDialogHost> {
+  Route<void>? _dialogRoute;
+  void Function()? _subscription;
+
+  @override
+  void initState() {
+    super.initState();
+    _subscription =
+        widget.monitor.warningVisible.subscribe(_onWarningVisibleChanged);
+  }
+
+  @override
+  void dispose() {
+    _subscription?.call();
+    _subscription = null;
+    super.dispose();
+  }
+
+  void _onWarningVisibleChanged(bool visible) {
+    if (!mounted) return;
+    if (visible && _dialogRoute == null) {
+      _showDialog();
+    } else if (!visible && _dialogRoute != null) {
+      _dismissDialog();
+    }
+  }
+
+  void _showDialog() {
+    final route = DialogRoute<void>(
+      context: context,
+      barrierDismissible: false,
+      animationStyle: AnimationStyle.noAnimation,
+      builder: (_) => InactivityDialog(
+        graceDeadline: widget.monitor.graceDeadline,
+        onExtend: widget.monitor.extendSession,
+        onLogout: widget.monitor.logoutNow,
+      ),
+    );
+    _dialogRoute = route;
+    Navigator.of(context, rootNavigator: true).push(route);
+  }
+
+  void _dismissDialog() {
+    final route = _dialogRoute;
+    _dialogRoute = null;
+    if (route == null || !route.isActive) return;
+    Navigator.of(context, rootNavigator: true).removeRoute(route);
+  }
+
+  @override
+  Widget build(BuildContext context) => widget.child;
+}

--- a/lib/src/core/inactivity/inactivity_dialog_host.dart
+++ b/lib/src/core/inactivity/inactivity_dialog_host.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 
 import 'inactivity_dialog.dart';
@@ -14,10 +16,18 @@ class InactivityDialogHost extends StatefulWidget {
   const InactivityDialogHost({
     super.key,
     required this.monitor,
+    required this.navigatorKey,
     required this.child,
   });
 
   final InactivityMonitor monitor;
+
+  /// Key for the navigator the dialog is pushed onto. The host itself
+  /// sits in `MaterialApp.router`'s `builder` slot, which is *above*
+  /// the navigator in the widget tree, so `Navigator.of(context)`
+  /// can't find one from the host's own context. The key gives the
+  /// host a direct handle to the navigator's state.
+  final GlobalKey<NavigatorState> navigatorKey;
   final Widget child;
 
   @override
@@ -44,16 +54,24 @@ class _InactivityDialogHostState extends State<InactivityDialogHost> {
 
   void _onWarningVisibleChanged(bool visible) {
     if (!mounted) return;
-    if (visible && _dialogRoute == null) {
-      _showDialog();
-    } else if (!visible && _dialogRoute != null) {
-      _dismissDialog();
-    }
+    // Microtask defers past the current signal-update batch but still
+    // runs before the next frame, so we don't depend on a frame being
+    // scheduled by some other code path before the dialog appears.
+    scheduleMicrotask(() {
+      if (!mounted) return;
+      if (visible && _dialogRoute == null) {
+        _showDialog();
+      } else if (!visible && _dialogRoute != null) {
+        _dismissDialog();
+      }
+    });
   }
 
   void _showDialog() {
+    final nav = widget.navigatorKey.currentState;
+    if (nav == null) return;
     final route = DialogRoute<void>(
-      context: context,
+      context: nav.context,
       barrierDismissible: false,
       animationStyle: AnimationStyle.noAnimation,
       builder: (_) => InactivityDialog(
@@ -63,14 +81,14 @@ class _InactivityDialogHostState extends State<InactivityDialogHost> {
       ),
     );
     _dialogRoute = route;
-    Navigator.of(context, rootNavigator: true).push(route);
+    nav.push(route);
   }
 
   void _dismissDialog() {
     final route = _dialogRoute;
     _dialogRoute = null;
     if (route == null || !route.isActive) return;
-    Navigator.of(context, rootNavigator: true).removeRoute(route);
+    widget.navigatorKey.currentState?.removeRoute(route);
   }
 
   @override

--- a/lib/src/core/inactivity/inactivity_monitor.dart
+++ b/lib/src/core/inactivity/inactivity_monitor.dart
@@ -67,9 +67,7 @@ class InactivityMonitor {
   /// timer from zero.
   void extendSession() {
     if (!_warningVisible.value) return;
-    _graceTimer?.cancel();
-    _graceTimer = null;
-    _graceDeadline.value = null;
+    _clearGrace();
     _warningVisible.value = false;
     _armWarningTimer();
   }
@@ -92,7 +90,7 @@ class InactivityMonitor {
       }
     } else {
       _cancelAllTimers();
-      _graceDeadline.value = null;
+      _clearGrace();
       _warningVisible.value = false;
     }
   }
@@ -114,9 +112,9 @@ class InactivityMonitor {
         .where((e) => e.auth.session.value is ActiveSession)
         .toList();
     for (final entry in active) {
-      // Mark before logout so a successful re-auth on a different code
-      // path doesn't race the flag write. The future is intentionally
-      // not awaited — best-effort persistence, fire-and-forget.
+      // Persist the flag best-effort (fire-and-forget); logout proceeds
+      // regardless. The storage layer swallows and logs its own failures,
+      // so the unawaited future never rejects.
       unawaited(_inactivityLogoutFlags?.mark(entry.serverId) ?? Future.value());
       entry.auth.logout();
     }
@@ -129,5 +127,13 @@ class InactivityMonitor {
     _graceTimer?.cancel();
     _warningTimer = null;
     _graceTimer = null;
+  }
+
+  /// Clears the grace state — the grace timer and its deadline always
+  /// move together, so they have a single reset point.
+  void _clearGrace() {
+    _graceTimer?.cancel();
+    _graceTimer = null;
+    _graceDeadline.value = null;
   }
 }

--- a/lib/src/core/inactivity/inactivity_monitor.dart
+++ b/lib/src/core/inactivity/inactivity_monitor.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 
+import 'package:clock/clock.dart';
 import 'package:soliplex_agent/soliplex_agent.dart';
 
 import '../../modules/auth/auth_tokens.dart';
@@ -100,7 +101,7 @@ class InactivityMonitor {
   void _onWarningFired() {
     _warningTimer = null;
     _warningVisible.value = true;
-    _graceDeadline.value = DateTime.now().add(_config.graceDuration);
+    _graceDeadline.value = clock.now().add(_config.graceDuration);
     _graceTimer = Timer(_config.graceDuration, _performLogout);
   }
 

--- a/lib/src/core/inactivity/inactivity_monitor.dart
+++ b/lib/src/core/inactivity/inactivity_monitor.dart
@@ -1,0 +1,124 @@
+import 'dart:async';
+
+import 'package:soliplex_agent/soliplex_agent.dart';
+
+import '../../modules/auth/auth_tokens.dart';
+import '../../modules/auth/server_entry.dart';
+import 'inactivity_config.dart';
+
+/// Tracks user activity and drives the "are you still there?" prompt.
+///
+/// The monitor watches every authenticated `ServerEntry` and arms a
+/// warning timer whenever at least one session is active. UI code calls
+/// [bumpActivity] in response to pointer and keyboard events; if no
+/// activity arrives within [InactivityConfig.warningDuration], the
+/// warning is shown and a grace timer starts. The grace timer signs
+/// every active session out locally when it fires.
+///
+/// All reactive state is exposed via signals so the shell can drive the
+/// dialog without rebuilding the whole tree.
+class InactivityMonitor {
+  InactivityMonitor({
+    required ReadonlySignal<Map<String, ServerEntry>> servers,
+    required InactivityConfig config,
+  })  : _servers = servers,
+        _config = config {
+    if (!_config.isEnabled) return;
+    final hasAnyActive = computed(() {
+      return _servers.value.values
+          .any((e) => e.auth.session.value is ActiveSession);
+    });
+    _hasAnyActive = hasAnyActive;
+    _activeSubscription = hasAnyActive.subscribe(_onActiveChanged);
+  }
+
+  final ReadonlySignal<Map<String, ServerEntry>> _servers;
+  final InactivityConfig _config;
+
+  ReadonlySignal<bool>? _hasAnyActive;
+  void Function()? _activeSubscription;
+
+  Timer? _warningTimer;
+  Timer? _graceTimer;
+
+  final Signal<bool> _warningVisible = Signal<bool>(false);
+  ReadonlySignal<bool> get warningVisible => _warningVisible;
+
+  final Signal<DateTime?> _graceDeadline = Signal<DateTime?>(null);
+  ReadonlySignal<DateTime?> get graceDeadline => _graceDeadline;
+
+  /// Resets the warning timer in response to a user interaction.
+  ///
+  /// No-op while the warning dialog is showing — once the prompt is up,
+  /// only an explicit choice (extend or sign out) should resolve it.
+  void bumpActivity() {
+    if (!_config.isEnabled) return;
+    if (_warningVisible.value) return;
+    if (_hasAnyActive?.value != true) return;
+    _armWarningTimer();
+  }
+
+  /// "Stay signed in" — dismiss the dialog and restart the warning
+  /// timer from zero.
+  void extendSession() {
+    if (!_warningVisible.value) return;
+    _graceTimer?.cancel();
+    _graceTimer = null;
+    _graceDeadline.value = null;
+    _warningVisible.value = false;
+    _armWarningTimer();
+  }
+
+  /// "Sign out now" — equivalent to letting the grace timer fire.
+  void logoutNow() {
+    _performLogout();
+  }
+
+  void dispose() {
+    _activeSubscription?.call();
+    _activeSubscription = null;
+    _cancelAllTimers();
+  }
+
+  void _onActiveChanged(bool hasActive) {
+    if (hasActive) {
+      if (_warningTimer == null && !_warningVisible.value) {
+        _armWarningTimer();
+      }
+    } else {
+      _cancelAllTimers();
+      _graceDeadline.value = null;
+      _warningVisible.value = false;
+    }
+  }
+
+  void _armWarningTimer() {
+    _warningTimer?.cancel();
+    _warningTimer = Timer(_config.warningDuration, _onWarningFired);
+  }
+
+  void _onWarningFired() {
+    _warningTimer = null;
+    _warningVisible.value = true;
+    _graceDeadline.value = DateTime.now().add(_config.graceDuration);
+    _graceTimer = Timer(_config.graceDuration, _performLogout);
+  }
+
+  void _performLogout() {
+    final active = _servers.value.values
+        .where((e) => e.auth.session.value is ActiveSession)
+        .toList();
+    for (final entry in active) {
+      entry.auth.logout();
+    }
+    // The hasAnyActive subscription handles dialog dismiss and timer
+    // cleanup when the last session flips to NoSession.
+  }
+
+  void _cancelAllTimers() {
+    _warningTimer?.cancel();
+    _graceTimer?.cancel();
+    _warningTimer = null;
+    _graceTimer = null;
+  }
+}

--- a/lib/src/core/inactivity/inactivity_monitor.dart
+++ b/lib/src/core/inactivity/inactivity_monitor.dart
@@ -27,6 +27,19 @@ class InactivityMonitor {
   })  : _servers = servers,
         _config = config,
         _inactivityLogoutFlags = inactivityLogoutFlags {
+    assert(
+      config.warningDuration >= Duration.zero &&
+          config.graceDuration >= Duration.zero,
+      'InactivityConfig durations must be non-negative '
+      '(warning=${config.warningDuration}, grace=${config.graceDuration}).',
+    );
+    assert(
+      (config.warningDuration == Duration.zero) ==
+          (config.graceDuration == Duration.zero),
+      'InactivityConfig must enable both durations or neither — a single '
+      'zero silently disables inactivity logout '
+      '(warning=${config.warningDuration}, grace=${config.graceDuration}).',
+    );
     if (!_config.isEnabled) return;
     final hasAnyActive = computed(() {
       return _servers.value.values
@@ -74,6 +87,10 @@ class InactivityMonitor {
 
   /// "Sign out now" — equivalent to letting the grace timer fire.
   void logoutNow() {
+    assert(
+      _warningVisible.value,
+      'logoutNow is only expected while the warning dialog is showing.',
+    );
     _performLogout();
   }
 

--- a/lib/src/core/inactivity/inactivity_monitor.dart
+++ b/lib/src/core/inactivity/inactivity_monitor.dart
@@ -4,6 +4,7 @@ import 'package:clock/clock.dart';
 import 'package:soliplex_agent/soliplex_agent.dart';
 
 import '../../modules/auth/auth_tokens.dart';
+import '../../modules/auth/inactivity_logout_storage.dart';
 import '../../modules/auth/server_entry.dart';
 import 'inactivity_config.dart';
 
@@ -22,8 +23,10 @@ class InactivityMonitor {
   InactivityMonitor({
     required ReadonlySignal<Map<String, ServerEntry>> servers,
     required InactivityConfig config,
+    InactivityLogoutFlagStorage? inactivityLogoutFlags,
   })  : _servers = servers,
-        _config = config {
+        _config = config,
+        _inactivityLogoutFlags = inactivityLogoutFlags {
     if (!_config.isEnabled) return;
     final hasAnyActive = computed(() {
       return _servers.value.values
@@ -35,6 +38,7 @@ class InactivityMonitor {
 
   final ReadonlySignal<Map<String, ServerEntry>> _servers;
   final InactivityConfig _config;
+  final InactivityLogoutFlagStorage? _inactivityLogoutFlags;
 
   ReadonlySignal<bool>? _hasAnyActive;
   void Function()? _activeSubscription;
@@ -110,6 +114,10 @@ class InactivityMonitor {
         .where((e) => e.auth.session.value is ActiveSession)
         .toList();
     for (final entry in active) {
+      // Mark before logout so a successful re-auth on a different code
+      // path doesn't race the flag write. The future is intentionally
+      // not awaited — best-effort persistence, fire-and-forget.
+      unawaited(_inactivityLogoutFlags?.mark(entry.serverId) ?? Future.value());
       entry.auth.logout();
     }
     // The hasAnyActive subscription handles dialog dismiss and timer

--- a/lib/src/core/inactivity/inactivity_provider.dart
+++ b/lib/src/core/inactivity/inactivity_provider.dart
@@ -1,3 +1,5 @@
+import 'dart:developer' as dev;
+
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../modules/auth/auth_providers.dart';
@@ -26,15 +28,19 @@ final inactivityMonitorProvider = Provider<InactivityMonitor?>((ref) {
   try {
     serverManager = ref.watch(serverManagerProvider);
     flags = ref.watch(inactivityLogoutFlagsProvider);
-  } catch (_) {
+  } catch (e) {
     // The auth-module providers throw UnimplementedError when not
     // overridden, but riverpod wraps that in a ProviderException that it
     // doesn't export — so it can't be caught by type. In practice this is
-    // the only thing this catch ever sees: those providers are always
+    // the only thing this catch sees: those providers are currently always
     // installed via overrideWithValue (a pre-built instance that can't
-    // throw at read time), so there is no "installed but errored" case to
-    // distinguish. Returning null keeps the shell bootable for consumers
-    // that don't include the auth module.
+    // throw at read time). Returning null keeps the shell bootable for
+    // consumers that don't include the auth module; logging leaves a
+    // breadcrumb if that assumption ever stops holding.
+    dev.log(
+      'Inactivity monitor disabled: auth providers unavailable ($e).',
+      name: 'soliplex_frontend.inactivity',
+    );
     return null;
   }
   final monitor = InactivityMonitor(

--- a/lib/src/core/inactivity/inactivity_provider.dart
+++ b/lib/src/core/inactivity/inactivity_provider.dart
@@ -1,0 +1,27 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../modules/auth/auth_providers.dart';
+import 'inactivity_config.dart';
+import 'inactivity_monitor.dart';
+
+/// Holds the active [InactivityConfig].
+///
+/// Overridden by [SoliplexShell] with the value from [ShellConfig.inactivity].
+final inactivityConfigProvider = Provider<InactivityConfig>(
+  (_) => throw UnimplementedError('must be overridden by SoliplexShell'),
+);
+
+/// The shell-scoped [InactivityMonitor].
+///
+/// Wired with the [ServerManager.servers] signal, the active
+/// [InactivityConfig], and the [InactivityLogoutFlagStorage] so it can
+/// flag servers whose tokens it drops at grace-timer expiry.
+final inactivityMonitorProvider = Provider<InactivityMonitor>((ref) {
+  final monitor = InactivityMonitor(
+    servers: ref.watch(serverManagerProvider).servers,
+    config: ref.watch(inactivityConfigProvider),
+    inactivityLogoutFlags: ref.watch(inactivityLogoutFlagsProvider),
+  );
+  ref.onDispose(monitor.dispose);
+  return monitor;
+});

--- a/lib/src/core/inactivity/inactivity_provider.dart
+++ b/lib/src/core/inactivity/inactivity_provider.dart
@@ -27,8 +27,14 @@ final inactivityMonitorProvider = Provider<InactivityMonitor?>((ref) {
     serverManager = ref.watch(serverManagerProvider);
     flags = ref.watch(inactivityLogoutFlagsProvider);
   } catch (_) {
-    // Auth module providers not overridden — keep the shell bootable
-    // for consumers that don't include them.
+    // The auth-module providers throw UnimplementedError when not
+    // overridden, but riverpod wraps that in a ProviderException that it
+    // doesn't export — so it can't be caught by type. In practice this is
+    // the only thing this catch ever sees: those providers are always
+    // installed via overrideWithValue (a pre-built instance that can't
+    // throw at read time), so there is no "installed but errored" case to
+    // distinguish. Returning null keeps the shell bootable for consumers
+    // that don't include the auth module.
     return null;
   }
   final monitor = InactivityMonitor(

--- a/lib/src/core/inactivity/inactivity_provider.dart
+++ b/lib/src/core/inactivity/inactivity_provider.dart
@@ -1,6 +1,8 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../modules/auth/auth_providers.dart';
+import '../../modules/auth/inactivity_logout_storage.dart';
+import '../../modules/auth/server_manager.dart';
 import 'inactivity_config.dart';
 import 'inactivity_monitor.dart';
 
@@ -11,16 +13,28 @@ final inactivityConfigProvider = Provider<InactivityConfig>(
   (_) => throw UnimplementedError('must be overridden by SoliplexShell'),
 );
 
-/// The shell-scoped [InactivityMonitor].
+/// The shell-scoped [InactivityMonitor], or `null` when the auth-module
+/// providers it depends on (`serverManagerProvider`,
+/// `inactivityLogoutFlagsProvider`) are not configured.
 ///
-/// Wired with the [ServerManager.servers] signal, the active
-/// [InactivityConfig], and the [InactivityLogoutFlagStorage] so it can
-/// flag servers whose tokens it drops at grace-timer expiry.
-final inactivityMonitorProvider = Provider<InactivityMonitor>((ref) {
+/// Returning nullable keeps the library bootable by consumers that
+/// don't include the auth module — inactivity logout simply stays
+/// disabled instead of crashing the shell.
+final inactivityMonitorProvider = Provider<InactivityMonitor?>((ref) {
+  final ServerManager serverManager;
+  final InactivityLogoutFlagStorage flags;
+  try {
+    serverManager = ref.watch(serverManagerProvider);
+    flags = ref.watch(inactivityLogoutFlagsProvider);
+  } catch (_) {
+    // Auth module providers not overridden — keep the shell bootable
+    // for consumers that don't include them.
+    return null;
+  }
   final monitor = InactivityMonitor(
-    servers: ref.watch(serverManagerProvider).servers,
+    servers: serverManager.servers,
     config: ref.watch(inactivityConfigProvider),
-    inactivityLogoutFlags: ref.watch(inactivityLogoutFlagsProvider),
+    inactivityLogoutFlags: flags,
   );
   ref.onDispose(monitor.dispose);
   return monitor;

--- a/lib/src/core/shell.dart
+++ b/lib/src/core/shell.dart
@@ -146,7 +146,10 @@ class _ShellRootState extends ConsumerState<_ShellRoot> {
       onPointerDown: _onPointer,
       // `onPointerSignal` fires on trackpad/wheel scroll on desktop and
       // web. On mobile, scrolling is a drag gesture starting with
-      // `onPointerDown`.
+      // `onPointerDown`. Bare cursor movement/hover (`onPointerHover`/
+      // `onPointerMove` with no button) is intentionally NOT counted as
+      // activity — presence of the cursor isn't engagement, and counting
+      // it would defeat inactivity detection on desktop/web.
       onPointerSignal: _onPointer,
       child: app,
     );

--- a/lib/src/core/shell.dart
+++ b/lib/src/core/shell.dart
@@ -4,8 +4,13 @@ import 'dart:io' show Platform;
 import 'package:file_picker/file_picker.dart';
 import 'package:flutter/foundation.dart' show kIsWeb;
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
 
+import 'inactivity/inactivity_dialog_host.dart';
+import 'inactivity/inactivity_monitor.dart';
+import 'inactivity/inactivity_provider.dart';
 import 'router.dart';
 import 'shell_config.dart';
 
@@ -61,14 +66,11 @@ class _SoliplexShellState extends State<SoliplexShell> {
   @override
   Widget build(BuildContext context) {
     return ProviderScope(
-      overrides: widget.config.overrides,
-      child: MaterialApp.router(
-        title: widget.config.appName,
-        theme: widget.config.lightTheme,
-        darkTheme: widget.config.darkTheme,
-        themeMode: widget.config.themeMode,
-        routerConfig: _router,
-      ),
+      overrides: [
+        ...widget.config.overrides,
+        inactivityConfigProvider.overrideWithValue(widget.config.inactivity),
+      ],
+      child: _ShellRoot(config: widget.config, router: _router),
     );
   }
 
@@ -76,5 +78,70 @@ class _SoliplexShellState extends State<SoliplexShell> {
   void dispose() {
     _router.dispose();
     super.dispose();
+  }
+}
+
+/// Lives inside [ProviderScope] so it can read the [InactivityMonitor]
+/// via Riverpod. Owns the global activity listeners (pointer + keyboard)
+/// and wraps [MaterialApp.router]'s builder slot with the dialog host.
+class _ShellRoot extends ConsumerStatefulWidget {
+  const _ShellRoot({required this.config, required this.router});
+
+  final ShellConfig config;
+  final GoRouter router;
+
+  @override
+  ConsumerState<_ShellRoot> createState() => _ShellRootState();
+}
+
+class _ShellRootState extends ConsumerState<_ShellRoot> {
+  late final InactivityMonitor _monitor = ref.read(inactivityMonitorProvider);
+
+  @override
+  void initState() {
+    super.initState();
+    // HardwareKeyboard sees every key the framework receives, regardless
+    // of which widget owns focus — a root `Focus` widget would miss keys
+    // consumed by descendants like `TextField`.
+    HardwareKeyboard.instance.addHandler(_onKeyEvent);
+  }
+
+  @override
+  void dispose() {
+    HardwareKeyboard.instance.removeHandler(_onKeyEvent);
+    super.dispose();
+  }
+
+  bool _onKeyEvent(KeyEvent event) {
+    if (event is KeyDownEvent) _monitor.bumpActivity();
+    // Returning false lets the framework continue normal dispatch.
+    return false;
+  }
+
+  void _onPointer(PointerEvent _) => _monitor.bumpActivity();
+
+  @override
+  Widget build(BuildContext context) {
+    return Listener(
+      behavior: HitTestBehavior.translucent,
+      onPointerDown: _onPointer,
+      // `onPointerSignal` fires on trackpad/wheel scroll on desktop and
+      // web. On mobile, scrolling is a drag gesture starting with
+      // `onPointerDown`.
+      onPointerSignal: _onPointer,
+      child: MaterialApp.router(
+        title: widget.config.appName,
+        theme: widget.config.lightTheme,
+        darkTheme: widget.config.darkTheme,
+        themeMode: widget.config.themeMode,
+        routerConfig: widget.router,
+        builder: (context, child) {
+          return InactivityDialogHost(
+            monitor: _monitor,
+            child: child ?? const SizedBox.shrink(),
+          );
+        },
+      ),
+    );
   }
 }

--- a/lib/src/core/shell.dart
+++ b/lib/src/core/shell.dart
@@ -136,6 +136,7 @@ class _ShellRootState extends ConsumerState<_ShellRoot> {
           ? null
           : (context, child) => InactivityDialogHost(
                 monitor: monitor,
+                navigatorKey: widget.router.routerDelegate.navigatorKey,
                 child: child ?? const SizedBox.shrink(),
               ),
     );

--- a/lib/src/core/shell.dart
+++ b/lib/src/core/shell.dart
@@ -95,33 +95,51 @@ class _ShellRoot extends ConsumerStatefulWidget {
 }
 
 class _ShellRootState extends ConsumerState<_ShellRoot> {
-  late final InactivityMonitor _monitor = ref.read(inactivityMonitorProvider);
+  late final InactivityMonitor? _monitor = ref.read(inactivityMonitorProvider);
 
   @override
   void initState() {
     super.initState();
-    // HardwareKeyboard sees every key the framework receives, regardless
-    // of which widget owns focus — a root `Focus` widget would miss keys
-    // consumed by descendants like `TextField`.
-    HardwareKeyboard.instance.addHandler(_onKeyEvent);
+    if (_monitor != null) {
+      // HardwareKeyboard sees every key the framework receives,
+      // regardless of which widget owns focus — a root `Focus` widget
+      // would miss keys consumed by descendants like `TextField`.
+      HardwareKeyboard.instance.addHandler(_onKeyEvent);
+    }
   }
 
   @override
   void dispose() {
-    HardwareKeyboard.instance.removeHandler(_onKeyEvent);
+    if (_monitor != null) {
+      HardwareKeyboard.instance.removeHandler(_onKeyEvent);
+    }
     super.dispose();
   }
 
   bool _onKeyEvent(KeyEvent event) {
-    if (event is KeyDownEvent) _monitor.bumpActivity();
-    // Returning false lets the framework continue normal dispatch.
+    if (event is KeyDownEvent) _monitor?.bumpActivity();
     return false;
   }
 
-  void _onPointer(PointerEvent _) => _monitor.bumpActivity();
+  void _onPointer(PointerEvent _) => _monitor?.bumpActivity();
 
   @override
   Widget build(BuildContext context) {
+    final monitor = _monitor;
+    final app = MaterialApp.router(
+      title: widget.config.appName,
+      theme: widget.config.lightTheme,
+      darkTheme: widget.config.darkTheme,
+      themeMode: widget.config.themeMode,
+      routerConfig: widget.router,
+      builder: monitor == null
+          ? null
+          : (context, child) => InactivityDialogHost(
+                monitor: monitor,
+                child: child ?? const SizedBox.shrink(),
+              ),
+    );
+    if (monitor == null) return app;
     return Listener(
       behavior: HitTestBehavior.translucent,
       onPointerDown: _onPointer,
@@ -129,19 +147,7 @@ class _ShellRootState extends ConsumerState<_ShellRoot> {
       // web. On mobile, scrolling is a drag gesture starting with
       // `onPointerDown`.
       onPointerSignal: _onPointer,
-      child: MaterialApp.router(
-        title: widget.config.appName,
-        theme: widget.config.lightTheme,
-        darkTheme: widget.config.darkTheme,
-        themeMode: widget.config.themeMode,
-        routerConfig: widget.router,
-        builder: (context, child) {
-          return InactivityDialogHost(
-            monitor: _monitor,
-            child: child ?? const SizedBox.shrink(),
-          );
-        },
-      ),
+      child: app,
     );
   }
 }

--- a/lib/src/core/shell_config.dart
+++ b/lib/src/core/shell_config.dart
@@ -3,6 +3,7 @@ import 'package:flutter_riverpod/misc.dart';
 import 'package:go_router/go_router.dart';
 
 import 'app_module.dart';
+import 'inactivity/inactivity_config.dart';
 import 'router.dart';
 
 class ShellConfig {
@@ -12,6 +13,7 @@ class ShellConfig {
   final ThemeMode themeMode;
   final String initialRoute;
   final Listenable? refreshListenable;
+  final InactivityConfig inactivity;
 
   /// Tears down every module's `onDispose` in reverse registration order.
   ///
@@ -37,6 +39,7 @@ class ShellConfig {
     required List<Override> overrides,
     required List<GoRouterRedirect> redirects,
     this.refreshListenable,
+    this.inactivity = const InactivityConfig(),
     this.dispose,
   })  : _routes = routes,
         _overrides = overrides,
@@ -64,6 +67,7 @@ class ShellConfig {
     ThemeMode themeMode = ThemeMode.system,
     String initialRoute = '/',
     Listenable? refreshListenable,
+    InactivityConfig inactivity = const InactivityConfig(),
   }) async {
     final coordinator = _AppModuleCoordinator(modules);
     return ShellConfig._internal(
@@ -76,6 +80,7 @@ class ShellConfig {
       overrides: coordinator.overrides,
       redirects: coordinator.redirects,
       refreshListenable: refreshListenable,
+      inactivity: inactivity,
       dispose: coordinator.disposeAll,
     );
   }

--- a/lib/src/flavors/standard.dart
+++ b/lib/src/flavors/standard.dart
@@ -123,7 +123,7 @@ Future<ShellConfig> standard({
 
   final registry = RunRegistry();
 
-  final inactivityLogoutFlags = SharedPrefsInactivityLogoutFlagStorage();
+  final inactivityLogoutFlags = LocalInactivityLogoutFlagStorage();
 
   final authMod = AuthAppModule(
     serverManager: serverManager,

--- a/lib/src/flavors/standard.dart
+++ b/lib/src/flavors/standard.dart
@@ -5,6 +5,7 @@ import 'package:soliplex_client_native/soliplex_client_native.dart';
 import 'package:soliplex_logging/soliplex_logging.dart' show LoggerFactory;
 
 import '../core/branding.dart';
+import '../core/inactivity/inactivity_config.dart';
 import '../core/routes.dart';
 import '../core/shell_config.dart';
 import 'package:soliplex_design/soliplex_design.dart';
@@ -37,6 +38,8 @@ Future<ShellConfig> standard({
   String defaultBackendUrl = 'http://localhost:8000',
   CallbackParams callbackParams = const NoCallbackParams(),
   ConsentNotice? consentNotice,
+  Duration inactivityWarningDuration = InactivityConfig.defaultWarningDuration,
+  Duration inactivityGraceDuration = InactivityConfig.defaultGraceDuration,
 }) async {
   final brand = branding ?? SoliplexBranding.soliplex;
   final lightTheme = soliplexLightTheme(
@@ -141,6 +144,10 @@ Future<ShellConfig> standard({
             ? AppRoutes.lobby
             : AppRoutes.home),
     refreshListenable: authMod.refreshListenable,
+    inactivity: InactivityConfig(
+      warningDuration: inactivityWarningDuration,
+      graceDuration: inactivityGraceDuration,
+    ),
     modules: [
       DiagnosticsAppModule(inspector: inspector),
       authMod,

--- a/lib/src/flavors/standard.dart
+++ b/lib/src/flavors/standard.dart
@@ -14,6 +14,7 @@ import '../modules/auth/auth_module.dart';
 import '../modules/auth/consent_notice.dart';
 import '../modules/auth/default_backend_url.dart';
 import '../modules/auth/auth_session.dart';
+import '../modules/auth/inactivity_logout_storage.dart';
 import '../modules/auth/platform/auth_flow.dart';
 import '../modules/auth/platform/callback_params.dart';
 import '../modules/auth/secure_server_storage.dart';
@@ -122,11 +123,14 @@ Future<ShellConfig> standard({
 
   final registry = RunRegistry();
 
+  final inactivityLogoutFlags = SharedPrefsInactivityLogoutFlagStorage();
+
   final authMod = AuthAppModule(
     serverManager: serverManager,
     probeClient: plainClient,
     authFlow: authFlow,
     appName: brand.appName,
+    inactivityLogoutFlags: inactivityLogoutFlags,
     callbackParams: callbackParams is! NoCallbackParams ? callbackParams : null,
     consentNotice: consentNotice,
     logo: brandLogo,

--- a/lib/src/modules/auth/auth_module.dart
+++ b/lib/src/modules/auth/auth_module.dart
@@ -8,6 +8,7 @@ import '../../core/signal_listenable.dart';
 import '../../interfaces/auth_state.dart';
 import 'auth_providers.dart';
 import 'consent_notice.dart';
+import 'inactivity_logout_storage.dart';
 import 'platform/auth_flow.dart';
 import 'platform/callback_params.dart';
 import 'server_manager.dart';
@@ -28,6 +29,7 @@ class AuthAppModule extends AppModule {
     required SoliplexHttpClient probeClient,
     required AuthFlow authFlow,
     required String appName,
+    required InactivityLogoutFlagStorage inactivityLogoutFlags,
     CallbackParams? callbackParams,
     ConsentNotice? consentNotice,
     Widget? logo,
@@ -36,6 +38,7 @@ class AuthAppModule extends AppModule {
         _probeClient = probeClient,
         _authFlow = authFlow,
         _appName = appName,
+        _inactivityLogoutFlags = inactivityLogoutFlags,
         _callbackParams = callbackParams,
         _consentNotice = consentNotice,
         _logo = logo,
@@ -46,6 +49,7 @@ class AuthAppModule extends AppModule {
   final SoliplexHttpClient _probeClient;
   final AuthFlow _authFlow;
   final String _appName;
+  final InactivityLogoutFlagStorage _inactivityLogoutFlags;
   final CallbackParams? _callbackParams;
   final ConsentNotice? _consentNotice;
   final Widget? _logo;
@@ -65,6 +69,8 @@ class AuthAppModule extends AppModule {
           serverManagerProvider.overrideWithValue(_serverManager),
           authFlowProvider.overrideWithValue(_authFlow),
           probeClientProvider.overrideWithValue(_probeClient),
+          inactivityLogoutFlagsProvider
+              .overrideWithValue(_inactivityLogoutFlags),
           if (_callbackParams != null)
             callbackParamsProvider.overrideWithValue(_callbackParams),
           if (_consentNotice != null)

--- a/lib/src/modules/auth/auth_providers.dart
+++ b/lib/src/modules/auth/auth_providers.dart
@@ -3,6 +3,7 @@ import 'package:soliplex_agent/soliplex_agent.dart' hide AuthException;
 
 import 'connection_probe.dart';
 import 'consent_notice.dart';
+import 'inactivity_logout_storage.dart';
 import 'platform/auth_flow.dart';
 import 'platform/callback_params.dart';
 import 'server_manager.dart';
@@ -18,6 +19,10 @@ final authFlowProvider = Provider<AuthFlow>(
 );
 
 final probeClientProvider = Provider<SoliplexHttpClient>(
+  (_) => throw UnimplementedError('must be overridden by authModule'),
+);
+
+final inactivityLogoutFlagsProvider = Provider<InactivityLogoutFlagStorage>(
   (_) => throw UnimplementedError('must be overridden by authModule'),
 );
 

--- a/lib/src/modules/auth/connect_flow.dart
+++ b/lib/src/modules/auth/connect_flow.dart
@@ -7,6 +7,7 @@ import 'auth_tokens.dart';
 import 'connection_probe.dart';
 import 'consent_notice.dart';
 import 'default_backend_url.dart';
+import 'inactivity_logout_storage.dart';
 import 'platform/auth_flow.dart';
 import 'pre_auth_state.dart';
 import 'server_entry.dart';
@@ -84,6 +85,7 @@ class ConnectFlow {
     required this.probeClient,
     required this.discover,
     required this.authFlow,
+    required this.inactivityLogoutFlags,
     this.consentNotice,
   });
 
@@ -91,6 +93,7 @@ class ConnectFlow {
   final SoliplexHttpClient probeClient;
   final DiscoverProviders discover;
   final AuthFlow authFlow;
+  final InactivityLogoutFlagStorage inactivityLogoutFlags;
   final ConsentNotice? consentNotice;
 
   final Signal<ConnectState> state = Signal<ConnectState>(const UrlInput());
@@ -244,17 +247,20 @@ class ConnectFlow {
       frontendReturnTo: _pendingReturnTo,
     ));
 
+    final serverId = serverIdFromUrl(probeResult.serverUrl);
+    final forceLoginPrompt = await inactivityLogoutFlags.isMarked(serverId);
+
     if (_isCancelled(gen)) return;
 
     try {
       final authResult = await authFlow.authenticate(
         provider,
         backendUrl: probeResult.serverUrl,
+        forceLoginPrompt: forceLoginPrompt,
       );
 
       if (_isCancelled(gen)) return;
 
-      final serverId = serverIdFromUrl(probeResult.serverUrl);
       final entry = serverManager.addServer(
         serverId: serverId,
         serverUrl: probeResult.serverUrl,
@@ -275,10 +281,15 @@ class ConnectFlow {
       );
 
       await PreAuthStateStorage.clear();
+      // Only clear after a successful login. If the IdP challenge was
+      // cancelled or failed, the flag stays set so the next attempt
+      // also forces prompt=login.
+      await inactivityLogoutFlags.clear(serverId);
       DefaultBackendUrlStorage.save(probeResult.serverUrl.toString());
       if (!_isCancelled(gen)) state.value = const Connected();
     } on AuthRedirectInitiated {
-      // Web: browser is redirecting to IdP.
+      // Web: browser is redirecting to IdP. The flag stays set;
+      // AuthCallbackScreen clears it after persisting the new tokens.
     } on AuthException catch (e) {
       await PreAuthStateStorage.clear();
       if (!_isCancelled(gen)) {

--- a/lib/src/modules/auth/connect_flow.dart
+++ b/lib/src/modules/auth/connect_flow.dart
@@ -280,7 +280,16 @@ class ConnectFlow {
         ),
       );
 
-      await PreAuthStateStorage.clear();
+      // Post-login housekeeping is best-effort: the user is already
+      // signed in, so a storage failure here must not bounce them to the
+      // error state. Guard the PreAuthState clear (the inactivity flag
+      // store swallows its own failures).
+      try {
+        await PreAuthStateStorage.clear();
+      } catch (e, st) {
+        debugPrint(
+            'ConnectFlow: post-login PreAuthState clear failed: $e\n$st');
+      }
       // Only clear after a successful login. If the IdP challenge was
       // cancelled or failed, the flag stays set so the next attempt
       // also forces prompt=login.

--- a/lib/src/modules/auth/inactivity_logout_storage.dart
+++ b/lib/src/modules/auth/inactivity_logout_storage.dart
@@ -1,0 +1,53 @@
+import 'package:shared_preferences/shared_preferences.dart';
+
+/// Per-server flag recording that the most recent logout was triggered by
+/// the inactivity monitor.
+///
+/// On the next sign-in for that server, [ConnectFlow] reads the flag via
+/// [isMarked] and forwards `prompt=login` to the IdP, forcing a
+/// credential challenge even when the IdP's SSO cookie is still valid.
+/// The flag is cleared via [clear] only after a successful sign-in —
+/// not on read — so a cancelled or failed IdP challenge does not
+/// silently downgrade the next attempt to SSO.
+abstract class InactivityLogoutFlagStorage {
+  /// Records that this server's last logout was due to inactivity.
+  Future<void> mark(String serverId);
+
+  /// Reads the flag without mutating it. Returns true if the next
+  /// sign-in for this server should include `prompt=login`.
+  Future<bool> isMarked(String serverId);
+
+  /// Clears the flag. Call only after the user has completed a
+  /// credential-challenged sign-in — leaving the flag in place across
+  /// cancelled or failed attempts keeps the security closure intact on
+  /// retry.
+  Future<void> clear(String serverId);
+}
+
+/// SharedPreferences-backed implementation. The flag is not sensitive —
+/// it carries no token material — so it lives in shared_preferences
+/// rather than secure storage.
+class SharedPrefsInactivityLogoutFlagStorage
+    implements InactivityLogoutFlagStorage {
+  static const _prefix = 'soliplex_inactivity_logout_pending_';
+
+  String _key(String serverId) => '$_prefix$serverId';
+
+  @override
+  Future<void> mark(String serverId) async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setBool(_key(serverId), true);
+  }
+
+  @override
+  Future<bool> isMarked(String serverId) async {
+    final prefs = await SharedPreferences.getInstance();
+    return prefs.getBool(_key(serverId)) ?? false;
+  }
+
+  @override
+  Future<void> clear(String serverId) async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.remove(_key(serverId));
+  }
+}

--- a/lib/src/modules/auth/inactivity_logout_storage.dart
+++ b/lib/src/modules/auth/inactivity_logout_storage.dart
@@ -35,11 +35,12 @@ abstract class InactivityLogoutFlagStorage {
 /// at SEVERE. Storage is best-effort here precisely because a thrown
 /// `PlatformException` must not wedge the auth flow ([isMarked] runs
 /// before sign-in) or mask a completed sign-in as a failure ([clear]
-/// runs after it). A dropped flag at worst forces a harmless extra
-/// `prompt=login`.
-class SharedPrefsInactivityLogoutFlagStorage
-    implements InactivityLogoutFlagStorage {
-  SharedPrefsInactivityLogoutFlagStorage({
+/// runs after it). The two write failures fail safe in opposite
+/// directions: a lost [clear] forces a harmless extra `prompt=login` on
+/// the next sign-in, while a lost [mark] lets the next sign-in proceed
+/// via SSO instead of forcing the intended re-authentication.
+class LocalInactivityLogoutFlagStorage implements InactivityLogoutFlagStorage {
+  LocalInactivityLogoutFlagStorage({
     Future<SharedPreferences> Function()? prefsFactory,
   }) : _prefsFactory = prefsFactory ?? SharedPreferences.getInstance;
 

--- a/lib/src/modules/auth/inactivity_logout_storage.dart
+++ b/lib/src/modules/auth/inactivity_logout_storage.dart
@@ -1,3 +1,5 @@
+import 'dart:developer' as dev;
+
 import 'package:shared_preferences/shared_preferences.dart';
 
 /// Per-server flag recording that the most recent logout was triggered by
@@ -27,27 +29,70 @@ abstract class InactivityLogoutFlagStorage {
 /// SharedPreferences-backed implementation. The flag is not sensitive —
 /// it carries no token material — so it lives in shared_preferences
 /// rather than secure storage.
+///
+/// Every method degrades gracefully if the storage layer throws: writes
+/// and clears become no-ops and reads default to not-marked, each logged
+/// at SEVERE. Storage is best-effort here precisely because a thrown
+/// `PlatformException` must not wedge the auth flow ([isMarked] runs
+/// before sign-in) or mask a completed sign-in as a failure ([clear]
+/// runs after it). A dropped flag at worst forces a harmless extra
+/// `prompt=login`.
 class SharedPrefsInactivityLogoutFlagStorage
     implements InactivityLogoutFlagStorage {
+  SharedPrefsInactivityLogoutFlagStorage({
+    Future<SharedPreferences> Function()? prefsFactory,
+  }) : _prefsFactory = prefsFactory ?? SharedPreferences.getInstance;
+
+  final Future<SharedPreferences> Function() _prefsFactory;
+
   static const _prefix = 'soliplex_inactivity_logout_pending_';
 
   String _key(String serverId) => '$_prefix$serverId';
 
   @override
   Future<void> mark(String serverId) async {
-    final prefs = await SharedPreferences.getInstance();
-    await prefs.setBool(_key(serverId), true);
+    try {
+      final prefs = await _prefsFactory();
+      await prefs.setBool(_key(serverId), true);
+    } catch (e, st) {
+      dev.log(
+        'Failed to persist inactivity-logout flag for $serverId',
+        error: e,
+        stackTrace: st,
+        level: 1000,
+      );
+    }
   }
 
   @override
   Future<bool> isMarked(String serverId) async {
-    final prefs = await SharedPreferences.getInstance();
-    return prefs.getBool(_key(serverId)) ?? false;
+    try {
+      final prefs = await _prefsFactory();
+      return prefs.getBool(_key(serverId)) ?? false;
+    } catch (e, st) {
+      dev.log(
+        'Failed to read inactivity-logout flag for $serverId; '
+        'defaulting to not-marked',
+        error: e,
+        stackTrace: st,
+        level: 1000,
+      );
+      return false;
+    }
   }
 
   @override
   Future<void> clear(String serverId) async {
-    final prefs = await SharedPreferences.getInstance();
-    await prefs.remove(_key(serverId));
+    try {
+      final prefs = await _prefsFactory();
+      await prefs.remove(_key(serverId));
+    } catch (e, st) {
+      dev.log(
+        'Failed to clear inactivity-logout flag for $serverId',
+        error: e,
+        stackTrace: st,
+        level: 1000,
+      );
+    }
   }
 }

--- a/lib/src/modules/auth/platform/auth_flow.dart
+++ b/lib/src/modules/auth/platform/auth_flow.dart
@@ -88,10 +88,18 @@ abstract interface class AuthFlow {
   /// [provider] contains the IdP configuration from server discovery.
   /// [backendUrl] is the backend URL for web BFF login (ignored on native).
   ///
+  /// Set [forceLoginPrompt] when the previous logout was triggered by the
+  /// inactivity monitor. On native this passes `prompt=login` to the IdP
+  /// via `flutter_appauth.additionalParameters`. On web it appends
+  /// `prompt=login` to the BFF login URL — the backend must forward the
+  /// parameter to its OIDC client for the full effect (tracked in
+  /// `docs/backend-requests.md`).
+  ///
   /// Returns [AuthResult] on native, throws [AuthRedirectInitiated] on web.
   Future<AuthResult> authenticate(
     AuthProviderConfig provider, {
     Uri? backendUrl,
+    bool forceLoginPrompt = false,
   });
 
   /// End the OIDC session.

--- a/lib/src/modules/auth/platform/auth_flow.dart
+++ b/lib/src/modules/auth/platform/auth_flow.dart
@@ -90,10 +90,9 @@ abstract interface class AuthFlow {
   ///
   /// Set [forceLoginPrompt] when the previous logout was triggered by the
   /// inactivity monitor. On native this passes `prompt=login` to the IdP
-  /// via `flutter_appauth.additionalParameters`. On web it appends
-  /// `prompt=login` to the BFF login URL — the backend must forward the
-  /// parameter to its OIDC client for the full effect (tracked in
-  /// `docs/backend-requests.md`).
+  /// via `flutter_appauth.additionalParameters`. On web it adds
+  /// `prompt=login` as a query parameter to the BFF login URL, which the
+  /// backend forwards to the IdP's authorization request.
   ///
   /// Returns [AuthResult] on native, throws [AuthRedirectInitiated] on web.
   Future<AuthResult> authenticate(

--- a/lib/src/modules/auth/platform/auth_flow_native.dart
+++ b/lib/src/modules/auth/platform/auth_flow_native.dart
@@ -36,6 +36,7 @@ class NativeAuthFlow implements AuthFlow {
   Future<AuthResult> authenticate(
     AuthProviderConfig provider, {
     Uri? backendUrl,
+    bool forceLoginPrompt = false,
   }) async {
     final discoveryUrl =
         '${provider.serverUrl}/.well-known/openid-configuration';
@@ -48,6 +49,8 @@ class NativeAuthFlow implements AuthFlow {
           scopes: provider.scope.split(' '),
           externalUserAgent:
               ExternalUserAgent.ephemeralAsWebAuthenticationSession,
+          additionalParameters:
+              forceLoginPrompt ? const {'prompt': 'login'} : null,
         ),
       );
 

--- a/lib/src/modules/auth/platform/auth_flow_web.dart
+++ b/lib/src/modules/auth/platform/auth_flow_web.dart
@@ -49,6 +49,7 @@ class WebAuthFlow implements AuthFlow {
   Future<AuthResult> authenticate(
     AuthProviderConfig provider, {
     Uri? backendUrl,
+    bool forceLoginPrompt = false,
   }) async {
     final frontendOrigin = _navigator.origin;
     final returnTo = Uri.encodeFull('$frontendOrigin/#/auth/callback');
@@ -56,8 +57,13 @@ class WebAuthFlow implements AuthFlow {
     // Use backendUrl for BFF endpoint, fall back to same origin.
     final backend = backendUrl?.toString() ?? frontendOrigin;
 
-    final loginUrl = '$backend/api/login/${provider.id}?return_to=$returnTo';
-    _navigator.navigateTo(loginUrl);
+    final buffer = StringBuffer(
+      '$backend/api/login/${provider.id}?return_to=$returnTo',
+    );
+    if (forceLoginPrompt) {
+      buffer.write('&prompt=login');
+    }
+    _navigator.navigateTo(buffer.toString());
 
     // Browser navigates away; throw to make the type system honest.
     throw const AuthRedirectInitiated();

--- a/lib/src/modules/auth/platform/auth_flow_web.dart
+++ b/lib/src/modules/auth/platform/auth_flow_web.dart
@@ -52,18 +52,22 @@ class WebAuthFlow implements AuthFlow {
     bool forceLoginPrompt = false,
   }) async {
     final frontendOrigin = _navigator.origin;
-    final returnTo = Uri.encodeFull('$frontendOrigin/#/auth/callback');
+    final returnTo = '$frontendOrigin/#/auth/callback';
 
     // Use backendUrl for BFF endpoint, fall back to same origin.
     final backend = backendUrl?.toString() ?? frontendOrigin;
 
-    final buffer = StringBuffer(
-      '$backend/api/login/${provider.id}?return_to=$returnTo',
+    // Build the query with Uri so values are percent-encoded. The '#' in
+    // return_to must become %23; left bare it starts a fragment the browser
+    // keeps client-side, dropping return_to's callback path and prompt
+    // before the request reaches the backend.
+    final loginUri = Uri.parse('$backend/api/login/${provider.id}').replace(
+      queryParameters: {
+        'return_to': returnTo,
+        if (forceLoginPrompt) 'prompt': 'login',
+      },
     );
-    if (forceLoginPrompt) {
-      buffer.write('&prompt=login');
-    }
-    _navigator.navigateTo(buffer.toString());
+    _navigator.navigateTo(loginUri.toString());
 
     // Browser navigates away; throw to make the type system honest.
     throw const AuthRedirectInitiated();

--- a/lib/src/modules/auth/ui/auth_callback_screen.dart
+++ b/lib/src/modules/auth/ui/auth_callback_screen.dart
@@ -86,6 +86,10 @@ class _AuthCallbackScreenState extends ConsumerState<AuthCallbackScreen> {
         ),
       );
 
+      // Web: the inactivity flag survived the redirect via storage.
+      // Clear it now that a credential-challenged sign-in has completed.
+      await ref.read(inactivityLogoutFlagsProvider).clear(serverId);
+
       if (mounted) context.go(_safeReturnTo(preAuth.frontendReturnTo));
     } catch (e, st) {
       dev.log(

--- a/lib/src/modules/auth/ui/home_screen.dart
+++ b/lib/src/modules/auth/ui/home_screen.dart
@@ -63,6 +63,7 @@ class _HomeScreenState extends ConsumerState<HomeScreen> {
       probeClient: ref.read(probeClientProvider),
       discover: ref.read(discoverProvidersProvider),
       authFlow: ref.read(authFlowProvider),
+      inactivityLogoutFlags: ref.read(inactivityLogoutFlagsProvider),
       consentNotice: ref.read(consentNoticeProvider),
     );
 

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -99,7 +99,7 @@ packages:
     source: hosted
     version: "0.4.2"
   clock:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: clock
       sha256: fddb70d9b5277016c77a80201021d40a2247104d9f4aa7bab7157b7e3f05b84b

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -20,6 +20,7 @@ workspace:
 dependencies:
   flutter:
     sdk: flutter
+  clock: ^1.1.2
   collection: ^1.18.0
   flutter_appauth: ^12.0.0
   flutter_highlight: ^0.7.0

--- a/test/core/inactivity/inactivity_config_test.dart
+++ b/test/core/inactivity/inactivity_config_test.dart
@@ -1,0 +1,48 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:soliplex_frontend/src/core/inactivity/inactivity_config.dart';
+
+void main() {
+  group('InactivityConfig', () {
+    test('defaults to 10 minute warning and 5 minute grace', () {
+      const config = InactivityConfig();
+
+      expect(config.warningDuration, const Duration(minutes: 10));
+      expect(config.graceDuration, const Duration(minutes: 5));
+    });
+
+    group('isEnabled', () {
+      test('true when both durations are positive', () {
+        const config = InactivityConfig(
+          warningDuration: Duration(seconds: 1),
+          graceDuration: Duration(seconds: 1),
+        );
+
+        expect(config.isEnabled, isTrue);
+      });
+
+      test('false when warning duration is zero', () {
+        const config = InactivityConfig(
+          warningDuration: Duration.zero,
+          graceDuration: Duration(seconds: 1),
+        );
+
+        expect(config.isEnabled, isFalse);
+      });
+
+      test('false when grace duration is zero', () {
+        const config = InactivityConfig(
+          warningDuration: Duration(seconds: 1),
+          graceDuration: Duration.zero,
+        );
+
+        expect(config.isEnabled, isFalse);
+      });
+    });
+
+    test('disabled has zero durations and is not enabled', () {
+      expect(InactivityConfig.disabled.warningDuration, Duration.zero);
+      expect(InactivityConfig.disabled.graceDuration, Duration.zero);
+      expect(InactivityConfig.disabled.isEnabled, isFalse);
+    });
+  });
+}

--- a/test/core/inactivity/inactivity_dialog_host_test.dart
+++ b/test/core/inactivity/inactivity_dialog_host_test.dart
@@ -1,0 +1,70 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:soliplex_agent/soliplex_agent.dart' show Signal;
+import 'package:soliplex_frontend/src/core/inactivity/inactivity_config.dart';
+import 'package:soliplex_frontend/src/core/inactivity/inactivity_dialog.dart';
+import 'package:soliplex_frontend/src/core/inactivity/inactivity_dialog_host.dart';
+import 'package:soliplex_frontend/src/core/inactivity/inactivity_monitor.dart';
+import 'package:soliplex_frontend/src/modules/auth/auth_tokens.dart';
+import 'package:soliplex_frontend/src/modules/auth/server_entry.dart';
+
+import '../../helpers/test_server_entry.dart';
+
+const _provider = OidcProvider(
+  discoveryUrl: 'https://idp.example.com/.well-known/openid-configuration',
+  clientId: 'test-client',
+);
+
+AuthTokens _tokens() => AuthTokens(
+      accessToken: 'a',
+      refreshToken: 'r',
+      expiresAt: DateTime.now().add(const Duration(hours: 1)),
+    );
+
+void main() {
+  testWidgets(
+    'pushes the dialog when the warning fires and removes it on extend',
+    (tester) async {
+      final servers = Signal<Map<String, ServerEntry>>({});
+      // Short warning so a pump can fire it; long grace so the logout
+      // timer doesn't fire mid-test.
+      final monitor = InactivityMonitor(
+        servers: servers,
+        config: const InactivityConfig(
+          warningDuration: Duration(seconds: 1),
+          graceDuration: Duration(minutes: 5),
+        ),
+      );
+
+      final entry = createTestServerEntry(serverId: 'server-1')
+        ..auth.login(provider: _provider, tokens: _tokens());
+      servers.value = {entry.serverId: entry};
+
+      final navKey = GlobalKey<NavigatorState>();
+      await tester.pumpWidget(MaterialApp(
+        navigatorKey: navKey,
+        home: InactivityDialogHost(
+          monitor: monitor,
+          navigatorKey: navKey,
+          child: const Scaffold(body: Center(child: Text('content'))),
+        ),
+      ));
+
+      // Nothing before the idle window elapses.
+      expect(find.byType(InactivityDialog), findsNothing);
+
+      await tester.pump(const Duration(seconds: 1)); // warning timer fires
+      await tester.pump(); // host's deferred microtask pushes the dialog
+      expect(find.byType(InactivityDialog), findsOneWidget);
+
+      // "Stay signed in" clears warningVisible; the host removes the route.
+      monitor.extendSession();
+      await tester.pump(); // host's deferred microtask calls removeRoute
+      await tester.pump(); // navigator rebuilds without the dialog
+      expect(find.byType(InactivityDialog), findsNothing);
+
+      // Cancel the re-armed warning timer before end-of-test invariants.
+      monitor.dispose();
+    },
+  );
+}

--- a/test/core/inactivity/inactivity_dialog_test.dart
+++ b/test/core/inactivity/inactivity_dialog_test.dart
@@ -1,0 +1,117 @@
+import 'package:clock/clock.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:soliplex_agent/soliplex_agent.dart';
+import 'package:soliplex_frontend/src/core/inactivity/inactivity_dialog.dart';
+
+Widget _hostDialog({
+  required ReadonlySignal<DateTime?> graceDeadline,
+  required VoidCallback onExtend,
+  required VoidCallback onLogout,
+}) {
+  return MaterialApp(
+    home: Scaffold(
+      body: InactivityDialog(
+        graceDeadline: graceDeadline,
+        onExtend: onExtend,
+        onLogout: onLogout,
+      ),
+    ),
+  );
+}
+
+void main() {
+  group('InactivityDialog', () {
+    testWidgets('tapping "Stay signed in" invokes onExtend', (tester) async {
+      var extendCount = 0;
+      final start = DateTime(2026);
+      final deadline = Signal<DateTime?>(start.add(const Duration(minutes: 5)));
+
+      await withClock(Clock.fixed(start), () async {
+        await tester.pumpWidget(_hostDialog(
+          graceDeadline: deadline,
+          onExtend: () => extendCount++,
+          onLogout: () {},
+        ));
+
+        await tester.tap(find.text('Stay signed in'));
+        await tester.pump();
+      });
+
+      expect(extendCount, 1);
+    });
+
+    testWidgets('tapping "Sign out now" invokes onLogout', (tester) async {
+      var logoutCount = 0;
+      final start = DateTime(2026);
+      final deadline = Signal<DateTime?>(start.add(const Duration(minutes: 5)));
+
+      await withClock(Clock.fixed(start), () async {
+        await tester.pumpWidget(_hostDialog(
+          graceDeadline: deadline,
+          onExtend: () {},
+          onLogout: () => logoutCount++,
+        ));
+
+        await tester.tap(find.text('Sign out now'));
+        await tester.pump();
+      });
+
+      expect(logoutCount, 1);
+    });
+
+    testWidgets('displays remaining time in mm:ss format', (tester) async {
+      final start = DateTime(2026);
+      final deadline = Signal<DateTime?>(
+        start.add(const Duration(minutes: 4, seconds: 7)),
+      );
+
+      await withClock(Clock.fixed(start), () async {
+        await tester.pumpWidget(_hostDialog(
+          graceDeadline: deadline,
+          onExtend: () {},
+          onLogout: () {},
+        ));
+
+        expect(find.text('04:07'), findsOneWidget);
+      });
+    });
+
+    testWidgets('countdown updates when one second elapses', (tester) async {
+      final start = DateTime(2026);
+      var now = start;
+      final deadline = Signal<DateTime?>(start.add(const Duration(minutes: 5)));
+
+      await withClock(Clock(() => now), () async {
+        await tester.pumpWidget(_hostDialog(
+          graceDeadline: deadline,
+          onExtend: () {},
+          onLogout: () {},
+        ));
+
+        expect(find.text('05:00'), findsOneWidget);
+
+        now = start.add(const Duration(seconds: 1));
+        await tester.pump(const Duration(seconds: 1));
+
+        expect(find.text('04:59'), findsOneWidget);
+      });
+    });
+
+    testWidgets('clamps to 00:00 when the deadline has passed', (tester) async {
+      final start = DateTime(2026);
+      final deadline =
+          Signal<DateTime?>(start.subtract(const Duration(seconds: 30)));
+
+      await withClock(Clock.fixed(start), () async {
+        await tester.pumpWidget(_hostDialog(
+          graceDeadline: deadline,
+          onExtend: () {},
+          onLogout: () {},
+        ));
+
+        expect(find.text('00:00'), findsOneWidget);
+      });
+    });
+  });
+}

--- a/test/core/inactivity/inactivity_monitor_test.dart
+++ b/test/core/inactivity/inactivity_monitor_test.dart
@@ -83,6 +83,25 @@ void main() {
       });
     });
 
+    test('a second active session does not reset the running warning timer',
+        () {
+      fakeAsync((async) {
+        final servers = Signal<Map<String, ServerEntry>>({});
+        final monitor = InactivityMonitor(servers: servers, config: _config);
+        final entry1 = _activeEntry(id: 's1');
+        servers.value = {entry1.serverId: entry1};
+
+        async.elapse(const Duration(minutes: 9));
+        final entry2 = _activeEntry(id: 's2');
+        servers.value = {entry1.serverId: entry1, entry2.serverId: entry2};
+
+        async.elapse(const Duration(minutes: 1));
+        expect(monitor.warningVisible.value, isTrue);
+
+        monitor.dispose();
+      });
+    });
+
     test('bumpActivity is a no-op while the warning dialog is open', () {
       fakeAsync((async) {
         final servers = Signal<Map<String, ServerEntry>>({});

--- a/test/core/inactivity/inactivity_monitor_test.dart
+++ b/test/core/inactivity/inactivity_monitor_test.dart
@@ -1,0 +1,241 @@
+import 'package:fake_async/fake_async.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:soliplex_agent/soliplex_agent.dart';
+import 'package:soliplex_frontend/src/core/inactivity/inactivity_config.dart';
+import 'package:soliplex_frontend/src/core/inactivity/inactivity_monitor.dart';
+import 'package:soliplex_frontend/src/modules/auth/auth_tokens.dart';
+import 'package:soliplex_frontend/src/modules/auth/server_entry.dart';
+
+import '../../helpers/test_server_entry.dart';
+
+const _provider = OidcProvider(
+  discoveryUrl: 'https://idp.example.com/.well-known/openid-configuration',
+  clientId: 'test-client',
+);
+
+AuthTokens _tokens() => AuthTokens(
+      accessToken: 'a',
+      refreshToken: 'r',
+      expiresAt: DateTime.now().add(const Duration(hours: 1)),
+    );
+
+ServerEntry _activeEntry({String id = 'server-1'}) {
+  final entry = createTestServerEntry(serverId: id);
+  entry.auth.login(provider: _provider, tokens: _tokens());
+  return entry;
+}
+
+const _config = InactivityConfig(
+  warningDuration: Duration(minutes: 10),
+  graceDuration: Duration(minutes: 5),
+);
+
+void main() {
+  group('InactivityMonitor', () {
+    test('does not show the warning when no servers are active', () {
+      fakeAsync((async) {
+        final servers = Signal<Map<String, ServerEntry>>({});
+        final monitor = InactivityMonitor(servers: servers, config: _config);
+
+        async.elapse(const Duration(hours: 1));
+
+        expect(monitor.warningVisible.value, isFalse);
+        monitor.dispose();
+      });
+    });
+
+    test('arms the warning timer when the first active session appears', () {
+      fakeAsync((async) {
+        final servers = Signal<Map<String, ServerEntry>>({});
+        final monitor = InactivityMonitor(servers: servers, config: _config);
+
+        final entry = _activeEntry();
+        servers.value = {entry.serverId: entry};
+
+        async.elapse(const Duration(minutes: 10) - const Duration(seconds: 1));
+        expect(monitor.warningVisible.value, isFalse);
+
+        async.elapse(const Duration(seconds: 1));
+        expect(monitor.warningVisible.value, isTrue);
+
+        monitor.dispose();
+      });
+    });
+
+    test('bumpActivity restarts the warning timer', () {
+      fakeAsync((async) {
+        final servers = Signal<Map<String, ServerEntry>>({});
+        final monitor = InactivityMonitor(servers: servers, config: _config);
+        final entry = _activeEntry();
+        servers.value = {entry.serverId: entry};
+
+        async.elapse(const Duration(minutes: 9));
+        monitor.bumpActivity();
+
+        async.elapse(const Duration(minutes: 9));
+        expect(monitor.warningVisible.value, isFalse);
+
+        async.elapse(const Duration(minutes: 1));
+        expect(monitor.warningVisible.value, isTrue);
+
+        monitor.dispose();
+      });
+    });
+
+    test('bumpActivity is a no-op while the warning dialog is open', () {
+      fakeAsync((async) {
+        final servers = Signal<Map<String, ServerEntry>>({});
+        final monitor = InactivityMonitor(servers: servers, config: _config);
+        final entry = _activeEntry();
+        servers.value = {entry.serverId: entry};
+
+        async.elapse(const Duration(minutes: 10));
+        expect(monitor.warningVisible.value, isTrue);
+
+        monitor.bumpActivity();
+        async.elapse(const Duration(minutes: 1));
+        monitor.bumpActivity();
+        async.elapse(const Duration(minutes: 4));
+
+        expect(entry.auth.session.value, isA<NoSession>());
+
+        monitor.dispose();
+      });
+    });
+
+    test('extendSession dismisses the dialog and restarts the warning timer',
+        () {
+      fakeAsync((async) {
+        final servers = Signal<Map<String, ServerEntry>>({});
+        final monitor = InactivityMonitor(servers: servers, config: _config);
+        final entry = _activeEntry();
+        servers.value = {entry.serverId: entry};
+
+        async.elapse(const Duration(minutes: 10));
+        expect(monitor.warningVisible.value, isTrue);
+
+        monitor.extendSession();
+        expect(monitor.warningVisible.value, isFalse);
+        expect(entry.auth.session.value, isA<ActiveSession>());
+
+        async.elapse(const Duration(minutes: 10));
+        expect(monitor.warningVisible.value, isTrue);
+
+        monitor.dispose();
+      });
+    });
+
+    test('the grace timer signs every active session out locally', () {
+      fakeAsync((async) {
+        final servers = Signal<Map<String, ServerEntry>>({});
+        final monitor = InactivityMonitor(servers: servers, config: _config);
+        final entry1 = _activeEntry(id: 's1');
+        final entry2 = _activeEntry(id: 's2');
+        servers.value = {entry1.serverId: entry1, entry2.serverId: entry2};
+
+        async.elapse(const Duration(minutes: 15));
+
+        expect(entry1.auth.session.value, isA<NoSession>());
+        expect(entry2.auth.session.value, isA<NoSession>());
+        expect(monitor.warningVisible.value, isFalse);
+
+        monitor.dispose();
+      });
+    });
+
+    test('logoutNow signs out immediately and dismisses the dialog', () {
+      fakeAsync((async) {
+        final servers = Signal<Map<String, ServerEntry>>({});
+        final monitor = InactivityMonitor(servers: servers, config: _config);
+        final entry = _activeEntry();
+        servers.value = {entry.serverId: entry};
+
+        async.elapse(const Duration(minutes: 10));
+        expect(monitor.warningVisible.value, isTrue);
+
+        monitor.logoutNow();
+
+        expect(entry.auth.session.value, isA<NoSession>());
+        expect(monitor.warningVisible.value, isFalse);
+
+        monitor.dispose();
+      });
+    });
+
+    test(
+        'losing the last active session cancels the timer and hides '
+        'the dialog', () {
+      fakeAsync((async) {
+        final servers = Signal<Map<String, ServerEntry>>({});
+        final monitor = InactivityMonitor(servers: servers, config: _config);
+        final entry = _activeEntry();
+        servers.value = {entry.serverId: entry};
+
+        async.elapse(const Duration(minutes: 10));
+        expect(monitor.warningVisible.value, isTrue);
+
+        entry.auth.logout();
+
+        expect(monitor.warningVisible.value, isFalse);
+
+        async.elapse(const Duration(hours: 1));
+        expect(monitor.warningVisible.value, isFalse);
+
+        monitor.dispose();
+      });
+    });
+
+    test('disabled config never schedules timers', () {
+      fakeAsync((async) {
+        final servers = Signal<Map<String, ServerEntry>>({});
+        final monitor = InactivityMonitor(
+          servers: servers,
+          config: InactivityConfig.disabled,
+        );
+        final entry = _activeEntry();
+        servers.value = {entry.serverId: entry};
+
+        async.elapse(const Duration(hours: 1));
+
+        expect(monitor.warningVisible.value, isFalse);
+        expect(entry.auth.session.value, isA<ActiveSession>());
+
+        monitor.dispose();
+      });
+    });
+
+    test('dispose cancels pending timers', () {
+      fakeAsync((async) {
+        final servers = Signal<Map<String, ServerEntry>>({});
+        final monitor = InactivityMonitor(servers: servers, config: _config);
+        final entry = _activeEntry();
+        servers.value = {entry.serverId: entry};
+
+        async.elapse(const Duration(minutes: 5));
+        monitor.dispose();
+        async.elapse(const Duration(minutes: 30));
+
+        expect(entry.auth.session.value, isA<ActiveSession>());
+      });
+    });
+
+    test('graceDeadline is set when the warning shows, cleared on extend', () {
+      fakeAsync((async) {
+        final servers = Signal<Map<String, ServerEntry>>({});
+        final monitor = InactivityMonitor(servers: servers, config: _config);
+        final entry = _activeEntry();
+        servers.value = {entry.serverId: entry};
+
+        expect(monitor.graceDeadline.value, isNull);
+
+        async.elapse(const Duration(minutes: 10));
+        expect(monitor.graceDeadline.value, isNotNull);
+
+        monitor.extendSession();
+        expect(monitor.graceDeadline.value, isNull);
+
+        monitor.dispose();
+      });
+    });
+  });
+}

--- a/test/core/inactivity/inactivity_monitor_test.dart
+++ b/test/core/inactivity/inactivity_monitor_test.dart
@@ -279,5 +279,35 @@ void main() {
         monitor.dispose();
       });
     });
+
+    test('rejects a half-configured config where one duration is zero', () {
+      final servers = Signal<Map<String, ServerEntry>>({});
+
+      expect(
+        () => InactivityMonitor(
+          servers: servers,
+          config: const InactivityConfig(
+            warningDuration: Duration(minutes: 10),
+            graceDuration: Duration.zero,
+          ),
+        ),
+        throwsA(isA<AssertionError>()),
+      );
+    });
+
+    test('rejects a negative duration', () {
+      final servers = Signal<Map<String, ServerEntry>>({});
+
+      expect(
+        () => InactivityMonitor(
+          servers: servers,
+          config: const InactivityConfig(
+            warningDuration: Duration(minutes: -1),
+            graceDuration: Duration(minutes: 5),
+          ),
+        ),
+        throwsA(isA<AssertionError>()),
+      );
+    });
   });
 }

--- a/test/core/inactivity/inactivity_monitor_test.dart
+++ b/test/core/inactivity/inactivity_monitor_test.dart
@@ -6,6 +6,7 @@ import 'package:soliplex_frontend/src/core/inactivity/inactivity_monitor.dart';
 import 'package:soliplex_frontend/src/modules/auth/auth_tokens.dart';
 import 'package:soliplex_frontend/src/modules/auth/server_entry.dart';
 
+import '../../helpers/fakes.dart';
 import '../../helpers/test_server_entry.dart';
 
 const _provider = OidcProvider(
@@ -216,6 +217,28 @@ void main() {
         async.elapse(const Duration(minutes: 30));
 
         expect(entry.auth.session.value, isA<ActiveSession>());
+      });
+    });
+
+    test('grace logout marks the inactivity flag for each active entry', () {
+      fakeAsync((async) {
+        final servers = Signal<Map<String, ServerEntry>>({});
+        final flags = InMemoryInactivityLogoutFlagStorage();
+        final monitor = InactivityMonitor(
+          servers: servers,
+          config: _config,
+          inactivityLogoutFlags: flags,
+        );
+        final entry1 = _activeEntry(id: 's1');
+        final entry2 = _activeEntry(id: 's2');
+        servers.value = {entry1.serverId: entry1, entry2.serverId: entry2};
+
+        async.elapse(const Duration(minutes: 15));
+        async.flushMicrotasks();
+
+        expect(flags.marked, containsAll([entry1.serverId, entry2.serverId]));
+
+        monitor.dispose();
       });
     });
 

--- a/test/core/inactivity/inactivity_provider_test.dart
+++ b/test/core/inactivity/inactivity_provider_test.dart
@@ -1,0 +1,46 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:soliplex_frontend/src/core/inactivity/inactivity_config.dart';
+import 'package:soliplex_frontend/src/core/inactivity/inactivity_monitor.dart';
+import 'package:soliplex_frontend/src/core/inactivity/inactivity_provider.dart';
+import 'package:soliplex_frontend/src/modules/auth/auth_providers.dart';
+import 'package:soliplex_frontend/src/modules/auth/auth_session.dart';
+import 'package:soliplex_frontend/src/modules/auth/server_manager.dart';
+
+import '../../helpers/fakes.dart';
+
+ServerManager _serverManager() => ServerManager(
+      authFactory: () => AuthSession(refreshService: FakeTokenRefreshService()),
+      clientFactory: ({getToken, tokenRefresher}) => FakeHttpClient(),
+      storage: InMemoryServerStorage(),
+    );
+
+void main() {
+  group('inactivityMonitorProvider', () {
+    test('is null when the auth-module providers are not overridden', () {
+      // Their defaults throw UnimplementedError; the shell stays bootable
+      // with inactivity logout disabled.
+      final container = ProviderContainer();
+      addTearDown(container.dispose);
+
+      expect(container.read(inactivityMonitorProvider), isNull);
+    });
+
+    test('returns a monitor when the dependencies are configured', () {
+      final container = ProviderContainer(
+        overrides: [
+          inactivityConfigProvider.overrideWithValue(const InactivityConfig()),
+          serverManagerProvider.overrideWithValue(_serverManager()),
+          inactivityLogoutFlagsProvider
+              .overrideWithValue(InMemoryInactivityLogoutFlagStorage()),
+        ],
+      );
+      addTearDown(container.dispose);
+
+      expect(
+        container.read(inactivityMonitorProvider),
+        isA<InactivityMonitor>(),
+      );
+    });
+  });
+}

--- a/test/core/inactivity/inactivity_provider_test.dart
+++ b/test/core/inactivity/inactivity_provider_test.dart
@@ -1,19 +1,6 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:soliplex_frontend/src/core/inactivity/inactivity_config.dart';
-import 'package:soliplex_frontend/src/core/inactivity/inactivity_monitor.dart';
 import 'package:soliplex_frontend/src/core/inactivity/inactivity_provider.dart';
-import 'package:soliplex_frontend/src/modules/auth/auth_providers.dart';
-import 'package:soliplex_frontend/src/modules/auth/auth_session.dart';
-import 'package:soliplex_frontend/src/modules/auth/server_manager.dart';
-
-import '../../helpers/fakes.dart';
-
-ServerManager _serverManager() => ServerManager(
-      authFactory: () => AuthSession(refreshService: FakeTokenRefreshService()),
-      clientFactory: ({getToken, tokenRefresher}) => FakeHttpClient(),
-      storage: InMemoryServerStorage(),
-    );
 
 void main() {
   group('inactivityMonitorProvider', () {
@@ -24,23 +11,6 @@ void main() {
       addTearDown(container.dispose);
 
       expect(container.read(inactivityMonitorProvider), isNull);
-    });
-
-    test('returns a monitor when the dependencies are configured', () {
-      final container = ProviderContainer(
-        overrides: [
-          inactivityConfigProvider.overrideWithValue(const InactivityConfig()),
-          serverManagerProvider.overrideWithValue(_serverManager()),
-          inactivityLogoutFlagsProvider
-              .overrideWithValue(InMemoryInactivityLogoutFlagStorage()),
-        ],
-      );
-      addTearDown(container.dispose);
-
-      expect(
-        container.read(inactivityMonitorProvider),
-        isA<InactivityMonitor>(),
-      );
     });
   });
 }

--- a/test/core/shell_test.dart
+++ b/test/core/shell_test.dart
@@ -6,11 +6,6 @@ import 'package:go_router/go_router.dart';
 import 'package:soliplex_frontend/src/core/app_module.dart';
 import 'package:soliplex_frontend/src/core/shell.dart';
 import 'package:soliplex_frontend/src/core/shell_config.dart';
-import 'package:soliplex_frontend/src/modules/auth/auth_providers.dart';
-import 'package:soliplex_frontend/src/modules/auth/auth_session.dart';
-import 'package:soliplex_frontend/src/modules/auth/server_manager.dart';
-
-import '../helpers/fakes.dart';
 
 // ---------------------------------------------------------------------------
 // Test helpers
@@ -33,33 +28,6 @@ class _TestModule extends AppModule {
   @override
   ModuleRoutes build() =>
       ModuleRoutes(routes: routes, overrides: overrides, redirect: redirect);
-}
-
-/// Stand-in for the auth module overrides that the shell wires the
-/// [InactivityMonitor] against. Tests that mount a real [SoliplexShell]
-/// without [AuthAppModule] include this so the monitor's
-/// [ServerManager] and [InactivityLogoutFlagStorage] reads resolve.
-class _AuthStubModule extends AppModule {
-  @override
-  String get namespace => 'auth-stub';
-
-  @override
-  ModuleRoutes build() => ModuleRoutes(
-        overrides: [
-          serverManagerProvider.overrideWithValue(
-            ServerManager(
-              authFactory: () => AuthSession(
-                refreshService: FakeTokenRefreshService(),
-              ),
-              clientFactory: ({getToken, tokenRefresher}) => FakeHttpClient(),
-              storage: InMemoryServerStorage(),
-            ),
-          ),
-          inactivityLogoutFlagsProvider.overrideWithValue(
-            InMemoryInactivityLogoutFlagStorage(),
-          ),
-        ],
-      );
 }
 
 // ---------------------------------------------------------------------------
@@ -89,7 +57,6 @@ void main() {
         lightTheme: ThemeData(),
         initialRoute: '/check',
         modules: [
-          _AuthStubModule(),
           _TestModule(
             overrides: [greeting.overrideWithValue('hello')],
           ),
@@ -127,7 +94,6 @@ void main() {
         lightTheme: ThemeData(),
         initialRoute: '/a',
         modules: [
-          _AuthStubModule(),
           _TestModule(
             redirect: (context, state) =>
                 state.matchedLocation == '/a' ? '/b' : null,
@@ -217,7 +183,7 @@ void main() {
         final config = await ShellConfig.fromModules(
           appName: 'Test',
           lightTheme: ThemeData(),
-          modules: [_AuthStubModule(), _LifecycleModule('x', log)],
+          modules: [_LifecycleModule('x', log)],
         );
 
         await tester.pumpWidget(SoliplexShell(config: config));

--- a/test/core/shell_test.dart
+++ b/test/core/shell_test.dart
@@ -6,6 +6,11 @@ import 'package:go_router/go_router.dart';
 import 'package:soliplex_frontend/src/core/app_module.dart';
 import 'package:soliplex_frontend/src/core/shell.dart';
 import 'package:soliplex_frontend/src/core/shell_config.dart';
+import 'package:soliplex_frontend/src/modules/auth/auth_providers.dart';
+import 'package:soliplex_frontend/src/modules/auth/auth_session.dart';
+import 'package:soliplex_frontend/src/modules/auth/server_manager.dart';
+
+import '../helpers/fakes.dart';
 
 // ---------------------------------------------------------------------------
 // Test helpers
@@ -28,6 +33,33 @@ class _TestModule extends AppModule {
   @override
   ModuleRoutes build() =>
       ModuleRoutes(routes: routes, overrides: overrides, redirect: redirect);
+}
+
+/// Stand-in for the auth module overrides that the shell wires the
+/// [InactivityMonitor] against. Tests that mount a real [SoliplexShell]
+/// without [AuthAppModule] include this so the monitor's
+/// [ServerManager] and [InactivityLogoutFlagStorage] reads resolve.
+class _AuthStubModule extends AppModule {
+  @override
+  String get namespace => 'auth-stub';
+
+  @override
+  ModuleRoutes build() => ModuleRoutes(
+        overrides: [
+          serverManagerProvider.overrideWithValue(
+            ServerManager(
+              authFactory: () => AuthSession(
+                refreshService: FakeTokenRefreshService(),
+              ),
+              clientFactory: ({getToken, tokenRefresher}) => FakeHttpClient(),
+              storage: InMemoryServerStorage(),
+            ),
+          ),
+          inactivityLogoutFlagsProvider.overrideWithValue(
+            InMemoryInactivityLogoutFlagStorage(),
+          ),
+        ],
+      );
 }
 
 // ---------------------------------------------------------------------------
@@ -57,6 +89,7 @@ void main() {
         lightTheme: ThemeData(),
         initialRoute: '/check',
         modules: [
+          _AuthStubModule(),
           _TestModule(
             overrides: [greeting.overrideWithValue('hello')],
           ),
@@ -94,6 +127,7 @@ void main() {
         lightTheme: ThemeData(),
         initialRoute: '/a',
         modules: [
+          _AuthStubModule(),
           _TestModule(
             redirect: (context, state) =>
                 state.matchedLocation == '/a' ? '/b' : null,
@@ -183,7 +217,7 @@ void main() {
         final config = await ShellConfig.fromModules(
           appName: 'Test',
           lightTheme: ThemeData(),
-          modules: [_LifecycleModule('x', log)],
+          modules: [_AuthStubModule(), _LifecycleModule('x', log)],
         );
 
         await tester.pumpWidget(SoliplexShell(config: config));

--- a/test/helpers/fakes.dart
+++ b/test/helpers/fakes.dart
@@ -12,6 +12,7 @@ import 'package:soliplex_client/soliplex_client.dart'
         UrlBuilder;
 import 'package:soliplex_logging/soliplex_logging.dart' show LoggerFactory;
 
+import 'package:soliplex_frontend/src/modules/auth/inactivity_logout_storage.dart';
 import 'package:soliplex_frontend/src/modules/auth/platform/auth_flow.dart';
 import 'package:soliplex_frontend/src/modules/auth/server_storage.dart';
 
@@ -105,11 +106,17 @@ class FakeAuthFlow implements AuthFlow {
   /// row while the IdP round-trip is outstanding).
   Completer<void>? endSessionCompleter;
 
+  /// Captures the [forceLoginPrompt] value from the most recent
+  /// [authenticate] call so tests can assert it was threaded through.
+  bool lastForceLoginPrompt = false;
+
   @override
   Future<AuthResult> authenticate(
     AuthProviderConfig provider, {
     Uri? backendUrl,
+    bool forceLoginPrompt = false,
   }) async {
+    lastForceLoginPrompt = forceLoginPrompt;
     if (throwRedirectInitiated) throw const AuthRedirectInitiated();
     if (nextError != null) throw nextError!;
     if (nextResult != null) return nextResult!;
@@ -146,6 +153,7 @@ class RecordingAuthFlow implements AuthFlow {
   Future<AuthResult> authenticate(
     AuthProviderConfig provider, {
     Uri? backendUrl,
+    bool forceLoginPrompt = false,
   }) async {
     throw StateError('RecordingAuthFlow: authenticate not configured');
   }
@@ -457,6 +465,30 @@ class TestPlatformConstraints implements PlatformConstraints {
 }
 
 /// In-memory server storage for tests.
+class InMemoryInactivityLogoutFlagStorage
+    implements InactivityLogoutFlagStorage {
+  final Set<String> marked = {};
+  final List<String> isMarkedLog = [];
+  final List<String> clearLog = [];
+
+  @override
+  Future<void> mark(String serverId) async {
+    marked.add(serverId);
+  }
+
+  @override
+  Future<bool> isMarked(String serverId) async {
+    isMarkedLog.add(serverId);
+    return marked.contains(serverId);
+  }
+
+  @override
+  Future<void> clear(String serverId) async {
+    clearLog.add(serverId);
+    marked.remove(serverId);
+  }
+}
+
 class InMemoryServerStorage implements ServerStorage {
   final Map<String, PersistedServer> _store = {};
   int saveCount = 0;

--- a/test/modules/auth/auth_module_test.dart
+++ b/test/modules/auth/auth_module_test.dart
@@ -23,6 +23,7 @@ AuthAppModule _createModule({ServerManager? serverManager}) => AuthAppModule(
       probeClient: FakeHttpClient(),
       authFlow: FakeAuthFlow(),
       appName: 'Soliplex',
+      inactivityLogoutFlags: InMemoryInactivityLogoutFlagStorage(),
     );
 
 void main() {

--- a/test/modules/auth/connect_flow_cancel_test.dart
+++ b/test/modules/auth/connect_flow_cancel_test.dart
@@ -28,6 +28,7 @@ ConnectFlow _createFlow({required FakeAuthFlow authFlow}) => ConnectFlow(
       probeClient: FakeHttpClient(),
       discover: (_, __) async => [_provider],
       authFlow: authFlow,
+      inactivityLogoutFlags: InMemoryInactivityLogoutFlagStorage(),
     );
 
 void main() {

--- a/test/modules/auth/connect_flow_test.dart
+++ b/test/modules/auth/connect_flow_test.dart
@@ -1,9 +1,11 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:shared_preferences/shared_preferences.dart';
-import 'package:soliplex_agent/soliplex_agent.dart';
+import 'package:soliplex_agent/soliplex_agent.dart' hide AuthException;
 
 import 'package:soliplex_frontend/src/modules/auth/auth_session.dart';
 import 'package:soliplex_frontend/src/modules/auth/connect_flow.dart';
+import 'package:soliplex_frontend/src/modules/auth/inactivity_logout_storage.dart';
+import 'package:soliplex_frontend/src/modules/auth/platform/auth_flow.dart';
 import 'package:soliplex_frontend/src/modules/auth/pre_auth_state.dart';
 import 'package:soliplex_frontend/src/modules/auth/server_manager.dart';
 
@@ -23,11 +25,17 @@ ServerManager _createManager() => ServerManager(
       storage: InMemoryServerStorage(),
     );
 
-ConnectFlow _createFlow({required FakeAuthFlow authFlow}) => ConnectFlow(
+ConnectFlow _createFlow({
+  required FakeAuthFlow authFlow,
+  InactivityLogoutFlagStorage? inactivityLogoutFlags,
+}) =>
+    ConnectFlow(
       serverManager: _createManager(),
       probeClient: FakeHttpClient(),
       discover: (_, __) async => [_provider],
       authFlow: authFlow,
+      inactivityLogoutFlags:
+          inactivityLogoutFlags ?? InMemoryInactivityLogoutFlagStorage(),
     );
 
 void main() {
@@ -74,5 +82,97 @@ void main() {
         expect(saved!.frontendReturnTo, isNull);
       },
     );
+  });
+
+  group('ConnectFlow._authenticate — forceLoginPrompt plumbing', () {
+    setUp(() {
+      SharedPreferences.setMockInitialValues({});
+    });
+
+    AuthResult successResult() => AuthResult(
+          accessToken: 'access',
+          refreshToken: 'refresh',
+          expiresAt: DateTime.now().add(const Duration(hours: 1)),
+        );
+
+    test('passes forceLoginPrompt=true when the inactivity flag is marked',
+        () async {
+      final flags = InMemoryInactivityLogoutFlagStorage();
+      final authFlow = FakeAuthFlow()..throwRedirectInitiated = true;
+      final flow =
+          _createFlow(authFlow: authFlow, inactivityLogoutFlags: flags);
+
+      await flags.mark('https://server.example.com');
+
+      await flow.connect('https://server.example.com');
+      await pumpEventQueue();
+
+      expect(authFlow.lastForceLoginPrompt, isTrue);
+    });
+
+    test('passes forceLoginPrompt=false when no flag is set', () async {
+      final flags = InMemoryInactivityLogoutFlagStorage();
+      final authFlow = FakeAuthFlow()..throwRedirectInitiated = true;
+      final flow =
+          _createFlow(authFlow: authFlow, inactivityLogoutFlags: flags);
+
+      await flow.connect('https://server.example.com');
+      await pumpEventQueue();
+
+      expect(authFlow.lastForceLoginPrompt, isFalse);
+    });
+
+    test('isMarked does not clear the flag on its own', () async {
+      final flags = InMemoryInactivityLogoutFlagStorage();
+      final authFlow = FakeAuthFlow()..throwRedirectInitiated = true;
+      final flow =
+          _createFlow(authFlow: authFlow, inactivityLogoutFlags: flags);
+
+      await flags.mark('https://server.example.com');
+
+      await flow.connect('https://server.example.com');
+      await pumpEventQueue();
+
+      // The web flow throws AuthRedirectInitiated before any clear can
+      // happen, so the flag must still be set when the browser returns.
+      expect(await flags.isMarked('https://server.example.com'), isTrue);
+    });
+
+    test('successful authentication clears the flag', () async {
+      final flags = InMemoryInactivityLogoutFlagStorage();
+      final authFlow = FakeAuthFlow()..nextResult = successResult();
+      final flow =
+          _createFlow(authFlow: authFlow, inactivityLogoutFlags: flags);
+
+      await flags.mark('https://server.example.com');
+
+      await flow.connect('https://server.example.com');
+      await pumpEventQueue();
+
+      expect(authFlow.lastForceLoginPrompt, isTrue);
+      expect(await flags.isMarked('https://server.example.com'), isFalse);
+    });
+
+    test('cancelled IdP challenge keeps the flag set for the next retry',
+        () async {
+      final flags = InMemoryInactivityLogoutFlagStorage();
+      final authFlow = FakeAuthFlow()
+        ..nextError = const AuthException(
+          'User cancelled',
+          kind: AuthFailureKind.cancelled,
+        );
+      final flow =
+          _createFlow(authFlow: authFlow, inactivityLogoutFlags: flags);
+
+      await flags.mark('https://server.example.com');
+
+      await flow.connect('https://server.example.com');
+      await pumpEventQueue();
+
+      // The cancel keeps the flag set so a retry also forces prompt=login
+      // — otherwise an attacker could cancel once and then sign in via
+      // silent SSO.
+      expect(await flags.isMarked('https://server.example.com'), isTrue);
+    });
   });
 }

--- a/test/modules/auth/inactivity_logout_storage_test.dart
+++ b/test/modules/auth/inactivity_logout_storage_test.dart
@@ -50,5 +50,27 @@ void main() {
       expect(await storage.isMarked('server-b'), isFalse);
       expect(await storage.isMarked('server-a'), isTrue);
     });
+
+    group('degrades gracefully when the storage layer throws', () {
+      // A thrown PlatformException from SharedPreferences must not wedge
+      // the auth flow (isMarked runs before sign-in) or surface as an
+      // error (mark/clear are best-effort side effects).
+      SharedPrefsInactivityLogoutFlagStorage failing() =>
+          SharedPrefsInactivityLogoutFlagStorage(
+            prefsFactory: () => Future.error(StateError('prefs unavailable')),
+          );
+
+      test('isMarked returns false instead of throwing', () async {
+        expect(await failing().isMarked('server-a'), isFalse);
+      });
+
+      test('mark completes without throwing', () async {
+        await expectLater(failing().mark('server-a'), completes);
+      });
+
+      test('clear completes without throwing', () async {
+        await expectLater(failing().clear('server-a'), completes);
+      });
+    });
   });
 }

--- a/test/modules/auth/inactivity_logout_storage_test.dart
+++ b/test/modules/auth/inactivity_logout_storage_test.dart
@@ -5,19 +5,19 @@ import 'package:soliplex_frontend/src/modules/auth/inactivity_logout_storage.dar
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
 
-  group('SharedPrefsInactivityLogoutFlagStorage', () {
+  group('LocalInactivityLogoutFlagStorage', () {
     setUp(() {
       SharedPreferences.setMockInitialValues({});
     });
 
     test('isMarked returns false when the flag was never set', () async {
-      final storage = SharedPrefsInactivityLogoutFlagStorage();
+      final storage = LocalInactivityLogoutFlagStorage();
 
       expect(await storage.isMarked('server-a'), isFalse);
     });
 
     test('mark sets the flag so isMarked returns true', () async {
-      final storage = SharedPrefsInactivityLogoutFlagStorage();
+      final storage = LocalInactivityLogoutFlagStorage();
 
       await storage.mark('server-a');
 
@@ -25,7 +25,7 @@ void main() {
     });
 
     test('isMarked does not clear the flag', () async {
-      final storage = SharedPrefsInactivityLogoutFlagStorage();
+      final storage = LocalInactivityLogoutFlagStorage();
 
       await storage.mark('server-a');
       await storage.isMarked('server-a');
@@ -34,7 +34,7 @@ void main() {
     });
 
     test('clear removes the flag', () async {
-      final storage = SharedPrefsInactivityLogoutFlagStorage();
+      final storage = LocalInactivityLogoutFlagStorage();
 
       await storage.mark('server-a');
       await storage.clear('server-a');
@@ -43,7 +43,7 @@ void main() {
     });
 
     test('flags are scoped per server id', () async {
-      final storage = SharedPrefsInactivityLogoutFlagStorage();
+      final storage = LocalInactivityLogoutFlagStorage();
 
       await storage.mark('server-a');
 
@@ -55,8 +55,8 @@ void main() {
       // A thrown PlatformException from SharedPreferences must not wedge
       // the auth flow (isMarked runs before sign-in) or surface as an
       // error (mark/clear are best-effort side effects).
-      SharedPrefsInactivityLogoutFlagStorage failing() =>
-          SharedPrefsInactivityLogoutFlagStorage(
+      LocalInactivityLogoutFlagStorage failing() =>
+          LocalInactivityLogoutFlagStorage(
             prefsFactory: () => Future.error(StateError('prefs unavailable')),
           );
 

--- a/test/modules/auth/inactivity_logout_storage_test.dart
+++ b/test/modules/auth/inactivity_logout_storage_test.dart
@@ -1,0 +1,54 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:soliplex_frontend/src/modules/auth/inactivity_logout_storage.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  group('SharedPrefsInactivityLogoutFlagStorage', () {
+    setUp(() {
+      SharedPreferences.setMockInitialValues({});
+    });
+
+    test('isMarked returns false when the flag was never set', () async {
+      final storage = SharedPrefsInactivityLogoutFlagStorage();
+
+      expect(await storage.isMarked('server-a'), isFalse);
+    });
+
+    test('mark sets the flag so isMarked returns true', () async {
+      final storage = SharedPrefsInactivityLogoutFlagStorage();
+
+      await storage.mark('server-a');
+
+      expect(await storage.isMarked('server-a'), isTrue);
+    });
+
+    test('isMarked does not clear the flag', () async {
+      final storage = SharedPrefsInactivityLogoutFlagStorage();
+
+      await storage.mark('server-a');
+      await storage.isMarked('server-a');
+
+      expect(await storage.isMarked('server-a'), isTrue);
+    });
+
+    test('clear removes the flag', () async {
+      final storage = SharedPrefsInactivityLogoutFlagStorage();
+
+      await storage.mark('server-a');
+      await storage.clear('server-a');
+
+      expect(await storage.isMarked('server-a'), isFalse);
+    });
+
+    test('flags are scoped per server id', () async {
+      final storage = SharedPrefsInactivityLogoutFlagStorage();
+
+      await storage.mark('server-a');
+
+      expect(await storage.isMarked('server-b'), isFalse);
+      expect(await storage.isMarked('server-a'), isTrue);
+    });
+  });
+}

--- a/test/modules/auth/platform/auth_flow_native_mapping_test.dart
+++ b/test/modules/auth/platform/auth_flow_native_mapping_test.dart
@@ -188,4 +188,41 @@ void main() {
       expect(e.message, contains('no access token'));
     });
   });
+
+  group('NativeAuthFlow forceLoginPrompt', () {
+    AuthorizationTokenResponse validResponse() => AuthorizationTokenResponse(
+          'access',
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+        );
+
+    test('omits prompt=login when forceLoginPrompt is false', () async {
+      when(() => appAuth.authorizeAndExchangeCode(any()))
+          .thenAnswer((_) async => validResponse());
+
+      await flow.authenticate(provider);
+
+      final captured = verify(
+        () => appAuth.authorizeAndExchangeCode(captureAny()),
+      ).captured.single as AuthorizationTokenRequest;
+      expect(captured.additionalParameters, isNull);
+    });
+
+    test('passes prompt=login when forceLoginPrompt is true', () async {
+      when(() => appAuth.authorizeAndExchangeCode(any()))
+          .thenAnswer((_) async => validResponse());
+
+      await flow.authenticate(provider, forceLoginPrompt: true);
+
+      final captured = verify(
+        () => appAuth.authorizeAndExchangeCode(captureAny()),
+      ).captured.single as AuthorizationTokenRequest;
+      expect(captured.additionalParameters, equals({'prompt': 'login'}));
+    });
+  });
 }

--- a/test/modules/auth/platform/auth_flow_web_test.dart
+++ b/test/modules/auth/platform/auth_flow_web_test.dart
@@ -71,14 +71,34 @@ void main() {
         throwsA(isA<AuthRedirectInitiated>()),
       );
 
+      // return_to must arrive as a real query parameter the backend can
+      // read — not swallowed into a client-only URL fragment.
+      final uri = Uri.parse(navigator.lastNavigatedUrl!);
       expect(
-        navigator.lastNavigatedUrl,
-        contains('return_to='),
+        uri.queryParameters['return_to'],
+        'https://app.example.com/#/auth/callback',
       );
+    });
+
+    test(
+        'authenticate sends return_to and prompt as query params, not '
+        'fragment', () {
       expect(
-        navigator.lastNavigatedUrl,
-        contains('/auth/callback'),
+        () => authFlow.authenticate(_provider, forceLoginPrompt: true),
+        throwsA(isA<AuthRedirectInitiated>()),
       );
+
+      // A bare '#' in the URL turns everything after it into a fragment
+      // that the browser keeps client-side and never sends to the backend.
+      // Both values must be query parameters, and the login URL itself
+      // must carry no fragment.
+      final uri = Uri.parse(navigator.lastNavigatedUrl!);
+      expect(uri.queryParameters['prompt'], 'login');
+      expect(
+        uri.queryParameters['return_to'],
+        'https://app.example.com/#/auth/callback',
+      );
+      expect(uri.fragment, isEmpty);
     });
 
     test('endSession redirects to IdP logout endpoint', () async {
@@ -154,7 +174,8 @@ void main() {
         throwsA(isA<AuthRedirectInitiated>()),
       );
 
-      expect(navigator.lastNavigatedUrl, contains('&prompt=login'));
+      final uri = Uri.parse(navigator.lastNavigatedUrl!);
+      expect(uri.queryParameters['prompt'], 'login');
     });
   });
 }

--- a/test/modules/auth/platform/auth_flow_web_test.dart
+++ b/test/modules/auth/platform/auth_flow_web_test.dart
@@ -138,5 +138,23 @@ void main() {
       final uri = Uri.parse(navigator.lastNavigatedUrl!);
       expect(uri.queryParameters.containsKey('id_token_hint'), isFalse);
     });
+
+    test('authenticate omits prompt=login by default', () {
+      expect(
+        () => authFlow.authenticate(_provider),
+        throwsA(isA<AuthRedirectInitiated>()),
+      );
+
+      expect(navigator.lastNavigatedUrl, isNot(contains('prompt=login')));
+    });
+
+    test('authenticate appends prompt=login when forceLoginPrompt is true', () {
+      expect(
+        () => authFlow.authenticate(_provider, forceLoginPrompt: true),
+        throwsA(isA<AuthRedirectInitiated>()),
+      );
+
+      expect(navigator.lastNavigatedUrl, contains('&prompt=login'));
+    });
   });
 }

--- a/test/modules/auth/ui/auth_callback_screen_test.dart
+++ b/test/modules/auth/ui/auth_callback_screen_test.dart
@@ -73,6 +73,8 @@ Widget _buildApp({
     overrides: [
       authFlowProvider.overrideWithValue(FakeAuthFlow()),
       callbackParamsProvider.overrideWithValue(callbackParams),
+      inactivityLogoutFlagsProvider
+          .overrideWithValue(InMemoryInactivityLogoutFlagStorage()),
     ],
     child: MaterialApp.router(routerConfig: router),
   );

--- a/test/modules/auth/ui/auth_callback_screen_test.dart
+++ b/test/modules/auth/ui/auth_callback_screen_test.dart
@@ -7,6 +7,7 @@ import 'package:go_router/go_router.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:soliplex_frontend/src/modules/auth/auth_providers.dart';
 import 'package:soliplex_frontend/src/modules/auth/auth_session.dart';
+import 'package:soliplex_frontend/src/modules/auth/inactivity_logout_storage.dart';
 import 'package:soliplex_frontend/src/modules/auth/platform/callback_params.dart';
 import 'package:soliplex_frontend/src/modules/auth/pre_auth_state.dart';
 import 'package:soliplex_frontend/src/modules/auth/server_manager.dart';
@@ -35,6 +36,7 @@ ServerManager _createServerManager() => ServerManager(
 Widget _buildApp({
   required ServerManager serverManager,
   required CallbackParams callbackParams,
+  InactivityLogoutFlagStorage? inactivityFlags,
 }) {
   final router = GoRouter(
     initialLocation: '/auth/callback',
@@ -73,8 +75,8 @@ Widget _buildApp({
     overrides: [
       authFlowProvider.overrideWithValue(FakeAuthFlow()),
       callbackParamsProvider.overrideWithValue(callbackParams),
-      inactivityLogoutFlagsProvider
-          .overrideWithValue(InMemoryInactivityLogoutFlagStorage()),
+      inactivityLogoutFlagsProvider.overrideWithValue(
+          inactivityFlags ?? InMemoryInactivityLogoutFlagStorage()),
     ],
     child: MaterialApp.router(routerConfig: router),
   );
@@ -305,6 +307,53 @@ void main() {
       expect(find.text('Lobby Screen'), findsOneWidget);
       final entry = serverManager.servers.value['https://api.example.com']!;
       expect(entry.isConnected, isTrue);
+    });
+
+    testWidgets('clears the inactivity flag on a successful callback',
+        (tester) async {
+      const serverId = 'https://api.example.com';
+      final flags = InMemoryInactivityLogoutFlagStorage()..marked.add(serverId);
+      final serverManager = _createServerManager();
+      await PreAuthStateStorage.save(_validPreAuthState());
+
+      await tester.pumpWidget(_buildApp(
+        serverManager: serverManager,
+        callbackParams: const WebCallbackSuccess(
+          accessToken: 'access',
+          refreshToken: 'refresh',
+          expiresIn: 3600,
+        ),
+        inactivityFlags: flags,
+      ));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Lobby Screen'), findsOneWidget);
+      expect(flags.clearLog, contains(serverId));
+      expect(flags.marked, isNot(contains(serverId)));
+    });
+
+    testWidgets('keeps the inactivity flag when the callback fails',
+        (tester) async {
+      // No pre-auth state saved → callback fails before login. The flag
+      // must survive so the next attempt still forces prompt=login.
+      const serverId = 'https://api.example.com';
+      final flags = InMemoryInactivityLogoutFlagStorage()..marked.add(serverId);
+      final serverManager = _createServerManager();
+
+      await tester.pumpWidget(_buildApp(
+        serverManager: serverManager,
+        callbackParams: const WebCallbackSuccess(
+          accessToken: 'access',
+          refreshToken: 'refresh',
+          expiresIn: 3600,
+        ),
+        inactivityFlags: flags,
+      ));
+      await tester.pumpAndSettle();
+
+      expect(find.textContaining('expired'), findsOneWidget);
+      expect(flags.clearLog, isEmpty);
+      expect(flags.marked, contains(serverId));
     });
 
     testWidgets('back to home button navigates to /', (tester) async {

--- a/test/modules/auth/ui/home_screen_test.dart
+++ b/test/modules/auth/ui/home_screen_test.dart
@@ -116,6 +116,8 @@ Widget _buildApp({
       serverManagerProvider.overrideWithValue(serverManager),
       authFlowProvider.overrideWithValue(fakeAuthFlow),
       probeClientProvider.overrideWithValue(FakeHttpClient()),
+      inactivityLogoutFlagsProvider
+          .overrideWithValue(InMemoryInactivityLogoutFlagStorage()),
       discoverProvidersProvider.overrideWithValue(
         discover ?? _noAuthDiscover,
       ),


### PR DESCRIPTION
## What

Adds an inactivity-logout security control: after a configurable idle period the user is warned, then logged out locally, and forced through a credential-challenged sign-in (`prompt=login`) on their next attempt.

## How it works

- **`InactivityConfig`** — compile-time `warningDuration` (idle before the prompt) + `graceDuration` (prompt visible before logout). Defaults 10 min / 5 min. Zero durations opt out; threaded through `ShellConfig`.
- **`InactivityMonitor`** — signal-driven state machine. Arms a warning timer while any session is active; on fire shows the dialog and starts the grace timer; on grace expiry signs every active session out locally. `bumpActivity()` resets the warning timer and is a no-op once the dialog is up.
- **`_ShellRoot`** wiring — a root `HardwareKeyboard` handler (key-down) and a translucent `Listener` (pointer-down / pointer-signal) feed `bumpActivity()`. Hover/move are deliberately excluded so a parked cursor isn't treated as engagement.
- **`InactivityDialog` / `InactivityDialogHost`** — the host owns show/dismiss via the router's `navigatorKey` (keeping imperative `Navigator` calls out of the build phase); the dialog renders an `mm:ss` countdown and never pops its own route.
- **Re-auth closure** — on logout the server is flagged in storage; the flag is cleared only after a *successful* re-auth (native: after login; web: in the callback after token persistence). Failures fail safe in documented directions. Web sign-in sends `return_to`/`prompt` as encoded query params (not a fragment).

## Tests

`InactivityMonitor` timer transitions are covered deterministically with `fakeAsync` + `clock`; storage persistence, the open-redirect defense, and the re-auth flag closure are covered across native and web paths. Full suite green.

## Known follow-ups (documented, out of scope)

- **App-lifecycle / mobile backgrounding** — the monitor uses relative timers with no `didChangeAppLifecycleState` handling, so inactivity isn't re-evaluated across a suspend/resume cycle. Context written up in `docs/inactivity-lifecycle-handling.md`.
- **`ServerId` value type** — the flag-store key is a bare `String`; a typed key would make a mismatch a compile error. See `docs/serverid-value-type.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)