### PR TITLE
feat(lobby): sort rooms by recent activity + show it on cards

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,9 @@ Versions follow the `version+build` scheme from `pubspec.yaml`, bumped via
 - Lobby: account block in the sidebar footer showing the selected server's
   signed-in identity (avatar, name, and email), with a ⋮ menu that collapses
   the Network Inspector and Versions actions.
+- Lobby: sort rooms by recent activity (a dropdown beside the view toggle),
+  grouping them under "Today"/"Yesterday"/… section headers, and show each
+  room's most-recent-thread time as a relative label ("3h ago") on its card.
 
 ### Changed
 

--- a/lib/src/modules/lobby/lobby_sort_mode.dart
+++ b/lib/src/modules/lobby/lobby_sort_mode.dart
@@ -1,0 +1,29 @@
+import 'package:shared_preferences/shared_preferences.dart';
+
+/// How the lobby orders a server's rooms.
+///
+/// [recentActivity] sorts by the most recently *created* thread in each room
+/// (the only recency signal the backend exposes today — there is no
+/// last-access field). Rooms with no threads sort last.
+enum LobbySortMode { none, recentActivity }
+
+/// Persists the user's preferred [LobbySortMode] across launches.
+///
+/// Backed by `shared_preferences` (the choice is a non-sensitive UI
+/// preference). An unset or unrecognized value falls back to
+/// [LobbySortMode.none].
+abstract final class LobbySortModeStorage {
+  static const _key = 'soliplex_lobby_sort_mode';
+
+  static Future<LobbySortMode> load() async {
+    final prefs = await SharedPreferences.getInstance();
+    final raw = prefs.getString(_key);
+    return LobbySortMode.values.where((mode) => mode.name == raw).firstOrNull ??
+        LobbySortMode.none;
+  }
+
+  static Future<void> save(LobbySortMode mode) async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setString(_key, mode.name);
+  }
+}

--- a/lib/src/modules/lobby/lobby_state.dart
+++ b/lib/src/modules/lobby/lobby_state.dart
@@ -9,6 +9,7 @@ import 'package:soliplex_client/soliplex_client.dart'
 import '../auth/auth_tokens.dart';
 import '../auth/server_entry.dart';
 import '../auth/server_manager.dart';
+import 'lobby_sort_mode.dart';
 import 'lobby_view_mode.dart';
 import 'selected_server_storage.dart';
 
@@ -76,6 +77,7 @@ class LobbyState {
         _apiResolver = apiResolver ?? _defaultResolver {
     _unsubscribe = _serverManager.servers.subscribe(_onServersChanged);
     unawaited(_loadViewMode());
+    unawaited(_loadSortMode());
     unawaited(_loadSelectedServer());
   }
 
@@ -131,6 +133,133 @@ class LobbyState {
     );
   }
 
+  /// How rooms are ordered in the main pane. Starts at [LobbySortMode.none];
+  /// replaced by the persisted preference once [_loadSortMode] resolves.
+  final Signal<LobbySortMode> _sortMode = Signal(LobbySortMode.none);
+  ReadonlySignal<LobbySortMode> get sortMode => _sortMode;
+
+  Future<void> _loadSortMode() async {
+    try {
+      _sortMode.value = await LobbySortModeStorage.load();
+      // A persisted "recent activity" choice needs its data fetched on launch.
+      _reconcileActivity();
+    } catch (error, st) {
+      dev.log(
+        'Failed to load lobby sort mode',
+        error: error,
+        stackTrace: st,
+        level: 900,
+      );
+    }
+  }
+
+  /// Updates the room ordering and persists the choice for next launch.
+  /// Selecting [LobbySortMode.recentActivity] lazily fetches per-room
+  /// activity for the selected server (see [_reconcileActivity]).
+  void setSortMode(LobbySortMode mode) {
+    if (mode == _sortMode.value) return;
+    _sortMode.value = mode;
+    _reconcileActivity();
+    unawaited(
+      LobbySortModeStorage.save(mode).catchError((Object error, StackTrace st) {
+        dev.log(
+          'Failed to persist lobby sort mode',
+          error: error,
+          stackTrace: st,
+          level: 900,
+        );
+      }),
+    );
+  }
+
+  /// Most-recent-thread timestamp per room, keyed by (serverId, roomId).
+  /// A present-but-null value means "fetched, room has no threads"; an absent
+  /// key means "not fetched yet". Used only to order [LobbySortMode]
+  /// .recentActivity; rooms without a timestamp sort last.
+  final Signal<Map<(String, String), DateTime?>> _roomActivity =
+      Signal<Map<(String, String), DateTime?>>({});
+  ReadonlySignal<Map<(String, String), DateTime?>> get roomActivity =>
+      _roomActivity;
+
+  /// True while per-room activity for the selected server is being fetched.
+  final Signal<bool> _activityLoading = Signal(false);
+  ReadonlySignal<bool> get activityLoading => _activityLoading;
+
+  /// Cancels an in-flight activity sweep when the selection changes or the
+  /// state is disposed.
+  CancelToken? _activityToken;
+
+  /// Loads activity timestamps for the selected server's rooms. Fetched
+  /// eagerly (the room cards display the relative time regardless of sort
+  /// order), and reused for [LobbySortMode.recentActivity] ordering. No-op
+  /// before a server is selected or before that server's rooms have loaded.
+  /// Only uncached rooms are fetched; results are merged into [_roomActivity],
+  /// so switching servers reuses prior fetches. The backend exposes no
+  /// last-access field, so "recency" is the newest thread's `createdAt` (one
+  /// `getThreads` per room — the transport's concurrency limiter throttles
+  /// the burst).
+  void _reconcileActivity() {
+    _activityToken?.cancel('activity reconcile');
+    _activityToken = null;
+
+    final serverId = _selectedServerId.value;
+    if (serverId == null) return;
+    final entry = _serverManager.servers.value[serverId];
+    if (entry == null) return;
+    final rooms = _roomsByServer.value[serverId];
+    if (rooms is! RoomsLoaded) return;
+
+    final missing = rooms.rooms
+        .where((r) => !_roomActivity.value.containsKey((serverId, r.id)))
+        .toList();
+    if (missing.isEmpty) {
+      _activityLoading.value = false;
+      return;
+    }
+
+    final token = CancelToken();
+    _activityToken = token;
+    _activityLoading.value = true;
+    final api = _apiResolver(entry);
+
+    Future.wait(
+      missing.map((room) async {
+        try {
+          final threads = await api.getThreads(room.id, cancelToken: token);
+          return MapEntry((serverId, room.id), _latestCreatedAt(threads));
+        } catch (error, st) {
+          // A room whose threads can't be listed simply has no recency
+          // signal; it sorts last rather than failing the whole view.
+          if (!token.isCancelled) {
+            dev.log(
+              'Failed to fetch thread activity for ${room.id} on $serverId',
+              error: error,
+              stackTrace: st,
+              level: 900,
+            );
+          }
+          return MapEntry<(String, String), DateTime?>(
+            (serverId, room.id),
+            null,
+          );
+        }
+      }),
+    ).then((entries) {
+      if (token.isCancelled) return;
+      _activityToken = null;
+      _activityLoading.value = false;
+      _roomActivity.value = {..._roomActivity.value}..addEntries(entries);
+    });
+  }
+
+  static DateTime? _latestCreatedAt(List<ThreadInfo> threads) {
+    DateTime? latest;
+    for (final t in threads) {
+      if (latest == null || t.createdAt.isAfter(latest)) latest = t.createdAt;
+    }
+    return latest;
+  }
+
   /// Free-text room-name filter. Ephemeral — intentionally not persisted,
   /// so each lobby visit starts unfiltered.
   final Signal<String> _searchQuery = Signal('');
@@ -173,6 +302,7 @@ class LobbyState {
     _selectionInitialized = true;
     if (restored != _selectedServerId.value) {
       _selectedServerId.value = restored;
+      _reconcileActivity();
     }
   }
 
@@ -181,6 +311,7 @@ class LobbyState {
     if (serverId == _selectedServerId.value) return;
     _selectedServerId.value = serverId;
     _persistSelection(serverId);
+    _reconcileActivity();
   }
 
   /// Keeps the selection valid as the server set changes: an explicit,
@@ -194,6 +325,7 @@ class LobbyState {
     if (next != current) {
       _selectedServerId.value = next;
       _persistSelection(next);
+      _reconcileActivity();
     }
   }
 
@@ -336,6 +468,13 @@ class LobbyState {
         ..._roomsByServer.value,
         serverId: RoomsLoaded(rooms),
       };
