### PR TITLE
refactor(room): adopt SoliplexButton + SoliplexInput in document picker

### DIFF
--- a/lib/src/modules/room/ui/document_picker.dart
+++ b/lib/src/modules/room/ui/document_picker.dart
@@ -57,27 +57,23 @@ class _DocumentPickerState extends State<DocumentPicker> {
             SoliplexSpacing.s4,
             SoliplexSpacing.s2,
           ),
-          child: TextField(
+          child: SoliplexInput(
             controller: _searchController,
-            decoration: InputDecoration(
-              hintText: 'Search documents...',
-              prefixIcon: const Icon(Icons.search),
-              suffixIcon: _query.isNotEmpty
-                  ? IconButton(
-                      icon: const Icon(Icons.clear),
-                      tooltip: 'Clear search',
-                      onPressed: () {
-                        setState(() {
-                          _searchController.clear();
-                          _query = '';
-                        });
-                        widget.onSearchChanged?.call(_filtered.length);
-                      },
-                    )
-                  : null,
-              isDense: true,
-              border: const OutlineInputBorder(),
-            ),
+            hintText: 'Search documents...',
+            leadingIcon: const Icon(Icons.search),
+            trailingIcon: _query.isNotEmpty
+                ? IconButton(
+                    icon: const Icon(Icons.clear),
+                    tooltip: 'Clear search',
+                    onPressed: () {
+                      setState(() {
+                        _searchController.clear();
+                        _query = '';
+                      });
+                      widget.onSearchChanged?.call(_filtered.length);
+                    },
+                  )
+                : null,
             onChanged: (v) {
               setState(() => _query = v);
               widget.onSearchChanged?.call(_filtered.length);
@@ -94,7 +90,7 @@ class _DocumentPickerState extends State<DocumentPicker> {
                   '${widget.selected.length} selected',
                   style: theme.textTheme.bodySmall,
                 ),
-                TextButton(
+                SoliplexButton.text(
                   onPressed: () => widget.onChanged(const {}),
                   child: const Text('Clear all'),
                 ),
@@ -198,12 +194,12 @@ Future<Set<RagDocument>?> showDocumentPicker({
                         ),
                   ),
                   const SizedBox(height: SoliplexSpacing.s2),
-                  TextButton.icon(
+                  SoliplexButton.text(
                     onPressed: () => setDialogState(() {
                       documentsFuture = fetchDocuments();
                     }),
                     icon: const Icon(Icons.refresh),
-                    label: const Text('Retry'),
+                    child: const Text('Retry'),
                   ),
                 ],
               ),
@@ -236,11 +232,11 @@ Future<Set<RagDocument>?> showDocumentPicker({
               child: SizedBox(width: double.maxFinite, child: content),
             ),
             actions: [
-              TextButton(
+              SoliplexButton.text(
                 onPressed: () => Navigator.pop(context),
                 child: const Text('Cancel'),
               ),
-              FilledButton(
+              SoliplexButton.filled(
                 onPressed:
                     canConfirm ? () => Navigator.pop(context, current) : null,
                 child: const Text('Done'),


### PR DESCRIPTION
**R5** of the room module design-system adoption (document-picker dialog).

> **Independent — base `main`.** Single file, disjoint from every other room PR. No design-package additions. Merge any time.

## Changes (`document_picker.dart`) — 4 buttons + 1 input

- Search `TextField` → `SoliplexInput` (leading search icon + trailing clear — same pattern as #293 diagnostics and #303 documents card).
- "Clear all" `TextButton` → `SoliplexButton.text`.
- "Retry" `TextButton.icon` → `SoliplexButton.text` (icon + child).
- Dialog Cancel `TextButton` → `SoliplexButton.text`; Done `FilledButton` → `SoliplexButton.filled`.

## Tests

`document_picker_test.dart` green (11 tests) unchanged — finders use `find.text` / `find.byType(TextField)` / `find.widgetWithText(FilledButton, 'Done')`, all of which survive the wrappers. Full `test/modules/room` suite green (803).

## Roadmap

R5 of 6 done. Remaining: **R6 — workdir/misc** (5 buttons + 1 chip; the chip will reuse the `soliplexLightTheme()` test-harness fix from R1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)