### PR TITLE
feat(auth): onboarding redesign 1/3 — shared HomeShell chrome + flow rail

### DIFF
--- a/lib/src/modules/auth/ui/connect_flow_rail.dart
+++ b/lib/src/modules/auth/ui/connect_flow_rail.dart
@@ -50,9 +50,7 @@ class ConnectFlowRail extends StatelessWidget {
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
     final colors = theme.colorScheme;
-    final baseStyle = context
-        .monospaceOn(theme.textTheme.labelSmall)
-        .copyWith(color: colors.onSurfaceVariant);
+    final baseStyle = theme.textTheme.labelLarge;
 
     return Container(
       padding: const EdgeInsets.symmetric(
@@ -64,8 +62,10 @@ class ConnectFlowRail extends StatelessWidget {
         border: Border.all(color: colors.outlineVariant),
         borderRadius: BorderRadius.circular(soliplexRadii.md),
       ),
-      child: FittedBox(
-        fit: BoxFit.scaleDown,
+      // The strip can be wider than its column on smaller desktop windows;
+      // scroll rather than shrink so every label stays legible.
+      child: SingleChildScrollView(
+        scrollDirection: Axis.horizontal,
         child: Row(
           mainAxisSize: MainAxisSize.min,
           children: [
@@ -78,7 +78,7 @@ class ConnectFlowRail extends StatelessWidget {
                   ),
                   child: Text(
                     '→',
-                    style: baseStyle.copyWith(color: colors.outline),
+                    style: baseStyle?.copyWith(color: colors.onSurfaceVariant),
                   ),
                 ),
             ],
@@ -98,7 +98,7 @@ class _RailNode extends StatelessWidget {
 
   final ConnectStep step;
   final ConnectStep current;
-  final TextStyle baseStyle;
+  final TextStyle? baseStyle;
 
   @override
   Widget build(BuildContext context) {
@@ -107,17 +107,13 @@ class _RailNode extends StatelessWidget {
     final isDone = step.index < current.index;
     final dimOptional = step.optional && !isActive && !isDone;
 
-    final Color foreground;
-    if (isActive) {
-      foreground = colors.onPrimary;
-    } else if (isDone) {
-      foreground = colors.onSurface;
-    } else {
-      foreground = colors.onSurfaceVariant;
-    }
+    // Active reads on the primary fill; everything else sits at full
+    // on-surface contrast so the rail stays readable. Optional steps that
+    // haven't been reached are softened with opacity, not a dim color.
+    final foreground = isActive ? colors.onPrimary : colors.onSurface;
 
     return Opacity(
-      opacity: dimOptional ? 0.5 : 1,
+      opacity: dimOptional ? 0.6 : 1,
       child: Container(
         padding: const EdgeInsets.symmetric(
           horizontal: SoliplexSpacing.s2,
@@ -133,12 +129,12 @@ class _RailNode extends StatelessWidget {
           mainAxisSize: MainAxisSize.min,
           children: [
             if (isDone) ...[
-              Icon(Icons.check, size: 12, color: foreground),
+              Icon(Icons.check, size: 16, color: foreground),
               const SizedBox(width: SoliplexSpacing.s1),
             ],
             Text(
               step.label,
-              style: baseStyle.copyWith(
+              style: baseStyle?.copyWith(
                 color: foreground,
                 fontWeight: isActive ? FontWeight.w600 : FontWeight.w500,
               ),

--- a/lib/src/modules/auth/ui/connect_flow_rail.dart
+++ b/lib/src/modules/auth/ui/connect_flow_rail.dart
@@ -1,0 +1,151 @@
+import 'package:flutter/material.dart';
+import 'package:soliplex_design/soliplex_design.dart';
+
+import '../connect_flow.dart';
+
+/// One node in the [ConnectFlowRail] breadcrumb.
+///
+/// Mirrors the [ConnectState] sealed hierarchy. The two `optional` steps
+/// (insecure / consent) only appear in some runs — an `http://` probe or a
+/// server-configured consent notice — so they render dimmed until reached.
+enum ConnectStep {
+  url('URL'),
+  probe('Probe'),
+  insecure('Insecure?', optional: true),
+  consent('Consent', optional: true),
+  provider('Provider'),
+  auth('Auth'),
+  connected('Connected');
+
+  const ConnectStep(this.label, {this.optional = false});
+
+  final String label;
+  final bool optional;
+}
+
+/// Maps the live [ConnectState] onto its [ConnectStep] node.
+ConnectStep stepForConnectState(ConnectState state) => switch (state) {
+      UrlInput() => ConnectStep.url,
+      Probing() => ConnectStep.probe,
+      InsecureWarning() => ConnectStep.insecure,
+      Consent() => ConnectStep.consent,
+      ProviderSelection() => ConnectStep.provider,
+      Authenticating() => ConnectStep.auth,
+      Connected() => ConnectStep.connected,
+    };
+
+/// A horizontal breadcrumb of the [ConnectFlow] state machine, surfacing
+/// where the user is in the connect → authenticate journey.
+///
+/// Shown only on wide viewports (the caller gates on
+/// [SoliplexBreakpoints.desktop]); on narrow screens the per-state heading
+/// carries the context instead. The strip scales down to fit its column so
+/// it never overflows.
+class ConnectFlowRail extends StatelessWidget {
+  const ConnectFlowRail({super.key, required this.current});
+
+  final ConnectStep current;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final colors = theme.colorScheme;
+    final baseStyle = context
+        .monospaceOn(theme.textTheme.labelSmall)
+        .copyWith(color: colors.onSurfaceVariant);
+
+    return Container(
+      padding: const EdgeInsets.symmetric(
+        horizontal: SoliplexSpacing.s3,
+        vertical: SoliplexSpacing.s2,
+      ),
+      decoration: BoxDecoration(
+        color: colors.surfaceContainerLow,
+        border: Border.all(color: colors.outlineVariant),
+        borderRadius: BorderRadius.circular(soliplexRadii.md),
+      ),
+      child: FittedBox(
+        fit: BoxFit.scaleDown,
+        child: Row(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            for (final step in ConnectStep.values) ...[
+              _RailNode(step: step, current: current, baseStyle: baseStyle),
+              if (step != ConnectStep.values.last)
+                Padding(
+                  padding: const EdgeInsets.symmetric(
+                    horizontal: SoliplexSpacing.s1,
+                  ),
+                  child: Text(
+                    '→',
+                    style: baseStyle.copyWith(color: colors.outline),
+                  ),
+                ),
+            ],
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _RailNode extends StatelessWidget {
+  const _RailNode({
+    required this.step,
+    required this.current,
+    required this.baseStyle,
+  });
+
+  final ConnectStep step;
+  final ConnectStep current;
+  final TextStyle baseStyle;
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = Theme.of(context).colorScheme;
+    final isActive = step == current;
+    final isDone = step.index < current.index;
+    final dimOptional = step.optional && !isActive && !isDone;
+
+    final Color foreground;
+    if (isActive) {
+      foreground = colors.onPrimary;
+    } else if (isDone) {
+      foreground = colors.onSurface;
+    } else {
+      foreground = colors.onSurfaceVariant;
+    }
+
+    return Opacity(
+      opacity: dimOptional ? 0.5 : 1,
+      child: Container(
+        padding: const EdgeInsets.symmetric(
+          horizontal: SoliplexSpacing.s2,
+          vertical: SoliplexSpacing.s1,
+        ),
+        decoration: isActive
+            ? BoxDecoration(
+                color: colors.primary,
+                borderRadius: BorderRadius.circular(soliplexRadii.sm),
+              )
+            : null,
+        child: Row(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            if (isDone) ...[
+              Icon(Icons.check, size: 12, color: foreground),
+              const SizedBox(width: SoliplexSpacing.s1),
+            ],
+            Text(
+              step.label,
+              style: baseStyle.copyWith(
+                color: foreground,
+                fontWeight: isActive ? FontWeight.w600 : FontWeight.w500,
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/src/modules/auth/ui/home_screen.dart
+++ b/lib/src/modules/auth/ui/home_screen.dart
@@ -11,6 +11,8 @@ import '../consent_notice.dart';
 import '../connection_probe.dart';
 import '../server_entry.dart';
 import '../server_manager.dart';
+import 'connect_flow_rail.dart';
+import 'home_shell.dart';
 import 'package:soliplex_design/soliplex_design.dart';
 
 class HomeScreen extends ConsumerStatefulWidget {
@@ -41,12 +43,7 @@ class HomeScreen extends ConsumerStatefulWidget {
 }
 
 class _HomeScreenState extends ConsumerState<HomeScreen> {
-  static const _logoSize = 64.0;
   static const _maxCollapsedServers = 5;
-
-  /// Max width of the centered auth column on wide viewports, so the form
-  /// and buttons don't stretch edge-to-edge on desktop/web.
-  static const _maxContentWidth = 400.0;
 
   late final ConnectFlow _flow;
   late final void Function() _unsubscribeFlow;
@@ -129,14 +126,37 @@ class _HomeScreenState extends ConsumerState<HomeScreen> {
 
   @override
   Widget build(BuildContext context) {
-    return Scaffold(
-      body: SafeArea(
-        child: Column(
-          children: [
-            Expanded(child: _buildBody(context)),
-            const _VersionFooter(),
+    final servers = widget.serverManager.servers.value;
+    final state = _flow.state.value;
+    final showRail =
+        MediaQuery.sizeOf(context).width >= SoliplexBreakpoints.desktop;
+
+    return HomeShell(
+      appName: widget.appName,
+      logo: widget.logo,
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          if (showRail) ...[
+            ConnectFlowRail(current: stepForConnectState(state)),
+            const SizedBox(height: SoliplexSpacing.s6),
           ],
-        ),
+          ...switch (state) {
+            UrlInput() => _buildUrlInput(context),
+            Probing() => _buildProbing(context),
+            InsecureWarning(:final probeResult) =>
+              _buildInsecureWarning(context, probeResult),
+            Consent(:final notice, :final probeResult, :final providers) =>
+              _buildConsent(context, notice, probeResult, providers),
+            ProviderSelection(:final providers) =>
+              _buildProviderSelection(context, providers),
+            Authenticating() => _buildAuthenticating(context),
+            Connected() => _buildAuthenticating(context),
+          },
+          if (servers.isNotEmpty && state is UrlInput)
+            ..._buildServerSection(context, servers),
+        ],
       ),
     );
   }
@@ -149,78 +169,20 @@ class _HomeScreenState extends ConsumerState<HomeScreen> {
     return false;
   }
 
-  Widget _buildBody(BuildContext context) {
-    final servers = widget.serverManager.servers.value;
+  // -- Per-state heading --
 
-    return Center(
-      child: SingleChildScrollView(
-        padding: const EdgeInsets.all(SoliplexSpacing.s6),
-        child: ConstrainedBox(
-          constraints: const BoxConstraints(maxWidth: _maxContentWidth),
-          child: Column(
-            mainAxisSize: MainAxisSize.min,
-            crossAxisAlignment: CrossAxisAlignment.stretch,
-            children: [
-              ...switch (_flow.state.value) {
-                UrlInput() => _buildUrlInput(context),
-                Probing() => _buildProbing(context),
-                InsecureWarning(:final probeResult) =>
-                  _buildInsecureWarning(context, probeResult),
-                Consent(:final notice, :final probeResult, :final providers) =>
-                  _buildConsent(context, notice, probeResult, providers),
-                ProviderSelection(:final providers) =>
-                  _buildProviderSelection(context, providers),
-                Authenticating() => _buildAuthenticating(context),
-                Connected() => _buildAuthenticating(context),
-              },
-              if (servers.isNotEmpty && _flow.state.value is UrlInput)
-                ..._buildServerSection(context, servers),
-            ],
-          ),
-        ),
+  /// A single centered heading for a flow state. The persistent [HomeShell]
+  /// top bar now carries the brand mark and name, so each state only needs to
+  /// name itself. PR2 reshapes these into title + description blocks.
+  Widget _heading(BuildContext context, String text) {
+    return Padding(
+      padding: const EdgeInsets.only(bottom: SoliplexSpacing.s6),
+      child: Text(
+        text,
+        style: Theme.of(context).textTheme.titleLarge,
+        textAlign: TextAlign.center,
       ),
     );
-  }
-
-  // -- Header --
-
-  List<Widget> _buildHeader(BuildContext context, String subtitle) {
-    final theme = Theme.of(context);
-
-    return [
-      if (widget.logo != null)
-        // Centered so the fixed-size box survives the header Column's
-        // CrossAxisAlignment.stretch — otherwise the logo (and any glow
-        // backplate behind it) gets stretched to the full column width.
-        Center(
-          child: SizedBox(
-            width: _logoSize,
-            height: _logoSize,
-            child: widget.logo,
-          ),
-        )
-      else
-        Icon(
-          Icons.dns_outlined,
-          size: _logoSize,
-          color: theme.colorScheme.primary,
-        ),
-      const SizedBox(height: SoliplexSpacing.s4),
-      Text(
-        widget.appName,
-        style: theme.textTheme.headlineMedium,
-        textAlign: TextAlign.center,
-      ),
-      const SizedBox(height: SoliplexSpacing.s2),
-      Text(
-        subtitle,
-        style: theme.textTheme.bodyMedium?.copyWith(
-          color: theme.colorScheme.onSurfaceVariant,
-        ),
-        textAlign: TextAlign.center,
-      ),
-      const SizedBox(height: SoliplexSpacing.s6),
-    ];
   }
 
   // -- State UIs --
@@ -229,7 +191,7 @@ class _HomeScreenState extends ConsumerState<HomeScreen> {
     final message = (_flow.state.value as UrlInput).message;
 
     return [
-      ..._buildHeader(context, 'Enter the URL of your backend server'),
+      _heading(context, 'Connect to a Soliplex server'),
       Form(
         key: _formKey,
         child: SoliplexInput(
@@ -267,7 +229,7 @@ class _HomeScreenState extends ConsumerState<HomeScreen> {
 
   List<Widget> _buildProbing(BuildContext context) {
     return [
-      ..._buildHeader(context, 'Connecting...'),
+      _heading(context, 'Probing server…'),
       const Center(child: CircularProgressIndicator()),
     ];
   }
@@ -279,7 +241,7 @@ class _HomeScreenState extends ConsumerState<HomeScreen> {
     final theme = Theme.of(context);
 
     return [
-      ..._buildHeader(context, 'Insecure Connection'),
+      _heading(context, 'Insecure connection'),
       Icon(Icons.warning_amber, size: 48, color: theme.colorScheme.warning),
       const SizedBox(height: SoliplexSpacing.s4),
       Text(
@@ -314,7 +276,7 @@ class _HomeScreenState extends ConsumerState<HomeScreen> {
     List<AuthProviderConfig> providers,
   ) {
     return [
-      ..._buildHeader(context, 'Sign in to continue'),
+      _heading(context, 'Before you connect'),
       Text(notice.title, style: Theme.of(context).textTheme.titleLarge),
       const SizedBox(height: SoliplexSpacing.s4),
       Text(notice.body, style: Theme.of(context).textTheme.bodyMedium),
@@ -341,7 +303,7 @@ class _HomeScreenState extends ConsumerState<HomeScreen> {
     List<AuthProviderConfig> providers,
   ) {
     return [
-      ..._buildHeader(context, 'Sign in to continue'),
+      _heading(context, 'Sign in to continue'),
       Text(
         'Choose authentication provider',
         style: Theme.of(context).textTheme.titleMedium,
@@ -365,7 +327,7 @@ class _HomeScreenState extends ConsumerState<HomeScreen> {
 
   List<Widget> _buildAuthenticating(BuildContext context) {
     return [
-      ..._buildHeader(context, 'Signing in...'),
+      _heading(context, 'Finish signing in'),
       const Center(child: CircularProgressIndicator()),
     ];
   }
@@ -472,20 +434,6 @@ class _HomeScreenState extends ConsumerState<HomeScreen> {
     _flow.connect(
       _urlController.text.trim(),
       returnTo: widget.autoConnectReturnTo,
-    );
-  }
-}
-
-class _VersionFooter extends StatelessWidget {
-  const _VersionFooter();
-
-  @override
-  Widget build(BuildContext context) {
-    return Center(
-      child: SoliplexButton.text(
-        onPressed: () => context.push(AppRoutes.versions),
-        child: const Text('Versions'),
-      ),
     );
   }
 }

--- a/lib/src/modules/auth/ui/home_shell.dart
+++ b/lib/src/modules/auth/ui/home_shell.dart
@@ -1,0 +1,109 @@
+import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
+import 'package:soliplex_design/soliplex_design.dart';
+
+import '../../../../version.dart';
+import '../../../core/routes.dart';
+
+/// Shared chrome for the unauthenticated onboarding surfaces (home /
+/// connect flow, the OAuth callback, and the server list).
+///
+/// Renders a persistent branded top bar — logo, app name, library version,
+/// and an about/versions affordance — above a centered, width-capped content
+/// column. Individual surfaces supply only their [child] body; the framing
+/// stays identical across the whole flow so it reads as one product.
+class HomeShell extends StatelessWidget {
+  const HomeShell({
+    super.key,
+    required this.appName,
+    required this.child,
+    this.logo,
+    this.maxContentWidth = 400,
+  });
+
+  final String appName;
+  final Widget child;
+  final Widget? logo;
+
+  /// Max width of the centered content column so forms and cards don't
+  /// stretch edge-to-edge on desktop/web.
+  final double maxContentWidth;
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      body: SafeArea(
+        child: Column(
+          children: [
+            _HomeShellHeader(appName: appName, logo: logo),
+            Expanded(
+              child: Center(
+                child: SingleChildScrollView(
+                  padding: const EdgeInsets.all(SoliplexSpacing.s6),
+                  child: ConstrainedBox(
+                    constraints: BoxConstraints(maxWidth: maxContentWidth),
+                    child: child,
+                  ),
+                ),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _HomeShellHeader extends StatelessWidget {
+  const _HomeShellHeader({required this.appName, this.logo});
+
+  final String appName;
+  final Widget? logo;
+
+  static const _logoSize = 24.0;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final colors = theme.colorScheme;
+
+    return Container(
+      padding: const EdgeInsets.symmetric(
+        horizontal: SoliplexSpacing.s4,
+        vertical: SoliplexSpacing.s3,
+      ),
+      decoration: BoxDecoration(
+        border: Border(bottom: BorderSide(color: colors.outlineVariant)),
+      ),
+      child: Row(
+        children: [
+          SizedBox(
+            width: _logoSize,
+            height: _logoSize,
+            child: logo ??
+                Icon(
+                  Icons.dns_outlined,
+                  size: _logoSize,
+                  color: colors.primary,
+                ),
+          ),
+          const SizedBox(width: SoliplexSpacing.s2),
+          Text(appName, style: theme.textTheme.titleSmall),
+          const SizedBox(width: SoliplexSpacing.s2),
+          Text(
+            soliplexVersion,
+            style: context
+                .monospaceOn(theme.textTheme.labelSmall)
+                .copyWith(color: colors.onSurfaceVariant),
+          ),
+          const Spacer(),
+          IconButton(
+            tooltip: 'About & versions',
+            icon: const Icon(Icons.info_outline),
+            onPressed: () => context.push(AppRoutes.versions),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/test/modules/auth/ui/connect_flow_rail_test.dart
+++ b/test/modules/auth/ui/connect_flow_rail_test.dart
@@ -69,5 +69,44 @@ void main() {
       await tester.pumpWidget(host(ConnectStep.url));
       expect(find.byIcon(Icons.check), findsNothing);
     });
+
+    // Confirms the rail actually scrolls once its content is wider than the
+    // visible space, rather than overflowing or shrinking to fit.
+    testWidgets('scrolls horizontally when wider than its column',
+        (tester) async {
+      // A column far narrower than the seven-node strip's intrinsic width.
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Scaffold(
+            body: Center(
+              child: SizedBox(
+                width: 120,
+                child: ConnectFlowRail(current: ConnectStep.connected),
+              ),
+            ),
+          ),
+        ),
+      );
+
+      // No RenderFlex overflow was thrown while laying the strip out.
+      expect(tester.takeException(), isNull);
+
+      final scrollable = find.descendant(
+        of: find.byType(ConnectFlowRail),
+        matching: find.byType(Scrollable),
+      );
+      expect(scrollable, findsOneWidget);
+
+      // The content genuinely exceeds the visible width (there is room to
+      // scroll), and starts pinned at the left edge.
+      final position = tester.state<ScrollableState>(scrollable).position;
+      expect(position.maxScrollExtent, greaterThan(0));
+      expect(position.pixels, 0);
+
+      // Dragging moves the strip — proving it scrolls rather than clips.
+      await tester.drag(scrollable, const Offset(-80, 0));
+      await tester.pump();
+      expect(position.pixels, greaterThan(0));
+    });
   });
 }

--- a/test/modules/auth/ui/connect_flow_rail_test.dart
+++ b/test/modules/auth/ui/connect_flow_rail_test.dart
@@ -1,0 +1,73 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:soliplex_frontend/src/modules/auth/connect_flow.dart';
+import 'package:soliplex_frontend/src/modules/auth/connection_probe.dart';
+import 'package:soliplex_frontend/src/modules/auth/consent_notice.dart';
+import 'package:soliplex_frontend/src/modules/auth/ui/connect_flow_rail.dart';
+
+final _probeResult = ConnectionSuccess(
+  serverUrl: Uri.parse('https://example.com'),
+  providers: const [],
+);
+
+void main() {
+  group('stepForConnectState', () {
+    test('maps each ConnectState to its rail node', () {
+      expect(stepForConnectState(const UrlInput()), ConnectStep.url);
+      expect(stepForConnectState(const Probing()), ConnectStep.probe);
+      expect(
+        stepForConnectState(
+          InsecureWarning(probeResult: _probeResult, providers: const []),
+        ),
+        ConnectStep.insecure,
+      );
+      expect(
+        stepForConnectState(
+          Consent(
+            notice: const ConsentNotice(title: 'T', body: 'B'),
+            probeResult: _probeResult,
+            providers: const [],
+          ),
+        ),
+        ConnectStep.consent,
+      );
+      expect(
+        stepForConnectState(
+          ProviderSelection(probeResult: _probeResult, providers: const []),
+        ),
+        ConnectStep.provider,
+      );
+      expect(stepForConnectState(const Authenticating()), ConnectStep.auth);
+      expect(stepForConnectState(const Connected()), ConnectStep.connected);
+    });
+  });
+
+  group('ConnectFlowRail', () {
+    Widget host(ConnectStep current) => MaterialApp(
+          home: Scaffold(
+            body: Center(child: ConnectFlowRail(current: current)),
+          ),
+        );
+
+    testWidgets('renders every step label', (tester) async {
+      await tester.pumpWidget(host(ConnectStep.provider));
+      for (final step in ConnectStep.values) {
+        expect(find.text(step.label), findsOneWidget);
+      }
+    });
+
+    testWidgets('marks every preceding step with a check', (tester) async {
+      // At the provider step, url/probe/insecure/consent precede it.
+      await tester.pumpWidget(host(ConnectStep.provider));
+      expect(
+        find.byIcon(Icons.check),
+        findsNWidgets(ConnectStep.provider.index),
+      );
+    });
+
+    testWidgets('shows no checks at the first step', (tester) async {
+      await tester.pumpWidget(host(ConnectStep.url));
+      expect(find.byIcon(Icons.check), findsNothing);
+    });
+  });
+}

--- a/test/modules/auth/ui/home_screen_test.dart
+++ b/test/modules/auth/ui/home_screen_test.dart
@@ -13,7 +13,9 @@ import 'package:soliplex_frontend/src/modules/auth/platform/auth_flow.dart';
 import 'package:soliplex_frontend/src/modules/auth/pre_auth_state.dart';
 import 'package:soliplex_frontend/src/modules/auth/server_entry.dart';
 import 'package:soliplex_frontend/src/modules/auth/server_manager.dart';
+import 'package:soliplex_frontend/src/modules/auth/ui/connect_flow_rail.dart';
 import 'package:soliplex_frontend/src/modules/auth/ui/home_screen.dart';
+import 'package:soliplex_frontend/version.dart';
 
 import '../../../helpers/fakes.dart';
 
@@ -156,7 +158,7 @@ void main() {
       expect(find.text('Connect'), findsOneWidget);
       expect(find.text('Soliplex'), findsOneWidget);
       expect(
-        find.text('Enter the URL of your backend server'),
+        find.text('Connect to a Soliplex server'),
         findsOneWidget,
       );
     });
@@ -171,6 +173,38 @@ void main() {
 
       expect(find.text('MyApp'), findsOneWidget);
       expect(find.text('Soliplex'), findsNothing);
+    });
+
+    testWidgets('shows the library version in the top bar', (tester) async {
+      final serverManager = _createServerManager();
+      await tester.pumpWidget(_buildApp(serverManager: serverManager));
+      await tester.pumpAndSettle();
+
+      expect(find.text(soliplexVersion), findsOneWidget);
+    });
+
+    testWidgets('hides the flow rail on narrow viewports', (tester) async {
+      final serverManager = _createServerManager();
+      await tester.pumpWidget(_buildApp(serverManager: serverManager));
+      await tester.pumpAndSettle();
+
+      // Default test viewport (800px) is below the desktop breakpoint.
+      expect(find.byType(ConnectFlowRail), findsNothing);
+    });
+
+    testWidgets('shows the flow rail on wide viewports', (tester) async {
+      tester.view.physicalSize = const Size(1200, 900);
+      tester.view.devicePixelRatio = 1.0;
+      addTearDown(tester.view.resetPhysicalSize);
+      addTearDown(tester.view.resetDevicePixelRatio);
+
+      final serverManager = _createServerManager();
+      await tester.pumpWidget(_buildApp(serverManager: serverManager));
+      await tester.pumpAndSettle();
+
+      expect(find.byType(ConnectFlowRail), findsOneWidget);
+      // On the URL-input state, the URL node is current.
+      expect(find.text(ConnectStep.url.label), findsOneWidget);
     });
 
     testWidgets('shows logo when provided', (tester) async {
@@ -360,7 +394,7 @@ void main() {
       await tester.pump();
 
       // Inline insecure warning
-      expect(find.text('Insecure Connection'), findsOneWidget);
+      expect(find.text('Insecure connection'), findsOneWidget);
       expect(find.textContaining('not encrypted'), findsOneWidget);
     });
 
@@ -419,7 +453,7 @@ void main() {
       await tester.pumpAndSettle();
 
       expect(find.text('Sign in to continue'), findsOneWidget);
-      expect(find.text('Enter the URL of your backend server'), findsNothing);
+      expect(find.text('Connect to a Soliplex server'), findsNothing);
     });
 
     testWidgets('shows "Change server" button on provider selection phase',
@@ -443,7 +477,7 @@ void main() {
       await tester.pumpAndSettle();
 
       expect(find.byType(TextFormField), findsOneWidget);
-      expect(find.text('Enter the URL of your backend server'), findsOneWidget);
+      expect(find.text('Connect to a Soliplex server'), findsOneWidget);
     });
 
     testWidgets('hides server section on provider selection phase',


### PR DESCRIPTION
## Onboarding redesign — PR 1 of 3: shared chrome

Aligns the auth ("Onboarding") module with the standalone mockup, starting
with the framing that every connect-flow surface shares. This is the
foundation the next two PRs build on.

### What's here

- **`HomeShell`** — a persistent branded top bar (logo + app name + library
  version + an about/versions `ⓘ` affordance) over a centered, width-capped
  content column. Replaces `HomeScreen`'s ad-hoc per-state header (a big
  centered logo + name + subtitle) and the bottom "Versions" button.
- **`ConnectFlowRail`** — a breadcrumb of the `ConnectState` state machine
  (URL → Probe → [Insecure?] → [Consent?] → Provider → Auth → Connected).
  Current step highlighted, completed steps checked, the two optional steps
  softened until reached. **Desktop-only** (shown at
  `≥ SoliplexBreakpoints.desktop`); on narrow viewports the per-state heading
  carries the context. Scrolls horizontally when wider than its column rather
  than shrinking, so every label stays legible.
- **Wiring** — `HomeScreen` now renders inside `HomeShell` and shows the rail
  above the state body on wide viewports. Each flow state contributes just a
  heading for now; **PR2** reshapes those into the mockup's title + description
  blocks and redesigns the state bodies.

### Notes / decisions

- The top-bar `ⓘ` reuses the existing `/versions` route as the "about"
  surface (consolidating the old footer button).
- Version shown is the canonical `soliplexVersion` (the *library* version, not
  a fork's app version).

### Not in this PR (follow-ups in the stack)

- **PR2** — per-state body redesign (URL input, probing, insecure, consent,
  provider tiles, authenticating).
- **PR3** — `auth_callback_screen` + `server_list_screen` surfaces.

### Verification

- `flutter analyze` clean.
- Auth suite green (284 tests), including new coverage: rail step-mapping,
  completed-step checks, version-in-top-bar, viewport gating, and a
  constrained-width test proving the rail scrolls (no overflow,
  `maxScrollExtent > 0`, drag advances offset).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
