### PR TITLE
polish(room-info): design-system adoption sweep

### DIFF
--- a/lib/src/modules/room/ui/room_info/documents_card.dart
+++ b/lib/src/modules/room/ui/room_info/documents_card.dart
@@ -68,7 +68,8 @@ class _DocumentsCardState extends State<DocumentsCard> {
                 Expanded(
                   child: Text(
                     'Failed to load documents',
-                    style: TextStyle(color: theme.colorScheme.error),
+                    style: theme.textTheme.bodyMedium
+                        ?.copyWith(color: theme.colorScheme.error),
                   ),
                 ),
                 SoliplexButton.filled(

--- a/lib/src/modules/room/ui/room_info_screen.dart
+++ b/lib/src/modules/room/ui/room_info_screen.dart
@@ -454,8 +454,8 @@ class _UploadedFilesCardState extends State<_UploadedFilesCard> {
         Align(
           alignment: Alignment.centerLeft,
           child: Wrap(
-            spacing: 8,
-            runSpacing: 8,
+            spacing: SoliplexSpacing.s2,
+            runSpacing: SoliplexSpacing.s2,
             children: [
               SoliplexButton.filled(
                 onPressed: () => _pickAndUpload(pickFiles),
@@ -530,7 +530,7 @@ class _UploadEntryRow extends StatelessWidget {
     final (icon, color, errorMessage) = switch (entry) {
       PersistedUpload() => (
           Icons.check_circle_outline,
-          theme.colorScheme.primary,
+          theme.colorScheme.success,
           null,
         ),
       PendingUpload() => (null, theme.colorScheme.primary, null),


### PR DESCRIPTION
Design-system adoption sweep of the room info screen. The screen was already largely compliant; this clears the remaining gaps. No behavioural change.

- Replace the magic `Wrap` spacing (`8`/`8`) on the upload buttons with `SoliplexSpacing.s2`.
- Persisted-upload check icon: `colorScheme.primary` → `SymbolicColors.success` — an uploaded file is a success result (matches the quiz / execution-timeline migrations). The identical `room_screen` twin gets the same fix (in the room redesign branch / #357) so the two upload lists stay in sync.
- `documents_card`: start the "Failed to load documents" style from `textTheme.bodyMedium` instead of a bare `TextStyle`.

## Verification
- `flutter analyze` clean; 814 room tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)