### PR TITLE
feat(diagnostics): give the network inspector the branded top bar

### DIFF
--- a/lib/src/flavors/standard.dart
+++ b/lib/src/flavors/standard.dart
@@ -159,7 +159,11 @@ Future<ShellConfig> standard({
       graceDuration: inactivityGraceDuration,
     ),
     modules: [
-      DiagnosticsAppModule(inspector: inspector),
+      DiagnosticsAppModule(
+        appName: brand.appName,
+        logo: brandLogo,
+        inspector: inspector,
+      ),
       authMod,
       LobbyAppModule(serverManager: serverManager, branding: brand),
       RoomAppModule(

--- a/lib/src/modules/auth/ui/home_shell.dart
+++ b/lib/src/modules/auth/ui/home_shell.dart
@@ -115,24 +115,31 @@ class HomeShellHeader extends StatelessWidget {
                 ),
           ),
           const SizedBox(width: SoliplexSpacing.s3),
-          // Flexible so a long app name ellipsizes rather than overflowing
-          // when the bar also carries a leading back button and a trailing
-          // action on a narrow viewport.
-          Flexible(
-            child: Text(
-              appName,
-              style: theme.textTheme.titleSmall,
-              overflow: TextOverflow.ellipsis,
+          // Expanded so the name/version group consumes the free space and
+          // the trailing actions sit flush at the end. The app name is
+          // Flexible within the group so it ellipsizes (rather than
+          // overflowing) when the bar also carries a leading back button and
+          // a trailing action on a narrow viewport.
+          Expanded(
+            child: Row(
+              children: [
+                Flexible(
+                  child: Text(
+                    appName,
+                    style: theme.textTheme.titleSmall,
+                    overflow: TextOverflow.ellipsis,
+                  ),
+                ),
+                const SizedBox(width: SoliplexSpacing.s2),
+                Text(
+                  soliplexVersion,
+                  style: theme.textTheme.bodySmall?.copyWith(
+                    color: colors.onSurfaceVariant,
+                  ),
+                ),
+              ],
             ),
           ),
-          const SizedBox(width: SoliplexSpacing.s2),
-          Text(
-            soliplexVersion,
-            style: theme.textTheme.bodySmall?.copyWith(
-              color: colors.onSurfaceVariant,
-            ),
-          ),
-          const Spacer(),
           ...?actions,
           if (showAbout)
             IconButton(

--- a/lib/src/modules/auth/ui/home_shell.dart
+++ b/lib/src/modules/auth/ui/home_shell.dart
@@ -115,7 +115,16 @@ class HomeShellHeader extends StatelessWidget {
                 ),
           ),
           const SizedBox(width: SoliplexSpacing.s3),
-          Text(appName, style: theme.textTheme.titleSmall),
+          // Flexible so a long app name ellipsizes rather than overflowing
+          // when the bar also carries a leading back button and a trailing
+          // action on a narrow viewport.
+          Flexible(
+            child: Text(
+              appName,
+              style: theme.textTheme.titleSmall,
+              overflow: TextOverflow.ellipsis,
+            ),
+          ),
           const SizedBox(width: SoliplexSpacing.s2),
           Text(
             soliplexVersion,

--- a/lib/src/modules/diagnostics/diagnostics_module.dart
+++ b/lib/src/modules/diagnostics/diagnostics_module.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/widgets.dart';
 import 'package:go_router/go_router.dart';
 
 import '../../core/app_module.dart';
@@ -7,8 +8,14 @@ import 'network_inspector.dart';
 import 'ui/network_inspector_screen.dart';
 
 class DiagnosticsAppModule extends AppModule {
-  DiagnosticsAppModule({required this.inspector});
+  DiagnosticsAppModule({
+    required this.appName,
+    required this.inspector,
+    this.logo,
+  });
 
+  final String appName;
+  final Widget? logo;
   final NetworkInspector inspector;
 
   @override
@@ -22,8 +29,11 @@ class DiagnosticsAppModule extends AppModule {
         routes: [
           GoRoute(
             path: AppRoutes.networkInspector,
-            builder: (context, state) =>
-                NetworkInspectorScreen(inspector: inspector),
+            builder: (context, state) => NetworkInspectorScreen(
+              appName: appName,
+              logo: logo,
+              inspector: inspector,
+            ),
           ),
         ],
       );

--- a/lib/src/modules/diagnostics/ui/network_inspector_screen.dart
+++ b/lib/src/modules/diagnostics/ui/network_inspector_screen.dart
@@ -1,6 +1,9 @@
 import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
 
 import 'package:soliplex_design/soliplex_design.dart';
+import '../../../core/routes.dart';
+import '../../auth/ui/home_shell.dart';
 import '../models/http_event_group.dart';
 import '../models/http_event_grouper.dart';
 import '../network_inspector.dart';
@@ -9,8 +12,15 @@ import 'http_event_tile.dart';
 import 'request_detail_view.dart';
 
 class NetworkInspectorScreen extends StatefulWidget {
-  const NetworkInspectorScreen({required this.inspector, super.key});
+  const NetworkInspectorScreen({
+    required this.appName,
+    required this.inspector,
+    this.logo,
+    super.key,
+  });
 
+  final String appName;
+  final Widget? logo;
   final NetworkInspector inspector;
 
   @override
@@ -29,43 +39,70 @@ class _NetworkInspectorScreenState extends State<NetworkInspectorScreen> {
         final sortedGroups = groups.reversed.toList();
 
         return Scaffold(
-          appBar: AppBar(
-            title: Text('Requests (${sortedGroups.length})'),
-            actions: [
-              IconButton(
-                icon: const Icon(Icons.delete_outline),
-                onPressed: widget.inspector.events.isEmpty &&
-                        widget.inspector.concurrencyEvents.isEmpty
-                    ? null
-                    : () {
-                        widget.inspector.clear();
-                        setState(() => _selectedRequestId = null);
-                      },
-                tooltip: 'Clear all requests',
-              ),
-            ],
-          ),
-          body: Column(
-            children: [
-              ConcurrencySummaryPanel(
-                events: widget.inspector.concurrencyEvents,
-              ),
-              Expanded(
-                child: LayoutBuilder(
-                  builder: (context, constraints) {
-                    if (sortedGroups.isEmpty) {
-                      return _buildEmptyState(context);
-                    }
-                    final isWide =
-                        constraints.maxWidth >= SoliplexBreakpoints.tablet;
-                    if (isWide) {
-                      return _buildMasterDetailLayout(context, sortedGroups);
-                    }
-                    return _buildListLayout(context, sortedGroups);
-                  },
+          body: SafeArea(
+            child: Column(
+              children: [
+                HomeShellHeader(
+                  appName: widget.appName,
+                  logo: widget.logo,
+                  showAbout: false,
+                  leading: IconButton(
+                    icon: Icon(Icons.adaptive.arrow_back),
+                    tooltip: 'Back',
+                    onPressed: () => context.canPop()
+                        ? context.pop()
+                        : context.go(AppRoutes.lobby),
+                  ),
+                  actions: [
+                    IconButton(
+                      icon: const Icon(Icons.delete_sweep_outlined),
+                      onPressed: widget.inspector.events.isEmpty &&
+                              widget.inspector.concurrencyEvents.isEmpty
+                          ? null
+                          : () {
+                              widget.inspector.clear();
+                              setState(() => _selectedRequestId = null);
+                            },
+                      tooltip: 'Clear all requests',
+                    ),
+                  ],
                 ),
-              ),
-            ],
+                ConcurrencySummaryPanel(
+                  events: widget.inspector.concurrencyEvents,
+                ),
+                if (sortedGroups.isNotEmpty)
+                  Padding(
+                    padding: const EdgeInsets.fromLTRB(
+                      SoliplexSpacing.s4,
+                      SoliplexSpacing.s4,
+                      SoliplexSpacing.s4,
+                      SoliplexSpacing.s2,
+                    ),
+                    child: Align(
+                      alignment: Alignment.centerLeft,
+                      child: Text(
+                        'Requests (${sortedGroups.length})',
+                        style: Theme.of(context).textTheme.titleMedium,
+                      ),
+                    ),
+                  ),
+                Expanded(
+                  child: LayoutBuilder(
+                    builder: (context, constraints) {
+                      if (sortedGroups.isEmpty) {
+                        return _buildEmptyState(context);
+                      }
+                      final isWide =
+                          constraints.maxWidth >= SoliplexBreakpoints.tablet;
+                      if (isWide) {
+                        return _buildMasterDetailLayout(context, sortedGroups);
+                      }
+                      return _buildListLayout(context, sortedGroups);
+                    },
+                  ),
+                ),
+              ],
+            ),
           ),
         );
       },

--- a/test/modules/diagnostics/ui/network_inspector_screen_test.dart
+++ b/test/modules/diagnostics/ui/network_inspector_screen_test.dart
@@ -20,9 +20,46 @@ void main() {
     testWidgets('shows empty state when inspector has no events',
         (tester) async {
       await tester.pumpWidget(
-        MaterialApp(home: NetworkInspectorScreen(inspector: inspector)),
+        MaterialApp(
+            home: NetworkInspectorScreen(
+                appName: 'Soliplex', inspector: inspector)),
       );
       expect(find.text('No HTTP requests yet'), findsOneWidget);
+    });
+
+    testWidgets('shows the branded bar (no about button) and back affordance',
+        (tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: NetworkInspectorScreen(appName: 'Acme', inspector: inspector),
+        ),
+      );
+
+      // Branded app name in the bar; the about/versions button is dropped.
+      expect(find.text('Acme'), findsOneWidget);
+      expect(find.byTooltip('About & versions'), findsNothing);
+      expect(find.byTooltip('Back'), findsOneWidget);
+      // The request-count heading stays hidden while the list is empty so it
+      // doesn't compete with the empty state.
+      expect(find.text('Requests (0)'), findsNothing);
+    });
+
+    testWidgets('surfaces the request-count heading in the body when non-empty',
+        (tester) async {
+      inspector.onRequest(createRequestEvent(requestId: 'req-1'));
+      inspector.onResponse(createResponseEvent(requestId: 'req-1'));
+
+      tester.view.physicalSize = const Size(400, 800);
+      tester.view.devicePixelRatio = 1.0;
+      addTearDown(tester.view.resetPhysicalSize);
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: NetworkInspectorScreen(appName: 'Acme', inspector: inspector),
+        ),
+      );
+
+      expect(find.text('Requests (1)'), findsOneWidget);
     });
 
     testWidgets('shows event tiles when events exist', (tester) async {
@@ -41,27 +78,33 @@ void main() {
       addTearDown(tester.view.resetPhysicalSize);
 
       await tester.pumpWidget(
-        MaterialApp(home: NetworkInspectorScreen(inspector: inspector)),
+        MaterialApp(
+            home: NetworkInspectorScreen(
+                appName: 'Soliplex', inspector: inspector)),
       );
       expect(find.text('GET'), findsOneWidget);
     });
 
     testWidgets('clear button is disabled when no events', (tester) async {
       await tester.pumpWidget(
-        MaterialApp(home: NetworkInspectorScreen(inspector: inspector)),
+        MaterialApp(
+            home: NetworkInspectorScreen(
+                appName: 'Soliplex', inspector: inspector)),
       );
       final button = tester.widget<IconButton>(
-          find.widgetWithIcon(IconButton, Icons.delete_outline));
+          find.widgetWithIcon(IconButton, Icons.delete_sweep_outlined));
       expect(button.onPressed, isNull);
     });
 
     testWidgets('clear button is enabled when events exist', (tester) async {
       inspector.onRequest(createRequestEvent());
       await tester.pumpWidget(
-        MaterialApp(home: NetworkInspectorScreen(inspector: inspector)),
+        MaterialApp(
+            home: NetworkInspectorScreen(
+                appName: 'Soliplex', inspector: inspector)),
       );
       final button = tester.widget<IconButton>(
-          find.widgetWithIcon(IconButton, Icons.delete_outline));
+          find.widgetWithIcon(IconButton, Icons.delete_sweep_outlined));
       expect(button.onPressed, isNotNull);
     });
 
@@ -74,10 +117,13 @@ void main() {
       addTearDown(tester.view.resetPhysicalSize);
 
       await tester.pumpWidget(
-        MaterialApp(home: NetworkInspectorScreen(inspector: inspector)),
+        MaterialApp(
+            home: NetworkInspectorScreen(
+                appName: 'Soliplex', inspector: inspector)),
       );
 
-      await tester.tap(find.widgetWithIcon(IconButton, Icons.delete_outline));
+      await tester
+          .tap(find.widgetWithIcon(IconButton, Icons.delete_sweep_outlined));
       await tester.pump();
 
       expect(find.text('No HTTP requests yet'), findsOneWidget);
@@ -88,11 +134,13 @@ void main() {
       inspector.onConcurrencyWait(createConcurrencyWaitEvent());
 
       await tester.pumpWidget(
-        MaterialApp(home: NetworkInspectorScreen(inspector: inspector)),
+        MaterialApp(
+            home: NetworkInspectorScreen(
+                appName: 'Soliplex', inspector: inspector)),
       );
 
       final button = tester.widget<IconButton>(
-          find.widgetWithIcon(IconButton, Icons.delete_outline));
+          find.widgetWithIcon(IconButton, Icons.delete_sweep_outlined));
       expect(
         button.onPressed,
         isNotNull,
@@ -115,13 +163,16 @@ void main() {
         );
 
       await tester.pumpWidget(
-        MaterialApp(home: NetworkInspectorScreen(inspector: inspector)),
+        MaterialApp(
+            home: NetworkInspectorScreen(
+                appName: 'Soliplex', inspector: inspector)),
       );
 
       // Panel is visible when concurrency events exist.
       expect(find.byIcon(Icons.hourglass_empty), findsOneWidget);
 
-      await tester.tap(find.widgetWithIcon(IconButton, Icons.delete_outline));
+      await tester
+          .tap(find.widgetWithIcon(IconButton, Icons.delete_sweep_outlined));
       await tester.pump();
 
       // Panel hides itself when the list is empty.


### PR DESCRIPTION
## What

Standardizes the **NetworkInspector** app bar to match the auth/onboarding and versions surfaces, so the whole product reads as one.

- Plain `AppBar` → shared `HomeShellHeader` (logo · Soliplex · version).
- A **back button** takes the leading slot (falls back to the lobby when it can't pop).
- The **history-cleanup** action stays trailing, now with the more fitting `Icons.delete_sweep_outlined` (was `delete_outline`); same disabled-when-empty behavior and tooltip.
- The about/versions button is **off** here.
- The branded bar shows the app name where the `Requests (N)` title used to be, so the **count is surfaced as an in-body heading** — shown only when the list is non-empty so it doesn't compete with the empty state.
- `appName`/`logo` threaded through `DiagnosticsAppModule` from the brand.

## Shared header note

`HomeShellHeader` gains a `leading` slot + a `showAbout` toggle, and its app name is now `Flexible` (ellipsizes) so it doesn't overflow when the bar carries both a leading and a trailing action on a narrow viewport.

⚠️ That `HomeShellHeader` generalization **overlaps with `polish/versions-navbar` (#352)** — the hunk is identical, so it no-ops when the two branches rebase against each other. No strict merge order required; whichever lands second just absorbs the no-op.

Detail/sub-pages (HTTP request detail) keep their contextual `AppBar` titles — out of scope for this pass.

## Tests

Added branded-bar coverage (app name renders, about button absent, back affordance present, count heading hidden when empty / shown when non-empty); migrated existing clear-button tests to the new icon. Full suite (1651) green; `flutter analyze` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)