### PR TITLE
feat(auth): align the onboarding module with the mockup

### DIFF
--- a/lib/src/modules/auth/auth_module.dart
+++ b/lib/src/modules/auth/auth_module.dart
@@ -98,13 +98,21 @@ class AuthAppModule extends AppModule {
           GoRoute(
             path: AppRoutes.servers,
             pageBuilder: (_, __) => NoTransitionPage(
-              child: ServerListScreen(serverManager: _serverManager),
+              child: ServerListScreen(
+                serverManager: _serverManager,
+                appName: _appName,
+                logo: _logo,
+              ),
             ),
           ),
           GoRoute(
             path: AppRoutes.authCallback,
             pageBuilder: (_, __) => NoTransitionPage(
-              child: AuthCallbackScreen(serverManager: _serverManager),
+              child: AuthCallbackScreen(
+                serverManager: _serverManager,
+                appName: _appName,
+                logo: _logo,
+              ),
             ),
           ),
         ],

--- a/lib/src/modules/auth/ui/auth_callback_screen.dart
+++ b/lib/src/modules/auth/ui/auth_callback_screen.dart
@@ -13,12 +13,20 @@ import '../platform/callback_params.dart';
 import '../pre_auth_state.dart';
 import '../server_entry.dart';
 import '../server_manager.dart';
