### PR TITLE
refactor(room): adopt SoliplexInput + SoliplexButton in dialogs

### DIFF
--- a/lib/src/modules/room/ui/approval_handler.dart
+++ b/lib/src/modules/room/ui/approval_handler.dart
@@ -140,11 +140,11 @@ class ApprovalDialog extends StatelessWidget {
         ],
       ),
       actions: [
-        TextButton(
+        SoliplexButton.text(
           onPressed: () => Navigator.of(context).pop(false),
           child: const Text('Deny'),
         ),
-        FilledButton(
+        SoliplexButton.filled(
           onPressed: () => Navigator.of(context).pop(true),
           child: const Text('Allow'),
         ),

--- a/lib/src/modules/room/ui/async_action_dialog.dart
+++ b/lib/src/modules/room/ui/async_action_dialog.dart
@@ -157,10 +157,10 @@ class _RenameDialogState extends State<RenameDialog> {
       actionLabel: 'Save',
       canSubmit: _canSave,
       onAction: () => widget.onAction(_controller.text.trim()),
-      contentBuilder: (onSubmit) => TextField(
+      contentBuilder: (onSubmit) => SoliplexInput(
         controller: _controller,
         autofocus: true,
-        decoration: const InputDecoration(labelText: 'Thread name'),
+        label: 'Thread name',
         onSubmitted: onSubmit != null ? (_) => onSubmit() : null,
       ),
     );

--- a/lib/src/modules/room/ui/feedback_reason_dialog.dart
+++ b/lib/src/modules/room/ui/feedback_reason_dialog.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:soliplex_design/soliplex_design.dart';
 
 class FeedbackReasonDialog extends StatefulWidget {
   const FeedbackReasonDialog({super.key});
@@ -20,21 +21,19 @@ class _FeedbackReasonDialogState extends State<FeedbackReasonDialog> {
   Widget build(BuildContext context) {
     return AlertDialog(
       title: const Text('Tell us why'),
-      content: TextField(
+      content: SoliplexInput(
         controller: _controller,
         autofocus: true,
         maxLines: 5,
-        decoration: const InputDecoration(
-          hintText: 'Add a reason (optional)',
-        ),
+        hintText: 'Add a reason (optional)',
         textInputAction: TextInputAction.newline,
       ),
       actions: [
-        TextButton(
+        SoliplexButton.text(
           onPressed: () => Navigator.of(context).pop(),
           child: const Text('Cancel'),
         ),
-        FilledButton(
+        SoliplexButton.filled(
           onPressed: () => Navigator.of(context).pop(_controller.text),
           child: const Text('Send'),
         ),


### PR DESCRIPTION
**R3** of the room module design-system adoption (modal/dialog surfaces).

> **Independent — base `main`.** Touches only dialog files, disjoint from the composer (#299) and sidebar (#301) stacks, and needs no design-package additions. Merge any time.

## Changes

- **`async_action_dialog.dart`** — `RenameDialog`'s `TextField` → `SoliplexInput` (`label` / `autofocus` / `onSubmitted`). Its action buttons were already `SoliplexButton` from an earlier pass.
- **`feedback_reason_dialog.dart`** — reason `TextField` → `SoliplexInput` (multi-line `maxLines: 5`, `hintText`, newline action); Cancel `TextButton` → `SoliplexButton.text`, Send `FilledButton` → `SoliplexButton.filled`.
- **`approval_handler.dart`** — `ApprovalDialog`'s Deny `TextButton` → `SoliplexButton.text`, Allow `FilledButton` → `SoliplexButton.filled`.

## Tests

All three dialog suites green (25 tests) unchanged — finders use `find.text` / `find.byType(TextField)` / `find.widgetWithText(TextButton, …)`, which survive the wrappers. Full `test/modules/room` suite green (803).

## Roadmap

R3 of 6 done. Remaining (disjoint files, any order): room-info cards · document picker · workdir/misc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)