### PR TITLE
feat(lobby): batch room stats and mark rooms with unread activity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,19 @@ Versions follow the `version+build` scheme from `pubspec.yaml`, bumped via
 
 ## [Unreleased]
 
+### Added
+
+- Lobby: an unread dot on each room card when the room has activity newer than
+  the last time the user opened it. Read state is tracked per-device; there is
+  no server-side read state or unread count.
+
+### Fixed
+
+- Lobby: a room's "last activity" now reflects the user's most recent run in
+  that room (served by the backend stats API), not the newest thread's
+  creation time — so a long-lived thread used minutes ago no longer reads as
+  stale. Activity loads in one batched request per server.
+
 ## [0.89.0+59] - 2026-06-12
 
 ### Added

--- a/lib/src/modules/lobby/lobby_read_markers.dart
+++ b/lib/src/modules/lobby/lobby_read_markers.dart
@@ -34,15 +34,39 @@ abstract final class LobbyReadMarkerStorage {
         );
         return {};
       }
+      var skipped = 0;
       for (final entry in decoded) {
-        if (entry is! Map) continue;
+        if (entry is! Map) {
+          skipped++;
+          continue;
+        }
         final s = entry['s'];
         final r = entry['r'];
         final t = entry['t'];
-        if (s is! String || r is! String || t is! String) continue;
+        if (s is! String || r is! String || t is! String) {
+          skipped++;
+          continue;
+        }
         final at = DateTime.tryParse(t);
-        if (at == null) continue;
+        if (at == null) {
+          skipped++;
+          continue;
+        }
         result[(serverId: s, roomId: r)] = at.toUtc();
+      }
+      if (skipped > 0 && result.isEmpty) {
+        // Every row dropped on a non-empty payload is a systemic serialization
+        // break, not one stale row, and it silently resets the read model
+        // (every room flips to unread). Surface it loudly.
+        dev.log(
+          'Discarding all $skipped lobby read markers; none parsed',
+          level: 1000,
+        );
+      } else if (skipped > 0) {
+        dev.log(
+          'Skipped $skipped malformed lobby read marker(s)',
+          level: 900,
+        );
       }
     } on FormatException catch (e, st) {
       // Corrupt payload: start fresh rather than wedging the lobby.

--- a/lib/src/modules/lobby/lobby_read_markers.dart
+++ b/lib/src/modules/lobby/lobby_read_markers.dart
@@ -1,4 +1,5 @@
 import 'dart:convert';
+import 'dart:developer' as dev;
 
 import 'package:shared_preferences/shared_preferences.dart';
 
@@ -26,7 +27,13 @@ abstract final class LobbyReadMarkerStorage {
     final result = <RoomActivityKey, DateTime>{};
     try {
       final decoded = jsonDecode(raw);
-      if (decoded is! List) return {};
+      if (decoded is! List) {
+        dev.log(
+          'Discarding corrupt lobby read markers (not a JSON array)',
+          level: 900,
+        );
+        return {};
+      }
       for (final entry in decoded) {
         if (entry is! Map) continue;
         final s = entry['s'];
@@ -37,8 +44,14 @@ abstract final class LobbyReadMarkerStorage {
         if (at == null) continue;
         result[(serverId: s, roomId: r)] = at.toUtc();
       }
-    } on FormatException {
+    } on FormatException catch (e, st) {
       // Corrupt payload: start fresh rather than wedging the lobby.
+      dev.log(
+        'Discarding corrupt lobby read markers',
+        error: e,
+        stackTrace: st,
+        level: 900,
+      );
       return {};
     }
     return result;

--- a/lib/src/modules/lobby/lobby_state.dart
+++ b/lib/src/modules/lobby/lobby_state.dart
@@ -4,7 +4,11 @@ import 'dart:developer' as dev;
 
 import 'package:soliplex_agent/soliplex_agent.dart' hide AuthException;
 import 'package:soliplex_client/soliplex_client.dart'
-    show AuthException, PermissionDeniedException, SoliplexApi;
+    show
+        AuthException,
+        NotFoundException,
+        PermissionDeniedException,
+        SoliplexApi;
 
 import '../auth/auth_tokens.dart';
 import '../auth/selected_server_storage.dart';
@@ -148,8 +152,8 @@ class LobbyState {
   Future<void> _loadSortMode() async {
     try {
       _sortMode.value = await LobbySortModeStorage.load();
-      // Kick off the activity sweep once the persisted mode is known. (The
-      // sweep is eager regardless of mode; this just runs it at launch.)
+      // Kick off the activity fetch once the persisted mode is known. (The
+      // fetch is eager regardless of mode; this just runs it at launch.)
       _reconcileActivity();
     } catch (error, st) {
       dev.log(
@@ -165,7 +169,7 @@ class LobbyState {
   /// Activity timestamps are already fetched eagerly on server selection (see
   /// [_reconcileActivity]); this only changes the ordering. The
   /// [_reconcileActivity] call is a safety net for the rare case where the
-  /// sweep has not run yet.
+  /// fetch has not run yet.
   void setSortMode(LobbySortMode mode) {
     if (mode == _sortMode.value) return;
     _sortMode.value = mode;
@@ -182,8 +186,8 @@ class LobbyState {
     );
   }
 
-  /// Most-recent-thread timestamp per room, keyed by (serverId, roomId).
-  /// A present-but-null value means "fetched, room has no threads"; an absent
+  /// Last-activity timestamp per room, keyed by (serverId, roomId).
+  /// A present-but-null value means "fetched, room has no activity"; an absent
   /// key means "not fetched yet". Used only to order [LobbySortMode]
   /// .recentActivity; rooms without a timestamp sort last.
   final Signal<Map<RoomActivityKey, DateTime?>> _roomActivity =
@@ -192,7 +196,7 @@ class LobbyState {
       _roomActivity;
 
   /// Per-room "last seen" timestamps, keyed by (serverId, roomId). A room is
-  /// *unread* when [roomActivity] reports a `lastMessageAt` newer than its
+  /// *unread* when [roomActivity] reports a last-activity time newer than its
   /// marker here (or newer than the epoch, when never opened). Persisted
   /// per-device; there is no server-side read state and no unread count.
   final Signal<Map<RoomActivityKey, DateTime>> _readMarkers =
@@ -216,7 +220,7 @@ class LobbyState {
   /// Marks [roomId] on [serverId] as read as of now, clearing its unread
   /// affordance until a later message arrives. Called when the user opens a
   /// room. Uses "now" rather than the cached activity time so a room is read
-  /// the moment it is opened, even if the activity sweep is stale or still in
+  /// the moment it is opened, even if the activity fetch is stale or still in
   /// flight.
   void markRoomRead(String serverId, String roomId) {
     final key = (serverId: serverId, roomId: roomId);
@@ -237,43 +241,55 @@ class LobbyState {
     );
   }
 
-  /// Whether [room] on [serverId] has activity newer than the user last saw.
+  /// Whether [roomId] on [serverId] has activity newer than the user last saw.
   /// False when there is no known activity (nothing to be unread about).
   bool isRoomUnread(String serverId, String roomId) {
     final key = (serverId: serverId, roomId: roomId);
-    final lastMessageAt = _roomActivity.value[key];
-    if (lastMessageAt == null) return false;
+    final lastActivity = _roomActivity.value[key];
+    if (lastActivity == null) return false;
     final seen = _readMarkers.value[key];
-    return seen == null || lastMessageAt.isAfter(seen);
+    return seen == null || lastActivity.isAfter(seen);
   }
 
-  /// True while per-room activity for the selected server is being fetched.
+  /// True while activity for the selected server is being fetched.
   final Signal<bool> _activityLoading = Signal(false);
   ReadonlySignal<bool> get activityLoading => _activityLoading;
 
-  /// Cancels an in-flight activity sweep when the selection changes or the
+  /// Cancels an in-flight activity fetch when the selection changes or the
   /// state is disposed.
   CancelToken? _activityToken;
 
-  /// Loads activity timestamps for the selected server's rooms. Fetched
-  /// eagerly (the room cards display the relative time regardless of sort
-  /// order), and reused for [LobbySortMode.recentActivity] ordering. No-op
-  /// before a server is selected or before that server's rooms have loaded.
-  /// Only uncached rooms are fetched; results are merged into [_roomActivity],
-  /// so switching servers reuses prior fetches. "Recency" is the room's
-  /// `lastMessageAt` from the stats endpoint (the time of the newest message
-  /// turn — not a thread's creation time), one `getRoomStats` per room. This
-  /// relies on the standard transport's concurrency limiter to throttle the
-  /// burst.
-  void _reconcileActivity() {
+  /// Server whose activity batch is currently in flight, or `null` when none
+  /// is. Lets [_reconcileActivity] coalesce repeat calls for the same server
+  /// instead of cancelling and restarting the request.
+  String? _activityFetchServerId;
+
+  /// Resets activity-fetch state to a clean idle baseline: cancels any in-flight
+  /// request and clears the loading flag.
+  void _cancelActivityFetch() {
     _activityToken?.cancel('activity reconcile');
     _activityToken = null;
-    // Cancelling means nothing is in flight; the start path below sets this
-    // back to true only if a new sweep actually launches. Resetting here
-    // keeps every early return from leaving the spinner stuck on.
+    _activityFetchServerId = null;
     _activityLoading.value = false;
+  }
 
+  /// Loads activity timestamps for the selected server's rooms in a single
+  /// batch request. Fetched eagerly (the room cards display the relative time
+  /// regardless of sort order) and reused for [LobbySortMode.recentActivity]
+  /// ordering. No-op before a server is selected or before that server's rooms
+  /// have loaded. Results are merged into [_roomActivity] keyed by
+  /// (serverId, roomId), so switching servers reuses prior fetches.
+  void _reconcileActivity() {
     final serverId = _selectedServerId.value;
+
+    // A batch for this server is already in flight: it owns the token and the
+    // spinner, so coalesce — return without touching either.
+    if (serverId != null && _activityFetchServerId == serverId) return;
+
+    // Otherwise we're (re)deciding. Cancel any stale fetch (a different server,
+    // or none) and reset to a clean baseline.
+    _cancelActivityFetch();
+
     if (serverId == null) return;
     final entry = _serverManager.servers.value[serverId];
     if (entry == null) return;
@@ -288,46 +304,57 @@ class LobbyState {
 
     final token = CancelToken();
     _activityToken = token;
+    _activityFetchServerId = serverId;
     _activityLoading.value = true;
-    final api = _apiResolver(entry);
 
-    Future.wait(
-      missing.map((room) async {
-        try {
-          final stats = await api.getRoomStats(room.id, cancelToken: token);
-          return MapEntry(
-            (serverId: serverId, roomId: room.id),
-            stats.lastMessageAt,
-          );
-        } catch (error, st) {
-          // A room whose stats can't be fetched simply has no recency
-          // signal; it sorts last rather than failing the whole view. An
-          // AuthException still funnels to session expiry (as the room-list
-          // and profile fetches do), and a PermissionDeniedException is an
-          // expected per-room state — so neither is logged as a failure.
-          if (!token.isCancelled) {
-            if (error is AuthException) {
-              entry.auth.markSessionExpired();
-            } else if (error is! PermissionDeniedException) {
-              dev.log(
-                'Failed to fetch room activity for ${room.id} on $serverId',
-                error: error,
-                stackTrace: st,
-                level: 900,
-              );
-            }
-          }
-          return MapEntry<RoomActivityKey, DateTime?>(
-            (serverId: serverId, roomId: room.id),
-            null,
-          );
-        }
-      }),
-    ).then((entries) {
+    _apiResolver(entry).getRoomsStats(cancelToken: token).then((stats) {
       if (token.isCancelled) return;
       _activityToken = null;
+      _activityFetchServerId = null;
       _activityLoading.value = false;
-      _roomActivity.value = {..._roomActivity.value}..addEntries(entries);
+      // Null-fill the requested rooms, then overlay the batch — in one update,
+      // after the network yield (seeding nulls before the await would flash
+      // every room to "no activity" and re-sort when results land). A room the
+      // batch omits (authz skew) keeps a null entry rather than staying absent;
+      // otherwise it would re-trigger the batch on every reconcile.
+      final next = {..._roomActivity.value};
+      for (final room in missing) {
+        next[(serverId: serverId, roomId: room.id)] =
+            stats[room.id]?.lastActivity;
+      }
+      _roomActivity.value = next;
+    }).catchError((Object error, StackTrace st) {
+      if (token.isCancelled) return;
+      _activityToken = null;
+      _activityFetchServerId = null;
+      _activityLoading.value = false;
+      if (error is AuthException) {
+        // Funnel to the per-server auth funnel (as the room-list and profile
+        // fetches do); _onAuthChanged paints RoomsExpired.
+        entry.auth.markSessionExpired();
+      } else if (error is! PermissionDeniedException &&
+          error is! NotFoundException) {
+        // PermissionDeniedException (per-server authz) and NotFoundException
+        // (a pre-stats backend, 404) are expected states that degrade to "no
+        // activity" — not failures, so they aren't logged. Everything else
+        // (network, 5xx, decode, programmer errors) is a genuine failure;
+        // log it at error level, matching the room-list fetch.
+        dev.log(
+          'Failed to fetch room activity for $serverId',
+          error: error,
+          stackTrace: st,
+          level: 1000,
+        );
+      }
+      // Degrade to no activity: null-fill the requested rooms so a persistent
+      // failure (e.g. a pre-stats backend's 404) is not retried on every
+      // subsequent reconcile. Recovery comes via refresh()/re-auth, which
+      // invalidates this server's slice in _fetchRooms.
+      final next = {..._roomActivity.value};
+      for (final room in missing) {
+        next[(serverId: serverId, roomId: room.id)] = null;
+      }
+      _roomActivity.value = next;
     });
   }
 
@@ -434,9 +461,16 @@ class LobbyState {
         _cancelTokens.remove(id)?.cancel('server removed');
         _authSubscriptions.remove(id)?.call();
         _lastSessionState.remove(id);
+        // Drop a stuck in-flight activity fetch for a removed server; otherwise
+        // _activityFetchServerId would block a future fetch if the id returns.
+        if (_activityFetchServerId == id) _cancelActivityFetch();
       }
       _roomsByServer.value = updatedRooms;
       _userProfiles.value = updatedProfiles;
+      if (_roomActivity.value.keys.any((k) => removed.contains(k.serverId))) {
+        _roomActivity.value = {..._roomActivity.value}
+          ..removeWhere((k, _) => removed.contains(k.serverId));
+      }
     }
 
     // Subscribe to auth changes for new servers and fetch if already connected
@@ -530,7 +564,11 @@ class LobbyState {
         serverId: RoomsLoaded(rooms),
       };
       // A fresh room list invalidates cached activity for this server (rooms
-      // may have been added); drop those entries so recency refetches.
+      // may have been added); drop those entries so recency refetches. Cancel
+      // an in-flight activity fetch for this server too, so the reconcile below
+      // starts one clean fetch instead of being short-circuited by the coalesce
+      // guard.
+      if (_activityFetchServerId == serverId) _cancelActivityFetch();
       if (_roomActivity.value.keys.any((k) => k.serverId == serverId)) {
         _roomActivity.value = {..._roomActivity.value}
           ..removeWhere((k, _) => k.serverId == serverId);
@@ -624,7 +662,7 @@ class LobbyState {
 
   void dispose() {
     _unsubscribe();
-    _activityToken?.cancel('disposed');
+    _cancelActivityFetch();
     for (final unsub in _authSubscriptions.values) {
       unsub();
     }

--- a/lib/src/modules/lobby/lobby_state.dart
+++ b/lib/src/modules/lobby/lobby_state.dart
@@ -216,7 +216,13 @@ class LobbyState {
 
   Future<void> _loadReadMarkers() async {
     try {
-      _readMarkers.value = await LobbyReadMarkerStorage.load();
+      // Merge persisted markers under any set in-memory while the load was in
+      // flight (an early markRoomRead on cold start), so a just-opened room
+      // isn't clobbered back to unread by the slower disk read.
+      _readMarkers.value = {
+        ...await LobbyReadMarkerStorage.load(),
+        ..._readMarkers.value,
+      };
     } catch (error, st) {
       dev.log(
         'Failed to load lobby read markers',

--- a/lib/src/modules/lobby/lobby_state.dart
+++ b/lib/src/modules/lobby/lobby_state.dart
@@ -25,6 +25,16 @@ typedef ApiResolver = SoliplexApi Function(ServerEntry entry);
 /// transposed at a lookup or insertion site.
 typedef RoomActivityKey = ({String serverId, String roomId});
 
+/// Whether a room is unread: it has a known [lastActivity] strictly newer than
+/// the user's last-[seen] marker (or it has never been opened). No known
+/// activity means there is nothing to be unread about. The tie case
+/// ([lastActivity] equal to [seen]) reads as seen — [LobbyState.markRoomRead]
+/// stamps "now", which is at or after any activity it has observed.
+bool isActivityUnread(DateTime? lastActivity, DateTime? seen) {
+  if (lastActivity == null) return false;
+  return seen == null || lastActivity.isAfter(seen);
+}
+
 class UserProfile {
   const UserProfile({
     required this.givenName,
@@ -245,10 +255,7 @@ class LobbyState {
   /// False when there is no known activity (nothing to be unread about).
   bool isRoomUnread(String serverId, String roomId) {
     final key = (serverId: serverId, roomId: roomId);
-    final lastActivity = _roomActivity.value[key];
-    if (lastActivity == null) return false;
-    final seen = _readMarkers.value[key];
-    return seen == null || lastActivity.isAfter(seen);
+    return isActivityUnread(_roomActivity.value[key], _readMarkers.value[key]);
   }
 
   /// True while activity for the selected server is being fetched.
@@ -330,31 +337,35 @@ class LobbyState {
       _activityLoading.value = false;
       if (error is AuthException) {
         // Funnel to the per-server auth funnel (as the room-list and profile
-        // fetches do); _onAuthChanged paints RoomsExpired.
+        // fetches do); _onAuthChanged paints RoomsExpired and re-auth refetches
+        // via _fetchRooms. Nothing to cache here.
         entry.auth.markSessionExpired();
-      } else if (error is! PermissionDeniedException &&
-          error is! NotFoundException) {
-        // PermissionDeniedException (per-server authz) and NotFoundException
-        // (a pre-stats backend, 404) are expected states that degrade to "no
-        // activity" — not failures, so they aren't logged. Everything else
-        // (network, 5xx, decode, programmer errors) is a genuine failure;
-        // log it at error level, matching the room-list fetch.
-        dev.log(
-          'Failed to fetch room activity for $serverId',
-          error: error,
-          stackTrace: st,
-          level: 1000,
-        );
+        return;
       }
-      // Degrade to no activity: null-fill the requested rooms so a persistent
-      // failure (e.g. a pre-stats backend's 404) is not retried on every
-      // subsequent reconcile. Recovery comes via refresh()/re-auth, which
-      // invalidates this server's slice in _fetchRooms.
-      final next = {..._roomActivity.value};
-      for (final room in missing) {
-        next[(serverId: serverId, roomId: room.id)] = null;
+      if (error is PermissionDeniedException || error is NotFoundException) {
+        // Stable per-server states — denied authz (403), or a pre-stats backend
+        // (404). They won't change between reconciles, so degrade to "no
+        // activity" by null-filling the requested rooms; this also keeps them
+        // out of the "missing" set so a later reconcile doesn't re-fire a
+        // request that can't succeed. Recovery comes via refresh()/re-auth,
+        // which invalidates this server's slice in _fetchRooms.
+        final next = {..._roomActivity.value};
+        for (final room in missing) {
+          next[(serverId: serverId, roomId: room.id)] = null;
+        }
+        _roomActivity.value = next;
+        return;
       }
-      _roomActivity.value = next;
+      // A genuine, possibly-transient failure (network, 5xx, decode, programmer
+      // error). Log at error level (matching the room-list fetch) and leave the
+      // rooms absent so the next reconcile retries, rather than freezing the
+      // lobby on "no activity" with no recovery cue.
+      dev.log(
+        'Failed to fetch room activity for $serverId',
+        error: error,
+        stackTrace: st,
+        level: 1000,
+      );
     });
   }
 

--- a/lib/src/modules/lobby/lobby_state.dart
+++ b/lib/src/modules/lobby/lobby_state.dart
@@ -237,7 +237,9 @@ class LobbyState {
   /// affordance until a later message arrives. Called when the user opens a
   /// room. Uses "now" rather than the cached activity time so a room is read
   /// the moment it is opened, even if the activity fetch is stale or still in
-  /// flight.
+  /// flight. This stamps the device clock against server-sourced activity
+  /// times, so a device clock running well ahead of the server can transiently
+  /// suppress the unread affordance until activity catches up to the marker.
   void markRoomRead(String serverId, String roomId) {
     final key = (serverId: serverId, roomId: roomId);
     _readMarkers.value = {
@@ -342,9 +344,9 @@ class LobbyState {
       _activityFetchServerId = null;
       _activityLoading.value = false;
       if (error is AuthException) {
-        // Funnel to the per-server auth funnel (as the room-list and profile
-        // fetches do); _onAuthChanged paints RoomsExpired and re-auth refetches
-        // via _fetchRooms. Nothing to cache here.
+        // Funnel to the per-server auth funnel; _onAuthChanged paints
+        // RoomsExpired and re-auth refetches via _fetchRooms. Nothing to cache
+        // here.
         entry.auth.markSessionExpired();
         return;
       }
@@ -363,9 +365,9 @@ class LobbyState {
         return;
       }
       // A genuine, possibly-transient failure (network, 5xx, decode, programmer
-      // error). Log at error level (matching the room-list fetch) and leave the
-      // rooms absent so the next reconcile retries, rather than freezing the
-      // lobby on "no activity" with no recovery cue.
+      // error). Log at error level and leave the rooms absent so the next
+      // reconcile retries, rather than freezing the lobby on "no activity" with
+      // no recovery cue.
       dev.log(
         'Failed to fetch room activity for $serverId',
         error: error,

--- a/lib/src/modules/lobby/ui/lobby_screen.dart
+++ b/lib/src/modules/lobby/ui/lobby_screen.dart
@@ -821,15 +821,9 @@ class _ServerSection extends StatelessWidget {
   DateTime? _activityFor(Room room) =>
       roomActivity[(serverId: serverId, roomId: room.id)];
 
-  /// A room is unread when its last-activity time is newer than the user's
-  /// stored read marker (or it was never opened). No known activity → not
-  /// unread (nothing to surface).
   bool _isUnread(Room room) {
     final key = (serverId: serverId, roomId: room.id);
-    final lastActivity = roomActivity[key];
-    if (lastActivity == null) return false;
-    final seen = readMarkers[key];
-    return seen == null || lastActivity.isAfter(seen);
+    return isActivityUnread(roomActivity[key], readMarkers[key]);
   }
 
   /// Renders [rooms] in the active view mode (no grouping).

--- a/lib/src/modules/lobby/ui/lobby_screen.dart
+++ b/lib/src/modules/lobby/ui/lobby_screen.dart
@@ -590,10 +590,10 @@ class _LobbyControlsState extends State<_LobbyControls> {
             onChanged: widget.onViewModeChanged,
           )
         : null;
-    // "Recent activity" is derived from each room's newest thread (the backend
-    // has no last-access field), so it can take a moment to populate; the
-    // dropdown stays live (so the user can switch back) and a small spinner
-    // sits beside it while the sweep runs.
+    // "Recent activity" orders rooms by their last activity, which the backend
+    // reports via a stats fetch that may still be in flight, so the ordering
+    // can take a moment to populate; the dropdown stays live (so the user can
+    // switch back) and a small spinner sits beside it while that fetch runs.
     final sort = SoliplexDropdown<LobbySortMode>(
       leadingIcon: const Icon(Icons.sort),
       initialValue: widget.sortMode,
@@ -821,15 +821,15 @@ class _ServerSection extends StatelessWidget {
   DateTime? _activityFor(Room room) =>
       roomActivity[(serverId: serverId, roomId: room.id)];
 
-  /// A room is unread when its last-message time is newer than the user's
+  /// A room is unread when its last-activity time is newer than the user's
   /// stored read marker (or it was never opened). No known activity → not
   /// unread (nothing to surface).
   bool _isUnread(Room room) {
     final key = (serverId: serverId, roomId: room.id);
-    final lastMessageAt = roomActivity[key];
-    if (lastMessageAt == null) return false;
+    final lastActivity = roomActivity[key];
+    if (lastActivity == null) return false;
     final seen = readMarkers[key];
-    return seen == null || lastMessageAt.isAfter(seen);
+    return seen == null || lastActivity.isAfter(seen);
   }
 
   /// Renders [rooms] in the active view mode (no grouping).

--- a/lib/src/modules/lobby/ui/room_card.dart
+++ b/lib/src/modules/lobby/ui/room_card.dart
@@ -19,8 +19,8 @@ class RoomCard extends StatelessWidget {
   final VoidCallback onTap;
   final VoidCallback onInfoTap;
 
-  /// Most-recent-thread timestamp, shown as a muted relative label under the
-  /// title. Null while unknown (not yet fetched, or the room has no threads).
+  /// The room's last-activity time, shown as a muted relative label under the
+  /// title. Null while unknown (not yet fetched, or the room has no activity).
   final DateTime? activityTime;
 
   /// Whether the room has activity newer than the user last saw, surfaced as

--- a/lib/src/modules/lobby/ui/room_card.dart
+++ b/lib/src/modules/lobby/ui/room_card.dart
@@ -31,8 +31,8 @@ class RoomCard extends StatelessWidget {
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
     return Card(
-      // The list owns the horizontal gutter; the card owns only the 12px
-      // (s3) inter-row gap, matching the design mockup's list tiles.
+      // The list owns the horizontal gutter; the card owns only the s3
+      // inter-row gap, matching the design mockup's list tiles.
       margin: const EdgeInsets.only(bottom: SoliplexSpacing.s3),
       child: ListTile(
         // Match RoomGridCard's title/subtitle styles so the two views read

--- a/lib/src/modules/lobby/ui/room_grid_card.dart
+++ b/lib/src/modules/lobby/ui/room_grid_card.dart
@@ -22,8 +22,8 @@ class RoomGridCard extends StatelessWidget {
   final VoidCallback onTap;
   final VoidCallback onInfoTap;
 
-  /// Most-recent-thread timestamp, shown as a muted relative label in the
-  /// footer's bottom-left. Null while unknown (not yet fetched, or no threads).
+  /// The room's last-activity time, shown as a muted relative label in the
+  /// footer's bottom-left. Null while unknown (not yet fetched, or no activity).
   final DateTime? activityTime;
 
   /// Whether the room has activity newer than the user last saw, surfaced as

--- a/lib/src/modules/lobby/ui/unread_dot.dart
+++ b/lib/src/modules/lobby/ui/unread_dot.dart
@@ -5,8 +5,7 @@ import 'package:soliplex_design/soliplex_design.dart';
 ///
 /// A boolean affordance only — the lobby tracks *whether* a room has newer
 /// activity than the user last saw, not how many messages. Shared by the
-/// list ([RoomCard]) and grid ([RoomGridCard]) views so the marker reads
-/// identically in both.
+/// list and grid room cards so the marker reads identically in both.
 class UnreadDot extends StatelessWidget {
   const UnreadDot({super.key});
 

--- a/packages/soliplex_client/lib/src/api/mappers.dart
+++ b/packages/soliplex_client/lib/src/api/mappers.dart
@@ -18,13 +18,17 @@ import 'package:soliplex_client/src/domain/workdir_file.dart';
 // Timestamp helpers
 // ============================================================
 
+/// Trailing timezone designator: a 'Z' or a numeric offset like '+00:00' /
+/// '-05:00'. Anchored to the tail so the hyphens in the date (`2026-06-01`) and
+/// the colons in a naive time (`12:30:45`) don't false-match.
 final _hasTimezone = RegExp(r'(Z|[+-]\d{2}:\d{2})$');
 
-/// Parses an ISO 8601 timestamp from the backend into UTC.
+/// Parses a backend timestamp into a UTC instant.
 ///
-/// Accepts both timezone-aware values (a trailing `Z` or a `±HH:MM`
-/// offset) and naive values; a naive value is assumed UTC. The result
-/// is always normalized to UTC.
+/// Naive ISO 8601 timestamps (no designator) are UTC-but-unmarked, so they get
+/// a 'Z'. Offset-tagged values (aware datetimes such as the stats API's
+/// `last_activity`, or Postgres-backed fields) already pin the instant and are
+/// parsed as-is. The result is always in UTC.
 ///
 /// Throws [FormatException] if [raw] is malformed.
 DateTime parseTimestamp(String raw) {
@@ -183,14 +187,19 @@ Map<String, dynamic> roomSkillToJson(RoomSkill skill) {
 }
 
 /// Parses a timestamp string, returning null on failure.
-DateTime? _tryParseTimestamp(String? raw) {
+///
+/// [logName] attributes a malformed-timestamp log to the calling subsystem.
+DateTime? _tryParseTimestamp(
+  String? raw, {
+  String logName = 'soliplex_client.document',
+}) {
   if (raw == null) return null;
   try {
     return parseTimestamp(raw);
   } on FormatException catch (e) {
     developer.log(
       'Malformed timestamp ignored: $e',
-      name: 'soliplex_client.document',
+      name: logName,
       level: 900,
     );
     return null;
@@ -452,13 +461,14 @@ WorkdirFile workdirFileFromJson(Map<String, dynamic> json) {
 
 /// Creates a [RoomStats] from JSON.
 ///
-/// `last_activity` is optional and tolerant of malformed timestamps
-/// (a bad value is treated as "no activity" rather than failing the
-/// whole lobby view).
-RoomStats roomStatsFromJson(String roomId, Map<String, dynamic> json) {
+/// An absent, null, non-string, or malformed `last_activity` yields a null
+/// activity rather than throwing, so one bad field never drops the entry.
+RoomStats roomStatsFromJson(Map<String, dynamic> json) {
+  final rawActivity = json['last_activity'];
   return RoomStats(
-    roomId: json['room_id'] as String? ?? roomId,
-    lastMessageAt: _tryParseTimestamp(json['last_activity'] as String?),
+    lastActivity: rawActivity is String
+        ? _tryParseTimestamp(rawActivity, logName: 'soliplex_client.api')
+        : null,
   );
 }
 

--- a/packages/soliplex_client/lib/src/api/mappers.dart
+++ b/packages/soliplex_client/lib/src/api/mappers.dart
@@ -465,6 +465,17 @@ WorkdirFile workdirFileFromJson(Map<String, dynamic> json) {
 /// activity rather than throwing, so one bad field never drops the entry.
 RoomStats roomStatsFromJson(Map<String, dynamic> json) {
   final rawActivity = json['last_activity'];
+  if (rawActivity != null && rawActivity is! String) {
+    // Present but wrong-typed (e.g. a backend switch to an epoch int): degrade
+    // to null like a malformed string, but log it — an absent/null field is a
+    // legitimate "no activity", a wrong type is a contract drift worth a trace.
+    developer.log(
+      'Non-string last_activity ignored: '
+      '$rawActivity (${rawActivity.runtimeType})',
+      name: 'soliplex_client.api',
+      level: 900,
+    );
+  }
   return RoomStats(
     lastActivity: rawActivity is String
         ? _tryParseTimestamp(rawActivity, logName: 'soliplex_client.api')

--- a/packages/soliplex_client/lib/src/api/soliplex_api.dart
+++ b/packages/soliplex_client/lib/src/api/soliplex_api.dart
@@ -315,7 +315,7 @@ class SoliplexApi {
       cancelToken: cancelToken,
     );
     // Skip malformed entries so one bad room doesn't drop the whole server's
-    // activity (mirrors getRooms).
+    // activity.
     final stats = <String, RoomStats>{};
     var skipped = 0;
     for (final entry in response.entries) {

--- a/packages/soliplex_client/lib/src/api/soliplex_api.dart
+++ b/packages/soliplex_client/lib/src/api/soliplex_api.dart
@@ -291,35 +291,69 @@ class SoliplexApi {
         .toList();
   }
 
-  /// Gets aggregate activity stats for a room.
+  /// Gets last-activity stats for the user's accessible rooms in one request.
   ///
-  /// Parameters:
-  /// - [roomId]: The room ID (must not be empty)
-  ///
-  /// Returns a [RoomStats] for the room, scoped to the requesting user's
-  /// own threads. Notably carries `lastMessageAt` — the time of the most
-  /// recent message turn, the authoritative "last activity" signal (a
-  /// thread's `createdAt` only marks when it was opened).
+  /// Returns a map keyed by room ID, holding what the stats endpoint reports
+  /// for the requesting user. The map may omit rooms — callers should treat an
+  /// absent room the same as one with no activity. Malformed entries are
+  /// skipped rather than failing the batch. A present entry with a `null`
+  /// [RoomStats.lastActivity] means the room has no activity for this user.
   ///
   /// Throws:
-  /// - [ArgumentError] if [roomId] is empty
-  /// - [NotFoundException] if room not found (404)
-  /// - [AuthException] if not authenticated (401/403)
+  /// - [AuthException] if unauthenticated (401)
+  /// - [PermissionDeniedException] if the authorization policy forbids it (403)
+  /// - [NotFoundException] if the endpoint is absent (pre-stats backend, 404)
   /// - [NetworkException] if connection fails
   /// - [ApiException] for other server errors
   /// - [CancelledException] if cancelled via [cancelToken]
-  Future<RoomStats> getRoomStats(
-    String roomId, {
+  Future<Map<String, RoomStats>> getRoomsStats({
     CancelToken? cancelToken,
   }) async {
-    _requireNonEmpty(roomId, 'roomId');
-
     final response = await _transport.request<Map<String, dynamic>>(
       'GET',
-      _urlBuilder.build(pathSegments: ['stats', 'rooms', roomId]),
+      _urlBuilder.build(pathSegments: ['stats', 'rooms']),
       cancelToken: cancelToken,
     );
-    return roomStatsFromJson(roomId, response);
+    // Skip malformed entries so one bad room doesn't drop the whole server's
+    // activity (mirrors getRooms).
+    final stats = <String, RoomStats>{};
+    var skipped = 0;
+    for (final entry in response.entries) {
+      try {
+        stats[entry.key] = roomStatsFromJson(
+          entry.value as Map<String, dynamic>,
+        );
+      } catch (e) {
+        skipped++;
+        developer.log(
+          'Malformed room stats ignored (${entry.key}): $e',
+          name: 'soliplex_client.api',
+          level: 900,
+        );
+      }
+    }
+    if (skipped > 0 && stats.isEmpty) {
+      // Every entry failing on a non-empty response is a systemic break (the
+      // payload shape changed), not a single bad room — surface it loudly. The
+      // caller can't tell this apart from "no activity", so it would otherwise
+      // be invisible.
+      developer.log(
+        'All $skipped room stats entries were malformed; '
+        'returning no activity',
+        name: 'soliplex_client.api',
+        level: 1000,
+      );
+    } else if (skipped > 0) {
+      // Partial failure: tie the scattered per-entry warnings together so a
+      // subset regression (e.g. a renamed field on some rooms) reads as one
+      // signal rather than isolated noise.
+      developer.log(
+        '$skipped of ${response.length} room stats entries were malformed',
+        name: 'soliplex_client.api',
+        level: 900,
+      );
+    }
+    return stats;
   }
 
   /// Gets a thread by ID.

--- a/packages/soliplex_client/lib/src/domain/room_stats.dart
+++ b/packages/soliplex_client/lib/src/domain/room_stats.dart
@@ -1,38 +1,36 @@
 import 'package:meta/meta.dart';
 
-/// Aggregate activity statistics for a single room.
+/// Activity statistics for a single room, scoped to the requesting user.
 ///
-/// Scoped to the requesting user's own threads. Intentionally open-ended:
-/// the backend stats payload is expected to grow (message/thread counts,
-/// token usage, ...), so new fields are added here rather than minting a
-/// new model per metric.
+/// Mirrors one room's entry in the room stats endpoint payload. Intentionally
+/// open-ended: the backend stats payload is expected to grow (message/thread
+/// counts, token usage, ...), so new fields are added here rather than minting
+/// a new model per metric. The room id is the map key in the endpoint payload,
+/// so it is not duplicated as a field.
 @immutable
 class RoomStats {
   /// Creates room stats.
-  const RoomStats({
-    required this.roomId,
-    this.lastMessageAt,
-  });
+  RoomStats({
+    this.lastActivity,
+  }) : assert(
+          lastActivity == null || lastActivity.isUtc,
+          'lastActivity must be UTC',
+        );
 
-  /// ID of the room these stats describe.
-  final String roomId;
-
-  /// Timestamp of the most recent message turn in the room, or `null`
-  /// when the user has no activity there.
-  final DateTime? lastMessageAt;
+  /// Most recent activity in the room for the requesting user, in UTC, or
+  /// `null` when there is none to report — the user has no activity in the
+  /// room, or its timestamp was absent or unparseable.
+  final DateTime? lastActivity;
 
   @override
   bool operator ==(Object other) {
     if (identical(this, other)) return true;
-    return other is RoomStats &&
-        other.roomId == roomId &&
-        other.lastMessageAt == lastMessageAt;
+    return other is RoomStats && other.lastActivity == lastActivity;
   }
 
   @override
-  int get hashCode => Object.hash(roomId, lastMessageAt);
+  int get hashCode => lastActivity.hashCode;
 
   @override
-  String toString() =>
-      'RoomStats(roomId: $roomId, lastMessageAt: $lastMessageAt)';
+  String toString() => 'RoomStats(lastActivity: $lastActivity)';
 }

--- a/packages/soliplex_client/test/api/mappers_test.dart
+++ b/packages/soliplex_client/test/api/mappers_test.dart
@@ -626,8 +626,8 @@ void main() {
     });
 
     test('does not double-suffix an offset-tagged UTC timestamp', () {
-      // The old endsWith('Z') logic appended 'Z' to '+00:00', yielding
-      // '...+00:00Z', which DateTime.parse rejects.
+      // An offset-tagged value must not get a trailing 'Z' — '...+00:00Z' is
+      // rejected by DateTime.parse.
       final parsed = parseTimestamp('2026-06-01T12:30:45+00:00');
 
       expect(parsed, equals(DateTime.utc(2026, 6, 1, 12, 30, 45)));
@@ -649,10 +649,10 @@ void main() {
   group('RoomStats mappers', () {
     group('roomStatsFromJson', () {
       test('parses an offset-tagged last_activity to the right instant', () {
-        // #1074 serializes last_activity as an aware datetime ('...+00:00').
-        // The shared parseTimestamp must NOT append 'Z' to an offset-tagged
-        // value (that would yield '...+00:00Z', which DateTime.parse rejects
-        // with a FormatException — surfacing as null activity).
+        // The backend serializes last_activity as an aware datetime
+        // ('...+00:00'). An offset-tagged value must parse to the right UTC
+        // instant rather than failing — a FormatException would surface as
+        // null activity.
         final stats = roomStatsFromJson(<String, dynamic>{
           'last_activity': '2026-06-01T12:00:00+00:00',
         });

--- a/packages/soliplex_client/test/api/mappers_test.dart
+++ b/packages/soliplex_client/test/api/mappers_test.dart
@@ -10,34 +10,6 @@ import 'package:soliplex_client/src/domain/thread_info.dart';
 import 'package:test/test.dart';
 
 void main() {
-  group('parseTimestamp', () {
-    test('appends Z when no timezone is present', () {
-      expect(
-        parseTimestamp('2026-06-01T12:00:00'),
-        equals(DateTime.utc(2026, 6, 1, 12)),
-      );
-    });
-
-    test('accepts a trailing Z', () {
-      expect(
-        parseTimestamp('2026-06-01T12:00:00Z'),
-        equals(DateTime.utc(2026, 6, 1, 12)),
-      );
-    });
-
-    test('accepts an explicit +00:00 offset', () {
-      final parsed = parseTimestamp('2026-06-01T12:00:00+00:00');
-      expect(parsed, equals(DateTime.utc(2026, 6, 1, 12)));
-      expect(parsed.isUtc, isTrue);
-    });
-
-    test('normalizes a non-UTC offset to UTC', () {
-      final parsed = parseTimestamp('2026-06-01T12:00:00+02:00');
-      expect(parsed, equals(DateTime.utc(2026, 6, 1, 10)));
-      expect(parsed.isUtc, isTrue);
-    });
-  });
-
   group('BackendVersionInfo mappers', () {
     group('backendVersionInfoFromJson', () {
       test('parses correctly with all fields', () {
@@ -638,47 +610,81 @@ void main() {
     });
   });
 
+  group('parseTimestamp', () {
+    test('appends Z to a naive timestamp and parses it as UTC', () {
+      final parsed = parseTimestamp('2026-06-01T12:30:45');
+
+      expect(parsed, equals(DateTime.utc(2026, 6, 1, 12, 30, 45)));
+      expect(parsed.isUtc, isTrue);
+    });
+
+    test('parses a Z-suffixed timestamp as UTC', () {
+      final parsed = parseTimestamp('2026-06-01T12:30:45Z');
+
+      expect(parsed, equals(DateTime.utc(2026, 6, 1, 12, 30, 45)));
+      expect(parsed.isUtc, isTrue);
+    });
+
+    test('does not double-suffix an offset-tagged UTC timestamp', () {
+      // The old endsWith('Z') logic appended 'Z' to '+00:00', yielding
+      // '...+00:00Z', which DateTime.parse rejects.
+      final parsed = parseTimestamp('2026-06-01T12:30:45+00:00');
+
+      expect(parsed, equals(DateTime.utc(2026, 6, 1, 12, 30, 45)));
+      expect(parsed.isUtc, isTrue);
+    });
+
+    test('converts a non-UTC offset to the right UTC instant', () {
+      final parsed = parseTimestamp('2026-06-01T12:00:00-05:00');
+
+      expect(parsed, equals(DateTime.utc(2026, 6, 1, 17)));
+      expect(parsed.isUtc, isTrue);
+    });
+
+    test('throws FormatException on a malformed value', () {
+      expect(() => parseTimestamp('not-a-date'), throwsFormatException);
+    });
+  });
+
   group('RoomStats mappers', () {
     group('roomStatsFromJson', () {
-      test('parses room_id and last_activity', () {
-        final stats = roomStatsFromJson('fallback', <String, dynamic>{
-          'room_id': 'room-1',
+      test('parses an offset-tagged last_activity to the right instant', () {
+        // #1074 serializes last_activity as an aware datetime ('...+00:00').
+        // The shared parseTimestamp must NOT append 'Z' to an offset-tagged
+        // value (that would yield '...+00:00Z', which DateTime.parse rejects
+        // with a FormatException — surfacing as null activity).
+        final stats = roomStatsFromJson(<String, dynamic>{
           'last_activity': '2026-06-01T12:00:00+00:00',
         });
 
-        expect(stats.roomId, equals('room-1'));
-        expect(
-          stats.lastMessageAt,
-          equals(DateTime.utc(2026, 6, 1, 12)),
-        );
-        expect(stats.lastMessageAt!.isUtc, isTrue);
+        expect(stats.lastActivity, equals(DateTime.utc(2026, 6, 1, 12)));
+        expect(stats.lastActivity!.isUtc, isTrue);
       });
 
       test('null last_activity means no activity', () {
-        final stats = roomStatsFromJson('room-1', <String, dynamic>{
-          'room_id': 'room-1',
+        final stats = roomStatsFromJson(<String, dynamic>{
           'last_activity': null,
         });
 
-        expect(stats.roomId, equals('room-1'));
-        expect(stats.lastMessageAt, isNull);
-      });
-
-      test('falls back to the passed roomId when room_id is absent', () {
-        final stats = roomStatsFromJson('fallback', <String, dynamic>{});
-
-        expect(stats.roomId, equals('fallback'));
-        expect(stats.lastMessageAt, isNull);
+        expect(stats.lastActivity, isNull);
       });
 
       test('a malformed timestamp is tolerated as no activity', () {
-        final stats = roomStatsFromJson('room-1', <String, dynamic>{
-          'room_id': 'room-1',
+        final stats = roomStatsFromJson(<String, dynamic>{
           'last_activity': 'not-a-date',
         });
 
-        expect(stats.roomId, equals('room-1'));
-        expect(stats.lastMessageAt, isNull);
+        expect(stats.lastActivity, isNull);
+      });
+
+      test('a non-string last_activity is tolerated as no activity', () {
+        // A wrong-typed field degrades like a malformed string (null activity)
+        // rather than throwing and dropping the whole entry.
+        final stats = roomStatsFromJson(<String, dynamic>{
+          'last_activity': 1717243200,
+        });
+
+        expect(stats.lastActivity, isNull);
       });
     });
   });

--- a/packages/soliplex_client/test/api/soliplex_api_test.dart
+++ b/packages/soliplex_client/test/api/soliplex_api_test.dart
@@ -494,8 +494,8 @@ void main() {
       });
     });
 
-    group('getRoomStats', () {
-      test('parses room_id and last_activity', () async {
+    group('getRoomsStats', () {
+      test('parses the dict[room_id, RoomStats] collection', () async {
         when(
           () => mockTransport.request<Map<String, dynamic>>(
             'GET',
@@ -508,18 +508,27 @@ void main() {
           ),
         ).thenAnswer(
           (_) async => {
-            'room_id': 'room-123',
-            'last_activity': '2026-06-01T12:00:00+00:00',
+            'room-1': {
+              'last_activity': '2026-06-01T12:00:00+00:00',
+            },
+            'room-2': {
+              'last_activity': null,
+            },
           },
         );
 
-        final stats = await api.getRoomStats('room-123');
+        final stats = await api.getRoomsStats();
 
-        expect(stats.roomId, equals('room-123'));
-        expect(stats.lastMessageAt, equals(DateTime.utc(2026, 6, 1, 12)));
+        expect(stats.keys, containsAll(<String>['room-1', 'room-2']));
+        expect(
+          stats['room-1']!.lastActivity,
+          equals(DateTime.utc(2026, 6, 1, 12)),
+        );
+        expect(stats['room-2']!.lastActivity, isNull);
       });
 
-      test('tolerates a null last_activity', () async {
+      test('skips a malformed entry instead of failing the whole batch',
+          () async {
         when(
           () => mockTransport.request<Map<String, dynamic>>(
             'GET',
@@ -531,47 +540,67 @@ void main() {
             timeout: any(named: 'timeout'),
           ),
         ).thenAnswer(
-          (_) async => {'room_id': 'room-123', 'last_activity': null},
+          (_) async => {
+            'room-1': {
+              'last_activity': '2026-06-01T12:00:00+00:00',
+            },
+            // Not a JSON object — must not abort the other rooms.
+            'room-2': null,
+          },
         );
 
-        final stats = await api.getRoomStats('room-123');
+        final stats = await api.getRoomsStats();
 
-        expect(stats.roomId, equals('room-123'));
-        expect(stats.lastMessageAt, isNull);
+        expect(stats.keys, equals(<String>['room-1']));
+        expect(
+          stats['room-1']!.lastActivity,
+          equals(DateTime.utc(2026, 6, 1, 12)),
+        );
       });
 
-      test('validates non-empty roomId', () {
-        expect(() => api.getRoomStats(''), throwsA(isA<ArgumentError>()));
-      });
-
-      test('supports cancellation', () async {
-        final cancelToken = CancelToken();
-
+      test('returns an empty map when every entry is malformed', () async {
+        // Distinct from a single bad room: a non-empty response where nothing
+        // parses is a systemic break (the payload shape changed). The method
+        // must still degrade to "no activity" rather than throwing, since the
+        // caller can't tell this apart from a server with no activity.
         when(
           () => mockTransport.request<Map<String, dynamic>>(
             'GET',
             any(),
-            cancelToken: cancelToken,
+            cancelToken: any(named: 'cancelToken'),
             fromJson: any(named: 'fromJson'),
             body: any(named: 'body'),
             headers: any(named: 'headers'),
             timeout: any(named: 'timeout'),
           ),
-        ).thenAnswer((_) async => {'room_id': 'room-123'});
+        ).thenAnswer(
+          (_) async => <String, dynamic>{
+            'room-1': null,
+            'room-2': 42,
+          },
+        );
 
-        await api.getRoomStats('room-123', cancelToken: cancelToken);
+        final stats = await api.getRoomsStats();
 
-        verify(
+        expect(stats, isEmpty);
+      });
+
+      test('returns an empty map for an empty collection', () async {
+        when(
           () => mockTransport.request<Map<String, dynamic>>(
             'GET',
             any(),
-            cancelToken: cancelToken,
+            cancelToken: any(named: 'cancelToken'),
             fromJson: any(named: 'fromJson'),
             body: any(named: 'body'),
             headers: any(named: 'headers'),
             timeout: any(named: 'timeout'),
           ),
-        ).called(1);
+        ).thenAnswer((_) async => <String, dynamic>{});
+
+        final stats = await api.getRoomsStats();
+
+        expect(stats, isEmpty);
       });
 
       test('uses correct URL', () async {
@@ -588,12 +617,12 @@ void main() {
           ),
         ).thenAnswer((invocation) async {
           capturedUri = invocation.positionalArguments[1] as Uri;
-          return {'room_id': 'room-123'};
+          return <String, dynamic>{};
         });
 
-        await api.getRoomStats('room-123');
+        await api.getRoomsStats();
 
-        expect(capturedUri?.path, equals('/api/v1/stats/rooms/room-123'));
+        expect(capturedUri?.path, equals('/api/v1/stats/rooms'));
       });
     });
 

--- a/packages/soliplex_client/test/domain/room_stats_test.dart
+++ b/packages/soliplex_client/test/domain/room_stats_test.dart
@@ -3,46 +3,15 @@ import 'package:test/test.dart';
 
 void main() {
   group('RoomStats', () {
-    test('creates with required fields and a null timestamp by default', () {
-      const stats = RoomStats(roomId: 'room-1');
-
-      expect(stats.roomId, equals('room-1'));
-      expect(stats.lastMessageAt, isNull);
-    });
-
-    test('creates with a last-message timestamp', () {
-      final at = DateTime.utc(2026, 6);
-      final stats = RoomStats(roomId: 'room-1', lastMessageAt: at);
-
-      expect(stats.roomId, equals('room-1'));
-      expect(stats.lastMessageAt, equals(at));
-    });
-
-    test('value equality and hashCode consider both fields', () {
-      final at = DateTime.utc(2026, 6);
-      final a = RoomStats(roomId: 'room-1', lastMessageAt: at);
-      final b = RoomStats(roomId: 'room-1', lastMessageAt: at);
-      final differentTime = RoomStats(
-        roomId: 'room-1',
-        lastMessageAt: DateTime.utc(2026, 6, 2),
+    test('rejects a non-UTC lastActivity', () {
+      // The unread comparison (lobby isRoomUnread) relies on lastActivity
+      // being UTC; a local DateTime would mis-order by the offset. The
+      // constructor guards against a caller that skips the mapper's
+      // normalization.
+      expect(
+        () => RoomStats(lastActivity: DateTime(2026)),
+        throwsA(isA<AssertionError>()),
       );
-      const differentRoom = RoomStats(roomId: 'room-2');
-
-      expect(a, equals(b));
-      expect(a.hashCode, equals(b.hashCode));
-      expect(a, isNot(equals(differentTime)));
-      expect(a, isNot(equals(differentRoom)));
-      expect(a, equals(a));
-    });
-
-    test('toString includes both fields', () {
-      final stats = RoomStats(
-        roomId: 'room-1',
-        lastMessageAt: DateTime.utc(2026, 6),
-      );
-
-      expect(stats.toString(), contains('room-1'));
-      expect(stats.toString(), contains('lastMessageAt'));
     });
   });
 }

--- a/test/helpers/fakes.dart
+++ b/test/helpers/fakes.dart
@@ -204,35 +204,22 @@ class FakeSoliplexApi extends SoliplexApi {
   Exception? nextMcpTokenError;
 
   List<ThreadInfo>? nextThreads;
-
-  /// Per-room thread lists, consulted before [nextThreads]. Lets a test give
-  /// different rooms different thread sets (e.g. for activity-based sorting).
-  final Map<String, List<ThreadInfo>> threadsByRoom = {};
-
-  /// Per-room [getThreads] errors, consulted before [threadsByRoom]. Lets a
-  /// test fail one room's thread fetch while others succeed.
-  final Map<String, Exception> threadsErrorByRoom = {};
-
-  /// When set, [getThreads] awaits this before returning, letting a test hold a
-  /// sweep in flight (e.g. to trigger a cancellation mid-fetch).
-  Completer<void>? threadsGate;
   Exception? nextThreadsError;
 
-  /// Per-room [getRoomStats] results, consulted before [nextStats]. Lets a
-  /// test give rooms distinct last-activity timestamps (e.g. for activity
-  /// sorting).
-  final Map<String, RoomStats> statsByRoom = {};
+  /// [getRoomsStats] result: the activity batch keyed by room id. Lets a test
+  /// give rooms distinct last-activity timestamps (e.g. for activity sorting).
+  Map<String, RoomStats> roomsStats = {};
 
-  /// Per-room [getRoomStats] errors, consulted before [statsByRoom]. Lets a
-  /// test fail one room's stats fetch while others succeed.
-  final Map<String, Exception> statsErrorByRoom = {};
+  /// When set, [getRoomsStats] throws it (e.g. a 404 from a pre-stats backend).
+  Exception? nextRoomsStatsError;
 
-  /// When set, [getRoomStats] awaits this before returning, letting a test
-  /// hold an activity sweep in flight (e.g. to trigger a cancellation
-  /// mid-fetch).
-  Completer<void>? statsGate;
-  RoomStats? nextStats;
-  Exception? nextStatsError;
+  /// When set, [getRoomsStats] awaits this before returning, letting a test
+  /// hold the activity batch in flight (to trigger a cancellation mid-fetch,
+  /// or fire repeat reconciles while one request is pending).
+  Completer<void>? roomsStatsGate;
+
+  /// How many times [getRoomsStats] was invoked, for coalesce assertions.
+  int getRoomsStatsCallCount = 0;
   ThreadHistory? nextThreadHistory;
   Exception? nextThreadHistoryError;
   (ThreadInfo, Map<String, dynamic>)? nextCreateThread;
@@ -271,33 +258,20 @@ class FakeSoliplexApi extends SoliplexApi {
     CancelToken? cancelToken,
   }) async {
     if (nextThreadsError != null) throw nextThreadsError!;
-    if (threadsErrorByRoom.containsKey(roomId)) {
-      throw threadsErrorByRoom[roomId]!;
-    }
-    if (threadsGate != null) {
-      await threadsGate!.future;
-    }
-    if (threadsByRoom.containsKey(roomId)) return threadsByRoom[roomId]!;
     if (nextThreads != null) return nextThreads!;
     throw StateError('FakeSoliplexApi: set nextThreads or nextThreadsError');
   }
 
   @override
-  Future<RoomStats> getRoomStats(
-    String roomId, {
+  Future<Map<String, RoomStats>> getRoomsStats({
     CancelToken? cancelToken,
   }) async {
-    if (nextStatsError != null) throw nextStatsError!;
-    if (statsErrorByRoom.containsKey(roomId)) {
-      throw statsErrorByRoom[roomId]!;
+    getRoomsStatsCallCount++;
+    if (roomsStatsGate != null) {
+      await roomsStatsGate!.future;
     }
-    if (statsGate != null) {
-      await statsGate!.future;
-    }
-    if (statsByRoom.containsKey(roomId)) return statsByRoom[roomId]!;
-    if (nextStats != null) return nextStats!;
-    throw StateError('FakeSoliplexApi: set statsByRoom, nextStats or '
-        'nextStatsError');
+    if (nextRoomsStatsError != null) throw nextRoomsStatsError!;
+    return roomsStats;
   }
 
   @override

--- a/test/modules/lobby/lobby_sort_mode_test.dart
+++ b/test/modules/lobby/lobby_sort_mode_test.dart
@@ -3,7 +3,8 @@ import 'dart:async';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:soliplex_agent/soliplex_agent.dart' hide AuthException;
-import 'package:soliplex_client/soliplex_client.dart' show AuthException;
+import 'package:soliplex_client/soliplex_client.dart'
+    show AuthException, PermissionDeniedException;
 import 'package:soliplex_frontend/src/modules/auth/auth_session.dart';
 import 'package:soliplex_frontend/src/modules/auth/auth_tokens.dart';
 import 'package:soliplex_frontend/src/modules/auth/server_manager.dart';
@@ -18,8 +19,8 @@ ServerManager _createManager() => ServerManager(
       storage: InMemoryServerStorage(),
     );
 
-RoomStats _stats(String roomId, DateTime? lastMessageAt) =>
-    RoomStats(roomId: roomId, lastMessageAt: lastMessageAt);
+RoomStats _stats(DateTime? lastActivity) =>
+    RoomStats(lastActivity: lastActivity);
 
 /// Drains pending microtasks. Over-pumps rather than coupling to the exact
 /// number of async hops the state machine takes to settle.
@@ -80,7 +81,7 @@ void main() {
     });
 
     test(
-        'fetches each room\'s last-message timestamp eagerly (so cards can '
+        'fetches each room\'s last-activity timestamp eagerly (so cards can '
         'show it), even with sorting at none', () async {
       final manager = _createManager();
       manager.addServer(
@@ -97,17 +98,19 @@ void main() {
           Room(id: 'r2', name: 'Random'),
           Room(id: 'r3', name: 'Empty'),
         ]
-        ..statsByRoom['r1'] = _stats('r1', older)
-        ..statsByRoom['r2'] = _stats('r2', newer)
-        // No activity → null timestamp.
-        ..statsByRoom['r3'] = _stats('r3', null);
+        ..roomsStats = {
+          'r1': _stats(older),
+          'r2': _stats(newer),
+          // No activity → null timestamp.
+          'r3': _stats(null),
+        };
 
       // Sorting stays at the default (none); activity is still fetched.
       final state = LobbyState(
         serverManager: manager,
         apiResolver: (_) => fakeApi,
       );
-      // Two turns: one for getRooms, one for the getRoomStats sweep it triggers.
+      // Two turns: one for getRooms, one for the activity batch it triggers.
       await Future<void>.delayed(Duration.zero);
       await Future<void>.delayed(Duration.zero);
 
@@ -136,17 +139,17 @@ void main() {
       final gate = Completer<void>();
       final fakeApi = FakeSoliplexApi()
         ..nextRooms = const [Room(id: 'r1', name: 'General')]
-        ..statsByRoom['r1'] = _stats('r1', DateTime.utc(2026))
-        ..statsGate = gate;
+        ..roomsStats = {'r1': _stats(DateTime.utc(2026))}
+        ..roomsStatsGate = gate;
 
       final state =
           LobbyState(serverManager: manager, apiResolver: (_) => fakeApi);
-      // Let rooms load and the sweep start; it then parks on the gate.
+      // Let rooms load and the batch start; it then parks on the gate.
       for (var i = 0; i < 12 && !state.activityLoading.value; i++) {
         await Future<void>.delayed(Duration.zero);
       }
       expect(state.activityLoading.value, isTrue,
-          reason: 'the sweep should be in flight, held open by the gate');
+          reason: 'the batch should be in flight, held open by the gate');
 
       // Removing the only server drops the selection to null, so the reconcile
       // it triggers hits an early return. The flag must still clear.
@@ -179,10 +182,10 @@ void main() {
       final fresh = DateTime.utc(2026, 6, 1);
       final apiA = FakeSoliplexApi()
         ..nextRooms = const [Room(id: 'ra', name: 'A-Room')]
-        ..statsByRoom['ra'] = _stats('ra', stale);
+        ..roomsStats = {'ra': _stats(stale)};
       final apiB = FakeSoliplexApi()
         ..nextRooms = const [Room(id: 'rb', name: 'B-Room')]
-        ..statsByRoom['rb'] = _stats('rb', other);
+        ..roomsStats = {'rb': _stats(other)};
 
       final state = LobbyState(
         serverManager: manager,
@@ -198,8 +201,8 @@ void main() {
       expect(state.roomActivity.value[(serverId: 'a', roomId: 'ra')], stale);
       expect(state.roomActivity.value[(serverId: 'b', roomId: 'rb')], other);
 
-      // Change 'a's last-message time and refetch only 'a'.
-      apiA.statsByRoom['ra'] = _stats('ra', fresh);
+      // Change 'a's last-activity time and refetch only 'a'.
+      apiA.roomsStats = {'ra': _stats(fresh)};
       state.refresh('a');
       await _settle();
 
@@ -210,38 +213,208 @@ void main() {
       state.dispose();
     });
 
-    test('a room whose stats fetch fails records a null timestamp', () async {
+    test(
+        'refreshing while the activity batch is in flight cancels it and '
+        'starts a fresh fetch (does not coalesce onto the stale batch)',
+        () async {
       final manager = _createManager();
       manager.addServer(
         serverId: 'local',
         serverUrl: Uri.parse('http://localhost:8000'),
         requiresAuth: false,
       );
-      final ok = DateTime.utc(2026, 6, 1);
+      final gate = Completer<void>();
+      final fakeApi = FakeSoliplexApi()
+        ..nextRooms = const [Room(id: 'r1', name: 'One')]
+        ..roomsStats = {'r1': _stats(DateTime.utc(2026, 6))}
+        ..roomsStatsGate = gate;
+
+      final state =
+          LobbyState(serverManager: manager, apiResolver: (_) => fakeApi);
+      // Let the first activity batch start and park on the gate.
+      for (var i = 0; i < 12 && !state.activityLoading.value; i++) {
+        await Future<void>.delayed(Duration.zero);
+      }
+      expect(state.activityLoading.value, isTrue);
+      expect(fakeApi.getRoomsStatsCallCount, 1);
+
+      // Refresh while the batch is still in flight. _fetchRooms must cancel the
+      // in-flight batch so the post-refresh reconcile starts a fresh fetch
+      // rather than being short-circuited by the coalesce guard.
+      state.refresh('local');
+      await _settle();
+      expect(fakeApi.getRoomsStatsCallCount, 2,
+          reason: 'a mid-batch refresh must start a new fetch, not coalesce '
+              'onto the stale one');
+
+      // Release both batches; the first (cancelled) is dropped, the second
+      // writes the activity.
+      gate.complete();
+      await _settle();
+      expect(state.roomActivity.value[(serverId: 'local', roomId: 'r1')],
+          DateTime.utc(2026, 6));
+      state.dispose();
+    });
+
+    test('a failed activity batch records a null timestamp for every room',
+        () async {
+      final manager = _createManager();
+      manager.addServer(
+        serverId: 'local',
+        serverUrl: Uri.parse('http://localhost:8000'),
+        requiresAuth: false,
+      );
       final fakeApi = FakeSoliplexApi()
         ..nextRooms = const [
-          Room(id: 'ok', name: 'Ok'),
-          Room(id: 'bad', name: 'Bad'),
+          Room(id: 'r1', name: 'One'),
+          Room(id: 'r2', name: 'Two'),
         ]
-        ..statsByRoom['ok'] = _stats('ok', ok)
-        ..statsErrorByRoom['bad'] = Exception('stats fetch boom');
+        ..nextRoomsStatsError = Exception('stats batch boom');
 
       final state =
           LobbyState(serverManager: manager, apiResolver: (_) => fakeApi);
       await _settle();
 
       final activity = state.roomActivity.value;
-      expect(activity[(serverId: 'local', roomId: 'ok')], ok);
-      expect(activity[(serverId: 'local', roomId: 'bad')], isNull,
-          reason: 'a failed stats fetch maps to a null timestamp');
-      expect(activity.containsKey((serverId: 'local', roomId: 'bad')), isTrue,
-          reason: 'the failed room is recorded as fetched, so it is not '
-              're-swept');
+      expect(activity[(serverId: 'local', roomId: 'r1')], isNull);
+      expect(activity[(serverId: 'local', roomId: 'r2')], isNull);
+      expect(activity.containsKey((serverId: 'local', roomId: 'r1')), isTrue,
+          reason: 'a failed batch records rooms as fetched (null), so it is '
+              'not re-swept');
+      expect(activity.containsKey((serverId: 'local', roomId: 'r2')), isTrue);
+
+      // The null-fill must keep a persistently-failing batch (e.g. a pre-stats
+      // backend's 404) out of the "missing" set, so a later reconcile does not
+      // re-fire it.
+      final callsAfterFirst = fakeApi.getRoomsStatsCallCount;
+      state.setSortMode(LobbySortMode.recentActivity);
+      await _settle();
+      expect(fakeApi.getRoomsStatsCallCount, callsAfterFirst,
+          reason: 'a failed batch must not be retried on every reconcile');
+      state.dispose();
+    });
+
+    test('a displayed room the batch omits caches null and is not re-fetched',
+        () async {
+      final manager = _createManager();
+      manager.addServer(
+        serverId: 'local',
+        serverUrl: Uri.parse('http://localhost:8000'),
+        requiresAuth: false,
+      );
+      final fakeApi = FakeSoliplexApi()
+        ..nextRooms = const [
+          Room(id: 'r1', name: 'One'),
+          Room(id: 'r2', name: 'Two'),
+        ]
+        // Authz skew: the batch omits r2 (it's displayed but not returned).
+        ..roomsStats = {'r1': _stats(DateTime.utc(2026, 6))};
+
+      final state =
+          LobbyState(serverManager: manager, apiResolver: (_) => fakeApi);
+      await _settle();
+
+      expect(
+          state.roomActivity.value[(serverId: 'local', roomId: 'r2')], isNull);
+      expect(
+        state.roomActivity.value.containsKey((serverId: 'local', roomId: 'r2')),
+        isTrue,
+        reason: 'an omitted room is recorded as fetched-with-no-activity',
+      );
+      final callsAfterFirst = fakeApi.getRoomsStatsCallCount;
+
+      // Toggling sort triggers a reconcile; the omitted room must not re-fire
+      // the batch (the null-fill keeps it out of the "missing" set).
+      state.setSortMode(LobbySortMode.recentActivity);
+      await _settle();
+      expect(fakeApi.getRoomsStatsCallCount, callsAfterFirst,
+          reason: 'an omitted room must not re-trigger the batch');
       state.dispose();
     });
 
     test(
-        'an AuthException during the sweep funnels to session expiry, like the '
+        'repeat reconciles while a batch is in flight issue exactly one '
+        'request and keep the spinner on', () async {
+      final manager = _createManager();
+      manager.addServer(
+        serverId: 'local',
+        serverUrl: Uri.parse('http://localhost:8000'),
+        requiresAuth: false,
+      );
+      final gate = Completer<void>();
+      final fakeApi = FakeSoliplexApi()
+        ..nextRooms = const [Room(id: 'r1', name: 'One')]
+        ..roomsStats = {'r1': _stats(DateTime.utc(2026, 6))}
+        ..roomsStatsGate = gate;
+
+      final state =
+          LobbyState(serverManager: manager, apiResolver: (_) => fakeApi);
+      for (var i = 0; i < 12 && !state.activityLoading.value; i++) {
+        await Future<void>.delayed(Duration.zero);
+      }
+      expect(state.activityLoading.value, isTrue);
+      expect(fakeApi.getRoomsStatsCallCount, 1);
+
+      // Fire repeat reconciles for the same server while the batch is gated.
+      state.setSortMode(LobbySortMode.recentActivity);
+      state.setSortMode(LobbySortMode.none);
+      await _settle();
+      expect(fakeApi.getRoomsStatsCallCount, 1,
+          reason: 'an in-flight batch must coalesce repeat reconciles');
+      expect(state.activityLoading.value, isTrue,
+          reason: 'the coalesce guard must not kill the spinner mid-fetch');
+
+      gate.complete();
+      await _settle();
+      expect(state.activityLoading.value, isFalse);
+      state.dispose();
+    });
+
+    test('removing the in-flight server then re-adding it re-fetches activity',
+        () async {
+      final manager = _createManager();
+      manager.addServer(
+        serverId: 'local',
+        serverUrl: Uri.parse('http://localhost:8000'),
+        requiresAuth: false,
+      );
+      final gate = Completer<void>();
+      final fakeApi = FakeSoliplexApi()
+        ..nextRooms = const [Room(id: 'r1', name: 'One')]
+        ..roomsStats = {'r1': _stats(DateTime.utc(2026, 6))}
+        ..roomsStatsGate = gate;
+
+      final state =
+          LobbyState(serverManager: manager, apiResolver: (_) => fakeApi);
+      for (var i = 0; i < 12 && !state.activityLoading.value; i++) {
+        await Future<void>.delayed(Duration.zero);
+      }
+      expect(state.activityLoading.value, isTrue);
+
+      // Remove the server whose batch is in flight, then release the now-orphan
+      // request (its cancelled token must drop the result).
+      manager.removeServer('local');
+      gate.complete();
+      await _settle();
+
+      // Re-add the same id; its activity must fetch again rather than being
+      // blocked forever by a stuck _activityFetchServerId.
+      fakeApi.roomsStatsGate = null;
+      manager.addServer(
+        serverId: 'local',
+        serverUrl: Uri.parse('http://localhost:8000'),
+        requiresAuth: false,
+      );
+      await _settle();
+
+      expect(state.roomActivity.value[(serverId: 'local', roomId: 'r1')],
+          DateTime.utc(2026, 6),
+          reason: 're-added server must re-fetch activity');
+      state.dispose();
+    });
+
+    test(
+        'an AuthException during the batch funnels to session expiry, like the '
         'room-list and profile fetches', () async {
       final manager = _createManager();
       final entry = manager.addServer(
@@ -261,19 +434,61 @@ void main() {
       );
       final fakeApi = FakeSoliplexApi()
         ..nextRooms = const [Room(id: 'r1', name: 'General')]
-        ..statsErrorByRoom['r1'] = const AuthException(message: 'expired');
+        ..nextRoomsStatsError = const AuthException(message: 'expired');
 
       final state =
           LobbyState(serverManager: manager, apiResolver: (_) => fakeApi);
       await _settle();
 
       expect(entry.auth.session.value, isA<ExpiredSession>(),
-          reason: 'a swept-room AuthException must drive session expiry rather '
-              'than being swallowed as a per-room warning');
+          reason: 'a batch AuthException must drive session expiry rather '
+              'than being swallowed as a warning');
       state.dispose();
     });
 
-    test('a sweep superseded by a selection change discards its stale results',
+    test(
+        'a PermissionDeniedException during the batch null-fills without '
+        'expiring the session', () async {
+      final manager = _createManager();
+      final entry = manager.addServer(
+        serverId: 'authz',
+        serverUrl: Uri.parse('https://api.example.com'),
+      );
+      entry.auth.login(
+        provider: const OidcProvider(
+          discoveryUrl: 'https://sso/.well-known/openid-configuration',
+          clientId: 'c',
+        ),
+        tokens: AuthTokens(
+          accessToken: 'a',
+          refreshToken: 'r',
+          expiresAt: DateTime.now().add(const Duration(hours: 1)),
+        ),
+      );
+      final fakeApi = FakeSoliplexApi()
+        ..nextRooms = const [Room(id: 'r1', name: 'General')]
+        ..nextRoomsStatsError =
+            const PermissionDeniedException(message: 'forbidden');
+
+      final state =
+          LobbyState(serverManager: manager, apiResolver: (_) => fakeApi);
+      await _settle();
+
+      expect(entry.auth.session.value, isNot(isA<ExpiredSession>()),
+          reason: 'a denied stats fetch is an expected per-server state, not '
+              'a session expiry');
+      expect(
+          state.roomActivity.value[(serverId: 'authz', roomId: 'r1')], isNull);
+      expect(
+          state.roomActivity.value
+              .containsKey((serverId: 'authz', roomId: 'r1')),
+          isTrue,
+          reason: 'a denied batch records rooms as fetched (null) so it is not '
+              'retried on every reconcile');
+      state.dispose();
+    });
+
+    test('a batch superseded by a selection change discards its stale results',
         () async {
       final manager = _createManager();
       manager.addServer(
@@ -289,37 +504,37 @@ void main() {
       final gateA = Completer<void>();
       final apiA = FakeSoliplexApi()
         ..nextRooms = const [Room(id: 'ra', name: 'A-Room')]
-        ..statsByRoom['ra'] = _stats('ra', DateTime.utc(2026, 1))
-        ..statsGate = gateA;
+        ..roomsStats = {'ra': _stats(DateTime.utc(2026, 1))}
+        ..roomsStatsGate = gateA;
       final apiB = FakeSoliplexApi()
         ..nextRooms = const [Room(id: 'rb', name: 'B-Room')]
-        ..statsByRoom['rb'] = _stats('rb', DateTime.utc(2026, 6));
+        ..roomsStats = {'rb': _stats(DateTime.utc(2026, 6))};
 
       final state = LobbyState(
         serverManager: manager,
         apiResolver: (entry) => entry.serverUrl.host == 'a' ? apiA : apiB,
       );
-      // 'a' is the initial selection; let its sweep start and park on the gate.
+      // 'a' is the initial selection; let its batch start and park on the gate.
       for (var i = 0; i < 12 && !state.activityLoading.value; i++) {
         await Future<void>.delayed(Duration.zero);
       }
       expect(state.activityLoading.value, isTrue,
-          reason: "'a's sweep should be in flight, held open by the gate");
+          reason: "'a's batch should be in flight, held open by the gate");
 
-      // Switching to 'b' cancels 'a's token and runs 'b's sweep to completion.
+      // Switching to 'b' cancels 'a's token and runs 'b's batch to completion.
       state.selectServer('b');
       await _settle();
       expect(state.roomActivity.value[(serverId: 'b', roomId: 'rb')],
           DateTime.utc(2026, 6));
 
-      // Release 'a's now-cancelled sweep; the isCancelled guard must drop its
+      // Release 'a's now-cancelled batch; the isCancelled guard must drop its
       // result rather than writing it over the current selection's state.
       gateA.complete();
       await _settle();
       expect(
         state.roomActivity.value.containsKey((serverId: 'a', roomId: 'ra')),
         isFalse,
-        reason: 'a sweep cancelled by a selection change must not write its '
+        reason: 'a batch cancelled by a selection change must not write its '
             'stale results',
       );
       state.dispose();

--- a/test/modules/lobby/lobby_sort_mode_test.dart
+++ b/test/modules/lobby/lobby_sort_mode_test.dart
@@ -4,7 +4,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:soliplex_agent/soliplex_agent.dart' hide AuthException;
 import 'package:soliplex_client/soliplex_client.dart'
-    show AuthException, PermissionDeniedException;
+    show AuthException, NotFoundException, PermissionDeniedException;
 import 'package:soliplex_frontend/src/modules/auth/auth_session.dart';
 import 'package:soliplex_frontend/src/modules/auth/auth_tokens.dart';
 import 'package:soliplex_frontend/src/modules/auth/server_manager.dart';
@@ -256,8 +256,9 @@ void main() {
       state.dispose();
     });
 
-    test('a failed activity batch records a null timestamp for every room',
-        () async {
+    test(
+        'a persistent failure (pre-stats 404) null-fills every room and is '
+        'not retried', () async {
       final manager = _createManager();
       manager.addServer(
         serverId: 'local',
@@ -269,7 +270,7 @@ void main() {
           Room(id: 'r1', name: 'One'),
           Room(id: 'r2', name: 'Two'),
         ]
-        ..nextRoomsStatsError = Exception('stats batch boom');
+        ..nextRoomsStatsError = const NotFoundException(message: 'no stats');
 
       final state =
           LobbyState(serverManager: manager, apiResolver: (_) => fakeApi);
@@ -279,18 +280,59 @@ void main() {
       expect(activity[(serverId: 'local', roomId: 'r1')], isNull);
       expect(activity[(serverId: 'local', roomId: 'r2')], isNull);
       expect(activity.containsKey((serverId: 'local', roomId: 'r1')), isTrue,
-          reason: 'a failed batch records rooms as fetched (null), so it is '
-              'not re-swept');
+          reason: 'a 404 records rooms as fetched (null), so it is not '
+              're-swept');
       expect(activity.containsKey((serverId: 'local', roomId: 'r2')), isTrue);
 
-      // The null-fill must keep a persistently-failing batch (e.g. a pre-stats
+      // The null-fill must keep a persistently-failing batch (a pre-stats
       // backend's 404) out of the "missing" set, so a later reconcile does not
       // re-fire it.
       final callsAfterFirst = fakeApi.getRoomsStatsCallCount;
       state.setSortMode(LobbySortMode.recentActivity);
       await _settle();
       expect(fakeApi.getRoomsStatsCallCount, callsAfterFirst,
-          reason: 'a failed batch must not be retried on every reconcile');
+          reason: 'a stable failure must not be retried on every reconcile');
+      state.dispose();
+    });
+
+    test(
+        'a transient failure leaves rooms unfetched so the next reconcile '
+        'retries', () async {
+      final manager = _createManager();
+      manager.addServer(
+        serverId: 'local',
+        serverUrl: Uri.parse('http://localhost:8000'),
+        requiresAuth: false,
+      );
+      final fakeApi = FakeSoliplexApi()
+        ..nextRooms = const [Room(id: 'r1', name: 'One')]
+        ..nextRoomsStatsError = Exception('network blip');
+
+      final state =
+          LobbyState(serverManager: manager, apiResolver: (_) => fakeApi);
+      await _settle();
+
+      // A transient failure (network/5xx/decode) must not be cached as "no
+      // activity": leaving the room absent lets a later reconcile retry,
+      // rather than freezing the lobby on no activity with no recovery cue.
+      expect(
+        state.roomActivity.value.containsKey((serverId: 'local', roomId: 'r1')),
+        isFalse,
+        reason: 'a transient failure leaves the room unfetched',
+      );
+
+      // Recover, then trigger a reconcile: the still-missing room is refetched.
+      fakeApi
+        ..nextRoomsStatsError = null
+        ..roomsStats = {'r1': _stats(DateTime.utc(2026, 6))};
+      final callsAfterFirst = fakeApi.getRoomsStatsCallCount;
+      state.setSortMode(LobbySortMode.recentActivity);
+      await _settle();
+      expect(fakeApi.getRoomsStatsCallCount, greaterThan(callsAfterFirst),
+          reason: 'a transient failure must be retried on the next reconcile');
+      expect(state.roomActivity.value[(serverId: 'local', roomId: 'r1')],
+          DateTime.utc(2026, 6),
+          reason: 'the retry populates the recovered activity');
       state.dispose();
     });
 

--- a/test/modules/lobby/lobby_state_test.dart
+++ b/test/modules/lobby/lobby_state_test.dart
@@ -1180,6 +1180,40 @@ void main() {
       reloaded.dispose();
     });
   });
+
+  group('isActivityUnread', () {
+    final seen = DateTime.utc(2026, 6, 1, 12);
+
+    test('no known activity is never unread', () {
+      expect(isActivityUnread(null, null), isFalse);
+      expect(isActivityUnread(null, seen), isFalse);
+    });
+
+    test('activity with no read marker is unread', () {
+      expect(isActivityUnread(seen, null), isTrue);
+    });
+
+    test('activity newer than the marker is unread', () {
+      expect(
+        isActivityUnread(seen.add(const Duration(seconds: 1)), seen),
+        isTrue,
+      );
+    });
+
+    test('activity older than the marker is read', () {
+      expect(
+        isActivityUnread(seen.subtract(const Duration(seconds: 1)), seen),
+        isFalse,
+      );
+    });
+
+    test('activity exactly at the marker is read (strict isAfter boundary)',
+        () {
+      // markRoomRead stamps "now", which is >= any activity it has seen, so an
+      // exact tie must read as seen, not unread.
+      expect(isActivityUnread(seen, seen), isFalse);
+    });
+  });
 }
 
 /// A [SoliplexApi] backed by a [Completer] for controlling fetch timing.

--- a/test/modules/lobby/lobby_state_test.dart
+++ b/test/modules/lobby/lobby_state_test.dart
@@ -1105,8 +1105,7 @@ void main() {
         () async {
       final api = FakeSoliplexApi()
         ..nextRooms = const [Room(id: 'r1', name: 'General')]
-        ..statsByRoom['r1'] =
-            RoomStats(roomId: 'r1', lastMessageAt: DateTime.utc(2026, 6));
+        ..roomsStats = {'r1': RoomStats(lastActivity: DateTime.utc(2026, 6))};
       final state = await startWith(api, managerWithLocal());
 
       expect(state.isRoomUnread('local', 'r1'), isTrue,
@@ -1125,7 +1124,7 @@ void main() {
     test('a room with no known activity is never unread', () async {
       final api = FakeSoliplexApi()
         ..nextRooms = const [Room(id: 'r1', name: 'Quiet')]
-        ..statsByRoom['r1'] = const RoomStats(roomId: 'r1');
+        ..roomsStats = {'r1': RoomStats()};
       final state = await startWith(api, managerWithLocal());
 
       expect(state.isRoomUnread('local', 'r1'), isFalse);
@@ -1139,8 +1138,7 @@ void main() {
       });
       final api = FakeSoliplexApi()
         ..nextRooms = const [Room(id: 'r1', name: 'General')]
-        ..statsByRoom['r1'] =
-            RoomStats(roomId: 'r1', lastMessageAt: DateTime.utc(2026, 6));
+        ..roomsStats = {'r1': RoomStats(lastActivity: DateTime.utc(2026, 6))};
       final state = await startWith(api, managerWithLocal());
 
       expect(state.isRoomUnread('local', 'r1'), isFalse,
@@ -1155,8 +1153,7 @@ void main() {
       });
       final api = FakeSoliplexApi()
         ..nextRooms = const [Room(id: 'r1', name: 'General')]
-        ..statsByRoom['r1'] =
-            RoomStats(roomId: 'r1', lastMessageAt: DateTime.utc(2026, 6));
+        ..roomsStats = {'r1': RoomStats(lastActivity: DateTime.utc(2026, 6))};
       final state = await startWith(api, managerWithLocal());
 
       expect(state.isRoomUnread('local', 'r1'), isTrue,
@@ -1167,8 +1164,7 @@ void main() {
     test('markRoomRead persists so a fresh LobbyState stays read', () async {
       final api = FakeSoliplexApi()
         ..nextRooms = const [Room(id: 'r1', name: 'General')]
-        ..statsByRoom['r1'] =
-            RoomStats(roomId: 'r1', lastMessageAt: DateTime.utc(2026, 6));
+        ..roomsStats = {'r1': RoomStats(lastActivity: DateTime.utc(2026, 6))};
       final manager = managerWithLocal();
       final state = await startWith(api, manager);
       state.markRoomRead('local', 'r1');

--- a/test/modules/lobby/lobby_state_test.dart
+++ b/test/modules/lobby/lobby_state_test.dart
@@ -1179,6 +1179,29 @@ void main() {
           reason: 'the persisted marker survives a new LobbyState');
       reloaded.dispose();
     });
+
+    test('an early markRoomRead survives a slower cold-start load', () async {
+      // Regression (64aaf09): the cold-start load must MERGE persisted markers
+      // *under* any set in-memory while it was in flight, not overwrite them. A
+      // room opened before the disk read lands must stay read. markRoomRead
+      // runs synchronously here, before _loadReadMarkers' await resolves, so a
+      // plain assignment would clobber it back to unread.
+      final api = FakeSoliplexApi()
+        ..nextRooms = const [Room(id: 'r1', name: 'General')]
+        ..roomsStats = {'r1': RoomStats(lastActivity: DateTime.utc(2026, 6))};
+      final state = LobbyState(
+        serverManager: managerWithLocal(),
+        apiResolver: (_) => api,
+      );
+      state.markRoomRead('local', 'r1');
+      for (var i = 0; i < 12; i++) {
+        await Future<void>.delayed(Duration.zero);
+      }
+
+      expect(state.isRoomUnread('local', 'r1'), isFalse,
+          reason: 'a room opened before the disk read lands stays read');
+      state.dispose();
+    });
   });
 
   group('isActivityUnread', () {

--- a/test/modules/lobby/ui/lobby_screen_test.dart
+++ b/test/modules/lobby/ui/lobby_screen_test.dart
@@ -464,10 +464,10 @@ void main() {
           Room(id: 'r1', name: 'General'),
           Room(id: 'r2', name: 'Random'),
         ]
-        ..statsByRoom['r1'] =
-            RoomStats(roomId: 'r1', lastMessageAt: DateTime.utc(2026, 1))
-        ..statsByRoom['r2'] =
-            RoomStats(roomId: 'r2', lastMessageAt: DateTime.utc(2026, 6));
+        ..roomsStats = {
+          'r1': RoomStats(lastActivity: DateTime.utc(2026, 1)),
+          'r2': RoomStats(lastActivity: DateTime.utc(2026, 6)),
+        };
 
       await tester.pumpWidget(_buildApp(manager, apiResolver: (_) => fakeApi));
       await tester.pumpAndSettle();
@@ -505,8 +505,7 @@ void main() {
       );
       final fakeApi = FakeSoliplexApi()
         ..nextRooms = const [Room(id: 'r1', name: 'General')]
-        ..statsByRoom['r1'] =
-            RoomStats(roomId: 'r1', lastMessageAt: DateTime.utc(2026, 6));
+        ..roomsStats = {'r1': RoomStats(lastActivity: DateTime.utc(2026, 6))};
 
       await tester.pumpWidget(_buildApp(manager, apiResolver: (_) => fakeApi));
       await tester.pumpAndSettle();
@@ -527,17 +526,18 @@ void main() {
         serverUrl: Uri.parse('http://localhost:8000'),
         requiresAuth: false,
       );
-      final now = DateTime.now();
+      final now = DateTime.now().toUtc();
       final fakeApi = FakeSoliplexApi()
         ..nextRooms = const [
           Room(id: 'r1', name: 'Fresh'),
           Room(id: 'r2', name: 'Stale'),
         ]
-        ..statsByRoom['r1'] = RoomStats(roomId: 'r1', lastMessageAt: now)
-        ..statsByRoom['r2'] = RoomStats(
-          roomId: 'r2',
-          lastMessageAt: now.subtract(const Duration(days: 10)),
-        );
+        ..roomsStats = {
+          'r1': RoomStats(lastActivity: now),
+          'r2': RoomStats(
+            lastActivity: now.subtract(const Duration(days: 10)),
+          ),
+        };
 
       await tester.pumpWidget(_buildApp(manager, apiResolver: (_) => fakeApi));
       await tester.pumpAndSettle();
@@ -577,10 +577,12 @@ void main() {
           Room(id: 'r3', name: 'Charlie'),
           Room(id: 'r4', name: 'Delta'),
         ]
-        ..statsByRoom['r1'] = const RoomStats(roomId: 'r1')
-        ..statsByRoom['r2'] = RoomStats(roomId: 'r2', lastMessageAt: newer)
-        ..statsByRoom['r3'] = const RoomStats(roomId: 'r3')
-        ..statsByRoom['r4'] = RoomStats(roomId: 'r4', lastMessageAt: older);
+        ..roomsStats = {
+          'r1': RoomStats(),
+          'r2': RoomStats(lastActivity: newer),
+          'r3': RoomStats(),
+          'r4': RoomStats(lastActivity: older),
+        };
 
       await tester.pumpWidget(_buildApp(manager, apiResolver: (_) => fakeApi));
       await tester.pumpAndSettle();


### PR DESCRIPTION
## What

Batches the lobby's per-room last-activity into a single request and wires it to the unread markers introduced in #350.

1. **Batched last-activity.** A room's recency now comes from a single per-server stats request (`GET /stats/rooms`) reporting each room's `last_activity` for the requesting user, replacing one `getThreads` call per room. Recency reflects the user's most recent run in the room, not the newest thread's creation time — so a long-lived thread used minutes ago no longer reads as stale.

2. **Unread markers wired to batched activity.** The unread dot, the per-device read-marker model, and its `shared_preferences` persistence landed in #350. This PR feeds those markers from the batched `last_activity` (previously the per-room thread time), and hardens the read-marker load path.

## How

- New `RoomStats` domain model + `getRoomsStats` API (per-entry malformed rows are skipped; an all-malformed non-empty payload is logged loudly so a shape change isn't invisible).
- `parseTimestamp` now accepts offset-tagged timestamps (the stats API's aware `last_activity`) as well as naive ones, via a tail-anchored timezone regex.
- `_reconcileActivity` issues one coalesced batch per server, classifying failures: auth → session-expiry funnel; 403/404 → degrade to "no activity" and stop retrying; transient → leave absent so the next reconcile retries.
- Cold-start read-marker load merges persisted markers *under* any set in-memory so an early open isn't clobbered (with a regression test pinning it).

## Notes

- Read markers use the device wall-clock against server-sourced activity times; a clock running well ahead of the server can transiently suppress the unread dot until activity catches up. Documented as a known limitation of the client-side read model (no server read state in scope).
- CHANGELOG `[Unreleased]` gains an "Added: unread dot" line backfilling #350 (which merged without one) plus the "Fixed: last activity" entry for this PR's batched-recency change.

## Testing

- `flutter test` (lobby state, read markers, UI cards) and `dart test` (client mappers/api/domain) green.
- Includes a regression test pinning the cold-start merge (a plain assignment reintroduces the early-open clobber).

🤖 Generated with [Claude Code](https://claude.com/claude-code)