### PR TITLE
feat(lobby): classification marking on room cards (3/4)

### DIFF
--- a/lib/src/flavors/standard.dart
+++ b/lib/src/flavors/standard.dart
@@ -34,6 +34,7 @@ import '../modules/versions/versions_module.dart';
 
 Future<ShellConfig> standard({
   SoliplexBranding? branding,
+  ClassificationTheme? classifications,
   ThemeMode themeMode = ThemeMode.system,
   String redirectScheme = 'ai.soliplex.client',
   String defaultBackendUrl = 'http://localhost:8000',
@@ -43,17 +44,22 @@ Future<ShellConfig> standard({
   Duration inactivityGraceDuration = InactivityConfig.defaultGraceDuration,
 }) async {
   final brand = branding ?? SoliplexBranding.soliplex;
+  // Markings don't flip with brightness — the same instance feeds both
+  // themes. Omitted → the design system's neutral built-in (no pills).
+  // This is the adopter's configuration point for deployment vocabularies.
   final lightTheme = soliplexLightTheme(
     colors: SoliplexColors.fromAccent(
       brand.accentLight,
       brightness: Brightness.light,
     ),
+    classifications: classifications,
   );
   final darkTheme = soliplexDarkTheme(
     colors: SoliplexColors.fromAccent(
       brand.accentDark,
       brightness: Brightness.dark,
     ),
+    classifications: classifications,
   );
   final brandLogo = BrandLogo(branding: brand);
 

--- a/lib/src/modules/lobby/ui/room_card.dart
+++ b/lib/src/modules/lobby/ui/room_card.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:soliplex_agent/soliplex_agent.dart';
+import 'package:soliplex_design/soliplex_design.dart';
 
 class RoomCard extends StatelessWidget {
   const RoomCard({
@@ -22,6 +23,11 @@ class RoomCard extends StatelessWidget {
         trailing: Row(
           mainAxisSize: MainAxisSize.min,
           children: [
+            // Leading marking; renders nothing until a deployment
+            // configures classifications. Backend per-room value wires in
+            // here later via `classification:`.
+            const SoliplexClassificationBadge(),
+            const SizedBox(width: SoliplexSpacing.s2),
             if (room.hasQuizzes)
               Tooltip(
                 message: 'Has quizzes',

--- a/lib/src/modules/lobby/ui/room_grid_card.dart
+++ b/lib/src/modules/lobby/ui/room_grid_card.dart
@@ -64,13 +64,19 @@ class RoomGridCard extends StatelessWidget {
                 ),
               ],
               const SizedBox(height: SoliplexSpacing.s2),
-              Align(
-                alignment: Alignment.centerRight,
-                child: IconButton(
-                  icon: const Icon(Icons.info_outline),
-                  tooltip: 'Room info',
-                  onPressed: onInfoTap,
-                ),
+              Row(
+                children: [
+                  // Bottom-left marking; renders nothing until a deployment
+                  // configures classifications. Backend per-room value
+                  // wires in here later via `classification:`.
+                  const SoliplexClassificationBadge(),
+                  const Spacer(),
+                  IconButton(
+                    icon: const Icon(Icons.info_outline),
+                    tooltip: 'Room info',
+                    onPressed: onInfoTap,
+                  ),
+                ],
               ),
             ],
           ),


### PR DESCRIPTION
**Stack 3 of 4 — configurable classification markings.** Builds on #320.

Adoption sweep: place the marking on the lobby cards and expose the
configuration point.

- **`room_grid_card`** — marking bottom-left, info button bottom-right
  (`Row` + `Spacer`).
- **`room_card`** — marking as the leading trailing item, before the quiz
  icon.
- **`standard()`** — new `classifications` param forwarded as the *same
  instance* to both light and dark themes (markings don't flip with
  brightness). This is the adopter's configuration point.

Cards pass no classification yet → in the default product the badge
resolves to the neutral built-in and **renders nothing**; a deployment
that configures levels sees its default pill. Backend per-room value
wires in later via `SoliplexClassificationBadge(classification:)`.

Existing lobby card tests stay green (ran locally: ✅).

### Stack
1. #319 — model + theme seat
2. #320 — logic + components
3. **this PR** — lobby adoption + flavor wiring
4. tests (unit + widget + goldens)

> ⚠️ Tests land in PR 4; coverage gate stays red until then. Review/merge
> the stack as a unit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)