### PR TITLE
feat(room): unread dots on the rooms rail + thread list

### DIFF
--- a/lib/src/modules/room/thread_read_markers.dart
+++ b/lib/src/modules/room/thread_read_markers.dart
@@ -1,0 +1,101 @@
+import 'dart:convert';
+import 'dart:developer' as dev;
+
+import 'package:shared_preferences/shared_preferences.dart';
+
+/// Identifies a thread across servers and rooms for the read model. Named
+/// fields (rather than a positional tuple) so the three ids can't be
+/// transposed at a lookup or insertion site.
+typedef ThreadActivityKey = ({String serverId, String roomId, String threadId});
+
+/// Persists per-thread "last seen" timestamps so the room can mark threads
+/// with newer activity as unread.
+///
+/// The thread-level twin of the lobby's room read model: a thread is unread
+/// when its last-message time is newer than the moment the user last opened
+/// it on this device. There is no server-side read state and no count — just
+/// a boolean affordance. Read markers are therefore per-device.
+///
+/// Backed by `shared_preferences` (non-sensitive UI state). Stored as a JSON
+/// array of `{s, r, th, t}` objects (server id, room id, thread id, ISO-8601
+/// UTC instant) so ids needn't be escaped into a composite key.
+abstract final class ThreadReadMarkerStorage {
+  static const _key = 'soliplex_thread_read_markers';
+
+  static Future<Map<ThreadActivityKey, DateTime>> load() async {
+    final prefs = await SharedPreferences.getInstance();
+    final raw = prefs.getString(_key);
+    if (raw == null || raw.isEmpty) return {};
+
+    final result = <ThreadActivityKey, DateTime>{};
+    try {
+      final decoded = jsonDecode(raw);
+      if (decoded is! List) {
+        dev.log(
+          'Discarding corrupt thread read markers (not a JSON array)',
+          level: 900,
+        );
+        return {};
+      }
+      var skipped = 0;
+      for (final entry in decoded) {
+        if (entry is! Map) {
+          skipped++;
+          continue;
+        }
+        final s = entry['s'];
+        final r = entry['r'];
+        final th = entry['th'];
+        final t = entry['t'];
+        if (s is! String || r is! String || th is! String || t is! String) {
+          skipped++;
+          continue;
+        }
+        final at = DateTime.tryParse(t);
+        if (at == null) {
+          skipped++;
+          continue;
+        }
+        result[(serverId: s, roomId: r, threadId: th)] = at.toUtc();
+      }
+      if (skipped > 0 && result.isEmpty) {
+        // Every row dropped on a non-empty payload is a systemic serialization
+        // break, not one stale row, and it silently resets the read model
+        // (every thread flips to unread). Surface it loudly.
+        dev.log(
+          'Discarding all $skipped thread read markers; none parsed',
+          level: 1000,
+        );
+      } else if (skipped > 0) {
+        dev.log(
+          'Skipped $skipped malformed thread read marker(s)',
+          level: 900,
+        );
+      }
+    } on FormatException catch (e, st) {
+      // Corrupt payload: start fresh rather than wedging the room.
+      dev.log(
+        'Discarding corrupt thread read markers',
+        error: e,
+        stackTrace: st,
+        level: 900,
+      );
+      return {};
+    }
+    return result;
+  }
+
+  static Future<void> save(Map<ThreadActivityKey, DateTime> markers) async {
+    final prefs = await SharedPreferences.getInstance();
+    final list = [
+      for (final entry in markers.entries)
+        {
+          's': entry.key.serverId,
+          'r': entry.key.roomId,
+          'th': entry.key.threadId,
+          't': entry.value.toUtc().toIso8601String(),
+        },
+    ];
+    await prefs.setString(_key, jsonEncode(list));
+  }
+}

--- a/lib/src/modules/room/ui/room_rail.dart
+++ b/lib/src/modules/room/ui/room_rail.dart
@@ -5,6 +5,7 @@ import 'package:soliplex_design/soliplex_design.dart';
 
 import '../../auth/auth_tokens.dart';
 import '../../auth/server_entry.dart';
+import '../../lobby/ui/unread_dot.dart';
 
 /// A signed-in identity for the rail's account menu: a display [name] and an
 /// optional [email]. Resolved by the room screen from `/api/user_info`.
@@ -30,10 +31,17 @@ class RoomRail extends StatelessWidget {
     required this.onVersions,
     this.roomsError,
     this.onRetryRooms,
+    this.unreadRoomIds = const {},
   });
 
   /// The server's rooms, or `null` while loading.
   final List<Room>? rooms;
+
+  /// Ids of rooms with activity newer than the user last saw — each gets an
+  /// [UnreadDot]. Shares the lobby's per-device read model, so a room read in
+  /// the lobby reads here too (and vice versa). Empty when stats are
+  /// unavailable (e.g. a pre-stats backend), which simply shows no dots.
+  final Set<String> unreadRoomIds;
 
   /// Non-null when the room list failed to load.
   final Object? roomsError;
@@ -101,6 +109,7 @@ class RoomRail extends StatelessWidget {
         return _RoomAvatarTile(
           room: room,
           selected: room.id == selectedRoomId,
+          unread: unreadRoomIds.contains(room.id),
           onTap: () => onSelectRoom(room.id),
         );
       },
