### PR TITLE
refactor(lobby): drop dead cellWidth from room grid layout

### DIFF
--- a/lib/src/modules/lobby/ui/lobby_screen.dart
+++ b/lib/src/modules/lobby/ui/lobby_screen.dart
@@ -853,7 +853,7 @@ class _ServerSection extends StatelessWidget {
 /// Lives inside the outer room `ListView`, so it lays the cards out as a
 /// [Column] of [IntrinsicHeight] rows rather than a nested scrollable grid.
 /// Each row stretches its cells with [Expanded] so cards in a row share the
-/// tallest one's height. Only the column count comes from [roomGridLayout].
+/// tallest one's height. Only the column count comes from [roomGridColumns].
 class _RoomGrid extends StatelessWidget {
   const _RoomGrid({
     required this.serverId,
@@ -876,8 +876,7 @@ class _RoomGrid extends StatelessWidget {
       child: LayoutBuilder(
         builder: (context, constraints) {
           const spacing = SoliplexSpacing.s3;
-          final columns =
-              roomGridLayout(constraints.maxWidth, spacing: spacing).columns;
+          final columns = roomGridColumns(constraints.maxWidth);
           // Lay the cards out as explicit rows rather than a Wrap so each row
           // can be wrapped in an IntrinsicHeight: cards in the same row then
           // share the tallest one's height and read as a regular grid,

--- a/lib/src/modules/lobby/ui/room_grid_layout.dart
+++ b/lib/src/modules/lobby/ui/room_grid_layout.dart
@@ -1,21 +1,13 @@
 import 'package:soliplex_design/soliplex_design.dart';
 
-/// Column count and cell width for the lobby room grid at a given [width],
-/// laid out with [spacing] between cells.
+/// Column count for the lobby room grid at a given [width].
 ///
 /// Three columns at [SoliplexBreakpoints.desktop] and wider, two at
-/// [SoliplexBreakpoints.mobile] and wider, one below that. The cell width
-/// removes the inter-cell gaps (`columns - 1` of them) before dividing the
-/// remaining width evenly.
-({int columns, double cellWidth}) roomGridLayout(
-  double width, {
-  double spacing = SoliplexSpacing.s3,
-}) {
-  final columns = width >= SoliplexBreakpoints.desktop
+/// [SoliplexBreakpoints.mobile] and wider, one below that.
+int roomGridColumns(double width) {
+  return width >= SoliplexBreakpoints.desktop
       ? 3
       : width >= SoliplexBreakpoints.mobile
           ? 2
           : 1;
-  final cellWidth = (width - spacing * (columns - 1)) / columns;
-  return (columns: columns, cellWidth: cellWidth);
 }

--- a/test/modules/lobby/ui/room_grid_layout_test.dart
+++ b/test/modules/lobby/ui/room_grid_layout_test.dart
@@ -3,32 +3,19 @@ import 'package:soliplex_design/soliplex_design.dart';
 import 'package:soliplex_frontend/src/modules/lobby/ui/room_grid_layout.dart';
 
 void main() {
-  group('roomGridLayout columns', () {
+  group('roomGridColumns', () {
     test('one column below the mobile breakpoint', () {
-      expect(roomGridLayout(SoliplexBreakpoints.mobile - 1).columns, 1);
+      expect(roomGridColumns(SoliplexBreakpoints.mobile - 1), 1);
     });
 
     test('two columns from the mobile breakpoint up to desktop', () {
-      expect(roomGridLayout(SoliplexBreakpoints.mobile).columns, 2);
-      expect(roomGridLayout(SoliplexBreakpoints.desktop - 1).columns, 2);
+      expect(roomGridColumns(SoliplexBreakpoints.mobile), 2);
+      expect(roomGridColumns(SoliplexBreakpoints.desktop - 1), 2);
     });
 
     test('three columns at the desktop breakpoint and wider', () {
-      expect(roomGridLayout(SoliplexBreakpoints.desktop).columns, 3);
-      expect(roomGridLayout(SoliplexBreakpoints.desktop + 200).columns, 3);
-    });
-  });
-
-  group('roomGridLayout cellWidth', () {
-    test('fills the full width in a single column', () {
-      expect(roomGridLayout(300, spacing: 12).cellWidth, 300);
-    });
-
-    test('subtracts the inter-cell gaps before dividing', () {
-      // Two columns: one gap. (600 - 12) / 2.
-      expect(roomGridLayout(600, spacing: 12).cellWidth, 294);
-      // Three columns: two gaps. (840 - 24) / 3.
-      expect(roomGridLayout(840, spacing: 12).cellWidth, 272);
+      expect(roomGridColumns(SoliplexBreakpoints.desktop), 3);
+      expect(roomGridColumns(SoliplexBreakpoints.desktop + 200), 3);
     });
   });
 }


### PR DESCRIPTION
## Summary

`roomGridLayout` returned `({int columns, double cellWidth})` and took a
`spacing` param, but the grid lays its cells out with `Expanded` inside
`IntrinsicHeight` rows — cells size themselves, so the precomputed
`cellWidth` had no consumer, and `spacing` existed only to feed it.

- Collapse `roomGridLayout(width, {spacing})` → `int roomGridColumns(double width)`.
- Update the `_RoomGrid` call site (the local `spacing` const stays — it still drives the inter-cell `SizedBox` gaps) and the docstring reference.
- Delete the `cellWidth` test group; rename the column-count group to `roomGridColumns`.

No behavior change — purely removes dead code. (Item 2 of the PR #328 follow-ups.)

## Test plan

- `flutter analyze` — zero warnings.
- `flutter test test/modules/lobby/ui/room_grid_layout_test.dart test/modules/lobby/ui/lobby_screen_test.dart` — 20 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)