### PR TITLE
fix(lobby): derive room recency from last message, not thread creation

### DIFF
--- a/lib/src/modules/lobby/lobby_state.dart
+++ b/lib/src/modules/lobby/lobby_state.dart
@@ -202,10 +202,11 @@ class LobbyState {
   /// order), and reused for [LobbySortMode.recentActivity] ordering. No-op
   /// before a server is selected or before that server's rooms have loaded.
   /// Only uncached rooms are fetched; results are merged into [_roomActivity],
-  /// so switching servers reuses prior fetches. The backend exposes no
-  /// last-access field, so "recency" is the newest thread's `createdAt` (one
-  /// `getThreads` per room — this relies on the standard transport's
-  /// concurrency limiter to throttle the burst).
+  /// so switching servers reuses prior fetches. "Recency" is the room's
+  /// `lastMessageAt` from the stats endpoint (the time of the newest message
+  /// turn — not a thread's creation time), one `getRoomStats` per room. This
+  /// relies on the standard transport's concurrency limiter to throttle the
+  /// burst.
   void _reconcileActivity() {
     _activityToken?.cancel('activity reconcile');
     _activityToken = null;
@@ -235,13 +236,13 @@ class LobbyState {
     Future.wait(
       missing.map((room) async {
         try {
-          final threads = await api.getThreads(room.id, cancelToken: token);
+          final stats = await api.getRoomStats(room.id, cancelToken: token);
           return MapEntry(
             (serverId: serverId, roomId: room.id),
-            _latestCreatedAt(threads),
+            stats.lastMessageAt,
           );
         } catch (error, st) {
-          // A room whose threads can't be listed simply has no recency
+          // A room whose stats can't be fetched simply has no recency
           // signal; it sorts last rather than failing the whole view. An
           // AuthException still funnels to session expiry (as the room-list
           // and profile fetches do), and a PermissionDeniedException is an
@@ -251,7 +252,7 @@ class LobbyState {
               entry.auth.markSessionExpired();
             } else if (error is! PermissionDeniedException) {
               dev.log(
-                'Failed to fetch thread activity for ${room.id} on $serverId',
+                'Failed to fetch room activity for ${room.id} on $serverId',
                 error: error,
                 stackTrace: st,
                 level: 900,
@@ -270,14 +271,6 @@ class LobbyState {
       _activityLoading.value = false;
       _roomActivity.value = {..._roomActivity.value}..addEntries(entries);
     });
-  }
-
-  static DateTime? _latestCreatedAt(List<ThreadInfo> threads) {
-    DateTime? latest;
-    for (final t in threads) {
-      if (latest == null || t.createdAt.isAfter(latest)) latest = t.createdAt;
-    }
-    return latest;
   }
 
   /// Free-text room-name filter. Ephemeral — intentionally not persisted,

--- a/packages/soliplex_client/lib/src/api/mappers.dart
+++ b/packages/soliplex_client/lib/src/api/mappers.dart
@@ -8,6 +8,7 @@ import 'package:soliplex_client/src/domain/rag_document.dart';
 import 'package:soliplex_client/src/domain/room.dart';
 import 'package:soliplex_client/src/domain/room_agent.dart';
 import 'package:soliplex_client/src/domain/room_skill.dart';
+import 'package:soliplex_client/src/domain/room_stats.dart';
 import 'package:soliplex_client/src/domain/room_tool.dart';
 import 'package:soliplex_client/src/domain/run_info.dart';
 import 'package:soliplex_client/src/domain/thread_info.dart';
@@ -439,6 +440,22 @@ WorkdirFile workdirFileFromJson(Map<String, dynamic> json) {
   return WorkdirFile(
     filename: filename,
     url: Uri.parse(_requireString(json, 'url', 'workdir file')),
+  );
+}
+
+// ============================================================
+// RoomStats mappers
+// ============================================================
+
+/// Creates a [RoomStats] from JSON.
+///
+/// `last_message_at` is optional and tolerant of malformed timestamps
+/// (a bad value is treated as "no activity" rather than failing the
+/// whole lobby view).
+RoomStats roomStatsFromJson(String roomId, Map<String, dynamic> json) {
+  return RoomStats(
+    roomId: json['room_id'] as String? ?? roomId,
+    lastMessageAt: _tryParseTimestamp(json['last_message_at'] as String?),
   );
 }
 

--- a/packages/soliplex_client/lib/src/api/mappers.dart
+++ b/packages/soliplex_client/lib/src/api/mappers.dart
@@ -18,14 +18,17 @@ import 'package:soliplex_client/src/domain/workdir_file.dart';
 // Timestamp helpers
 // ============================================================
 
-/// Parses a UTC timestamp from the backend.
+final _hasTimezone = RegExp(r'(Z|[+-]\d{2}:\d{2})$');
+
+/// Parses an ISO 8601 timestamp from the backend into UTC.
 ///
-/// Backend sends ISO 8601 timestamps without 'Z' suffix. This normalizes
-/// the format and ensures UTC parsing.
+/// Accepts both timezone-aware values (a trailing `Z` or a `±HH:MM`
+/// offset) and naive values; a naive value is assumed UTC. The result
+/// is always normalized to UTC.
 ///
 /// Throws [FormatException] if [raw] is malformed.
 DateTime parseTimestamp(String raw) {
-  final normalized = raw.endsWith('Z') ? raw : '${raw}Z';
+  final normalized = _hasTimezone.hasMatch(raw) ? raw : '${raw}Z';
   return DateTime.parse(normalized).toUtc();
 }
 
@@ -449,13 +452,13 @@ WorkdirFile workdirFileFromJson(Map<String, dynamic> json) {
 
 /// Creates a [RoomStats] from JSON.
 ///
-/// `last_message_at` is optional and tolerant of malformed timestamps
+/// `last_activity` is optional and tolerant of malformed timestamps
 /// (a bad value is treated as "no activity" rather than failing the
 /// whole lobby view).
 RoomStats roomStatsFromJson(String roomId, Map<String, dynamic> json) {
   return RoomStats(
     roomId: json['room_id'] as String? ?? roomId,
-    lastMessageAt: _tryParseTimestamp(json['last_message_at'] as String?),
+    lastMessageAt: _tryParseTimestamp(json['last_activity'] as String?),
   );
 }
 

--- a/packages/soliplex_client/lib/src/api/soliplex_api.dart
+++ b/packages/soliplex_client/lib/src/api/soliplex_api.dart
@@ -316,7 +316,7 @@ class SoliplexApi {
 
     final response = await _transport.request<Map<String, dynamic>>(
       'GET',
-      _urlBuilder.build(pathSegments: ['rooms', roomId, 'stats']),
+      _urlBuilder.build(pathSegments: ['stats', 'rooms', roomId]),
       cancelToken: cancelToken,
     );
     return roomStatsFromJson(roomId, response);

--- a/packages/soliplex_client/lib/src/api/soliplex_api.dart
+++ b/packages/soliplex_client/lib/src/api/soliplex_api.dart
@@ -17,6 +17,7 @@ import 'package:soliplex_client/src/domain/message_state.dart';
 import 'package:soliplex_client/src/domain/quiz.dart';
 import 'package:soliplex_client/src/domain/rag_document.dart';
 import 'package:soliplex_client/src/domain/room.dart';
+import 'package:soliplex_client/src/domain/room_stats.dart';
 import 'package:soliplex_client/src/domain/run_info.dart';
 import 'package:soliplex_client/src/domain/thread_history.dart';
 import 'package:soliplex_client/src/domain/thread_info.dart';
@@ -288,6 +289,37 @@ class SoliplexApi {
     return threads
         .map((e) => threadInfoFromJson(e as Map<String, dynamic>))
         .toList();
+  }
+
+  /// Gets aggregate activity stats for a room.
+  ///
+  /// Parameters:
+  /// - [roomId]: The room ID (must not be empty)
+  ///
+  /// Returns a [RoomStats] for the room, scoped to the requesting user's
+  /// own threads. Notably carries `lastMessageAt` — the time of the most
+  /// recent message turn, the authoritative "last activity" signal (a
+  /// thread's `createdAt` only marks when it was opened).
+  ///
+  /// Throws:
+  /// - [ArgumentError] if [roomId] is empty
+  /// - [NotFoundException] if room not found (404)
+  /// - [AuthException] if not authenticated (401/403)
+  /// - [NetworkException] if connection fails
+  /// - [ApiException] for other server errors
+  /// - [CancelledException] if cancelled via [cancelToken]
+  Future<RoomStats> getRoomStats(
+    String roomId, {
+    CancelToken? cancelToken,
+  }) async {
+    _requireNonEmpty(roomId, 'roomId');
+
+    final response = await _transport.request<Map<String, dynamic>>(
+      'GET',
+      _urlBuilder.build(pathSegments: ['rooms', roomId, 'stats']),
+      cancelToken: cancelToken,
+    );
+    return roomStatsFromJson(roomId, response);
   }
 
   /// Gets a thread by ID.

--- a/packages/soliplex_client/lib/src/domain/domain.dart
+++ b/packages/soliplex_client/lib/src/domain/domain.dart
@@ -15,6 +15,7 @@ export 'rag_document.dart';
 export 'room.dart';
 export 'room_agent.dart';
 export 'room_skill.dart';
+export 'room_stats.dart';
 export 'room_tool.dart';
 export 'run_info.dart';
 export 'skill_tool_call_activity.dart';

--- a/packages/soliplex_client/lib/src/domain/room_stats.dart
+++ b/packages/soliplex_client/lib/src/domain/room_stats.dart
@@ -1,0 +1,38 @@
+import 'package:meta/meta.dart';
+
+/// Aggregate activity statistics for a single room.
+///
+/// Scoped to the requesting user's own threads. Intentionally open-ended:
+/// the backend stats payload is expected to grow (message/thread counts,
+/// token usage, ...), so new fields are added here rather than minting a
+/// new model per metric.
+@immutable
+class RoomStats {
+  /// Creates room stats.
+  const RoomStats({
+    required this.roomId,
+    this.lastMessageAt,
+  });
+
+  /// ID of the room these stats describe.
+  final String roomId;
+
+  /// Timestamp of the most recent message turn in the room, or `null`
+  /// when the user has no activity there.
+  final DateTime? lastMessageAt;
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    return other is RoomStats &&
+        other.roomId == roomId &&
+        other.lastMessageAt == lastMessageAt;
+  }
+
+  @override
+  int get hashCode => Object.hash(roomId, lastMessageAt);
+
+  @override
+  String toString() =>
+      'RoomStats(roomId: $roomId, lastMessageAt: $lastMessageAt)';
+}

--- a/packages/soliplex_client/test/api/mappers_test.dart
+++ b/packages/soliplex_client/test/api/mappers_test.dart
@@ -610,6 +610,51 @@ void main() {
     });
   });
 
+  group('RoomStats mappers', () {
+    group('roomStatsFromJson', () {
+      test('parses room_id and last_message_at', () {
+        final stats = roomStatsFromJson('fallback', <String, dynamic>{
+          'room_id': 'room-1',
+          'last_message_at': '2026-06-01T12:00:00',
+        });
+
+        expect(stats.roomId, equals('room-1'));
+        expect(
+          stats.lastMessageAt,
+          equals(DateTime.utc(2026, 6, 1, 12)),
+        );
+        expect(stats.lastMessageAt!.isUtc, isTrue);
+      });
+
+      test('null last_message_at means no activity', () {
+        final stats = roomStatsFromJson('room-1', <String, dynamic>{
+          'room_id': 'room-1',
+          'last_message_at': null,
+        });
+
+        expect(stats.roomId, equals('room-1'));
+        expect(stats.lastMessageAt, isNull);
+      });
+
+      test('falls back to the passed roomId when room_id is absent', () {
+        final stats = roomStatsFromJson('fallback', <String, dynamic>{});
+
+        expect(stats.roomId, equals('fallback'));
+        expect(stats.lastMessageAt, isNull);
+      });
+
+      test('a malformed timestamp is tolerated as no activity', () {
+        final stats = roomStatsFromJson('room-1', <String, dynamic>{
+          'room_id': 'room-1',
+          'last_message_at': 'not-a-date',
+        });
+
+        expect(stats.roomId, equals('room-1'));
+        expect(stats.lastMessageAt, isNull);
+      });
+    });
+  });
+
   group('ThreadInfo mappers', () {
     group('threadInfoFromJson', () {
       test('parses correctly with all fields', () {

--- a/packages/soliplex_client/test/api/mappers_test.dart
+++ b/packages/soliplex_client/test/api/mappers_test.dart
@@ -10,6 +10,34 @@ import 'package:soliplex_client/src/domain/thread_info.dart';
 import 'package:test/test.dart';
 
 void main() {
+  group('parseTimestamp', () {
+    test('appends Z when no timezone is present', () {
+      expect(
+        parseTimestamp('2026-06-01T12:00:00'),
+        equals(DateTime.utc(2026, 6, 1, 12)),
+      );
+    });
+
+    test('accepts a trailing Z', () {
+      expect(
+        parseTimestamp('2026-06-01T12:00:00Z'),
+        equals(DateTime.utc(2026, 6, 1, 12)),
+      );
+    });
+
+    test('accepts an explicit +00:00 offset', () {
+      final parsed = parseTimestamp('2026-06-01T12:00:00+00:00');
+      expect(parsed, equals(DateTime.utc(2026, 6, 1, 12)));
+      expect(parsed.isUtc, isTrue);
+    });
+
+    test('normalizes a non-UTC offset to UTC', () {
+      final parsed = parseTimestamp('2026-06-01T12:00:00+02:00');
+      expect(parsed, equals(DateTime.utc(2026, 6, 1, 10)));
+      expect(parsed.isUtc, isTrue);
+    });
+  });
+
   group('BackendVersionInfo mappers', () {
     group('backendVersionInfoFromJson', () {
       test('parses correctly with all fields', () {
@@ -612,10 +640,10 @@ void main() {
 
   group('RoomStats mappers', () {
     group('roomStatsFromJson', () {
-      test('parses room_id and last_message_at', () {
+      test('parses room_id and last_activity', () {
         final stats = roomStatsFromJson('fallback', <String, dynamic>{
           'room_id': 'room-1',
-          'last_message_at': '2026-06-01T12:00:00',
+          'last_activity': '2026-06-01T12:00:00+00:00',
         });
 
         expect(stats.roomId, equals('room-1'));
@@ -626,10 +654,10 @@ void main() {
         expect(stats.lastMessageAt!.isUtc, isTrue);
       });
 
-      test('null last_message_at means no activity', () {
+      test('null last_activity means no activity', () {
         final stats = roomStatsFromJson('room-1', <String, dynamic>{
           'room_id': 'room-1',
-          'last_message_at': null,
+          'last_activity': null,
         });
 
         expect(stats.roomId, equals('room-1'));
@@ -646,7 +674,7 @@ void main() {
       test('a malformed timestamp is tolerated as no activity', () {
         final stats = roomStatsFromJson('room-1', <String, dynamic>{
           'room_id': 'room-1',
-          'last_message_at': 'not-a-date',
+          'last_activity': 'not-a-date',
         });
 
         expect(stats.roomId, equals('room-1'));

--- a/packages/soliplex_client/test/api/soliplex_api_test.dart
+++ b/packages/soliplex_client/test/api/soliplex_api_test.dart
@@ -494,6 +494,109 @@ void main() {
       });
     });
 
+    group('getRoomStats', () {
+      test('parses room_id and last_message_at', () async {
+        when(
+          () => mockTransport.request<Map<String, dynamic>>(
+            'GET',
+            any(),
+            cancelToken: any(named: 'cancelToken'),
+            fromJson: any(named: 'fromJson'),
+            body: any(named: 'body'),
+            headers: any(named: 'headers'),
+            timeout: any(named: 'timeout'),
+          ),
+        ).thenAnswer(
+          (_) async => {
+            'room_id': 'room-123',
+            'last_message_at': '2026-06-01T12:00:00',
+          },
+        );
+
+        final stats = await api.getRoomStats('room-123');
+
+        expect(stats.roomId, equals('room-123'));
+        expect(stats.lastMessageAt, equals(DateTime.utc(2026, 6, 1, 12)));
+      });
+
+      test('tolerates a null last_message_at', () async {
+        when(
+          () => mockTransport.request<Map<String, dynamic>>(
+            'GET',
+            any(),
+            cancelToken: any(named: 'cancelToken'),
+            fromJson: any(named: 'fromJson'),
+            body: any(named: 'body'),
+            headers: any(named: 'headers'),
+            timeout: any(named: 'timeout'),
+          ),
+        ).thenAnswer(
+          (_) async => {'room_id': 'room-123', 'last_message_at': null},
+        );
+
+        final stats = await api.getRoomStats('room-123');
+
+        expect(stats.roomId, equals('room-123'));
+        expect(stats.lastMessageAt, isNull);
+      });
+
+      test('validates non-empty roomId', () {
+        expect(() => api.getRoomStats(''), throwsA(isA<ArgumentError>()));
+      });
+
+      test('supports cancellation', () async {
+        final cancelToken = CancelToken();
+
+        when(
+          () => mockTransport.request<Map<String, dynamic>>(
+            'GET',
+            any(),
+            cancelToken: cancelToken,
+            fromJson: any(named: 'fromJson'),
+            body: any(named: 'body'),
+            headers: any(named: 'headers'),
+            timeout: any(named: 'timeout'),
+          ),
+        ).thenAnswer((_) async => {'room_id': 'room-123'});
+
+        await api.getRoomStats('room-123', cancelToken: cancelToken);
+
+        verify(
+          () => mockTransport.request<Map<String, dynamic>>(
+            'GET',
+            any(),
+            cancelToken: cancelToken,
+            fromJson: any(named: 'fromJson'),
+            body: any(named: 'body'),
+            headers: any(named: 'headers'),
+            timeout: any(named: 'timeout'),
+          ),
+        ).called(1);
+      });
+
+      test('uses correct URL', () async {
+        Uri? capturedUri;
+        when(
+          () => mockTransport.request<Map<String, dynamic>>(
+            'GET',
+            any(),
+            cancelToken: any(named: 'cancelToken'),
+            fromJson: any(named: 'fromJson'),
+            body: any(named: 'body'),
+            headers: any(named: 'headers'),
+            timeout: any(named: 'timeout'),
+          ),
+        ).thenAnswer((invocation) async {
+          capturedUri = invocation.positionalArguments[1] as Uri;
+          return {'room_id': 'room-123'};
+        });
+
+        await api.getRoomStats('room-123');
+
+        expect(capturedUri?.path, equals('/api/v1/rooms/room-123/stats'));
+      });
+    });
+
     group('getThread', () {
       test('returns thread by ID', () async {
         when(

--- a/packages/soliplex_client/test/api/soliplex_api_test.dart
+++ b/packages/soliplex_client/test/api/soliplex_api_test.dart
@@ -495,7 +495,7 @@ void main() {
     });
 
     group('getRoomStats', () {
-      test('parses room_id and last_message_at', () async {
+      test('parses room_id and last_activity', () async {
         when(
           () => mockTransport.request<Map<String, dynamic>>(
             'GET',
@@ -509,7 +509,7 @@ void main() {
         ).thenAnswer(
           (_) async => {
             'room_id': 'room-123',
-            'last_message_at': '2026-06-01T12:00:00',
+            'last_activity': '2026-06-01T12:00:00+00:00',
           },
         );
 
@@ -519,7 +519,7 @@ void main() {
         expect(stats.lastMessageAt, equals(DateTime.utc(2026, 6, 1, 12)));
       });
 
-      test('tolerates a null last_message_at', () async {
+      test('tolerates a null last_activity', () async {
         when(
           () => mockTransport.request<Map<String, dynamic>>(
             'GET',
@@ -531,7 +531,7 @@ void main() {
             timeout: any(named: 'timeout'),
           ),
         ).thenAnswer(
-          (_) async => {'room_id': 'room-123', 'last_message_at': null},
+          (_) async => {'room_id': 'room-123', 'last_activity': null},
         );
 
         final stats = await api.getRoomStats('room-123');
@@ -593,7 +593,7 @@ void main() {
 
         await api.getRoomStats('room-123');
 
-        expect(capturedUri?.path, equals('/api/v1/rooms/room-123/stats'));
+        expect(capturedUri?.path, equals('/api/v1/stats/rooms/room-123'));
       });
     });
 

--- a/packages/soliplex_client/test/domain/room_stats_test.dart
+++ b/packages/soliplex_client/test/domain/room_stats_test.dart
@@ -1,0 +1,48 @@
+import 'package:soliplex_client/soliplex_client.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('RoomStats', () {
+    test('creates with required fields and a null timestamp by default', () {
+      const stats = RoomStats(roomId: 'room-1');
+
+      expect(stats.roomId, equals('room-1'));
+      expect(stats.lastMessageAt, isNull);
+    });
+
+    test('creates with a last-message timestamp', () {
+      final at = DateTime.utc(2026, 6);
+      final stats = RoomStats(roomId: 'room-1', lastMessageAt: at);
+
+      expect(stats.roomId, equals('room-1'));
+      expect(stats.lastMessageAt, equals(at));
+    });
+
+    test('value equality and hashCode consider both fields', () {
+      final at = DateTime.utc(2026, 6);
+      final a = RoomStats(roomId: 'room-1', lastMessageAt: at);
+      final b = RoomStats(roomId: 'room-1', lastMessageAt: at);
+      final differentTime = RoomStats(
+        roomId: 'room-1',
+        lastMessageAt: DateTime.utc(2026, 6, 2),
+      );
+      const differentRoom = RoomStats(roomId: 'room-2');
+
+      expect(a, equals(b));
+      expect(a.hashCode, equals(b.hashCode));
+      expect(a, isNot(equals(differentTime)));
+      expect(a, isNot(equals(differentRoom)));
+      expect(a, equals(a));
+    });
+
+    test('toString includes both fields', () {
+      final stats = RoomStats(
+        roomId: 'room-1',
+        lastMessageAt: DateTime.utc(2026, 6),
+      );
+
+      expect(stats.toString(), contains('room-1'));
+      expect(stats.toString(), contains('lastMessageAt'));
+    });
+  });
+}

--- a/test/helpers/fakes.dart
+++ b/test/helpers/fakes.dart
@@ -217,6 +217,22 @@ class FakeSoliplexApi extends SoliplexApi {
   /// sweep in flight (e.g. to trigger a cancellation mid-fetch).
   Completer<void>? threadsGate;
   Exception? nextThreadsError;
+
+  /// Per-room [getRoomStats] results, consulted before [nextStats]. Lets a
+  /// test give rooms distinct last-activity timestamps (e.g. for activity
+  /// sorting).
+  final Map<String, RoomStats> statsByRoom = {};
+
+  /// Per-room [getRoomStats] errors, consulted before [statsByRoom]. Lets a
+  /// test fail one room's stats fetch while others succeed.
+  final Map<String, Exception> statsErrorByRoom = {};
+
+  /// When set, [getRoomStats] awaits this before returning, letting a test
+  /// hold an activity sweep in flight (e.g. to trigger a cancellation
+  /// mid-fetch).
+  Completer<void>? statsGate;
+  RoomStats? nextStats;
+  Exception? nextStatsError;
   ThreadHistory? nextThreadHistory;
   Exception? nextThreadHistoryError;
   (ThreadInfo, Map<String, dynamic>)? nextCreateThread;
@@ -264,6 +280,24 @@ class FakeSoliplexApi extends SoliplexApi {
     if (threadsByRoom.containsKey(roomId)) return threadsByRoom[roomId]!;
     if (nextThreads != null) return nextThreads!;
     throw StateError('FakeSoliplexApi: set nextThreads or nextThreadsError');
+  }
+
+  @override
+  Future<RoomStats> getRoomStats(
+    String roomId, {
+    CancelToken? cancelToken,
+  }) async {
+    if (nextStatsError != null) throw nextStatsError!;
+    if (statsErrorByRoom.containsKey(roomId)) {
+      throw statsErrorByRoom[roomId]!;
+    }
+    if (statsGate != null) {
+      await statsGate!.future;
+    }
+    if (statsByRoom.containsKey(roomId)) return statsByRoom[roomId]!;
+    if (nextStats != null) return nextStats!;
+    throw StateError('FakeSoliplexApi: set statsByRoom, nextStats or '
+        'nextStatsError');
   }
 
   @override

--- a/test/modules/lobby/lobby_sort_mode_test.dart
+++ b/test/modules/lobby/lobby_sort_mode_test.dart
@@ -18,8 +18,8 @@ ServerManager _createManager() => ServerManager(
       storage: InMemoryServerStorage(),
     );
 
-ThreadInfo _thread(String id, DateTime createdAt) =>
-    ThreadInfo(id: id, roomId: 'room', createdAt: createdAt);
+RoomStats _stats(String roomId, DateTime? lastMessageAt) =>
+    RoomStats(roomId: roomId, lastMessageAt: lastMessageAt);
 
 /// Drains pending microtasks. Over-pumps rather than coupling to the exact
 /// number of async hops the state machine takes to settle.
@@ -80,7 +80,7 @@ void main() {
     });
 
     test(
-        'fetches each room\'s newest thread timestamp eagerly (so cards can '
+        'fetches each room\'s last-message timestamp eagerly (so cards can '
         'show it), even with sorting at none', () async {
       final manager = _createManager();
       manager.addServer(
@@ -97,18 +97,17 @@ void main() {
           Room(id: 'r2', name: 'Random'),
           Room(id: 'r3', name: 'Empty'),
         ]
-        ..threadsByRoom['r1'] = [_thread('t1', older)]
-        // Newest of several should win.
-        ..threadsByRoom['r2'] = [_thread('t2', older), _thread('t3', newer)]
-        // No threads → null timestamp.
-        ..threadsByRoom['r3'] = const [];
+        ..statsByRoom['r1'] = _stats('r1', older)
+        ..statsByRoom['r2'] = _stats('r2', newer)
+        // No activity → null timestamp.
+        ..statsByRoom['r3'] = _stats('r3', null);
 
       // Sorting stays at the default (none); activity is still fetched.
       final state = LobbyState(
         serverManager: manager,
         apiResolver: (_) => fakeApi,
       );
-      // Two turns: one for getRooms, one for the getThreads sweep it triggers.
+      // Two turns: one for getRooms, one for the getRoomStats sweep it triggers.
       await Future<void>.delayed(Duration.zero);
       await Future<void>.delayed(Duration.zero);
 
@@ -137,8 +136,8 @@ void main() {
       final gate = Completer<void>();
       final fakeApi = FakeSoliplexApi()
         ..nextRooms = const [Room(id: 'r1', name: 'General')]
-        ..threadsByRoom['r1'] = [_thread('t1', DateTime.utc(2026))]
-        ..threadsGate = gate;
+        ..statsByRoom['r1'] = _stats('r1', DateTime.utc(2026))
+        ..statsGate = gate;
 
       final state =
           LobbyState(serverManager: manager, apiResolver: (_) => fakeApi);
@@ -180,10 +179,10 @@ void main() {
       final fresh = DateTime.utc(2026, 6, 1);
       final apiA = FakeSoliplexApi()
         ..nextRooms = const [Room(id: 'ra', name: 'A-Room')]
-        ..threadsByRoom['ra'] = [_thread('t', stale)];
+        ..statsByRoom['ra'] = _stats('ra', stale);
       final apiB = FakeSoliplexApi()
         ..nextRooms = const [Room(id: 'rb', name: 'B-Room')]
-        ..threadsByRoom['rb'] = [_thread('t', other)];
+        ..statsByRoom['rb'] = _stats('rb', other);
 
       final state = LobbyState(
         serverManager: manager,
@@ -199,8 +198,8 @@ void main() {
       expect(state.roomActivity.value[(serverId: 'a', roomId: 'ra')], stale);
       expect(state.roomActivity.value[(serverId: 'b', roomId: 'rb')], other);
 
-      // Change 'a's newest thread and refetch only 'a'.
-      apiA.threadsByRoom['ra'] = [_thread('t2', fresh)];
+      // Change 'a's last-message time and refetch only 'a'.
+      apiA.statsByRoom['ra'] = _stats('ra', fresh);
       state.refresh('a');
       await _settle();
 
@@ -211,7 +210,7 @@ void main() {
       state.dispose();
     });
 
-    test('a room whose thread fetch fails records a null timestamp', () async {
+    test('a room whose stats fetch fails records a null timestamp', () async {
       final manager = _createManager();
       manager.addServer(
         serverId: 'local',
@@ -224,8 +223,8 @@ void main() {
           Room(id: 'ok', name: 'Ok'),
           Room(id: 'bad', name: 'Bad'),
         ]
-        ..threadsByRoom['ok'] = [_thread('t', ok)]
-        ..threadsErrorByRoom['bad'] = Exception('thread fetch boom');
+        ..statsByRoom['ok'] = _stats('ok', ok)
+        ..statsErrorByRoom['bad'] = Exception('stats fetch boom');
 
       final state =
           LobbyState(serverManager: manager, apiResolver: (_) => fakeApi);
@@ -234,7 +233,7 @@ void main() {
       final activity = state.roomActivity.value;
       expect(activity[(serverId: 'local', roomId: 'ok')], ok);
       expect(activity[(serverId: 'local', roomId: 'bad')], isNull,
-          reason: 'a failed thread fetch maps to a null timestamp');
+          reason: 'a failed stats fetch maps to a null timestamp');
       expect(activity.containsKey((serverId: 'local', roomId: 'bad')), isTrue,
           reason: 'the failed room is recorded as fetched, so it is not '
               're-swept');
@@ -262,7 +261,7 @@ void main() {
       );
       final fakeApi = FakeSoliplexApi()
         ..nextRooms = const [Room(id: 'r1', name: 'General')]
-        ..threadsErrorByRoom['r1'] = const AuthException(message: 'expired');
+        ..statsErrorByRoom['r1'] = const AuthException(message: 'expired');
 
       final state =
           LobbyState(serverManager: manager, apiResolver: (_) => fakeApi);
@@ -290,11 +289,11 @@ void main() {
       final gateA = Completer<void>();
       final apiA = FakeSoliplexApi()
         ..nextRooms = const [Room(id: 'ra', name: 'A-Room')]
-        ..threadsByRoom['ra'] = [_thread('ta', DateTime.utc(2026, 1))]
-        ..threadsGate = gateA;
+        ..statsByRoom['ra'] = _stats('ra', DateTime.utc(2026, 1))
+        ..statsGate = gateA;
       final apiB = FakeSoliplexApi()
         ..nextRooms = const [Room(id: 'rb', name: 'B-Room')]
-        ..threadsByRoom['rb'] = [_thread('tb', DateTime.utc(2026, 6))];
+        ..statsByRoom['rb'] = _stats('rb', DateTime.utc(2026, 6));
 
       final state = LobbyState(
         serverManager: manager,

--- a/test/modules/lobby/ui/lobby_screen_test.dart
+++ b/test/modules/lobby/ui/lobby_screen_test.dart
@@ -3,7 +3,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:go_router/go_router.dart';
 import 'package:shared_preferences/shared_preferences.dart';
-import 'package:soliplex_agent/soliplex_agent.dart' show Room, ThreadInfo;
+import 'package:soliplex_agent/soliplex_agent.dart' show Room, RoomStats;
 import 'package:soliplex_frontend/src/modules/auth/auth_session.dart';
 import 'package:soliplex_frontend/src/modules/auth/auth_tokens.dart';
 import 'package:soliplex_frontend/src/modules/auth/server_manager.dart';
@@ -444,7 +444,7 @@ void main() {
     });
 
     testWidgets(
-        'sorting by recent activity reorders rooms by their newest thread',
+        'sorting by recent activity reorders rooms by their last message',
         (tester) async {
       tester.view.physicalSize = const Size(900, 600);
       tester.view.devicePixelRatio = 1.0;
@@ -456,19 +456,17 @@ void main() {
         serverUrl: Uri.parse('http://localhost:8000'),
         requiresAuth: false,
       );
-      // 'General' is listed first but has the older thread; 'Random' has the
+      // 'General' is listed first but has the older message; 'Random' has the
       // newer one, so recent-activity sorting must put 'Random' on top.
       final fakeApi = FakeSoliplexApi()
         ..nextRooms = const [
           Room(id: 'r1', name: 'General'),
           Room(id: 'r2', name: 'Random'),
         ]
-        ..threadsByRoom['r1'] = [
-          ThreadInfo(id: 't1', roomId: 'r1', createdAt: DateTime.utc(2026, 1)),
-        ]
-        ..threadsByRoom['r2'] = [
-          ThreadInfo(id: 't2', roomId: 'r2', createdAt: DateTime.utc(2026, 6)),
-        ];
+        ..statsByRoom['r1'] =
+            RoomStats(roomId: 'r1', lastMessageAt: DateTime.utc(2026, 1))
+        ..statsByRoom['r2'] =
+            RoomStats(roomId: 'r2', lastMessageAt: DateTime.utc(2026, 6));
 
       await tester.pumpWidget(_buildApp(manager, apiResolver: (_) => fakeApi));
       await tester.pumpAndSettle();
@@ -510,16 +508,11 @@ void main() {
           Room(id: 'r1', name: 'Fresh'),
           Room(id: 'r2', name: 'Stale'),
         ]
-        ..threadsByRoom['r1'] = [
-          ThreadInfo(id: 't1', roomId: 'r1', createdAt: now),
-        ]
-        ..threadsByRoom['r2'] = [
-          ThreadInfo(
-            id: 't2',
-            roomId: 'r2',
-            createdAt: now.subtract(const Duration(days: 10)),
-          ),
-        ];
+        ..statsByRoom['r1'] = RoomStats(roomId: 'r1', lastMessageAt: now)
+        ..statsByRoom['r2'] = RoomStats(
+          roomId: 'r2',
+          lastMessageAt: now.subtract(const Duration(days: 10)),
+        );
 
       await tester.pumpWidget(_buildApp(manager, apiResolver: (_) => fakeApi));
       await tester.pumpAndSettle();
@@ -551,7 +544,7 @@ void main() {
       );
       final older = DateTime.utc(2026, 1, 1);
       final newer = DateTime.utc(2026, 6, 1);
-      // Alpha and Charlie have no threads (undated); Bravo/Delta are dated.
+      // Alpha and Charlie have no activity (undated); Bravo/Delta are dated.
       final fakeApi = FakeSoliplexApi()
         ..nextRooms = const [
           Room(id: 'r1', name: 'Alpha'),
@@ -559,14 +552,10 @@ void main() {
           Room(id: 'r3', name: 'Charlie'),
           Room(id: 'r4', name: 'Delta'),
         ]
-        ..threadsByRoom['r1'] = const []
-        ..threadsByRoom['r2'] = [
-          ThreadInfo(id: 't2', roomId: 'r2', createdAt: newer),
-        ]
-        ..threadsByRoom['r3'] = const []
-        ..threadsByRoom['r4'] = [
-          ThreadInfo(id: 't4', roomId: 'r4', createdAt: older),
-        ];
+        ..statsByRoom['r1'] = const RoomStats(roomId: 'r1')
+        ..statsByRoom['r2'] = RoomStats(roomId: 'r2', lastMessageAt: newer)
+        ..statsByRoom['r3'] = const RoomStats(roomId: 'r3')
+        ..statsByRoom['r4'] = RoomStats(roomId: 'r4', lastMessageAt: older);
 
       await tester.pumpWidget(_buildApp(manager, apiResolver: (_) => fakeApi));
       await tester.pumpAndSettle();


### PR DESCRIPTION
## What

The lobby's last-activity affordance (the clock on room cards and the **Recent activity** sort) computed recency from the newest thread's `createdAt` — when a thread was *opened*, not when it was last *used*. A long-lived thread messaged minutes ago showed as days stale.

This switches the lobby to the new backend **room stats** endpoint, which reports the time of the most recent message turn.

## Changes

**`soliplex_client`**
- `RoomStats` domain model (`roomId`, `lastMessageAt`) — open-ended, exported from the barrel.
- `roomStatsFromJson` mapper — tolerant of `null`/malformed `last_message_at`.
- `SoliplexApi.getRoomStats(roomId)` → `GET /api/v1/rooms/{id}/stats`.

**App**
- `LobbyState._reconcileActivity` now calls `getRoomStats` and stores `stats.lastMessageAt`, replacing `getThreads` + `_latestCreatedAt`. Caching, cancellation, and `AuthException`→session-expiry are unchanged.

## Tests

- `RoomStats` model, `roomStatsFromJson`, and `getRoomStats` API tests.
- `FakeSoliplexApi` gains `statsByRoom`/`statsErrorByRoom`/`statsGate`/`nextStats(Error)` + a `getRoomStats` override; the lobby sort/activity tests are migrated off thread fixtures onto stats.
- Lobby suite green; client + full app suites green locally.

## Dependency

Requires the backend stats endpoint: **WilliamKarolDiCioccio/soliplex#1**. Until that's deployed, `getRoomStats` 404s and cards simply show no timestamp (gracefully handled — recorded as null, same as a room with no activity).