### PR TITLE
feat(lobby): mark rooms with unseen activity as unread

### DIFF
--- a/lib/src/modules/lobby/lobby_read_markers.dart
+++ b/lib/src/modules/lobby/lobby_read_markers.dart
@@ -1,0 +1,59 @@
+import 'dart:convert';
+
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'lobby_state.dart' show RoomActivityKey;
+
+/// Persists per-room "last seen" timestamps so the lobby can mark rooms with
+/// newer activity as unread.
+///
+/// This is a deliberately simple, *client-side* read model: a room is unread
+/// when its last-message time is newer than the moment the user last opened
+/// it on this device. There is no server-side read state and no count — just
+/// a boolean affordance. Read markers are therefore per-device.
+///
+/// Backed by `shared_preferences` (non-sensitive UI state). Stored as a JSON
+/// array of `{s, r, t}` objects (server id, room id, ISO-8601 UTC instant) so
+/// ids needn't be escaped into a composite key.
+abstract final class LobbyReadMarkerStorage {
+  static const _key = 'soliplex_lobby_read_markers';
+
+  static Future<Map<RoomActivityKey, DateTime>> load() async {
+    final prefs = await SharedPreferences.getInstance();
+    final raw = prefs.getString(_key);
+    if (raw == null || raw.isEmpty) return {};
+
+    final result = <RoomActivityKey, DateTime>{};
+    try {
+      final decoded = jsonDecode(raw);
+      if (decoded is! List) return {};
+      for (final entry in decoded) {
+        if (entry is! Map) continue;
+        final s = entry['s'];
+        final r = entry['r'];
+        final t = entry['t'];
+        if (s is! String || r is! String || t is! String) continue;
+        final at = DateTime.tryParse(t);
+        if (at == null) continue;
+        result[(serverId: s, roomId: r)] = at.toUtc();
+      }
+    } on FormatException {
+      // Corrupt payload: start fresh rather than wedging the lobby.
+      return {};
+    }
+    return result;
+  }
+
+  static Future<void> save(Map<RoomActivityKey, DateTime> markers) async {
+    final prefs = await SharedPreferences.getInstance();
+    final list = [
+      for (final entry in markers.entries)
+        {
+          's': entry.key.serverId,
+          'r': entry.key.roomId,
+          't': entry.value.toUtc().toIso8601String(),
+        },
+    ];
+    await prefs.setString(_key, jsonEncode(list));
+  }
+}

--- a/lib/src/modules/lobby/lobby_state.dart
+++ b/lib/src/modules/lobby/lobby_state.dart
@@ -10,6 +10,7 @@ import '../auth/auth_tokens.dart';
 import '../auth/selected_server_storage.dart';
 import '../auth/server_entry.dart';
 import '../auth/server_manager.dart';
+import 'lobby_read_markers.dart';
 import 'lobby_sort_mode.dart';
 import 'lobby_view_mode.dart';
 
@@ -83,6 +84,7 @@ class LobbyState {
     _unsubscribe = _serverManager.servers.subscribe(_onServersChanged);
     unawaited(_loadViewMode());
     unawaited(_loadSortMode());
+    unawaited(_loadReadMarkers());
     unawaited(_loadSelectedServer());
   }
 
