### PR TITLE
polish(room-info): branded header + Server/Room section cards

### DIFF
--- a/lib/src/flavors/standard.dart
+++ b/lib/src/flavors/standard.dart
@@ -166,6 +166,8 @@ Future<ShellConfig> standard({
         serverManager: serverManager,
         runtimeManager: runtimeManager,
         registry: registry,
+        appName: brand.appName,
+        logo: brandLogo,
         enableDocumentFilter: true,
       ),
       QuizAppModule(serverManager: serverManager),

--- a/lib/src/modules/room/room_module.dart
+++ b/lib/src/modules/room/room_module.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/widgets.dart';
 import 'package:go_router/go_router.dart';
 
 import '../../core/app_module.dart';
@@ -17,6 +18,8 @@ class RoomAppModule extends AppModule {
     required this.serverManager,
     required this.runtimeManager,
     required this.registry,
+    required this.appName,
+    this.logo,
     this.enableDocumentFilter = false,
   })  : _documentSelections = DocumentSelections(),
         _messageExpansions = MessageExpansions(),
@@ -25,6 +28,10 @@ class RoomAppModule extends AppModule {
   final ServerManager serverManager;
   final AgentRuntimeManager runtimeManager;
   final RunRegistry registry;
+
+  /// Brand identity for the room-info screen's branded header.
+  final String appName;
+  final Widget? logo;
   final bool enableDocumentFilter;
 
   final DocumentSelections _documentSelections;
@@ -55,6 +62,8 @@ class RoomAppModule extends AppModule {
                   roomId: state.pathParameters['roomId']!,
                   toolRegistryResolver: runtimeManager.toolRegistryResolver,
                   uploadRegistry: _uploadRegistry,
+                  appName: appName,
+                  logo: logo,
                 ),
               );
             },

--- a/lib/src/modules/room/ui/room_info_screen.dart
+++ b/lib/src/modules/room/ui/room_info_screen.dart
@@ -11,6 +11,7 @@ import '../pick_file.dart';
 
 import '../../../core/routes.dart';
 import '../../auth/server_entry.dart';
+import '../../auth/ui/home_shell.dart';
 import '../upload_tracker.dart';
 import '../upload_tracker_registry.dart';
 import 'room_info/client_tools_card.dart';
@@ -30,12 +31,16 @@ class RoomInfoScreen extends StatefulWidget {
     required this.roomId,
     required this.toolRegistryResolver,
     required this.uploadRegistry,
+    required this.appName,
+    this.logo,
   });
 
   final ServerEntry serverEntry;
   final String roomId;
   final Future<ToolRegistry> Function(String roomId) toolRegistryResolver;
   final UploadTrackerRegistry uploadRegistry;
+  final String appName;
+  final Widget? logo;
 
   @override
   State<RoomInfoScreen> createState() => _RoomInfoScreenState();
@@ -79,47 +84,57 @@ class _RoomInfoScreenState extends State<RoomInfoScreen> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(
-        leading: IconButton(
-          icon: Icon(Icons.adaptive.arrow_back),
-          tooltip: 'Back',
-          onPressed: () {
-            if (context.canPop()) {
-              context.pop();
-            } else {
-              context.go(
-                AppRoutes.room(widget.serverEntry.alias, widget.roomId),
-              );
-            }
-          },
+      body: SafeArea(
+        child: Column(
+          children: [
+            HomeShellHeader(
+              appName: widget.appName,
+              logo: widget.logo,
+              showAbout: false,
+              leading: IconButton(
+                icon: Icon(Icons.adaptive.arrow_back),
+                tooltip: 'Back to room',
+                onPressed: () {
+                  if (context.canPop()) {
+                    context.pop();
+                  } else {
+                    context.go(
+                      AppRoutes.room(widget.serverEntry.alias, widget.roomId),
+                    );
+                  }
+                },
+              ),
+            ),
+            Expanded(
+              child: FutureBuilder<Room>(
+                future: _roomFuture,
+                builder: (context, snapshot) {
+                  if (snapshot.connectionState == ConnectionState.waiting) {
+                    return const Center(child: CircularProgressIndicator());
+                  }
+                  if (snapshot.hasError) {
+                    return const Center(child: Text('Failed to load room'));
+                  }
+                  if (!snapshot.hasData) {
+                    return const Center(child: Text('Room not found'));
+                  }
+                  return _RoomInfoBody(
+                    room: snapshot.data!,
+                    serverUrl: widget.serverEntry.serverUrl,
+                    serverEntry: widget.serverEntry,
+                    api: widget.serverEntry.connection.api,
+                    serverAlias: widget.serverEntry.alias,
+                    roomId: widget.roomId,
+                    documentsFuture: _documentsFuture,
+                    clientToolsFuture: _clientToolsFuture,
+                    onRetryDocuments: _retryDocuments,
+                    uploadRegistry: widget.uploadRegistry,
+                  );
+                },
+              ),
+            ),
+          ],
         ),
-        title: const Text('Room Information'),
-      ),
-      body: FutureBuilder<Room>(
-        future: _roomFuture,
-        builder: (context, snapshot) {
-          if (snapshot.connectionState == ConnectionState.waiting) {
-            return const Center(child: CircularProgressIndicator());
-          }
-          if (snapshot.hasError) {
-            return const Center(child: Text('Failed to load room'));
-          }
-          if (!snapshot.hasData) {
-            return const Center(child: Text('Room not found'));
-          }
-          return _RoomInfoBody(
-            room: snapshot.data!,
-            serverUrl: widget.serverEntry.serverUrl,
-            serverEntry: widget.serverEntry,
-            api: widget.serverEntry.connection.api,
-            serverAlias: widget.serverEntry.alias,
-            roomId: widget.roomId,
-            documentsFuture: _documentsFuture,
-            clientToolsFuture: _clientToolsFuture,
-            onRetryDocuments: _retryDocuments,
-            uploadRegistry: widget.uploadRegistry,
-          );
-        },
       ),
     );
   }
