### PR TITLE
feat(lobby): account block + ⋮ menu in the sidebar footer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@ Versions follow the `version+build` scheme from `pubspec.yaml`, bumped via
   `soliplex_design` dependency.
 - Lobby: branded header in the server sidebar (logo, app name, and version),
   sourced from the flavor's `SoliplexBranding`.
+- Lobby: account block in the sidebar footer showing the selected server's
+  signed-in identity (avatar, name, and email), with a ⋮ menu that collapses
+  the Network Inspector and Versions actions.
 
 ### Changed
 
@@ -33,6 +36,9 @@ Versions follow the `version+build` scheme from `pubspec.yaml`, bumped via
 - Lobby: align list-card gutters and spacing to the design mockup, give grid
   cards equal height with a pinned footer, and match list-card title/subtitle
   styles to the grid card.
+- Lobby: keep the sidebar's brand header and account bar clear of the status
+  bar, notch, and home indicator by wrapping the two-pane body and the drawer
+  in a safe area.
 - soliplex_client: pin the `ag_ui` git dependency to a fixed ref for
   deterministic resolution; a floating HEAD pulled an incompatible release that
   broke web builds.

--- a/lib/src/modules/lobby/ui/lobby_screen.dart
+++ b/lib/src/modules/lobby/ui/lobby_screen.dart
@@ -191,40 +191,44 @@ class _WideLayout extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    // No AppBar in this two-pane layout, so SafeArea keeps the sidebar and
+    // room pane clear of the status bar, home indicator, and side notches.
     return Scaffold(
-      body: Row(
-        children: [
-          SizedBox(
-            width: _sidebarWidth,
-            child: ServerSidebar(
-              servers: servers,
-              profiles: profiles,
-              branding: branding,
-              selectedServerId: selectedServerId,
-              onSelectServer: onSelectServer,
-              onServerTap: onServerTap,
-              onAddServer: onAddServer,
-              onNetworkInspector: onNetworkInspector,
-              onVersions: onVersions,
+      body: SafeArea(
+        child: Row(
+          children: [
+            SizedBox(
+              width: _sidebarWidth,
+              child: ServerSidebar(
+                servers: servers,
+                profiles: profiles,
+                branding: branding,
+                selectedServerId: selectedServerId,
+                onSelectServer: onSelectServer,
+                onServerTap: onServerTap,
+                onAddServer: onAddServer,
+                onNetworkInspector: onNetworkInspector,
+                onVersions: onVersions,
+              ),
             ),
-          ),
-          const VerticalDivider(width: 1),
-          Expanded(
-            child: _RoomContent(
-              roomsByServer: roomsByServer,
-              servers: servers,
-              viewMode: viewMode,
-              onViewModeChanged: onViewModeChanged,
-              searchQuery: searchQuery,
-              onSearchChanged: onSearchChanged,
-              selectedServerId: selectedServerId,
-              onRoomTap: onRoomTap,
-              onInfoTap: onInfoTap,
-              onAddServer: onAddServer,
-              onSignIn: onSignIn,
+            const VerticalDivider(width: 1),
+            Expanded(
+              child: _RoomContent(
+                roomsByServer: roomsByServer,
+                servers: servers,
+                viewMode: viewMode,
+                onViewModeChanged: onViewModeChanged,
+                searchQuery: searchQuery,
+                onSearchChanged: onSearchChanged,
+                selectedServerId: selectedServerId,
+                onRoomTap: onRoomTap,
+                onInfoTap: onInfoTap,
+                onAddServer: onAddServer,
+                onSignIn: onSignIn,
+              ),
             ),
-          ),
-        ],
+          ],
+        ),
       ),
     );
   }
@@ -281,22 +285,26 @@ class _NarrowLayout extends StatelessWidget {
         ),
       ),
       drawer: Drawer(
-        // Builder gives a context under this Scaffold so selecting a server
-        // can close the drawer before revealing its rooms.
-        child: Builder(
-          builder: (drawerContext) => ServerSidebar(
-            servers: servers,
-            profiles: profiles,
-            branding: branding,
-            selectedServerId: selectedServerId,
-            onSelectServer: (id) {
-              onSelectServer(id);
-              Scaffold.of(drawerContext).closeDrawer();
-            },
-            onServerTap: onServerTap,
-            onAddServer: onAddServer,
-            onNetworkInspector: onNetworkInspector,
-            onVersions: onVersions,
+        // A Drawer adds no inset of its own, so SafeArea keeps the brand
+        // header and account bar clear of the status bar and home indicator.
+        child: SafeArea(
+          // Builder gives a context under this Scaffold so selecting a server
+          // can close the drawer before revealing its rooms.
+          child: Builder(
+            builder: (drawerContext) => ServerSidebar(
+              servers: servers,
+              profiles: profiles,
+              branding: branding,
+              selectedServerId: selectedServerId,
+              onSelectServer: (id) {
+                onSelectServer(id);
+                Scaffold.of(drawerContext).closeDrawer();
+              },
+              onServerTap: onServerTap,
+              onAddServer: onAddServer,
+              onNetworkInspector: onNetworkInspector,
+              onVersions: onVersions,
+            ),
           ),
         ),
       ),

--- a/lib/src/modules/lobby/ui/server_sidebar.dart
+++ b/lib/src/modules/lobby/ui/server_sidebar.dart
@@ -49,7 +49,7 @@ class ServerSidebar extends StatelessWidget {
     final selectedProfile =
         selectedServerId == null ? null : profiles[selectedServerId];
     return Padding(
-      padding: EdgeInsets.symmetric(horizontal: SoliplexSpacing.s3),
+      padding: const EdgeInsets.symmetric(horizontal: SoliplexSpacing.s3),
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.stretch,
         children: [
@@ -229,17 +229,20 @@ class _ServerTile extends StatelessWidget {
     return switch (session) {
       ExpiredSession() => 'Session expired',
       NoSession() => 'Not signed in',
-      ActiveSession() => _activeIdentityLabel(),
+      ActiveSession() => _signedInName(profile),
     };
   }
+}
 
-  String _activeIdentityLabel() {
-    if (profile == null) return 'Signed in';
-    final name = '${profile!.givenName} ${profile!.familyName}'.trim();
-    if (name.isNotEmpty) return name;
-    if (profile!.email.isNotEmpty) return profile!.email;
-    return 'Signed in';
-  }
+/// The signed-in user's display name from [profile], falling back through the
+/// preferred username and email to a generic label when no name is set.
+String _signedInName(UserProfile? profile) {
+  if (profile == null) return 'Signed in';
+  final full = '${profile.givenName} ${profile.familyName}'.trim();
+  if (full.isNotEmpty) return full;
+  if (profile.preferredUsername.isNotEmpty) return profile.preferredUsername;
+  if (profile.email.isNotEmpty) return profile.email;
+  return 'Signed in';
 }
 
 /// The actions collapsed behind the sidebar's "more" (⋮) menu. These are
@@ -342,7 +345,7 @@ class _AccountBlock extends StatelessWidget {
       final identity = _resolveIdentity();
       return Row(
         children: [
-          _Avatar(initial: identity.initial),
+          _Avatar(initial: identity.name.characters.first.toUpperCase()),
           const SizedBox(width: SoliplexSpacing.s2),
           Expanded(
             child: Column(
@@ -372,34 +375,23 @@ class _AccountBlock extends StatelessWidget {
     });
   }
 
-  ({String name, String? email, String initial}) _resolveIdentity() {
+  ({String name, String? email}) _resolveIdentity() {
     final isAuthenticated = entry != null &&
         entry!.requiresAuth &&
         entry!.auth.session.value is ActiveSession;
     if (!isAuthenticated) {
-      return (name: 'Guest', email: null, initial: 'G');
+      return (name: 'Guest', email: null);
     }
-    final name = _displayName(profile);
     final email = (profile?.email.isNotEmpty ?? false) ? profile!.email : null;
-    final initial = name.substring(0, 1).toUpperCase();
-    return (name: name, email: email, initial: initial);
-  }
-
-  String _displayName(UserProfile? profile) {
-    if (profile == null) return 'Signed in';
-    final full = '${profile.givenName} ${profile.familyName}'.trim();
-    if (full.isNotEmpty) return full;
-    if (profile.preferredUsername.isNotEmpty) return profile.preferredUsername;
-    if (profile.email.isNotEmpty) return profile.email;
-    return 'Signed in';
+    return (name: _signedInName(profile), email: email);
   }
 }
 
 class _Avatar extends StatelessWidget {
   const _Avatar({required this.initial});
 
-  /// Avatar side. Sized to the two-line name/email block, not tokenised
-  /// (there is no avatar-size token), consistent with other icon sizes.
+  /// Avatar side, sized to the two-line name/email block. Not tokenised —
+  /// there is no avatar-size token.
   static const double _size = 36;
 
   final String initial;

--- a/lib/src/modules/lobby/ui/server_sidebar.dart
+++ b/lib/src/modules/lobby/ui/server_sidebar.dart
@@ -48,30 +48,32 @@ class ServerSidebar extends StatelessWidget {
         selectedServerId == null ? null : servers[selectedServerId];
     final selectedProfile =
         selectedServerId == null ? null : profiles[selectedServerId];
-    return Column(
-      crossAxisAlignment: CrossAxisAlignment.stretch,
-      children: [
-        _BrandHeader(branding: branding),
-        const Divider(height: 1),
-        Expanded(
-          child: _ServerList(
-            servers: servers,
-            profiles: profiles,
-            selectedServerId: selectedServerId,
-            onSelectServer: onSelectServer,
-            onServerTap: onServerTap,
-            onAddServer: onAddServer,
+    return Padding(
+      padding: EdgeInsets.symmetric(horizontal: SoliplexSpacing.s3),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          _BrandHeader(branding: branding),
+          const Divider(height: 1),
+          Expanded(
+            child: _ServerList(
+              servers: servers,
+              profiles: profiles,
+              selectedServerId: selectedServerId,
+              onSelectServer: onSelectServer,
+              onServerTap: onServerTap,
+              onAddServer: onAddServer,
+            ),
           ),
-        ),
-        const Divider(height: 1),
-        _AccountBar(
-          entry: selectedEntry,
-          profile: selectedProfile,
-          onHome: onAddServer,
-          onNetworkInspector: onNetworkInspector,
-          onVersions: onVersions,
-        ),
-      ],
+          const Divider(height: 1),
+          _AccountBar(
+            entry: selectedEntry,
+            profile: selectedProfile,
+            onNetworkInspector: onNetworkInspector,
+            onVersions: onVersions,
+          ),
+        ],
+      ),
     );
   }
 }
@@ -103,7 +105,7 @@ class _BrandHeader extends StatelessWidget {
               child: BrandLogo(branding: branding),
             ),
           ),
-          const SizedBox(width: SoliplexSpacing.s4),
+          const SizedBox(width: SoliplexSpacing.s6),
           Expanded(
             child: Column(
               crossAxisAlignment: CrossAxisAlignment.start,
@@ -182,9 +184,7 @@ class _ServerList extends StatelessWidget {
             onTap: () => onSelectServer(entry.key),
           ),
         Padding(
-          // s3 above lifts the button off the last server tile.
-          padding: const EdgeInsets.fromLTRB(SoliplexSpacing.s2,
-              SoliplexSpacing.s3, SoliplexSpacing.s2, SoliplexSpacing.s2),
+          padding: const EdgeInsets.only(top: SoliplexSpacing.s2),
           child: SoliplexButton.outlined(
             onPressed: onAddServer,
             icon: const Icon(Icons.add, size: 18),
@@ -243,9 +243,10 @@ class _ServerTile extends StatelessWidget {
 }
 
 /// The actions collapsed behind the sidebar's "more" (⋮) menu. These are
-/// mostly developer/utility destinations, deliberately de-emphasised vs. the
-/// account block they sit beside.
-enum _SidebarAction { home, networkInspector, versions }
+/// developer/utility destinations, deliberately de-emphasised vs. the account
+/// block they sit beside. ("Home" is intentionally absent — the Add Server
+/// button already routes to the home screen.)
+enum _SidebarAction { networkInspector, versions }
 
 /// Sidebar footer: the signed-in account on the left, a ⋮ menu of utility
 /// actions on the right.
@@ -253,21 +254,17 @@ class _AccountBar extends StatelessWidget {
   const _AccountBar({
     required this.entry,
     required this.profile,
-    required this.onHome,
     required this.onNetworkInspector,
     required this.onVersions,
   });
 
   final ServerEntry? entry;
   final UserProfile? profile;
-  final VoidCallback onHome;
   final VoidCallback onNetworkInspector;
   final VoidCallback onVersions;
 
   void _onSelected(_SidebarAction action) {
     switch (action) {
-      case _SidebarAction.home:
-        onHome();
       case _SidebarAction.networkInspector:
         onNetworkInspector();
       case _SidebarAction.versions:
@@ -278,8 +275,8 @@ class _AccountBar extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Padding(
-      padding: const EdgeInsets.fromLTRB(SoliplexSpacing.s4, SoliplexSpacing.s2,
-          SoliplexSpacing.s2, SoliplexSpacing.s2),
+      padding: const EdgeInsets.fromLTRB(
+          SoliplexSpacing.s2, SoliplexSpacing.s2, 0, SoliplexSpacing.s2),
       child: Row(
         children: [
           Expanded(child: _AccountBlock(entry: entry, profile: profile)),
@@ -289,10 +286,6 @@ class _AccountBar extends StatelessWidget {
             tooltip: 'More',
             onSelected: _onSelected,
             itemBuilder: (context) => const [
-              PopupMenuItem(
-                value: _SidebarAction.home,
-                child: _MenuRow(icon: Icons.home_outlined, label: 'Home'),
-              ),
               PopupMenuItem(
                 value: _SidebarAction.networkInspector,
                 child: _MenuRow(

--- a/lib/src/modules/lobby/ui/server_sidebar.dart
+++ b/lib/src/modules/lobby/ui/server_sidebar.dart
@@ -42,6 +42,12 @@ class ServerSidebar extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    // The account block reflects whoever is signed in on the selected
+    // server (or Guest when there's no selection / no auth).
+    final selectedEntry =
+        selectedServerId == null ? null : servers[selectedServerId];
+    final selectedProfile =
+        selectedServerId == null ? null : profiles[selectedServerId];
     return Column(
       crossAxisAlignment: CrossAxisAlignment.stretch,
       children: [
@@ -58,8 +64,10 @@ class ServerSidebar extends StatelessWidget {
           ),
         ),
         const Divider(height: 1),
-        _ActionButtons(
-          onAddServer: onAddServer,
+        _AccountBar(
+          entry: selectedEntry,
+          profile: selectedProfile,
+          onHome: onAddServer,
           onNetworkInspector: onNetworkInspector,
           onVersions: onVersions,
         ),
@@ -234,35 +242,193 @@ class _ServerTile extends StatelessWidget {
   }
 }
 
-class _ActionButtons extends StatelessWidget {
-  const _ActionButtons({
-    required this.onAddServer,
+/// The actions collapsed behind the sidebar's "more" (⋮) menu. These are
+/// mostly developer/utility destinations, deliberately de-emphasised vs. the
+/// account block they sit beside.
+enum _SidebarAction { home, networkInspector, versions }
+
+/// Sidebar footer: the signed-in account on the left, a ⋮ menu of utility
+/// actions on the right.
+class _AccountBar extends StatelessWidget {
+  const _AccountBar({
+    required this.entry,
+    required this.profile,
+    required this.onHome,
     required this.onNetworkInspector,
     required this.onVersions,
   });
 
-  final VoidCallback onAddServer;
+  final ServerEntry? entry;
+  final UserProfile? profile;
+  final VoidCallback onHome;
   final VoidCallback onNetworkInspector;
   final VoidCallback onVersions;
 
+  void _onSelected(_SidebarAction action) {
+    switch (action) {
+      case _SidebarAction.home:
+        onHome();
+      case _SidebarAction.networkInspector:
+        onNetworkInspector();
+      case _SidebarAction.versions:
+        onVersions();
+    }
+  }
+
   @override
   Widget build(BuildContext context) {
-    return Column(
-      crossAxisAlignment: CrossAxisAlignment.stretch,
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(SoliplexSpacing.s4, SoliplexSpacing.s2,
+          SoliplexSpacing.s2, SoliplexSpacing.s2),
+      child: Row(
+        children: [
+          Expanded(child: _AccountBlock(entry: entry, profile: profile)),
+          const SizedBox(width: SoliplexSpacing.s2),
+          PopupMenuButton<_SidebarAction>(
+            icon: const Icon(Icons.more_vert),
+            tooltip: 'More',
+            onSelected: _onSelected,
+            itemBuilder: (context) => const [
+              PopupMenuItem(
+                value: _SidebarAction.home,
+                child: _MenuRow(icon: Icons.home_outlined, label: 'Home'),
+              ),
+              PopupMenuItem(
+                value: _SidebarAction.networkInspector,
+                child: _MenuRow(
+                    icon: Icons.lan_outlined, label: 'Network Inspector'),
+              ),
+              PopupMenuItem(
+                value: _SidebarAction.versions,
+                child: _MenuRow(icon: Icons.info_outline, label: 'Versions'),
+              ),
+            ],
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _MenuRow extends StatelessWidget {
+  const _MenuRow({required this.icon, required this.label});
+
+  final IconData icon;
+  final String label;
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      mainAxisSize: MainAxisSize.min,
       children: [
-        SoliplexButton.text(
-          onPressed: onAddServer,
-          child: const Text('Home'),
-        ),
-        SoliplexButton.text(
-          onPressed: onNetworkInspector,
-          child: const Text('Network Inspector'),
-        ),
-        SoliplexButton.text(
-          onPressed: onVersions,
-          child: const Text('Versions'),
-        ),
+        Icon(icon, size: 20),
+        const SizedBox(width: SoliplexSpacing.s3),
+        // Flexible so a long label (e.g. "Network Inspector") can't overflow
+        // the menu's width; the menu widens to fit when there's room.
+        Flexible(child: Text(label, overflow: TextOverflow.ellipsis)),
       ],
+    );
+  }
+}
+
+/// The account identity for the selected server: name, optional email, and a
+/// colored initial avatar. Falls back to a "Guest" identity when the server
+/// is unauthenticated or in no-auth mode.
+class _AccountBlock extends StatelessWidget {
+  const _AccountBlock({required this.entry, required this.profile});
+
+  final ServerEntry? entry;
+  final UserProfile? profile;
+
+  @override
+  Widget build(BuildContext context) {
+    // Session is a per-entry signal the parent does not watch; Watch rebuilds
+    // the block when it flips (e.g. sign-in / expiry) without a map mutation.
+    return Watch((context) {
+      final theme = Theme.of(context);
+      final identity = _resolveIdentity();
+      return Row(
+        children: [
+          _Avatar(initial: identity.initial),
+          const SizedBox(width: SoliplexSpacing.s2),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                Text(
+                  identity.name,
+                  style: theme.textTheme.bodyMedium,
+                  maxLines: 1,
+                  overflow: TextOverflow.ellipsis,
+                ),
+                if (identity.email != null)
+                  Text(
+                    identity.email!,
+                    style: theme.textTheme.labelSmall?.copyWith(
+                      color: theme.colorScheme.onSurfaceVariant,
+                    ),
+                    maxLines: 1,
+                    overflow: TextOverflow.ellipsis,
+                  ),
+              ],
+            ),
+          ),
+        ],
+      );
+    });
+  }
+
+  ({String name, String? email, String initial}) _resolveIdentity() {
+    final isAuthenticated = entry != null &&
+        entry!.requiresAuth &&
+        entry!.auth.session.value is ActiveSession;
+    if (!isAuthenticated) {
+      return (name: 'Guest', email: null, initial: 'G');
+    }
+    final name = _displayName(profile);
+    final email = (profile?.email.isNotEmpty ?? false) ? profile!.email : null;
+    final initial = name.substring(0, 1).toUpperCase();
+    return (name: name, email: email, initial: initial);
+  }
+
+  String _displayName(UserProfile? profile) {
+    if (profile == null) return 'Signed in';
+    final full = '${profile.givenName} ${profile.familyName}'.trim();
+    if (full.isNotEmpty) return full;
+    if (profile.preferredUsername.isNotEmpty) return profile.preferredUsername;
+    if (profile.email.isNotEmpty) return profile.email;
+    return 'Signed in';
+  }
+}
+
+class _Avatar extends StatelessWidget {
+  const _Avatar({required this.initial});
+
+  /// Avatar side. Sized to the two-line name/email block, not tokenised
+  /// (there is no avatar-size token), consistent with other icon sizes.
+  static const double _size = 36;
+
+  final String initial;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Container(
+      width: _size,
+      height: _size,
+      alignment: Alignment.center,
+      decoration: BoxDecoration(
+        color: theme.colorScheme.primaryContainer,
+        borderRadius: BorderRadius.circular(soliplexRadii.sm),
+      ),
+      child: Text(
+        initial,
+        style: theme.textTheme.labelMedium?.copyWith(
+          color: theme.colorScheme.onPrimaryContainer,
+          fontWeight: FontWeight.w600,
+        ),
+      ),
     );
   }
 }

--- a/test/modules/lobby/ui/lobby_screen_test.dart
+++ b/test/modules/lobby/ui/lobby_screen_test.dart
@@ -10,6 +10,7 @@ import 'package:soliplex_frontend/src/modules/lobby/lobby_state.dart';
 import 'package:soliplex_frontend/src/modules/lobby/ui/lobby_screen.dart';
 import 'package:soliplex_frontend/src/modules/lobby/ui/room_card.dart';
 import 'package:soliplex_frontend/src/modules/lobby/ui/room_grid_card.dart';
+import 'package:soliplex_frontend/src/modules/lobby/ui/server_sidebar.dart';
 
 import '../../../helpers/fakes.dart';
 
@@ -102,6 +103,48 @@ void main() {
           matching: find.text('Add Server'),
         ),
         findsOneWidget,
+      );
+    });
+
+    testWidgets('wide layout insets content below the top safe area',
+        (tester) async {
+      tester.view.physicalSize = const Size(900, 600);
+      tester.view.devicePixelRatio = 1.0;
+      tester.view.padding = const FakeViewPadding(top: 50);
+      addTearDown(tester.view.reset);
+
+      final manager = _createManager();
+      await tester.pumpWidget(_buildApp(manager));
+      await tester.pump();
+
+      // The wide layout has no AppBar, so without a SafeArea the sidebar
+      // would paint under the status bar / notch. It must start below the
+      // top inset.
+      expect(
+        tester.getTopLeft(find.byType(ServerSidebar)).dy,
+        greaterThanOrEqualTo(50.0),
+      );
+    });
+
+    testWidgets('narrow drawer insets the sidebar below the top safe area',
+        (tester) async {
+      tester.view.physicalSize = const Size(400, 600);
+      tester.view.devicePixelRatio = 1.0;
+      tester.view.padding = const FakeViewPadding(top: 50);
+      addTearDown(tester.view.reset);
+
+      final manager = _createManager();
+      await tester.pumpWidget(_buildApp(manager));
+      await tester.pump();
+
+      await tester.tap(find.byIcon(Icons.menu));
+      await tester.pumpAndSettle();
+
+      // A Drawer applies no inset of its own; without a SafeArea the brand
+      // header would paint under the status bar / notch.
+      expect(
+        tester.getTopLeft(find.byType(ServerSidebar)).dy,
+        greaterThanOrEqualTo(50.0),
       );
     });
 

--- a/test/modules/lobby/ui/server_sidebar_test.dart
+++ b/test/modules/lobby/ui/server_sidebar_test.dart
@@ -90,36 +90,31 @@ void main() {
       expect(find.text('No authentication required'), findsOneWidget);
     });
 
-    testWidgets('the more menu routes Home / Network Inspector / Versions',
+    testWidgets('the more menu routes Network Inspector / Versions',
         (tester) async {
-      var home = 0;
       var inspector = 0;
       var versions = 0;
 
       await tester.pumpWidget(_buildSidebar(
         servers: const {},
-        onAddServer: () => home++,
         onNetworkInspector: () => inspector++,
         onVersions: () => versions++,
       ));
 
-      // Actions are collapsed behind the ⋮ menu, not shown inline.
+      // Open the menu: no "Home" item (the Add Server button already routes
+      // home), and selecting Network Inspector routes and closes it.
+      await tester.tap(find.byIcon(Icons.more_vert));
+      await tester.pumpAndSettle();
       expect(find.text('Home'), findsNothing);
-
-      Future<void> selectMenu(String label) async {
-        await tester.tap(find.byIcon(Icons.more_vert));
-        await tester.pumpAndSettle();
-        await tester.tap(find.text(label));
-        await tester.pumpAndSettle();
-      }
-
-      await selectMenu('Home');
-      expect(home, 1);
-
-      await selectMenu('Network Inspector');
+      await tester.tap(find.text('Network Inspector'));
+      await tester.pumpAndSettle();
       expect(inspector, 1);
 
-      await selectMenu('Versions');
+      // Reopen for Versions.
+      await tester.tap(find.byIcon(Icons.more_vert));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('Versions'));
+      await tester.pumpAndSettle();
       expect(versions, 1);
     });
 

--- a/test/modules/lobby/ui/server_sidebar_test.dart
+++ b/test/modules/lobby/ui/server_sidebar_test.dart
@@ -90,32 +90,37 @@ void main() {
       expect(find.text('No authentication required'), findsOneWidget);
     });
 
-    testWidgets('Home action button fires the add-server callback',
+    testWidgets('the more menu routes Home / Network Inspector / Versions',
         (tester) async {
-      var addTapped = false;
+      var home = 0;
+      var inspector = 0;
+      var versions = 0;
 
       await tester.pumpWidget(_buildSidebar(
         servers: const {},
-        onAddServer: () => addTapped = true,
+        onAddServer: () => home++,
+        onNetworkInspector: () => inspector++,
+        onVersions: () => versions++,
       ));
 
-      expect(find.text('Home'), findsOneWidget);
-      await tester.tap(find.text('Home'));
-      expect(addTapped, isTrue);
-    });
+      // Actions are collapsed behind the ⋮ menu, not shown inline.
+      expect(find.text('Home'), findsNothing);
 
-    testWidgets('shows Network Inspector button that fires callback',
-        (tester) async {
-      var inspectorTapped = false;
+      Future<void> selectMenu(String label) async {
+        await tester.tap(find.byIcon(Icons.more_vert));
+        await tester.pumpAndSettle();
+        await tester.tap(find.text(label));
+        await tester.pumpAndSettle();
+      }
 
-      await tester.pumpWidget(_buildSidebar(
-        servers: const {},
-        onNetworkInspector: () => inspectorTapped = true,
-      ));
+      await selectMenu('Home');
+      expect(home, 1);
 
-      expect(find.text('Network Inspector'), findsOneWidget);
-      await tester.tap(find.text('Network Inspector'));
-      expect(inspectorTapped, isTrue);
+      await selectMenu('Network Inspector');
+      expect(inspector, 1);
+
+      await selectMenu('Versions');
+      expect(versions, 1);
     });
 
     testWidgets(
@@ -220,6 +225,103 @@ void main() {
 
       await tester.tap(find.byIcon(Icons.settings_outlined));
       expect(managed, isTrue);
+    });
+
+    group('account block', () {
+      ServerEntry addServer(ServerManager m, {required bool requiresAuth}) =>
+          m.addServer(
+            serverId: 'srv',
+            serverUrl: Uri.parse('https://api.example.com'),
+            requiresAuth: requiresAuth,
+          );
+
+      void signIn(ServerEntry entry) => entry.auth.login(
+            provider: const OidcProvider(
+              discoveryUrl: 'https://sso/.well-known/openid-configuration',
+              clientId: 'c',
+            ),
+            tokens: AuthTokens(
+              accessToken: 'a',
+              refreshToken: 'r',
+              expiresAt: DateTime.now().add(const Duration(hours: 1)),
+            ),
+          );
+
+      testWidgets('shows Guest for a no-auth server', (tester) async {
+        final manager = _createManager();
+        addServer(manager, requiresAuth: false);
+
+        await tester.pumpWidget(_buildSidebar(
+          servers: manager.servers.value,
+          selectedServerId: 'srv',
+        ));
+
+        expect(find.text('Guest'), findsOneWidget);
+        expect(find.text('G'), findsOneWidget);
+      });
+
+      testWidgets('shows Guest when auth is required but not signed in',
+          (tester) async {
+        final manager = _createManager();
+        addServer(manager, requiresAuth: true); // session is NoSession
+
+        await tester.pumpWidget(_buildSidebar(
+          servers: manager.servers.value,
+          selectedServerId: 'srv',
+        ));
+
+        expect(find.text('Guest'), findsOneWidget);
+      });
+
+      testWidgets('shows the signed-in name, email, and initial',
+          (tester) async {
+        final manager = _createManager();
+        final entry = addServer(manager, requiresAuth: true);
+        signIn(entry);
+
+        await tester.pumpWidget(_buildSidebar(
+          servers: manager.servers.value,
+          selectedServerId: 'srv',
+          profiles: const {
+            'srv': UserProfile(
+              givenName: 'Ada',
+              familyName: 'Lovelace',
+              email: 'ada@example.com',
+              preferredUsername: 'ada',
+            ),
+          },
+        ));
+
+        // The name renders in both the account block and the selected
+        // server's tile subtitle; the email and avatar initial are unique to
+        // the account block.
+        expect(find.text('Ada Lovelace'), findsNWidgets(2));
+        expect(find.text('ada@example.com'), findsOneWidget);
+        expect(find.text('A'), findsOneWidget); // avatar initial
+      });
+
+      testWidgets('falls back to preferred_username when no full name',
+          (tester) async {
+        final manager = _createManager();
+        final entry = addServer(manager, requiresAuth: true);
+        signIn(entry);
+
+        await tester.pumpWidget(_buildSidebar(
+          servers: manager.servers.value,
+          selectedServerId: 'srv',
+          profiles: const {
+            'srv': UserProfile(
+              givenName: '',
+              familyName: '',
+              email: '',
+              preferredUsername: 'ada99',
+            ),
+          },
+        ));
+
+        expect(find.text('ada99'), findsOneWidget);
+        expect(find.text('A'), findsOneWidget);
+      });
     });
   });
 }

--- a/test/modules/lobby/ui/server_sidebar_test.dart
+++ b/test/modules/lobby/ui/server_sidebar_test.dart
@@ -314,8 +314,85 @@ void main() {
           },
         ));
 
-        expect(find.text('ada99'), findsOneWidget);
+        // Renders in both the account block and the tile subtitle (both
+        // resolve names through the same helper); the initial is block-only.
+        expect(find.text('ada99'), findsNWidgets(2));
         expect(find.text('A'), findsOneWidget);
+      });
+
+      testWidgets(
+          'shows Signed in when authenticated but the profile is absent',
+          (tester) async {
+        final manager = _createManager();
+        final entry = addServer(manager, requiresAuth: true);
+        signIn(entry);
+
+        // No profiles entry for 'srv': the profile fetch has not resolved
+        // (or failed), but the session is active.
+        await tester.pumpWidget(_buildSidebar(
+          servers: manager.servers.value,
+          selectedServerId: 'srv',
+        ));
+
+        // Both the account block and the tile subtitle fall back to the
+        // generic label; the avatar initial is unique to the block.
+        expect(find.text('Signed in'), findsNWidgets(2));
+        expect(find.text('S'), findsOneWidget);
+      });
+
+      testWidgets('omits the email line when the profile has no email',
+          (tester) async {
+        final manager = _createManager();
+        final entry = addServer(manager, requiresAuth: true);
+        signIn(entry);
+
+        await tester.pumpWidget(_buildSidebar(
+          servers: manager.servers.value,
+          selectedServerId: 'srv',
+          profiles: const {
+            'srv': UserProfile(
+              givenName: 'Ada',
+              familyName: 'Lovelace',
+              email: '',
+              preferredUsername: 'ada',
+            ),
+          },
+        ));
+
+        expect(find.text('Ada Lovelace'), findsNWidgets(2));
+        expect(find.textContaining('@'), findsNothing);
+      });
+
+      testWidgets(
+          'reacts to the selected server signing out without a server-map '
+          'mutation', (tester) async {
+        final manager = _createManager();
+        final entry = addServer(manager, requiresAuth: true);
+        signIn(entry);
+
+        // Snapshot the map once and never refresh it: the block must update
+        // from the per-entry session signal, not from a map change.
+        final servers = manager.servers.value;
+        await tester.pumpWidget(_buildSidebar(
+          servers: servers,
+          selectedServerId: 'srv',
+          profiles: const {
+            'srv': UserProfile(
+              givenName: 'Ada',
+              familyName: 'Lovelace',
+              email: 'ada@example.com',
+              preferredUsername: 'ada',
+            ),
+          },
+        ));
+        expect(find.text('Ada Lovelace'), findsNWidgets(2));
+
+        entry.auth.markSessionExpired();
+        await tester.pump();
+
+        // The block falls back to Guest; the signed-in name is gone.
+        expect(find.text('Guest'), findsOneWidget);
+        expect(find.text('Ada Lovelace'), findsNothing);
       });
     });
   });


### PR DESCRIPTION
## Summary
Replaces the three stacked text buttons with an account-aware footer: signed-in identity on the left, a ⋮ menu of utility actions on the right.

- **Account block** (selected server): avatar (initial on a `primaryContainer` tile), display name, email. Name resolves givenName+familyName → preferred_username → email → "Signed in". Unauthenticated / no-auth / no selection → **Guest / "G" / no email**. A `Watch` on the per-entry session signal keeps it live across sign-in/expiry.
- **⋮ menu**: Network Inspector + Versions as icon+text items. (No "Home" — the Add Server button already routes to the home screen.)

## Test plan
- [x] `flutter test` (full suite) green — **1598 tests**. Adds the auth-path widget coverage that can't be run manually without credentials: authenticated identity (name/email/initial), both Guest fallbacks, preferred_username fallback, and ⋮ routing.

**Lobby polish stack** (review/merge bottom-up): `polish/lobby` → `feat/lobby-single-server` → `feat/lobby-branded-header` → `feat/lobby-account-bar`. `polish/segmented-button-radius` is independent (off `main`).
🤖 Generated with [Claude Code](https://claude.com/claude-code)