### PR TITLE
feat(design): SoliplexInput focusNode + readOnly passthroughs

### DIFF
--- a/packages/soliplex_design/lib/src/components/input/input.dart
+++ b/packages/soliplex_design/lib/src/components/input/input.dart
@@ -23,6 +23,7 @@ class SoliplexInput extends StatefulWidget {
   const SoliplexInput({
     super.key,
     this.controller,
+    this.focusNode,
     this.initialValue,
     this.label,
     this.hintText,
@@ -36,6 +37,7 @@ class SoliplexInput extends StatefulWidget {
     this.isPassword = false,
     this.isLoading = false,
     this.enabled = true,
+    this.readOnly = false,
     this.maxLines = 1,
     this.minLines,
     this.keyboardType,
@@ -45,6 +47,10 @@ class SoliplexInput extends StatefulWidget {
 
   /// External text controller. Mutually exclusive with [initialValue].
   final TextEditingController? controller;
+
+  /// External focus node. Lets callers drive focus programmatically
+  /// (e.g. refocusing the field after a submit).
+  final FocusNode? focusNode;
 
   /// One-time initial value. Use [controller] if you need to read or
   /// programmatically change the text after construction.
@@ -83,6 +89,12 @@ class SoliplexInput extends StatefulWidget {
   /// Set false to disable both interaction and visual emphasis.
   final bool enabled;
 
+  /// Locks editing while keeping the field's normal (non-disabled)
+  /// styling. Unlike [enabled], the text stays fully legible and the
+  /// field remains focusable — use it to freeze input during a
+  /// transient busy state without greying the field out.
+  final bool readOnly;
+
   /// Material's [TextField.maxLines]. Defaults to 1 (single-line).
   /// Set to `null` for unbounded multi-line growth.
   final int? maxLines;
@@ -106,8 +118,10 @@ class _SoliplexInputState extends State<SoliplexInput> {
 
     return TextFormField(
       controller: widget.controller,
+      focusNode: widget.focusNode,
       initialValue: widget.initialValue,
       enabled: widget.enabled && !widget.isLoading,
+      readOnly: widget.readOnly,
       obscureText: obscure,
       maxLines: obscure ? 1 : widget.maxLines,
       minLines: widget.minLines,

--- a/packages/soliplex_design/test/components/input/input_test.dart
+++ b/packages/soliplex_design/test/components/input/input_test.dart
@@ -80,4 +80,35 @@ void main() {
     expect(controller.text, isEmpty);
     expect(find.byType(CircularProgressIndicator), findsNothing);
   });
+
+  testWidgets('readOnly blocks edits while staying enabled', (tester) async {
+    final controller = TextEditingController();
+    await tester.pumpWidget(
+      _harness(
+        SoliplexInput(
+          label: 'Frozen',
+          controller: controller,
+          readOnly: true,
+        ),
+      ),
+    );
+    await tester.enterText(find.byType(TextFormField), 'hi');
+    expect(controller.text, isEmpty, reason: 'readOnly must reject edits');
+    final field = tester.widget<TextField>(find.byType(TextField));
+    expect(field.enabled, isTrue, reason: 'readOnly keeps the field enabled');
+  });
+
+  testWidgets('forwards an external focusNode to the field', (tester) async {
+    final focusNode = FocusNode();
+    addTearDown(focusNode.dispose);
+    await tester.pumpWidget(
+      _harness(SoliplexInput(label: 'Name', focusNode: focusNode)),
+    );
+    expect(focusNode.hasFocus, isFalse);
+    focusNode.requestFocus();
+    await tester.pump();
+    expect(focusNode.hasFocus, isTrue);
+    final field = tester.widget<TextField>(find.byType(TextField));
+    expect(field.focusNode, same(focusNode));
+  });
 }


### PR DESCRIPTION
## What

Adds two `TextField` passthroughs that `SoliplexInput` didn't expose:

- **`focusNode`** — lets callers drive focus programmatically (e.g. refocusing the field after a submit).
- **`readOnly`** — locks editing while keeping the field's normal, non-greyed styling. Unlike `enabled: false`, the text stays fully legible and the field remains focusable — for freezing input during a transient busy state.

## Why

Surfaced while starting the **room module** design-system adoption. The chat composer refocuses its field after each send (`focusNode.requestFocus()`) and sets `readOnly: true` (not `enabled: false`) while an agent run is in flight so the field stays styled normally but locked. `SoliplexInput` couldn't express either, which would have forced the app's single most-used input to stay raw Material.

Same pattern as #283 (adoption revealed `SoliplexButton` needed `iconAlignment`).

## Scope

Both params are additive and have no visual effect at rest — **input goldens are unchanged**. This is the dependency that unblocks the room-composer adoption PR.

## Tests

- `readOnly blocks edits while staying enabled`
- `forwards an external focusNode to the field`

Full `soliplex_design/test/components/input` suite green (incl. goldens, no drift).

🤖 Generated with [Claude Code](https://claude.com/claude-code)