### PR TITLE
refactor(room): adopt SoliplexChip + SoliplexInput in the composer

### DIFF
--- a/lib/src/modules/room/ui/chat_input.dart
+++ b/lib/src/modules/room/ui/chat_input.dart
@@ -181,18 +181,11 @@ class _ChatInputState extends State<ChatInput> {
                               runSpacing: 4,
                               children: [
                                 for (final doc in widget.selectedDocuments)
-                                  Chip(
-                                    avatar: Icon(
-                                      getFileTypeIcon(
-                                        documentIconPath(doc),
-                                      ),
-                                      size: 16,
+                                  SoliplexChip(
+                                    icon: Icon(
+                                      getFileTypeIcon(documentIconPath(doc)),
                                     ),
                                     label: Text(documentDisplayName(doc)),
-                                    deleteIcon: const Icon(
-                                      Icons.close,
-                                      size: 16,
-                                    ),
                                     onDeleted:
                                         widget.onDocumentRemoved == null ||
                                                 disabled
@@ -200,9 +193,6 @@ class _ChatInputState extends State<ChatInput> {
                                             : () => widget.onDocumentRemoved!(
                                                   doc,
                                                 ),
-                                    materialTapTargetSize:
-                                        MaterialTapTargetSize.shrinkWrap,
-                                    visualDensity: VisualDensity.compact,
                                   ),
                               ],
                             ),
@@ -278,16 +268,13 @@ class _ChatInputState extends State<ChatInput> {
                   bindings: {
                     const SingleActivator(LogicalKeyboardKey.enter): _send,
                   },
-                  child: TextField(
+                  child: SoliplexInput(
                     controller: _controller,
                     focusNode: _focusNode,
                     readOnly: disabled,
                     maxLines: null,
                     textInputAction: TextInputAction.newline,
-                    decoration: const InputDecoration(
-                      hintText: 'Type a message...',
-                      border: OutlineInputBorder(),
-                    ),
+                    hintText: 'Type a message...',
                   ),
                 ),
               ),

--- a/test/modules/room/ui/chat_input_test.dart
+++ b/test/modules/room/ui/chat_input_test.dart
@@ -3,6 +3,7 @@ import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:signals_flutter/signals_flutter.dart';
 import 'package:soliplex_agent/soliplex_agent.dart' hide State;
+import 'package:soliplex_design/soliplex_design.dart';
 
 import 'package:soliplex_frontend/src/modules/room/ui/chat_input.dart';
 
@@ -12,6 +13,7 @@ void main() {
     final sessionState = signal<AgentSessionState?>(null);
 
     await tester.pumpWidget(MaterialApp(
+      theme: soliplexLightTheme(),
       home: Scaffold(
         body: ChatInput(
           onSend: (text) => sentText = text,
@@ -40,6 +42,7 @@ void main() {
     final sessionState = signal<AgentSessionState?>(null);
 
     await tester.pumpWidget(MaterialApp(
+      theme: soliplexLightTheme(),
       home: Scaffold(
         body: ChatInput(
           onSend: (_) {},
@@ -62,6 +65,7 @@ void main() {
     final sessionState = signal<AgentSessionState?>(AgentSessionState.running);
 
     await tester.pumpWidget(MaterialApp(
+      theme: soliplexLightTheme(),
       home: Scaffold(
         body: ChatInput(
           onSend: (_) {},
@@ -85,6 +89,7 @@ void main() {
     final sessionState = signal<AgentSessionState?>(AgentSessionState.running);
 
     await tester.pumpWidget(MaterialApp(
+      theme: soliplexLightTheme(),
       home: Scaffold(
         body: ChatInput(
           onSend: (_) {},
@@ -105,6 +110,7 @@ void main() {
     final sessionState = signal<AgentSessionState?>(null);
 
     await tester.pumpWidget(MaterialApp(
+      theme: soliplexLightTheme(),
       home: Scaffold(
         body: ChatInput(
           onSend: (text) => sentText = text,
@@ -130,6 +136,7 @@ void main() {
     final sessionState = signal<AgentSessionState?>(AgentSessionState.running);
 
     await tester.pumpWidget(MaterialApp(
+      theme: soliplexLightTheme(),
       home: Scaffold(
         body: ChatInput(
           onSend: (text) => sentText = text,
@@ -163,6 +170,7 @@ void main() {
 
     await tester.pumpWidget(
       MaterialApp(
+        theme: soliplexLightTheme(),
         home: Scaffold(
           body: ChatInput(
             onSend: (_) {},
@@ -178,7 +186,7 @@ void main() {
     // onDeleted is null, which removes the delete icon entirely.
     final chip = tester.widget<Chip>(find.byType(Chip));
     expect(chip.onDeleted, isNull);
-    expect(find.byIcon(Icons.close), findsNothing);
+    expect(find.byIcon(Icons.cancel), findsNothing);
     expect(removed, isNull);
 
     sessionState.dispose();
@@ -190,6 +198,7 @@ void main() {
 
     await tester.pumpWidget(
       MaterialApp(
+        theme: soliplexLightTheme(),
         home: Scaffold(
           body: ChatInput(
             onSend: (_) {},
@@ -213,6 +222,7 @@ void main() {
   testWidgets('filter button hidden when onFilterTap is null', (tester) async {
     await tester.pumpWidget(
       MaterialApp(
+        theme: soliplexLightTheme(),
         home: Scaffold(
           body: ChatInput(
             onSend: (_) {},
@@ -233,6 +243,7 @@ void main() {
 
       await tester.pumpWidget(
         MaterialApp(
+          theme: soliplexLightTheme(),
           home: Scaffold(
             body: ChatInput(
               onSend: (_) {},
@@ -250,6 +261,7 @@ void main() {
         (tester) async {
       await tester.pumpWidget(
         MaterialApp(
+          theme: soliplexLightTheme(),
           home: Scaffold(
             body: ChatInput(
               onSend: (_) {},
@@ -269,6 +281,7 @@ void main() {
 
       await tester.pumpWidget(
         MaterialApp(
+          theme: soliplexLightTheme(),
           home: Scaffold(
             body: ChatInput(
               onSend: (_) {},
@@ -280,7 +293,8 @@ void main() {
         ),
       );
 
-      await tester.tap(find.byIcon(Icons.close).first);
+      // SoliplexChip uses Material's default delete glyph (Icons.cancel).
+      await tester.tap(find.byIcon(Icons.cancel).first);
       expect(removed, doc);
     });
   });
@@ -289,6 +303,7 @@ void main() {
     testWidgets('shows when onAttachFile provided', (tester) async {
       await tester.pumpWidget(
         MaterialApp(
+          theme: soliplexLightTheme(),
           home: Scaffold(
             body: ChatInput(
               onSend: (_) {},
@@ -305,6 +320,7 @@ void main() {
     testWidgets('hidden when onAttachFile is null', (tester) async {
       await tester.pumpWidget(
         MaterialApp(
+          theme: soliplexLightTheme(),
           home: Scaffold(
             body: ChatInput(
               onSend: (_) {},
@@ -324,6 +340,7 @@ void main() {
 
       await tester.pumpWidget(
         MaterialApp(
+          theme: soliplexLightTheme(),
           home: Scaffold(
             body: ChatInput(
               onSend: (_) {},
@@ -349,6 +366,7 @@ void main() {
 
       await tester.pumpWidget(
         MaterialApp(
+          theme: soliplexLightTheme(),
           home: Scaffold(
             body: ChatInput(
               onSend: (_) {},
@@ -369,6 +387,7 @@ void main() {
       (tester) async {
         await tester.pumpWidget(
           MaterialApp(
+            theme: soliplexLightTheme(),
             home: Scaffold(
               body: ChatInput(
                 onSend: (_) {},
@@ -400,6 +419,7 @@ void main() {
 
         await tester.pumpWidget(
           MaterialApp(
+            theme: soliplexLightTheme(),
             home: Scaffold(
               body: ChatInput(
                 onSend: (_) {},


### PR DESCRIPTION
First of the **room module** design-system adoption PRs (composer surface).

> **Stacked on #298** — base is `feat/soliplex-input-focusnode-readonly`, which adds the `focusNode`/`readOnly` passthroughs this PR consumes. Review/merge #298 first, then this retargets cleanly to `main`.

## Changes (`chat_input.dart`)

- **Selected-document pills**: `Chip` → `SoliplexChip` (display). Maps avatar→`icon`, keeps `onDeleted`. Drops the ad-hoc `MaterialTapTargetSize.shrinkWrap` / `VisualDensity.compact` and the custom `×` glyph in favour of the branded chip's defaults (chips render very slightly larger; delete glyph is Material's default `Icons.cancel`).
- **Message field**: `TextField` → `SoliplexInput`. Uses the new `focusNode` (refocus-after-send) and `readOnly` (freeze input while an agent run is in flight, without greying) passthroughs. Drops the hand-rolled `OutlineInputBorder` so it picks up the brand input decoration.

The composer's IconButtons (filter / attach / stop / send) stay raw Material — there is no Soliplex IconButton wrapper.

## Tests

- Themed the test harness with `soliplexLightTheme()` so `SoliplexChip` can resolve the `SoliplexTheme` extension (it would null-crash under a bare `MaterialApp`).
- Retargeted the chip delete-glyph finder from `Icons.close` to `Icons.cancel`.
- Full `test/modules/room` suite green (803 tests).

## Adoption roadmap (room, ~29 buttons + 2 chips + 5 inputs across 17 files)

This is **R1 of 6**. Remaining, all touching disjoint files so they merge in any order: thread sidebar (12 buttons) · dialogs · room-info cards · document picker · workdir/misc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)