### PR TITLE
feat(design): classification resolution + badge component (2/4)

### DIFF
--- a/packages/soliplex_design/example/lib/main.dart
+++ b/packages/soliplex_design/example/lib/main.dart
@@ -32,6 +32,7 @@ class _GalleryHomeState extends State<GalleryHome> {
     ('Buttons', ButtonGallery()),
     ('Badges', BadgeGallery()),
     ('Chips', ChipGallery()),
+    ('Classification', ClassificationBadgeGallery()),
     ('Inputs', InputGallery()),
     ('Dropdowns', DropdownGallery()),
     ('Pickers', PickerGallery()),
@@ -322,6 +323,98 @@ class BadgeGallery extends StatelessWidget {
           ],
         ),
       ],
+    );
+  }
+}
+
+// =====================================================================
+// Classification
+// =====================================================================
+
+/// Sample multi-level theme for the gallery. Neutral placeholders only —
+/// deployments supply their own vocabulary in flavor code; nothing here is
+/// a real-world classification scheme.
+final _sampleClassifications = ClassificationTheme(
+  defaultId: 'public',
+  levels: const [
+    ClassificationLevel(
+      id: 'public',
+      label: 'PUBLIC',
+      background: Color(0xFFDCF3E4),
+      foreground: Color(0xFF1B5E36),
+    ),
+    ClassificationLevel(
+      id: 'internal',
+      label: 'INTERNAL',
+      background: Color(0xFFFDF1D6),
+      foreground: Color(0xFF6B5310),
+      icon: Icons.lock_outline,
+    ),
+    ClassificationLevel(
+      id: 'restricted',
+      label: 'RESTRICTED',
+      background: Color(0xFFF8DAD6),
+      foreground: Color(0xFF7A271F),
+      icon: Icons.lock,
+    ),
+    ClassificationLevel(
+      id: 'partner-confidential',
+      label: 'PARTNER CONFIDENTIAL',
+      background: Color(0xFFE7DEF8),
+      foreground: Color(0xFF3D2A6B),
+      icon: Icons.lock,
+    ),
+  ],
+);
+
+/// Gallery of `SoliplexClassificationBadge` against a sample multi-level
+/// theme. Reused by golden tests. Shows configured levels, the default
+/// (null) marking, a fail-loud unknown id, and a long label wrapping
+/// inside a narrow container.
+class ClassificationBadgeGallery extends StatelessWidget {
+  const ClassificationBadgeGallery({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final base = Theme.of(context);
+    final extensions = List<ThemeExtension<dynamic>>.of(base.extensions.values)
+      ..add(_sampleClassifications);
+    return Theme(
+      data: base.copyWith(extensions: extensions),
+      child: const Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          _Section(
+            title: 'Configured levels',
+            children: [
+              SoliplexClassificationBadge(classification: 'public'),
+              SoliplexClassificationBadge(classification: 'internal'),
+              SoliplexClassificationBadge(classification: 'restricted'),
+              SoliplexClassificationBadge(
+                classification: 'partner-confidential',
+              ),
+            ],
+          ),
+          _Section(
+            title: 'Default (null) + unknown id (fail-loud)',
+            children: [
+              SoliplexClassificationBadge(),
+              SoliplexClassificationBadge(classification: 'totally-unknown'),
+            ],
+          ),
+          _Section(
+            title: 'Long label wraps in a narrow container',
+            children: [
+              SizedBox(
+                width: 96,
+                child: SoliplexClassificationBadge(
+                  classification: 'partner-confidential',
+                ),
+              ),
+            ],
+          ),
+        ],
+      ),
     );
   }
 }

--- a/packages/soliplex_design/lib/soliplex_design.dart
+++ b/packages/soliplex_design/lib/soliplex_design.dart
@@ -5,6 +5,7 @@ export 'src/components/button/button.dart';
 export 'src/components/button/intent.dart';
 export 'src/components/chip/chip.dart';
 export 'src/components/chip/intent.dart';