@@ -188,6 +190,62 @@ class LobbyState {
       Signal<Map<RoomActivityKey, DateTime?>>({});
   ReadonlySignal<Map<RoomActivityKey, DateTime?>> get roomActivity =>
       _roomActivity;
+
+  /// Per-room "last seen" timestamps, keyed by (serverId, roomId). A room is
+  /// *unread* when [roomActivity] reports a `lastMessageAt` newer than its
+  /// marker here (or newer than the epoch, when never opened). Persisted
+  /// per-device; there is no server-side read state and no unread count.
+  final Signal<Map<RoomActivityKey, DateTime>> _readMarkers =
+      Signal<Map<RoomActivityKey, DateTime>>({});
+  ReadonlySignal<Map<RoomActivityKey, DateTime>> get readMarkers =>
+      _readMarkers;
+
+  Future<void> _loadReadMarkers() async {
+    try {
+      _readMarkers.value = await LobbyReadMarkerStorage.load();
+    } catch (error, st) {
+      dev.log(
+        'Failed to load lobby read markers',
+        error: error,
+        stackTrace: st,
+        level: 900,
+      );
+    }
+  }
+
+  /// Marks [roomId] on [serverId] as read as of now, clearing its unread
+  /// affordance until a later message arrives. Called when the user opens a
+  /// room. Uses "now" rather than the cached activity time so a room is read
+  /// the moment it is opened, even if the activity sweep is stale or still in
+  /// flight.
+  void markRoomRead(String serverId, String roomId) {
+    final key = (serverId: serverId, roomId: roomId);
+    _readMarkers.value = {
+      ..._readMarkers.value,
+      key: DateTime.now().toUtc(),
+    };
+    unawaited(
+      LobbyReadMarkerStorage.save(_readMarkers.value)
+          .catchError((Object e, StackTrace st) {
+        dev.log(
+          'Failed to persist lobby read markers',
+          error: e,
+          stackTrace: st,
+          level: 900,
+        );
+      }),
+    );
+  }
+
+  /// Whether [room] on [serverId] has activity newer than the user last saw.
+  /// False when there is no known activity (nothing to be unread about).
+  bool isRoomUnread(String serverId, String roomId) {
+    final key = (serverId: serverId, roomId: roomId);
+    final lastMessageAt = _roomActivity.value[key];
+    if (lastMessageAt == null) return false;
+    final seen = _readMarkers.value[key];
+    return seen == null || lastMessageAt.isAfter(seen);
+  }
 
   /// True while per-room activity for the selected server is being fetched.
   final Signal<bool> _activityLoading = Signal(false);

--- a/lib/src/modules/lobby/ui/lobby_screen.dart
+++ b/lib/src/modules/lobby/ui/lobby_screen.dart
@@ -75,6 +75,8 @@ class _LobbyScreenState extends State<LobbyScreen> {
     final entry = widget.serverManager.servers.value[serverId];
     assert(entry != null, 'Room tap for unknown serverId: $serverId');
     if (entry == null) return;
+    // Opening a room clears its unread affordance until a later message.
+    _state.markRoomRead(serverId, roomId);
     context.go(AppRoutes.room(entry.alias, roomId));
   }
 
@@ -107,6 +109,7 @@ class _LobbyScreenState extends State<LobbyScreen> {
     final selectedServerId = _state.selectedServerId.watch(context);
     final sortMode = _state.sortMode.watch(context);
     final roomActivity = _state.roomActivity.watch(context);
+    final readMarkers = _state.readMarkers.watch(context);
     final activityLoading = _state.activityLoading.watch(context);
     return LayoutBuilder(
       builder: (context, constraints) {
@@ -126,6 +129,7 @@ class _LobbyScreenState extends State<LobbyScreen> {
                 sortMode: sortMode,
                 onSortModeChanged: _state.setSortMode,
                 roomActivity: roomActivity,
+                readMarkers: readMarkers,
                 activityLoading: activityLoading,
                 selectedServerId: selectedServerId,
                 onSelectServer: _state.selectServer,
@@ -149,6 +153,7 @@ class _LobbyScreenState extends State<LobbyScreen> {
                 sortMode: sortMode,
                 onSortModeChanged: _state.setSortMode,
                 roomActivity: roomActivity,
+                readMarkers: readMarkers,
                 activityLoading: activityLoading,
                 selectedServerId: selectedServerId,
                 onSelectServer: _state.selectServer,
@@ -178,6 +183,7 @@ class _WideLayout extends StatelessWidget {
     required this.sortMode,
     required this.onSortModeChanged,
     required this.roomActivity,
+    required this.readMarkers,
     required this.activityLoading,
     required this.selectedServerId,
     required this.onSelectServer,
@@ -201,6 +207,7 @@ class _WideLayout extends StatelessWidget {
   final LobbySortMode sortMode;
   final void Function(LobbySortMode) onSortModeChanged;
   final Map<RoomActivityKey, DateTime?> roomActivity;
+  final Map<RoomActivityKey, DateTime> readMarkers;
   final bool activityLoading;
   final String? selectedServerId;
   final void Function(String serverId) onSelectServer;
@@ -247,6 +254,7 @@ class _WideLayout extends StatelessWidget {
                 sortMode: sortMode,
                 onSortModeChanged: onSortModeChanged,
                 roomActivity: roomActivity,
+                readMarkers: readMarkers,
                 activityLoading: activityLoading,
                 selectedServerId: selectedServerId,
                 onRoomTap: onRoomTap,
@@ -275,6 +283,7 @@ class _NarrowLayout extends StatelessWidget {
     required this.sortMode,
     required this.onSortModeChanged,
     required this.roomActivity,
+    required this.readMarkers,
     required this.activityLoading,
     required this.selectedServerId,
     required this.onSelectServer,
@@ -298,6 +307,7 @@ class _NarrowLayout extends StatelessWidget {
   final LobbySortMode sortMode;
   final void Function(LobbySortMode) onSortModeChanged;
   final Map<RoomActivityKey, DateTime?> roomActivity;
+  final Map<RoomActivityKey, DateTime> readMarkers;
   final bool activityLoading;
   final String? selectedServerId;
   final void Function(String serverId) onSelectServer;
@@ -355,6 +365,7 @@ class _NarrowLayout extends StatelessWidget {
         sortMode: sortMode,
         onSortModeChanged: onSortModeChanged,
         roomActivity: roomActivity,
+        readMarkers: readMarkers,
         activityLoading: activityLoading,
         selectedServerId: selectedServerId,
         onRoomTap: onRoomTap,
@@ -377,6 +388,7 @@ class _RoomContent extends StatelessWidget {
     required this.sortMode,
     required this.onSortModeChanged,
     required this.roomActivity,
+    required this.readMarkers,
     required this.activityLoading,
     required this.selectedServerId,
     required this.onRoomTap,
@@ -394,6 +406,7 @@ class _RoomContent extends StatelessWidget {
   final LobbySortMode sortMode;
   final void Function(LobbySortMode) onSortModeChanged;
   final Map<RoomActivityKey, DateTime?> roomActivity;
+  final Map<RoomActivityKey, DateTime> readMarkers;
   final bool activityLoading;
   final String? selectedServerId;
   final void Function(String serverId, String roomId) onRoomTap;
@@ -489,6 +502,7 @@ class _RoomContent extends StatelessWidget {
           searchQuery: searchQuery,
           sortMode: sortMode,
           roomActivity: roomActivity,
+          readMarkers: readMarkers,
           onRoomTap: onRoomTap,
           onInfoTap: onInfoTap,
           onSignIn: onSignIn,
@@ -678,6 +692,7 @@ class _ServerSection extends StatelessWidget {
     required this.searchQuery,
     required this.sortMode,
     required this.roomActivity,
+    required this.readMarkers,
     required this.onRoomTap,
     required this.onInfoTap,
     required this.onSignIn,
@@ -689,6 +704,7 @@ class _ServerSection extends StatelessWidget {
   final String searchQuery;
   final LobbySortMode sortMode;
   final Map<RoomActivityKey, DateTime?> roomActivity;
+  final Map<RoomActivityKey, DateTime> readMarkers;
   final void Function(String serverId, String roomId) onRoomTap;
   final void Function(String serverId, String roomId) onInfoTap;
   final void Function(String serverId) onSignIn;
@@ -805,6 +821,17 @@ class _ServerSection extends StatelessWidget {
   DateTime? _activityFor(Room room) =>
       roomActivity[(serverId: serverId, roomId: room.id)];
 
+  /// A room is unread when its last-message time is newer than the user's
+  /// stored read marker (or it was never opened). No known activity → not
+  /// unread (nothing to surface).
+  bool _isUnread(Room room) {
+    final key = (serverId: serverId, roomId: room.id);
+    final lastMessageAt = roomActivity[key];
+    if (lastMessageAt == null) return false;
+    final seen = readMarkers[key];
+    return seen == null || lastMessageAt.isAfter(seen);
+  }
+
   /// Renders [rooms] in the active view mode (no grouping).
   Widget _buildBlock(BuildContext context, List<Room> rooms) {
     return switch (viewMode) {
@@ -818,6 +845,7 @@ class _ServerSection extends StatelessWidget {
                 RoomCard(
                   room: room,
                   activityTime: _activityFor(room),
+                  isUnread: _isUnread(room),
                   onTap: () => onRoomTap(serverId, room.id),
                   onInfoTap: () => onInfoTap(serverId, room.id),
                 ),
@@ -828,6 +856,7 @@ class _ServerSection extends StatelessWidget {
           serverId: serverId,
           rooms: rooms,
           activityFor: _activityFor,
+          isUnread: _isUnread,
           onRoomTap: onRoomTap,
           onInfoTap: onInfoTap,
         ),
@@ -870,6 +899,7 @@ class _RoomGrid extends StatelessWidget {
     required this.serverId,
     required this.rooms,
     required this.activityFor,
+    required this.isUnread,
     required this.onRoomTap,
     required this.onInfoTap,
   });
@@ -877,6 +907,7 @@ class _RoomGrid extends StatelessWidget {
   final String serverId;
   final List<Room> rooms;
   final DateTime? Function(Room) activityFor;
+  final bool Function(Room) isUnread;
   final void Function(String serverId, String roomId) onRoomTap;
   final void Function(String serverId, String roomId) onInfoTap;
 
@@ -910,6 +941,7 @@ class _RoomGrid extends StatelessWidget {
                             ? RoomGridCard(
                                 room: rowRooms[i],
                                 activityTime: activityFor(rowRooms[i]),
+                                isUnread: isUnread(rowRooms[i]),
                                 onTap: () =>
                                     onRoomTap(serverId, rowRooms[i].id),
                                 onInfoTap: () =>

--- a/lib/src/modules/lobby/ui/room_card.dart
+++ b/lib/src/modules/lobby/ui/room_card.dart
@@ -3,6 +3,7 @@ import 'package:soliplex_agent/soliplex_agent.dart';
 import 'package:soliplex_design/soliplex_design.dart';
 
 import '../../../shared/relative_time.dart';
+import 'unread_dot.dart';
 
 class RoomCard extends StatelessWidget {
   const RoomCard({
@@ -11,6 +12,7 @@ class RoomCard extends StatelessWidget {
     required this.onTap,
     required this.onInfoTap,
     this.activityTime,
+    this.isUnread = false,
   });
 
   final Room room;
@@ -20,6 +22,10 @@ class RoomCard extends StatelessWidget {
   /// Most-recent-thread timestamp, shown as a muted relative label under the
   /// title. Null while unknown (not yet fetched, or the room has no threads).
   final DateTime? activityTime;
+
+  /// Whether the room has activity newer than the user last saw, surfaced as
+  /// a small dot. A boolean affordance only — there is no unread count.
+  final bool isUnread;
 
   @override
   Widget build(BuildContext context) {
@@ -36,6 +42,10 @@ class RoomCard extends StatelessWidget {
         trailing: Row(
           mainAxisSize: MainAxisSize.min,
           children: [
+            if (isUnread) ...[
+              const UnreadDot(),
+              const SizedBox(width: SoliplexSpacing.s2),
+            ],
             // Leading marking; renders nothing until a deployment
             // configures classifications. Backend per-room value wires in
             // here later via `classification:`.

--- a/lib/src/modules/lobby/ui/room_grid_card.dart
+++ b/lib/src/modules/lobby/ui/room_grid_card.dart
@@ -3,6 +3,7 @@ import 'package:soliplex_agent/soliplex_agent.dart';
 import 'package:soliplex_design/soliplex_design.dart';
 
 import '../../../shared/relative_time.dart';
+import 'unread_dot.dart';
 
 /// Vertical card used for the lobby's grid layout: open on tap, info
 /// button, and a quiz indicator, in a shape that tiles cleanly into a
@@ -14,6 +15,7 @@ class RoomGridCard extends StatelessWidget {
     required this.onTap,
     required this.onInfoTap,
     this.activityTime,
+    this.isUnread = false,
   });
 
   final Room room;
@@ -23,6 +25,10 @@ class RoomGridCard extends StatelessWidget {
   /// Most-recent-thread timestamp, shown as a muted relative label in the
   /// footer's bottom-left. Null while unknown (not yet fetched, or no threads).
   final DateTime? activityTime;
+
+  /// Whether the room has activity newer than the user last saw, surfaced as
+  /// a small dot beside the name. A boolean affordance only — no count.
+  final bool isUnread;
 
   @override
   Widget build(BuildContext context) {
@@ -47,6 +53,10 @@ class RoomGridCard extends StatelessWidget {
             children: [
               Row(
                 children: [
+                  if (isUnread) ...[
+                    const UnreadDot(),
+                    const SizedBox(width: SoliplexSpacing.s2),
+                  ],
                   Expanded(
                     child: Text(
                       room.name,

--- a/lib/src/modules/lobby/ui/unread_dot.dart
+++ b/lib/src/modules/lobby/ui/unread_dot.dart
@@ -1,0 +1,27 @@
+import 'package:flutter/material.dart';
+import 'package:soliplex_design/soliplex_design.dart';
+
+/// A small primary-colored dot marking a room with unread activity.
+///
+/// A boolean affordance only — the lobby tracks *whether* a room has newer
+/// activity than the user last saw, not how many messages. Shared by the
+/// list ([RoomCard]) and grid ([RoomGridCard]) views so the marker reads
+/// identically in both.
+class UnreadDot extends StatelessWidget {
+  const UnreadDot({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Tooltip(
+      message: 'Unread activity',
+      child: Container(
+        width: SoliplexSpacing.s2,
+        height: SoliplexSpacing.s2,
+        decoration: BoxDecoration(
+          color: Theme.of(context).colorScheme.primary,
+          shape: BoxShape.circle,
+        ),
+      ),
+    );
+  }
+}

--- a/test/modules/lobby/lobby_read_markers_test.dart
+++ b/test/modules/lobby/lobby_read_markers_test.dart
@@ -1,0 +1,71 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:soliplex_frontend/src/modules/lobby/lobby_read_markers.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+  setUp(() => SharedPreferences.setMockInitialValues({}));
+
+  group('LobbyReadMarkerStorage', () {
+    test('defaults to empty when nothing is persisted', () async {
+      expect(await LobbyReadMarkerStorage.load(), isEmpty);
+    });
+
+    test('round-trips markers, normalizing to UTC', () async {
+      final markers = {
+        (serverId: 'a', roomId: 'r1'): DateTime.utc(2026, 6, 1, 12),
+        (serverId: 'b', roomId: 'r2'): DateTime.utc(2026, 1, 2, 3, 4),
+      };
+      await LobbyReadMarkerStorage.save(markers);
+
+      final loaded = await LobbyReadMarkerStorage.load();
+      expect(loaded, hasLength(2));
+      expect(
+          loaded[(serverId: 'a', roomId: 'r1')], DateTime.utc(2026, 6, 1, 12));
+      expect(loaded[(serverId: 'b', roomId: 'r2')]!.isUtc, isTrue);
+    });
+
+    test('preserves ids that would collide under a naive composite key',
+        () async {
+      // Ids with separators must survive the JSON round-trip intact.
+      final markers = {
+        (serverId: 'a|b', roomId: 'r'): DateTime.utc(2026),
+        (serverId: 'a', roomId: 'b|r'): DateTime.utc(2025),
+      };
+      await LobbyReadMarkerStorage.save(markers);
+
+      final loaded = await LobbyReadMarkerStorage.load();
+      expect(loaded, hasLength(2));
+      expect(loaded[(serverId: 'a|b', roomId: 'r')], DateTime.utc(2026));
+      expect(loaded[(serverId: 'a', roomId: 'b|r')], DateTime.utc(2025));
+    });
+
+    test('a corrupt payload loads as empty rather than throwing', () async {
+      SharedPreferences.setMockInitialValues(
+        {'soliplex_lobby_read_markers': 'not json{'},
+      );
+      expect(await LobbyReadMarkerStorage.load(), isEmpty);
+    });
+
+    test('skips malformed entries but keeps valid ones', () async {
+      SharedPreferences.setMockInitialValues({
+        'soliplex_lobby_read_markers': '['
+            '{"s":"a","r":"r1","t":"2026-06-01T00:00:00Z"},'
+            '{"s":"a","r":"r2","t":"not-a-date"},'
+            '{"s":"a","t":"2026-06-01T00:00:00Z"},'
+            '"garbage"'
+            ']',
+      });
+      final loaded = await LobbyReadMarkerStorage.load();
+      expect(loaded, hasLength(1));
+      expect(loaded[(serverId: 'a', roomId: 'r1')], DateTime.utc(2026, 6));
+    });
+
+    test('a non-list payload loads as empty', () async {
+      SharedPreferences.setMockInitialValues(
+        {'soliplex_lobby_read_markers': '{"s":"a"}'},
+      );
+      expect(await LobbyReadMarkerStorage.load(), isEmpty);
+    });
+  });
+}

--- a/test/modules/lobby/lobby_state_test.dart
+++ b/test/modules/lobby/lobby_state_test.dart
@@ -9,6 +9,7 @@ import 'package:soliplex_frontend/src/modules/auth/auth_session.dart';
 import 'package:soliplex_frontend/src/modules/auth/auth_tokens.dart';
 import 'package:soliplex_frontend/src/modules/auth/selected_server_storage.dart';
 import 'package:soliplex_frontend/src/modules/auth/server_manager.dart';
+import 'package:soliplex_frontend/src/modules/lobby/lobby_read_markers.dart';
 import 'package:soliplex_frontend/src/modules/lobby/lobby_state.dart';
 
 import '../../helpers/fakes.dart';
@@ -1077,6 +1078,110 @@ void main() {
         expect(await SelectedServerStorage.load(), isNull);
         state.dispose();
       });
+    });
+  });
+
+  group('LobbyState unread markers', () {
+    Future<LobbyState> startWith(FakeSoliplexApi api, ServerManager mgr) async {
+      final state = LobbyState(serverManager: mgr, apiResolver: (_) => api);
+      // Let rooms load and the activity sweep populate roomActivity.
+      for (var i = 0; i < 12; i++) {
+        await Future<void>.delayed(Duration.zero);
+      }
+      return state;
+    }
+
+    ServerManager managerWithLocal() {
+      final manager = _createManager();
+      manager.addServer(
+        serverId: 'local',
+        serverUrl: Uri.parse('http://localhost:8000'),
+        requiresAuth: false,
+      );
+      return manager;
+    }
+
+    test('a room with activity and no marker is unread; opening it clears it',
+        () async {
+      final api = FakeSoliplexApi()
+        ..nextRooms = const [Room(id: 'r1', name: 'General')]
+        ..statsByRoom['r1'] =
+            RoomStats(roomId: 'r1', lastMessageAt: DateTime.utc(2026, 6));
+      final state = await startWith(api, managerWithLocal());
+
+      expect(state.isRoomUnread('local', 'r1'), isTrue,
+          reason: 'never-opened room with activity is unread');
+
+      state.markRoomRead('local', 'r1');
+      expect(state.isRoomUnread('local', 'r1'), isFalse,
+          reason: 'opening the room clears the unread affordance');
+      expect(
+        state.readMarkers.value[(serverId: 'local', roomId: 'r1')],
+        isNotNull,
+      );
+      state.dispose();
+    });
+
+    test('a room with no known activity is never unread', () async {
+      final api = FakeSoliplexApi()
+        ..nextRooms = const [Room(id: 'r1', name: 'Quiet')]
+        ..statsByRoom['r1'] = const RoomStats(roomId: 'r1');
+      final state = await startWith(api, managerWithLocal());
+
+      expect(state.isRoomUnread('local', 'r1'), isFalse);
+      state.dispose();
+    });
+
+    test('a persisted marker newer than the activity keeps the room read',
+        () async {
+      await LobbyReadMarkerStorage.save({
+        (serverId: 'local', roomId: 'r1'): DateTime.utc(2027),
+      });
+      final api = FakeSoliplexApi()
+        ..nextRooms = const [Room(id: 'r1', name: 'General')]
+        ..statsByRoom['r1'] =
+            RoomStats(roomId: 'r1', lastMessageAt: DateTime.utc(2026, 6));
+      final state = await startWith(api, managerWithLocal());
+
+      expect(state.isRoomUnread('local', 'r1'), isFalse,
+          reason: 'a read marker after the last message means nothing new');
+      state.dispose();
+    });
+
+    test('a persisted marker older than the activity leaves the room unread',
+        () async {
+      await LobbyReadMarkerStorage.save({
+        (serverId: 'local', roomId: 'r1'): DateTime.utc(2025),
+      });
+      final api = FakeSoliplexApi()
+        ..nextRooms = const [Room(id: 'r1', name: 'General')]
+        ..statsByRoom['r1'] =
+            RoomStats(roomId: 'r1', lastMessageAt: DateTime.utc(2026, 6));
+      final state = await startWith(api, managerWithLocal());
+
+      expect(state.isRoomUnread('local', 'r1'), isTrue,
+          reason: 'a message after the last-seen time is unread');
+      state.dispose();
+    });
+
+    test('markRoomRead persists so a fresh LobbyState stays read', () async {
+      final api = FakeSoliplexApi()
+        ..nextRooms = const [Room(id: 'r1', name: 'General')]
+        ..statsByRoom['r1'] =
+            RoomStats(roomId: 'r1', lastMessageAt: DateTime.utc(2026, 6));
+      final manager = managerWithLocal();
+      final state = await startWith(api, manager);
+      state.markRoomRead('local', 'r1');
+      // Let the async persist complete.
+      for (var i = 0; i < 4; i++) {
+        await Future<void>.delayed(Duration.zero);
+      }
+      state.dispose();
+
+      final reloaded = await startWith(api, manager);
+      expect(reloaded.isRoomUnread('local', 'r1'), isFalse,
+          reason: 'the persisted marker survives a new LobbyState');
+      reloaded.dispose();
     });
   });
 }

--- a/test/modules/lobby/ui/lobby_screen_test.dart
+++ b/test/modules/lobby/ui/lobby_screen_test.dart
@@ -13,6 +13,7 @@ import 'package:soliplex_frontend/src/modules/lobby/ui/lobby_screen.dart';
 import 'package:soliplex_frontend/src/modules/lobby/ui/room_card.dart';
 import 'package:soliplex_frontend/src/modules/lobby/ui/room_grid_card.dart';
 import 'package:soliplex_frontend/src/modules/lobby/ui/server_sidebar.dart';
+import 'package:soliplex_frontend/src/modules/lobby/ui/unread_dot.dart';
 
 import '../../../helpers/fakes.dart';
 
@@ -488,6 +489,30 @@ void main() {
       await tester.pumpAndSettle();
 
       expect(roomOrder(), ['Random', 'General']);
+    });
+
+    testWidgets('shows an unread dot for a room with unseen activity',
+        (tester) async {
+      tester.view.physicalSize = const Size(900, 600);
+      tester.view.devicePixelRatio = 1.0;
+      addTearDown(tester.view.resetPhysicalSize);
+
+      final manager = _createManager();
+      manager.addServer(
+        serverId: 'local',
+        serverUrl: Uri.parse('http://localhost:8000'),
+        requiresAuth: false,
+      );
+      final fakeApi = FakeSoliplexApi()
+        ..nextRooms = const [Room(id: 'r1', name: 'General')]
+        ..statsByRoom['r1'] =
+            RoomStats(roomId: 'r1', lastMessageAt: DateTime.utc(2026, 6));
+
+      await tester.pumpWidget(_buildApp(manager, apiResolver: (_) => fakeApi));
+      await tester.pumpAndSettle();
+
+      // The room has activity and no read marker, so it reads as unread.
+      expect(find.byType(UnreadDot), findsOneWidget);
     });
 
     testWidgets('recent-activity sort groups rooms under date-bucket headers',

--- a/test/modules/lobby/ui/room_card_test.dart
+++ b/test/modules/lobby/ui/room_card_test.dart
@@ -3,6 +3,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:soliplex_agent/soliplex_agent.dart';
 import 'package:soliplex_design/soliplex_design.dart';
 import 'package:soliplex_frontend/src/modules/lobby/ui/room_card.dart';
+import 'package:soliplex_frontend/src/modules/lobby/ui/unread_dot.dart';
 
 ClassificationTheme _classifications() => ClassificationTheme(
       defaultId: 'internal',
@@ -20,6 +21,7 @@ Widget _buildCard({
   required Room room,
   VoidCallback? onTap,
   VoidCallback? onInfoTap,
+  bool isUnread = false,
 }) {
   return MaterialApp(
     home: Scaffold(
@@ -27,6 +29,7 @@ Widget _buildCard({
         room: room,
         onTap: onTap ?? () {},
         onInfoTap: onInfoTap ?? () {},
+        isUnread: isUnread,
       ),
     ),
   );
@@ -41,6 +44,16 @@ void main() {
 
       expect(find.text('Test Room'), findsOneWidget);
       expect(find.text('A room'), findsOneWidget);
+    });
+
+    testWidgets('shows the unread dot only when isUnread', (tester) async {
+      const room = Room(id: 'r1', name: 'Test Room');
+
+      await tester.pumpWidget(_buildCard(room: room));
+      expect(find.byType(UnreadDot), findsNothing);
+
+      await tester.pumpWidget(_buildCard(room: room, isUnread: true));
+      expect(find.byType(UnreadDot), findsOneWidget);
     });
 
     testWidgets('hides description when empty', (tester) async {

--- a/test/modules/lobby/ui/room_grid_card_test.dart
+++ b/test/modules/lobby/ui/room_grid_card_test.dart
@@ -3,6 +3,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:soliplex_agent/soliplex_agent.dart';
 import 'package:soliplex_design/soliplex_design.dart';
 import 'package:soliplex_frontend/src/modules/lobby/ui/room_grid_card.dart';
+import 'package:soliplex_frontend/src/modules/lobby/ui/unread_dot.dart';
 
 // RoomGridCard fills the height of its grid cell (footer pinned to bottom),
 // so it must be given a bounded height — mirror that here with a sized cell.
@@ -28,6 +29,25 @@ ClassificationTheme _classifications() => ClassificationTheme(
 
 void main() {
   group('RoomGridCard', () {
+    testWidgets('shows the unread dot only when isUnread', (tester) async {
+      const room = Room(id: 'r1', name: 'General');
+
+      await tester.pumpWidget(_harness(
+        RoomGridCard(room: room, onTap: () {}, onInfoTap: () {}),
+      ));
+      expect(find.byType(UnreadDot), findsNothing);
+
+      await tester.pumpWidget(_harness(
+        RoomGridCard(
+          room: room,
+          onTap: () {},
+          onInfoTap: () {},
+          isUnread: true,
+        ),
+      ));
+      expect(find.byType(UnreadDot), findsOneWidget);
+    });
+
     testWidgets('renders name and description', (tester) async {
       await tester.pumpWidget(_harness(
         RoomGridCard(


### PR DESCRIPTION
## What

Surfaces a small primary **unread dot** on lobby room cards (list + grid) when a room has activity newer than the user last saw it.

A deliberately simple, **client-side, per-device** read model — a boolean affordance, **no count** and **no server-side read state**. It builds directly on the last-message recency from #349: a room is unread when its `lastMessageAt` is newer than the moment the user last opened it.

## How

- **`LobbyReadMarkerStorage`** — persists per-`(serverId, roomId)` "last seen" timestamps in `shared_preferences` (JSON; tolerant of corrupt/partial payloads).
- **`LobbyState`** — loads markers on init; exposes `readMarkers` + `isRoomUnread`; `markRoomRead` stamps *now* when a room is opened (so a room reads as read the instant it's opened, even if the activity sweep is stale or in flight).
- **Unread predicate** — `lastMessageAt != null && (marker == null || lastMessageAt.isAfter(marker))`. No known activity → never unread.
- **UI** — `RoomCard` / `RoomGridCard` gain `isUnread` (default `false`) and render a shared `UnreadDot`; `_onRoomTap` marks the room read before navigating.

## Tests

- Storage round-trip + resilience (corrupt payload, malformed entries, id-collision safety).
- `LobbyState` unread derivation, mark-read clearing, persistence across instances.
- The dot's presence/absence on both card types, plus a lobby-screen integration check.
- Lobby suite green (129); full app suite green (1663).

## Stacking

Based on **#349** (`fix/lobby-last-activity`), which it depends on for `RoomStats.lastMessageAt`. Rebase to `main` once #349 merges.