### PR TITLE
polish(quiz): design-system adoption sweep

### DIFF
--- a/lib/src/modules/quiz/ui/quiz_answer_input.dart
+++ b/lib/src/modules/quiz/ui/quiz_answer_input.dart
@@ -107,10 +107,16 @@ class _OptionTile extends StatelessWidget {
                           ? colorScheme.primary
                           : colorScheme.onSurfaceVariant,
                 ),
+                const SizedBox(width: SoliplexSpacing.s3),
                 Expanded(child: Text(option)),
-                if (isCorrect)
-                  Icon(Icons.check_circle, color: colorScheme.primary),
-                if (isWrong) Icon(Icons.cancel, color: colorScheme.error),
+                if (isCorrect) ...[
+                  const SizedBox(width: SoliplexSpacing.s2),
+                  Icon(Icons.check_circle, color: colorScheme.success),
+                ],
+                if (isWrong) ...[
+                  const SizedBox(width: SoliplexSpacing.s2),
+                  Icon(Icons.cancel, color: colorScheme.error),
+                ],
               ],
             ),
           ),

--- a/lib/src/modules/quiz/ui/quiz_feedback.dart
+++ b/lib/src/modules/quiz/ui/quiz_feedback.dart
@@ -24,7 +24,7 @@ class QuizAnswerFeedback extends StatelessWidget {
         children: [
           Icon(
             isCorrect ? Icons.check_circle : Icons.cancel,
-            color: isCorrect ? colorScheme.primary : colorScheme.error,
+            color: isCorrect ? colorScheme.success : colorScheme.error,
           ),
           const SizedBox(width: SoliplexSpacing.s2),
           Expanded(
@@ -89,6 +89,7 @@ class QuizErrorFeedback extends StatelessWidget {
               ),
             ),
           ),
+          const SizedBox(width: SoliplexSpacing.s2),
           SoliplexButton.text(onPressed: onRetry, child: const Text('Retry')),
         ],
       ),

--- a/lib/src/modules/quiz/ui/quiz_question.dart
+++ b/lib/src/modules/quiz/ui/quiz_question.dart
@@ -63,7 +63,7 @@ class QuizQuestionView extends StatelessWidget {
                     Text(
                       'Question ${session.currentIndex + 1} of '
                       '${session.quiz.questionCount}',
-                      style: theme.textTheme.labelLarge?.copyWith(
+                      style: theme.textTheme.labelMedium?.copyWith(
                         color: theme.colorScheme.onSurfaceVariant,
                       ),
                     ),

--- a/lib/src/modules/quiz/ui/quiz_results.dart
+++ b/lib/src/modules/quiz/ui/quiz_results.dart
@@ -21,9 +21,9 @@ class QuizResultsView extends StatelessWidget {
     final percent = session.scorePercent;
 
     final (scoreColor, scoreIcon) = switch (percent) {
-      >= 70 => (theme.colorScheme.primary, Icons.emoji_events),
-      >= 40 => (theme.colorScheme.tertiary, Icons.thumb_up),
-      _ => (theme.colorScheme.error, Icons.refresh),
+      >= 70 => (theme.colorScheme.success, Icons.emoji_events),
+      >= 40 => (theme.colorScheme.warning, Icons.thumb_up),
+      _ => (theme.colorScheme.danger, Icons.refresh),
     };
 
     return Center(
@@ -55,8 +55,8 @@ class QuizResultsView extends StatelessWidget {
               const SizedBox(height: SoliplexSpacing.s6),
               Wrap(
                 alignment: WrapAlignment.center,
-                spacing: 8,
-                runSpacing: 8,
+                spacing: SoliplexSpacing.s2,
+                runSpacing: SoliplexSpacing.s2,
                 children: [
                   SoliplexButton.outlined(
                     onPressed: onBack,


### PR DESCRIPTION
Continues the UI polish sweep into the **quiz** module. Scope was deliberately minimal: `soliplex_design` adoption + clear blunders (e.g. missing padding). Touches only `lib/src/modules/quiz/ui/`; no behavioural changes.

## Changes

- **Missing padding** — multiple-choice options (`_OptionTile`) had the radio icon flush against the option label, and the trailing correct/wrong icons flush too. Added `SoliplexSpacing.s3` after the radio and `s2` before each trailing icon.
- **Status colors → `SymbolicColors`** — results score tiers `primary/tertiary/error` → `success/warning/danger`; the "correct" check icon (option tile + answer feedback) → `success`. Incorrect keeps `error`; the colored container surfaces (`primaryContainer`/`errorContainer`) stay as-is, since no `successContainer` token exists.
- **Off-theme text style** — the "Question X of Y" eyebrow used `labelLarge`, which the brand `TextTheme` does not define, so it silently fell back to Material's default font → `labelMedium`. (These were the only off-theme text styles left in all of `lib/`.)
- **Magic numbers** — results `Wrap(spacing: 8, runSpacing: 8)` → `SoliplexSpacing.s2`.

## Known exception

The hero score percentage on the results screen keeps `textTheme.displayLarge`, which the brand `TextTheme` does **not** define and so renders in Material's default font. Preserved deliberately (per William) to keep the large hero size; a branded display token is the proper fix and is deferred.

## Out of scope

`quiz_screen.dart` keeps its plain `AppBar` (dynamic quiz title + back button) — the branded `HomeShellHeader` treatment was not requested for this minimal sweep.

## Verification

- `flutter analyze` clean (zero warnings).
- 99 quiz tests green; no test asserted on the changed colors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)