### PR TITLE
fix(room): display backend timestamps in the viewer's local zone

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,10 @@ Versions follow the `version+build` scheme from `pubspec.yaml`, bumped via
 - soliplex_client: pin the `ag_ui` git dependency to a fixed ref for
   deterministic resolution; a floating HEAD pulled an incompatible release that
   broke web builds.
+- Room: render document and thread timestamps in the viewer's local time zone.
+  Backend timestamps are UTC, so the document card's date and time showed the
+  wrong time-of-day, and a week-old thread's date could be off by one, for any
+  viewer not in UTC.
 
 ## [0.88.0+58] - 2026-06-03
 

--- a/lib/src/modules/lobby/room_activity_format.dart
+++ b/lib/src/modules/lobby/room_activity_format.dart
@@ -1,31 +1,15 @@
-/// Formatting + bucketing for a room's most-recent-thread activity timestamp.
+/// Recency bucketing for a room's most-recent-thread activity timestamp.
 ///
-/// The lobby shows this both as a per-card relative label ("3h ago") and, when
-/// sorting by recent activity, as date-bucketed section headers ("Today",
-/// "Yesterday", ...) in the manner of an LLM chat history.
-///
-/// The label and the buckets use different recency models on purpose:
-/// [formatRelativeActivity] measures elapsed duration ("2d ago"), while
-/// [bucketFor] uses calendar-day deltas. So near a day boundary a room can read
-/// "23h ago" on its card yet sit under a "Yesterday" header (23h elapsed but
-/// the calendar day rolled over), and a timestamp old enough to show a numeric
-/// date (>7 days elapsed) always buckets under "This month"/"Older", never
-/// "This week" — expected, not a bug.
+/// When sorting by recent activity the lobby groups rooms under date-bucketed
+/// section headers ("Today", "Yesterday", ...) in the manner of an LLM chat
+/// history. The per-card relative label ("3h ago") comes from the shared
+/// `formatRelativeTime` helper; the buckets here use a different recency model
+/// on purpose. [bucketFor] uses calendar-day deltas, so near a day boundary a
+/// room can read "23h ago" on its card yet sit under a "Yesterday" header (23h
+/// elapsed but the calendar day rolled over), and a timestamp old enough to
+/// show a numeric date (>7 days elapsed) always buckets under "This
+/// month"/"Older", never "This week" — expected, not a bug.
 library;
-
-/// Short relative label for [time], e.g. "Just now", "5m ago", "3h ago",
-/// "2d ago", falling back to a numeric date for anything older than a week.
-String formatRelativeActivity(DateTime time, {DateTime? now}) {
-  final reference = now ?? DateTime.now();
-  final diff = reference.difference(time);
-  if (diff.inMinutes < 1) return 'Just now';
-  if (diff.inMinutes < 60) return '${diff.inMinutes}m ago';
-  if (diff.inHours < 24) return '${diff.inHours}h ago';
-  if (diff.inDays < 7) return '${diff.inDays}d ago';
-  // Backend timestamps are UTC; render the date in the viewer's zone.
-  final local = time.toLocal();
-  return '${local.month}/${local.day}/${local.year}';
-}
 
 /// Recency buckets used to group rooms under section headers. Ordered from
 /// most to least recent; [none] (no known timestamp) always sorts last.

--- a/lib/src/modules/lobby/ui/room_card.dart
+++ b/lib/src/modules/lobby/ui/room_card.dart
@@ -2,7 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:soliplex_agent/soliplex_agent.dart';
 import 'package:soliplex_design/soliplex_design.dart';
 
