### PR TITLE
soliplex_client: pin ag_ui git dep to a fixed ref

### DIFF
--- a/packages/soliplex_client/pubspec.yaml
+++ b/packages/soliplex_client/pubspec.yaml
@@ -12,6 +12,12 @@ dependencies:
     git:
       url: https://github.com/ag-ui-protocol/ag-ui.git
       path: sdks/community/dart
+      # Pin to a fixed ref. Without it the dep floats to upstream HEAD: a
+      # fresh resolution (e.g. an external consumer with no lockfile) pulls
+      # ag_ui 0.3.0, which retyped ActivitySnapshotEvent.content from
+      # Map<String, dynamic> to Object? and fails to web-compile here. This
+      # is the commit already in pubspec.lock, so behavior is unchanged.
+      ref: d4552e3ad0d5e33e34a3df5325260d88ede8bff9
   collection: ^1.19.1
   http: ^1.2.0
   meta: ^1.9.0

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -13,7 +13,7 @@ packages:
     dependency: transitive
     description:
       path: "sdks/community/dart"
-      ref: HEAD
+      ref: d4552e3ad0d5e33e34a3df5325260d88ede8bff9
       resolved-ref: d4552e3ad0d5e33e34a3df5325260d88ede8bff9
       url: "https://github.com/ag-ui-protocol/ag-ui.git"
     source: git


### PR DESCRIPTION
## Problem

`packages/soliplex_client/pubspec.yaml` declares `ag_ui` as a git dependency **with no `ref`**, so it floats to upstream `HEAD`. Our committed `pubspec.lock` pins `d4552e3` (ag_ui 0.1.0), so CI is fine — but any **fresh resolution without our lockfile** (an external consumer of `soliplex_client`) pulls whatever `HEAD` is now: **ag_ui 0.3.0**.

ag_ui 0.3.0 retyped `ActivitySnapshotEvent.content` from `Map<String, dynamic>` to **`Object?`**. `soliplex_client` uses it as a map, so the package no longer web-compiles for such consumers:

```
lib/src/application/activity_events.dart:62: Error: The argument type 'Object?' can't be assigned to the parameter type 'Map<String, dynamic>'.
lib/src/application/agui_event_processor.dart:456: Error: The operator '[]' isn't defined for the type 'Object?'.
```

(Hit while consuming `soliplex_client` from an external Flutter app — `dart2wasm`/`dart2js` both fail.)

## Fix

Pin `ag_ui` to `d4552e3ad0d5e33e34a3df5325260d88ede8bff9` — **the exact commit already in `pubspec.lock`**. Resolution becomes deterministic for everyone; behavior is unchanged for this repo.

## Verification

- `dart analyze` → No issues found
- `flutter test --exclude-tags integration` (packages/soliplex_client) → **1483 tests, all passed**
- `pubspec.lock` diff is a single line (`ref: HEAD` → `ref: d4552e3`); `resolved-ref` already matched.

## Follow-up (not this PR)

Adopting ag_ui 0.3.0 (the `Object? content` API) is a separate, larger migration across the monorepo.