@@ -114,11 +123,13 @@ class _RoomAvatarTile extends StatelessWidget {
   const _RoomAvatarTile({
     required this.room,
     required this.selected,
+    required this.unread,
     required this.onTap,
   });
 
   final Room room;
   final bool selected;
+  final bool unread;
   final VoidCallback onTap;
 
   static const double _avatar = 44;
@@ -153,24 +164,36 @@ class _RoomAvatarTile extends StatelessWidget {
                     ),
                   ),
                 ),
-              Material(
-                color: bg,
-                // A selected avatar squares off (larger radius) so the shape
-                // shift reinforces the leading bar.
-                borderRadius: BorderRadius.circular(
-                    selected ? soliplexRadii.md : _avatar / 2),
-                clipBehavior: Clip.antiAlias,
-                child: InkWell(
-                  onTap: onTap,
-                  child: SizedBox.square(
-                    dimension: _avatar,
-                    child: Center(
-                      child: Text(
-                        _initial(room.name),
-                        style: theme.textTheme.titleMedium?.copyWith(color: fg),
+              // Fixed-size box so the unread badge anchors to the avatar's
+              // corner rather than the wider rail column.
+              SizedBox.square(
+                dimension: _avatar,
+                child: Stack(
+                  clipBehavior: Clip.none,
+                  children: [
+                    Positioned.fill(
+                      child: Material(
+                        color: bg,
+                        // A selected avatar squares off (larger radius) so the
+                        // shape shift reinforces the leading bar.
+                        borderRadius: BorderRadius.circular(
+                            selected ? soliplexRadii.md : _avatar / 2),
+                        clipBehavior: Clip.antiAlias,
+                        child: InkWell(
+                          onTap: onTap,
+                          child: Center(
+                            child: Text(
+                              _initial(room.name),
+                              style: theme.textTheme.titleMedium
+                                  ?.copyWith(color: fg),
+                            ),
+                          ),
+                        ),
                       ),
                     ),
-                  ),
+                    if (unread)
+                      const Positioned(top: 0, right: 0, child: _UnreadBadge()),
+                  ],
                 ),
               ),
             ],
@@ -184,6 +207,27 @@ class _RoomAvatarTile extends StatelessWidget {
     final trimmed = name.trim();
     if (trimmed.isEmpty) return '?';
     return trimmed.characters.first.toUpperCase();
+  }
+}
+
+/// The shared [UnreadDot] ringed by a surface-colored circle so the marker
+/// stays legible where it overlaps the colored avatar at its corner. The
+/// 12px ring around the 8px dot yields an even 2px border on the scale.
+class _UnreadBadge extends StatelessWidget {
+  const _UnreadBadge();
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      width: SoliplexSpacing.s3,
+      height: SoliplexSpacing.s3,
+      alignment: Alignment.center,
+      decoration: BoxDecoration(
+        color: Theme.of(context).colorScheme.surface,
+        shape: BoxShape.circle,
+      ),
+      child: const UnreadDot(),
+    );
   }
 }
 

--- a/lib/src/modules/room/ui/room_screen.dart
+++ b/lib/src/modules/room/ui/room_screen.dart
@@ -21,6 +21,8 @@ import 'package:soliplex_client/soliplex_client.dart'
 import '../../../core/routes.dart';
 import '../../auth/return_to_storage.dart';
 import '../../auth/server_entry.dart';
+import '../../lobby/lobby_read_markers.dart';
+import '../../lobby/lobby_state.dart' show RoomActivityKey, isActivityUnread;
 import '../document_selections.dart';
 import '../pick_file.dart';
 import '../agent_runtime_manager.dart';
@@ -104,6 +106,19 @@ class _RoomScreenState extends State<RoomScreen> {
   List<Room>? _serverRooms;
   Object? _serverRoomsError;
   CancelToken? _roomsCancelToken;
+
+  /// Last-activity per room id for the current server (from the room stats
+  /// batch). Absent/empty when stats are unavailable — which simply shows no
+  /// unread dots (graceful on a pre-stats backend). Drives [_unreadRoomIds]
+  /// together with [_readMarkers].
+  Map<String, DateTime?> _roomActivity = const {};
+  CancelToken? _activityCancelToken;
+
+  /// Per-`(serverId, roomId)` "last seen" markers, shared with the lobby's
+  /// device-local read model (same storage). A room is unread when its
+  /// last-activity is newer than its marker; opening a room here stamps "now",
+  /// clearing its dot here and in the lobby.
+  Map<RoomActivityKey, DateTime> _readMarkers = const {};
 
   /// Best-effort account identity for the rail's footer menu; `null` until
   /// resolved (or when the server is unauthenticated / the fetch fails).
@@ -199,6 +214,90 @@ class _RoomScreenState extends State<RoomScreen> {
     });
   }
 
