### PR TITLE
feat(versions): give the versions screens the branded top bar

### DIFF
--- a/lib/src/flavors/standard.dart
+++ b/lib/src/flavors/standard.dart
@@ -171,6 +171,7 @@ Future<ShellConfig> standard({
       QuizAppModule(serverManager: serverManager),
       VersionsAppModule(
         appName: brand.appName,
+        logo: brandLogo,
         serverManager: serverManager,
       ),
     ],

--- a/lib/src/modules/auth/ui/home_shell.dart
+++ b/lib/src/modules/auth/ui/home_shell.dart
@@ -55,23 +55,33 @@ class HomeShell extends StatelessWidget {
 }
 
 /// The branded top bar shared across the onboarding surfaces (home / connect
-/// flow, the OAuth callback, and the server list): logo, app name, library
-/// version, and trailing [actions] — defaulting to just an about/versions
-/// button so the bar reads the same everywhere.
+/// flow, the OAuth callback, and the server list) and the versions screens:
+/// logo, app name, library version, and trailing [actions] — followed by an
+/// about/versions button so the bar reads the same everywhere.
 class HomeShellHeader extends StatelessWidget {
   const HomeShellHeader({
     super.key,
     required this.appName,
     this.logo,
+    this.leading,
     this.actions,
+    this.showAbout = true,
   });
 
   final String appName;
   final Widget? logo;
 
+  /// Optional leading widget shown before the logo — e.g. a back button on
+  /// pushed sub-pages like the versions screens.
+  final Widget? leading;
+
   /// Trailing actions shown before the about/versions button. Screens like the
   /// server list slot their navigation here.
   final List<Widget>? actions;
+
+  /// Whether to show the trailing about/versions button. Off on the versions
+  /// screens themselves, which are already the about destination.
+  final bool showAbout;
 
   static const _logoSize = 24.0;
 
@@ -90,6 +100,10 @@ class HomeShellHeader extends StatelessWidget {
       ),
       child: Row(
         children: [
+          if (leading != null) ...[
+            leading!,
+            const SizedBox(width: SoliplexSpacing.s2),
+          ],
           SizedBox(
             width: _logoSize,
             height: _logoSize,
@@ -111,11 +125,12 @@ class HomeShellHeader extends StatelessWidget {
           ),
           const Spacer(),
           ...?actions,
-          IconButton(
-            tooltip: 'About & versions',
-            icon: const Icon(Icons.info_outline),
-            onPressed: () => context.push(AppRoutes.versions),
-          ),
+          if (showAbout)
+            IconButton(
+              tooltip: 'About & versions',
+              icon: const Icon(Icons.info_outline),
+              onPressed: () => context.push(AppRoutes.versions),
+            ),
         ],
       ),
     );

--- a/lib/src/modules/versions/server_versions_screen.dart
+++ b/lib/src/modules/versions/server_versions_screen.dart
@@ -7,6 +7,7 @@ import 'package:soliplex_logging/soliplex_logging.dart';
 import '../../core/routes.dart';
 import 'package:soliplex_design/soliplex_design.dart';
 import '../auth/server_entry.dart';
+import '../auth/ui/home_shell.dart';
 import 'backend_version_fetcher.dart';
 
 final _logger = LogManager.instance.getLogger('versions');
@@ -14,10 +15,14 @@ final _logger = LogManager.instance.getLogger('versions');
 class ServerVersionsScreen extends StatefulWidget {
   const ServerVersionsScreen({
     super.key,
+    required this.appName,
     required this.serverEntry,
     required this.versionFetcher,
+    this.logo,
   });
 
+  final String appName;
+  final Widget? logo;
   final ServerEntry serverEntry;
   final BackendVersionFetcher versionFetcher;
 
@@ -59,39 +64,65 @@ class _ServerVersionsScreenState extends State<ServerVersionsScreen> {
   Widget build(BuildContext context) {
     final url = formatServerUrl(widget.serverEntry.serverUrl);
     return Scaffold(
-      appBar: AppBar(
-        leading: IconButton(
-          icon: Icon(Icons.adaptive.arrow_back),
-          tooltip: 'Back to versions',
-          onPressed: () =>
-              context.canPop() ? context.pop() : context.go(AppRoutes.versions),
+      body: SafeArea(
+        child: Column(
+          children: [
+            HomeShellHeader(
+              appName: widget.appName,
+              logo: widget.logo,
+              showAbout: false,
+              leading: IconButton(
+                icon: Icon(Icons.adaptive.arrow_back),
+                tooltip: 'Back to versions',
+                onPressed: () => context.canPop()
+                    ? context.pop()
+                    : context.go(AppRoutes.versions),
+              ),
+            ),
+            Expanded(
+              child: FutureBuilder<BackendVersionInfo>(
+                future: _future,
+                builder: (context, snapshot) {
+                  if (snapshot.connectionState != ConnectionState.done) {
+                    return const Center(child: CircularProgressIndicator());
+                  }
+                  if (snapshot.hasError) {
+                    return const Center(
+                      child: Text('Failed to load version information'),
+                    );
+                  }
+                  return _buildContent(url, snapshot.data!);
+                },
+              ),
+            ),
+          ],
         ),
-        title: Text(url),
-      ),
-      body: FutureBuilder<BackendVersionInfo>(
-        future: _future,
-        builder: (context, snapshot) {
-          if (snapshot.connectionState != ConnectionState.done) {
-            return const Center(child: CircularProgressIndicator());
-          }
-          if (snapshot.hasError) {
-            return const Center(
-              child: Text('Failed to load version information'),
-            );
-          }
-          return _buildContent(snapshot.data!);
-        },
       ),
     );
   }
 
-  Widget _buildContent(BackendVersionInfo info) {
+  Widget _buildContent(String url, BackendVersionInfo info) {
     final filtered = _filterPackages(info.packageVersions);
     final sortedKeys = filtered.keys.toList()..sort();
     final total = info.packageVersions.length;
 
     return Column(
       children: [
+        Padding(
+          padding: const EdgeInsets.fromLTRB(
+            SoliplexSpacing.s4,
+            SoliplexSpacing.s4,
+            SoliplexSpacing.s4,
+            0,
+          ),
+          child: Align(
+            alignment: Alignment.centerLeft,
+            child: SelectableText(
+              url,
+              style: Theme.of(context).textTheme.titleMedium,
+            ),
+          ),
+        ),
         Padding(
           padding: const EdgeInsets.all(SoliplexSpacing.s4),
           child: SoliplexInput(

--- a/lib/src/modules/versions/versions_module.dart
+++ b/lib/src/modules/versions/versions_module.dart
@@ -14,12 +14,14 @@ class VersionsAppModule extends AppModule {
   VersionsAppModule({
     required this.appName,
     required this.serverManager,
+    this.logo,
     AppVersionLoader? versionLoader,
     BackendVersionFetcher? versionFetcher,
   })  : _versionLoader = versionLoader ?? loadFlavorVersion,
         _versionFetcher = versionFetcher ?? fetchBackendVersionInfo;
 
   final String appName;
+  final Widget? logo;
   final ServerManager serverManager;
   final AppVersionLoader _versionLoader;
   final BackendVersionFetcher _versionFetcher;
@@ -35,6 +37,7 @@ class VersionsAppModule extends AppModule {
             pageBuilder: (context, state) => NoTransitionPage(
               child: VersionsScreen(
                 appName: appName,
+                logo: logo,
                 serverManager: serverManager,
                 versionLoader: _versionLoader,
                 versionFetcher: _versionFetcher,
@@ -60,6 +63,8 @@ class VersionsAppModule extends AppModule {
               }
               return NoTransitionPage(
                 child: ServerVersionsScreen(
+                  appName: appName,
+                  logo: logo,
                   serverEntry: entry,
                   versionFetcher: _versionFetcher,
                 ),

--- a/lib/src/modules/versions/versions_screen.dart
+++ b/lib/src/modules/versions/versions_screen.dart
@@ -10,6 +10,7 @@ import '../../core/routes.dart';
 import 'package:soliplex_design/soliplex_design.dart';
 import '../auth/server_entry.dart';
 import '../auth/server_manager.dart';
+import '../auth/ui/home_shell.dart';
 import 'app_version_loader.dart';
 import 'backend_version_fetcher.dart';
 
@@ -22,9 +23,11 @@ class VersionsScreen extends StatefulWidget {
     required this.serverManager,
     required this.versionLoader,
     required this.versionFetcher,
+    this.logo,
   });
 
   final String appName;
+  final Widget? logo;
   final ServerManager serverManager;
   final AppVersionLoader versionLoader;
   final BackendVersionFetcher versionFetcher;
@@ -59,40 +62,54 @@ class _VersionsScreenState extends State<VersionsScreen> {
   Widget build(BuildContext context) {
     final servers = widget.serverManager.servers.watch(context);
     return Scaffold(
-      appBar: AppBar(
-        leading: IconButton(
-          icon: Icon(Icons.adaptive.arrow_back),
-          tooltip: 'Back',
-          onPressed: () =>
-              context.canPop() ? context.pop() : context.go(AppRoutes.home),
+      body: SafeArea(
+        child: Column(
+          children: [
+            HomeShellHeader(
+              appName: widget.appName,
+              logo: widget.logo,
+              showAbout: false,
+              leading: IconButton(
+                icon: Icon(Icons.adaptive.arrow_back),
+                tooltip: 'Back',
+                onPressed: () => context.canPop()
+                    ? context.pop()
+                    : context.go(AppRoutes.home),
+              ),
+            ),
+            Expanded(
+              child: ListView(
+                children: [
+                  _SectionHeader(label: 'Frontend'),
+                  _AppRow(
+                    appName: widget.appName,
+                    versionFuture: _flavorVersion,
+                  ),
+                  const _FrameworkRow(),
+                  const Divider(height: 1),
+                  _SectionHeader(
+                    label: 'Servers (${servers.length})',
+                  ),
+                  if (servers.isEmpty)
+                    const Padding(
+                      padding: EdgeInsets.all(SoliplexSpacing.s4),
+                      child: Text(
+                        'No servers connected. Connect to a server to see its '
+                        'backend version.',
+                      ),
+                    )
+                  else
+                    for (final entry in servers.values)
+                      _ServerVersionTile(
+                        key: ValueKey(entry.serverId),
+                        entry: entry,
+                        versionFetcher: widget.versionFetcher,
+                      ),
+                ],
+              ),
+            ),
+          ],
         ),
-        title: const Text('Versions'),
-      ),
-      body: ListView(
-        children: [
-          _SectionHeader(label: 'Frontend'),
-          _AppRow(appName: widget.appName, versionFuture: _flavorVersion),
-          const _FrameworkRow(),
-          const Divider(height: 1),
-          _SectionHeader(
-            label: 'Servers (${servers.length})',
-          ),
-          if (servers.isEmpty)
-            const Padding(
-              padding: EdgeInsets.all(SoliplexSpacing.s4),
-              child: Text(
-                'No servers connected. Connect to a server to see its '
-                'backend version.',
-              ),
-            )
-          else
-            for (final entry in servers.values)
-              _ServerVersionTile(
-                key: ValueKey(entry.serverId),
-                entry: entry,
-                versionFetcher: widget.versionFetcher,
-              ),
-        ],
       ),
     );
   }

--- a/test/modules/versions/server_versions_screen_test.dart
+++ b/test/modules/versions/server_versions_screen_test.dart
@@ -20,8 +20,27 @@ Widget _wrap(Widget child) => MaterialApp(home: child);
 
 void main() {
   group('ServerVersionsScreen', () {
+    testWidgets('shows the branded bar (no about button) and URL heading',
+        (tester) async {
+      await tester.pumpWidget(_wrap(ServerVersionsScreen(
+        appName: 'Acme',
+        serverEntry: createTestServerEntry(),
+        versionFetcher: (_) async => _info,
+      )));
+      await tester.pumpAndSettle();
+
+      // Branded app name in the bar; the about/versions button is dropped
+      // because this screen is itself part of the about destination.
+      expect(find.text('Acme'), findsOneWidget);
+      expect(find.byTooltip('About & versions'), findsNothing);
+      // Back affordance and the server URL surfaced in the body.
+      expect(find.byTooltip('Back to versions'), findsOneWidget);
+      expect(find.text('http://test-server:8000'), findsOneWidget);
+    });
+
     testWidgets('renders all packages by default, sorted', (tester) async {
       await tester.pumpWidget(_wrap(ServerVersionsScreen(
+        appName: 'Soliplex',
         serverEntry: createTestServerEntry(),
         versionFetcher: (_) async => _info,
       )));
@@ -35,6 +54,7 @@ void main() {
 
     testWidgets('filters packages by search query', (tester) async {
       await tester.pumpWidget(_wrap(ServerVersionsScreen(
+        appName: 'Soliplex',
         serverEntry: createTestServerEntry(),
         versionFetcher: (_) async => _info,
       )));
@@ -51,6 +71,7 @@ void main() {
 
     testWidgets('search is case-insensitive', (tester) async {
       await tester.pumpWidget(_wrap(ServerVersionsScreen(
+        appName: 'Soliplex',
         serverEntry: createTestServerEntry(),
         versionFetcher: (_) async => _info,
       )));
@@ -67,6 +88,7 @@ void main() {
       'shows distinct empty state when backend reports zero packages',
       (tester) async {
         await tester.pumpWidget(_wrap(ServerVersionsScreen(
+          appName: 'Soliplex',
           serverEntry: createTestServerEntry(),
           versionFetcher: (_) async => const BackendVersionInfo(
             soliplexVersion: '0.36.dev0',
@@ -83,6 +105,7 @@ void main() {
 
     testWidgets('shows empty-search state', (tester) async {
       await tester.pumpWidget(_wrap(ServerVersionsScreen(
+        appName: 'Soliplex',
         serverEntry: createTestServerEntry(),
         versionFetcher: (_) async => _info,
       )));
@@ -97,6 +120,7 @@ void main() {
     testWidgets('shows progress while loading', (tester) async {
       final completer = Completer<BackendVersionInfo>();
       await tester.pumpWidget(_wrap(ServerVersionsScreen(
+        appName: 'Soliplex',
         serverEntry: createTestServerEntry(),
         versionFetcher: (_) => completer.future,
       )));
@@ -110,6 +134,7 @@ void main() {
 
     testWidgets('shows error state when fetch fails', (tester) async {
       await tester.pumpWidget(_wrap(ServerVersionsScreen(
+        appName: 'Soliplex',
         serverEntry: createTestServerEntry(),
         versionFetcher: (_) async => throw Exception('boom'),
       )));

--- a/test/modules/versions/versions_screen_test.dart
+++ b/test/modules/versions/versions_screen_test.dart
@@ -19,6 +19,23 @@ Widget _buildApp(Widget child) => MaterialApp(home: child);
 
 void main() {
   group('VersionsScreen', () {
+    testWidgets('shows the branded bar without the about button',
+        (tester) async {
+      await tester.pumpWidget(_buildApp(VersionsScreen(
+        appName: 'Acme',
+        serverManager: _serverManager(),
+        versionLoader: () async => '0.0.46+48',
+        versionFetcher: (_) async => throw StateError('not called'),
+      )));
+      await tester.pumpAndSettle();
+
+      // Branded app name shows in the bar; the about/versions button is
+      // dropped because we are already on the versions destination.
+      expect(find.text('Acme'), findsOneWidget);
+      expect(find.byTooltip('About & versions'), findsNothing);
+      expect(find.byTooltip('Back'), findsOneWidget);
+    });
+
     testWidgets('shows app and framework rows in Frontend section',
         (tester) async {
       await tester.pumpWidget(_buildApp(VersionsScreen(


### PR DESCRIPTION
## What

Aligns the navbar on both versions surfaces — the versions index and the per-server packages list — with the branded top bar used across the auth/onboarding flow, so the whole product reads as one.

- `HomeShellHeader` gains an optional **`leading`** slot (back button) and a **`showAbout`** toggle. The about/versions button is dropped on the versions screens themselves (they *are* the about destination); a back button takes the leading slot.
- The brand **logo** is threaded through `VersionsAppModule` from the flavor.
- Because the branded bar shows the app name where the contextual title used to be, the **packages screen surfaces the server URL as an in-body heading** above the search field, so that context isn't lost.

## Before / after

Before: plain `AppBar` with back button + contextual title ("Versions" / the server URL).
After: branded bar `[←] ⬡ Soliplex 0.89.0`, no info button; packages screen shows the URL in the body.

## Tests

- Added branded-bar coverage to both screens: app name renders in the bar, the "About & versions" button is absent, the back affordance is present, and (packages) the server URL renders in the body.
- Updated the `ServerVersionsScreen` constructions for the new required `appName`.

Full suite (1651) green; `flutter analyze` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)