+export 'src/components/classification/classification_badge.dart';
 export 'src/components/dropdown/dropdown.dart';
 export 'src/components/input/input.dart';
 export 'src/components/picker/date_picker.dart';

--- a/packages/soliplex_design/lib/src/components/badge/badge.dart
+++ b/packages/soliplex_design/lib/src/components/badge/badge.dart
@@ -1,8 +1,8 @@
 import 'package:flutter/material.dart';
 
 import 'package:soliplex_design/src/components/badge/intent.dart';
+import 'package:soliplex_design/src/components/badge/pill.dart';
 import 'package:soliplex_design/src/theme/theme_extensions.dart';
-import 'package:soliplex_design/src/tokens/spacing.dart';
 
 /// An inline status pill — a small rounded surface carrying a short label
 /// and optional leading icon, tinted by [BadgeIntent].
@@ -37,35 +37,15 @@ class SoliplexBadge extends StatelessWidget {
   Widget build(BuildContext context) {
     final colors = badgeIntentColors(intent, context);
     final theme = SoliplexTheme.of(context);
-    final textStyle = theme.badgeTheme.textStyle.copyWith(
-      color: colors.foreground,
-    );
 
-    return Container(
+    return BadgePill(
+      label: label,
+      icon: icon,
+      background: colors.background,
+      foreground: colors.foreground,
       padding: theme.badgeTheme.padding,
-      decoration: BoxDecoration(
-        color: colors.background,
-        borderRadius: BorderRadius.circular(theme.radii.sm),
-      ),
-      child: DefaultTextStyle.merge(
-        style: textStyle,
-        child: IconTheme.merge(
-          data: IconThemeData(
-            color: colors.foreground,
-            size: textStyle.fontSize,
-          ),
-          child: icon == null
-              ? label
-              : Row(
-                  mainAxisSize: MainAxisSize.min,
-                  children: [
-                    icon!,
-                    const SizedBox(width: SoliplexSpacing.s1),
-                    label,
-                  ],
-                ),
-        ),
-      ),
+      radius: theme.radii.sm,
+      textStyle: theme.badgeTheme.textStyle,
     );
   }
 }

--- a/packages/soliplex_design/lib/src/components/badge/pill.dart
+++ b/packages/soliplex_design/lib/src/components/badge/pill.dart
@@ -1,0 +1,67 @@
+import 'package:flutter/material.dart';
+
+import 'package:soliplex_design/src/tokens/spacing.dart';
+
+/// Shared pill chrome for the badge family: a rounded tinted surface
+/// carrying a label and an optional leading icon.
+///
+/// Package-internal — **not exported** from the barrel. Callers
+/// (`SoliplexBadge`, `SoliplexClassificationBadge`) resolve their own
+/// colors from whatever source is appropriate (intent tokens vs. a
+/// configured classification level) and hand the pill the finished
+/// values, so the pill itself is colour-source agnostic. [foreground] is
+/// applied to both the text style and the icon.
+class BadgePill extends StatelessWidget {
+  const BadgePill({
+    required this.label,
+    required this.background,
+    required this.foreground,
+    required this.padding,
+    required this.radius,
+    required this.textStyle,
+    this.icon,
+    super.key,
+  });
+
+  final Widget label;
+  final Color background;
+  final Color foreground;
+  final EdgeInsetsGeometry padding;
+  final double radius;
+
+  /// Base text style; its color is overridden by [foreground].
+  final TextStyle textStyle;
+  final Widget? icon;
+
+  @override
+  Widget build(BuildContext context) {
+    final style = textStyle.copyWith(color: foreground);
+    return Container(
+      padding: padding,
+      decoration: BoxDecoration(
+        color: background,
+        borderRadius: BorderRadius.circular(radius),
+      ),
+      child: DefaultTextStyle.merge(
+        style: style,
+        child: IconTheme.merge(
+          data: IconThemeData(color: foreground, size: style.fontSize),
+          child: icon == null
+              ? label
+              : Row(
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    icon!,
+                    const SizedBox(width: SoliplexSpacing.s1),
+                    // Flexible so a long label wraps within a constrained
+                    // pill instead of overflowing. Loose fit keeps the
+                    // natural size when the pill is unbounded, so short
+                    // badges are unaffected.
+                    Flexible(child: label),
+                  ],
+                ),
+        ),
+      ),
+    );
+  }
+}