+  /// Fetches last-activity for the current server's rooms in one batch so the
+  /// rail can mark rooms with unseen activity as unread. Mirrors the lobby's
+  /// fetch. Degrades to no dots on any failure (e.g. a pre-stats backend 404).
+  void _fetchRoomActivity() {
+    _activityCancelToken?.cancel('refresh');
+    final token = CancelToken();
+    _activityCancelToken = token;
+    widget.serverEntry.connection.api
+        .getRoomsStats(cancelToken: token)
+        .then((stats) {
+      if (!mounted || token != _activityCancelToken) return;
+      setState(() {
+        _roomActivity = {
+          for (final entry in stats.entries)
+            entry.key: entry.value.lastActivity,
+        };
+      });
+    }).catchError((Object error, StackTrace stackTrace) {
+      if (!mounted || token != _activityCancelToken) return;
+      dev.log(
+        'Failed to load room activity; unread dots disabled',
+        error: error,
+        stackTrace: stackTrace,
+        name: 'RoomScreen',
+        level: 900,
+      );
+      setState(() => _roomActivity = const {});
+    });
+  }
+
+  /// Loads the shared read markers from disk, merging under any already set
+  /// in-memory (an early [_markRoomRead] on mount) so a just-opened room isn't
+  /// clobbered back to unread by the slower disk read.
+  Future<void> _loadReadMarkers() async {
+    try {
+      final loaded = await LobbyReadMarkerStorage.load();
+      if (!mounted) return;
+      setState(() => _readMarkers = {...loaded, ..._readMarkers});
+    } catch (error, stackTrace) {
+      dev.log(
+        'Failed to load room read markers',
+        error: error,
+        stackTrace: stackTrace,
+        name: 'RoomScreen',
+        level: 900,
+      );
+    }
+  }
+
+  /// Marks [roomId] on the current server as read as of now, clearing its
+  /// unread dot until later activity arrives. Persisted to the shared store so
+  /// the lobby agrees. Uses "now" (not the cached activity time) so an open
+  /// room is read immediately, even if the activity batch is stale or pending.
+  void _markRoomRead(String roomId) {
+    final key = (serverId: widget.serverEntry.serverId, roomId: roomId);
+    setState(() {
+      _readMarkers = {..._readMarkers, key: DateTime.now().toUtc()};
+    });
+    unawaited(
+      LobbyReadMarkerStorage.save(_readMarkers)
+          .catchError((Object error, StackTrace stackTrace) {
+        dev.log(
+          'Failed to persist room read markers',
+          error: error,
+          stackTrace: stackTrace,
+          name: 'RoomScreen',
+          level: 900,
+        );
+      }),
+    );
+  }
+
+  /// Ids of the current server's rooms with activity newer than the user last
+  /// saw. Empty when activity is unavailable.
+  Set<String> get _unreadRoomIds {
+    final serverId = widget.serverEntry.serverId;
+    return {
+      for (final entry in _roomActivity.entries)
+        if (isActivityUnread(
+            entry.value, _readMarkers[(serverId: serverId, roomId: entry.key)]))
+          entry.key,
+    };
+  }
+
   /// Best-effort fetch of the signed-in identity for the rail's account menu.
   /// No-op (and clears the cached account) when the server is unauthenticated;
   /// a failure leaves the generic "Signed in" label in place.
