### PR TITLE
refactor(room): adopt SoliplexButton + SoliplexChip in workdir/misc surfaces

### DIFF
--- a/lib/src/modules/room/ui/chunk_visualization_page.dart
+++ b/lib/src/modules/room/ui/chunk_visualization_page.dart
@@ -306,10 +306,10 @@ class _ChunkVisualizationPageState extends State<ChunkVisualizationPage> {
             style: theme.textTheme.bodyMedium,
           ),
           const SizedBox(height: SoliplexSpacing.s4),
-          FilledButton.icon(
+          SoliplexButton.filled(
             onPressed: _retry,
             icon: const Icon(Icons.refresh),
-            label: const Text('Retry'),
+            child: const Text('Retry'),
           ),
         ],
       ),

--- a/lib/src/modules/room/ui/error_retry_panel.dart
+++ b/lib/src/modules/room/ui/error_retry_panel.dart
@@ -44,7 +44,7 @@ class ErrorRetryPanel extends StatelessWidget {
               child: const Text('Sign in'),
             )
           else if (onRetry != null)
-            FilledButton.tonal(
+            SoliplexButton.filled(
               onPressed: onRetry,
               child: const Text('Retry'),
             ),

--- a/lib/src/modules/room/ui/room_welcome.dart
+++ b/lib/src/modules/room/ui/room_welcome.dart
@@ -102,13 +102,17 @@ class RoomWelcome extends StatelessWidget {
                       alignment: WrapAlignment.center,
                       children: [
                         for (final entry in currentRoom.quizzes.entries)
-                          ActionChip(
-                            avatar: const Icon(Icons.play_arrow, size: 16),
-                            label: Text(entry.value),
-                            onPressed: onQuizTapped != null
-                                ? () => onQuizTapped!(entry.key)
-                                : null,
-                          ),
+                          if (onQuizTapped != null)
+                            SoliplexChip.action(
+                              icon: const Icon(Icons.play_arrow),
+                              label: Text(entry.value),
+                              onPressed: () => onQuizTapped!(entry.key),
+                            )
+                          else
+                            SoliplexChip(
+                              icon: const Icon(Icons.play_arrow),
+                              label: Text(entry.value),
+                            ),
                       ],
                     ),
                   ],

--- a/lib/src/modules/room/ui/workdir_files_section.dart
+++ b/lib/src/modules/room/ui/workdir_files_section.dart
@@ -540,10 +540,10 @@ class _WorkdirPreviewPageState extends State<WorkdirPreviewPage> {
             style: theme.textTheme.bodyMedium,
           ),
           const SizedBox(height: SoliplexSpacing.s4),
-          FilledButton.icon(
+          SoliplexButton.filled(
             onPressed: () => _retry(file),
             icon: const Icon(Icons.refresh),
-            label: const Text('Retry'),
+            child: const Text('Retry'),
           ),
         ],
       ),
@@ -857,10 +857,10 @@ class _CannotPreview extends StatelessWidget {
             logTag: 'preview-fallback download callback threw',
             builder: (context, state, onTap) {
               final (btnIcon, label) = state.affordance;
-              return FilledButton.icon(
+              return SoliplexButton.filled(
                 onPressed: onTap,
                 icon: Icon(btnIcon),
-                label: Text(label),
+                child: Text(label),
               );
             },
           ),

--- a/lib/src/modules/room/ui/workdir_preview/too_large_preview.dart
+++ b/lib/src/modules/room/ui/workdir_preview/too_large_preview.dart
@@ -53,10 +53,10 @@ class TooLargePreview extends StatelessWidget {
             extraLogAttributes: {'byteSize': byteSize},
             builder: (context, state, onTap) {
               final (icon, label) = state.affordance;
-              return FilledButton.icon(
+              return SoliplexButton.filled(
                 onPressed: onTap,
                 icon: Icon(icon),
-                label: Text(label),
+                child: Text(label),
               );
             },
           ),

--- a/test/modules/room/ui/room_welcome_test.dart
+++ b/test/modules/room/ui/room_welcome_test.dart
@@ -1,11 +1,15 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:soliplex_agent/soliplex_agent.dart';
+import 'package:soliplex_design/soliplex_design.dart';
 
 import 'package:soliplex_frontend/src/modules/room/ui/room_welcome.dart';
 
 void main() {
-  Widget wrap(Widget child) => MaterialApp(home: Scaffold(body: child));
+  Widget wrap(Widget child) => MaterialApp(
+        theme: soliplexLightTheme(),
+        home: Scaffold(body: child),
+      );
 
   testWidgets('shows quiz section when room has quizzes', (tester) async {
     String? tappedQuizId;


### PR DESCRIPTION
Final room-module adoption pass (R6 of 6) — converts the last raw Material widgets in the room module to the branded `soliplex_design` library. With this, the room module **and the whole app** are on the design system.

## Changes

| File | Conversion |
| --- | --- |
| `workdir_files_section.dart` | 2× `FilledButton.icon` (preview retry, fallback download) → `SoliplexButton.filled` |
| `workdir_preview/too_large_preview.dart` | download `FilledButton.icon` → `SoliplexButton.filled` |
| `chunk_visualization_page.dart` | retry `FilledButton.icon` → `SoliplexButton.filled` |
| `error_retry_panel.dart` | Retry `FilledButton.tonal` → `SoliplexButton.filled` |
| `room_welcome.dart` | quiz `ActionChip` → `SoliplexChip.action` (with a display `SoliplexChip` fallback when no tap handler) |

### Notes

- **No tonal axis** in `SoliplexButton`, so the error-panel Retry maps to `.filled` — it's the panel's sole primary action and matches the parallel Sign-in branch.
- The lone `IconButton.filledTonal` rotate control in `chunk_visualization_page` **stays** — there's no Soliplex IconButton wrapper.
- `room_welcome_test` now themes its `MaterialApp` with `soliplexLightTheme()` because `SoliplexChip` resolves the `SoliplexTheme` extension unconditionally (crashes under a bare `MaterialApp`).

## Verification

- `dart format` + `dart analyze` clean (zero issues)
- Full `test/modules/room` suite green (809 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)