### PR TITLE
fix(design): round SegmentedButton to the md radius

### DIFF
--- a/packages/soliplex_design/lib/src/theme/theme.dart
+++ b/packages/soliplex_design/lib/src/theme/theme.dart
@@ -212,6 +212,18 @@ ThemeData _buildTheme({
     toggleButtonsTheme: ToggleButtonsThemeData(
       borderRadius: BorderRadius.circular(soliplexRadii.md),
     ),
+    // Material's M3 default is a StadiumBorder (full pill). Pin the segmented
+    // control to the system's md radius so it matches ToggleButtons and the
+    // rest of the rounded surfaces.
+    segmentedButtonTheme: SegmentedButtonThemeData(
+      style: ButtonStyle(
+        shape: WidgetStateProperty.all<OutlinedBorder?>(
+          RoundedRectangleBorder(
+            borderRadius: BorderRadius.circular(soliplexRadii.md),
+          ),
+        ),
+      ),
+    ),
     dropdownMenuTheme: DropdownMenuThemeData(
       textStyle: textTheme.bodyMedium,
       menuStyle: MenuStyle(

--- a/packages/soliplex_design/test/theme/theme_test.dart
+++ b/packages/soliplex_design/test/theme/theme_test.dart
@@ -131,6 +131,20 @@ void main() {
       expect(theme.dividerTheme.thickness, 1);
       expect(theme.cardTheme.elevation, 0);
     });
+
+    test('segmented button uses the md radius, not a stadium border', () {
+      final theme = soliplexLightTheme();
+      final radii = theme.extension<SoliplexTheme>()!.radii;
+
+      final shape =
+          theme.segmentedButtonTheme.style?.shape?.resolve(<WidgetState>{});
+
+      expect(shape, isA<RoundedRectangleBorder>());
+      expect(
+        (shape! as RoundedRectangleBorder).borderRadius,
+        BorderRadius.circular(radii.md),
+      );
+    });
   });
 
   group('soliplexDarkTheme', () {


### PR DESCRIPTION
## Summary
Material's M3 default for `SegmentedButton` is a `StadiumBorder` (full pill), so the lobby view-mode toggle and the diagnostics stream toggle rendered with the wrong rounding. Adds a `segmentedButtonTheme` pinning the segment shape to `soliplexRadii.md`, matching `ToggleButtons`. Fixes both call sites at once.

## Test plan
- [x] `flutter test` (design package) green — 92; adds a theme test asserting md radius (not stadium). No golden shifts.

Independent of the lobby polish stack (off `main`).
🤖 Generated with [Claude Code](https://claude.com/claude-code)