+import 'home_shell.dart';
 import 'package:soliplex_design/soliplex_design.dart';
 
 class AuthCallbackScreen extends ConsumerStatefulWidget {
-  const AuthCallbackScreen({super.key, required this.serverManager});
+  const AuthCallbackScreen({
+    super.key,
+    required this.serverManager,
+    this.appName = 'Soliplex',
+    this.logo,
+  });
 
   final ServerManager serverManager;
+  final String appName;
+  final Widget? logo;
 
   @override
   ConsumerState<AuthCallbackScreen> createState() => _AuthCallbackScreenState();
@@ -142,36 +150,38 @@ class _AuthCallbackScreenState extends ConsumerState<AuthCallbackScreen> {
   @override
   Widget build(BuildContext context) {
     if (_processing && _error == null) {
-      return const Scaffold(
-        body: Center(child: CircularProgressIndicator()),
+      return HomeShell(
+        appName: widget.appName,
+        logo: widget.logo,
+        child: const Center(
+          child: Padding(
+            padding: EdgeInsets.all(SoliplexSpacing.s4),
+            child: CircularProgressIndicator(),
+          ),
+        ),
       );
     }
 
-    return Scaffold(
-      body: Center(
-        child: Padding(
-          padding: const EdgeInsets.all(SoliplexSpacing.s4),
-          child: Column(
-            mainAxisSize: MainAxisSize.min,
-            children: [
-              Icon(
-                Icons.error_outline,
-                size: 48,
-                color: Theme.of(context).colorScheme.error,
-              ),
-              const SizedBox(height: SoliplexSpacing.s4),
-              Text(
-                _error ?? 'An error occurred',
-                style: Theme.of(context).textTheme.bodyMedium,
-              ),
-              const SizedBox(height: SoliplexSpacing.s4),
-              SoliplexButton.filled(
-                onPressed: () => context.go(AppRoutes.home),
-                child: const Text('Back to home'),
-              ),
-            ],
+    final theme = Theme.of(context);
+    return HomeShell(
+      appName: widget.appName,
+      logo: widget.logo,
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Icon(Icons.error_outline, size: 48, color: theme.colorScheme.error),
+          const SizedBox(height: SoliplexSpacing.s4),
+          Text(
+            _error ?? 'An error occurred',
+            textAlign: TextAlign.center,
+            style: theme.textTheme.bodyMedium,
           ),
-        ),
+          const SizedBox(height: SoliplexSpacing.s4),
+          SoliplexButton.filled(
+            onPressed: () => context.go(AppRoutes.home),
+            child: const Text('Back to home'),
+          ),
+        ],
       ),
     );
   }

--- a/lib/src/modules/auth/ui/connect_flow_rail.dart
+++ b/lib/src/modules/auth/ui/connect_flow_rail.dart
@@ -50,9 +50,7 @@ class ConnectFlowRail extends StatelessWidget {
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
     final colors = theme.colorScheme;
-    final baseStyle = context
-        .monospaceOn(theme.textTheme.labelSmall)
-        .copyWith(color: colors.onSurfaceVariant);
+    final baseStyle = theme.textTheme.labelLarge;
 
     return Container(
       padding: const EdgeInsets.symmetric(
@@ -64,8 +62,10 @@ class ConnectFlowRail extends StatelessWidget {
         border: Border.all(color: colors.outlineVariant),
         borderRadius: BorderRadius.circular(soliplexRadii.md),
       ),
-      child: FittedBox(
-        fit: BoxFit.scaleDown,
+      // The strip can be wider than its column on smaller desktop windows;
+      // scroll rather than shrink so every label stays legible.
+      child: SingleChildScrollView(
+        scrollDirection: Axis.horizontal,
         child: Row(
           mainAxisSize: MainAxisSize.min,
           children: [
@@ -78,7 +78,7 @@ class ConnectFlowRail extends StatelessWidget {
                   ),
                   child: Text(
                     '→',
-                    style: baseStyle.copyWith(color: colors.outline),
+                    style: baseStyle?.copyWith(color: colors.onSurfaceVariant),
                   ),
                 ),
             ],
@@ -98,7 +98,7 @@ class _RailNode extends StatelessWidget {
 
   final ConnectStep step;
   final ConnectStep current;
-  final TextStyle baseStyle;
+  final TextStyle? baseStyle;
 
   @override
   Widget build(BuildContext context) {
@@ -107,17 +107,13 @@ class _RailNode extends StatelessWidget {
     final isDone = step.index < current.index;
     final dimOptional = step.optional && !isActive && !isDone;
 
-    final Color foreground;
-    if (isActive) {
-      foreground = colors.onPrimary;
-    } else if (isDone) {
-      foreground = colors.onSurface;
-    } else {
-      foreground = colors.onSurfaceVariant;
-    }
+    // Active reads on the primary fill; everything else sits at full
+    // on-surface contrast so the rail stays readable. Optional steps that
+    // haven't been reached are softened with opacity, not a dim color.
+    final foreground = isActive ? colors.onPrimary : colors.onSurface;
 
     return Opacity(
-      opacity: dimOptional ? 0.5 : 1,
+      opacity: dimOptional ? 0.6 : 1,
       child: Container(
         padding: const EdgeInsets.symmetric(
           horizontal: SoliplexSpacing.s2,
@@ -133,12 +129,12 @@ class _RailNode extends StatelessWidget {
           mainAxisSize: MainAxisSize.min,
           children: [
             if (isDone) ...[
-              Icon(Icons.check, size: 12, color: foreground),
+              Icon(Icons.check, size: 16, color: foreground),
               const SizedBox(width: SoliplexSpacing.s1),
             ],
             Text(
               step.label,
-              style: baseStyle.copyWith(
+              style: baseStyle?.copyWith(
                 color: foreground,
                 fontWeight: isActive ? FontWeight.w600 : FontWeight.w500,
               ),

--- a/lib/src/modules/auth/ui/connect_flow_rail.dart
+++ b/lib/src/modules/auth/ui/connect_flow_rail.dart
@@ -39,8 +39,9 @@ ConnectStep stepForConnectState(ConnectState state) => switch (state) {
 ///
 /// Shown only on wide viewports (the caller gates on
 /// [SoliplexBreakpoints.desktop]); on narrow screens the per-state heading
-/// carries the context instead. The strip scales down to fit its column so
-/// it never overflows.
+/// carries the context instead. The strip scrolls horizontally when it's
+/// wider than its column, so every label stays legible rather than being
+/// squeezed.
 class ConnectFlowRail extends StatelessWidget {
   const ConnectFlowRail({super.key, required this.current});
 
@@ -50,7 +51,10 @@ class ConnectFlowRail extends StatelessWidget {
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
     final colors = theme.colorScheme;
-    final baseStyle = theme.textTheme.labelLarge;
+    // The brand type ramp ships only labelMedium / labelSmall for labels, so
+    // labelMedium keeps the rail on-token; a larger label style would fall
+    // through to Material's off-brand default.
+    final baseStyle = theme.textTheme.labelMedium;
 
     return Container(
       padding: const EdgeInsets.symmetric(
@@ -104,6 +108,11 @@ class _RailNode extends StatelessWidget {
   Widget build(BuildContext context) {
     final colors = Theme.of(context).colorScheme;
     final isActive = step == current;
+    // A step is done once the flow is past its position. The branch-only
+    // insecure / consent steps are marked done this way too, even on a run
+    // that skipped them: the rail only knows `current`, and a stray check on
+    // a step the user may not have seen is preferable to leaving a step they
+    // did complete unchecked.
     final isDone = step.index < current.index;
     final dimOptional = step.optional && !isActive && !isDone;
 

--- a/lib/src/modules/auth/ui/connect_flow_rail.dart
+++ b/lib/src/modules/auth/ui/connect_flow_rail.dart
@@ -1,0 +1,151 @@
+import 'package:flutter/material.dart';
+import 'package:soliplex_design/soliplex_design.dart';
+
+import '../connect_flow.dart';
+
+/// One node in the [ConnectFlowRail] breadcrumb.
+///
+/// Mirrors the [ConnectState] sealed hierarchy. The two `optional` steps
+/// (insecure / consent) only appear in some runs — an `http://` probe or a
+/// server-configured consent notice — so they render dimmed until reached.
+enum ConnectStep {
+  url('URL'),
+  probe('Probe'),
+  insecure('Insecure?', optional: true),
+  consent('Consent', optional: true),
+  provider('Provider'),
+  auth('Auth'),
+  connected('Connected');
+
+  const ConnectStep(this.label, {this.optional = false});
+
+  final String label;
+  final bool optional;
+}
+
+/// Maps the live [ConnectState] onto its [ConnectStep] node.
+ConnectStep stepForConnectState(ConnectState state) => switch (state) {
+      UrlInput() => ConnectStep.url,
+      Probing() => ConnectStep.probe,
+      InsecureWarning() => ConnectStep.insecure,
+      Consent() => ConnectStep.consent,
+      ProviderSelection() => ConnectStep.provider,
+      Authenticating() => ConnectStep.auth,
+      Connected() => ConnectStep.connected,
+    };
+
+/// A horizontal breadcrumb of the [ConnectFlow] state machine, surfacing
+/// where the user is in the connect → authenticate journey.
+///
+/// Shown only on wide viewports (the caller gates on
+/// [SoliplexBreakpoints.desktop]); on narrow screens the per-state heading
+/// carries the context instead. The strip scales down to fit its column so
+/// it never overflows.
+class ConnectFlowRail extends StatelessWidget {
+  const ConnectFlowRail({super.key, required this.current});
+
+  final ConnectStep current;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final colors = theme.colorScheme;
+    final baseStyle = context
+        .monospaceOn(theme.textTheme.labelSmall)
+        .copyWith(color: colors.onSurfaceVariant);
+
+    return Container(
+      padding: const EdgeInsets.symmetric(
+        horizontal: SoliplexSpacing.s3,
+        vertical: SoliplexSpacing.s2,
+      ),
+      decoration: BoxDecoration(
+        color: colors.surfaceContainerLow,
+        border: Border.all(color: colors.outlineVariant),
+        borderRadius: BorderRadius.circular(soliplexRadii.md),
+      ),
+      child: FittedBox(
+        fit: BoxFit.scaleDown,
+        child: Row(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            for (final step in ConnectStep.values) ...[
+              _RailNode(step: step, current: current, baseStyle: baseStyle),
+              if (step != ConnectStep.values.last)
+                Padding(
+                  padding: const EdgeInsets.symmetric(
+                    horizontal: SoliplexSpacing.s1,
+                  ),
+                  child: Text(
+                    '→',
+                    style: baseStyle.copyWith(color: colors.outline),
+                  ),
+                ),
+            ],
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _RailNode extends StatelessWidget {
+  const _RailNode({
+    required this.step,
+    required this.current,
+    required this.baseStyle,
+  });
+
+  final ConnectStep step;
+  final ConnectStep current;
+  final TextStyle baseStyle;
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = Theme.of(context).colorScheme;
+    final isActive = step == current;
+    final isDone = step.index < current.index;
+    final dimOptional = step.optional && !isActive && !isDone;
+
+    final Color foreground;
+    if (isActive) {
+      foreground = colors.onPrimary;
+    } else if (isDone) {
+      foreground = colors.onSurface;
+    } else {
+      foreground = colors.onSurfaceVariant;
+    }
+
+    return Opacity(
+      opacity: dimOptional ? 0.5 : 1,
+      child: Container(
+        padding: const EdgeInsets.symmetric(
+          horizontal: SoliplexSpacing.s2,
+          vertical: SoliplexSpacing.s1,
+        ),
+        decoration: isActive
+            ? BoxDecoration(
+                color: colors.primary,
+                borderRadius: BorderRadius.circular(soliplexRadii.sm),
+              )
+            : null,
+        child: Row(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            if (isDone) ...[
+              Icon(Icons.check, size: 12, color: foreground),
+              const SizedBox(width: SoliplexSpacing.s1),
+            ],
+            Text(
+              step.label,
+              style: baseStyle.copyWith(
+                color: foreground,
+                fontWeight: isActive ? FontWeight.w600 : FontWeight.w500,
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/src/modules/auth/ui/home_screen.dart
+++ b/lib/src/modules/auth/ui/home_screen.dart
@@ -11,6 +11,8 @@ import '../consent_notice.dart';
 import '../connection_probe.dart';
 import '../server_entry.dart';
 import '../server_manager.dart';
+import 'connect_flow_rail.dart';
+import 'home_shell.dart';
 import 'package:soliplex_design/soliplex_design.dart';
 
 class HomeScreen extends ConsumerStatefulWidget {
@@ -41,12 +43,7 @@ class HomeScreen extends ConsumerStatefulWidget {
 }
 
 class _HomeScreenState extends ConsumerState<HomeScreen> {
-  static const _logoSize = 64.0;
   static const _maxCollapsedServers = 5;
-
-  /// Max width of the centered auth column on wide viewports, so the form
-  /// and buttons don't stretch edge-to-edge on desktop/web.
-  static const _maxContentWidth = 400.0;
 
   late final ConnectFlow _flow;
   late final void Function() _unsubscribeFlow;
@@ -129,14 +126,37 @@ class _HomeScreenState extends ConsumerState<HomeScreen> {
 
   @override
   Widget build(BuildContext context) {
-    return Scaffold(
-      body: SafeArea(
-        child: Column(
-          children: [
-            Expanded(child: _buildBody(context)),
-            const _VersionFooter(),
+    final servers = widget.serverManager.servers.value;
+    final state = _flow.state.value;
+    final showRail =
+        MediaQuery.sizeOf(context).width >= SoliplexBreakpoints.desktop;
+
+    return HomeShell(
+      appName: widget.appName,
+      logo: widget.logo,
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          if (showRail) ...[
+            ConnectFlowRail(current: stepForConnectState(state)),
+            const SizedBox(height: SoliplexSpacing.s6),
           ],
-        ),
+          ...switch (state) {
+            UrlInput() => _buildUrlInput(context),
+            Probing() => _buildProbing(context),
+            InsecureWarning(:final probeResult) =>
+              _buildInsecureWarning(context, probeResult),
+            Consent(:final notice, :final probeResult, :final providers) =>
+              _buildConsent(context, notice, probeResult, providers),
+            ProviderSelection(:final providers) =>
+              _buildProviderSelection(context, providers),
+            Authenticating() => _buildAuthenticating(context),
+            Connected() => _buildAuthenticating(context),
+          },
+          if (servers.isNotEmpty && state is UrlInput)
+            ..._buildServerSection(context, servers),
+        ],
       ),
     );
   }
@@ -149,78 +169,20 @@ class _HomeScreenState extends ConsumerState<HomeScreen> {
     return false;
   }
 
-  Widget _buildBody(BuildContext context) {
-    final servers = widget.serverManager.servers.value;
+  // -- Per-state heading --
 
-    return Center(
-      child: SingleChildScrollView(
-        padding: const EdgeInsets.all(SoliplexSpacing.s6),
-        child: ConstrainedBox(
-          constraints: const BoxConstraints(maxWidth: _maxContentWidth),
-          child: Column(
-            mainAxisSize: MainAxisSize.min,
-            crossAxisAlignment: CrossAxisAlignment.stretch,
-            children: [
-              ...switch (_flow.state.value) {
-                UrlInput() => _buildUrlInput(context),
-                Probing() => _buildProbing(context),
-                InsecureWarning(:final probeResult) =>
-                  _buildInsecureWarning(context, probeResult),
-                Consent(:final notice, :final probeResult, :final providers) =>
-                  _buildConsent(context, notice, probeResult, providers),
-                ProviderSelection(:final providers) =>
-                  _buildProviderSelection(context, providers),
-                Authenticating() => _buildAuthenticating(context),
-                Connected() => _buildAuthenticating(context),
-              },
-              if (servers.isNotEmpty && _flow.state.value is UrlInput)
-                ..._buildServerSection(context, servers),
-            ],
-          ),
-        ),
+  /// A single centered heading for a flow state. The persistent [HomeShell]
+  /// top bar now carries the brand mark and name, so each state only needs to
+  /// name itself. PR2 reshapes these into title + description blocks.
+  Widget _heading(BuildContext context, String text) {
+    return Padding(
+      padding: const EdgeInsets.only(bottom: SoliplexSpacing.s6),
+      child: Text(
+        text,
+        style: Theme.of(context).textTheme.titleLarge,
+        textAlign: TextAlign.center,
       ),
     );
-  }
-
-  // -- Header --
-
-  List<Widget> _buildHeader(BuildContext context, String subtitle) {
-    final theme = Theme.of(context);
-
-    return [
-      if (widget.logo != null)
-        // Centered so the fixed-size box survives the header Column's
-        // CrossAxisAlignment.stretch — otherwise the logo (and any glow
-        // backplate behind it) gets stretched to the full column width.
-        Center(
-          child: SizedBox(
-            width: _logoSize,
-            height: _logoSize,
-            child: widget.logo,
-          ),
-        )
-      else
-        Icon(
-          Icons.dns_outlined,
-          size: _logoSize,
-          color: theme.colorScheme.primary,
-        ),
-      const SizedBox(height: SoliplexSpacing.s4),
-      Text(
-        widget.appName,
-        style: theme.textTheme.headlineMedium,
-        textAlign: TextAlign.center,
-      ),
-      const SizedBox(height: SoliplexSpacing.s2),
-      Text(
-        subtitle,
-        style: theme.textTheme.bodyMedium?.copyWith(
-          color: theme.colorScheme.onSurfaceVariant,
-        ),
-        textAlign: TextAlign.center,
-      ),
-      const SizedBox(height: SoliplexSpacing.s6),
-    ];
   }
 
   // -- State UIs --
@@ -229,7 +191,7 @@ class _HomeScreenState extends ConsumerState<HomeScreen> {
     final message = (_flow.state.value as UrlInput).message;
 
     return [
-      ..._buildHeader(context, 'Enter the URL of your backend server'),
+      _heading(context, 'Connect to a Soliplex server'),
       Form(
         key: _formKey,
         child: SoliplexInput(
@@ -267,7 +229,7 @@ class _HomeScreenState extends ConsumerState<HomeScreen> {
 
   List<Widget> _buildProbing(BuildContext context) {
     return [
-      ..._buildHeader(context, 'Connecting...'),
+      _heading(context, 'Probing server…'),
       const Center(child: CircularProgressIndicator()),
     ];
   }
@@ -279,7 +241,7 @@ class _HomeScreenState extends ConsumerState<HomeScreen> {
     final theme = Theme.of(context);
 
     return [
-      ..._buildHeader(context, 'Insecure Connection'),
+      _heading(context, 'Insecure connection'),
       Icon(Icons.warning_amber, size: 48, color: theme.colorScheme.warning),
       const SizedBox(height: SoliplexSpacing.s4),
       Text(
@@ -314,7 +276,7 @@ class _HomeScreenState extends ConsumerState<HomeScreen> {
     List<AuthProviderConfig> providers,
   ) {
     return [
-      ..._buildHeader(context, 'Sign in to continue'),
+      _heading(context, 'Before you connect'),
       Text(notice.title, style: Theme.of(context).textTheme.titleLarge),
       const SizedBox(height: SoliplexSpacing.s4),
       Text(notice.body, style: Theme.of(context).textTheme.bodyMedium),
@@ -341,7 +303,7 @@ class _HomeScreenState extends ConsumerState<HomeScreen> {
     List<AuthProviderConfig> providers,
   ) {
     return [
-      ..._buildHeader(context, 'Sign in to continue'),
+      _heading(context, 'Sign in to continue'),
       Text(
         'Choose authentication provider',
         style: Theme.of(context).textTheme.titleMedium,
@@ -365,7 +327,7 @@ class _HomeScreenState extends ConsumerState<HomeScreen> {
 
   List<Widget> _buildAuthenticating(BuildContext context) {
     return [
-      ..._buildHeader(context, 'Signing in...'),
+      _heading(context, 'Finish signing in'),
       const Center(child: CircularProgressIndicator()),
     ];
   }
@@ -472,20 +434,6 @@ class _HomeScreenState extends ConsumerState<HomeScreen> {
     _flow.connect(
       _urlController.text.trim(),
       returnTo: widget.autoConnectReturnTo,
-    );
-  }
-}
-
-class _VersionFooter extends StatelessWidget {
-  const _VersionFooter();
-
-  @override
-  Widget build(BuildContext context) {
-    return Center(
-      child: SoliplexButton.text(
-        onPressed: () => context.push(AppRoutes.versions),
-        child: const Text('Versions'),
-      ),
     );
   }
 }

--- a/lib/src/modules/auth/ui/home_screen.dart
+++ b/lib/src/modules/auth/ui/home_screen.dart
@@ -55,6 +55,10 @@ class _HomeScreenState extends ConsumerState<HomeScreen> {
   bool _showAllServers = false;
   bool _hasUrlText = false;
 
+  /// Whether the user has ticked the agreement box on the consent screen.
+  /// Gates the "continue" action; reset whenever the flow leaves [Consent].
+  bool _consentAgreed = false;
+
   @override
   void initState() {
     super.initState();
@@ -76,6 +80,9 @@ class _HomeScreenState extends ConsumerState<HomeScreen> {
         context.go(AppRoutes.lobby);
         return;
       }
+      // Drop the agreement tick on the way out of consent so a later visit
+      // starts unchecked.
+      if (state is! Consent) _consentAgreed = false;
       if (mounted) setState(() {});
     });
 
@@ -149,8 +156,8 @@ class _HomeScreenState extends ConsumerState<HomeScreen> {
               _buildInsecureWarning(context, probeResult),
             Consent(:final notice, :final probeResult, :final providers) =>
               _buildConsent(context, notice, probeResult, providers),
-            ProviderSelection(:final providers) =>
-              _buildProviderSelection(context, providers),
+            ProviderSelection(:final probeResult, :final providers) =>
+              _buildProviderSelection(context, probeResult, providers),
             Authenticating() => _buildAuthenticating(context),
             Connected() => _buildAuthenticating(context),
           },
@@ -169,19 +176,27 @@ class _HomeScreenState extends ConsumerState<HomeScreen> {
     return false;
   }
 
-  // -- Per-state heading --
+  // -- Shared layout --
 
-  /// A single centered heading for a flow state. The persistent [HomeShell]
-  /// top bar now carries the brand mark and name, so each state only needs to
-  /// name itself. PR2 reshapes these into title + description blocks.
-  Widget _heading(BuildContext context, String text) {
-    return Padding(
-      padding: const EdgeInsets.only(bottom: SoliplexSpacing.s6),
-      child: Text(
-        text,
-        style: Theme.of(context).textTheme.titleLarge,
-        textAlign: TextAlign.center,
-      ),
+  /// Left-aligned title with an optional supporting line — the lede for each
+  /// flow state. The persistent [HomeShell] top bar carries the brand mark and
+  /// name, so each state just introduces itself.
+  Widget _titleBlock(BuildContext context, String title,
+      [String? description]) {
+    final theme = Theme.of(context);
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text(title, style: theme.textTheme.titleLarge),
+        if (description != null) ...[
+          const SizedBox(height: SoliplexSpacing.s2),
+          Text(
+            description,
+            style: theme.textTheme.bodyMedium
+                ?.copyWith(color: theme.colorScheme.onSurfaceVariant),
+          ),
+        ],
+      ],
     );
   }
 
@@ -191,7 +206,14 @@ class _HomeScreenState extends ConsumerState<HomeScreen> {
     final message = (_flow.state.value as UrlInput).message;
 
     return [
-      _heading(context, 'Connect to a Soliplex server'),
+      _titleBlock(
+        context,
+        'Connect to a Soliplex server',
+        "Enter the URL of the backend you want to connect to. If you're "
+            "self-hosting, that's usually a localhost address or your own "
+            'domain.',
+      ),
+      const SizedBox(height: SoliplexSpacing.s6),
       Form(
         key: _formKey,
         child: SoliplexInput(
@@ -202,7 +224,8 @@ class _HomeScreenState extends ConsumerState<HomeScreen> {
           validator: _validateUrl,
           label: 'Backend URL',
           hintText: 'api.example.com',
-          leadingIcon: const Icon(Icons.link),
+          helperText: 'Include http:// or https://, or just the host.',
+          leadingIcon: const Icon(Icons.public),
           trailingIcon: _hasUrlText
               ? IconButton(
                   icon: const Icon(Icons.clear),
@@ -221,16 +244,64 @@ class _HomeScreenState extends ConsumerState<HomeScreen> {
       ],
       SoliplexButton.filled(
         onPressed: _connect,
-        icon: const Icon(Icons.login),
+        icon: const Icon(Icons.arrow_forward),
+        iconAlignment: IconAlignment.end,
         child: const Text('Connect'),
       ),
     ];
   }
 
   List<Widget> _buildProbing(BuildContext context) {
+    final theme = Theme.of(context);
+    final colors = theme.colorScheme;
+
     return [
-      _heading(context, 'Probing server…'),
-      const Center(child: CircularProgressIndicator()),
+      _titleBlock(
+        context,
+        'Probing server…',
+        'Discovering the sign-in options at the URL you entered.',
+      ),
+      const SizedBox(height: SoliplexSpacing.s6),
+      // The probe is a single discovery call — no fake DNS / TLS sub-steps.
+      _FlowCard(
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Row(
+              children: [
+                Icon(Icons.public, size: 16, color: colors.onSurfaceVariant),
+                const SizedBox(width: SoliplexSpacing.s2),
+                Expanded(
+                  child: Text(
+                    _urlController.text,
+                    maxLines: 1,
+                    overflow: TextOverflow.ellipsis,
+                    style: context.monospaceOn(theme.textTheme.bodySmall),
+                  ),
+                ),
+              ],
+            ),
+            const SizedBox(height: SoliplexSpacing.s3),
+            Row(
+              children: [
+                const SizedBox(
+                  width: 16,
+                  height: 16,
+                  child: CircularProgressIndicator(strokeWidth: 2),
+                ),
+                const SizedBox(width: SoliplexSpacing.s3),
+                Text('Discovering providers…',
+                    style: theme.textTheme.bodyMedium),
+              ],
+            ),
+          ],
+        ),
+      ),
+      const SizedBox(height: SoliplexSpacing.s4),
+      SoliplexButton.outlined(
+        onPressed: _flow.reset,
+        child: const Text('Cancel'),
+      ),
     ];
   }
 
@@ -239,30 +310,80 @@ class _HomeScreenState extends ConsumerState<HomeScreen> {
     ConnectionSuccess probeResult,
   ) {
     final theme = Theme.of(context);
+    final colors = theme.colorScheme;
 
     return [
-      _heading(context, 'Insecure connection'),
-      Icon(Icons.warning_amber, size: 48, color: theme.colorScheme.warning),
-      const SizedBox(height: SoliplexSpacing.s4),
-      Text(
-        'This connection to ${formatServerUrl(probeResult.serverUrl)} is not '
-        'encrypted. Your data, including credentials, may be visible to '
-        'others on the network.',
-        style: theme.textTheme.bodyMedium,
-        textAlign: TextAlign.center,
+      _FlowCard(
+        accentColor: colors.error,
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Row(
+              children: [
+                Container(
+                  width: 28,
+                  height: 28,
+                  alignment: Alignment.center,
+                  decoration: BoxDecoration(
+                    color: colors.errorContainer,
+                    borderRadius: BorderRadius.circular(soliplexRadii.sm),
+                  ),
+                  child: Icon(
+                    Icons.lock_outline,
+                    size: 16,
+                    color: colors.onErrorContainer,
+                  ),
+                ),
+                const SizedBox(width: SoliplexSpacing.s3),
+                Expanded(
+                  child: Text(
+                    'This connection is not encrypted',
+                    style: theme.textTheme.titleSmall,
+                  ),
+                ),
+              ],
+            ),
+            const SizedBox(height: SoliplexSpacing.s3),
+            Text(
+              "You're connecting over http://. Anyone on your network can read "
+              'the traffic between you and the server, including your auth '
+              'token.',
+              style: theme.textTheme.bodyMedium
+                  ?.copyWith(color: colors.onSurfaceVariant),
+            ),
+            const SizedBox(height: SoliplexSpacing.s3),
+            Container(
+              width: double.infinity,
+              padding: const EdgeInsets.all(SoliplexSpacing.s2),
+              decoration: BoxDecoration(
+                color: colors.surface,
+                borderRadius: BorderRadius.circular(soliplexRadii.sm),
+                border: Border.all(color: colors.outlineVariant),
+              ),
+              child: Text(
+                probeResult.serverUrl.toString(),
+                style: context.monospaceOn(theme.textTheme.bodySmall),
+              ),
+            ),
+          ],
+        ),
       ),
-      const SizedBox(height: SoliplexSpacing.s6),
+      const SizedBox(height: SoliplexSpacing.s4),
       Row(
-        mainAxisAlignment: MainAxisAlignment.center,
         children: [
-          SoliplexButton.outlined(
-            onPressed: _flow.reset,
-            child: const Text('Cancel'),
+          Expanded(
+            child: SoliplexButton.outlined(
+              onPressed: _flow.reset,
+              child: const Text('Cancel'),
+            ),
           ),
-          const SizedBox(width: SoliplexSpacing.s4),
-          SoliplexButton.filled(
-            onPressed: _flow.acceptInsecure,
-            child: const Text('Connect anyway'),
+          const SizedBox(width: SoliplexSpacing.s3),
+          Expanded(
+            child: SoliplexButton.filled(
+              intent: ButtonIntent.danger,
+              onPressed: _flow.acceptInsecure,
+              child: const Text('Connect anyway'),
+            ),
           ),
         ],
       ),
@@ -275,23 +396,73 @@ class _HomeScreenState extends ConsumerState<HomeScreen> {
     ConnectionSuccess probeResult,
     List<AuthProviderConfig> providers,
   ) {
+    final theme = Theme.of(context);
+    final colors = theme.colorScheme;
+
     return [
-      _heading(context, 'Before you connect'),
-      Text(notice.title, style: Theme.of(context).textTheme.titleLarge),
+      _titleBlock(
+        context,
+        'Before you connect',
+        'This server has a notice you need to acknowledge before signing in.',
+      ),
+      const SizedBox(height: SoliplexSpacing.s6),
+      _FlowCard(
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(notice.title, style: theme.textTheme.titleSmall),
+            const SizedBox(height: SoliplexSpacing.s2),
+            Text(
+              notice.body,
+              style: theme.textTheme.bodyMedium
+                  ?.copyWith(color: colors.onSurfaceVariant),
+            ),
+          ],
+        ),
+      ),
       const SizedBox(height: SoliplexSpacing.s4),
-      Text(notice.body, style: Theme.of(context).textTheme.bodyMedium),
+      // Pure-frontend agreement gate — the consent is the user ticking this,
+      // no extra backend round-trip.
+      Container(
+        padding: const EdgeInsets.all(SoliplexSpacing.s2),
+        decoration: BoxDecoration(
+          borderRadius: BorderRadius.circular(soliplexRadii.md),
+          border: Border.all(
+            color: _consentAgreed ? colors.primary : colors.outlineVariant,
+          ),
+        ),
+        child: Row(
+          crossAxisAlignment: CrossAxisAlignment.center,
+          children: [
+            Checkbox(
+              value: _consentAgreed,
+              onChanged: (v) => setState(() => _consentAgreed = v ?? false),
+            ),
+            const SizedBox(width: SoliplexSpacing.s1),
+            Expanded(
+              child: Text(
+                'I understand and agree to the usage terms.',
+                style: theme.textTheme.bodyMedium,
+              ),
+            ),
+          ],
+        ),
+      ),
       const SizedBox(height: SoliplexSpacing.s4),
       Row(
-        mainAxisAlignment: MainAxisAlignment.center,
         children: [
-          SoliplexButton.outlined(
-            onPressed: _flow.reset,
-            child: const Text('Cancel'),
+          Expanded(
+            child: SoliplexButton.outlined(
+              onPressed: _flow.reset,
+              child: const Text('Back'),
+            ),
           ),
-          const SizedBox(width: SoliplexSpacing.s4),
-          SoliplexButton.filled(
-            onPressed: _flow.acknowledgeConsent,
-            child: Text(notice.acknowledgmentLabel),
+          const SizedBox(width: SoliplexSpacing.s3),
+          Expanded(
+            child: SoliplexButton.filled(
+              onPressed: _consentAgreed ? _flow.acknowledgeConsent : null,
+              child: Text(notice.acknowledgmentLabel),
+            ),
           ),
         ],
       ),
@@ -300,23 +471,23 @@ class _HomeScreenState extends ConsumerState<HomeScreen> {
 
   List<Widget> _buildProviderSelection(
     BuildContext context,
+    ConnectionSuccess probeResult,
     List<AuthProviderConfig> providers,
   ) {
     return [
-      _heading(context, 'Sign in to continue'),
-      Text(
-        'Choose authentication provider',
-        style: Theme.of(context).textTheme.titleMedium,
+      _titleBlock(
+        context,
+        'Sign in to ${probeResult.serverUrl.host}',
+        'Choose how you want to authenticate.',
       ),
-      const SizedBox(height: SoliplexSpacing.s4),
-      for (final provider in providers)
-        Padding(
-          padding: const EdgeInsets.only(bottom: SoliplexSpacing.s2),
-          child: SoliplexButton.filled(
-            onPressed: () => _flow.selectProvider(provider),
-            child: Text(provider.name),
-          ),
+      const SizedBox(height: SoliplexSpacing.s6),
+      for (final provider in providers) ...[
+        _ProviderTile(
+          provider: provider,
+          onTap: () => _flow.selectProvider(provider),
         ),
+        const SizedBox(height: SoliplexSpacing.s2),
+      ],
       const SizedBox(height: SoliplexSpacing.s2),
       SoliplexButton.text(
         onPressed: _flow.reset,
@@ -326,9 +497,45 @@ class _HomeScreenState extends ConsumerState<HomeScreen> {
   }
 
   List<Widget> _buildAuthenticating(BuildContext context) {
+    final theme = Theme.of(context);
+    final colors = theme.colorScheme;
+
     return [
-      _heading(context, 'Finish signing in'),
-      const Center(child: CircularProgressIndicator()),
+      Center(
+        child: Column(
+          children: [
+            Container(
+              width: 56,
+              height: 56,
+              alignment: Alignment.center,
+              decoration: BoxDecoration(
+                color: colors.primaryContainer,
+                borderRadius: BorderRadius.circular(soliplexRadii.lg),
+              ),
+              child: const SizedBox(
+                width: 28,
+                height: 28,
+                child: CircularProgressIndicator(strokeWidth: 3),
+              ),
+            ),
+            const SizedBox(height: SoliplexSpacing.s4),
+            Text('Finish signing in', style: theme.textTheme.titleLarge),
+            const SizedBox(height: SoliplexSpacing.s2),
+            Text(
+              "We've opened a secure browser window so you can sign in. Come "
+              'back here once you’re done.',
+              textAlign: TextAlign.center,
+              style: theme.textTheme.bodyMedium
+                  ?.copyWith(color: colors.onSurfaceVariant),
+            ),
+          ],
+        ),
+      ),
+      const SizedBox(height: SoliplexSpacing.s6),
+      SoliplexButton.outlined(
+        onPressed: _flow.reset,
+        child: const Text('Cancel'),
+      ),
     ];
   }
 
@@ -483,5 +690,127 @@ class UrlMessageBanner extends StatelessWidget {
           ),
         ),
     };
+  }
+}
+
+/// A bordered surface card used by the connect-flow states (probing, insecure
+/// warning, consent). Pass [accentColor] for a coloured left edge — used to
+/// flag the insecure-connection warning.
+///
+/// Candidate for promotion to `soliplex_design` if other modules grow the same
+/// pattern; kept local while it's auth-only.
+class _FlowCard extends StatelessWidget {
+  const _FlowCard({required this.child, this.accentColor});
+
+  final Widget child;
+  final Color? accentColor;
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = Theme.of(context).colorScheme;
+
+    // A rounded border must be uniform, so the accent edge is a clipped bar
+    // rather than a coloured left border side.
+    return Container(
+      clipBehavior: Clip.antiAlias,
+      decoration: BoxDecoration(
+        color: colors.surfaceContainerLow,
+        borderRadius: BorderRadius.circular(soliplexRadii.md),
+        border: Border.all(color: colors.outlineVariant),
+      ),
+      // IntrinsicHeight gives the row a finite height (it lives in a vertical
+      // scroll view) so the accent bar can stretch to the card's height.
+      child: IntrinsicHeight(
+        child: Row(
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            if (accentColor != null) Container(width: 3, color: accentColor),
+            Expanded(
+              child: Padding(
+                padding: const EdgeInsets.all(SoliplexSpacing.s4),
+                child: child,
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+/// A tappable provider row on the sign-in screen: a derived initial avatar,
+/// the provider name, and its id.
+///
+/// [AuthProviderConfig] carries no brand icon or "recommended" flag, so the
+/// tile shows only what the discovery response actually provides.
+class _ProviderTile extends StatelessWidget {
+  const _ProviderTile({required this.provider, required this.onTap});
+
+  final AuthProviderConfig provider;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final colors = theme.colorScheme;
+    final name = provider.name.trim();
+    final initial = name.isEmpty ? '?' : name.substring(0, 1).toUpperCase();
+
+    return Material(
+      color: colors.surface,
+      borderRadius: BorderRadius.circular(soliplexRadii.md),
+      child: InkWell(
+        onTap: onTap,
+        borderRadius: BorderRadius.circular(soliplexRadii.md),
+        child: Container(
+          padding: const EdgeInsets.all(SoliplexSpacing.s3),
+          decoration: BoxDecoration(
+            borderRadius: BorderRadius.circular(soliplexRadii.md),
+            border: Border.all(color: colors.outlineVariant),
+          ),
+          child: Row(
+            children: [
+              Container(
+                width: 32,
+                height: 32,
+                alignment: Alignment.center,
+                decoration: BoxDecoration(
+                  color: colors.primaryContainer,
+                  borderRadius: BorderRadius.circular(soliplexRadii.sm),
+                ),
+                child: Text(
+                  initial,
+                  style: theme.textTheme.titleSmall
+                      ?.copyWith(color: colors.onPrimaryContainer),
+                ),
+              ),
+              const SizedBox(width: SoliplexSpacing.s3),
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text(
+                      provider.name,
+                      maxLines: 1,
+                      overflow: TextOverflow.ellipsis,
+                      style: theme.textTheme.bodyLarge,
+                    ),
+                    Text(
+                      provider.id,
+                      maxLines: 1,
+                      overflow: TextOverflow.ellipsis,
+                      style: context
+                          .monospaceOn(theme.textTheme.labelSmall)
+                          .copyWith(color: colors.onSurfaceVariant),
+                    ),
+                  ],
+                ),
+              ),
+              Icon(Icons.chevron_right, color: colors.onSurfaceVariant),
+            ],
+          ),
+        ),
+      ),
+    );
   }
 }

--- a/lib/src/modules/auth/ui/home_shell.dart
+++ b/lib/src/modules/auth/ui/home_shell.dart
@@ -87,14 +87,14 @@ class _HomeShellHeader extends StatelessWidget {
                   color: colors.primary,
                 ),
           ),
-          const SizedBox(width: SoliplexSpacing.s2),
+          const SizedBox(width: SoliplexSpacing.s3),
           Text(appName, style: theme.textTheme.titleSmall),
           const SizedBox(width: SoliplexSpacing.s2),
           Text(
             soliplexVersion,
-            style: context
-                .monospaceOn(theme.textTheme.labelSmall)
-                .copyWith(color: colors.onSurfaceVariant),
+            style: theme.textTheme.bodySmall?.copyWith(
+              color: colors.onSurfaceVariant,
+            ),
           ),
           const Spacer(),
           IconButton(

--- a/lib/src/modules/auth/ui/home_shell.dart
+++ b/lib/src/modules/auth/ui/home_shell.dart
@@ -1,0 +1,109 @@
+import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
+import 'package:soliplex_design/soliplex_design.dart';
+
+import '../../../../version.dart';
+import '../../../core/routes.dart';
+
+/// Shared chrome for the unauthenticated onboarding surfaces (home /
+/// connect flow, the OAuth callback, and the server list).
+///
+/// Renders a persistent branded top bar — logo, app name, library version,
+/// and an about/versions affordance — above a centered, width-capped content
+/// column. Individual surfaces supply only their [child] body; the framing
+/// stays identical across the whole flow so it reads as one product.
+class HomeShell extends StatelessWidget {
+  const HomeShell({
+    super.key,
+    required this.appName,
+    required this.child,
+    this.logo,
+    this.maxContentWidth = 400,
+  });
+
+  final String appName;
+  final Widget child;
+  final Widget? logo;
+
+  /// Max width of the centered content column so forms and cards don't
+  /// stretch edge-to-edge on desktop/web.
+  final double maxContentWidth;
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      body: SafeArea(
+        child: Column(
+          children: [
+            _HomeShellHeader(appName: appName, logo: logo),
+            Expanded(
+              child: Center(
+                child: SingleChildScrollView(
+                  padding: const EdgeInsets.all(SoliplexSpacing.s6),
+                  child: ConstrainedBox(
+                    constraints: BoxConstraints(maxWidth: maxContentWidth),
+                    child: child,
+                  ),
+                ),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _HomeShellHeader extends StatelessWidget {
+  const _HomeShellHeader({required this.appName, this.logo});
+
+  final String appName;
+  final Widget? logo;
+
+  static const _logoSize = 24.0;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final colors = theme.colorScheme;
+
+    return Container(
+      padding: const EdgeInsets.symmetric(
+        horizontal: SoliplexSpacing.s4,
+        vertical: SoliplexSpacing.s3,
+      ),
+      decoration: BoxDecoration(
+        border: Border(bottom: BorderSide(color: colors.outlineVariant)),
+      ),
+      child: Row(
+        children: [
+          SizedBox(
+            width: _logoSize,
+            height: _logoSize,
+            child: logo ??
+                Icon(
+                  Icons.dns_outlined,
+                  size: _logoSize,
+                  color: colors.primary,
+                ),
+          ),
+          const SizedBox(width: SoliplexSpacing.s2),
+          Text(appName, style: theme.textTheme.titleSmall),
+          const SizedBox(width: SoliplexSpacing.s2),
+          Text(
+            soliplexVersion,
+            style: context
+                .monospaceOn(theme.textTheme.labelSmall)
+                .copyWith(color: colors.onSurfaceVariant),
+          ),
+          const Spacer(),
+          IconButton(
+            tooltip: 'About & versions',
+            icon: const Icon(Icons.info_outline),
+            onPressed: () => context.push(AppRoutes.versions),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/src/modules/auth/ui/home_shell.dart
+++ b/lib/src/modules/auth/ui/home_shell.dart
@@ -35,7 +35,7 @@ class HomeShell extends StatelessWidget {
       body: SafeArea(
         child: Column(
           children: [
-            _HomeShellHeader(appName: appName, logo: logo),
+            HomeShellHeader(appName: appName, logo: logo),
             Expanded(
               child: Center(
                 child: SingleChildScrollView(
@@ -54,11 +54,24 @@ class HomeShell extends StatelessWidget {
   }
 }
 
-class _HomeShellHeader extends StatelessWidget {
-  const _HomeShellHeader({required this.appName, this.logo});
+/// The branded top bar shared across the onboarding surfaces (home / connect
+/// flow, the OAuth callback, and the server list): logo, app name, library
+/// version, and trailing [actions] — defaulting to just an about/versions
+/// button so the bar reads the same everywhere.
+class HomeShellHeader extends StatelessWidget {
+  const HomeShellHeader({
+    super.key,
+    required this.appName,
+    this.logo,
+    this.actions,
+  });
 
   final String appName;
   final Widget? logo;
+
+  /// Trailing actions shown before the about/versions button. Screens like the
+  /// server list slot their navigation here.
+  final List<Widget>? actions;
 
   static const _logoSize = 24.0;
 
@@ -97,6 +110,7 @@ class _HomeShellHeader extends StatelessWidget {
             ),
           ),
           const Spacer(),
+          ...?actions,
           IconButton(
             tooltip: 'About & versions',
             icon: const Icon(Icons.info_outline),

--- a/lib/src/modules/auth/ui/server_list_screen.dart
+++ b/lib/src/modules/auth/ui/server_list_screen.dart
@@ -14,12 +14,20 @@ import '../auth_providers.dart';
 import '../auth_tokens.dart';
 import '../server_entry.dart';
 import '../server_manager.dart';
+import 'home_shell.dart';
 import 'package:soliplex_design/soliplex_design.dart';
 
 class ServerListScreen extends ConsumerStatefulWidget {
-  const ServerListScreen({super.key, required this.serverManager});
+  const ServerListScreen({
+    super.key,
+    required this.serverManager,
+    this.appName = 'Soliplex',
+    this.logo,
+  });
 
   final ServerManager serverManager;
+  final String appName;
+  final Widget? logo;
 
   @override
   ConsumerState<ServerListScreen> createState() => _ServerListScreenState();
@@ -58,32 +66,42 @@ class _ServerListScreenState extends ConsumerState<ServerListScreen> {
     final theme = Theme.of(context);
 
     return Scaffold(
-      appBar: AppBar(
-        title: const Text('Servers'),
-        automaticallyImplyLeading: false,
-        actions: [
-          SoliplexButton.text(
-            onPressed: () => context.go(AppRoutes.home),
-            child: const Text('Home'),
-          ),
-          if (connected.isNotEmpty)
-            SoliplexButton.text(
-              onPressed: () => context.go(AppRoutes.lobby),
-              child: const Text('Lobby'),
+      body: SafeArea(
+        child: Column(
+          children: [
+            HomeShellHeader(
+              appName: widget.appName,
+              logo: widget.logo,
+              actions: [
+                SoliplexButton.text(
+                  onPressed: () => context.go(AppRoutes.home),
+                  child: const Text('Home'),
+                ),
+                if (connected.isNotEmpty)
+                  SoliplexButton.text(
+                    onPressed: () => context.go(AppRoutes.lobby),
+                    child: const Text('Lobby'),
+                  ),
+              ],
             ),
-        ],
-      ),
-      body: ListView(
-        children: [
-          if (connected.isNotEmpty) ...[
-            _sectionHeader(theme, 'Connected (${connected.length})'),
-            for (final entry in connected) _connectedTile(theme, entry),
+            Expanded(
+              child: ListView(
+                children: [
+                  if (connected.isNotEmpty) ...[
+                    _sectionHeader(theme, 'Connected (${connected.length})'),
+                    for (final entry in connected) _connectedTile(theme, entry),
+                  ],
+                  if (disconnected.isNotEmpty) ...[
+                    _sectionHeader(
+                        theme, 'Disconnected (${disconnected.length})'),
+                    for (final entry in disconnected)
+                      _disconnectedTile(theme, entry),
+                  ],
+                ],
+              ),
+            ),
           ],
-          if (disconnected.isNotEmpty) ...[
-            _sectionHeader(theme, 'Disconnected (${disconnected.length})'),
-            for (final entry in disconnected) _disconnectedTile(theme, entry),
-          ],
-        ],
+        ),
       ),
     );
   }

--- a/packages/soliplex_design/lib/src/effects/glow.dart
+++ b/packages/soliplex_design/lib/src/effects/glow.dart
@@ -8,12 +8,16 @@ import 'package:flutter/material.dart';
 /// bounds, so [SoliplexGlow] takes exactly [child]'s size and does not
 /// disturb surrounding layout. The glow is brightest at the center and
 /// fades to fully transparent at its rim.
+///
+/// The halo scales with [child]: it fills the child's box and is enlarged by
+/// [extentFactor], so the same mark reads correctly whether it's a 24px logo
+/// in a top bar or a 96px one on a sign-in screen.
 class SoliplexGlow extends StatelessWidget {
   const SoliplexGlow({
     required this.color,
     required this.child,
     super.key,
-    this.extent = 16,
+    this.extentFactor = 0.25,
   });
 
   /// Color of the glow at its center; fades to transparent at the rim.
@@ -21,9 +25,10 @@ class SoliplexGlow extends StatelessWidget {
 
   final Widget child;
 
-  /// How far the glow radiates beyond each edge of [child], in logical
-  /// pixels.
-  final double extent;
+  /// How far the glow radiates beyond each edge of [child], as a fraction of
+  /// the child's size. `0.25` (the default) grows the backplate to 1.5× the
+  /// child — a quarter of its size bleeding past every edge.
+  final double extentFactor;
 
   @override
   Widget build(BuildContext context) {
@@ -31,16 +36,17 @@ class SoliplexGlow extends StatelessWidget {
       clipBehavior: Clip.none,
       alignment: Alignment.center,
       children: [
-        Positioned(
-          left: -extent,
-          right: -extent,
-          top: -extent,
-          bottom: -extent,
-          child: DecoratedBox(
-            decoration: BoxDecoration(
-              shape: BoxShape.circle,
-              gradient: RadialGradient(
-                colors: [color, color.withAlpha(0)],
+        // Fill the child's box, then scale past it so the halo stays
+        // proportional to the mark at any size.
+        Positioned.fill(
+          child: Transform.scale(
+            scale: 1 + 2 * extentFactor,
+            child: DecoratedBox(
+              decoration: BoxDecoration(
+                shape: BoxShape.circle,
+                gradient: RadialGradient(
+                  colors: [color, color.withAlpha(0)],
+                ),
               ),
             ),
           ),

--- a/packages/soliplex_design/test/effects/glow_test.dart
+++ b/packages/soliplex_design/test/effects/glow_test.dart
@@ -59,29 +59,28 @@ void main() {
       );
     });
 
-    testWidgets('extent controls how far the backplate bleeds past the child',
+    testWidgets('extentFactor scales the backplate relative to the child',
         (tester) async {
       await tester.pumpWidget(
         wrap(
           const SoliplexGlow(
             color: Colors.white,
-            extent: 24,
+            extentFactor: 0.5,
             child: SizedBox(width: 32, height: 32),
           ),
         ),
       );
 
-      final positioned = tester.widget<Positioned>(
+      // The backplate fills the child's box, then scales past it: a 0.5
+      // factor bleeds half the child's size beyond every edge (scale 2.0).
+      final transform = tester.widget<Transform>(
         find.descendant(
           of: find.byType(SoliplexGlow),
-          matching: find.byType(Positioned),
+          matching: find.byType(Transform),
         ),
       );
 
-      expect(positioned.left, -24);
-      expect(positioned.top, -24);
-      expect(positioned.right, -24);
-      expect(positioned.bottom, -24);
+      expect(transform.transform.getMaxScaleOnAxis(), 2.0);
     });
   });
 }

--- a/test/modules/auth/ui/connect_flow_rail_test.dart
+++ b/test/modules/auth/ui/connect_flow_rail_test.dart
@@ -69,5 +69,44 @@ void main() {
       await tester.pumpWidget(host(ConnectStep.url));
       expect(find.byIcon(Icons.check), findsNothing);
     });
+
+    // Confirms the rail actually scrolls once its content is wider than the
+    // visible space, rather than overflowing or shrinking to fit.
+    testWidgets('scrolls horizontally when wider than its column',
+        (tester) async {
+      // A column far narrower than the seven-node strip's intrinsic width.
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Scaffold(
+            body: Center(
+              child: SizedBox(
+                width: 120,
+                child: ConnectFlowRail(current: ConnectStep.connected),
+              ),
+            ),
+          ),
+        ),
+      );
+
+      // No RenderFlex overflow was thrown while laying the strip out.
+      expect(tester.takeException(), isNull);
+
+      final scrollable = find.descendant(
+        of: find.byType(ConnectFlowRail),
+        matching: find.byType(Scrollable),
+      );
+      expect(scrollable, findsOneWidget);
+
+      // The content genuinely exceeds the visible width (there is room to
+      // scroll), and starts pinned at the left edge.
+      final position = tester.state<ScrollableState>(scrollable).position;
+      expect(position.maxScrollExtent, greaterThan(0));
+      expect(position.pixels, 0);
+
+      // Dragging moves the strip — proving it scrolls rather than clips.
+      await tester.drag(scrollable, const Offset(-80, 0));
+      await tester.pump();
+      expect(position.pixels, greaterThan(0));
+    });
   });
 }

--- a/test/modules/auth/ui/connect_flow_rail_test.dart
+++ b/test/modules/auth/ui/connect_flow_rail_test.dart
@@ -56,13 +56,25 @@ void main() {
       }
     });
 
-    testWidgets('marks every preceding step with a check', (tester) async {
-      // At the provider step, url/probe/insecure/consent precede it.
+    testWidgets('marks every preceding step done, optional ones included',
+        (tester) async {
+      // Done-ness is purely positional: every node before `current` shows a
+      // check. This documents a deliberate choice for the two branch-only
+      // steps (insecure / consent) — the rail is handed only `current`, so it
+      // cannot tell whether an optional branch was actually taken. A run takes
+      // at most one of insecure/consent, yet at `provider` BOTH show a check.
+      // We accept a stray check on a possibly-skipped step rather than leave a
+      // genuinely-completed step unchecked.
       await tester.pumpWidget(host(ConnectStep.provider));
+
+      // url, probe, insecure, consent all precede provider → four checks,
+      // including both optional nodes.
       expect(
         find.byIcon(Icons.check),
         findsNWidgets(ConnectStep.provider.index),
       );
+      expect(find.text(ConnectStep.insecure.label), findsOneWidget);
+      expect(find.text(ConnectStep.consent.label), findsOneWidget);
     });
 
     testWidgets('shows no checks at the first step', (tester) async {

--- a/test/modules/auth/ui/connect_flow_rail_test.dart
+++ b/test/modules/auth/ui/connect_flow_rail_test.dart
@@ -1,0 +1,73 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:soliplex_frontend/src/modules/auth/connect_flow.dart';
+import 'package:soliplex_frontend/src/modules/auth/connection_probe.dart';
+import 'package:soliplex_frontend/src/modules/auth/consent_notice.dart';
+import 'package:soliplex_frontend/src/modules/auth/ui/connect_flow_rail.dart';
+
+final _probeResult = ConnectionSuccess(
+  serverUrl: Uri.parse('https://example.com'),
+  providers: const [],
+);
+
+void main() {
+  group('stepForConnectState', () {
+    test('maps each ConnectState to its rail node', () {
+      expect(stepForConnectState(const UrlInput()), ConnectStep.url);
+      expect(stepForConnectState(const Probing()), ConnectStep.probe);
+      expect(
+        stepForConnectState(
+          InsecureWarning(probeResult: _probeResult, providers: const []),
+        ),
+        ConnectStep.insecure,
+      );
+      expect(
+        stepForConnectState(
+          Consent(
+            notice: const ConsentNotice(title: 'T', body: 'B'),
+            probeResult: _probeResult,
+            providers: const [],
+          ),
+        ),
+        ConnectStep.consent,
+      );
+      expect(
+        stepForConnectState(
+          ProviderSelection(probeResult: _probeResult, providers: const []),
+        ),
+        ConnectStep.provider,
+      );
+      expect(stepForConnectState(const Authenticating()), ConnectStep.auth);
+      expect(stepForConnectState(const Connected()), ConnectStep.connected);
+    });
+  });
+
+  group('ConnectFlowRail', () {
+    Widget host(ConnectStep current) => MaterialApp(
+          home: Scaffold(
+            body: Center(child: ConnectFlowRail(current: current)),
+          ),
+        );
+
+    testWidgets('renders every step label', (tester) async {
+      await tester.pumpWidget(host(ConnectStep.provider));
+      for (final step in ConnectStep.values) {
+        expect(find.text(step.label), findsOneWidget);
+      }
+    });
+
+    testWidgets('marks every preceding step with a check', (tester) async {
+      // At the provider step, url/probe/insecure/consent precede it.
+      await tester.pumpWidget(host(ConnectStep.provider));
+      expect(
+        find.byIcon(Icons.check),
+        findsNWidgets(ConnectStep.provider.index),
+      );
+    });
+
+    testWidgets('shows no checks at the first step', (tester) async {
+      await tester.pumpWidget(host(ConnectStep.url));
+      expect(find.byIcon(Icons.check), findsNothing);
+    });
+  });
+}

--- a/test/modules/auth/ui/home_screen_test.dart
+++ b/test/modules/auth/ui/home_screen_test.dart
@@ -154,7 +154,7 @@ void main() {
       await tester.pumpAndSettle();
 
       expect(find.byType(TextFormField), findsOneWidget);
-      expect(find.byIcon(Icons.link), findsOneWidget);
+      expect(find.byIcon(Icons.public), findsOneWidget);
       expect(find.text('Connect'), findsOneWidget);
       expect(find.text('Soliplex'), findsOneWidget);
       expect(
@@ -263,7 +263,10 @@ void main() {
 
       // Should go to lobby, not provider selection.
       expect(find.text('Lobby placeholder'), findsOneWidget);
-      expect(find.text('Choose authentication provider'), findsNothing);
+      expect(
+        find.text('Choose how you want to authenticate.'),
+        findsNothing,
+      );
     });
 
     testWidgets('different ports are treated as different servers',
@@ -394,7 +397,10 @@ void main() {
       await tester.pump();
 
       // Inline insecure warning
-      expect(find.text('Insecure connection'), findsOneWidget);
+      expect(
+        find.text('This connection is not encrypted'),
+        findsOneWidget,
+      );
       expect(find.textContaining('not encrypted'), findsOneWidget);
     });
 
@@ -438,7 +444,7 @@ void main() {
       );
     });
 
-    testWidgets('shows "Sign in to continue" on provider selection phase',
+    testWidgets('shows the sign-in heading on provider selection phase',
         (tester) async {
       final serverManager = _createServerManager();
       await tester.pumpWidget(_buildApp(
@@ -452,7 +458,7 @@ void main() {
       await tester.tap(find.text('Connect'));
       await tester.pumpAndSettle();
 
-      expect(find.text('Sign in to continue'), findsOneWidget);
+      expect(find.text('Sign in to api.example.com'), findsOneWidget);
       expect(find.text('Connect to a Soliplex server'), findsNothing);
     });
 
@@ -530,7 +536,10 @@ void main() {
       await tester.tap(find.text('Connect'));
       await tester.pumpAndSettle();
 
-      expect(find.text('Choose authentication provider'), findsOneWidget);
+      expect(
+        find.text('Choose how you want to authenticate.'),
+        findsOneWidget,
+      );
 
       // Pick a provider to authenticate.
       await tester.tap(find.text('Authenticate with Keycloak'));

--- a/test/modules/auth/ui/home_screen_test.dart
+++ b/test/modules/auth/ui/home_screen_test.dart
@@ -13,7 +13,9 @@ import 'package:soliplex_frontend/src/modules/auth/platform/auth_flow.dart';
 import 'package:soliplex_frontend/src/modules/auth/pre_auth_state.dart';
 import 'package:soliplex_frontend/src/modules/auth/server_entry.dart';
 import 'package:soliplex_frontend/src/modules/auth/server_manager.dart';
+import 'package:soliplex_frontend/src/modules/auth/ui/connect_flow_rail.dart';
 import 'package:soliplex_frontend/src/modules/auth/ui/home_screen.dart';
+import 'package:soliplex_frontend/version.dart';
 
 import '../../../helpers/fakes.dart';
 
@@ -156,7 +158,7 @@ void main() {
       expect(find.text('Connect'), findsOneWidget);
       expect(find.text('Soliplex'), findsOneWidget);
       expect(
-        find.text('Enter the URL of your backend server'),
+        find.text('Connect to a Soliplex server'),
         findsOneWidget,
       );
     });
@@ -171,6 +173,38 @@ void main() {
 
       expect(find.text('MyApp'), findsOneWidget);
       expect(find.text('Soliplex'), findsNothing);
+    });
+
+    testWidgets('shows the library version in the top bar', (tester) async {
+      final serverManager = _createServerManager();
+      await tester.pumpWidget(_buildApp(serverManager: serverManager));
+      await tester.pumpAndSettle();
+
+      expect(find.text(soliplexVersion), findsOneWidget);
+    });
+
+    testWidgets('hides the flow rail on narrow viewports', (tester) async {
+      final serverManager = _createServerManager();
+      await tester.pumpWidget(_buildApp(serverManager: serverManager));
+      await tester.pumpAndSettle();
+
+      // Default test viewport (800px) is below the desktop breakpoint.
+      expect(find.byType(ConnectFlowRail), findsNothing);
+    });
+
+    testWidgets('shows the flow rail on wide viewports', (tester) async {
+      tester.view.physicalSize = const Size(1200, 900);
+      tester.view.devicePixelRatio = 1.0;
+      addTearDown(tester.view.resetPhysicalSize);
+      addTearDown(tester.view.resetDevicePixelRatio);
+
+      final serverManager = _createServerManager();
+      await tester.pumpWidget(_buildApp(serverManager: serverManager));
+      await tester.pumpAndSettle();
+
+      expect(find.byType(ConnectFlowRail), findsOneWidget);
+      // On the URL-input state, the URL node is current.
+      expect(find.text(ConnectStep.url.label), findsOneWidget);
     });
 
     testWidgets('shows logo when provided', (tester) async {
@@ -360,7 +394,7 @@ void main() {
       await tester.pump();
 
       // Inline insecure warning
-      expect(find.text('Insecure Connection'), findsOneWidget);
+      expect(find.text('Insecure connection'), findsOneWidget);
       expect(find.textContaining('not encrypted'), findsOneWidget);
     });
 
@@ -419,7 +453,7 @@ void main() {
       await tester.pumpAndSettle();
 
       expect(find.text('Sign in to continue'), findsOneWidget);
-      expect(find.text('Enter the URL of your backend server'), findsNothing);
+      expect(find.text('Connect to a Soliplex server'), findsNothing);
     });
 
     testWidgets('shows "Change server" button on provider selection phase',
@@ -443,7 +477,7 @@ void main() {
       await tester.pumpAndSettle();
 
       expect(find.byType(TextFormField), findsOneWidget);
-      expect(find.text('Enter the URL of your backend server'), findsOneWidget);
+      expect(find.text('Connect to a Soliplex server'), findsOneWidget);
     });
 
     testWidgets('hides server section on provider selection phase',

--- a/test/modules/auth/ui/home_screen_test.dart
+++ b/test/modules/auth/ui/home_screen_test.dart
@@ -9,6 +9,7 @@ import 'package:soliplex_frontend/src/modules/auth/auth_providers.dart';
 import 'package:soliplex_frontend/src/modules/auth/auth_session.dart';
 import 'package:soliplex_frontend/src/modules/auth/auth_tokens.dart';
 import 'package:soliplex_frontend/src/modules/auth/connection_probe.dart';
+import 'package:soliplex_frontend/src/modules/auth/consent_notice.dart';
 import 'package:soliplex_frontend/src/modules/auth/platform/auth_flow.dart';
 import 'package:soliplex_frontend/src/modules/auth/pre_auth_state.dart';
 import 'package:soliplex_frontend/src/modules/auth/server_entry.dart';
@@ -82,6 +83,7 @@ Widget _buildApp({
   DiscoverProviders? discover,
   String? defaultBackendUrl,
   String? initialLocation,
+  ConsentNotice? consentNotice,
 }) {
   final fakeAuthFlow = authFlow ?? FakeAuthFlow();
 
@@ -123,6 +125,8 @@ Widget _buildApp({
       discoverProvidersProvider.overrideWithValue(
         discover ?? _noAuthDiscover,
       ),
+      if (consentNotice != null)
+        consentNoticeProvider.overrideWithValue(consentNotice),
     ],
     child: MaterialApp.router(routerConfig: router),
   );
@@ -942,6 +946,92 @@ void main() {
 
       final field = tester.widget<TextFormField>(find.byType(TextFormField));
       expect(field.controller!.text, 'https://api.example.com');
+    });
+  });
+
+  group('HomeScreen consent gate', () {
+    const notice = ConsentNotice(
+      title: 'Usage notice',
+      body: 'You agree to the terms.',
+      acknowledgmentLabel: 'Agree & continue',
+    );
+
+    Future<void> reachConsent(WidgetTester tester) async {
+      await tester.enterText(
+          find.byType(TextFormField), 'https://api.example.com');
+      await tester.tap(find.text('Connect'));
+      await tester.pumpAndSettle();
+    }
+
+    testWidgets('a server with a consent notice lands on the consent gate',
+        (tester) async {
+      final serverManager = _createServerManager();
+      await tester.pumpWidget(_buildApp(
+        serverManager: serverManager,
+        discover: _multiProviderDiscover,
+        consentNotice: notice,
+      ));
+      await tester.pumpAndSettle();
+
+      await reachConsent(tester);
+
+      expect(find.text('Before you connect'), findsOneWidget);
+      expect(find.text('Usage notice'), findsOneWidget);
+      expect(find.text('You agree to the terms.'), findsOneWidget);
+    });
+
+    testWidgets('continue is gated until the agreement box is ticked',
+        (tester) async {
+      final serverManager = _createServerManager();
+      await tester.pumpWidget(_buildApp(
+        serverManager: serverManager,
+        discover: _multiProviderDiscover,
+        consentNotice: notice,
+      ));
+      await tester.pumpAndSettle();
+
+      await reachConsent(tester);
+
+      // Unticked: tapping the acknowledge button does nothing.
+      await tester.tap(find.text('Agree & continue'));
+      await tester.pumpAndSettle();
+      expect(find.text('Before you connect'), findsOneWidget);
+
+      // Tick the box, then the button advances to provider selection.
+      await tester.tap(find.byType(Checkbox));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('Agree & continue'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Choose how you want to authenticate.'), findsOneWidget);
+      expect(find.text('Before you connect'), findsNothing);
+    });
+
+    testWidgets('leaving and re-entering consent re-arms the gate',
+        (tester) async {
+      final serverManager = _createServerManager();
+      await tester.pumpWidget(_buildApp(
+        serverManager: serverManager,
+        discover: _multiProviderDiscover,
+        consentNotice: notice,
+      ));
+      await tester.pumpAndSettle();
+
+      await reachConsent(tester);
+
+      // Tick the box, then back out of consent.
+      await tester.tap(find.byType(Checkbox));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('Back'));
+      await tester.pumpAndSettle();
+
+      // Re-enter consent: the box starts unticked again, and the gate is
+      // closed — tapping continue leaves us on the consent screen.
+      await reachConsent(tester);
+      expect(tester.widget<Checkbox>(find.byType(Checkbox)).value, isFalse);
+      await tester.tap(find.text('Agree & continue'));
+      await tester.pumpAndSettle();
+      expect(find.text('Before you connect'), findsOneWidget);
     });
   });
 }


### PR DESCRIPTION
Aligns the auth/onboarding surfaces with the standalone mockup, building only
what the existing flow API can actually back — no faked capabilities.

## Chrome
- `HomeShell` + `HomeShellHeader`: a branded top bar (logo, app name, library
  version) shared across the home/connect flow, the OAuth callback, and the
  server list, so the whole module reads as one product.
- `ConnectFlowRail`: a desktop-only breadcrumb of the connect → authenticate
  journey (scrolls rather than shrinks when narrow).

## Per-state connect-flow bodies
Each `ConnectState` reshaped to the mockup layout, held to what the API exposes:
- **URL input** — title + description lede, globe icon, helper text.
- **Probing** — honest single-stage card (entered URL + one "discovering
  providers" spinner) + Cancel. No faked DNS/TLS/metadata sub-steps or timings;
  the probe is a single discovery call.
- **Insecure warning** — accent-edged card, lock chip, the real probed URL,
  danger-intent "Connect anyway".
- **Consent** — notice card + a real agreement checkbox gating Continue (pure
  frontend; resets on leaving the state).
- **Provider selection** — tiles with a derived initial avatar, provider name,
  and id. No RECOMMENDED badge or brand icons — `AuthProviderConfig` carries
  neither.
- **Authenticating** — spinner tile + honest generic copy + Cancel. The state
  carries no provider/auth URL, so nothing is invented.

## Neighbor screens
- `AuthCallbackScreen` and `ServerListScreen` adopt the same `HomeShellHeader`;
  their bodies are otherwise unchanged.

## Design system
- `SoliplexGlow` halo now scales with its child (`extentFactor`) instead of a
  fixed 16px extent, so the logo backplate is proportional at any size.

## Tests
- 284 auth tests pass; `flutter analyze` clean. Added rail-scroll and
  flow-rail-mapping tests; updated home-screen copy assertions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)