### PR TITLE
fix(auth): persist backend URL after web OIDC sign-in

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,8 @@ Versions follow the `version+build` scheme from `pubspec.yaml`, bumped via
 
 ### Fixed
 
+- Auth: persist the last-connected backend URL after a web OIDC sign-in, so the
+  empty home screen prefills it the same way it does after a native sign-in.
 - Lobby: adding and signing in to a new server now selects that server on
   return, instead of restoring the previously viewed one. The connected server
   is persisted as the active selection at each connect-success point.

--- a/lib/src/modules/auth/default_backend_url.dart
+++ b/lib/src/modules/auth/default_backend_url.dart
@@ -1,3 +1,5 @@
+import 'dart:developer' as dev;
+
 import 'package:shared_preferences/shared_preferences.dart';
 
 /// Resolves the default backend URL using platform logic.
@@ -16,6 +18,14 @@ String platformDefaultBackendUrl({
 }
 
 /// Persists and retrieves the user's last-connected backend URL.
+///
+/// Backed by `shared_preferences` (a non-sensitive UI preference used only to
+/// prefill the URL field on the empty home screen).
+///
+/// [load] propagates failures so its caller can fall back to
+/// [platformDefaultBackendUrl]; [save] is best-effort and never throws,
+/// because its callers sit on a connect-success path where a failed write must
+/// not derail the flow.
 abstract final class DefaultBackendUrlStorage {
   static const _key = 'backend_base_url';
 
@@ -26,8 +36,23 @@ abstract final class DefaultBackendUrlStorage {
     return url;
   }
 
+  /// Persists [url] as the last-connected backend.
+  ///
+  /// Best-effort: a storage failure is logged and swallowed rather than
+  /// thrown (see the class doc), so it can't bounce a successful connect to
+  /// an error state. A missed write just falls back to the platform default
+  /// on the next launch.
   static Future<void> save(String url) async {
-    final prefs = await SharedPreferences.getInstance();
-    await prefs.setString(_key, url);
+    try {
+      final prefs = await SharedPreferences.getInstance();
+      await prefs.setString(_key, url);
+    } catch (e, st) {
+      dev.log(
+        'Failed to persist default backend url ($url)',
+        error: e,
+        stackTrace: st,
+        level: 1000,
+      );
+    }
   }
 }

--- a/lib/src/modules/auth/ui/auth_callback_screen.dart
+++ b/lib/src/modules/auth/ui/auth_callback_screen.dart
@@ -8,6 +8,7 @@ import '../../../core/routes.dart';
 import '../auth_failure_description.dart';
 import '../auth_providers.dart';
 import '../auth_tokens.dart';
+import '../default_backend_url.dart';
 import '../platform/auth_flow.dart';
 import '../platform/callback_params.dart';
 import '../pre_auth_state.dart';
@@ -94,6 +95,10 @@ class _AuthCallbackScreenState extends ConsumerState<AuthCallbackScreen> {
       // Record the connected server as the active selection so the lobby
       // restores it on its next boot (best-effort; never throws).
       await SelectedServerStorage.save(serverId);
+
+      // Mirror the native sign-in: persist the backend URL so the empty home
+      // screen prefills it (best-effort; never throws).
+      await DefaultBackendUrlStorage.save(preAuth.serverUrl.toString());
 
       if (mounted) context.go(_safeReturnTo(preAuth.frontendReturnTo));
     } catch (e, st) {

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -70,10 +70,10 @@ packages:
     dependency: transitive
     description:
       name: characters
-      sha256: faf38497bda5ead2a8c7615f4f7939df04333478bf32e4173fcb06d428b5716b
+      sha256: f71061c654a3380576a52b451dd5532377954cf9dbd272a78fc8479606670803
       url: "https://pub.dev"
     source: hosted
-    version: "1.4.1"
+    version: "1.4.0"
   checked_yaml:
     dependency: transitive
     description:
@@ -481,6 +481,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.0.1"
+  js:
+    dependency: transitive
+    description:
+      name: js
+      sha256: "53385261521cc4a0c4658fd0ad07a7d14591cf8fc33abbceae306ddb974888dc"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.7.2"
   json_annotation:
     dependency: transitive
     description:
@@ -541,26 +549,26 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: dc0b7dc7651697ea4ff3e69ef44b0407ea32c487a39fff6a4004fa585e901861
+      sha256: dc58c723c3c24bf8d3e2d3ad3f2f9d7bd9cf43ec6feaa64181775e60190153f2
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.19"
+    version: "0.12.17"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: "9c337007e82b1889149c82ed242ed1cb24a66044e30979c44912381e9be4c48b"
+      sha256: f7142bb1154231d7ea5f96bc7bde4bda2a0945d2806bb11670e30b850d56bdec
       url: "https://pub.dev"
     source: hosted
-    version: "0.13.0"
+    version: "0.11.1"
   meta:
     dependency: transitive
     description:
       name: meta
-      sha256: "1741988757a65eb6b36abe716829688cf01910bbf91c34354ff7ec1c3de2b349"
+      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
       url: "https://pub.dev"
     source: hosted
-    version: "1.18.0"
+    version: "1.17.0"
   mime:
     dependency: "direct main"
     description:
@@ -946,26 +954,26 @@ packages:
     dependency: transitive
     description:
       name: test
-      sha256: "8d9ceddbab833f180fbefed08afa76d7c03513dfdba87ffcec2718b02bbcbf20"
+      sha256: "75906bf273541b676716d1ca7627a17e4c4070a3a16272b7a3dc7da3b9f3f6b7"
       url: "https://pub.dev"
     source: hosted
-    version: "1.31.0"
+    version: "1.26.3"
   test_api:
     dependency: transitive
     description:
       name: test_api
-      sha256: "949a932224383300f01be9221c39180316445ecb8e7547f70a41a35bf421fb9e"
+      sha256: ab2726c1a94d3176a45960b6234466ec367179b87dd74f1611adb1f3b5fb9d55
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.11"
+    version: "0.7.7"
   test_core:
     dependency: transitive
     description:
       name: test_core
-      sha256: "1991d4cfe85d5043241acac92962c3977c8d2f2add1ee73130c7b286417d1d34"
+      sha256: "0cc24b5ff94b38d2ae73e1eb43cc302b77964fbf67abad1e296025b78deb53d0"
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.17"
+    version: "0.6.12"
   tuple:
     dependency: transitive
     description:

--- a/test/modules/auth/ui/auth_callback_screen_test.dart
+++ b/test/modules/auth/ui/auth_callback_screen_test.dart
@@ -7,6 +7,7 @@ import 'package:go_router/go_router.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:soliplex_frontend/src/modules/auth/auth_providers.dart';
 import 'package:soliplex_frontend/src/modules/auth/auth_session.dart';
+import 'package:soliplex_frontend/src/modules/auth/default_backend_url.dart';
 import 'package:soliplex_frontend/src/modules/auth/inactivity_logout_storage.dart';
 import 'package:soliplex_frontend/src/modules/auth/platform/callback_params.dart';
 import 'package:soliplex_frontend/src/modules/auth/pre_auth_state.dart';
@@ -208,6 +209,24 @@ void main() {
       await tester.pumpAndSettle();
 
       expect(await SelectedServerStorage.load(), serverId);
+    });
+
+    testWidgets('persists the connected backend url as the default',
+        (tester) async {
+      final serverManager = _createServerManager();
+      await PreAuthStateStorage.save(_validPreAuthState());
+
+      await tester.pumpWidget(_buildApp(
+        serverManager: serverManager,
+        callbackParams: const WebCallbackSuccess(
+          accessToken: 'access',
+          refreshToken: 'refresh',
+          expiresIn: 3600,
+        ),
+      ));
+      await tester.pumpAndSettle();
+
+      expect(await DefaultBackendUrlStorage.load(), 'https://api.example.com');
     });
 
     testWidgets('navigates to frontendReturnTo when set', (tester) async {


### PR DESCRIPTION
## Summary

Fixes #342. The last-connected backend URL (`DefaultBackendUrlStorage`, key `backend_base_url`) was persisted after a **native** OIDC sign-in and after a **no-auth** connect, but **not** after a **web** OIDC sign-in.

On web, `ConnectFlow._authenticate` throws `AuthRedirectInitiated` at the `authFlow.authenticate(...)` call — before reaching the native branch's `DefaultBackendUrlStorage.save(...)` — and the flow completes a page-load later in `AuthCallbackScreen`, which never wrote the URL. The empty home screen then prefilled the platform default instead of the user's last backend.

## Changes

- **`auth_callback_screen.dart`** — persist the backend URL on the web completion path, right after the existing `SelectedServerStorage.save`, mirroring the native branch.
- **`default_backend_url.dart`** — make `DefaultBackendUrlStorage.save` best-effort (log + swallow via `dev.log`), mirroring `SelectedServerStorage.save`. `_processCallback` wraps its body in a try/catch that routes any throw to the error screen, so an unguarded `save` could bounce an already-signed-in user to an error on a trivial prefs write failure. This also fixes a latent unobserved-throw at the native fire-and-forget call site. `load()` stays propagating so its caller can fall back to `platformDefaultBackendUrl`.

## Out of scope (deliberately not done)

- The already-connected early return in `connect()` — redundant, the URL is already saved on first connect.
- Folding the URL into `SelectedServerStorage` — they hold orthogonal data (server-id vs full URL; the URL is needed even when no server is selected).

## Tests

Added one regression test in `auth_callback_screen_test.dart` (TDD: confirmed failing first), asserting `DefaultBackendUrlStorage.load()` returns the URL after a successful web callback. Full auth suite green; analyzer, format, and markdown lint clean.

## Note

This branch also includes a separate commit realigning `pubspec.lock` to the pinned Flutter 3.38.7 (`.github/actions/setup-dart-env`). A prior dependabot bump regenerated the lock in dependabot's own image, which ships a newer SDK than the repo pins, leaving SDK-bundled packages (`meta`, `test`, `material_color_utilities`, …) inconsistent with the SDK both CI and local use.

🤖 Generated with [Claude Code](https://claude.com/claude-code)