### PR TITLE
refactor(room): adopt SoliplexButton + SoliplexInput in room-info cards

### DIFF
--- a/lib/src/modules/room/ui/room_info/documents_card.dart
+++ b/lib/src/modules/room/ui/room_info/documents_card.dart
@@ -71,7 +71,7 @@ class _DocumentsCardState extends State<DocumentsCard> {
                     style: TextStyle(color: theme.colorScheme.error),
                   ),
                 ),
-                FilledButton(
+                SoliplexButton.filled(
                   onPressed: widget.onRetry,
                   child: const Text('Retry'),
                 ),
@@ -99,28 +99,20 @@ class _DocumentsCardState extends State<DocumentsCard> {
               if (docs.length > 1)
                 Padding(
                   padding: const EdgeInsets.only(bottom: SoliplexSpacing.s2),
-                  child: TextField(
+                  child: SoliplexInput(
                     controller: _searchController,
-                    decoration: InputDecoration(
-                      hintText: 'Search documents...',
-                      prefixIcon: const Icon(Icons.search),
-                      suffixIcon: _searchQuery.isNotEmpty
-                          ? IconButton(
-                              icon: const Icon(Icons.clear),
-                              tooltip: 'Clear search',
-                              onPressed: () => setState(() {
-                                _searchController.clear();
-                                _searchQuery = '';
-                              }),
-                            )
-                          : null,
-                      isDense: true,
-                      border: const OutlineInputBorder(),
-                      contentPadding: const EdgeInsets.symmetric(
-                        horizontal: SoliplexSpacing.s3,
-                        vertical: SoliplexSpacing.s2,
-                      ),
-                    ),
+                    hintText: 'Search documents...',
+                    leadingIcon: const Icon(Icons.search),
+                    trailingIcon: _searchQuery.isNotEmpty
+                        ? IconButton(
+                            icon: const Icon(Icons.clear),
+                            tooltip: 'Clear search',
+                            onPressed: () => setState(() {
+                              _searchController.clear();
+                              _searchQuery = '';
+                            }),
+                          )
+                        : null,
                     onChanged: (value) => setState(() => _searchQuery = value),
                   ),
                 ),
@@ -267,14 +259,7 @@ class _DocumentsCardState extends State<DocumentsCard> {
             if (doc.metadata.isNotEmpty)
               Align(
                 alignment: Alignment.centerRight,
-                child: TextButton(
-                  style: TextButton.styleFrom(
-                    textStyle: theme.textTheme.labelSmall,
-                    padding: const EdgeInsets.symmetric(
-                      horizontal: SoliplexSpacing.s4,
-                      vertical: SoliplexSpacing.s2,
-                    ),
-                  ),
+                child: SoliplexButton.text(
                   onPressed: () => showDialog<void>(
                     context: context,
                     builder: (_) => MetadataDialog(
@@ -363,7 +348,7 @@ class MetadataDialog extends StatelessWidget {
         ),
       ),
       actions: [
-        TextButton(
+        SoliplexButton.text(
           onPressed: () => Navigator.of(context).pop(),
           child: const Text('Close'),
         ),

--- a/lib/src/modules/room/ui/room_info/features_card.dart
+++ b/lib/src/modules/room/ui/room_info/features_card.dart
@@ -113,12 +113,12 @@ class _McpTokenRowState extends State<McpTokenRow> {
         if (snapshot.hasError) {
           return Padding(
             padding: const EdgeInsets.symmetric(vertical: SoliplexSpacing.s1),
-            child: OutlinedButton.icon(
+            child: SoliplexButton.outlined(
               icon: const Icon(Icons.refresh, size: 16),
-              label: const Text('Retry token'),
               onPressed: () => setState(() {
                 _tokenFuture = widget.api.getMcpToken(widget.roomId);
               }),
+              child: const Text('Retry token'),
             ),
           );
         }
@@ -133,12 +133,12 @@ class _McpTokenRowState extends State<McpTokenRow> {
         };
         return Padding(
           padding: const EdgeInsets.symmetric(vertical: SoliplexSpacing.s1),
-          child: OutlinedButton.icon(
+          child: SoliplexButton.outlined(
             icon: Icon(icon, size: 16),
-            label: Text(label),
             onPressed: _copyState == _TokenCopyState.idle
                 ? () => _copyToken(token)
                 : null,
+            child: Text(label),
           ),
         );
       },

--- a/lib/src/modules/room/ui/room_info/room_info_widgets.dart
+++ b/lib/src/modules/room/ui/room_info/room_info_widgets.dart
@@ -100,15 +100,9 @@ class DialogButton extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final theme = Theme.of(context);
     return Align(
       alignment: Alignment.centerRight,
-      child: TextButton(
-        style: TextButton.styleFrom(
-          textStyle: theme.textTheme.labelSmall,
-          padding: const EdgeInsets.symmetric(
-              horizontal: SoliplexSpacing.s4, vertical: SoliplexSpacing.s2),
-        ),
+      child: SoliplexButton.text(
         onPressed: onPressed,
         child: Text(label),
       ),

--- a/lib/src/modules/room/ui/room_info/skill_card.dart
+++ b/lib/src/modules/room/ui/room_info/skill_card.dart
@@ -149,7 +149,7 @@ class SkillDetailDialog extends StatelessWidget {
         ),
       ),
       actions: [
-        TextButton(
+        SoliplexButton.text(
           onPressed: () => Navigator.of(context).pop(),
           child: const Text('Close'),
         ),

--- a/lib/src/modules/room/ui/room_info/system_prompt_viewer.dart
+++ b/lib/src/modules/room/ui/room_info/system_prompt_viewer.dart
@@ -80,7 +80,7 @@ class _SystemPromptViewerState extends State<SystemPromptViewer> {
                   if (overflows || _expanded)
                     Align(
                       alignment: Alignment.centerRight,
-                      child: TextButton(
+                      child: SoliplexButton.text(
                         onPressed: () => setState(() => _expanded = !_expanded),
                         child: Text(_expanded ? 'Collapse' : 'Expand'),
                       ),

--- a/lib/src/modules/room/ui/room_info_screen.dart
+++ b/lib/src/modules/room/ui/room_info_screen.dart
@@ -457,15 +457,15 @@ class _UploadedFilesCardState extends State<_UploadedFilesCard> {
             spacing: 8,
             runSpacing: 8,
             children: [
-              FilledButton.icon(
+              SoliplexButton.filled(
                 onPressed: () => _pickAndUpload(pickFiles),
                 icon: const Icon(Icons.upload_file, size: 18),
-                label: const Text('Upload files to room'),
+                child: const Text('Upload files to room'),
               ),
-              FilledButton.icon(
+              SoliplexButton.filled(
                 onPressed: () => _pickAndUpload(pickFolder),
                 icon: const Icon(Icons.drive_folder_upload, size: 18),
-                label: const Text('Upload folder to room'),
+                child: const Text('Upload folder to room'),
               ),
             ],
           ),


### PR DESCRIPTION
**R4** of the room module design-system adoption (room-info card family — the biggest remaining cluster).

> **Independent — base `main`.** Disjoint from the composer (#299) and sidebar (#301) stacks and the dialogs PR (#302). No design-package additions. Merge any time.

## Changes — 10 buttons + 1 input across 6 files

- **`system_prompt_viewer.dart`** — Expand/Collapse `TextButton` → `SoliplexButton.text`.
- **`skill_card.dart`** — dialog Close `TextButton` → `SoliplexButton.text`.
- **`features_card.dart`** — Retry-token + Copy-token `OutlinedButton.icon` → `SoliplexButton.outlined`.
- **`room_info_widgets.dart`** — shared `DialogButton` `TextButton` → `SoliplexButton.text`. **Drops** its bespoke `labelSmall` `textStyle` + custom `padding` `styleFrom` — the design system owns button type/padding (no per-call `textStyle` axis, by design). Minor: these affordances render at the theme-standard button size.
- **`documents_card.dart`** — Retry `FilledButton` → `SoliplexButton.filled`; search `TextField` → `SoliplexInput` (leading search icon + trailing clear, the #293 diagnostics pattern); "Show metadata" + metadata-dialog Close → `SoliplexButton.text`.
- **`room_info_screen.dart`** — Upload files / Upload folder `FilledButton.icon` → `SoliplexButton.filled`.

## Tests

All 6 room-info suites green (65 tests) unchanged — finders use `find.byType(TextField)` / `find.widgetWithText(TextButton, …)`, which survive the wrappers. Full `test/modules/room` suite green (803).

## Roadmap

R4 of 6 done. Remaining (disjoint files): document picker (R5) · workdir/misc (R6).

🤖 Generated with [Claude Code](https://claude.com/claude-code)