### PR TITLE
feat(lobby): add a branded header to the sidebar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ Versions follow the `version+build` scheme from `pubspec.yaml`, bumped via
 - Design: re-export `ClassificationTheme` and `ClassificationLevel` from the
   public API so adopters can configure classification without a direct
   `soliplex_design` dependency.
+- Lobby: branded header in the server sidebar (logo, app name, and version),
+  sourced from the flavor's `SoliplexBranding`.
 
 ### Changed
 

--- a/lib/src/flavors/standard.dart
+++ b/lib/src/flavors/standard.dart
@@ -161,7 +161,7 @@ Future<ShellConfig> standard({
     modules: [
       DiagnosticsAppModule(inspector: inspector),
       authMod,
-      LobbyAppModule(serverManager: serverManager),
+      LobbyAppModule(serverManager: serverManager, branding: brand),
       RoomAppModule(
         serverManager: serverManager,
         runtimeManager: runtimeManager,

--- a/lib/src/modules/lobby/lobby_module.dart
+++ b/lib/src/modules/lobby/lobby_module.dart
@@ -1,14 +1,18 @@
 import 'package:go_router/go_router.dart';
 
 import '../../core/app_module.dart';
+import '../../core/branding.dart';
 import '../../core/routes.dart';
 import '../auth/server_manager.dart';
 import 'ui/lobby_screen.dart';
 
 class LobbyAppModule extends AppModule {
-  LobbyAppModule({required this.serverManager});
+  LobbyAppModule({required this.serverManager, required this.branding});
 
   final ServerManager serverManager;
+
+  /// Brand identity surfaced in the sidebar header (logo + app name).
+  final SoliplexBranding branding;
 
   @override
   String get namespace => 'lobby';
@@ -19,7 +23,10 @@ class LobbyAppModule extends AppModule {
           GoRoute(
             path: AppRoutes.lobby,
             pageBuilder: (_, __) => NoTransitionPage(
-              child: LobbyScreen(serverManager: serverManager),
+              child: LobbyScreen(
+                serverManager: serverManager,
+                branding: branding,
+              ),
             ),
           ),
         ],

--- a/lib/src/modules/lobby/ui/lobby_screen.dart
+++ b/lib/src/modules/lobby/ui/lobby_screen.dart
@@ -5,6 +5,7 @@ import 'package:soliplex_agent/soliplex_agent.dart' show Room;
 import 'package:soliplex_client/soliplex_client.dart'
     show PermissionDeniedException;
 
+import '../../../core/branding.dart';
 import '../../../core/routes.dart';
 import '../../auth/server_entry.dart';
 import '../../auth/server_manager.dart';
@@ -22,10 +23,14 @@ class LobbyScreen extends StatefulWidget {
   const LobbyScreen({
     super.key,
     required this.serverManager,
+    required this.branding,
     this.apiResolver,
   });
 
   final ServerManager serverManager;
+
+  /// Brand identity for the sidebar header (logo + app name).
+  final SoliplexBranding branding;
 
   /// Test seam forwarded to [LobbyState]; production uses the default
   /// per-entry API resolver.
@@ -105,6 +110,7 @@ class _LobbyScreenState extends State<LobbyScreen> {
             ? _WideLayout(
                 servers: servers,
                 profiles: profiles,
+                branding: widget.branding,
                 roomsByServer: roomsByServer,
                 viewMode: viewMode,
                 onViewModeChanged: _state.setViewMode,
@@ -123,6 +129,7 @@ class _LobbyScreenState extends State<LobbyScreen> {
             : _NarrowLayout(
                 servers: servers,
                 profiles: profiles,
+                branding: widget.branding,
                 roomsByServer: roomsByServer,
                 viewMode: viewMode,
                 onViewModeChanged: _state.setViewMode,
@@ -147,6 +154,7 @@ class _WideLayout extends StatelessWidget {
   const _WideLayout({
     required this.servers,
     required this.profiles,
+    required this.branding,
     required this.roomsByServer,
     required this.viewMode,
     required this.onViewModeChanged,
@@ -165,6 +173,7 @@ class _WideLayout extends StatelessWidget {
 
   final Map<String, ServerEntry> servers;
   final Map<String, UserProfile?> profiles;
+  final SoliplexBranding branding;
   final Map<String, ServerRooms> roomsByServer;
   final LobbyViewMode viewMode;
   final void Function(LobbyViewMode) onViewModeChanged;
@@ -190,6 +199,7 @@ class _WideLayout extends StatelessWidget {
             child: ServerSidebar(
               servers: servers,
               profiles: profiles,
+              branding: branding,
               selectedServerId: selectedServerId,
               onSelectServer: onSelectServer,
               onServerTap: onServerTap,
@@ -224,6 +234,7 @@ class _NarrowLayout extends StatelessWidget {
   const _NarrowLayout({
     required this.servers,
     required this.profiles,
+    required this.branding,
     required this.roomsByServer,
     required this.viewMode,
     required this.onViewModeChanged,
@@ -242,6 +253,7 @@ class _NarrowLayout extends StatelessWidget {
 
   final Map<String, ServerEntry> servers;
   final Map<String, UserProfile?> profiles;
+  final SoliplexBranding branding;
   final Map<String, ServerRooms> roomsByServer;
   final LobbyViewMode viewMode;
   final void Function(LobbyViewMode) onViewModeChanged;
@@ -275,6 +287,7 @@ class _NarrowLayout extends StatelessWidget {
           builder: (drawerContext) => ServerSidebar(
             servers: servers,
             profiles: profiles,
+            branding: branding,
             selectedServerId: selectedServerId,
             onSelectServer: (id) {
               onSelectServer(id);

--- a/lib/src/modules/lobby/ui/server_sidebar.dart
+++ b/lib/src/modules/lobby/ui/server_sidebar.dart
@@ -74,6 +74,11 @@ class ServerSidebar extends StatelessWidget {
 class _BrandHeader extends StatelessWidget {
   const _BrandHeader({required this.branding});
 
+  /// Logo box height. Kept close to the title + version block so the mark
+  /// reads as part of the header rather than dominating it; the flavor's
+  /// logo is scaled to fit regardless of its intrinsic size.
+  static const double _logoSize = 40;
+
   final SoliplexBranding branding;
 
   @override
@@ -83,8 +88,14 @@ class _BrandHeader extends StatelessWidget {
       padding: const EdgeInsets.all(SoliplexSpacing.s4),
       child: Row(
         children: [
-          BrandLogo(branding: branding),
-          const SizedBox(width: SoliplexSpacing.s3),
+          SizedBox.square(
+            dimension: _logoSize,
+            child: FittedBox(
+              fit: BoxFit.contain,
+              child: BrandLogo(branding: branding),
+            ),
+          ),
+          const SizedBox(width: SoliplexSpacing.s4),
           Expanded(
             child: Column(
               crossAxisAlignment: CrossAxisAlignment.start,
@@ -163,7 +174,9 @@ class _ServerList extends StatelessWidget {
             onTap: () => onSelectServer(entry.key),
           ),
         Padding(
-          padding: const EdgeInsets.symmetric(horizontal: SoliplexSpacing.s2),
+          // s3 above lifts the button off the last server tile.
+          padding: const EdgeInsets.fromLTRB(SoliplexSpacing.s2,
+              SoliplexSpacing.s3, SoliplexSpacing.s2, SoliplexSpacing.s2),
           child: SoliplexButton.outlined(
             onPressed: onAddServer,
             icon: const Icon(Icons.add, size: 18),

--- a/lib/src/modules/lobby/ui/server_sidebar.dart
+++ b/lib/src/modules/lobby/ui/server_sidebar.dart
@@ -74,7 +74,7 @@ class ServerSidebar extends StatelessWidget {
 class _BrandHeader extends StatelessWidget {
   const _BrandHeader({required this.branding});
 
-  /// Logo box height. Kept close to the title + version block so the mark
+  /// Logo box size. Kept close to the title + version block so the mark
   /// reads as part of the header rather than dominating it; the flavor's
   /// logo is scaled to fit regardless of its intrinsic size.
   static const double _logoSize = 40;

--- a/lib/src/modules/lobby/ui/server_sidebar.dart
+++ b/lib/src/modules/lobby/ui/server_sidebar.dart
@@ -1,6 +1,8 @@
 import 'package:flutter/material.dart';
 import 'package:signals_flutter/signals_flutter.dart';
 
+import '../../../../version.dart';
+import '../../../core/branding.dart';
 import '../../auth/auth_tokens.dart';
 import '../../auth/server_entry.dart';
 import '../lobby_state.dart';
@@ -11,6 +13,7 @@ class ServerSidebar extends StatelessWidget {
     super.key,
     required this.servers,
     required this.profiles,
+    required this.branding,
     required this.selectedServerId,
     required this.onSelectServer,
     required this.onServerTap,
@@ -21,6 +24,9 @@ class ServerSidebar extends StatelessWidget {
 
   final Map<String, ServerEntry> servers;
   final Map<String, UserProfile?> profiles;
+
+  /// Brand identity shown in the header (logo + app name).
+  final SoliplexBranding branding;
 
   /// The currently-viewed server; its tile is highlighted.
   final String? selectedServerId;
@@ -39,6 +45,8 @@ class ServerSidebar extends StatelessWidget {
     return Column(
       crossAxisAlignment: CrossAxisAlignment.stretch,
       children: [
+        _BrandHeader(branding: branding),
+        const Divider(height: 1),
         Expanded(
           child: _ServerList(
             servers: servers,
@@ -56,6 +64,49 @@ class ServerSidebar extends StatelessWidget {
           onVersions: onVersions,
         ),
       ],
+    );
+  }
+}
+
+/// Branded sidebar header: the flavor's logo, app name, and the running
+/// library version. Whitelabel forks change the logo and name through the
+/// branding API; the version is the shipped `soliplexVersion` constant.
+class _BrandHeader extends StatelessWidget {
+  const _BrandHeader({required this.branding});
+
+  final SoliplexBranding branding;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Padding(
+      padding: const EdgeInsets.all(SoliplexSpacing.s4),
+      child: Row(
+        children: [
+          BrandLogo(branding: branding),
+          const SizedBox(width: SoliplexSpacing.s3),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                Text(
+                  branding.appName,
+                  style: theme.textTheme.titleMedium,
+                  maxLines: 1,
+                  overflow: TextOverflow.ellipsis,
+                ),
+                Text(
+                  'v$soliplexVersion',
+                  style: theme.textTheme.labelSmall?.copyWith(
+                    color: theme.colorScheme.onSurfaceVariant,
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ],
+      ),
     );
   }
 }

--- a/test/helpers/fakes.dart
+++ b/test/helpers/fakes.dart
@@ -12,9 +12,20 @@ import 'package:soliplex_client/soliplex_client.dart'
         UrlBuilder;
 import 'package:soliplex_logging/soliplex_logging.dart' show LoggerFactory;
 
+import 'package:flutter/material.dart';
+import 'package:soliplex_frontend/src/core/branding.dart';
 import 'package:soliplex_frontend/src/modules/auth/inactivity_logout_storage.dart';
 import 'package:soliplex_frontend/src/modules/auth/platform/auth_flow.dart';
 import 'package:soliplex_frontend/src/modules/auth/server_storage.dart';
+
+/// Minimal branding for widget tests: a trivial inline logo (no asset
+/// loading) plus placeholder accents and name.
+SoliplexBranding testBranding() => const SoliplexBranding(
+      accentLight: Colors.green,
+      accentDark: Colors.lightGreen,
+      appName: 'Test App',
+      logoLight: Icon(Icons.bolt),
+    );
 
 /// Minimal HTTP client with configurable responses.
 ///

--- a/test/modules/lobby/lobby_module_test.dart
+++ b/test/modules/lobby/lobby_module_test.dart
@@ -15,16 +15,20 @@ ServerManager _createManager() => ServerManager(
 void main() {
   group('LobbyAppModule', () {
     test('contributes /lobby route', () {
-      final contribution =
-          LobbyAppModule(serverManager: _createManager()).build();
+      final contribution = LobbyAppModule(
+        serverManager: _createManager(),
+        branding: testBranding(),
+      ).build();
       final paths =
           contribution.routes.whereType<GoRoute>().map((r) => r.path).toList();
       expect(paths, contains('/lobby'));
     });
 
     test('does not contribute a redirect', () {
-      final contribution =
-          LobbyAppModule(serverManager: _createManager()).build();
+      final contribution = LobbyAppModule(
+        serverManager: _createManager(),
+        branding: testBranding(),
+      ).build();
       expect(contribution.redirect, isNull);
     });
   });

--- a/test/modules/lobby/ui/lobby_screen_test.dart
+++ b/test/modules/lobby/ui/lobby_screen_test.dart
@@ -31,6 +31,7 @@ Widget _buildApp(
         path: '/lobby',
         builder: (_, __) => LobbyScreen(
           serverManager: manager,
+          branding: testBranding(),
           apiResolver: apiResolver,
         ),
       ),

--- a/test/modules/lobby/ui/server_sidebar_test.dart
+++ b/test/modules/lobby/ui/server_sidebar_test.dart
@@ -1,11 +1,13 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:soliplex_frontend/src/core/branding.dart';
 import 'package:soliplex_frontend/src/modules/auth/auth_session.dart';
 import 'package:soliplex_frontend/src/modules/auth/auth_tokens.dart';
 import 'package:soliplex_frontend/src/modules/auth/server_entry.dart';
 import 'package:soliplex_frontend/src/modules/auth/server_manager.dart';
 import 'package:soliplex_frontend/src/modules/lobby/lobby_state.dart';
 import 'package:soliplex_frontend/src/modules/lobby/ui/server_sidebar.dart';
+import 'package:soliplex_frontend/version.dart';
 
 import '../../../helpers/fakes.dart';
 
@@ -18,6 +20,7 @@ ServerManager _createManager() => ServerManager(
 Widget _buildSidebar({
   required Map<String, ServerEntry> servers,
   Map<String, UserProfile?> profiles = const {},
+  SoliplexBranding? branding,
   String? selectedServerId,
   void Function(String serverId)? onSelectServer,
   VoidCallback? onServerTap,
@@ -30,6 +33,7 @@ Widget _buildSidebar({
       body: ServerSidebar(
         servers: servers,
         profiles: profiles,
+        branding: branding ?? testBranding(),
         selectedServerId: selectedServerId,
         onSelectServer: onSelectServer ?? (_) {},
         onServerTap: onServerTap ?? () {},
@@ -43,6 +47,15 @@ Widget _buildSidebar({
 
 void main() {
   group('ServerSidebar', () {
+    testWidgets('header shows the brand logo, app name, and version',
+        (tester) async {
+      await tester.pumpWidget(_buildSidebar(servers: const {}));
+
+      expect(find.byType(BrandLogo), findsOneWidget);
+      expect(find.text('Test App'), findsOneWidget);
+      expect(find.text('v$soliplexVersion'), findsOneWidget);
+    });
+
     testWidgets('displays connected servers with formatted URLs',
         (tester) async {
       final manager = _createManager();


### PR DESCRIPTION
## Summary
Adds a top section to the sidebar — the flavor's logo, app name, and app version — divider-separated from the server list. Whitelabel forks swap logo + name via the existing `SoliplexBranding` API (threaded `standard()` → `LobbyAppModule` → `LobbyScreen` → `ServerSidebar`; `BrandLogo` reused).

⚠️ **Version source**: renders the `soliplexVersion` constant — the *library* version, which we control, not a fork's app version. **@alan** to confirm whether forks need their own (PackageInfo/`loadFlavorVersion()` is the alternative).

Also tidies the header (logo scaled to a 40px box) and the Add Server spacing.

## Test plan
- [x] `flutter test test/modules/lobby` green; adds a shared `testBranding()` helper + a header test (logo + name + version).

**Lobby polish stack** (review/merge bottom-up): `polish/lobby` → `feat/lobby-single-server` → `feat/lobby-branded-header` → `feat/lobby-account-bar`. `polish/segmented-button-radius` is independent (off `main`).
🤖 Generated with [Claude Code](https://claude.com/claude-code)