### PR TITLE
feat(skill): design-system adoption skill for whitelabel forks

### DIFF
--- a/.claude/skills/adopt-design-system/SKILL.md
+++ b/.claude/skills/adopt-design-system/SKILL.md
@@ -1,14 +1,13 @@
 ---
 name: adopt-design-system
 description: >-
-  Migrate a whitelabel fork's custom UI onto the soliplex_design system and
-  the SoliplexBranding API. Use when a fork or downstream deployment has its
-  own hand-rolled theming, hex colors, magic spacing, raw Material widgets, or
-  a custom ThemeData, and wants to adopt Soliplex tokens, branded components,
-  and per-flavor branding (light/dark accents, logo, app name). Triggers:
-  "adopt the design system", "migrate our fork to soliplex_design",
-  "whitelabel branding", "replace our custom theme", "switch to Soliplex
-  tokens".
+  Use when a whitelabel fork or downstream deployment has its own hand-rolled
+  theming — a custom ThemeData/ColorScheme, hex color literals, magic
+  spacing/radii, raw Material widgets, or font-family strings — and wants to
+  adopt soliplex_design tokens, branded components, and per-flavor
+  SoliplexBranding (light/dark accents, logo, app name). Triggers: "adopt the
+  design system", "migrate our fork to soliplex_design", "whitelabel branding",
+  "replace our custom theme", "switch to Soliplex tokens".
 ---
 
 # Adopt the Soliplex design system
