### PR TITLE
fix(lobby): align list-card gutters/spacing and regularize the grid

### DIFF
--- a/lib/src/modules/lobby/ui/lobby_screen.dart
+++ b/lib/src/modules/lobby/ui/lobby_screen.dart
@@ -17,7 +17,6 @@ import 'server_sidebar.dart';
 import 'package:soliplex_design/soliplex_design.dart';
 
 const double _sidebarWidth = 240;
-const double _wideBreakpoint = 600;
 
 class LobbyScreen extends StatefulWidget {
   const LobbyScreen({
@@ -99,7 +98,9 @@ class _LobbyScreenState extends State<LobbyScreen> {
     final hiddenServerIds = _state.hiddenServerIds.watch(context);
     return LayoutBuilder(
       builder: (context, constraints) {
-        final isWide = constraints.maxWidth >= _wideBreakpoint;
+        // Persistent sidebar / two-pane layout is a desktop affordance; the
+        // tablet band (600–840) uses the drawer, per the design spec.
+        final isWide = constraints.maxWidth >= SoliplexBreakpoints.desktop;
         return isWide
             ? _WideLayout(
                 servers: servers,
@@ -621,15 +622,20 @@ class _ServerSection extends StatelessWidget {
     }
 
     return switch (viewMode) {
-      LobbyViewMode.list => Column(
-          children: [
-            for (final room in matches)
-              RoomCard(
-                room: room,
-                onTap: () => onRoomTap(serverId, room.id),
-                onInfoTap: () => onInfoTap(serverId, room.id),
-              ),
-          ],
+      LobbyViewMode.list => Padding(
+          // Match the section heading and the grid's s4 gutter so list rows
+          // align with everything around them instead of hugging the edge.
+          padding: const EdgeInsets.symmetric(horizontal: SoliplexSpacing.s4),
+          child: Column(
+            children: [
+              for (final room in matches)
+                RoomCard(
+                  room: room,
+                  onTap: () => onRoomTap(serverId, room.id),
+                  onInfoTap: () => onInfoTap(serverId, room.id),
+                ),
+            ],
+          ),
         ),
       LobbyViewMode.grid => _RoomGrid(
           serverId: serverId,

--- a/lib/src/modules/lobby/ui/lobby_screen.dart
+++ b/lib/src/modules/lobby/ui/lobby_screen.dart
@@ -672,20 +672,48 @@ class _RoomGrid extends StatelessWidget {
       child: LayoutBuilder(
         builder: (context, constraints) {
           const spacing = SoliplexSpacing.s3;
-          final layout = roomGridLayout(constraints.maxWidth, spacing: spacing);
-          return Wrap(
-            spacing: spacing,
-            runSpacing: spacing,
-            children: [
-              for (final room in rooms)
-                SizedBox(
-                  width: layout.cellWidth,
-                  child: RoomGridCard(
-                    room: room,
-                    onTap: () => onRoomTap(serverId, room.id),
-                    onInfoTap: () => onInfoTap(serverId, room.id),
-                  ),
+          final columns =
+              roomGridLayout(constraints.maxWidth, spacing: spacing).columns;
+          // Lay the cards out as explicit rows rather than a Wrap so each row
+          // can be wrapped in an IntrinsicHeight: cards in the same row then
+          // share the tallest one's height and read as a regular grid,
+          // instead of each sizing to its own text. Cells stretch and the
+          // last row is padded with empty slots to keep widths uniform.
+          final rows = <Widget>[];
+          for (var start = 0; start < rooms.length; start += columns) {
+            final end =
+                start + columns < rooms.length ? start + columns : rooms.length;
+            final rowRooms = rooms.sublist(start, end);
+            rows.add(
+              IntrinsicHeight(
+                child: Row(
+                  crossAxisAlignment: CrossAxisAlignment.stretch,
+                  children: [
+                    for (var i = 0; i < columns; i++) ...[
+                      if (i > 0) const SizedBox(width: spacing),
+                      Expanded(
+                        child: i < rowRooms.length
+                            ? RoomGridCard(
+                                room: rowRooms[i],
+                                onTap: () =>
+                                    onRoomTap(serverId, rowRooms[i].id),
+                                onInfoTap: () =>
+                                    onInfoTap(serverId, rowRooms[i].id),
+                              )
+                            : const SizedBox.shrink(),
+                      ),
+                    ],
+                  ],
                 ),
+              ),
+            );
+          }
+          return Column(
+            children: [
+              for (var r = 0; r < rows.length; r++) ...[
+                if (r > 0) const SizedBox(height: spacing),
+                rows[r],
+              ],
             ],
           );
         },

--- a/lib/src/modules/lobby/ui/room_card.dart
+++ b/lib/src/modules/lobby/ui/room_card.dart
@@ -17,6 +17,9 @@ class RoomCard extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Card(
+      // The list owns the horizontal gutter; the card owns only the 12px
+      // (s3) inter-row gap, matching the design mockup's list tiles.
+      margin: const EdgeInsets.only(bottom: SoliplexSpacing.s3),
       child: ListTile(
         title: Text(room.name),
         subtitle: room.description.isNotEmpty ? Text(room.description) : null,

--- a/lib/src/modules/lobby/ui/room_card.dart
+++ b/lib/src/modules/lobby/ui/room_card.dart
@@ -16,13 +16,23 @@ class RoomCard extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final theme = Theme.of(context);
     return Card(
       // The list owns the horizontal gutter; the card owns only the 12px
       // (s3) inter-row gap, matching the design mockup's list tiles.
       margin: const EdgeInsets.only(bottom: SoliplexSpacing.s3),
       child: ListTile(
-        title: Text(room.name),
-        subtitle: room.description.isNotEmpty ? Text(room.description) : null,
+        // Match RoomGridCard's title/subtitle styles so the two views read
+        // identically: titleMedium name, small muted description.
+        title: Text(room.name, style: theme.textTheme.titleMedium),
+        subtitle: room.description.isNotEmpty
+            ? Text(
+                room.description,
+                style: theme.textTheme.bodySmall?.copyWith(
+                  color: theme.colorScheme.onSurfaceVariant,
+                ),
+              )
+            : null,
         trailing: Row(
           mainAxisSize: MainAxisSize.min,
           children: [
@@ -37,7 +47,7 @@ class RoomCard extends StatelessWidget {
                 child: Icon(
                   Icons.quiz,
                   size: 20,
-                  color: Theme.of(context).colorScheme.primary,
+                  color: theme.colorScheme.primary,
                 ),
               ),
             IconButton(

--- a/lib/src/modules/lobby/ui/room_grid_card.dart
+++ b/lib/src/modules/lobby/ui/room_grid_card.dart
@@ -32,7 +32,11 @@ class RoomGridCard extends StatelessWidget {
           padding: const EdgeInsets.all(SoliplexSpacing.s3),
           child: Column(
             crossAxisAlignment: CrossAxisAlignment.start,
-            mainAxisSize: MainAxisSize.min,
+            // Fill the cell height the grid hands us so a row of cards reads
+            // as a regular block; the footer is then pinned to the bottom via
+            // the Spacer below. The grid (or any host) must give this card a
+            // bounded height — see _RoomGrid in lobby_screen.dart.
+            mainAxisSize: MainAxisSize.max,
             children: [
               Row(
                 children: [
@@ -66,7 +70,10 @@ class RoomGridCard extends StatelessWidget {
                   overflow: TextOverflow.ellipsis,
                 ),
               ],
+              // Minimum gap above the footer, then a Spacer so the footer
+              // sits at the bottom of a taller-than-content card.
               const SizedBox(height: SoliplexSpacing.s2),
+              const Spacer(),
               Row(
                 children: [
                   // Bottom-left marking; renders nothing until a deployment

--- a/lib/src/modules/lobby/ui/room_grid_card.dart
+++ b/lib/src/modules/lobby/ui/room_grid_card.dart
@@ -22,6 +22,9 @@ class RoomGridCard extends StatelessWidget {
     final theme = Theme.of(context);
     final radius = BorderRadius.circular(soliplexRadii.md);
     return Card(
+      // The grid's Wrap owns all spacing (s3 run/cross gaps); drop the
+      // default card margin so each card fills its cell cleanly.
+      margin: EdgeInsets.zero,
       child: InkWell(
         onTap: onTap,
         borderRadius: radius,

--- a/test/modules/lobby/ui/lobby_screen_test.dart
+++ b/test/modules/lobby/ui/lobby_screen_test.dart
@@ -56,7 +56,7 @@ void main() {
   group('LobbyScreen', () {
     testWidgets('shows sidebar on wide viewport with Add Server visible',
         (tester) async {
-      tester.view.physicalSize = const Size(800, 600);
+      tester.view.physicalSize = const Size(900, 600);
       tester.view.devicePixelRatio = 1.0;
       addTearDown(tester.view.resetPhysicalSize);
 
@@ -106,7 +106,7 @@ void main() {
 
     testWidgets('shows empty state CTA when no servers connected',
         (tester) async {
-      tester.view.physicalSize = const Size(800, 600);
+      tester.view.physicalSize = const Size(900, 600);
       tester.view.devicePixelRatio = 1.0;
       addTearDown(tester.view.resetPhysicalSize);
 
@@ -126,7 +126,7 @@ void main() {
         // give the user a way to recover. A regression that removed
         // the button or mis-wired its onPressed would re-introduce
         // the "invisible expired server" bug this commit fixes.
-        tester.view.physicalSize = const Size(800, 600);
+        tester.view.physicalSize = const Size(900, 600);
         tester.view.devicePixelRatio = 1.0;
         addTearDown(tester.view.resetPhysicalSize);
 
@@ -177,7 +177,7 @@ void main() {
 
     testWidgets('toggle switches loaded rooms from list to grid cards',
         (tester) async {
-      tester.view.physicalSize = const Size(800, 600);
+      tester.view.physicalSize = const Size(900, 600);
       tester.view.devicePixelRatio = 1.0;
       addTearDown(tester.view.resetPhysicalSize);
 
@@ -208,7 +208,7 @@ void main() {
       SharedPreferences.setMockInitialValues(
         {'soliplex_lobby_view_mode': 'grid'},
       );
-      tester.view.physicalSize = const Size(800, 600);
+      tester.view.physicalSize = const Size(900, 600);
       tester.view.devicePixelRatio = 1.0;
       addTearDown(tester.view.resetPhysicalSize);
 
@@ -230,7 +230,7 @@ void main() {
 
     testWidgets('search filters rooms by name within the section',
         (tester) async {
-      tester.view.physicalSize = const Size(800, 600);
+      tester.view.physicalSize = const Size(900, 600);
       tester.view.devicePixelRatio = 1.0;
       addTearDown(tester.view.resetPhysicalSize);
 
@@ -260,7 +260,7 @@ void main() {
 
     testWidgets('shows no-match copy when the filter excludes everything',
         (tester) async {
-      tester.view.physicalSize = const Size(800, 600);
+      tester.view.physicalSize = const Size(900, 600);
       tester.view.devicePixelRatio = 1.0;
       addTearDown(tester.view.resetPhysicalSize);
 
@@ -284,7 +284,7 @@ void main() {
     });
 
     testWidgets('clear button resets the filter', (tester) async {
-      tester.view.physicalSize = const Size(800, 600);
+      tester.view.physicalSize = const Size(900, 600);
       tester.view.devicePixelRatio = 1.0;
       addTearDown(tester.view.resetPhysicalSize);
 
@@ -314,7 +314,7 @@ void main() {
     });
 
     testWidgets('hiding a server removes its rooms section', (tester) async {
-      tester.view.physicalSize = const Size(800, 600);
+      tester.view.physicalSize = const Size(900, 600);
       tester.view.devicePixelRatio = 1.0;
       addTearDown(tester.view.resetPhysicalSize);
 
@@ -343,7 +343,7 @@ void main() {
       SharedPreferences.setMockInitialValues({
         'soliplex_lobby_hidden_servers': ['local'],
       });
-      tester.view.physicalSize = const Size(800, 600);
+      tester.view.physicalSize = const Size(900, 600);
       tester.view.devicePixelRatio = 1.0;
       addTearDown(tester.view.resetPhysicalSize);
 

--- a/test/modules/lobby/ui/room_grid_card_test.dart
+++ b/test/modules/lobby/ui/room_grid_card_test.dart
@@ -4,8 +4,15 @@ import 'package:soliplex_agent/soliplex_agent.dart';
 import 'package:soliplex_design/soliplex_design.dart';
 import 'package:soliplex_frontend/src/modules/lobby/ui/room_grid_card.dart';
 
-Widget _harness(Widget child) =>
-    MaterialApp(home: Scaffold(body: Center(child: child)));
+// RoomGridCard fills the height of its grid cell (footer pinned to bottom),
+// so it must be given a bounded height — mirror that here with a sized cell.
+Widget _harness(Widget child) => MaterialApp(
+      home: Scaffold(
+        body: Center(
+          child: SizedBox(width: 280, height: 220, child: child),
+        ),
+      ),
+    );
 
 ClassificationTheme _classifications() => ClassificationTheme(
       defaultId: 'internal',


### PR DESCRIPTION
## Summary
First PR in the lobby polish stack. Aligns the lobby to Erik's "Cards & List Tiles" mockup.

- **List gutter**: list rows were a bare `Column` at the `Card`'s 4px default margin (edge-hugging, misaligned). Now an `s4` horizontal gutter matching the heading + grid.
- **Inter-card gap**: `RoomCard` owns a bottom `s3` (12px) margin per the mockup; the grid already uses `s3` run spacing.
- **Equal-height grid**: `Wrap` → per-row `IntrinsicHeight` + stretched `Expanded` cells, so a row of cards shares the tallest one's height; footer pinned to the bottom. Last row padded for uniform widths.
- **List/grid text parity**: list card title/subtitle now match the grid card (`titleMedium` + small muted `bodySmall`).
- **Breakpoint**: wide/two-pane switches at `SoliplexBreakpoints.desktop` (840) instead of a hardcoded 600, per spec; tablet uses the drawer.

## Test plan
- [x] `flutter analyze` clean; `flutter test test/modules/lobby` green (screen tests bumped 800→900px for the wide layout under 840).

**Lobby polish stack** (review/merge bottom-up): `polish/lobby` → `feat/lobby-single-server` → `feat/lobby-branded-header` → `feat/lobby-account-bar`. `polish/segmented-button-radius` is independent (off `main`).
🤖 Generated with [Claude Code](https://claude.com/claude-code)