### PR TITLE
feat(design): configurable ClassificationTheme model (1/4)

### DIFF
--- a/packages/soliplex_design/lib/soliplex_design.dart
+++ b/packages/soliplex_design/lib/soliplex_design.dart
@@ -10,6 +10,7 @@ export 'src/components/input/input.dart';
 export 'src/components/picker/date_picker.dart';
 export 'src/components/picker/time_picker.dart';
 export 'src/effects/glow.dart';
+export 'src/theme/classification_theme.dart';
 export 'src/theme/markdown_theme_extension.dart';
 export 'src/theme/theme.dart';
 export 'src/theme/theme_extensions.dart';

--- a/packages/soliplex_design/lib/src/theme/classification_theme.dart
+++ b/packages/soliplex_design/lib/src/theme/classification_theme.dart
@@ -1,0 +1,115 @@
+import 'package:flutter/material.dart';
+
+/// A single configurable confidentiality marking.
+///
+/// Deployments define their own ordered set of these in flavor code — the
+/// design system ships only the mechanism, never a vocabulary. [id] is the
+/// stable key (and the future backend value); [label] is the authoritative
+/// text, rendered **verbatim** with no uppercasing or transformation.
+///
+/// [background] / [foreground] are discrete, deployment-chosen colors —
+/// deliberately *not* derived from `colorScheme` or the brand accent, so a
+/// brand restyling can never silently change the appearance of a security
+/// marking. The same instance is used in light and dark (markings do not
+/// flip with brightness).
+@immutable
+class ClassificationLevel {
+  const ClassificationLevel({
+    required this.id,
+    required this.label,
+    required this.background,
+    required this.foreground,
+    this.icon,
+  });
+
+  /// Stable key for this level. Unique within a [ClassificationTheme] and
+  /// the value a backend would eventually send per room.
+  final String id;
+
+  /// Authoritative marking text, rendered verbatim.
+  final String label;
+
+  /// Pill background color.
+  final Color background;
+
+  /// Pill text/icon color.
+  final Color foreground;
+
+  /// Optional leading glyph.
+  final IconData? icon;
+}
+
+/// Deployment-configurable confidentiality markings, carried on [ThemeData]
+/// as a [ThemeExtension] (riding alongside `SoliplexTheme`).
+///
+/// The [levels] list is **ordered least → most restrictive** — list
+/// position *is* the severity. A closed enum could not represent a
+/// deployment-defined vocabulary, and an unordered map could not express
+/// severity; an ordered list gives both. Resolution and aggregation
+/// helpers that consume the ordering are added in a follow-up.
+///
+/// When no extension is registered, [of] returns [fallback]: a single
+/// neutral built-in level. The badge therefore never crashes in a host app
+/// running on bare [ThemeData].
+class ClassificationTheme extends ThemeExtension<ClassificationTheme> {
+  ClassificationTheme({required this.levels, required this.defaultId})
+      : assert(levels.isNotEmpty, 'levels must not be empty'),
+        assert(
+          levels.map((l) => l.id).toSet().length == levels.length,
+          'ClassificationLevel ids must be unique',
+        ),
+        assert(
+          levels.any((l) => l.id == defaultId),
+          'defaultId must match one of the levels',
+        );
+
+  /// Ordered least → most restrictive; list position is the severity.
+  final List<ClassificationLevel> levels;
+
+  /// Id of the level applied when a surface supplies no classification.
+  /// Required — the deployment decides the err-direction; we never guess.
+  final String defaultId;
+
+  @override
+  ClassificationTheme copyWith({
+    List<ClassificationLevel>? levels,
+    String? defaultId,
+  }) {
+    return ClassificationTheme(
+      levels: levels ?? this.levels,
+      defaultId: defaultId ?? this.defaultId,
+    );
+  }
+
+  /// Markings are discrete, not interpolated — animating between two
+  /// confidentiality values would render a meaningless in-between color.
+  /// [lerp] snaps to `this` (matching `SoliplexTheme.colors`).
+  @override
+  ClassificationTheme lerp(covariant ClassificationTheme? other, double t) {
+    return this;
+  }
+
+  /// Null-safe accessor: falls back to [fallback] when no extension is
+  /// registered, so consumers work under bare [ThemeData].
+  static ClassificationTheme of(BuildContext context) {
+    return Theme.of(context).extension<ClassificationTheme>() ?? fallback;
+  }
+
+  /// The single neutral level used by [fallback]. Exposed so consumers can
+  /// detect the unconfigured built-in (e.g. to suppress a meaningless pill)
+  /// by identity.
+  static const ClassificationLevel fallbackLevel = ClassificationLevel(
+    id: 'unmarked',
+    label: 'UNMARKED',
+    background: Color(0xFFE2E3E5),
+    foreground: Color(0xFF3A3D42),
+    icon: Icons.shield_outlined,
+  );
+
+  /// Built-in default used when a deployment configures no classifications:
+  /// a single neutral [fallbackLevel].
+  static final ClassificationTheme fallback = ClassificationTheme(
+    levels: const [fallbackLevel],
+    defaultId: fallbackLevel.id,
+  );
+}