--- a/packages/soliplex_design/lib/src/components/classification/classification_badge.dart
+++ b/packages/soliplex_design/lib/src/components/classification/classification_badge.dart
@@ -1,0 +1,63 @@
+import 'package:flutter/material.dart';
+
+import 'package:soliplex_design/src/components/badge/pill.dart';
+import 'package:soliplex_design/src/theme/classification_theme.dart';
+import 'package:soliplex_design/src/tokens/radii.dart';
+import 'package:soliplex_design/src/tokens/spacing.dart';
+
+/// Display-only confidentiality marking pill.
+///
+/// Resolves [classification] against the ambient [ClassificationTheme]
+/// (`null` → the theme's default level) and renders it as a badge-style
+/// pill. The label **wraps** rather than truncating — clipping a marking
+/// is an integrity bug — so this widget is given a bounded width by its
+/// parent. Not tappable.
+///
+/// In a deployment that has configured no classifications the resolved
+/// level is the neutral built-in and this widget renders nothing: an
+/// unconfigured product should not sprout meaningless pills. A configured
+/// deployment always shows its default, and an unrecognized id always
+/// resolves to a fail-loud alarm marking that is shown.
+///
+/// Safe under bare [ThemeData]: it reads only the null-safe
+/// [ClassificationTheme.of] and const tokens, never the `!`-guarded
+/// `SoliplexTheme.of`.
+class SoliplexClassificationBadge extends StatelessWidget {
+  const SoliplexClassificationBadge({this.classification, super.key});
+
+  /// Stable level id. `null` → the theme's default level.
+  final String? classification;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = ClassificationTheme.of(context);
+    final level = theme.resolve(context, classification);
+
+    // Suppress only the unconfigured built-in (identity check). Configured
+    // defaults and the alarm level are distinct instances and still show.
+    if (identical(level, ClassificationTheme.fallbackLevel)) {
+      return const SizedBox.shrink();
+    }
+
+    final textTheme = Theme.of(context).textTheme;
+    return Semantics(
+      label: 'Classification: ${level.label}',
+      child: ExcludeSemantics(
+        child: BadgePill(
+          label: Text(level.label),
+          icon: level.icon != null ? Icon(level.icon) : null,
+          background: level.background,
+          foreground: level.foreground,
+          padding: const EdgeInsets.symmetric(
+            horizontal: SoliplexSpacing.s2,
+            vertical: SoliplexSpacing.s1,
+          ),
+          radius: soliplexRadii.sm,
+          textStyle: textTheme.labelMedium!.copyWith(
+            fontWeight: FontWeight.w700,
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/packages/soliplex_design/lib/src/theme/classification_theme.dart
+++ b/packages/soliplex_design/lib/src/theme/classification_theme.dart
@@ -1,3 +1,5 @@
+import 'dart:developer' as developer;
+
 import 'package:flutter/material.dart';
 
 /// A single configurable confidentiality marking.
@@ -69,6 +71,66 @@ class ClassificationTheme extends ThemeExtension<ClassificationTheme> {
   /// Id of the level applied when a surface supplies no classification.
   /// Required — the deployment decides the err-direction; we never guess.
   final String defaultId;
+
+  /// Resolves [id] to a level. `null` → the [defaultId] level. A known id
+  /// → its level. An **unrecognized** id → a fail-loud alarm level built
+  /// from `colorScheme.errorContainer`/`onErrorContainer`, carrying the
+  /// raw id in its label, plus a `developer.log` warning. An unknown
+  /// marking must read as alarming, never as a benign pill.
+  ClassificationLevel resolve(BuildContext context, String? id) {
+    final effectiveId = id ?? defaultId;
+    for (final level in levels) {
+      if (level.id == effectiveId) return level;
+    }
+    return _alarm(context, effectiveId);
+  }
+
+  /// The most restrictive level among [ids] by list position. Empty → the
+  /// default level. Any unrecognized id → the fail-loud alarm level (an
+  /// aggregate containing something unknown must not under-report). `null`
+  /// entries count as [defaultId].
+  ClassificationLevel highestOf(BuildContext context, Iterable<String?> ids) {
+    final list = ids.toList();
+    if (list.isEmpty) return resolve(context, null);
+
+    var bestIndex = -1;
+    ClassificationLevel? best;
+    for (final id in list) {
+      final effectiveId = id ?? defaultId;
+      final index = levels.indexWhere((l) => l.id == effectiveId);
+      if (index < 0) return _alarm(context, effectiveId);
+      if (index > bestIndex) {
+        bestIndex = index;
+        best = levels[index];
+      }
+    }
+    return best!;
+  }
+
+  /// Whether [ids] resolve to more than one distinct level. `null` entries
+  /// count as [defaultId]; distinct unrecognized ids each count as
+  /// themselves.
+  bool isMixed(Iterable<String?> ids) {
+    return ids.map((id) => id ?? defaultId).toSet().length > 1;
+  }
+
+  /// Fail-loud level for an unrecognized id.
+  ClassificationLevel _alarm(BuildContext context, String id) {
+    developer.log(
+      'Unrecognized classification id "$id"; rendering fail-loud alarm '
+      'marking.',
+      name: 'ClassificationTheme',
+      level: 900,
+    );
+    final scheme = Theme.of(context).colorScheme;
+    return ClassificationLevel(
+      id: id,
+      label: 'UNKNOWN: $id',
+      background: scheme.errorContainer,
+      foreground: scheme.onErrorContainer,
+      icon: Icons.error_outline,
+    );
+  }
 
   @override
   ClassificationTheme copyWith({


### PR DESCRIPTION
**Stack 2 of 4 — configurable classification markings.** Builds on #319.

Adds the resolution logic and the rendering layer.

### Logic (on `ClassificationTheme`)
- `resolve()` — `null` → default; known id → its level; **unknown id →
  fail-loud alarm** (errorContainer + raw id in label + `developer.log`).
- `highestOf()` — most restrictive by list position; empty → default; any
  unknown id → alarm (an aggregate must not under-report).
- `isMixed()` — more than one distinct resolved level.

### Components
- **`BadgePill`** — package-internal pill chrome extracted *verbatim* from
  `SoliplexBadge`. Not exported.
- **`SoliplexBadge`** — now delegates to `BadgePill`; public API and
  pixels unchanged. The existing `badge_golden_test.dart` stays green
  (ran locally: ✅) — that's the behavior-preserving guard.
- **`SoliplexClassificationBadge`** — display-only marking pill. Label
  **wraps** (never truncates). `Semantics` + `ExcludeSemantics` for a
  single clean announce. **Suppresses the unconfigured built-in fallback
  by identity**, so an unconfigured product shows no pill while configured
  defaults and alarm markings always render. Safe under bare `ThemeData`.

### Gallery
A `Classification` tab over a **neutral placeholder** multi-level theme:
configured levels, default/unknown, and a long label wrapping in a narrow
container. (No real-world vocabulary anywhere.)

### Stack
1. #319 — model + theme seat
2. **this PR** — logic + components
3. lobby card adoption + flavor wiring
4. tests (unit + widget + goldens)

> ⚠️ Tests land in PR 4; coverage gate stays red until then. Review/merge
> the stack as a unit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)