### PR TITLE
polish(auth): design-system text styles + insecure-connection warning

### DIFF
--- a/lib/src/modules/auth/ui/auth_callback_screen.dart
+++ b/lib/src/modules/auth/ui/auth_callback_screen.dart
@@ -160,7 +160,10 @@ class _AuthCallbackScreenState extends ConsumerState<AuthCallbackScreen> {
                 color: Theme.of(context).colorScheme.error,
               ),
               const SizedBox(height: SoliplexSpacing.s4),
-              Text(_error ?? 'An error occurred'),
+              Text(
+                _error ?? 'An error occurred',
+                style: Theme.of(context).textTheme.bodyMedium,
+              ),
               const SizedBox(height: SoliplexSpacing.s4),
               SoliplexButton.filled(
                 onPressed: () => context.go(AppRoutes.home),

--- a/lib/src/modules/auth/ui/home_screen.dart
+++ b/lib/src/modules/auth/ui/home_screen.dart
@@ -280,12 +280,13 @@ class _HomeScreenState extends ConsumerState<HomeScreen> {
 
     return [
       ..._buildHeader(context, 'Insecure Connection'),
-      Icon(Icons.warning_amber, size: 48, color: theme.colorScheme.error),
+      Icon(Icons.warning_amber, size: 48, color: theme.colorScheme.warning),
       const SizedBox(height: SoliplexSpacing.s4),
       Text(
         'This connection to ${formatServerUrl(probeResult.serverUrl)} is not '
         'encrypted. Your data, including credentials, may be visible to '
         'others on the network.',
+        style: theme.textTheme.bodyMedium,
         textAlign: TextAlign.center,
       ),
       const SizedBox(height: SoliplexSpacing.s6),
@@ -316,7 +317,7 @@ class _HomeScreenState extends ConsumerState<HomeScreen> {
       ..._buildHeader(context, 'Sign in to continue'),
       Text(notice.title, style: Theme.of(context).textTheme.titleLarge),
       const SizedBox(height: SoliplexSpacing.s4),
-      Text(notice.body),
+      Text(notice.body, style: Theme.of(context).textTheme.bodyMedium),
       const SizedBox(height: SoliplexSpacing.s4),
       Row(
         mainAxisAlignment: MainAxisAlignment.center,

--- a/lib/src/modules/auth/ui/home_screen.dart
+++ b/lib/src/modules/auth/ui/home_screen.dart
@@ -44,6 +44,10 @@ class _HomeScreenState extends ConsumerState<HomeScreen> {
   static const _logoSize = 64.0;
   static const _maxCollapsedServers = 5;
 
+  /// Max width of the centered auth column on wide viewports, so the form
+  /// and buttons don't stretch edge-to-edge on desktop/web.
+  static const _maxContentWidth = 400.0;
+
   late final ConnectFlow _flow;
   late final void Function() _unsubscribeFlow;
   late final void Function() _unsubscribeServers;
@@ -152,7 +156,7 @@ class _HomeScreenState extends ConsumerState<HomeScreen> {
       child: SingleChildScrollView(
         padding: const EdgeInsets.all(SoliplexSpacing.s6),
         child: ConstrainedBox(
-          constraints: const BoxConstraints(maxWidth: 400),
+          constraints: const BoxConstraints(maxWidth: _maxContentWidth),
           child: Column(
             mainAxisSize: MainAxisSize.min,
             crossAxisAlignment: CrossAxisAlignment.stretch,
@@ -515,7 +519,7 @@ class UrlMessageBanner extends StatelessWidget {
               Expanded(
                 child: Text(
                   text,
-                  style: TextStyle(
+                  style: theme.textTheme.bodyMedium?.copyWith(
                     color: theme.colorScheme.onErrorContainer,
                   ),
                 ),


### PR DESCRIPTION
Auth-module design-system polish (clear-cut + design-reviewed items). Layout/spacing and new features are out of scope — to follow later.

The module was already adopted in the integration phase: the design-system scanner reports **zero** hard-rule hits. This PR covers the remaining compliance gaps:

### home_screen.dart
- Error-banner text built its style from a bare `TextStyle(color:)` → now `textTheme.bodyMedium?.copyWith(color:)`, matching its `ConnectNotice` sibling.
- `BoxConstraints(maxWidth: 400)` magic number → named `_maxContentWidth` const (alongside `_logoSize`).
- **Insecure connection is a warning, not an error** — it doesn't block connecting (there's a "Connect anyway"). Icon recolored `colorScheme.error` → `colorScheme.warning` (SymbolicColors).
- Insecure-warning body and consent-notice body get explicit `textTheme.bodyMedium`.

### auth_callback_screen.dart
- Error message gets explicit `textTheme.bodyMedium`.

Every free-standing `Text` now carries an explicit Soliplex `textTheme` style chosen to match its role; `ListTile`/`AppBar` titles already render through the brand `textTheme` via their component themes and are left as-is.

No behavioral or layout change. `flutter analyze` clean; 276 auth tests pass.