+      // A fresh room list invalidates cached activity for this server (rooms
+      // may have been added); drop those entries so recency refetches.
+      if (_roomActivity.value.keys.any((k) => k.$1 == serverId)) {
+        _roomActivity.value = {..._roomActivity.value}
+          ..removeWhere((k, _) => k.$1 == serverId);
+      }
+      if (serverId == _selectedServerId.value) _reconcileActivity();
     }).catchError((Object error, StackTrace st) {
       if (token.isCancelled) return;
       _cancelTokens.remove(serverId);
@@ -424,6 +563,7 @@ class LobbyState {
 
   void dispose() {
     _unsubscribe();
+    _activityToken?.cancel('disposed');
     for (final unsub in _authSubscriptions.values) {
       unsub();
     }

--- a/lib/src/modules/lobby/lobby_state.dart
+++ b/lib/src/modules/lobby/lobby_state.dart
@@ -15,6 +15,11 @@ import 'selected_server_storage.dart';
 
 typedef ApiResolver = SoliplexApi Function(ServerEntry entry);
 
+/// Identifies a room across servers for the activity cache. Named fields
+/// (rather than a positional `(String, String)`) so the two ids can't be
+/// transposed at a lookup or insertion site.
+typedef RoomActivityKey = ({String serverId, String roomId});
+
 class UserProfile {
   const UserProfile({
     required this.givenName,
@@ -141,7 +146,8 @@ class LobbyState {
   Future<void> _loadSortMode() async {
     try {
       _sortMode.value = await LobbySortModeStorage.load();
-      // A persisted "recent activity" choice needs its data fetched on launch.
+      // Kick off the activity sweep once the persisted mode is known. (The
+      // sweep is eager regardless of mode; this just runs it at launch.)
       _reconcileActivity();
     } catch (error, st) {
       dev.log(
@@ -154,8 +160,10 @@ class LobbyState {
   }
 
   /// Updates the room ordering and persists the choice for next launch.
-  /// Selecting [LobbySortMode.recentActivity] lazily fetches per-room
-  /// activity for the selected server (see [_reconcileActivity]).
+  /// Activity timestamps are already fetched eagerly on server selection (see
+  /// [_reconcileActivity]); this only changes the ordering. The
+  /// [_reconcileActivity] call is a safety net for the rare case where the
+  /// sweep has not run yet.
   void setSortMode(LobbySortMode mode) {
     if (mode == _sortMode.value) return;
     _sortMode.value = mode;
@@ -176,9 +184,9 @@ class LobbyState {
   /// A present-but-null value means "fetched, room has no threads"; an absent
   /// key means "not fetched yet". Used only to order [LobbySortMode]
   /// .recentActivity; rooms without a timestamp sort last.
-  final Signal<Map<(String, String), DateTime?>> _roomActivity =
-      Signal<Map<(String, String), DateTime?>>({});
-  ReadonlySignal<Map<(String, String), DateTime?>> get roomActivity =>
+  final Signal<Map<RoomActivityKey, DateTime?>> _roomActivity =
+      Signal<Map<RoomActivityKey, DateTime?>>({});
+  ReadonlySignal<Map<RoomActivityKey, DateTime?>> get roomActivity =>
       _roomActivity;
 
   /// True while per-room activity for the selected server is being fetched.
@@ -196,11 +204,15 @@ class LobbyState {
   /// Only uncached rooms are fetched; results are merged into [_roomActivity],
   /// so switching servers reuses prior fetches. The backend exposes no
   /// last-access field, so "recency" is the newest thread's `createdAt` (one
-  /// `getThreads` per room — the transport's concurrency limiter throttles
-  /// the burst).
+  /// `getThreads` per room — this relies on the standard transport's
+  /// concurrency limiter to throttle the burst).
   void _reconcileActivity() {
     _activityToken?.cancel('activity reconcile');
     _activityToken = null;
+    // Cancelling means nothing is in flight; the start path below sets this
+    // back to true only if a new sweep actually launches. Resetting here
+    // keeps every early return from leaving the spinner stuck on.
+    _activityLoading.value = false;
 
     final serverId = _selectedServerId.value;
     if (serverId == null) return;
@@ -210,12 +222,10 @@ class LobbyState {
     if (rooms is! RoomsLoaded) return;
 
     final missing = rooms.rooms
-        .where((r) => !_roomActivity.value.containsKey((serverId, r.id)))
+        .where((r) => !_roomActivity.value
+            .containsKey((serverId: serverId, roomId: r.id)))
         .toList();
-    if (missing.isEmpty) {
-      _activityLoading.value = false;
-      return;
-    }
+    if (missing.isEmpty) return;
 
     final token = CancelToken();
     _activityToken = token;
@@ -226,20 +236,30 @@ class LobbyState {
       missing.map((room) async {
         try {
           final threads = await api.getThreads(room.id, cancelToken: token);
-          return MapEntry((serverId, room.id), _latestCreatedAt(threads));
+          return MapEntry(
+            (serverId: serverId, roomId: room.id),
+            _latestCreatedAt(threads),
+          );
         } catch (error, st) {
           // A room whose threads can't be listed simply has no recency
-          // signal; it sorts last rather than failing the whole view.
+          // signal; it sorts last rather than failing the whole view. An
+          // AuthException still funnels to session expiry (as the room-list
+          // and profile fetches do), and a PermissionDeniedException is an
+          // expected per-room state — so neither is logged as a failure.
           if (!token.isCancelled) {
-            dev.log(
-              'Failed to fetch thread activity for ${room.id} on $serverId',
-              error: error,
-              stackTrace: st,
-              level: 900,
-            );
+            if (error is AuthException) {
+              entry.auth.markSessionExpired();
+            } else if (error is! PermissionDeniedException) {
+              dev.log(
+                'Failed to fetch thread activity for ${room.id} on $serverId',
+                error: error,
+                stackTrace: st,
+                level: 900,
+              );
+            }
           }
-          return MapEntry<(String, String), DateTime?>(
-            (serverId, room.id),
+          return MapEntry<RoomActivityKey, DateTime?>(
+            (serverId: serverId, roomId: room.id),
             null,
           );
         }
@@ -470,9 +490,9 @@ class LobbyState {
       };
       // A fresh room list invalidates cached activity for this server (rooms
       // may have been added); drop those entries so recency refetches.
-      if (_roomActivity.value.keys.any((k) => k.$1 == serverId)) {
+      if (_roomActivity.value.keys.any((k) => k.serverId == serverId)) {
         _roomActivity.value = {..._roomActivity.value}
-          ..removeWhere((k, _) => k.$1 == serverId);
+          ..removeWhere((k, _) => k.serverId == serverId);
       }
       if (serverId == _selectedServerId.value) _reconcileActivity();
     }).catchError((Object error, StackTrace st) {

--- a/lib/src/modules/lobby/room_activity_format.dart
+++ b/lib/src/modules/lobby/room_activity_format.dart
@@ -1,0 +1,50 @@
+/// Formatting + bucketing for a room's most-recent-thread activity timestamp.
+///
+/// The lobby shows this both as a per-card relative label ("3h ago") and, when
+/// sorting by recent activity, as date-bucketed section headers ("Today",
+/// "Yesterday", ...) in the manner of an LLM chat history.
+library;
+
+/// Short relative label for [time], e.g. "Just now", "5m ago", "3h ago",
+/// "2d ago", falling back to a numeric date for anything older than a week.
+String formatRelativeActivity(DateTime time, {DateTime? now}) {
+  final reference = now ?? DateTime.now();
+  final diff = reference.difference(time);
+  if (diff.inMinutes < 1) return 'Just now';
+  if (diff.inMinutes < 60) return '${diff.inMinutes}m ago';
+  if (diff.inHours < 24) return '${diff.inHours}h ago';
+  if (diff.inDays < 7) return '${diff.inDays}d ago';
+  return '${time.month}/${time.day}/${time.year}';
+}
+
+/// Recency buckets used to group rooms under section headers. Ordered from
+/// most to least recent; [none] (no known timestamp) always sorts last.
+enum ActivityBucket {
+  today('Today'),
+  yesterday('Yesterday'),
+  thisWeek('This week'),
+  thisMonth('This month'),
+  older('Older'),
+  none('No activity');
+
+  const ActivityBucket(this.label);
+
+  /// Human-readable section header.
+  final String label;
+}
+
+/// Buckets [time] relative to [now] (defaults to the current time). A `null`
+/// timestamp — no threads, not yet fetched, or a failed lookup — maps to
+/// [ActivityBucket.none].
+ActivityBucket bucketFor(DateTime? time, {DateTime? now}) {
+  if (time == null) return ActivityBucket.none;
+  final reference = now ?? DateTime.now();
+  final today = DateTime(reference.year, reference.month, reference.day);
+  final thatDay = DateTime(time.year, time.month, time.day);
+  final dayDelta = today.difference(thatDay).inDays;
+  if (dayDelta <= 0) return ActivityBucket.today;
+  if (dayDelta == 1) return ActivityBucket.yesterday;
+  if (dayDelta < 7) return ActivityBucket.thisWeek;
+  if (dayDelta < 30) return ActivityBucket.thisMonth;
+  return ActivityBucket.older;
+}

--- a/lib/src/modules/lobby/room_activity_format.dart
+++ b/lib/src/modules/lobby/room_activity_format.dart
@@ -3,6 +3,14 @@
 /// The lobby shows this both as a per-card relative label ("3h ago") and, when
 /// sorting by recent activity, as date-bucketed section headers ("Today",
 /// "Yesterday", ...) in the manner of an LLM chat history.
+///
+/// The label and the buckets use different recency models on purpose:
+/// [formatRelativeActivity] measures elapsed duration ("2d ago"), while
+/// [bucketFor] uses calendar-day deltas. So near a day boundary a room can read
+/// "23h ago" on its card yet sit under a "Yesterday" header (23h elapsed but
+/// the calendar day rolled over), and a timestamp old enough to show a numeric
+/// date (>7 days elapsed) always buckets under "This month"/"Older", never
+/// "This week" — expected, not a bug.
 library;
 
 /// Short relative label for [time], e.g. "Just now", "5m ago", "3h ago",
@@ -14,7 +22,9 @@ String formatRelativeActivity(DateTime time, {DateTime? now}) {
   if (diff.inMinutes < 60) return '${diff.inMinutes}m ago';
   if (diff.inHours < 24) return '${diff.inHours}h ago';
   if (diff.inDays < 7) return '${diff.inDays}d ago';
-  return '${time.month}/${time.day}/${time.year}';
+  // Backend timestamps are UTC; render the date in the viewer's zone.
+  final local = time.toLocal();
+  return '${local.month}/${local.day}/${local.year}';
 }
 
 /// Recency buckets used to group rooms under section headers. Ordered from
@@ -38,9 +48,14 @@ enum ActivityBucket {
 /// [ActivityBucket.none].
 ActivityBucket bucketFor(DateTime? time, {DateTime? now}) {
   if (time == null) return ActivityBucket.none;
-  final reference = now ?? DateTime.now();
-  final today = DateTime(reference.year, reference.month, reference.day);
-  final thatDay = DateTime(time.year, time.month, time.day);
+  // Buckets are calendar days in the viewer's zone. Thread timestamps arrive in
+  // UTC, so read each side's day in local time. The two days are then pinned to
+  // UTC midnight before differencing: that keeps the gap an exact 24h multiple,
+  // so a DST transition (a 23h or 25h local day) can't shift the day count.
+  final reference = (now ?? DateTime.now()).toLocal();
+  final local = time.toLocal();
+  final today = DateTime.utc(reference.year, reference.month, reference.day);
+  final thatDay = DateTime.utc(local.year, local.month, local.day);
   final dayDelta = today.difference(thatDay).inDays;
   if (dayDelta <= 0) return ActivityBucket.today;
   if (dayDelta == 1) return ActivityBucket.yesterday;

--- a/lib/src/modules/lobby/ui/lobby_screen.dart
+++ b/lib/src/modules/lobby/ui/lobby_screen.dart
@@ -9,8 +9,10 @@ import '../../../core/branding.dart';
 import '../../../core/routes.dart';
 import '../../auth/server_entry.dart';
 import '../../auth/server_manager.dart';
+import '../lobby_sort_mode.dart';
 import '../lobby_state.dart';
 import '../lobby_view_mode.dart';
+import '../room_activity_format.dart';
 import 'room_card.dart';
 import 'room_grid_card.dart';
 import 'room_grid_layout.dart';
@@ -101,6 +103,9 @@ class _LobbyScreenState extends State<LobbyScreen> {
     final viewMode = _state.viewMode.watch(context);
     final searchQuery = _state.searchQuery.watch(context);
     final selectedServerId = _state.selectedServerId.watch(context);
+    final sortMode = _state.sortMode.watch(context);
+    final roomActivity = _state.roomActivity.watch(context);
+    final activityLoading = _state.activityLoading.watch(context);
     return LayoutBuilder(
       builder: (context, constraints) {
         // Persistent sidebar / two-pane layout is a desktop affordance; the
@@ -116,6 +121,10 @@ class _LobbyScreenState extends State<LobbyScreen> {
                 onViewModeChanged: _state.setViewMode,
                 searchQuery: searchQuery,
                 onSearchChanged: _state.setSearchQuery,
+                sortMode: sortMode,
+                onSortModeChanged: _state.setSortMode,
+                roomActivity: roomActivity,
+                activityLoading: activityLoading,
                 selectedServerId: selectedServerId,
                 onSelectServer: _state.selectServer,
                 onServerTap: _onServerTap,
@@ -135,6 +144,10 @@ class _LobbyScreenState extends State<LobbyScreen> {
                 onViewModeChanged: _state.setViewMode,
                 searchQuery: searchQuery,
                 onSearchChanged: _state.setSearchQuery,
+                sortMode: sortMode,
+                onSortModeChanged: _state.setSortMode,
+                roomActivity: roomActivity,
+                activityLoading: activityLoading,
                 selectedServerId: selectedServerId,
                 onSelectServer: _state.selectServer,
                 onServerTap: _onServerTap,
@@ -160,6 +173,10 @@ class _WideLayout extends StatelessWidget {
     required this.onViewModeChanged,
     required this.searchQuery,
     required this.onSearchChanged,
+    required this.sortMode,
+    required this.onSortModeChanged,
+    required this.roomActivity,
+    required this.activityLoading,
     required this.selectedServerId,
     required this.onSelectServer,
     required this.onServerTap,
@@ -179,6 +196,10 @@ class _WideLayout extends StatelessWidget {
   final void Function(LobbyViewMode) onViewModeChanged;
   final String searchQuery;
   final void Function(String) onSearchChanged;
+  final LobbySortMode sortMode;
+  final void Function(LobbySortMode) onSortModeChanged;
+  final Map<(String, String), DateTime?> roomActivity;
+  final bool activityLoading;
   final String? selectedServerId;
   final void Function(String serverId) onSelectServer;
   final VoidCallback onServerTap;
@@ -220,6 +241,10 @@ class _WideLayout extends StatelessWidget {
                 onViewModeChanged: onViewModeChanged,
                 searchQuery: searchQuery,
                 onSearchChanged: onSearchChanged,
+                sortMode: sortMode,
+                onSortModeChanged: onSortModeChanged,
+                roomActivity: roomActivity,
+                activityLoading: activityLoading,
                 selectedServerId: selectedServerId,
                 onRoomTap: onRoomTap,
                 onInfoTap: onInfoTap,
@@ -244,6 +269,10 @@ class _NarrowLayout extends StatelessWidget {
     required this.onViewModeChanged,
     required this.searchQuery,
     required this.onSearchChanged,
+    required this.sortMode,
+    required this.onSortModeChanged,
+    required this.roomActivity,
+    required this.activityLoading,
     required this.selectedServerId,
     required this.onSelectServer,
     required this.onServerTap,
@@ -263,6 +292,10 @@ class _NarrowLayout extends StatelessWidget {
   final void Function(LobbyViewMode) onViewModeChanged;
   final String searchQuery;
   final void Function(String) onSearchChanged;
+  final LobbySortMode sortMode;
+  final void Function(LobbySortMode) onSortModeChanged;
+  final Map<(String, String), DateTime?> roomActivity;
+  final bool activityLoading;
   final String? selectedServerId;
   final void Function(String serverId) onSelectServer;
   final VoidCallback onServerTap;
@@ -315,6 +348,10 @@ class _NarrowLayout extends StatelessWidget {
         onViewModeChanged: onViewModeChanged,
         searchQuery: searchQuery,
         onSearchChanged: onSearchChanged,
+        sortMode: sortMode,
+        onSortModeChanged: onSortModeChanged,
+        roomActivity: roomActivity,
+        activityLoading: activityLoading,
         selectedServerId: selectedServerId,
         onRoomTap: onRoomTap,
         onInfoTap: onInfoTap,
@@ -333,6 +370,10 @@ class _RoomContent extends StatelessWidget {
     required this.onViewModeChanged,
     required this.searchQuery,
     required this.onSearchChanged,
+    required this.sortMode,
+    required this.onSortModeChanged,
+    required this.roomActivity,
+    required this.activityLoading,
     required this.selectedServerId,
     required this.onRoomTap,
     required this.onInfoTap,
@@ -346,6 +387,10 @@ class _RoomContent extends StatelessWidget {
   final void Function(LobbyViewMode) onViewModeChanged;
   final String searchQuery;
   final void Function(String) onSearchChanged;
+  final LobbySortMode sortMode;
+  final void Function(LobbySortMode) onSortModeChanged;
+  final Map<(String, String), DateTime?> roomActivity;
+  final bool activityLoading;
   final String? selectedServerId;
   final void Function(String serverId, String roomId) onRoomTap;
   final void Function(String serverId, String roomId) onInfoTap;
@@ -380,6 +425,9 @@ class _RoomContent extends StatelessWidget {
             onViewModeChanged: onViewModeChanged,
             searchQuery: searchQuery,
             onSearchChanged: onSearchChanged,
+            sortMode: sortMode,
+            onSortModeChanged: onSortModeChanged,
+            sortLoading: activityLoading,
           ),
         ),
         Expanded(child: _buildSelectedServer(context)),
@@ -423,6 +471,8 @@ class _RoomContent extends StatelessWidget {
           serverRooms: serverRooms,
           viewMode: viewMode,
           searchQuery: searchQuery,
+          sortMode: sortMode,
+          roomActivity: roomActivity,
           onRoomTap: onRoomTap,
           onInfoTap: onInfoTap,
           onSignIn: onSignIn,
@@ -444,12 +494,18 @@ class _LobbyControls extends StatefulWidget {
     required this.onViewModeChanged,
     required this.searchQuery,
     required this.onSearchChanged,
+    required this.sortMode,
+    required this.onSortModeChanged,
+    required this.sortLoading,
   });
 
   final LobbyViewMode viewMode;
   final void Function(LobbyViewMode) onViewModeChanged;
   final String searchQuery;
   final void Function(String) onSearchChanged;
+  final LobbySortMode sortMode;
+  final void Function(LobbySortMode) onSortModeChanged;
+  final bool sortLoading;
 
   @override
   State<_LobbyControls> createState() => _LobbyControlsState();
@@ -497,6 +553,33 @@ class _LobbyControlsState extends State<_LobbyControls> {
       viewMode: widget.viewMode,
       onChanged: widget.onViewModeChanged,
     );
+    // "Recent activity" is derived from each room's newest thread (the backend
+    // has no last-access field), so it can take a moment to populate; the
+    // dropdown stays live (so the user can switch back) and a small spinner
+    // sits beside it while the sweep runs.
+    final sort = SoliplexDropdown<LobbySortMode>(
+      leadingIcon: const Icon(Icons.sort),
+      initialValue: widget.sortMode,
+      onSelected: (mode) =>
+          widget.onSortModeChanged(mode ?? LobbySortMode.none),
+      entries: const [
+        SoliplexDropdownEntry(value: LobbySortMode.none, label: 'None'),
+        SoliplexDropdownEntry(
+          value: LobbySortMode.recentActivity,
+          label: 'Recent activity',
+        ),
+      ],
+    );
+    final busy =
+        widget.sortLoading && widget.sortMode == LobbySortMode.recentActivity
+            ? const Padding(
+                padding: EdgeInsets.only(left: SoliplexSpacing.s2),
+                child: SizedBox.square(
+                  dimension: 16,
+                  child: CircularProgressIndicator(strokeWidth: 2),
+                ),
+              )
+            : const SizedBox.shrink();
 
     return LayoutBuilder(
       builder: (context, constraints) {
@@ -504,6 +587,9 @@ class _LobbyControlsState extends State<_LobbyControls> {
           return Row(
             children: [
               Expanded(child: search),
+              const SizedBox(width: SoliplexSpacing.s3),
+              SizedBox(width: 184, child: sort),
+              busy,
               const SizedBox(width: SoliplexSpacing.s3),
               toggle,
             ],
@@ -514,7 +600,14 @@ class _LobbyControlsState extends State<_LobbyControls> {
           children: [
             search,
             const SizedBox(height: SoliplexSpacing.s2),
-            Align(alignment: Alignment.centerRight, child: toggle),
+            Row(
+              children: [
+                Expanded(child: sort),
+                busy,
+                const SizedBox(width: SoliplexSpacing.s3),
+                toggle,
+              ],
+            ),
           ],
         );
       },
@@ -557,6 +650,8 @@ class _ServerSection extends StatelessWidget {
     required this.serverRooms,
     required this.viewMode,
     required this.searchQuery,
+    required this.sortMode,
+    required this.roomActivity,
     required this.onRoomTap,
     required this.onInfoTap,
     required this.onSignIn,
@@ -567,6 +662,8 @@ class _ServerSection extends StatelessWidget {
   final ServerRooms serverRooms;
   final LobbyViewMode viewMode;
   final String searchQuery;
+  final LobbySortMode sortMode;
+  final Map<(String, String), DateTime?> roomActivity;
   final void Function(String serverId, String roomId) onRoomTap;
   final void Function(String serverId, String roomId) onInfoTap;
   final void Function(String serverId) onSignIn;
@@ -665,6 +762,35 @@ class _ServerSection extends StatelessWidget {
       );
     }
 
+    final ordered = _applySort(matches);
+
+    // When sorting by recency, split the (already date-descending) list into
+    // "Today / Yesterday / ..." sections, each under a header + divider — like
+    // an LLM chat history. Otherwise render one flat block.
+    if (sortMode != LobbySortMode.recentActivity) {
+      return _buildBlock(context, ordered);
+    }
+
+    final groups = <ActivityBucket, List<Room>>{};
+    for (final room in ordered) {
+      (groups[bucketFor(_activityFor(room))] ??= []).add(room);
+    }
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        for (final bucket in ActivityBucket.values)
+          if (groups[bucket] case final bucketRooms?) ...[
+            _GroupHeader(label: bucket.label),
+            _buildBlock(context, bucketRooms),
+          ],
+      ],
+    );
+  }
+
+  DateTime? _activityFor(Room room) => roomActivity[(serverId, room.id)];
+
+  /// Renders [rooms] in the active view mode (no grouping).
+  Widget _buildBlock(BuildContext context, List<Room> rooms) {
     return switch (viewMode) {
       LobbyViewMode.list => Padding(
           // Match the section heading and the grid's s4 gutter so list rows
@@ -672,9 +798,10 @@ class _ServerSection extends StatelessWidget {
           padding: const EdgeInsets.symmetric(horizontal: SoliplexSpacing.s4),
           child: Column(
             children: [
-              for (final room in matches)
+              for (final room in rooms)
                 RoomCard(
                   room: room,
+                  activityTime: _activityFor(room),
                   onTap: () => onRoomTap(serverId, room.id),
                   onInfoTap: () => onInfoTap(serverId, room.id),
                 ),
@@ -683,11 +810,32 @@ class _ServerSection extends StatelessWidget {
         ),
       LobbyViewMode.grid => _RoomGrid(
           serverId: serverId,
-          rooms: matches,
+          rooms: rooms,
+          roomActivity: roomActivity,
           onRoomTap: onRoomTap,
           onInfoTap: onInfoTap,
         ),
     };
+  }
+
+  /// Orders rooms by most-recent-thread activity (descending) when that sort
+  /// is active. Rooms without a known timestamp — none fetched, no threads,
+  /// or a failed lookup — keep their original relative order at the end. Does
+  /// not mutate the input list.
+  List<Room> _applySort(List<Room> rooms) {
+    if (sortMode != LobbySortMode.recentActivity) return rooms;
+    final dated = <Room>[];
+    final undated = <Room>[];
+    for (final room in rooms) {
+      if (roomActivity[(serverId, room.id)] != null) {
+        dated.add(room);
+      } else {
+        undated.add(room);
+      }
+    }
+    dated.sort((a, b) => roomActivity[(serverId, b.id)]!
+        .compareTo(roomActivity[(serverId, a.id)]!));
+    return [...dated, ...undated];
   }
 }
 
@@ -701,12 +849,14 @@ class _RoomGrid extends StatelessWidget {
   const _RoomGrid({
     required this.serverId,
     required this.rooms,
+    required this.roomActivity,
     required this.onRoomTap,
     required this.onInfoTap,
   });
 
   final String serverId;
   final List<Room> rooms;
+  final Map<(String, String), DateTime?> roomActivity;
   final void Function(String serverId, String roomId) onRoomTap;
   final void Function(String serverId, String roomId) onInfoTap;
 
@@ -740,6 +890,8 @@ class _RoomGrid extends StatelessWidget {
                         child: i < rowRooms.length
                             ? RoomGridCard(
                                 room: rowRooms[i],
+                                activityTime:
+                                    roomActivity[(serverId, rowRooms[i].id)],
                                 onTap: () =>
                                     onRoomTap(serverId, rowRooms[i].id),
                                 onInfoTap: () =>
@@ -762,6 +914,35 @@ class _RoomGrid extends StatelessWidget {
             ],
           );
         },
+      ),
+    );
+  }
+}
+
+/// A recency-bucket section header: a muted label with a trailing rule, used
+/// to separate "Today", "Yesterday", ... groups when sorting by activity.
+class _GroupHeader extends StatelessWidget {
+  const _GroupHeader({required this.label});
+
+  final String label;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(SoliplexSpacing.s4, SoliplexSpacing.s3,
+          SoliplexSpacing.s4, SoliplexSpacing.s2),
+      child: Row(
+        children: [
+          Text(
+            label,
+            style: theme.textTheme.labelMedium?.copyWith(
+              color: theme.colorScheme.onSurfaceVariant,
+            ),
+          ),
+          const SizedBox(width: SoliplexSpacing.s3),
+          const Expanded(child: Divider()),
+        ],
       ),
     );
   }

--- a/lib/src/modules/lobby/ui/lobby_screen.dart
+++ b/lib/src/modules/lobby/ui/lobby_screen.dart
@@ -21,6 +21,10 @@ import 'package:soliplex_design/soliplex_design.dart';
 
 const double _sidebarWidth = 240;
 
+/// Fixed width of the sort dropdown on wide layouts, so it doesn't stretch to
+/// the full row and crowd the view-mode toggle beside it.
+const double _sortControlWidth = 184;
+
 class LobbyScreen extends StatefulWidget {
   const LobbyScreen({
     super.key,
@@ -198,7 +202,7 @@ class _WideLayout extends StatelessWidget {
   final void Function(String) onSearchChanged;
   final LobbySortMode sortMode;
   final void Function(LobbySortMode) onSortModeChanged;
-  final Map<(String, String), DateTime?> roomActivity;
+  final Map<RoomActivityKey, DateTime?> roomActivity;
   final bool activityLoading;
   final String? selectedServerId;
   final void Function(String serverId) onSelectServer;
@@ -294,7 +298,7 @@ class _NarrowLayout extends StatelessWidget {
   final void Function(String) onSearchChanged;
   final LobbySortMode sortMode;
   final void Function(LobbySortMode) onSortModeChanged;
-  final Map<(String, String), DateTime?> roomActivity;
+  final Map<RoomActivityKey, DateTime?> roomActivity;
   final bool activityLoading;
   final String? selectedServerId;
   final void Function(String serverId) onSelectServer;
@@ -389,7 +393,7 @@ class _RoomContent extends StatelessWidget {
   final void Function(String) onSearchChanged;
   final LobbySortMode sortMode;
   final void Function(LobbySortMode) onSortModeChanged;
-  final Map<(String, String), DateTime?> roomActivity;
+  final Map<RoomActivityKey, DateTime?> roomActivity;
   final bool activityLoading;
   final String? selectedServerId;
   final void Function(String serverId, String roomId) onRoomTap;
@@ -588,7 +592,7 @@ class _LobbyControlsState extends State<_LobbyControls> {
             children: [
               Expanded(child: search),
               const SizedBox(width: SoliplexSpacing.s3),
-              SizedBox(width: 184, child: sort),
+              SizedBox(width: _sortControlWidth, child: sort),
               busy,
               const SizedBox(width: SoliplexSpacing.s3),
               toggle,
@@ -663,7 +667,7 @@ class _ServerSection extends StatelessWidget {
   final LobbyViewMode viewMode;
   final String searchQuery;
   final LobbySortMode sortMode;
-  final Map<(String, String), DateTime?> roomActivity;
+  final Map<RoomActivityKey, DateTime?> roomActivity;
   final void Function(String serverId, String roomId) onRoomTap;
   final void Function(String serverId, String roomId) onInfoTap;
   final void Function(String serverId) onSignIn;
@@ -787,7 +791,8 @@ class _ServerSection extends StatelessWidget {
     );
   }
 
-  DateTime? _activityFor(Room room) => roomActivity[(serverId, room.id)];
+  DateTime? _activityFor(Room room) =>
+      roomActivity[(serverId: serverId, roomId: room.id)];
 
   /// Renders [rooms] in the active view mode (no grouping).
   Widget _buildBlock(BuildContext context, List<Room> rooms) {
@@ -811,7 +816,7 @@ class _ServerSection extends StatelessWidget {
       LobbyViewMode.grid => _RoomGrid(
           serverId: serverId,
           rooms: rooms,
-          roomActivity: roomActivity,
+          activityFor: _activityFor,
           onRoomTap: onRoomTap,
           onInfoTap: onInfoTap,
         ),
@@ -820,22 +825,26 @@ class _ServerSection extends StatelessWidget {
 
   /// Orders rooms by most-recent-thread activity (descending) when that sort
   /// is active. Rooms without a known timestamp — none fetched, no threads,
-  /// or a failed lookup — keep their original relative order at the end. Does
-  /// not mutate the input list.
+  /// or a failed lookup — keep their original relative order at the end. Ties
+  /// break by original index so equal timestamps stay in their input order
+  /// (`List.sort` is not guaranteed stable). Does not mutate the input list.
   List<Room> _applySort(List<Room> rooms) {
     if (sortMode != LobbySortMode.recentActivity) return rooms;
-    final dated = <Room>[];
+    final dated = <(Room, DateTime, int)>[];
     final undated = <Room>[];
-    for (final room in rooms) {
-      if (roomActivity[(serverId, room.id)] != null) {
-        dated.add(room);
+    for (var i = 0; i < rooms.length; i++) {
+      final time = _activityFor(rooms[i]);
+      if (time != null) {
+        dated.add((rooms[i], time, i));
       } else {
-        undated.add(room);
+        undated.add(rooms[i]);
       }
     }
-    dated.sort((a, b) => roomActivity[(serverId, b.id)]!
-        .compareTo(roomActivity[(serverId, a.id)]!));
-    return [...dated, ...undated];
+    dated.sort((a, b) {
+      final byTime = b.$2.compareTo(a.$2);
+      return byTime != 0 ? byTime : a.$3.compareTo(b.$3);
+    });
+    return [...dated.map((e) => e.$1), ...undated];
   }
 }
 
@@ -849,14 +858,14 @@ class _RoomGrid extends StatelessWidget {
   const _RoomGrid({
     required this.serverId,
     required this.rooms,
-    required this.roomActivity,
+    required this.activityFor,
     required this.onRoomTap,
     required this.onInfoTap,
   });
 
   final String serverId;
   final List<Room> rooms;
-  final Map<(String, String), DateTime?> roomActivity;
+  final DateTime? Function(Room) activityFor;
   final void Function(String serverId, String roomId) onRoomTap;
   final void Function(String serverId, String roomId) onInfoTap;
 
@@ -890,8 +899,7 @@ class _RoomGrid extends StatelessWidget {
                         child: i < rowRooms.length
                             ? RoomGridCard(
                                 room: rowRooms[i],
-                                activityTime:
-                                    roomActivity[(serverId, rowRooms[i].id)],
+                                activityTime: activityFor(rowRooms[i]),
                                 onTap: () =>
                                     onRoomTap(serverId, rowRooms[i].id),
                                 onInfoTap: () =>

--- a/lib/src/modules/lobby/ui/room_card.dart
+++ b/lib/src/modules/lobby/ui/room_card.dart
@@ -2,17 +2,24 @@ import 'package:flutter/material.dart';
 import 'package:soliplex_agent/soliplex_agent.dart';
 import 'package:soliplex_design/soliplex_design.dart';
 
+import '../room_activity_format.dart';
+
 class RoomCard extends StatelessWidget {
   const RoomCard({
     super.key,
     required this.room,
     required this.onTap,
     required this.onInfoTap,
+    this.activityTime,
   });
 
   final Room room;
   final VoidCallback onTap;
   final VoidCallback onInfoTap;
+
+  /// Most-recent-thread timestamp, shown as a muted relative label under the
+  /// title. Null while unknown (not yet fetched, or the room has no threads).
+  final DateTime? activityTime;
 
   @override
   Widget build(BuildContext context) {
@@ -25,14 +32,7 @@ class RoomCard extends StatelessWidget {
         // Match RoomGridCard's title/subtitle styles so the two views read
         // identically: titleMedium name, small muted description.
         title: Text(room.name, style: theme.textTheme.titleMedium),
-        subtitle: room.description.isNotEmpty
-            ? Text(
-                room.description,
-                style: theme.textTheme.bodySmall?.copyWith(
-                  color: theme.colorScheme.onSurfaceVariant,
-                ),
-              )
-            : null,
+        subtitle: _buildSubtitle(theme),
         trailing: Row(
           mainAxisSize: MainAxisSize.min,
           children: [
@@ -58,6 +58,28 @@ class RoomCard extends StatelessWidget {
         ),
         onTap: onTap,
       ),
+    );
+  }
+
+  /// Description and/or the relative activity time, stacked left-aligned below
+  /// the title (so the time reads at the row's bottom-left, opposite the
+  /// trailing info button). Null when there is neither.
+  Widget? _buildSubtitle(ThemeData theme) {
+    final muted = theme.textTheme.bodySmall?.copyWith(
+      color: theme.colorScheme.onSurfaceVariant,
+    );
+    final hasDescription = room.description.isNotEmpty;
+    final time = activityTime;
+    if (!hasDescription && time == null) return null;
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        if (hasDescription) Text(room.description, style: muted),
+        if (time != null) ...[
+          if (hasDescription) const SizedBox(height: SoliplexSpacing.s1),
+          Text(formatRelativeActivity(time), style: muted),
+        ],
+      ],
     );
   }
 }

--- a/lib/src/modules/lobby/ui/room_grid_card.dart
+++ b/lib/src/modules/lobby/ui/room_grid_card.dart
@@ -2,6 +2,8 @@ import 'package:flutter/material.dart';
 import 'package:soliplex_agent/soliplex_agent.dart';
 import 'package:soliplex_design/soliplex_design.dart';
 
+import '../room_activity_format.dart';
+
 /// Vertical card used for the lobby's grid layout: open on tap, info
 /// button, and a quiz indicator, in a shape that tiles cleanly into a
 /// grid cell. The list-row counterpart is [RoomCard].
@@ -11,11 +13,16 @@ class RoomGridCard extends StatelessWidget {
     required this.room,
     required this.onTap,
     required this.onInfoTap,
+    this.activityTime,
   });
 
   final Room room;
   final VoidCallback onTap;
   final VoidCallback onInfoTap;
+
+  /// Most-recent-thread timestamp, shown as a muted relative label in the
+  /// footer's bottom-left. Null while unknown (not yet fetched, or no threads).
+  final DateTime? activityTime;
 
   @override
   Widget build(BuildContext context) {
@@ -76,11 +83,23 @@ class RoomGridCard extends StatelessWidget {
               const Spacer(),
               Row(
                 children: [
-                  // Bottom-left marking; renders nothing until a deployment
-                  // configures classifications. Backend per-room value
-                  // wires in here later via `classification:`.
+                  // Bottom-left: relative activity time when known, then the
+                  // marking (which renders nothing until a deployment
+                  // configures classifications — backend per-room value wires
+                  // in here later via `classification:`).
+                  Expanded(
+                    child: activityTime == null
+                        ? const SizedBox.shrink()
+                        : Text(
+                            formatRelativeActivity(activityTime!),
+                            style: theme.textTheme.bodySmall?.copyWith(
+                              color: theme.colorScheme.onSurfaceVariant,
+                            ),
+                            maxLines: 1,
+                            overflow: TextOverflow.ellipsis,
+                          ),
+                  ),
                   const SoliplexClassificationBadge(),
-                  const Spacer(),
                   IconButton(
                     icon: const Icon(Icons.info_outline),
                     tooltip: 'Room info',

--- a/test/helpers/fakes.dart
+++ b/test/helpers/fakes.dart
@@ -208,6 +208,14 @@ class FakeSoliplexApi extends SoliplexApi {
   /// Per-room thread lists, consulted before [nextThreads]. Lets a test give
   /// different rooms different thread sets (e.g. for activity-based sorting).
   final Map<String, List<ThreadInfo>> threadsByRoom = {};
+
+  /// Per-room [getThreads] errors, consulted before [threadsByRoom]. Lets a
+  /// test fail one room's thread fetch while others succeed.
+  final Map<String, Exception> threadsErrorByRoom = {};
+
+  /// When set, [getThreads] awaits this before returning, letting a test hold a
+  /// sweep in flight (e.g. to trigger a cancellation mid-fetch).
+  Completer<void>? threadsGate;
   Exception? nextThreadsError;
   ThreadHistory? nextThreadHistory;
   Exception? nextThreadHistoryError;
@@ -247,6 +255,12 @@ class FakeSoliplexApi extends SoliplexApi {
     CancelToken? cancelToken,
   }) async {
     if (nextThreadsError != null) throw nextThreadsError!;
+    if (threadsErrorByRoom.containsKey(roomId)) {
+      throw threadsErrorByRoom[roomId]!;
+    }
+    if (threadsGate != null) {
+      await threadsGate!.future;
+    }
     if (threadsByRoom.containsKey(roomId)) return threadsByRoom[roomId]!;
     if (nextThreads != null) return nextThreads!;
     throw StateError('FakeSoliplexApi: set nextThreads or nextThreadsError');

--- a/test/helpers/fakes.dart
+++ b/test/helpers/fakes.dart
@@ -204,6 +204,10 @@ class FakeSoliplexApi extends SoliplexApi {
   Exception? nextMcpTokenError;
 
   List<ThreadInfo>? nextThreads;
+
+  /// Per-room thread lists, consulted before [nextThreads]. Lets a test give
+  /// different rooms different thread sets (e.g. for activity-based sorting).
+  final Map<String, List<ThreadInfo>> threadsByRoom = {};
   Exception? nextThreadsError;
   ThreadHistory? nextThreadHistory;
   Exception? nextThreadHistoryError;
@@ -243,6 +247,7 @@ class FakeSoliplexApi extends SoliplexApi {
     CancelToken? cancelToken,
   }) async {
     if (nextThreadsError != null) throw nextThreadsError!;
+    if (threadsByRoom.containsKey(roomId)) return threadsByRoom[roomId]!;
     if (nextThreads != null) return nextThreads!;
     throw StateError('FakeSoliplexApi: set nextThreads or nextThreadsError');
   }

--- a/test/modules/lobby/lobby_sort_mode_test.dart
+++ b/test/modules/lobby/lobby_sort_mode_test.dart
@@ -1,7 +1,11 @@
+import 'dart:async';
+
 import 'package:flutter_test/flutter_test.dart';
 import 'package:shared_preferences/shared_preferences.dart';
-import 'package:soliplex_agent/soliplex_agent.dart';
+import 'package:soliplex_agent/soliplex_agent.dart' hide AuthException;
+import 'package:soliplex_client/soliplex_client.dart' show AuthException;
 import 'package:soliplex_frontend/src/modules/auth/auth_session.dart';
+import 'package:soliplex_frontend/src/modules/auth/auth_tokens.dart';
 import 'package:soliplex_frontend/src/modules/auth/server_manager.dart';
 import 'package:soliplex_frontend/src/modules/lobby/lobby_sort_mode.dart';
 import 'package:soliplex_frontend/src/modules/lobby/lobby_state.dart';
@@ -16,6 +20,14 @@ ServerManager _createManager() => ServerManager(
 
 ThreadInfo _thread(String id, DateTime createdAt) =>
     ThreadInfo(id: id, roomId: 'room', createdAt: createdAt);
+
+/// Drains pending microtasks. Over-pumps rather than coupling to the exact
+/// number of async hops the state machine takes to settle.
+Future<void> _settle([int turns = 12]) async {
+  for (var i = 0; i < turns; i++) {
+    await Future<void>.delayed(Duration.zero);
+  }
+}
 
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
@@ -102,11 +114,215 @@ void main() {
 
       expect(state.sortMode.value, LobbySortMode.none);
       final activity = state.roomActivity.value;
-      expect(activity[('local', 'r1')], older);
-      expect(activity[('local', 'r2')], newer);
-      expect(activity[('local', 'r3')], isNull);
-      expect(activity.containsKey(('local', 'r3')), isTrue);
+      expect(activity[(serverId: 'local', roomId: 'r1')], older);
+      expect(activity[(serverId: 'local', roomId: 'r2')], newer);
+      expect(activity[(serverId: 'local', roomId: 'r3')], isNull);
+      expect(activity.containsKey((serverId: 'local', roomId: 'r3')), isTrue);
       expect(state.activityLoading.value, isFalse);
+      state.dispose();
+    });
+
+    test(
+        'clears the activity-loading flag when a reconcile cannot fetch '
+        '(no stuck spinner)', () async {
+      SharedPreferences.setMockInitialValues(
+        {'soliplex_lobby_sort_mode': 'recentActivity'},
+      );
+      final manager = _createManager();
+      manager.addServer(
+        serverId: 'local',
+        serverUrl: Uri.parse('http://localhost:8000'),
+        requiresAuth: false,
+      );
+      final gate = Completer<void>();
+      final fakeApi = FakeSoliplexApi()
+        ..nextRooms = const [Room(id: 'r1', name: 'General')]
+        ..threadsByRoom['r1'] = [_thread('t1', DateTime.utc(2026))]
+        ..threadsGate = gate;
+
+      final state =
+          LobbyState(serverManager: manager, apiResolver: (_) => fakeApi);
+      // Let rooms load and the sweep start; it then parks on the gate.
+      for (var i = 0; i < 12 && !state.activityLoading.value; i++) {
+        await Future<void>.delayed(Duration.zero);
+      }
+      expect(state.activityLoading.value, isTrue,
+          reason: 'the sweep should be in flight, held open by the gate');
+
+      // Removing the only server drops the selection to null, so the reconcile
+      // it triggers hits an early return. The flag must still clear.
+      manager.removeServer('local');
+      expect(state.selectedServerId.value, isNull);
+      expect(state.activityLoading.value, isFalse);
+
+      gate.complete();
+      await _settle();
+      state.dispose();
+    });
+
+    test(
+        'refetching a server recomputes its activity and leaves other '
+        "servers' cached activity intact", () async {
+      final manager = _createManager();
+      manager.addServer(
+        serverId: 'a',
+        serverUrl: Uri.parse('http://a'),
+        requiresAuth: false,
+      );
+      manager.addServer(
+        serverId: 'b',
+        serverUrl: Uri.parse('http://b'),
+        requiresAuth: false,
+      );
+
+      final stale = DateTime.utc(2026, 1, 1);
+      final other = DateTime.utc(2026, 3, 1);
+      final fresh = DateTime.utc(2026, 6, 1);
+      final apiA = FakeSoliplexApi()
+        ..nextRooms = const [Room(id: 'ra', name: 'A-Room')]
+        ..threadsByRoom['ra'] = [_thread('t', stale)];
+      final apiB = FakeSoliplexApi()
+        ..nextRooms = const [Room(id: 'rb', name: 'B-Room')]
+        ..threadsByRoom['rb'] = [_thread('t', other)];
+
+      final state = LobbyState(
+        serverManager: manager,
+        apiResolver: (entry) => entry.serverUrl.host == 'a' ? apiA : apiB,
+      );
+      await _settle();
+      // Activity is fetched only for the selected server, so visit 'b' to
+      // populate its cache, then return to 'a'.
+      state.selectServer('b');
+      await _settle();
+      state.selectServer('a');
+      await _settle();
+      expect(state.roomActivity.value[(serverId: 'a', roomId: 'ra')], stale);
+      expect(state.roomActivity.value[(serverId: 'b', roomId: 'rb')], other);
+
+      // Change 'a's newest thread and refetch only 'a'.
+      apiA.threadsByRoom['ra'] = [_thread('t2', fresh)];
+      state.refresh('a');
+      await _settle();
+
+      expect(state.roomActivity.value[(serverId: 'a', roomId: 'ra')], fresh,
+          reason: "a refetch must recompute the refreshed server's activity");
+      expect(state.roomActivity.value[(serverId: 'b', roomId: 'rb')], other,
+          reason: "other servers' cached activity must survive");
+      state.dispose();
+    });
+
+    test('a room whose thread fetch fails records a null timestamp', () async {
+      final manager = _createManager();
+      manager.addServer(
+        serverId: 'local',
+        serverUrl: Uri.parse('http://localhost:8000'),
+        requiresAuth: false,
+      );
+      final ok = DateTime.utc(2026, 6, 1);
+      final fakeApi = FakeSoliplexApi()
+        ..nextRooms = const [
+          Room(id: 'ok', name: 'Ok'),
+          Room(id: 'bad', name: 'Bad'),
+        ]
+        ..threadsByRoom['ok'] = [_thread('t', ok)]
+        ..threadsErrorByRoom['bad'] = Exception('thread fetch boom');
+
+      final state =
+          LobbyState(serverManager: manager, apiResolver: (_) => fakeApi);
+      await _settle();
+
+      final activity = state.roomActivity.value;
+      expect(activity[(serverId: 'local', roomId: 'ok')], ok);
+      expect(activity[(serverId: 'local', roomId: 'bad')], isNull,
+          reason: 'a failed thread fetch maps to a null timestamp');
+      expect(activity.containsKey((serverId: 'local', roomId: 'bad')), isTrue,
+          reason: 'the failed room is recorded as fetched, so it is not '
+              're-swept');
+      state.dispose();
+    });
+
+    test(
+        'an AuthException during the sweep funnels to session expiry, like the '
+        'room-list and profile fetches', () async {
+      final manager = _createManager();
+      final entry = manager.addServer(
+        serverId: 'auth',
+        serverUrl: Uri.parse('https://api.example.com'),
+      );
+      entry.auth.login(
+        provider: const OidcProvider(
+          discoveryUrl: 'https://sso/.well-known/openid-configuration',
+          clientId: 'c',
+        ),
+        tokens: AuthTokens(
+          accessToken: 'a',
+          refreshToken: 'r',
+          expiresAt: DateTime.now().add(const Duration(hours: 1)),
+        ),
+      );
+      final fakeApi = FakeSoliplexApi()
+        ..nextRooms = const [Room(id: 'r1', name: 'General')]
+        ..threadsErrorByRoom['r1'] = const AuthException(message: 'expired');
+
+      final state =
+          LobbyState(serverManager: manager, apiResolver: (_) => fakeApi);
+      await _settle();
+
+      expect(entry.auth.session.value, isA<ExpiredSession>(),
+          reason: 'a swept-room AuthException must drive session expiry rather '
+              'than being swallowed as a per-room warning');
+      state.dispose();
+    });
+
+    test('a sweep superseded by a selection change discards its stale results',
+        () async {
+      final manager = _createManager();
+      manager.addServer(
+        serverId: 'a',
+        serverUrl: Uri.parse('http://a'),
+        requiresAuth: false,
+      );
+      manager.addServer(
+        serverId: 'b',
+        serverUrl: Uri.parse('http://b'),
+        requiresAuth: false,
+      );
+      final gateA = Completer<void>();
+      final apiA = FakeSoliplexApi()
+        ..nextRooms = const [Room(id: 'ra', name: 'A-Room')]
+        ..threadsByRoom['ra'] = [_thread('ta', DateTime.utc(2026, 1))]
+        ..threadsGate = gateA;
+      final apiB = FakeSoliplexApi()
+        ..nextRooms = const [Room(id: 'rb', name: 'B-Room')]
+        ..threadsByRoom['rb'] = [_thread('tb', DateTime.utc(2026, 6))];
+
+      final state = LobbyState(
+        serverManager: manager,
+        apiResolver: (entry) => entry.serverUrl.host == 'a' ? apiA : apiB,
+      );
+      // 'a' is the initial selection; let its sweep start and park on the gate.
+      for (var i = 0; i < 12 && !state.activityLoading.value; i++) {
+        await Future<void>.delayed(Duration.zero);
+      }
+      expect(state.activityLoading.value, isTrue,
+          reason: "'a's sweep should be in flight, held open by the gate");
+
+      // Switching to 'b' cancels 'a's token and runs 'b's sweep to completion.
+      state.selectServer('b');
+      await _settle();
+      expect(state.roomActivity.value[(serverId: 'b', roomId: 'rb')],
+          DateTime.utc(2026, 6));
+
+      // Release 'a's now-cancelled sweep; the isCancelled guard must drop its
+      // result rather than writing it over the current selection's state.
+      gateA.complete();
+      await _settle();
+      expect(
+        state.roomActivity.value.containsKey((serverId: 'a', roomId: 'ra')),
+        isFalse,
+        reason: 'a sweep cancelled by a selection change must not write its '
+            'stale results',
+      );
       state.dispose();
     });
   });

--- a/test/modules/lobby/lobby_sort_mode_test.dart
+++ b/test/modules/lobby/lobby_sort_mode_test.dart
@@ -1,0 +1,113 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:soliplex_agent/soliplex_agent.dart';
+import 'package:soliplex_frontend/src/modules/auth/auth_session.dart';
+import 'package:soliplex_frontend/src/modules/auth/server_manager.dart';
+import 'package:soliplex_frontend/src/modules/lobby/lobby_sort_mode.dart';
+import 'package:soliplex_frontend/src/modules/lobby/lobby_state.dart';
+
+import '../../helpers/fakes.dart';
+
+ServerManager _createManager() => ServerManager(
+      authFactory: () => AuthSession(refreshService: FakeTokenRefreshService()),
+      clientFactory: ({getToken, tokenRefresher}) => FakeHttpClient(),
+      storage: InMemoryServerStorage(),
+    );
+
+ThreadInfo _thread(String id, DateTime createdAt) =>
+    ThreadInfo(id: id, roomId: 'room', createdAt: createdAt);
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+  setUp(() => SharedPreferences.setMockInitialValues({}));
+
+  group('LobbySortModeStorage', () {
+    test('defaults to none when nothing is persisted', () async {
+      SharedPreferences.setMockInitialValues({});
+      expect(await LobbySortModeStorage.load(), LobbySortMode.none);
+    });
+
+    test('round-trips the saved mode', () async {
+      SharedPreferences.setMockInitialValues({});
+      await LobbySortModeStorage.save(LobbySortMode.recentActivity);
+      expect(await LobbySortModeStorage.load(), LobbySortMode.recentActivity);
+    });
+
+    test('falls back to none on an unrecognized stored value', () async {
+      SharedPreferences.setMockInitialValues(
+        {'soliplex_lobby_sort_mode': 'bogus'},
+      );
+      expect(await LobbySortModeStorage.load(), LobbySortMode.none);
+    });
+  });
+
+  group('LobbyState sorting', () {
+    test('starts at none and adopts the persisted mode after async load',
+        () async {
+      SharedPreferences.setMockInitialValues(
+        {'soliplex_lobby_sort_mode': 'recentActivity'},
+      );
+      final state = LobbyState(serverManager: _createManager());
+      expect(state.sortMode.value, LobbySortMode.none);
+      await Future<void>.delayed(Duration.zero);
+      expect(state.sortMode.value, LobbySortMode.recentActivity);
+      state.dispose();
+    });
+
+    test('setSortMode updates the signal and persists the choice', () async {
+      final state = LobbyState(serverManager: _createManager());
+      await Future<void>.delayed(Duration.zero);
+
+      state.setSortMode(LobbySortMode.recentActivity);
+      expect(state.sortMode.value, LobbySortMode.recentActivity);
+      expect(
+        await LobbySortModeStorage.load(),
+        LobbySortMode.recentActivity,
+      );
+      state.dispose();
+    });
+
+    test(
+        'fetches each room\'s newest thread timestamp eagerly (so cards can '
+        'show it), even with sorting at none', () async {
+      final manager = _createManager();
+      manager.addServer(
+        serverId: 'local',
+        serverUrl: Uri.parse('http://localhost:8000'),
+        requiresAuth: false,
+      );
+
+      final older = DateTime.utc(2026, 1, 1);
+      final newer = DateTime.utc(2026, 6, 1);
+      final fakeApi = FakeSoliplexApi()
+        ..nextRooms = const [
+          Room(id: 'r1', name: 'General'),
+          Room(id: 'r2', name: 'Random'),
+          Room(id: 'r3', name: 'Empty'),
+        ]
+        ..threadsByRoom['r1'] = [_thread('t1', older)]
+        // Newest of several should win.
+        ..threadsByRoom['r2'] = [_thread('t2', older), _thread('t3', newer)]
+        // No threads → null timestamp.
+        ..threadsByRoom['r3'] = const [];
+
+      // Sorting stays at the default (none); activity is still fetched.
+      final state = LobbyState(
+        serverManager: manager,
+        apiResolver: (_) => fakeApi,
+      );
+      // Two turns: one for getRooms, one for the getThreads sweep it triggers.
+      await Future<void>.delayed(Duration.zero);
+      await Future<void>.delayed(Duration.zero);
+
+      expect(state.sortMode.value, LobbySortMode.none);
+      final activity = state.roomActivity.value;
+      expect(activity[('local', 'r1')], older);
+      expect(activity[('local', 'r2')], newer);
+      expect(activity[('local', 'r3')], isNull);
+      expect(activity.containsKey(('local', 'r3')), isTrue);
+      expect(state.activityLoading.value, isFalse);
+      state.dispose();
+    });
+  });
+}

--- a/test/modules/lobby/room_activity_format_test.dart
+++ b/test/modules/lobby/room_activity_format_test.dart
@@ -1,0 +1,54 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:soliplex_frontend/src/modules/lobby/room_activity_format.dart';
+
+void main() {
+  final now = DateTime(2026, 6, 9, 12);
+
+  group('formatRelativeActivity', () {
+    test('renders minute/hour/day granularity then a numeric date', () {
+      expect(
+        formatRelativeActivity(now.subtract(const Duration(seconds: 30)),
+            now: now),
+        'Just now',
+      );
+      expect(
+        formatRelativeActivity(now.subtract(const Duration(minutes: 5)),
+            now: now),
+        '5m ago',
+      );
+      expect(
+        formatRelativeActivity(now.subtract(const Duration(hours: 3)),
+            now: now),
+        '3h ago',
+      );
+      expect(
+        formatRelativeActivity(now.subtract(const Duration(days: 2)), now: now),
+        '2d ago',
+      );
+      // Older than a week → numeric date (M/D/YYYY).
+      expect(
+        formatRelativeActivity(DateTime(2026, 1, 15), now: now),
+        '1/15/2026',
+      );
+    });
+  });
+
+  group('bucketFor', () {
+    test('null maps to the no-activity bucket', () {
+      expect(bucketFor(null, now: now), ActivityBucket.none);
+    });
+
+    test('groups by calendar-relative recency', () {
+      expect(bucketFor(now.subtract(const Duration(hours: 2)), now: now),
+          ActivityBucket.today);
+      // Yesterday is the previous calendar day, even if <24h ago.
+      expect(bucketFor(DateTime(2026, 6, 8, 23), now: now),
+          ActivityBucket.yesterday);
+      expect(
+          bucketFor(DateTime(2026, 6, 5), now: now), ActivityBucket.thisWeek);
+      expect(
+          bucketFor(DateTime(2026, 5, 25), now: now), ActivityBucket.thisMonth);
+      expect(bucketFor(DateTime(2026, 1, 1), now: now), ActivityBucket.older);
+    });
+  });
+}

--- a/test/modules/lobby/room_activity_format_test.dart
+++ b/test/modules/lobby/room_activity_format_test.dart
@@ -31,6 +31,23 @@ void main() {
         '1/15/2026',
       );
     });
+
+    test('switches label exactly at each threshold', () {
+      String at(Duration ago) =>
+          formatRelativeActivity(now.subtract(ago), now: now);
+      // minute boundary
+      expect(at(const Duration(seconds: 59)), 'Just now');
+      expect(at(const Duration(minutes: 1)), '1m ago');
+      // minute → hour
+      expect(at(const Duration(minutes: 59)), '59m ago');
+      expect(at(const Duration(hours: 1)), '1h ago');
+      // hour → day
+      expect(at(const Duration(hours: 23)), '23h ago');
+      expect(at(const Duration(hours: 24)), '1d ago');
+      // day → numeric date at exactly a week
+      expect(at(const Duration(days: 6)), '6d ago');
+      expect(at(const Duration(days: 7)), '6/2/2026');
+    });
   });
 
   group('bucketFor', () {
@@ -49,6 +66,18 @@ void main() {
       expect(
           bucketFor(DateTime(2026, 5, 25), now: now), ActivityBucket.thisMonth);
       expect(bucketFor(DateTime(2026, 1, 1), now: now), ActivityBucket.older);
+    });
+
+    test('places the week and month cusps on the older side', () {
+      // 6 vs 7 calendar days: still this week, then this month.
+      expect(
+          bucketFor(DateTime(2026, 6, 3), now: now), ActivityBucket.thisWeek);
+      expect(
+          bucketFor(DateTime(2026, 6, 2), now: now), ActivityBucket.thisMonth);
+      // 29 vs 30 calendar days: this month, then older.
+      expect(
+          bucketFor(DateTime(2026, 5, 11), now: now), ActivityBucket.thisMonth);
+      expect(bucketFor(DateTime(2026, 5, 10), now: now), ActivityBucket.older);
     });
   });
 }

--- a/test/modules/lobby/ui/lobby_screen_test.dart
+++ b/test/modules/lobby/ui/lobby_screen_test.dart
@@ -511,6 +511,56 @@ void main() {
       expect(find.text('This month'), findsOneWidget);
     });
 
+    testWidgets('recent-activity sort keeps undated rooms last in input order',
+        (tester) async {
+      tester.view.physicalSize = const Size(900, 600);
+      tester.view.devicePixelRatio = 1.0;
+      addTearDown(tester.view.resetPhysicalSize);
+
+      final manager = _createManager();
+      manager.addServer(
+        serverId: 'local',
+        serverUrl: Uri.parse('http://localhost:8000'),
+        requiresAuth: false,
+      );
+      final older = DateTime.utc(2026, 1, 1);
+      final newer = DateTime.utc(2026, 6, 1);
+      // Alpha and Charlie have no threads (undated); Bravo/Delta are dated.
+      final fakeApi = FakeSoliplexApi()
+        ..nextRooms = const [
+          Room(id: 'r1', name: 'Alpha'),
+          Room(id: 'r2', name: 'Bravo'),
+          Room(id: 'r3', name: 'Charlie'),
+          Room(id: 'r4', name: 'Delta'),
+        ]
+        ..threadsByRoom['r1'] = const []
+        ..threadsByRoom['r2'] = [
+          ThreadInfo(id: 't2', roomId: 'r2', createdAt: newer),
+        ]
+        ..threadsByRoom['r3'] = const []
+        ..threadsByRoom['r4'] = [
+          ThreadInfo(id: 't4', roomId: 'r4', createdAt: older),
+        ];
+
+      await tester.pumpWidget(_buildApp(manager, apiResolver: (_) => fakeApi));
+      await tester.pumpAndSettle();
+
+      List<String> roomOrder() => tester
+          .widgetList<RoomCard>(find.byType(RoomCard))
+          .map((c) => c.room.name)
+          .toList();
+
+      expect(roomOrder(), ['Alpha', 'Bravo', 'Charlie', 'Delta']);
+
+      await tester.tap(find.byType(DropdownMenu<LobbySortMode>));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('Recent activity').hitTestable());
+      await tester.pumpAndSettle();
+
+      // Dated rooms first (newest -> oldest), then undated in original order.
+      expect(roomOrder(), ['Bravo', 'Delta', 'Alpha', 'Charlie']);
+    });
+
     testWidgets(
         'shows only the selected server, and switching the sidebar '
         'selection swaps the shown rooms', (tester) async {

--- a/test/modules/lobby/ui/lobby_screen_test.dart
+++ b/test/modules/lobby/ui/lobby_screen_test.dart
@@ -2,10 +2,11 @@ import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:go_router/go_router.dart';
 import 'package:shared_preferences/shared_preferences.dart';
-import 'package:soliplex_agent/soliplex_agent.dart' show Room;
+import 'package:soliplex_agent/soliplex_agent.dart' show Room, ThreadInfo;
 import 'package:soliplex_frontend/src/modules/auth/auth_session.dart';
 import 'package:soliplex_frontend/src/modules/auth/auth_tokens.dart';
 import 'package:soliplex_frontend/src/modules/auth/server_manager.dart';
+import 'package:soliplex_frontend/src/modules/lobby/lobby_sort_mode.dart';
 import 'package:soliplex_frontend/src/modules/lobby/lobby_state.dart';
 import 'package:soliplex_frontend/src/modules/lobby/ui/lobby_screen.dart';
 import 'package:soliplex_frontend/src/modules/lobby/ui/room_card.dart';
@@ -350,7 +351,8 @@ void main() {
       await tester.pumpAndSettle();
       expect(find.byType(RoomCard), findsNWidgets(2));
 
-      await tester.enterText(find.byType(TextField), 'gen');
+      await tester.enterText(
+          find.widgetWithIcon(TextField, Icons.search), 'gen');
       await tester.pumpAndSettle();
 
       expect(find.byType(RoomCard), findsOneWidget);
@@ -376,7 +378,8 @@ void main() {
       await tester.pumpWidget(_buildApp(manager, apiResolver: (_) => fakeApi));
       await tester.pumpAndSettle();
 
-      await tester.enterText(find.byType(TextField), 'zzz');
+      await tester.enterText(
+          find.widgetWithIcon(TextField, Icons.search), 'zzz');
       await tester.pumpAndSettle();
 
       expect(find.byType(RoomCard), findsNothing);
@@ -403,7 +406,8 @@ void main() {
       await tester.pumpWidget(_buildApp(manager, apiResolver: (_) => fakeApi));
       await tester.pumpAndSettle();
 
-      await tester.enterText(find.byType(TextField), 'gen');
+      await tester.enterText(
+          find.widgetWithIcon(TextField, Icons.search), 'gen');
       await tester.pumpAndSettle();
       expect(find.byType(RoomCard), findsOneWidget);
 
@@ -411,6 +415,100 @@ void main() {
       await tester.pumpAndSettle();
 
       expect(find.byType(RoomCard), findsNWidgets(2));
+    });
+
+    testWidgets(
+        'sorting by recent activity reorders rooms by their newest thread',
+        (tester) async {
+      tester.view.physicalSize = const Size(900, 600);
+      tester.view.devicePixelRatio = 1.0;
+      addTearDown(tester.view.resetPhysicalSize);
+
+      final manager = _createManager();
+      manager.addServer(
+        serverId: 'local',
+        serverUrl: Uri.parse('http://localhost:8000'),
+        requiresAuth: false,
+      );
+      // 'General' is listed first but has the older thread; 'Random' has the
+      // newer one, so recent-activity sorting must put 'Random' on top.
+      final fakeApi = FakeSoliplexApi()
+        ..nextRooms = const [
+          Room(id: 'r1', name: 'General'),
+          Room(id: 'r2', name: 'Random'),
+        ]
+        ..threadsByRoom['r1'] = [
+          ThreadInfo(id: 't1', roomId: 'r1', createdAt: DateTime.utc(2026, 1)),
+        ]
+        ..threadsByRoom['r2'] = [
+          ThreadInfo(id: 't2', roomId: 'r2', createdAt: DateTime.utc(2026, 6)),
+        ];
+
+      await tester.pumpWidget(_buildApp(manager, apiResolver: (_) => fakeApi));
+      await tester.pumpAndSettle();
+
+      List<String> roomOrder() => tester
+          .widgetList<RoomCard>(find.byType(RoomCard))
+          .map((c) => c.room.name)
+          .toList();
+
+      // Default sort (none): backend order is preserved.
+      expect(roomOrder(), ['General', 'Random']);
+
+      // Open the sort dropdown and choose "Recent activity" (the offstage
+      // measurement copy of the entry isn't hit-testable, so target the
+      // on-screen one).
+      await tester.tap(find.byType(DropdownMenu<LobbySortMode>));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('Recent activity').hitTestable());
+      await tester.pumpAndSettle();
+
+      expect(roomOrder(), ['Random', 'General']);
+    });
+
+    testWidgets('recent-activity sort groups rooms under date-bucket headers',
+        (tester) async {
+      tester.view.physicalSize = const Size(900, 600);
+      tester.view.devicePixelRatio = 1.0;
+      addTearDown(tester.view.resetPhysicalSize);
+
+      final manager = _createManager();
+      manager.addServer(
+        serverId: 'local',
+        serverUrl: Uri.parse('http://localhost:8000'),
+        requiresAuth: false,
+      );
+      final now = DateTime.now();
+      final fakeApi = FakeSoliplexApi()
+        ..nextRooms = const [
+          Room(id: 'r1', name: 'Fresh'),
+          Room(id: 'r2', name: 'Stale'),
+        ]
+        ..threadsByRoom['r1'] = [
+          ThreadInfo(id: 't1', roomId: 'r1', createdAt: now),
+        ]
+        ..threadsByRoom['r2'] = [
+          ThreadInfo(
+            id: 't2',
+            roomId: 'r2',
+            createdAt: now.subtract(const Duration(days: 10)),
+          ),
+        ];
+
+      await tester.pumpWidget(_buildApp(manager, apiResolver: (_) => fakeApi));
+      await tester.pumpAndSettle();
+
+      // No section headers until sorting by recent activity.
+      expect(find.text('Today'), findsNothing);
+
+      await tester.tap(find.byType(DropdownMenu<LobbySortMode>));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('Recent activity').hitTestable());
+      await tester.pumpAndSettle();
+
+      // Two buckets: today (Fresh) and ~10 days ago (This month).
+      expect(find.text('Today'), findsOneWidget);
+      expect(find.text('This month'), findsOneWidget);
     });
 
     testWidgets(


### PR DESCRIPTION
Stacked on **#331** (`feat/lobby-account-bar`) — L4 of the lobby sweep. Will retarget to `main` as the stack lands.

## What

Adds room sorting to the lobby plus a per-card activity timestamp.

- **Sort dropdown** (None / Recent activity) sits between the room filter and the view-mode toggle. Choice persists across launches like the view mode.
- **Recent activity** orders rooms by their newest thread's `createdAt`. The backend exposes no last-access field, so this is the only recency signal available — derived with one `getThreads` per room and cached.
- **Per-card time**: activity is fetched eagerly for the selected server so every card shows a muted relative timestamp ("3h ago", "2d ago", …) in its **bottom-left, opposite the info button**.
- **Date grouping**: when sorting by recent activity, rooms render under bucket headers — **Today / Yesterday / This week / This month / Older** (+ a **No activity** tail) — like an LLM chat history, in both list and grid views.

## Notes for review

- The activity sweep is bounded by the client's existing concurrency limiter, cancelled on server switch/dispose, and reused across switches (only the *selected* server is fetched).
- "Recent activity" is a label over *newest-thread-created*, not literal last-access — flagged for a possible future backend endpoint that would collapse the N+1 into one call.
- One non-token magic number: the dropdown field is `SizedBox(width: 184)` (no component-width token exists).

## Tests

New: `lobby_sort_mode_test` (storage + eager fetch/derivation), `room_activity_format_test` (relative labels + buckets), plus lobby_screen tests for reordering and bucket headers. Full suite green (1609); `flutter analyze` clean.