-import '../room_activity_format.dart';
+import '../../../shared/relative_time.dart';
 
 class RoomCard extends StatelessWidget {
   const RoomCard({
@@ -77,7 +77,7 @@ class RoomCard extends StatelessWidget {
         if (hasDescription) Text(room.description, style: muted),
         if (time != null) ...[
           if (hasDescription) const SizedBox(height: SoliplexSpacing.s1),
-          Text(formatRelativeActivity(time), style: muted),
+          Text(formatRelativeTime(time), style: muted),
         ],
       ],
     );

--- a/lib/src/modules/lobby/ui/room_grid_card.dart
+++ b/lib/src/modules/lobby/ui/room_grid_card.dart
@@ -2,7 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:soliplex_agent/soliplex_agent.dart';
 import 'package:soliplex_design/soliplex_design.dart';
 
-import '../room_activity_format.dart';
+import '../../../shared/relative_time.dart';
 
 /// Vertical card used for the lobby's grid layout: open on tap, info
 /// button, and a quiz indicator, in a shape that tiles cleanly into a
@@ -91,7 +91,7 @@ class RoomGridCard extends StatelessWidget {
                     child: activityTime == null
                         ? const SizedBox.shrink()
                         : Text(
-                            formatRelativeActivity(activityTime!),
+                            formatRelativeTime(activityTime!),
                             style: theme.textTheme.bodySmall?.copyWith(
                               color: theme.colorScheme.onSurfaceVariant,
                             ),

--- a/lib/src/modules/room/ui/room_info/documents_card.dart
+++ b/lib/src/modules/room/ui/room_info/documents_card.dart
@@ -277,10 +277,12 @@ class _DocumentsCardState extends State<DocumentsCard> {
   }
 
   String _formatDateTime(DateTime dt) {
-    return '${dt.year}-${dt.month.toString().padLeft(2, '0')}-'
-        '${dt.day.toString().padLeft(2, '0')} '
-        '${dt.hour.toString().padLeft(2, '0')}:'
-        '${dt.minute.toString().padLeft(2, '0')}';
+    // Backend timestamps are UTC; render in the viewer's zone.
+    final local = dt.toLocal();
+    return '${local.year}-${local.month.toString().padLeft(2, '0')}-'
+        '${local.day.toString().padLeft(2, '0')} '
+        '${local.hour.toString().padLeft(2, '0')}:'
+        '${local.minute.toString().padLeft(2, '0')}';
   }
 }
 

--- a/lib/src/modules/room/ui/thread_tile.dart
+++ b/lib/src/modules/room/ui/thread_tile.dart
@@ -4,6 +4,8 @@ import 'package:flutter/material.dart';
 import 'package:soliplex_agent/soliplex_agent.dart' hide State;
 import 'package:soliplex_design/soliplex_design.dart';
 
+import '../../../shared/relative_time.dart';
+
 enum _ThreadAction { rename, delete }
 
 class ThreadTile extends StatefulWidget {
@@ -58,7 +60,7 @@ class _ThreadTileState extends State<ThreadTile> {
           overflow: TextOverflow.ellipsis,
         ),
         subtitle: Text(
-          _formatRelativeTime(widget.thread.createdAt),
+          formatRelativeTime(widget.thread.createdAt),
           style: theme.textTheme.bodySmall,
         ),
         dense: true,
@@ -134,15 +136,5 @@ class _ThreadTileState extends State<ThreadTile> {
         ),
       ],
     );
-  }
-
-  static String _formatRelativeTime(DateTime dateTime) {
-    final now = DateTime.now();
-    final diff = now.difference(dateTime);
-    if (diff.inMinutes < 1) return 'Just now';
-    if (diff.inMinutes < 60) return '${diff.inMinutes}m ago';
-    if (diff.inHours < 24) return '${diff.inHours}h ago';
-    if (diff.inDays < 7) return '${diff.inDays}d ago';
-    return '${dateTime.month}/${dateTime.day}/${dateTime.year}';
   }
 }

--- a/lib/src/shared/relative_time.dart
+++ b/lib/src/shared/relative_time.dart
@@ -1,0 +1,17 @@
+/// Short relative label for [time], e.g. "Just now", "5m ago", "3h ago",
+/// "2d ago", falling back to a numeric date (M/D/YYYY) for anything older than
+/// a week.
+///
+/// Backend timestamps arrive as UTC instants, so [time] is converted to the
+/// viewer's zone up front: every calendar field read below is local, and the
+/// numeric-date fallback shows the viewer's date rather than the UTC date.
+String formatRelativeTime(DateTime time, {DateTime? now}) {
+  final local = time.toLocal();
+  final reference = now ?? DateTime.now();
+  final diff = reference.difference(local);
+  if (diff.inMinutes < 1) return 'Just now';
+  if (diff.inMinutes < 60) return '${diff.inMinutes}m ago';
+  if (diff.inHours < 24) return '${diff.inHours}h ago';
+  if (diff.inDays < 7) return '${diff.inDays}d ago';
+  return '${local.month}/${local.day}/${local.year}';
+}