--- a/packages/soliplex_design/lib/src/theme/theme.dart
+++ b/packages/soliplex_design/lib/src/theme/theme.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 
+import 'package:soliplex_design/src/theme/classification_theme.dart';
 import 'package:soliplex_design/src/theme/markdown_theme_extension.dart';
 import 'package:soliplex_design/src/theme/theme_extensions.dart';
 import 'package:soliplex_design/src/tokens/colors.dart';
@@ -7,15 +8,30 @@ import 'package:soliplex_design/src/tokens/radii.dart';
 import 'package:soliplex_design/src/tokens/spacing.dart';
 import 'package:soliplex_design/src/tokens/typography.dart';
 
-ThemeData soliplexLightTheme({SoliplexColors colors = lightSoliplexColors}) =>
-    _buildTheme(colors: colors, brightness: Brightness.light);
+ThemeData soliplexLightTheme({
+  SoliplexColors colors = lightSoliplexColors,
+  ClassificationTheme? classifications,
+}) =>
+    _buildTheme(
+      colors: colors,
+      brightness: Brightness.light,
+      classifications: classifications,
+    );
 
-ThemeData soliplexDarkTheme({SoliplexColors colors = darkSoliplexColors}) =>
-    _buildTheme(colors: colors, brightness: Brightness.dark);
+ThemeData soliplexDarkTheme({
+  SoliplexColors colors = darkSoliplexColors,
+  ClassificationTheme? classifications,
+}) =>
+    _buildTheme(
+      colors: colors,
+      brightness: Brightness.dark,
+      classifications: classifications,
+    );
 
 ThemeData _buildTheme({
   required SoliplexColors colors,
   required Brightness brightness,
+  ClassificationTheme? classifications,
 }) {
   final textTheme = soliplexTextTheme(colors);
   final colorScheme = ColorScheme(
@@ -224,6 +240,7 @@ ThemeData _buildTheme({
     useMaterial3: true,
     textTheme: textTheme,
     extensions: [
+      classifications ?? ClassificationTheme.fallback,
       SoliplexTheme(
         colors: colors,
         radii: soliplexRadii,


### PR DESCRIPTION
**Stack 1 of 4 — configurable classification markings.**

Adds the data model and its ThemeData seat. No resolution logic, no
widgets, no UI change yet.

### What's here
- `ClassificationLevel` — `id` (stable key / future backend value),
  verbatim `label`, discrete `background`/`foreground` colors
  (deliberately *not* derived from the brand accent, so a restyle can't
  silently change a security marking), optional `icon`.
- `ClassificationTheme` `ThemeExtension` — ordered `levels` (position =
  severity), required `defaultId`, `copyWith`, `lerp` that snaps to
  `this`, null-safe `of` → neutral built-in `fallback`, and an exposed
  `fallbackLevel` for identity checks.
- `soliplexLightTheme` / `soliplexDarkTheme` gain an optional
  `classifications` param; the extension is always registered (falling
  back to the built-in).

### Why ordered list (not enum/map)
A closed enum can't represent a deployment-defined vocabulary; an
unordered map can't express severity. An ordered list gives both — and is
the basis for future highest/mixed-marking surfaces.

### Stack
1. **this PR** — model + theme seat
2. logic (`resolve`/`highestOf`/`isMixed`) + components (`BadgePill`,
   `SoliplexClassificationBadge`, gallery)
3. lobby card adoption + flavor wiring
4. tests (unit + widget + goldens)

> ⚠️ Tests land in PR 4 per the agreed staging, so the coverage gate will
> be red on PRs 1–3. Please review/merge the stack as a unit (or merge
> tip-down once PR 4 is approved).

🤖 Generated with [Claude Code](https://claude.com/claude-code)