### PR TITLE
chore: version 0.88.0+58

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,15 @@ Versions follow the `version+build` scheme from `pubspec.yaml`, bumped via
 
 ## [Unreleased]
 
+## [0.88.0+58] - 2026-06-03
+
+### Added
+
+- Design: configurable `ClassificationTheme` with classification resolution
+  logic, a `ClassificationBadge` component, and a `Pill` primitive shared with
+  the badge family.
+- Lobby: show a classification marking on room cards.
+
 ### Changed
 
 - Upgraded within-constraint dependencies: `flutter_appauth` 12.0.1,

--- a/lib/version.dart
+++ b/lib/version.dart
@@ -2,4 +2,4 @@
 ///
 /// Generated from pubspec.yaml. Run `dart run tool/update_version.dart` after
 /// changing the version in pubspec.yaml.
-const String soliplexVersion = '0.87.2+57';
+const String soliplexVersion = '0.88.0+58';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,7 +3,7 @@ description: Modular Flutter frontend framework for Soliplex
 publish_to: none
 # To update version, run:
 # dart run tool/bump_version.dart <major|minor|patch|build>
-version: 0.87.2+57
+version: 0.88.0+58
 
 environment:
   sdk: ^3.6.0


### PR DESCRIPTION
Version bump to `0.88.0+58`.

### Changes
- `pubspec.yaml` + `lib/version.dart` → `0.88.0+58`
- CHANGELOG: cut `[0.88.0+58]` section covering the configurable `ClassificationTheme` / `ClassificationBadge` / `Pill` design work, the lobby room-card classification marking, and the within-constraint dependency upgrades.

Minor bump: new backward-compatible classification-markings feature.

🤖 Generated with [Claude Code](https://claude.com/claude-code)