### PR TITLE
refactor: adopt SoliplexInput + SoliplexButton in versions & auth

### DIFF
--- a/lib/src/modules/auth/ui/home_screen.dart
+++ b/lib/src/modules/auth/ui/home_screen.dart
@@ -228,27 +228,24 @@ class _HomeScreenState extends ConsumerState<HomeScreen> {
       ..._buildHeader(context, 'Enter the URL of your backend server'),
       Form(
         key: _formKey,
-        child: TextFormField(
+        child: SoliplexInput(
           controller: _urlController,
           focusNode: _urlFocusNode,
           autofocus: true,
           autovalidateMode: AutovalidateMode.onUserInteraction,
           validator: _validateUrl,
-          decoration: InputDecoration(
-            labelText: 'Backend URL',
-            hintText: 'api.example.com',
-            prefixIcon: const Icon(Icons.link),
-            border: const OutlineInputBorder(),
-            suffixIcon: _hasUrlText
-                ? IconButton(
-                    icon: const Icon(Icons.clear),
-                    onPressed: () => _urlController.clear(),
-                  )
-                : null,
-          ),
+          label: 'Backend URL',
+          hintText: 'api.example.com',
+          leadingIcon: const Icon(Icons.link),
+          trailingIcon: _hasUrlText
+              ? IconButton(
+                  icon: const Icon(Icons.clear),
+                  onPressed: () => _urlController.clear(),
+                )
+              : null,
           keyboardType: TextInputType.url,
           textInputAction: TextInputAction.go,
-          onFieldSubmitted: (_) => _connect(),
+          onSubmitted: (_) => _connect(),
         ),
       ),
       const SizedBox(height: SoliplexSpacing.s4),

--- a/lib/src/modules/versions/server_versions_screen.dart
+++ b/lib/src/modules/versions/server_versions_screen.dart
@@ -94,13 +94,10 @@ class _ServerVersionsScreenState extends State<ServerVersionsScreen> {
       children: [
         Padding(
           padding: const EdgeInsets.all(SoliplexSpacing.s4),
-          child: TextField(
+          child: SoliplexInput(
             controller: _searchController,
-            decoration: const InputDecoration(
-              hintText: 'Search packages…',
-              prefixIcon: Icon(Icons.search),
-              border: OutlineInputBorder(),
-            ),
+            hintText: 'Search packages…',
+            leadingIcon: const Icon(Icons.search),
             onChanged: (value) => setState(() => _searchQuery = value),
           ),
         ),

--- a/lib/src/modules/versions/versions_screen.dart
+++ b/lib/src/modules/versions/versions_screen.dart
@@ -251,7 +251,7 @@ class _ServerVersionTileState extends State<_ServerVersionTile> {
                   onPressed: _retry,
                 )
               else
-                TextButton(
+                SoliplexButton.text(
                   onPressed: info == null
                       ? null
                       : () => context.push(

--- a/packages/soliplex_design/lib/src/components/input/input.dart
+++ b/packages/soliplex_design/lib/src/components/input/input.dart
@@ -34,6 +34,7 @@ class SoliplexInput extends StatefulWidget {
     this.onChanged,
     this.onSubmitted,
     this.validator,
+    this.autovalidateMode,
     this.isPassword = false,
     this.isLoading = false,
     this.enabled = true,
@@ -79,6 +80,12 @@ class SoliplexInput extends StatefulWidget {
   final ValueChanged<String>? onChanged;
   final ValueChanged<String>? onSubmitted;
   final FormFieldValidator<String>? validator;
+
+  /// When to run [validator]. Defaults to Material's behaviour
+  /// ([AutovalidateMode.disabled] — validate only on
+  /// `Form.validate()`). Pass [AutovalidateMode.onUserInteraction] for
+  /// fields that should surface errors as the user types.
+  final AutovalidateMode? autovalidateMode;
 
   /// Obscures the input and shows an eye toggle as the trailing icon.
   final bool isPassword;
@@ -131,6 +138,7 @@ class _SoliplexInputState extends State<SoliplexInput> {
       onChanged: widget.onChanged,
       onFieldSubmitted: widget.onSubmitted,
       validator: widget.validator,
+      autovalidateMode: widget.autovalidateMode,
       decoration: InputDecoration(
         labelText: widget.label,
         hintText: widget.hintText,

--- a/packages/soliplex_design/test/components/input/input_test.dart
+++ b/packages/soliplex_design/test/components/input/input_test.dart
@@ -111,4 +111,23 @@ void main() {
     final field = tester.widget<TextField>(find.byType(TextField));
     expect(field.focusNode, same(focusNode));
   });
+
+  testWidgets('autovalidateMode validates on user interaction', (tester) async {
+    await tester.pumpWidget(
+      _harness(
+        SoliplexInput(
+          label: 'URL',
+          autovalidateMode: AutovalidateMode.onUserInteraction,
+          validator: (v) => (v ?? '').isEmpty ? 'Required' : null,
+        ),
+      ),
+    );
+    // No Form.validate() call — the error only appears because the
+    // field self-validates as the user types.
+    expect(find.text('Required'), findsNothing);
+    await tester.enterText(find.byType(TextFormField), 'x');
+    await tester.enterText(find.byType(TextFormField), '');
+    await tester.pump();
+    expect(find.text('Required'), findsOneWidget);
+  });
 }


### PR DESCRIPTION
Final design-system cleanup — closes the last gaps a repo-wide sweep turned up *outside* the five tracked modules. After this, **every adoptable Material button/chip/input across `lib/` is on `soliplex_design`.**

## Why this exists

The room adoption plan covered auth/lobby/room/quiz/diagnostics. A whole-`lib/` sweep surfaced three stragglers:
- the **`versions`** module — a real module wired into the standard flavor (reachable from the auth home + room sidebar) but never in the adoption plan;
- one **auth** field that slipped through an earlier pass.

## Changes

| File | Conversion |
| --- | --- |
| `versions/server_versions_screen.dart` | package-search `TextField` → `SoliplexInput` |
| `versions/versions_screen.dart` | "View packages" `TextButton` → `SoliplexButton.text` |
| `auth/ui/home_screen.dart` | backend-URL `TextFormField` → `SoliplexInput` |
| `soliplex_design/.../input/input.dart` | **new** additive `autovalidateMode` passthrough |

### The one design-system touch

The auth URL field uses `AutovalidateMode.onUserInteraction` (errors surface as you type). `SoliplexInput` exposed `validator` but not `autovalidateMode`, so a straight conversion would have regressed that UX. Added an optional `autovalidateMode` passthrough — same additive pattern as the earlier `focusNode` / `readOnly` (#298) and `alignment` (#300) extensions. Defaults to Material's behaviour (`disabled`), so it's a no-op for every existing call site and produces **no golden drift**.

Dropped the explicit `OutlineInputBorder()` / `InputDecoration` on both inputs — they now inherit the branded input styling, which is the point of adoption.

## Verification

- `dart format` + `dart analyze` clean (zero issues)
- design-package input tests green (8, incl. a new `autovalidateMode` test)
- `test/modules/versions` + auth `home_screen_test` green (54)

Fully disjoint from the open queue (#316, #75, #198, #203–#206) — merges in any order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)