### PR TITLE
fix(lobby): drop the status dot for no-auth servers

### DIFF
--- a/lib/src/modules/lobby/ui/server_sidebar.dart
+++ b/lib/src/modules/lobby/ui/server_sidebar.dart
@@ -232,9 +232,12 @@ class _ServerTileState extends State<_ServerTile> {
       onEnter: (_) => setState(() => _hovered = true),
       onExit: (_) => setState(() => _hovered = false),
       child: ListTile(
-        // Tighten the leading slot so the status dot reads as a marker beside
-        // the name rather than a far-left icon.
-        leading: _StatusDot(entry: widget.entry),
+        // The status dot only signals sign-in state, which is meaningless for
+        // a no-auth server (it's always ready) — so those carry no leading
+        // dot at all. Tighten the slot so the dot reads as a marker beside the
+        // name rather than a far-left icon.
+        leading:
+            widget.entry.requiresAuth ? _StatusDot(entry: widget.entry) : null,
         minLeadingWidth: 0,
         horizontalTitleGap: SoliplexSpacing.s3,
         selected: widget.selected,
@@ -257,15 +260,16 @@ class _ServerTileState extends State<_ServerTile> {
   }
 }
 
-/// A small status dot for a server tile:
+/// A small sign-in status dot for an auth-required server tile:
 ///
-/// - **neutral** (`onSurfaceVariant`) — no authentication required;
-/// - **green** (`success`) — auth required and signed in;
-/// - **red** (`danger`) — auth required but not signed in (or expired).
+/// - **green** (`success`) — signed in;
+/// - **red** (`danger`) — not signed in (or expired).
 ///
-/// Reads the per-entry session signal, so the dot lives in a [Watch] and
-/// updates on sign-in / expiry without a server-map mutation. The tooltip
-/// carries the same status as text for accessibility.
+/// Only rendered for servers where `requiresAuth` is true: a no-auth server
+/// is always ready, so it carries no dot (see [_ServerTile]). Reads the
+/// per-entry session signal, so the dot lives in a [Watch] and updates on
+/// sign-in / expiry without a server-map mutation. The tooltip carries the
+/// same status as text for accessibility.
 class _StatusDot extends StatelessWidget {
   const _StatusDot({required this.entry});
 
@@ -277,12 +281,9 @@ class _StatusDot extends StatelessWidget {
   Widget build(BuildContext context) {
     return Watch((context) {
       final colors = Theme.of(context).colorScheme;
-      final session = entry.auth.session.value;
-      final (Color color, String label) = !entry.requiresAuth
-          ? (colors.onSurfaceVariant, 'No authentication required')
-          : session is ActiveSession
-              ? (colors.success, 'Signed in')
-              : (colors.danger, 'Not signed in');
+      final signedIn = entry.auth.session.value is ActiveSession;
+      final color = signedIn ? colors.success : colors.danger;
+      final label = signedIn ? 'Signed in' : 'Not signed in';
       return Tooltip(
         message: label,
         child: Container(

--- a/test/modules/lobby/ui/server_sidebar_test.dart
+++ b/test/modules/lobby/ui/server_sidebar_test.dart
@@ -581,8 +581,9 @@ void main() {
         return (container.decoration! as BoxDecoration).color!;
       }
 
-      testWidgets('maps the three auth states to distinct colored dots',
-          (tester) async {
+      testWidgets(
+          'shows a distinct dot per sign-in state, and none for a no-auth '
+          'server', (tester) async {
         final manager = _createManager();
         manager.addServer(
           serverId: 'noauth',
@@ -601,18 +602,18 @@ void main() {
 
         await tester.pumpWidget(_buildSidebar(servers: manager.servers.value));
 
-        // Each state has a labelled dot...
-        expect(find.byTooltip('No authentication required'), findsOneWidget);
+        // A no-auth server is always ready, so it carries no status dot.
+        expect(find.byTooltip('No authentication required'), findsNothing);
+
+        // The two sign-in states each get a labelled dot...
         expect(find.byTooltip('Not signed in'), findsOneWidget);
         expect(find.byTooltip('Signed in'), findsOneWidget);
 
-        // ...and the three colors are all different.
-        final colors = {
-          dotColor(tester, 'No authentication required'),
+        // ...in different colors.
+        expect(
           dotColor(tester, 'Not signed in'),
-          dotColor(tester, 'Signed in'),
-        };
-        expect(colors.length, 3);
+          isNot(dotColor(tester, 'Signed in')),
+        );
       });
 
       testWidgets('flips from signed-in to signed-out on session expiry',


### PR DESCRIPTION
## What

A `--no-auth-mode` server showed a neutral **grey** status dot (the `!requiresAuth` branch of `_StatusDot`). Grey reads as a muted *"signed out"* state, but a no-auth server is always ready — there's no sign-in state to convey — so the dot was misleading.

Now the dot appears **only where sign-in matters**:

- `_ServerTile` gives a no-auth server **no `leading` at all** (no dot, no reserved slot).
- `_StatusDot` is a two-state sign-in indicator — green `success` (signed in) / red `danger` (not signed in or expired) — built only for `requiresAuth` servers.

## Not a backend issue

The dot derives purely from `requiresAuth` + the per-entry session signal. The `/api/user_info` 404 in `--no-auth-mode` (intentional backend behavior) is unrelated: `LobbyState._fetchUserProfile` treats any non-401 failure as a null profile and never touches session state, so it can't affect the dot.

## Tests

- Updated the sidebar status-dot test: a no-auth server has **no** dot (`No authentication required` tooltip gone); the two sign-in states still render distinct green/red dots; the expiry-flip test is unchanged.
- Sidebar suite (27) + full lobby suite (115) green; analyze clean.

Independent of the room-stats stack (#349/#350) — branches off `main`.