@@ -279,6 +378,11 @@ class _RoomScreenState extends State<RoomScreen> {
     _workdirs = _createWorkdirController();
     _refreshFilterableDocuments();
     _fetchServerRooms();
+    _fetchRoomActivity();
+    unawaited(_loadReadMarkers());
+    // Viewing a room reads it: stamp now so its dot clears here and in the
+    // lobby (the marker merges with any persisted markers as they load).
+    _markRoomRead(widget.roomId);
     _fetchAccount();
     if (widget.threadId != null) {
       _state.selectThread(widget.threadId!);
@@ -336,6 +440,8 @@ class _RoomScreenState extends State<RoomScreen> {
       _filterDocsLoadFailed = false;
       _refreshFilterableDocuments();
       _fetchServerRooms();
+      _fetchRoomActivity();
+      _markRoomRead(widget.roomId);
       _fetchAccount();
       if (widget.threadId != null) {
         _state.selectThread(widget.threadId!);
@@ -413,6 +519,7 @@ class _RoomScreenState extends State<RoomScreen> {
     _cancelAutoSelect();
     _filterDocsCancelToken?.cancel('disposed');
     _roomsCancelToken?.cancel('disposed');
+    _activityCancelToken?.cancel('disposed');
     HardwareKeyboard.instance.removeHandler(_handleKey);
     _state.dispose();
     _chatController.dispose();
@@ -687,6 +794,7 @@ class _RoomScreenState extends State<RoomScreen> {
       rooms: _serverRooms,
       roomsError: _serverRoomsError,
       onRetryRooms: () => setState(_fetchServerRooms),
+      unreadRoomIds: _unreadRoomIds,
       selectedRoomId: widget.roomId,
       onSelectRoom: (roomId) {
         onNavigate?.call();

--- a/lib/src/modules/room/ui/room_screen.dart
+++ b/lib/src/modules/room/ui/room_screen.dart
@@ -23,6 +23,7 @@ import '../../auth/return_to_storage.dart';
 import '../../auth/server_entry.dart';
 import '../../lobby/lobby_read_markers.dart';
 import '../../lobby/lobby_state.dart' show RoomActivityKey, isActivityUnread;
+import '../thread_read_markers.dart';
 import '../document_selections.dart';
 import '../pick_file.dart';
 import '../agent_runtime_manager.dart';
@@ -119,6 +120,12 @@ class _RoomScreenState extends State<RoomScreen> {
   /// last-activity is newer than its marker; opening a room here stamps "now",
   /// clearing its dot here and in the lobby.
   Map<RoomActivityKey, DateTime> _readMarkers = const {};
+
+  /// Per-`(serverId, roomId, threadId)` "last seen" markers for threads,
+  /// device-local. A thread is unread when its [ThreadInfo.lastActivity] is
+  /// newer than its marker; opening a thread stamps "now". Distinct store from
+  /// the room markers (different granularity), but the same pattern.
+  Map<ThreadActivityKey, DateTime> _threadReadMarkers = const {};
 
   /// Best-effort account identity for the rail's footer menu; `null` until
   /// resolved (or when the server is unauthenticated / the fetch fails).
@@ -298,6 +305,75 @@ class _RoomScreenState extends State<RoomScreen> {
     };
   }
 
+  /// Loads the thread read markers from disk, merging under any already set
+  /// in-memory (an early [_markThreadRead] on mount).
+  Future<void> _loadThreadReadMarkers() async {
+    try {
+      final loaded = await ThreadReadMarkerStorage.load();
+      if (!mounted) return;
+      setState(() => _threadReadMarkers = {...loaded, ..._threadReadMarkers});
+    } catch (error, stackTrace) {
+      dev.log(
+        'Failed to load thread read markers',
+        error: error,
+        stackTrace: stackTrace,
+        name: 'RoomScreen',
+        level: 900,
+      );
+    }
+  }
+
+  /// Marks [threadId] on the current room as read as of now, clearing its
+  /// unread dot. No-op when [threadId] is null (no thread open yet).
+  void _markThreadRead(String? threadId) {
+    if (threadId == null) return;
+    final key = (
+      serverId: widget.serverEntry.serverId,
+      roomId: widget.roomId,
+      threadId: threadId,
+    );
+    setState(() {
+      _threadReadMarkers = {..._threadReadMarkers, key: DateTime.now().toUtc()};
+    });
+    unawaited(
+      ThreadReadMarkerStorage.save(_threadReadMarkers)
+          .catchError((Object error, StackTrace stackTrace) {
+        dev.log(
+          'Failed to persist thread read markers',
+          error: error,
+          stackTrace: stackTrace,
+          name: 'RoomScreen',
+          level: 900,
+        );
+      }),
+    );
+  }
+
+  /// Ids of the room's threads with activity newer than the user last saw.
+  /// The selected thread is excluded — you're looking at it, so it reads as
+  /// read even if its activity advances while open.
+  Set<String> _unreadThreadIds(
+    ThreadListStatus status,
+    String? selectedThreadId,
+  ) {
+    if (status is! ThreadsLoaded) return const {};
+    final serverId = widget.serverEntry.serverId;
+    final roomId = widget.roomId;
+    return {
+      for (final thread in status.threads)
+        if (thread.id != selectedThreadId &&
+            isActivityUnread(
+              thread.lastActivity,
+              _threadReadMarkers[(
+                serverId: serverId,
+                roomId: roomId,
+                threadId: thread.id,
+              )],
+            ))
+          thread.id,
+    };
+  }
+
   /// Best-effort fetch of the signed-in identity for the rail's account menu.
   /// No-op (and clears the cached account) when the server is unauthenticated;
   /// a failure leaves the generic "Signed in" label in place.
@@ -380,9 +456,11 @@ class _RoomScreenState extends State<RoomScreen> {
     _fetchServerRooms();
     _fetchRoomActivity();
     unawaited(_loadReadMarkers());
-    // Viewing a room reads it: stamp now so its dot clears here and in the
-    // lobby (the marker merges with any persisted markers as they load).
+    unawaited(_loadThreadReadMarkers());
+    // Viewing a room/thread reads it: stamp now so the dot clears here and in
+    // the lobby (the marker merges with any persisted markers as they load).
     _markRoomRead(widget.roomId);
+    _markThreadRead(widget.threadId);
     _fetchAccount();
     if (widget.threadId != null) {
       _state.selectThread(widget.threadId!);
@@ -442,6 +520,7 @@ class _RoomScreenState extends State<RoomScreen> {
       _fetchServerRooms();
       _fetchRoomActivity();
       _markRoomRead(widget.roomId);
+      _markThreadRead(widget.threadId);
       _fetchAccount();
       if (widget.threadId != null) {
         _state.selectThread(widget.threadId!);
@@ -453,6 +532,7 @@ class _RoomScreenState extends State<RoomScreen> {
         _cancelAutoSelect();
         _chatController.clear();
         _workdirs.clearCache();
+        _markThreadRead(widget.threadId);
         if (_filterEnabled && oldWidget.threadId == null) {
           _documentSelections.migrateToThread(widget.roomId, widget.threadId!);
         }
@@ -684,6 +764,8 @@ class _RoomScreenState extends State<RoomScreen> {
   Widget build(BuildContext context) {
     final threadListStatus = _state.threadList.threads.watch(context);
     final selectedThreadId = _state.activeThreadView?.threadId;
+    final unreadThreadIds =
+        _unreadThreadIds(threadListStatus, selectedThreadId);
     final roomStatus = _state.room.watch(context);
     final room = roomStatus is RoomLoaded ? roomStatus.room : null;
     final roomName = room?.name ?? widget.roomId;
@@ -706,6 +788,7 @@ class _RoomScreenState extends State<RoomScreen> {
             onRenameThread: _showRenameDialog,
             onDeleteThread: _showDeleteDialog,
             runningThreadIds: _state.runningThreadIds,
+            unreadThreadIds: unreadThreadIds,
           );
           final content = _buildContent(room);
 
@@ -761,6 +844,7 @@ class _RoomScreenState extends State<RoomScreen> {
                             _state.createThread();
                           },
                           runningThreadIds: _state.runningThreadIds,
+                          unreadThreadIds: unreadThreadIds,
                           onRetryThreads: () => _state.threadList.refresh(),
                           onReauthenticate: _onReauthenticate,
                           quizzes: room?.quizzes ?? const {},

--- a/lib/src/modules/room/ui/thread_sidebar.dart
+++ b/lib/src/modules/room/ui/thread_sidebar.dart
@@ -15,6 +15,7 @@ class ThreadSidebar extends StatelessWidget {
     required this.onBackToLobby,
     required this.onCreateThread,
     required this.runningThreadIds,
+    this.unreadThreadIds = const {},
     this.onRetryThreads,
     this.onReauthenticate,
     this.quizzes = const {},
@@ -35,6 +36,11 @@ class ThreadSidebar extends StatelessWidget {
   final void Function(String threadId, String currentName)? onRenameThread;
   final void Function(String threadId)? onDeleteThread;
   final ReadonlySignal<Set<String>> runningThreadIds;
+
+  /// Ids of threads with activity newer than the user last saw — each gets an
+  /// [UnreadDot]. Empty when activity is unavailable. The selected thread is
+  /// excluded by the caller (you're looking at it).
+  final Set<String> unreadThreadIds;
 
   @override
   Widget build(BuildContext context) {
@@ -111,6 +117,7 @@ class ThreadSidebar extends StatelessWidget {
                         thread: thread,
                         isSelected: thread.id == selectedThreadId,
                         isRunning: running.contains(thread.id),
+                        unread: unreadThreadIds.contains(thread.id),
                         onTap: () => onThreadSelected(thread.id),
                         onRename: () =>
                             onRenameThread?.call(thread.id, thread.name),

--- a/lib/src/modules/room/ui/thread_tile.dart
+++ b/lib/src/modules/room/ui/thread_tile.dart
@@ -5,6 +5,7 @@ import 'package:soliplex_agent/soliplex_agent.dart' hide State;
 import 'package:soliplex_design/soliplex_design.dart';
 
 import '../../../shared/relative_time.dart';
+import '../../lobby/ui/unread_dot.dart';
 
 enum _ThreadAction { rename, delete }
 
@@ -17,6 +18,7 @@ class ThreadTile extends StatefulWidget {
     required this.onRename,
     required this.onDelete,
     this.isRunning = false,
+    this.unread = false,
   });
 
   final ThreadInfo thread;
@@ -25,6 +27,10 @@ class ThreadTile extends StatefulWidget {
   final VoidCallback onRename;
   final VoidCallback onDelete;
   final bool isRunning;
+
+  /// Whether the thread has activity newer than the user last saw — shows a
+  /// leading [UnreadDot]. The selected thread is never marked unread.
+  final bool unread;
 
   @override
   State<ThreadTile> createState() => _ThreadTileState();
@@ -54,10 +60,20 @@ class _ThreadTileState extends State<ThreadTile> {
       child: ListTile(
         selected: widget.isSelected,
         selectedTileColor: theme.colorScheme.primaryContainer,
-        title: Text(
-          widget.thread.hasName ? widget.thread.name : 'New Thread',
-          maxLines: 1,
-          overflow: TextOverflow.ellipsis,
+        title: Row(
+          children: [
+            if (widget.unread) ...[
+              const UnreadDot(),
+              const SizedBox(width: SoliplexSpacing.s2),
+            ],
+            Expanded(
+              child: Text(
+                widget.thread.hasName ? widget.thread.name : 'New Thread',
+                maxLines: 1,
+                overflow: TextOverflow.ellipsis,
+              ),
+            ),
+          ],
         ),
         subtitle: Text(
           formatRelativeTime(widget.thread.createdAt),

--- a/packages/soliplex_client/lib/src/api/mappers.dart
+++ b/packages/soliplex_client/lib/src/api/mappers.dart
@@ -504,6 +504,14 @@ ThreadInfo threadInfoFromJson(Map<String, dynamic> json) {
       (metadata['description'] as String?) ??
       '';
 
+  // Optional: absent on a pre-stats backend, null when the thread has no
+  // runs. A malformed value degrades to null rather than failing the whole
+  // listing (mirrors roomStatsFromJson).
+  final rawActivity = json['last_activity'];
+  final lastActivity = rawActivity is String
+      ? _tryParseTimestamp(rawActivity, logName: 'soliplex_client.api')
+      : null;
+
   return ThreadInfo(
     id: json['id'] as String? ?? json['thread_id'] as String,
     roomId: json['room_id'] as String? ?? '',
@@ -512,6 +520,7 @@ ThreadInfo threadInfoFromJson(Map<String, dynamic> json) {
     description: description,
     createdAt: createdAt,
     metadata: metadata,
+    lastActivity: lastActivity,
   );
 }
 
@@ -524,6 +533,8 @@ Map<String, dynamic> threadInfoToJson(ThreadInfo thread) {
     if (thread.name.isNotEmpty) 'name': thread.name,
     if (thread.description.isNotEmpty) 'description': thread.description,
     'created': formatTimestamp(thread.createdAt),
+    if (thread.lastActivity != null)
+      'last_activity': formatTimestamp(thread.lastActivity!),
     if (thread.metadata.isNotEmpty) 'metadata': thread.metadata,
   };
 }

--- a/packages/soliplex_client/lib/src/domain/thread_info.dart
+++ b/packages/soliplex_client/lib/src/domain/thread_info.dart
@@ -12,6 +12,7 @@ class ThreadInfo {
     this.name = '',
     this.description = '',
     this.metadata = const {},
+    this.lastActivity,
   });
 
   /// Unique identifier for the thread.
@@ -31,6 +32,13 @@ class ThreadInfo {
 
   /// When the thread was created.
   final DateTime createdAt;
+
+  /// Most recent message turn (AG-UI run) in the thread, in UTC, or `null`
+  /// when the thread has no runs or the backend did not report it (e.g. a
+  /// pre-stats backend). Distinct from [createdAt] — the thread's birth — this
+  /// tracks its latest activity, letting clients mark threads with unseen
+  /// messages.
+  final DateTime? lastActivity;
 
   /// Metadata for the thread (empty map if not provided).
   final Map<String, dynamic> metadata;
@@ -53,6 +61,7 @@ class ThreadInfo {
     String? description,
     DateTime? createdAt,
     Map<String, dynamic>? metadata,
+    DateTime? lastActivity,
   }) {
     return ThreadInfo(
       id: id ?? this.id,
@@ -62,6 +71,7 @@ class ThreadInfo {
       description: description ?? this.description,
       createdAt: createdAt ?? this.createdAt,
       metadata: metadata ?? this.metadata,
+      lastActivity: lastActivity ?? this.lastActivity,
     );
   }
 

--- a/packages/soliplex_client/test/api/mappers_test.dart
+++ b/packages/soliplex_client/test/api/mappers_test.dart
@@ -699,6 +699,7 @@ void main() {
           'name': 'Test Thread',
           'description': 'A test thread',
           'created': '2025-01-01T00:00:00.000',
+          'last_activity': '2025-01-02T03:04:00.000',
           'metadata': {'key': 'value'},
         };
 
@@ -710,7 +711,23 @@ void main() {
         expect(thread.name, equals('Test Thread'));
         expect(thread.description, equals('A test thread'));
         expect(thread.createdAt, equals(DateTime.utc(2025)));
+        expect(thread.lastActivity, equals(DateTime.utc(2025, 1, 2, 3, 4)));
         expect(thread.metadata, equals({'key': 'value'}));
+      });
+
+      test('last_activity is null when absent, malformed, or null', () {
+        ThreadInfo parse(Object? value) => threadInfoFromJson({
+              'id': 'thread-1',
+              'room_id': 'room-1',
+              'created': '2025-01-15T10:30:00.000',
+              if (value != #absent) 'last_activity': value,
+            });
+
+        expect(parse(#absent).lastActivity, isNull);
+        expect(parse(null).lastActivity, isNull);
+        expect(parse('not-a-date').lastActivity, isNull);
+        // A present, valid value is UTC-normalized.
+        expect(parse('2026-06-01T12:00:00+02:00').lastActivity!.isUtc, isTrue);
       });
 
       test('parses correctly with only required fields', () {
@@ -853,6 +870,7 @@ void main() {
           description: 'A test thread',
           createdAt: createdAt,
           metadata: const {'key': 'value'},
+          lastActivity: DateTime.utc(2025, 1, 2, 3, 4),
         );
 
         final json = threadInfoToJson(thread);
@@ -863,6 +881,7 @@ void main() {
         expect(json['name'], equals('Test Thread'));
         expect(json['description'], equals('A test thread'));
         expect(json['created'], equals('2025-01-01T00:00:00.000'));
+        expect(json['last_activity'], equals('2025-01-02T03:04:00.000'));
         expect(json['metadata'], equals({'key': 'value'}));
       });
 
@@ -881,6 +900,7 @@ void main() {
         expect(json.containsKey('initial_run_id'), isFalse);
         expect(json.containsKey('name'), isFalse);
         expect(json.containsKey('description'), isFalse);
+        expect(json.containsKey('last_activity'), isFalse);
         expect(json.containsKey('metadata'), isFalse);
       });
     });
@@ -895,6 +915,7 @@ void main() {
         description: 'A test thread',
         createdAt: createdAt,
         metadata: const {'key': 'value'},
+        lastActivity: DateTime.utc(2025, 2, 3, 4, 5),
       );
 
       final json = threadInfoToJson(original);
@@ -906,6 +927,7 @@ void main() {
       expect(restored.name, equals(original.name));
       expect(restored.description, equals(original.description));
       expect(restored.createdAt, equals(original.createdAt));
+      expect(restored.lastActivity, equals(original.lastActivity));
       expect(restored.metadata, equals(original.metadata));
     });
   });

--- a/packages/soliplex_client/test/domain/thread_info_test.dart
+++ b/packages/soliplex_client/test/domain/thread_info_test.dart
@@ -33,6 +33,7 @@ void main() {
         description: 'A test thread',
         createdAt: createdAt,
         metadata: const {'key': 'value'},
+        lastActivity: DateTime.utc(2025, 2),
       );
 
       expect(thread.id, equals('thread-1'));
@@ -41,6 +42,7 @@ void main() {
       expect(thread.name, equals('Test Thread'));
       expect(thread.description, equals('A test thread'));
       expect(thread.createdAt, equals(createdAt));
+      expect(thread.lastActivity, equals(DateTime.utc(2025, 2)));
       expect(thread.metadata, equals({'key': 'value'}));
       expect(thread.hasInitialRun, isTrue);
       expect(thread.hasName, isTrue);
@@ -69,6 +71,7 @@ void main() {
           createdAt: DateTime(2025),
         );
         final newCreated = DateTime(2025, 6);
+        final newActivity = DateTime.utc(2025, 7);
         final modified = thread.copyWith(
           id: 'thread-2',
           roomId: 'room-2',
@@ -77,6 +80,7 @@ void main() {
           description: 'New description',
           createdAt: newCreated,
           metadata: {'new': 'data'},
+          lastActivity: newActivity,
         );
 
         expect(modified.id, equals('thread-2'));
@@ -85,6 +89,7 @@ void main() {
         expect(modified.name, equals('New Name'));
         expect(modified.description, equals('New description'));
         expect(modified.createdAt, equals(newCreated));
+        expect(modified.lastActivity, equals(newActivity));
         expect(modified.metadata, equals({'new': 'data'}));
       });
 

--- a/test/modules/room/thread_read_markers_test.dart
+++ b/test/modules/room/thread_read_markers_test.dart
@@ -1,0 +1,71 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:soliplex_frontend/src/modules/room/thread_read_markers.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+  setUp(() => SharedPreferences.setMockInitialValues({}));
+
+  group('ThreadReadMarkerStorage', () {
+    test('defaults to empty when nothing is persisted', () async {
+      expect(await ThreadReadMarkerStorage.load(), isEmpty);
+    });
+
+    test('round-trips markers, normalizing to UTC', () async {
+      final markers = {
+        (serverId: 'a', roomId: 'r1', threadId: 't1'):
+            DateTime.utc(2026, 6, 1, 12),
+        (serverId: 'b', roomId: 'r2', threadId: 't2'):
+            DateTime.utc(2026, 1, 2, 3, 4),
+      };
+      await ThreadReadMarkerStorage.save(markers);
+
+      final loaded = await ThreadReadMarkerStorage.load();
+      expect(loaded, hasLength(2));
+      expect(
+        loaded[(serverId: 'a', roomId: 'r1', threadId: 't1')],
+        DateTime.utc(2026, 6, 1, 12),
+      );
+      expect(
+        loaded[(serverId: 'b', roomId: 'r2', threadId: 't2')]!.isUtc,
+        isTrue,
+      );
+    });
+
+    test('preserves ids that would collide under a naive composite key',
+        () async {
+      final markers = {
+        (serverId: 'a:b', roomId: 'r/1', threadId: 't|2'): DateTime.utc(2026),
+      };
+      await ThreadReadMarkerStorage.save(markers);
+
+      final loaded = await ThreadReadMarkerStorage.load();
+      expect(
+        loaded[(serverId: 'a:b', roomId: 'r/1', threadId: 't|2')],
+        DateTime.utc(2026),
+      );
+    });
+
+    test('discards a corrupt (non-array) payload', () async {
+      SharedPreferences.setMockInitialValues({
+        'soliplex_thread_read_markers': '{"not":"an array"}',
+      });
+      expect(await ThreadReadMarkerStorage.load(), isEmpty);
+    });
+
+    test('skips malformed rows but keeps valid ones', () async {
+      SharedPreferences.setMockInitialValues({
+        'soliplex_thread_read_markers':
+            '[{"s":"a","r":"r1","th":"t1","t":"2026-06-01T12:00:00Z"},'
+                '{"s":"a","r":"r1"},'
+                '{"s":"a","r":"r1","th":"t2","t":"not-a-date"}]',
+      });
+      final loaded = await ThreadReadMarkerStorage.load();
+      expect(loaded, hasLength(1));
+      expect(
+        loaded[(serverId: 'a', roomId: 'r1', threadId: 't1')],
+        DateTime.utc(2026, 6, 1, 12),
+      );
+    });
+  });
+}

--- a/test/modules/room/ui/room_rail_test.dart
+++ b/test/modules/room/ui/room_rail_test.dart
@@ -18,6 +18,7 @@ RoomRail _rail({
   ],
   Object? roomsError,
   String selectedRoomId = 'r1',
+  Set<String> unreadRoomIds = const {},
   void Function(String)? onSelectRoom,
   VoidCallback? onRetryRooms,
   RoomAccount? account,
@@ -28,6 +29,7 @@ RoomRail _rail({
       rooms: rooms,
       roomsError: roomsError,
       onRetryRooms: onRetryRooms,
+      unreadRoomIds: unreadRoomIds,
       selectedRoomId: selectedRoomId,
       onSelectRoom: onSelectRoom ?? (_) {},
       entry: createTestServerEntry(),
@@ -54,6 +56,16 @@ void main() {
     testWidgets('shows a spinner while rooms are loading', (tester) async {
       await tester.pumpWidget(_wrap(_rail(rooms: null)));
       expect(find.byType(CircularProgressIndicator), findsOneWidget);
+    });
+
+    testWidgets('marks only unread rooms with a dot', (tester) async {
+      await tester.pumpWidget(_wrap(_rail(unreadRoomIds: const {'r2'})));
+      expect(find.byTooltip('Unread activity'), findsOneWidget);
+    });
+
+    testWidgets('shows no dots when nothing is unread', (tester) async {
+      await tester.pumpWidget(_wrap(_rail()));
+      expect(find.byTooltip('Unread activity'), findsNothing);
     });
 
     testWidgets('shows an error affordance that retries', (tester) async {

--- a/test/modules/room/ui/thread_sidebar_test.dart
+++ b/test/modules/room/ui/thread_sidebar_test.dart
@@ -59,6 +59,42 @@ void main() {
     expect(find.text('Second thread'), findsOneWidget);
   });
 
+  testWidgets('marks listed threads in unreadThreadIds with a dot',
+      (tester) async {
+    final threads = [
+      ThreadInfo(
+        id: 't-1',
+        roomId: 'room-1',
+        name: 'First thread',
+        createdAt: DateTime(2026, 3, 1),
+      ),
+      ThreadInfo(
+        id: 't-2',
+        roomId: 'room-1',
+        name: 'Second thread',
+        createdAt: DateTime(2026, 3, 2),
+      ),
+    ];
+
+    await tester.pumpWidget(MaterialApp(
+      home: Scaffold(
+        body: ThreadSidebar(
+          threadListStatus: ThreadsLoaded(threads),
+          selectedThreadId: null,
+          onThreadSelected: (_) {},
+          onBackToLobby: () {},
+          onCreateThread: () {},
+          runningThreadIds: _emptyRunning,
+          unreadThreadIds: const {'t-2'},
+          onRetryThreads: () async {},
+        ),
+      ),
+    ));
+
+    // Exactly one of the two threads is unread.
+    expect(find.byTooltip('Unread activity'), findsOneWidget);
+  });
+
   testWidgets('calls onThreadSelected on tap', (tester) async {
     String? selectedId;
     final threads = [

--- a/test/modules/room/ui/thread_tile_test.dart
+++ b/test/modules/room/ui/thread_tile_test.dart
@@ -35,6 +35,27 @@ void main() {
     expect(find.text('New Thread'), findsOneWidget);
   });
 
+  testWidgets('shows an unread dot only when unread', (tester) async {
+    Widget tile({required bool unread}) => MaterialApp(
+          home: Scaffold(
+            body: ThreadTile(
+              thread: thread,
+              isSelected: false,
+              unread: unread,
+              onTap: () {},
+              onRename: () {},
+              onDelete: () {},
+            ),
+          ),
+        );
+
+    await tester.pumpWidget(tile(unread: false));
+    expect(find.byTooltip('Unread activity'), findsNothing);
+
+    await tester.pumpWidget(tile(unread: true));
+    expect(find.byTooltip('Unread activity'), findsOneWidget);
+  });
+
   testWidgets('overflow menu shows Rename and Delete options', (tester) async {
     await tester.pumpWidget(MaterialApp(
       home: Scaffold(


### PR DESCRIPTION
Lights up unread markers in the room module, reusing the lobby’s device-local read-model pattern. Follow-up to #357 (the rooms rail).

## What

- **Rooms rail** — each room avatar gets an `UnreadDot` when it has activity newer than the user last saw. Reuses the lobby’s read model (same `LobbyReadMarkerStorage`, same `(serverId, roomId)` keying), so a room read in the lobby reads here too, and opening a room from the rail clears its lobby badge.
- **Thread list** — each `ThreadTile` gets a dot when the thread has unseen activity, driven by the new `ThreadInfo.lastActivity` + a per-`(serverId, roomId, threadId)` `ThreadReadMarkerStorage`. The selected thread is never marked (you’re looking at it).
- Opening a room/thread stamps "now"; both degrade to **no dots** when stats are unavailable (e.g. a pre-stats backend) — never a hard failure.

## Depends on

- **Backend** WilliamKarolDiCioccio/soliplex#1 — supplies `GET /v1/stats/rooms` (batch room activity) and `AGUI_Thread.last_activity` (per-thread). Until deployed, dots simply don’t show.
- **#357** (`polish/room`) — the rooms rail this builds on. This branch is **stacked on #357** and merges current `main` for the shared lobby primitives (`UnreadDot`, `getRoomsStats`, `RoomStats`, `isActivityUnread` from #349/#350/#355). Once #357 lands in `main`, rebase and the merge noise disappears — review the two `feat(room)` commits.

## Tests

Full suite + analyze green. New: rail dot, thread-tile dot, sidebar pass-through, `ThreadReadMarkerStorage` round-trip/corruption, `ThreadInfo.lastActivity` mapper round-trip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)