@@ -157,43 +172,27 @@ class _RoomInfoBody extends StatelessWidget {
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.stretch,
         children: [
-          Padding(
-            padding: const EdgeInsets.only(bottom: SoliplexSpacing.s4),
-            child: Column(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: [
-                Text(
-                  'Server',
-                  style: Theme.of(context).textTheme.titleMedium,
-                ),
-                const SizedBox(height: SoliplexSpacing.s1),
-                Text(
-                  formatServerUrl(serverUrl),
-                  style: Theme.of(context).textTheme.bodyMedium?.copyWith(
-                        color: Theme.of(context).colorScheme.onSurfaceVariant,
-                      ),
-                ),
-              ],
-            ),
+          SectionCard(
+            title: 'SERVER',
+            children: [
+              Text(
+                formatServerUrl(serverUrl),
+                style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                      color: Theme.of(context).colorScheme.onSurfaceVariant,
+                    ),
+              ),
+            ],
           ),
-          Padding(
-            padding: const EdgeInsets.only(bottom: SoliplexSpacing.s4),
-            child: Column(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: [
-                Text(
-                  'Room',
-                  style: Theme.of(context).textTheme.titleMedium,
-                ),
-                const SizedBox(height: SoliplexSpacing.s1),
-                Text(
-                  room.name,
-                  style: Theme.of(context).textTheme.bodyMedium?.copyWith(
-                        color: Theme.of(context).colorScheme.onSurfaceVariant,
-                      ),
-                ),
-              ],
-            ),
+          SectionCard(
+            title: 'ROOM',
+            children: [
+              Text(
+                room.name,
+                style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                      color: Theme.of(context).colorScheme.onSurfaceVariant,
+                    ),
+              ),
+            ],
           ),
           if (room.hasDescription)
             Padding(

--- a/test/modules/room/room_module_test.dart
+++ b/test/modules/room/room_module_test.dart
@@ -34,6 +34,7 @@ void main() {
       serverManager: _createManager(),
       runtimeManager: runtimeManager,
       registry: registry,
+      appName: 'Soliplex',
     );
   });
 

--- a/test/modules/room/ui/room_info_screen_test.dart
+++ b/test/modules/room/ui/room_info_screen_test.dart
@@ -54,6 +54,7 @@ Widget _buildScreen({
       toolRegistryResolver:
           toolRegistryResolver ?? (_) async => const ToolRegistry(),
       uploadRegistry: uploadRegistry,
+      appName: 'Soliplex',
     ),
   );
 }
@@ -84,6 +85,7 @@ Widget _buildScreen({
         toolRegistryResolver:
             toolRegistryResolver ?? (_) async => const ToolRegistry(),
         uploadRegistry: registry,
+        appName: 'Soliplex',
       ),
     ),
     entry: entry,


### PR DESCRIPTION
Visual polish of the room info screen. **Stacked on #359** (the design-system adoption sweep) — review/merge that first.

- Swap the plain `AppBar` for the branded `HomeShellHeader` (logo + app name + back button, `showAbout: false`), matching auth / versions / diagnostics. `appName` + `logo` are threaded through `RoomAppModule` (from `brand` in `standard.dart`) into `RoomInfoScreen`. The 'Room Information' title is dropped — the body already names Server/Room — consistent with the versions screens.
- Promote the loose "Server" and "Room" text blocks into `SectionCard`s so they match the rest of the screen's card styling. The room description stays a loose intro paragraph.

## Verification
- `flutter analyze` clean; 814 room tests green (updated `room_info_screen_test` + `room_module_test` for the new `appName`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)