--- a/test/modules/lobby/room_activity_format_test.dart
+++ b/test/modules/lobby/room_activity_format_test.dart
@@ -4,52 +4,6 @@ import 'package:soliplex_frontend/src/modules/lobby/room_activity_format.dart';
 void main() {
   final now = DateTime(2026, 6, 9, 12);
 
-  group('formatRelativeActivity', () {
-    test('renders minute/hour/day granularity then a numeric date', () {
-      expect(
-        formatRelativeActivity(now.subtract(const Duration(seconds: 30)),
-            now: now),
-        'Just now',
-      );
-      expect(
-        formatRelativeActivity(now.subtract(const Duration(minutes: 5)),
-            now: now),
-        '5m ago',
-      );
-      expect(
-        formatRelativeActivity(now.subtract(const Duration(hours: 3)),
-            now: now),
-        '3h ago',
-      );
-      expect(
-        formatRelativeActivity(now.subtract(const Duration(days: 2)), now: now),
-        '2d ago',
-      );
-      // Older than a week → numeric date (M/D/YYYY).
-      expect(
-        formatRelativeActivity(DateTime(2026, 1, 15), now: now),
-        '1/15/2026',
-      );
-    });
-
-    test('switches label exactly at each threshold', () {
-      String at(Duration ago) =>
-          formatRelativeActivity(now.subtract(ago), now: now);
-      // minute boundary
-      expect(at(const Duration(seconds: 59)), 'Just now');
-      expect(at(const Duration(minutes: 1)), '1m ago');
-      // minute → hour
-      expect(at(const Duration(minutes: 59)), '59m ago');
-      expect(at(const Duration(hours: 1)), '1h ago');
-      // hour → day
-      expect(at(const Duration(hours: 23)), '23h ago');
-      expect(at(const Duration(hours: 24)), '1d ago');
-      // day → numeric date at exactly a week
-      expect(at(const Duration(days: 6)), '6d ago');
-      expect(at(const Duration(days: 7)), '6/2/2026');
-    });
-  });
-
   group('bucketFor', () {
     test('null maps to the no-activity bucket', () {
       expect(bucketFor(null, now: now), ActivityBucket.none);

--- a/test/modules/room/ui/room_info/documents_card_test.dart
+++ b/test/modules/room/ui/room_info/documents_card_test.dart
@@ -268,6 +268,39 @@ void main() {
       expect(find.text('2024-03-15 10:30'), findsOneWidget);
       expect(find.text('2024-06-20 14:45'), findsOneWidget);
     });
+
+    // Regression for issue #338: backend timestamps are UTC instants, so the
+    // rendered date+time must be the viewer's local clock, not raw UTC fields.
+    // Caveat: only fails on a runner whose zone differs from UTC.
+    testWidgets('renders a UTC timestamp in the viewer local zone',
+        (tester) async {
+      final utcCreated = DateTime.utc(2024, 3, 15, 2, 30);
+      final local = utcCreated.toLocal();
+      final expected = '${local.year}-${local.month.toString().padLeft(2, '0')}'
+          '-${local.day.toString().padLeft(2, '0')} '
+          '${local.hour.toString().padLeft(2, '0')}:'
+          '${local.minute.toString().padLeft(2, '0')}';
+
+      final doc = RagDocument(
+        id: 'id-utc',
+        title: 'UTC Doc',
+        uri: '/files/utc.txt',
+        createdAt: utcCreated,
+      );
+
+      await tester.pumpWidget(wrap(
+        DocumentsCard(
+          documentsFuture: Future.value([doc]),
+          onRetry: () {},
+        ),
+      ));
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.text('utc.txt'));
+      await tester.pump();
+
+      expect(find.text(expected), findsOneWidget);
+    });
   });
 
   group('metadata dialog', () {

--- a/test/shared/relative_time_test.dart
+++ b/test/shared/relative_time_test.dart
@@ -1,0 +1,59 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:soliplex_frontend/src/shared/relative_time.dart';
+
+void main() {
+  final now = DateTime(2026, 6, 9, 12);
+
+  group('formatRelativeTime', () {
+    test('renders minute/hour/day granularity then a numeric date', () {
+      expect(
+        formatRelativeTime(now.subtract(const Duration(seconds: 30)), now: now),
+        'Just now',
+      );
+      expect(
+        formatRelativeTime(now.subtract(const Duration(minutes: 5)), now: now),
+        '5m ago',
+      );
+      expect(
+        formatRelativeTime(now.subtract(const Duration(hours: 3)), now: now),
+        '3h ago',
+      );
+      expect(
+        formatRelativeTime(now.subtract(const Duration(days: 2)), now: now),
+        '2d ago',
+      );
+      expect(
+        formatRelativeTime(DateTime(2026, 1, 15), now: now),
+        '1/15/2026',
+      );
+    });
+
+    test('switches label exactly at each threshold', () {
+      String at(Duration ago) =>
+          formatRelativeTime(now.subtract(ago), now: now);
+      expect(at(const Duration(seconds: 59)), 'Just now');
+      expect(at(const Duration(minutes: 1)), '1m ago');
+      expect(at(const Duration(minutes: 59)), '59m ago');
+      expect(at(const Duration(hours: 1)), '1h ago');
+      expect(at(const Duration(hours: 23)), '23h ago');
+      expect(at(const Duration(hours: 24)), '1d ago');
+      expect(at(const Duration(days: 6)), '6d ago');
+      expect(at(const Duration(days: 7)), '6/2/2026');
+    });
+
+    // Regression for issue #338: the numeric-date fallback must read the
+    // viewer's local calendar fields, not the raw UTC instant. Backend
+    // timestamps arrive in UTC, so a date rendered from UTC fields is off by a
+    // day for viewers whose local day differs. Caveat: this can only fail on a
+    // runner whose zone differs from UTC; on a UTC runner both sides coincide.
+    test('renders the numeric-date fallback in the viewer local zone', () {
+      final utcInstant = DateTime.utc(2026, 1, 15, 3);
+      final local = utcInstant.toLocal();
+      final reference = utcInstant.add(const Duration(days: 30));
+      expect(
+        formatRelativeTime(utcInstant, now: reference),
+        '${local.month}/${local.day}/${local.year}',
+      );
+    });
+  });
+}


### PR DESCRIPTION
## What

Backend timestamps arrive as UTC instants (`parseTimestamp` appends `Z` and calls `.toUtc()`). Two room display sites read calendar fields off those instants **without** `.toLocal()` first, so they rendered the wrong time-of-day (or a date off by one) for any viewer outside UTC:

- `documents_card.dart` `_formatDateTime` — full date **and** time, wrong hour on every render.
- `thread_tile.dart` `_formatRelativeTime` — the `>7-day` numeric-date fallback only.

Both bugs originated from copy-pasting a relative-time formatter that read raw fields, so the fix also removes that duplication.

## Changes

- **Fix:** `.toLocal()` at both display sites.
- **Consolidate:** extract the duplicated relative-time label into a shared, already-localized `formatRelativeTime` in `lib/src/shared/relative_time.dart`, with `.toLocal()` normalized at the top of the function so the fallback can't regress. `thread_tile`, `room_card`, and `room_grid_card` all call it; the duplicate `_formatRelativeTime` and lobby's `formatRelativeActivity` are deleted.
- **Kept in place:** lobby's `bucketFor` / `ActivityBucket` (single consumer, lobby-specific section headers); `documents_card`'s absolute formatter (different concept, single caller — not shared).

## Design notes

`shared/` (not `core/`) is the home: `core/` is shell infrastructure, and a pure presentation helper shared by two sibling modules must live below both — `room → lobby` would be a wrong directional dependency. `shared/` already holds the pure-function `file_type_icons.dart`.

## Tests

- New `test/shared/relative_time_test.dart` — thresholds + a UTC-instant fallback regression case.
- New regression in `documents_card_test.dart` — the existing timestamp test used a *local* `DateTime`, so it never exercised the UTC→local path (confirmed RED before the fix, GREEN after).
- Caveat: both UTC regression tests can only fail on a non-UTC runner; the top-of-function normalization is the durable guard.

Full suite green, `dart format` clean, `flutter analyze` zero warnings.

Closes #338

🤖 Generated with [Claude Code](https://claude.com/claude-code)
