### PR TITLE
feat(room): hide document filter button when no datasets exist

### DIFF
--- a/lib/src/modules/room/ui/room_screen.dart
+++ b/lib/src/modules/room/ui/room_screen.dart
@@ -8,6 +8,7 @@ import 'package:go_router/go_router.dart';
 import 'package:signals_flutter/signals_flutter.dart';
 import 'package:soliplex_client/soliplex_client.dart'
     show
+        CancelToken,
         MalformedResponseException,
         RagDocument,
         ReconnectFailed,
@@ -99,6 +100,25 @@ class _RoomScreenState extends State<RoomScreen> {
 
   bool get _filterEnabled => widget.enableDocumentFilter;
 
+  /// Whether the room exposes any filterable documents/datasets. Resolved
+  /// asynchronously by [_refreshFilterableDocuments]; starts `false` so the
+  /// filter button pops in once a non-empty corpus is confirmed rather than
+  /// flashing and disappearing for empty rooms.
+  bool _hasFilterableDocuments = false;
+
+  /// Set when the document fetch fails. We can't tell whether the room has a
+  /// corpus, so the filter button stays visible to avoid stripping the
+  /// affordance on a transient network error — the picker handles its own
+  /// retry.
+  bool _filterDocsLoadFailed = false;
+
+  CancelToken? _filterDocsCancelToken;
+
+  /// Show the filter button only when filtering is enabled and there is
+  /// something to filter (or we failed to find out).
+  bool get _showDocumentFilter =>
+      _filterEnabled && (_hasFilterableDocuments || _filterDocsLoadFailed);
+
   DocumentSelections get _documentSelections => widget.documentSelections;
 
   Set<RagDocument> get _selectedDocuments => _filterEnabled
@@ -108,6 +128,35 @@ class _RoomScreenState extends State<RoomScreen> {
   void _updateSelection(Set<RagDocument> selection) {
     setState(() {
       _documentSelections.set(widget.roomId, widget.threadId, selection);
+    });
+  }
+
+  /// Fetches the room's document corpus to decide whether the filter button
+  /// should be shown. No-op when filtering is disabled. Cancels any in-flight
+  /// fetch so a room switch can't apply a stale result.
+  void _refreshFilterableDocuments() {
+    if (!_filterEnabled) return;
+    _filterDocsCancelToken?.cancel('refresh');
+    final token = CancelToken();
+    _filterDocsCancelToken = token;
+    widget.serverEntry.connection.api
+        .getDocuments(widget.roomId, cancelToken: token)
+        .then((docs) {
+      if (!mounted || token != _filterDocsCancelToken) return;
+      setState(() {
+        _hasFilterableDocuments = docs.isNotEmpty;
+        _filterDocsLoadFailed = false;
+      });
+    }).catchError((Object error, StackTrace stackTrace) {
+      if (!mounted || token != _filterDocsCancelToken) return;
+      dev.log(
+        'Failed to load filterable documents',
+        error: error,
+        stackTrace: stackTrace,
+        name: 'RoomScreen',
+        level: 1000,
+      );
+      setState(() => _filterDocsLoadFailed = true);
     });
   }
 
@@ -147,6 +196,7 @@ class _RoomScreenState extends State<RoomScreen> {
     HardwareKeyboard.instance.addHandler(_handleKey);
     _state = _createRoomState();
     _workdirs = _createWorkdirController();
+    _refreshFilterableDocuments();
     if (widget.threadId != null) {
       _state.selectThread(widget.threadId!);
     } else {
@@ -199,6 +249,9 @@ class _RoomScreenState extends State<RoomScreen> {
       _chatController.clear();
       _state = _createRoomState();
       _workdirs = _createWorkdirController();
+      _hasFilterableDocuments = false;
+      _filterDocsLoadFailed = false;
+      _refreshFilterableDocuments();
       if (widget.threadId != null) {
         _state.selectThread(widget.threadId!);
       } else {
@@ -273,6 +326,7 @@ class _RoomScreenState extends State<RoomScreen> {
   @override
   void dispose() {
     _cancelAutoSelect();
+    _filterDocsCancelToken?.cancel('disposed');
     HardwareKeyboard.instance.removeHandler(_handleKey);
     _state.dispose();
     _chatController.dispose();
@@ -1106,7 +1160,7 @@ class _RoomScreenState extends State<RoomScreen> {
       focusNode: _chatFocusNode,
       enabled: threadView == null || status is MessagesLoaded,
       selectedDocuments: _selectedDocuments,
-      onFilterTap: _filterEnabled ? _openDocumentPicker : null,
+      onFilterTap: _showDocumentFilter ? _openDocumentPicker : null,
       onDocumentRemoved: _filterEnabled
           ? (doc) => _updateSelection(Set.of(_selectedDocuments)..remove(doc))
           : null,

--- a/test/modules/room/ui/room_screen_test.dart
+++ b/test/modules/room/ui/room_screen_test.dart
@@ -544,4 +544,53 @@ void main() {
 
     blockingApi.completeThreads(blockingApi.nextThreads!);
   });
+
+  group('document filter button visibility', () {
+    Future<void> pumpRoom(WidgetTester tester) async {
+      tester.view.physicalSize = const Size(400, 800);
+      tester.view.devicePixelRatio = 1.0;
+      addTearDown(tester.view.resetPhysicalSize);
+
+      await tester.pumpWidget(MaterialApp(
+        home: RoomScreen(
+          serverEntry: entry,
+          roomId: 'room-1',
+          threadId: null,
+          runtimeManager: runtimeManager,
+          registry: registry,
+          uploadRegistry: uploadRegistry,
+          enableDocumentFilter: true,
+          documentSelections: DocumentSelections(),
+        ),
+      ));
+      await tester.pumpAndSettle();
+    }
+
+    testWidgets('hidden when the room has no filterable documents',
+        (tester) async {
+      api.nextDocuments = const [];
+
+      await pumpRoom(tester);
+
+      expect(find.byTooltip('Filter documents'), findsNothing);
+    });
+
+    testWidgets('shown when the room has filterable documents', (tester) async {
+      api.nextDocuments = const [RagDocument(id: '1', title: 'Report.pdf')];
+
+      await pumpRoom(tester);
+
+      expect(find.byTooltip('Filter documents'), findsOneWidget);
+    });
+
+    testWidgets(
+        'shown when the document fetch fails so the affordance '
+        'is not lost on a transient error', (tester) async {
+      api.nextDocumentsError = Exception('network down');
+
+      await pumpRoom(tester);
+
+      expect(find.byTooltip('Filter documents'), findsOneWidget);
+    });
+  });
 }

--- a/test/modules/room/ui/room_screen_test.dart
+++ b/test/modules/room/ui/room_screen_test.dart
@@ -31,6 +31,19 @@ class _BlockingThreadsApi extends FakeSoliplexApi {
       _completer.future;
 }
 
+/// Holds `room-1`'s document fetch open until [firstRoomDocuments] is
+/// completed, while every other room resolves immediately to an empty corpus.
+class _StaleDocumentsApi extends FakeSoliplexApi {
+  final firstRoomDocuments = Completer<List<RagDocument>>();
+
+  @override
+  Future<List<RagDocument>> getDocuments(
+    String roomId, {
+    CancelToken? cancelToken,
+  }) =>
+      roomId == 'room-1' ? firstRoomDocuments.future : Future.value(const []);
+}
+
 Widget _buildRouted({
   required ServerEntry entry,
   required AgentRuntimeManager runtimeManager,
@@ -591,6 +604,49 @@ void main() {
       await pumpRoom(tester);
 
       expect(find.byTooltip('Filter documents'), findsOneWidget);
+    });
+
+    testWidgets(
+        'a slow fetch from the previous room cannot reveal the button '
+        'after switching to an empty room', (tester) async {
+      final staleApi = _StaleDocumentsApi()
+        ..nextThreads = const []
+        ..nextThreadHistory = ThreadHistory(messages: const []);
+      final staleEntry = createTestServerEntry(api: staleApi);
+
+      tester.view.physicalSize = const Size(400, 800);
+      tester.view.devicePixelRatio = 1.0;
+      addTearDown(tester.view.resetPhysicalSize);
+
+      Widget roomScreen(String roomId) => MaterialApp(
+            home: RoomScreen(
+              serverEntry: staleEntry,
+              roomId: roomId,
+              threadId: null,
+              runtimeManager: runtimeManager,
+              registry: registry,
+              uploadRegistry: uploadRegistry,
+              enableDocumentFilter: true,
+              documentSelections: DocumentSelections(),
+            ),
+          );
+
+      // room-1's fetch is in flight and held open by the completer.
+      await tester.pumpWidget(roomScreen('room-1'));
+      await tester.pumpAndSettle();
+
+      // Switch to room-2, which resolves to an empty corpus.
+      await tester.pumpWidget(roomScreen('room-2'));
+      await tester.pumpAndSettle();
+      expect(find.byTooltip('Filter documents'), findsNothing);
+
+      // room-1's now-stale fetch resolves with documents; it must not
+      // resurrect the button for the empty room-2.
+      staleApi.firstRoomDocuments
+          .complete(const [RagDocument(id: '1', title: 'Report.pdf')]);
+      await tester.pumpAndSettle();
+
+      expect(find.byTooltip('Filter documents'), findsNothing);
     });
   });
 }


### PR DESCRIPTION
## What

Makes the chat composer's **document filter button** dynamically visible: it now hides when the room has no filterable documents/datasets, and shows otherwise.

## Why

The button was gated only by the static `enableDocumentFilter` config flag, so it rendered even in rooms with an empty document corpus — where there's nothing to filter. This declutters the composer for those rooms.

## How

- `RoomScreen` fetches the room's document corpus (`api.getDocuments`) once on mount and again on room switch, via `_refreshFilterableDocuments()`. The fetch uses a `CancelToken` so a stale result from a previous room can't apply, and is cancelled on dispose.
- The filter button's `onFilterTap` is now gated by `_showDocumentFilter` (filtering enabled **and** a non-empty corpus) instead of the raw flag.
- `_hasFilterableDocuments` starts `false` so the button pops in once a non-empty corpus is confirmed, rather than flashing then disappearing for empty rooms.

### Error handling

If the document list **fails to load**, the button stays visible — a transient network error shouldn't strip the affordance, and the picker handles its own retry. Only a confirmed empty corpus hides it.

## Tests

Added a 3-test group to `room_screen_test.dart`:
- hidden when the room has no filterable documents
- shown when the room has filterable documents
- shown when the document fetch fails

`dart format` clean, `flutter analyze` zero issues, full `test/modules/room/` suite passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)