@@ -41,10 +40,10 @@ Run the bundled scanner against the fork's UI (default target `lib`):
 ```
 
 It reports every hard-rule candidate as `file:line:match` and exits non-zero
-when any are found, so it also works as a CI gate. The scanner over-reports by
-design — treat each hit as something to review, not an automatic defect. The
-spacing/breakpoint section is advisory because token values and raw numbers
-look alike; those need human eyes.
+when any are found. The scanner over-reports by design — treat each hit as
+something to review, not an automatic defect. The spacing/breakpoint section
+is advisory because token values and raw numbers look alike; those need human
+eyes.
 
 Group the findings by rule before editing so the migration is systematic, not
 file-by-file whack-a-mole.
@@ -147,7 +146,7 @@ Run from the fork root and resolve everything before opening the PR:
 1. `dart format .` (or `mcp__dart__dart_format`)
 2. `flutter analyze` — **zero** warnings (or `mcp__dart__analyze_files`)
 3. `flutter test --reporter failures-only` — fix any golden/widget drift
-4. Re-run `audit.sh lib` — it should now report no violations
+4. Re-run `audit.sh lib` — the sanctioned brand-accent hex is expected; review any other hits
 5. `markdownlint-cli2 "**/*.md" "#node_modules"` if any `.md` changed
 
 Then walk the adoption checklist (also in `packages/soliplex_design/README.md`):

--- a/.claude/skills/adopt-design-system/SKILL.md
+++ b/.claude/skills/adopt-design-system/SKILL.md
@@ -1,0 +1,165 @@
+---
+name: adopt-design-system
+description: >-
+  Migrate a whitelabel fork's custom UI onto the soliplex_design system and
+  the SoliplexBranding API. Use when a fork or downstream deployment has its
+  own hand-rolled theming, hex colors, magic spacing, raw Material widgets, or
+  a custom ThemeData, and wants to adopt Soliplex tokens, branded components,
+  and per-flavor branding (light/dark accents, logo, app name). Triggers:
+  "adopt the design system", "migrate our fork to soliplex_design",
+  "whitelabel branding", "replace our custom theme", "switch to Soliplex
+  tokens".
+---
+
+# Adopt the Soliplex design system
+
+Guides a whitelabel fork from a hand-rolled UI to `soliplex_design`: brand
+identity flows through one `SoliplexBranding`, and every screen consumes
+tokens and branded components instead of literals and raw Material widgets.
+
+The design system is the single source of truth (`packages/soliplex_design/`,
+documented in `packages/soliplex_design/README.md`). **Read that README first**
+— it has the full accessor cheat sheet and component inventory this skill
+abbreviates. The branding API and light/dark theme split were introduced in
+PR #261 (`feat(branding): whitelabel branding API + light/dark theming`).
+
+## When to use
+
+A fork has any of: a custom `ThemeData`/`ColorScheme`, `Color(0x...)` literals,
+`Colors.red`-style status colors, magic `EdgeInsets`/`SizedBox` numbers, raw
+`BorderRadius.circular(N)`, `TextStyle(fontSize:)`, `fontFamily:` strings, or
+raw `FilledButton`/`TextField`/`Chip`-family widgets where a `SoliplexX`
+wrapper exists. The goal is to delete all of that and route it through the
+design system.
+
+## Step 1 — Audit
+
+Run the bundled scanner against the fork's UI (default target `lib`):
+
+```bash
+.claude/skills/adopt-design-system/audit.sh lib
+```
+
+It reports every hard-rule candidate as `file:line:match` and exits non-zero
+when any are found, so it also works as a CI gate. The scanner over-reports by
+design — treat each hit as something to review, not an automatic defect. The
+spacing/breakpoint section is advisory because token values and raw numbers
+look alike; those need human eyes.
+
+Group the findings by rule before editing so the migration is systematic, not
+file-by-file whack-a-mole.
+
+## Step 2 — Migrate the violations
+
+Import the barrel once per file: `import 'package:soliplex_design/soliplex_design.dart';`
+
+| Found | Replace with |
+| --- | --- |
+| `Color(0x...)`, `Color.fromARGB/RGBO` | `Theme.of(context).colorScheme.<token>` or `SoliplexTheme.of(context).colors.<token>` |
+| `Colors.red/green/orange/blue/yellow` (status) | `colorScheme.danger \| success \| warning \| info` (via `SymbolicColors`); for a *container* surface use `errorContainer`/`onErrorContainer` (or `colors.successContainer`/`onSuccessContainer`) |
+| Destructive action color | `colorScheme.error` / `errorContainer` — never red hex |
+| `EdgeInsets`/`SizedBox` magic numbers | `SoliplexSpacing.{s1=4, s2=8, s3=12, s4=16, s6=24}` — there is **no s5**; use `s6` for 24, never reach for 20 |
+| `BorderRadius.circular(N)` | `SoliplexTheme.of(context).radii.{sm=6, md=12, lg=16, xl=24}` — default `md`; `sm` only for checkboxes/small wells |
+| `TextStyle(fontSize:)` / bare `fontSize:` in `copyWith` | start from `Theme.of(context).textTheme.<style>` and `copyWith` only the delta |
+| `fontFamily: 'monospace' \| 'Roboto Mono' \| 'SF Mono' \| 'Menlo'` | `context.monospace` |
+| Hardcoded width breakpoint | `SoliplexBreakpoints.{mobile=320, tablet=600, desktop=840}` |
+| `FilledButton`/`OutlinedButton`/`TextButton` | `SoliplexButton.{filled,outlined,text}` with `intent: ButtonIntent.{primary,danger}` |
+| `Chip`/`ActionChip`/`FilterChip` | `SoliplexChip` (display), `.action`, `.filter` |
+| `TextField`/`TextFormField` | `SoliplexInput` |
+| `DropdownMenu<T>` | `SoliplexDropdown<T>` |
+| `showDatePicker`/`showTimePicker` ad-hoc wiring | `SoliplexDatePickerField` / `SoliplexTimePickerField` (or `showSoliplexDatePicker()` / `showSoliplexTimePicker()`) |
+| inline status pill | `SoliplexBadge(label, intent, icon)` |
+
+Available text styles: `headlineMedium, titleLarge, titleMedium, titleSmall,
+bodyLarge, bodyMedium, bodySmall, labelMedium, labelSmall`. Raw Material
+widgets are fine when no Soliplex wrapper exists — they still pick up the brand
+`ThemeData`.
+
+**Never add a token to make a value fit.** If a value is genuinely missing,
+stop and raise it in the PR — do not invent a token or keep the literal.
+
+## Gotchas from real adoption sweeps
+
+These cost time during the first-party sweeps; check them as you go.
+
+- **`SoliplexTheme.of(context)` throws under bare `ThemeData`.** It resolves
+  the extension with `!`, so a widget pumped in a test (or hosted) on a plain
+  `MaterialApp` with no Soliplex theme crashes. Either pump a real
+  `soliplexLightTheme()`/`soliplexDarkTheme()` in tests, or — for a widget that
+  *must* survive bare `ThemeData` — read the const `soliplexRadii` token
+  directly instead of `SoliplexTheme.of(context).radii`. (`ClassificationTheme.of`
+  is the deliberate null-safe exception: it returns a fallback.)
+- **Long label + leading icon overflows a constrained pill/row.** A `Row` with
+  an icon and a `Text` will throw `RenderFlex overflowed` when the label is
+  long and the parent is width-bounded. Wrap the label in `Flexible` so it
+  wraps instead of truncating; a loose fit keeps the natural size when
+  unbounded, so short labels are unaffected.
+- **Golden text renders as placeholder boxes.** That is Flutter's test font,
+  not a regression. After an *intentional* visual change, regenerate with
+  `flutter test --update-goldens` and eyeball the PNG diff; never update
+  goldens to paper over an unexplained change.
+- **The spacing scale skips `s5`.** It steps `s4` (16) → `s6` (24); there is no
+  20. The only sanctioned off-scale padding in the whole codebase is the chat
+  bubble's `14/10` — do not introduce new exceptions.
+- **`SymbolicColors` are single shades, and arrive with the barrel import.**
+  `colorScheme.danger/success/warning/info` are flat colors. A status surface
+  that needs a *container* tone uses `errorContainer`/`onErrorContainer` (or
+  `colors.successContainer`/`onSuccessContainer`) — not the symbolic shade.
+- **A `textTheme` style already carries a color.** When you `copyWith` from one
+  onto a surface with different contrast, override `color:` explicitly — don't
+  assume the base is neutral.
+- **Use `withAlpha(N)`, not `withOpacity`.** `withOpacity` is deprecated;
+  `flutter analyze` flags it, and the CI gate is zero warnings.
+
+## Step 3 — Wire the branding
+
+Replace the fork's custom `ThemeData` with one `SoliplexBranding`, then let the
+standard flavor build both themes from it. `SoliplexColors.fromAccent` derives
+`primary` (and a readable `onPrimary`) from the accent only — every neutral
+surface, container tone, and status color stays Soliplex, so the platform
+identity survives the rebrand.
+
+```dart
+final branding = SoliplexBranding(
+  accentLight: const Color(0xFF1B5E20), // brand accent — light theme
+  accentDark: const Color(0xFF66BB6A),  // brand accent — dark theme
+  appName: 'Acme Workspace',
+  logoLight: Image.asset('assets/acme/logo.png', width: 64, height: 64),
+  // logoDark optional: when omitted, BrandLogo wraps logoLight in a
+  // SoliplexGlow halo so a dark-on-light mark stays legible on dark surfaces.
+);
+
+final config = await standard(
+  branding: branding,
+  themeMode: ThemeMode.system,
+  // classifications: ...  // optional, only if the deployment marks rooms
+);
+```
+
+The hex literals in `accentLight`/`accentDark` are the **one** sanctioned place
+for raw colors in consumer code — a brand accent has no token by definition.
+Everything downstream of `branding` must stay token-driven.
+
+## Step 4 — Verify
+
+Run from the fork root and resolve everything before opening the PR:
+
+1. `dart format .` (or `mcp__dart__dart_format`)
+2. `flutter analyze` — **zero** warnings (or `mcp__dart__analyze_files`)
+3. `flutter test --reporter failures-only` — fix any golden/widget drift
+4. Re-run `audit.sh lib` — it should now report no violations
+5. `markdownlint-cli2 "**/*.md" "#node_modules"` if any `.md` changed
+
+Then walk the adoption checklist (also in `packages/soliplex_design/README.md`):
+
+- [ ] Colors from `colorScheme`/`SoliplexTheme`, not hex (accent excepted).
+- [ ] Padding from `SoliplexSpacing`; radii from `radii`; text from `textTheme`.
+- [ ] Monospace via `context.monospace`; status via `SymbolicColors`.
+- [ ] Branded `SoliplexX` wrapper used wherever one exists.
+- [ ] Screen behaves at all three `SoliplexBreakpoints`.
+- [ ] Both light and dark palettes look correct.
+- [ ] Destructive actions use `colorScheme.error`; never red hex.
+
+For live visual review, run the component gallery
+(`packages/soliplex_design/example/`, `flutter run`) or skim the golden
+snapshots under `packages/soliplex_design/test/components/*/goldens/`.

--- a/.claude/skills/adopt-design-system/audit.sh
+++ b/.claude/skills/adopt-design-system/audit.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+#
+# audit.sh — scan a target directory for soliplex_design hard-rule violations.
+#
+# Usage:
+#   .claude/skills/adopt-design-system/audit.sh [path]
+#
+# `path` defaults to `lib` (a fork's own UI). The soliplex_design package is
+# always excluded — hex literals and raw radii are legal *inside* the design
+# system, only banned in consumers. Generated files (*.g.dart, *.freezed.dart,
+# *.gen.dart) are skipped too.
+#
+# Uses plain `grep` so it runs on any machine with no extra tooling. Exit
+# status is non-zero when any violation is found, so the script doubles as a
+# CI gate. Each finding prints `file:line:match`; review every hit and migrate
+# it per the mapping table in SKILL.md.
+
+set -uo pipefail
+
+TARGET="${1:-lib}"
+
+if [[ ! -e "$TARGET" ]]; then
+  echo "error: target path '$TARGET' does not exist." >&2
+  exit 2
+fi
+
+GREP=(grep -rEn --include='*.dart'
+  --exclude-dir=soliplex_design
+  --exclude='*.g.dart' --exclude='*.freezed.dart' --exclude='*.gen.dart')
+
+found=0
+
+# Each entry: "Human-readable rule|extended-regex pattern".
+# Patterns are deliberately conservative — they over-report rather than miss,
+# so treat the output as candidates for review, not guaranteed violations.
+RULES=(
+  "Hex color literal (use colorScheme/SoliplexTheme tokens)|Color\(0x|Color\.fromARGB|Color\.fromRGBO"
+  "Material status color (use SymbolicColors: danger/success/warning/info)|Colors\.(red|green|orange|blue|yellow)"
+  "Raw border radius (use SoliplexTheme.of(context).radii.*)|BorderRadius\.circular\("
+  "Hardcoded font size (start from textTheme + copyWith)|fontSize:"
+  "Font-family string literal (use context.monospace)|fontFamily: *['\"](monospace|Roboto Mono|SF Mono|Menlo)"
+  "Material widget with a Soliplex wrapper (prefer SoliplexX)|\b(FilledButton|OutlinedButton|TextButton|ActionChip|FilterChip|TextField|TextFormField|DropdownMenu)\b"
+)
+
+for rule in "${RULES[@]}"; do
+  label="${rule%%|*}"
+  pattern="${rule#*|}"
+  echo "── ${label}"
+  if "${GREP[@]}" -e "$pattern" "$TARGET"; then
+    found=1
+  else
+    echo "   (none)"
+  fi
+  echo
+done
+
+# Raw EdgeInsets / SizedBox numbers and width breakpoints need human eyes —
+# the numbers overlap with legitimate token values, so we only point at them.
+echo "── Manual review: spacing, breakpoints"
+echo "   Padding/SizedBox must come from SoliplexSpacing (s1=4, s2=8, s3=12,"
+echo "   s4=16, s6=24 — no s5). Width thresholds must use SoliplexBreakpoints"
+echo "   (mobile=320, tablet=600, desktop=840). Grep candidates:"
+"${GREP[@]}" \
+  -e 'EdgeInsets\.(all|symmetric|only|fromLTRB)\( *[0-9]' \
+  -e 'SizedBox\((width|height): *[0-9]' \
+  -e 'MediaQuery.*\.width *[<>]' "$TARGET" || echo "   (none)"
+echo
+
+if [[ "$found" -ne 0 ]]; then
+  echo "Violations found. Migrate each per .claude/skills/adopt-design-system/SKILL.md."
+  exit 1
+fi
+
+echo "No hard-rule violations detected. Still complete the manual review above."
+exit 0

--- a/.claude/skills/adopt-design-system/audit.sh
+++ b/.claude/skills/adopt-design-system/audit.sh
@@ -10,10 +10,12 @@
 # system, only banned in consumers. Generated files (*.g.dart, *.freezed.dart,
 # *.gen.dart) are skipped too.
 #
-# Uses plain `grep` so it runs on any machine with no extra tooling. Exit
-# status is non-zero when any violation is found, so the script doubles as a
-# CI gate. Each finding prints `file:line:match`; review every hit and migrate
-# it per the mapping table in SKILL.md.
+# Uses plain `grep` so it runs on any machine with no extra tooling. Each
+# finding prints `file:line:match`; review every hit and migrate it per the
+# mapping table in SKILL.md. Exit status is non-zero when any candidate is
+# found, but sanctioned residuals (e.g. a brand accent written as a raw
+# `Color(0x...)` literal) keep it non-zero on a clean repo — so it surfaces
+# candidates for review, not a pass/fail CI gate.
 
 set -uo pipefail
 
@@ -36,7 +38,7 @@ found=0
 RULES=(
   "Hex color literal (use colorScheme/SoliplexTheme tokens)|Color\(0x|Color\.fromARGB|Color\.fromRGBO"
   "Material status color (use SymbolicColors: danger/success/warning/info)|Colors\.(red|green|orange|blue|yellow)"
-  "Raw border radius (use SoliplexTheme.of(context).radii.*)|BorderRadius\.circular\("
+  "Raw border radius (use SoliplexTheme.of(context).radii.*)|BorderRadius\.circular\( *[0-9]"
   "Hardcoded font size (start from textTheme + copyWith)|fontSize:"
   "Font-family string literal (use context.monospace)|fontFamily: *['\"](monospace|Roboto Mono|SF Mono|Menlo)"
   "Material widget with a Soliplex wrapper (prefer SoliplexX)|\b(FilledButton|OutlinedButton|TextButton|ActionChip|FilterChip|TextField|TextFormField|DropdownMenu)\b"


### PR DESCRIPTION
## Summary

Adds a Claude Code **skill** that helps a whitelabel fork (often carrying its
own hand-rolled UI) adopt `soliplex_design` and the `SoliplexBranding` API
introduced in #261. It turns the design-system adoption knowledge — the hard
rules, the accessor cheat sheet, the branding wiring, and the traps we hit
during the first-party sweeps — into a guided, repeatable workflow.

Lives at `.claude/skills/adopt-design-system/`:

- **`SKILL.md`** — the workflow: audit → migrate (found→replacement table) →
  wire `SoliplexBranding` (light/dark accents, logo, app name via `standard()`)
  → verify against the adoption checklist. Includes a **gotchas** section
  distilled from real sweeps (e.g. `SoliplexTheme.of` crashing under bare
  `ThemeData`, icon+label `RenderFlex` overflow, the missing `s5` spacing step,
  `withOpacity` deprecation under the zero-warning gate).
- **`audit.sh`** — a `grep`-based scanner for hard-rule violations (hex
  literals, Material status colors, raw radii, `fontSize:`, font-family
  strings, Material widgets with a `SoliplexX` equivalent), plus an advisory
  spacing/breakpoint pass. Uses plain `grep` so it needs no extra tooling on a
  fork machine, excludes the design package itself, and exits non-zero on a
  hit so it doubles as a CI gate.

## Why a skill

A fork can't just be handed the README — adoption is a multi-step sweep with
ordering and verification that's easy to get wrong. Encoding it as a skill
means any fork running Claude Code gets the same systematic migration, and the
hard-won edge cases don't have to be rediscovered.

## Notes for reviewers

- Pure docs/tooling — no app or library code changes; nothing in `lib/` or the
  packages is touched.
- Content cross-checked against `packages/soliplex_design/README.md`, the root
  `CLAUDE.md` design-system rules, and the branding API from #261; the skill
  abbreviates and links rather than duplicating the canonical docs.

## Test plan

- [x] `audit.sh lib` runs, reports candidates, exits non-zero on findings.
- [x] `bash -n audit.sh` — syntax clean.
- [x] `markdownlint-cli2` on `SKILL.md` — 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)