### PR TITLE
Harden the room rail's identity and rooms fetching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,14 @@ Versions follow the `version+build` scheme from `pubspec.yaml`, bumped via
   that room (served by the backend stats API), not the newest thread's
   creation time — so a long-lived thread used minutes ago no longer reads as
   stale. Activity loads in one batched request per server.
+- Room rail: a permission-denied (403) room list shows a distinct,
+  non-retryable lock affordance instead of a generic "try again" error, and an
+  expired session during the rail's room or identity fetch redirects to login
+  rather than flashing an error.
+- Room rail: the account menu's signed-in identity resolves more robustly —
+  whitespace-only profile fields are ignored, a malformed claim no longer
+  discards its valid siblings, and an email standing in for a missing name no
+  longer renders twice.
 
 ## [0.89.0+59] - 2026-06-12
 

--- a/lib/src/modules/room/ui/room_rail.dart
+++ b/lib/src/modules/room/ui/room_rail.dart
@@ -118,7 +118,7 @@ class RoomRail extends StatelessWidget {
 }
 
 /// One room in the rail: an initial avatar tinted by [roomAvatarColor], with a
-/// leading selection bar and the room name in a tooltip.
+/// leading selection bar when selected and the room name in a tooltip.
 class _RoomAvatarTile extends StatelessWidget {
   const _RoomAvatarTile({
     required this.room,
@@ -262,9 +262,8 @@ class _RailMessage extends StatelessWidget {
 enum _RailMenuAction { networkInspector, versions }
 
 /// The rail footer: a single ⋮ that opens the account identity (as a header)
-/// plus the developer utilities. Mirrors the lobby's account "more" menu, but
-/// folds the identity inside since the rail is too narrow for a block beside
-/// the button.
+/// plus the developer utilities. The identity folds inside the menu since the
+/// rail is too narrow for a block beside the button.
 class _RailAccountMenu extends StatelessWidget {
   const _RailAccountMenu({
     required this.entry,
@@ -386,7 +385,7 @@ class _AccountHeader extends StatelessWidget {
   }
 }
 
-/// An icon + label row for a ⋮ menu item. Mirrors the lobby sidebar's row.
+/// An icon + label row for a ⋮ menu item.
 class _MenuRow extends StatelessWidget {
   const _MenuRow({required this.icon, required this.label});
 

--- a/lib/src/modules/room/ui/room_rail.dart
+++ b/lib/src/modules/room/ui/room_rail.dart
@@ -86,11 +86,13 @@ class RoomRail extends StatelessWidget {
   Widget _buildList(BuildContext context) {
     final rooms = this.rooms;
     if (roomsError != null) {
-      return _RailMessage(
-        icon: Icons.error_outline,
-        tooltip: 'Failed to load rooms',
-        onTap: onRetryRooms,
-        color: Theme.of(context).colorScheme.error,
+      return Center(
+        child: IconButton(
+          icon: Icon(Icons.error_outline,
+              color: Theme.of(context).colorScheme.error),
+          tooltip: 'Failed to load rooms',
+          onPressed: onRetryRooms,
+        ),
       );
     }
     if (rooms == null) {
@@ -229,36 +231,6 @@ class _UnreadBadge extends StatelessWidget {
   }
 }
 
-/// A centered status glyph for the rail body (loading-failed / retry).
-class _RailMessage extends StatelessWidget {
-  const _RailMessage({
-    required this.icon,
-    required this.tooltip,
-    required this.color,
-    this.onTap,
-  });
-
-  final IconData icon;
-  final String tooltip;
-  final Color color;
-  final VoidCallback? onTap;
-
-  @override
-  Widget build(BuildContext context) {
-    return Center(
-      child: IconButton(
-        icon: Icon(icon, color: color),
-        tooltip: tooltip,
-        onPressed: onTap,
-      ),
-    );
-  }
-}
-
-/// The actions folded behind the rail's footer ⋮ menu. Account identity is a
-/// non-interactive header above these.
-enum _RailMenuAction { networkInspector, versions }
-
 /// The rail footer: a single ⋮ that opens the account identity (as a header)
 /// plus the developer utilities. The identity folds inside the menu since the
 /// rail is too narrow for a block beside the button.
@@ -275,39 +247,29 @@ class _RailAccountMenu extends StatelessWidget {
   final VoidCallback onNetworkInspector;
   final VoidCallback onVersions;
 
-  void _onSelected(_RailMenuAction action) {
-    switch (action) {
-      case _RailMenuAction.networkInspector:
-        onNetworkInspector();
-      case _RailMenuAction.versions:
-        onVersions();
-    }
-  }
-
   @override
   Widget build(BuildContext context) {
     // Session is a per-entry signal; Watch refreshes the identity label on
     // sign-in / expiry without a parent rebuild.
     return Watch((context) {
       final identity = _resolveIdentity();
-      return PopupMenuButton<_RailMenuAction>(
+      return PopupMenuButton<void>(
         icon: const Icon(Icons.more_vert),
         tooltip: 'Account & more',
-        onSelected: _onSelected,
         itemBuilder: (context) => [
-          PopupMenuItem<_RailMenuAction>(
+          PopupMenuItem(
             enabled: false,
             child: _AccountHeader(name: identity.name, email: identity.email),
           ),
           const PopupMenuDivider(),
-          const PopupMenuItem(
-            value: _RailMenuAction.networkInspector,
-            child:
-                _MenuRow(icon: Icons.lan_outlined, label: 'Network Inspector'),
+          PopupMenuItem(
+            onTap: onNetworkInspector,
+            child: const _MenuRow(
+                icon: Icons.lan_outlined, label: 'Network Inspector'),
           ),
-          const PopupMenuItem(
-            value: _RailMenuAction.versions,
-            child: _MenuRow(icon: Icons.info_outline, label: 'Versions'),
+          PopupMenuItem(
+            onTap: onVersions,
+            child: const _MenuRow(icon: Icons.info_outline, label: 'Versions'),
           ),
         ],
       );

--- a/lib/src/modules/room/ui/room_rail.dart
+++ b/lib/src/modules/room/ui/room_rail.dart
@@ -174,7 +174,7 @@ class _RoomAvatarTile extends StatelessWidget {
                     Positioned.fill(
                       child: Material(
                         color: bg,
-                        // A selected avatar squares off (larger radius) so the
+                        // A selected avatar squares off (smaller radius) so the
                         // shape shift reinforces the leading bar.
                         borderRadius: BorderRadius.circular(
                             selected ? soliplexRadii.md : _avatar / 2),

--- a/lib/src/modules/room/ui/room_rail.dart
+++ b/lib/src/modules/room/ui/room_rail.dart
@@ -11,6 +11,11 @@ import '../../lobby/ui/unread_dot.dart';
 /// optional [email]. Resolved by the room screen from `/api/user_info`.
 typedef RoomAccount = ({String name, String? email});
 
+/// Fallback display name for an authenticated user whose profile carries no
+/// usable label. Shared so the room screen's parse and the rail's resolution
+/// agree on the same string.
+const String signedInLabel = 'Signed in';
+
 /// The compact, always-visible rail of rooms for the current server.
 ///
 /// Discord-style: each room is a small initial avatar tinted by a hash of its
@@ -274,7 +279,7 @@ class _RailAccountMenu extends StatelessWidget {
     final isAuthenticated =
         entry.requiresAuth && entry.auth.session.value is ActiveSession;
     if (!isAuthenticated) return (name: 'Guest', email: null);
-    return account ?? (name: 'Signed in', email: null);
+    return account ?? (name: signedInLabel, email: null);
   }
 }
 

--- a/lib/src/modules/room/ui/room_rail.dart
+++ b/lib/src/modules/room/ui/room_rail.dart
@@ -183,7 +183,7 @@ class _RoomAvatarTile extends StatelessWidget {
                           onTap: onTap,
                           child: Center(
                             child: Text(
-                              _initial(room.name),
+                              _avatarInitial(room.name),
                               style: theme.textTheme.titleMedium
                                   ?.copyWith(color: fg),
                             ),
@@ -201,12 +201,6 @@ class _RoomAvatarTile extends StatelessWidget {
         ),
       ),
     );
-  }
-
-  static String _initial(String name) {
-    final trimmed = name.trim();
-    if (trimmed.isEmpty) return '?';
-    return trimmed.characters.first.toUpperCase();
   }
 }
 
@@ -309,7 +303,7 @@ class _AccountHeader extends StatelessWidget {
             borderRadius: BorderRadius.circular(soliplexRadii.sm),
           ),
           child: Text(
-            name.characters.first.toUpperCase(),
+            _avatarInitial(name),
             style: theme.textTheme.labelMedium?.copyWith(
               color: theme.colorScheme.onPrimaryContainer,
               fontWeight: FontWeight.w600,
@@ -363,6 +357,13 @@ class _MenuRow extends StatelessWidget {
       ],
     );
   }
+}
+
+/// The single uppercase initial for an avatar, or '?' when the name is blank.
+String _avatarInitial(String name) {
+  final trimmed = name.trim();
+  if (trimmed.isEmpty) return '?';
+  return trimmed.characters.first.toUpperCase();
 }
 
 /// A deterministic, theme-aware accent color for a room's avatar, derived from

--- a/lib/src/modules/room/ui/room_rail.dart
+++ b/lib/src/modules/room/ui/room_rail.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:signals_flutter/signals_flutter.dart';
-import 'package:soliplex_client/soliplex_client.dart' show Room;
+import 'package:soliplex_client/soliplex_client.dart'
+    show PermissionDeniedException, Room;
 import 'package:soliplex_design/soliplex_design.dart';
 
 import '../../auth/auth_tokens.dart';
@@ -91,12 +92,21 @@ class RoomRail extends StatelessWidget {
   Widget _buildList(BuildContext context) {
     final rooms = this.rooms;
     if (roomsError != null) {
+      // A permission denial is a steady state — re-trying can't resolve it —
+      // so it gets a muted lock glyph and a disabled button, distinct from the
+      // error glyph that retries a genuine (transient) load failure.
+      final denied = roomsError is PermissionDeniedException;
+      final scheme = Theme.of(context).colorScheme;
       return Center(
         child: IconButton(
-          icon: Icon(Icons.error_outline,
-              color: Theme.of(context).colorScheme.error),
-          tooltip: 'Failed to load rooms',
-          onPressed: onRetryRooms,
+          icon: Icon(
+            denied ? Icons.lock_outline : Icons.error_outline,
+            color: denied ? scheme.onSurfaceVariant : scheme.error,
+          ),
+          tooltip: denied
+              ? "You don't have permission to view rooms"
+              : 'Failed to load rooms',
+          onPressed: denied ? null : onRetryRooms,
         ),
       );
     }

--- a/lib/src/modules/room/ui/room_rail.dart
+++ b/lib/src/modules/room/ui/room_rail.dart
@@ -138,9 +138,7 @@ class _RoomAvatarTile extends StatelessWidget {
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
     final bg = roomAvatarColor(room.name, theme.brightness);
-    final fg = ThemeData.estimateBrightnessForColor(bg) == Brightness.dark
-        ? Colors.white
-        : Colors.black;
+    final fg = contrastingForeground(bg);
 
     return Tooltip(
       message: room.name,

--- a/lib/src/modules/room/ui/room_screen.dart
+++ b/lib/src/modules/room/ui/room_screen.dart
@@ -11,6 +11,7 @@ import 'package:soliplex_client/soliplex_client.dart'
         AuthException,
         CancelToken,
         MalformedResponseException,
+        PermissionDeniedException,
         RagDocument,
         ReconnectFailed,
         ReconnectStatus,
@@ -242,13 +243,19 @@ class _RoomScreenState extends State<RoomScreen> {
         return;
       }
       if (!mounted || token != _roomsCancelToken) return;
-      dev.log(
-        'Failed to load server rooms',
-        error: error,
-        stackTrace: stackTrace,
-        name: 'RoomScreen',
-        level: 1000,
-      );
+      // A PermissionDeniedException (403) is an expected steady state — the
+      // server denies access and re-auth won't help — and the rail surfaces it
+      // inline, so keep it below the severe channel reserved for genuine
+      // failures.
+      if (error is! PermissionDeniedException) {
+        dev.log(
+          'Failed to load server rooms',
+          error: error,
+          stackTrace: stackTrace,
+          name: 'RoomScreen',
+          level: 1000,
+        );
+      }
       setState(() => _serverRoomsError = error);
     });
   }

--- a/lib/src/modules/room/ui/room_screen.dart
+++ b/lib/src/modules/room/ui/room_screen.dart
@@ -82,13 +82,8 @@ RoomAccount accountFromJson(Map<String, dynamic> json) {
   final email = json['email'] as String? ?? '';
   final full = '$given $family'.trim();
   final hasName = full.isNotEmpty || preferred.isNotEmpty;
-  final name = full.isNotEmpty
-      ? full
-      : preferred.isNotEmpty
-          ? preferred
-          : email.isNotEmpty
-              ? email
-              : 'Signed in';
+  final name = [full, preferred, email]
+      .firstWhere((s) => s.isNotEmpty, orElse: () => 'Signed in');
   // Omit the email line when the email is doubling as the name, so the header
   // doesn't render the same string twice.
   return (name: name, email: hasName && email.isNotEmpty ? email : null);
@@ -227,6 +222,7 @@ class _RoomScreenState extends State<RoomScreen> {
   /// Fetches the current server's room list for the rail. Cancels any
   /// in-flight fetch so a server switch can't apply a stale result.
   void _fetchServerRooms() {
+    final entry = widget.serverEntry;
     _roomsCancelToken?.cancel('refresh');
     final token = CancelToken();
     _roomsCancelToken = token;
@@ -234,12 +230,17 @@ class _RoomScreenState extends State<RoomScreen> {
     // the async callbacks below trigger the rebuild once a result lands.
     _serverRooms = null;
     _serverRoomsError = null;
-    widget.serverEntry.connection.api
-        .getRooms(cancelToken: token)
-        .then((rooms) {
+    entry.connection.api.getRooms(cancelToken: token).then((rooms) {
       if (!mounted || token != _roomsCancelToken) return;
       setState(() => _serverRooms = rooms);
     }).catchError((Object error, StackTrace stackTrace) {
+      if (error is AuthException) {
+        // The captured entry's session has expired; funnel it so the route
+        // guard redirects to login even if we have since switched servers.
+        // Leaving the loading state means no error banner flashes first.
+        entry.auth.markSessionExpired();
+        return;
+      }
       if (!mounted || token != _roomsCancelToken) return;
       dev.log(
         'Failed to load server rooms',

--- a/lib/src/modules/room/ui/room_screen.dart
+++ b/lib/src/modules/room/ui/room_screen.dart
@@ -69,6 +69,27 @@ String uploadChipLabel(int roomCount, int threadCount) {
   return '$threadCount thread';
 }
 
+/// Resolves a display identity from an OIDC `/api/user_info` payload, trying
+/// the most specific label first: the full name (`given_name` + `family_name`),
+/// then `preferred_username`, then `email`, falling back to a generic
+/// "Signed in" when the payload carries no usable label. The returned email is
+/// null when absent so the rail's account header can omit the secondary line.
+RoomAccount accountFromJson(Map<String, dynamic> json) {
+  final given = json['given_name'] as String? ?? '';
+  final family = json['family_name'] as String? ?? '';
+  final preferred = json['preferred_username'] as String? ?? '';
+  final email = json['email'] as String? ?? '';
+  final full = '$given $family'.trim();
+  final name = full.isNotEmpty
+      ? full
+      : preferred.isNotEmpty
+          ? preferred
+          : email.isNotEmpty
+              ? email
+              : 'Signed in';
+  return (name: name, email: email.isNotEmpty ? email : null);
+}
+
 class RoomScreen extends StatefulWidget {
   const RoomScreen({
     super.key,
@@ -402,7 +423,7 @@ class _RoomScreenState extends State<RoomScreen> {
         return;
       }
       final json = jsonDecode(response.body) as Map<String, dynamic>;
-      setState(() => _account = _accountFromJson(json));
+      setState(() => _account = accountFromJson(json));
     }).catchError((Object error, StackTrace stackTrace) {
       dev.log(
         'Failed to load account profile',
@@ -412,22 +433,6 @@ class _RoomScreenState extends State<RoomScreen> {
         level: 900,
       );
     });
-  }
-
-  RoomAccount _accountFromJson(Map<String, dynamic> json) {
-    final given = json['given_name'] as String? ?? '';
-    final family = json['family_name'] as String? ?? '';
-    final preferred = json['preferred_username'] as String? ?? '';
-    final email = json['email'] as String? ?? '';
-    final full = '$given $family'.trim();
-    final name = full.isNotEmpty
-        ? full
-        : preferred.isNotEmpty
-            ? preferred
-            : email.isNotEmpty
-                ? email
-                : 'Signed in';
-    return (name: name, email: email.isNotEmpty ? email : null);
   }
 
   Future<void> _openDocumentPicker() async {

--- a/lib/src/modules/room/ui/room_screen.dart
+++ b/lib/src/modules/room/ui/room_screen.dart
@@ -83,7 +83,7 @@ RoomAccount accountFromJson(Map<String, dynamic> json) {
   final full = '$given $family'.trim();
   final hasName = full.isNotEmpty || preferred.isNotEmpty;
   final name = [full, preferred, email]
-      .firstWhere((s) => s.isNotEmpty, orElse: () => 'Signed in');
+      .firstWhere((s) => s.isNotEmpty, orElse: () => signedInLabel);
   // Omit the email line when the email is doubling as the name, so the header
   // doesn't render the same string twice.
   return (name: name, email: hasName && email.isNotEmpty ? email : null);
@@ -409,11 +409,11 @@ class _RoomScreenState extends State<RoomScreen> {
   /// Best-effort fetch of the signed-in identity for the rail's account menu.
   /// No-op (and clears the cached account) when the server is unauthenticated;
   /// a failure leaves the generic "Signed in" label in place.
-  ///
-  /// The fetch + parse here duplicate the lobby's `_fetchUserProfile` /
-  /// `UserProfile.fromJson` against the same `/api/user_info` endpoint. They
-  /// should collapse into one shared `fetchUserInfo(ServerEntry)` helper; the
-  /// room can't reuse the lobby's cache because `LobbyState` is screen-scoped.
+  //
+  // TODO: The fetch + parse here duplicate the lobby's `_fetchUserProfile` /
+  // `UserProfile.fromJson` against the same `/api/user_info` endpoint. Collapse
+  // them into one shared `fetchUserInfo(ServerEntry)` helper. The room can't
+  // reuse the lobby's cache because `LobbyState` is screen-scoped.
   void _fetchAccount() {
     final entry = widget.serverEntry;
     // Direct assignments here (not setState): this may run from initState
@@ -438,10 +438,13 @@ class _RoomScreenState extends State<RoomScreen> {
       }
       if (!mounted || generation != _accountFetchGeneration) return;
       if (response.statusCode != 200) {
+        // A 403 is the expected steady state for a permission-restricted
+        // profile endpoint, so log it below the warning channel reserved for
+        // genuine 5xx / decode failures — debuggable without crying wolf.
         dev.log(
           'Account profile fetch returned ${response.statusCode}',
           name: 'RoomScreen',
-          level: 900,
+          level: response.statusCode == 403 ? 500 : 900,
         );
         return;
       }

--- a/lib/src/modules/room/ui/room_screen.dart
+++ b/lib/src/modules/room/ui/room_screen.dart
@@ -131,6 +131,12 @@ class _RoomScreenState extends State<RoomScreen> {
   /// resolved (or when the server is unauthenticated / the fetch fails).
   RoomAccount? _account;
 
+  /// Bumped on each account fetch so a slow in-flight request for a previous
+  /// server can't write its identity onto the current one. The raw
+  /// `/api/user_info` request can't be cancelled, so we guard the result
+  /// against the latest generation instead.
+  int _accountFetchGeneration = 0;
+
   bool get _filterEnabled => widget.enableDocumentFilter;
 
   /// Whether the room exposes any filterable documents/datasets. Resolved
@@ -379,14 +385,22 @@ class _RoomScreenState extends State<RoomScreen> {
   /// a failure leaves the generic "Signed in" label in place.
   void _fetchAccount() {
     final entry = widget.serverEntry;
+    // Direct assignments here (not setState): this may run from initState
+    // before the first build, and the async callbacks below trigger the
+    // rebuild once a result lands. Clearing eagerly drops the previous
+    // server's identity instead of letting it linger through the switch.
+    _account = null;
+    final generation = ++_accountFetchGeneration;
     if (!entry.requiresAuth || entry.auth.session.value is! ActiveSession) {
-      // Direct assignment: may run from initState before the first build.
-      _account = null;
       return;
     }
     final url = entry.serverUrl.resolve('/api/user_info');
     Future.sync(() => entry.httpClient.request('GET', url)).then((response) {
-      if (!mounted || response.statusCode != 200) return;
+      if (!mounted ||
+          generation != _accountFetchGeneration ||
+          response.statusCode != 200) {
+        return;
+      }
       final json = jsonDecode(response.body) as Map<String, dynamic>;
       setState(() => _account = _accountFromJson(json));
     }).catchError((Object error, StackTrace stackTrace) {

--- a/lib/src/modules/room/ui/room_screen.dart
+++ b/lib/src/modules/room/ui/room_screen.dart
@@ -8,6 +8,7 @@ import 'package:go_router/go_router.dart';
 import 'package:signals_flutter/signals_flutter.dart';
 import 'package:soliplex_client/soliplex_client.dart'
     show
+        AuthException,
         CancelToken,
         MalformedResponseException,
         RagDocument,
@@ -425,14 +426,31 @@ class _RoomScreenState extends State<RoomScreen> {
     }
     final url = entry.serverUrl.resolve('/api/user_info');
     Future.sync(() => entry.httpClient.request('GET', url)).then((response) {
-      if (!mounted ||
-          generation != _accountFetchGeneration ||
-          response.statusCode != 200) {
+      // entry.httpClient is the raw decorator chain (no HttpTransport), so a
+      // 401 arrives as a response rather than a thrown AuthException — funnel
+      // it to the session explicitly. The captured entry's session is expired
+      // even if we have since switched servers, so this fires regardless of
+      // the staleness guard below.
+      if (response.statusCode == 401) {
+        entry.auth.markSessionExpired();
+        return;
+      }
+      if (!mounted || generation != _accountFetchGeneration) return;
+      if (response.statusCode != 200) {
+        dev.log(
+          'Account profile fetch returned ${response.statusCode}',
+          name: 'RoomScreen',
+          level: 900,
+        );
         return;
       }
       final json = jsonDecode(response.body) as Map<String, dynamic>;
       setState(() => _account = accountFromJson(json));
     }).catchError((Object error, StackTrace stackTrace) {
+      if (error is AuthException) {
+        entry.auth.markSessionExpired();
+        return;
+      }
       dev.log(
         'Failed to load account profile',
         error: error,
@@ -534,8 +552,9 @@ class _RoomScreenState extends State<RoomScreen> {
   @override
   void didUpdateWidget(RoomScreen oldWidget) {
     super.didUpdateWidget(oldWidget);
-    if (widget.roomId != oldWidget.roomId ||
-        widget.serverEntry.serverId != oldWidget.serverEntry.serverId) {
+    final serverChanged =
+        widget.serverEntry.serverId != oldWidget.serverEntry.serverId;
+    if (widget.roomId != oldWidget.roomId || serverChanged) {
       _cancelAutoSelect();
       _state.dispose();
       _chatController.clear();
@@ -544,11 +563,18 @@ class _RoomScreenState extends State<RoomScreen> {
       _hasFilterableDocuments = false;
       _filterDocsLoadFailed = false;
       _refreshFilterableDocuments();
-      _fetchServerRooms();
-      _fetchRoomActivity();
       _markRoomRead(widget.roomId);
       _markThreadRead(widget.threadId);
-      _fetchAccount();
+      // Room list, account identity, and room-activity stats are all
+      // server-scoped: refetch only on a server change, not on every in-server
+      // room switch (which would otherwise flash the rail back to a spinner and
+      // fire redundant requests). The switch still clears the read dot locally
+      // via _markRoomRead above.
+      if (serverChanged) {
+        _fetchServerRooms();
+        _fetchRoomActivity();
+        _fetchAccount();
+      }
       if (widget.threadId != null) {
         _state.selectThread(widget.threadId!);
       } else {

--- a/lib/src/modules/room/ui/room_screen.dart
+++ b/lib/src/modules/room/ui/room_screen.dart
@@ -78,8 +78,8 @@ String uploadChipLabel(int roomCount, int threadCount) {
 RoomAccount accountFromJson(Map<String, dynamic> json) {
   final given = json['given_name'] as String? ?? '';
   final family = json['family_name'] as String? ?? '';
-  final preferred = json['preferred_username'] as String? ?? '';
-  final email = json['email'] as String? ?? '';
+  final preferred = (json['preferred_username'] as String? ?? '').trim();
+  final email = (json['email'] as String? ?? '').trim();
   final full = '$given $family'.trim();
   final hasName = full.isNotEmpty || preferred.isNotEmpty;
   final name = [full, preferred, email]

--- a/lib/src/modules/room/ui/room_screen.dart
+++ b/lib/src/modules/room/ui/room_screen.dart
@@ -80,6 +80,7 @@ RoomAccount accountFromJson(Map<String, dynamic> json) {
   final preferred = json['preferred_username'] as String? ?? '';
   final email = json['email'] as String? ?? '';
   final full = '$given $family'.trim();
+  final hasName = full.isNotEmpty || preferred.isNotEmpty;
   final name = full.isNotEmpty
       ? full
       : preferred.isNotEmpty
@@ -87,7 +88,9 @@ RoomAccount accountFromJson(Map<String, dynamic> json) {
           : email.isNotEmpty
               ? email
               : 'Signed in';
-  return (name: name, email: email.isNotEmpty ? email : null);
+  // Omit the email line when the email is doubling as the name, so the header
+  // doesn't render the same string twice.
+  return (name: name, email: hasName && email.isNotEmpty ? email : null);
 }
 
 class RoomScreen extends StatefulWidget {
@@ -404,6 +407,11 @@ class _RoomScreenState extends State<RoomScreen> {
   /// Best-effort fetch of the signed-in identity for the rail's account menu.
   /// No-op (and clears the cached account) when the server is unauthenticated;
   /// a failure leaves the generic "Signed in" label in place.
+  ///
+  /// The fetch + parse here duplicate the lobby's `_fetchUserProfile` /
+  /// `UserProfile.fromJson` against the same `/api/user_info` endpoint. They
+  /// should collapse into one shared `fetchUserInfo(ServerEntry)` helper; the
+  /// room can't reuse the lobby's cache because `LobbyState` is screen-scoped.
   void _fetchAccount() {
     final entry = widget.serverEntry;
     // Direct assignments here (not setState): this may run from initState
@@ -994,8 +1002,6 @@ class _RoomScreenState extends State<RoomScreen> {
               overflow: TextOverflow.ellipsis,
             ),
           ),
-          // Documents + room info sit in the top-right corner — the anchor
-          // for the future right-hand side panel (documents / info).
           if (documentsButton != null) documentsButton,
           IconButton(
             icon: const Icon(Icons.info_outline),
@@ -1011,7 +1017,7 @@ class _RoomScreenState extends State<RoomScreen> {
   /// The top-right documents button: a simple icon toggle for the attached-
   /// files panel. Returns null to hide it when both scopes are Loaded-empty.
   /// The icon reflects upload state (spinner while in flight, error glyph on
-  /// failure); the count is surfaced through the tooltip rather than a label.
+  /// failure); the file count appears in the tooltip once both scopes load.
   Widget? _buildDocumentsButton(
     UploadsStatus roomStatus,
     UploadsStatus threadStatus,

--- a/lib/src/modules/room/ui/room_screen.dart
+++ b/lib/src/modules/room/ui/room_screen.dart
@@ -77,10 +77,17 @@ String uploadChipLabel(int roomCount, int threadCount) {
 /// "Signed in" when the payload carries no usable label. The returned email is
 /// null when absent so the rail's account header can omit the secondary line.
 RoomAccount accountFromJson(Map<String, dynamic> json) {
-  final given = json['given_name'] as String? ?? '';
-  final family = json['family_name'] as String? ?? '';
-  final preferred = (json['preferred_username'] as String? ?? '').trim();
-  final email = (json['email'] as String? ?? '').trim();
+  // Read each claim independently: a non-string value is treated as absent so
+  // one malformed field can't discard its valid siblings.
+  String claim(String key) {
+    final value = json[key];
+    return value is String ? value : '';
+  }
+
+  final given = claim('given_name');
+  final family = claim('family_name');
+  final preferred = claim('preferred_username').trim();
+  final email = claim('email').trim();
   final full = '$given $family'.trim();
   final hasName = full.isNotEmpty || preferred.isNotEmpty;
   final name = [full, preferred, email]
@@ -415,7 +422,7 @@ class _RoomScreenState extends State<RoomScreen> {
 
   /// Best-effort fetch of the signed-in identity for the rail's account menu.
   /// No-op (and clears the cached account) when the server is unauthenticated;
-  /// a failure leaves the generic "Signed in" label in place.
+  /// a failure falls back to the generic "Signed in" label.
   //
   // TODO: The fetch + parse here duplicate the lobby's `_fetchUserProfile` /
   // `UserProfile.fromJson` against the same `/api/user_info` endpoint. Collapse

--- a/lib/src/modules/room/ui/room_screen.dart
+++ b/lib/src/modules/room/ui/room_screen.dart
@@ -253,8 +253,14 @@ class _RoomScreenState extends State<RoomScreen> {
       // A PermissionDeniedException (403) is an expected steady state — the
       // server denies access and re-auth won't help — and the rail surfaces it
       // inline, so keep it below the severe channel reserved for genuine
-      // failures.
-      if (error is! PermissionDeniedException) {
+      // failures. Still log it at debug so a misconfigured ACL leaves a trace.
+      if (error is PermissionDeniedException) {
+        dev.log(
+          'Rooms fetch denied (403)',
+          name: 'RoomScreen',
+          level: 500,
+        );
+      } else {
         dev.log(
           'Failed to load server rooms',
           error: error,

--- a/packages/soliplex_design/lib/src/tokens/colors.dart
+++ b/packages/soliplex_design/lib/src/tokens/colors.dart
@@ -55,7 +55,7 @@ class SoliplexColors {
         : darkSoliplexColors;
     return base.copyWith(
       primary: accent,
-      onPrimary: _contrastingForeground(accent),
+      onPrimary: contrastingForeground(accent),
     );
   }
 
@@ -168,7 +168,9 @@ class SoliplexColors {
   }
 }
 
-Color _contrastingForeground(Color background) =>
+/// The legible foreground (near-white or near-black) for text or icons drawn
+/// on top of an arbitrary [background] — e.g. a hashed avatar tint.
+Color contrastingForeground(Color background) =>
     ThemeData.estimateBrightnessForColor(background) == Brightness.dark
         ? const Color(0xFFFFFFFF)
         : const Color(0xFF0A0A0A);

--- a/test/helpers/fakes.dart
+++ b/test/helpers/fakes.dart
@@ -198,6 +198,10 @@ class FakeSoliplexApi extends SoliplexApi {
   Exception? nextError;
   int getRoomsCallCount = 0;
 
+  /// When set, [getRooms] awaits this before returning, letting a test hold a
+  /// rooms fetch in flight (e.g. to exercise the rail's staleness guard).
+  Completer<void>? roomsGate;
+
   List<RagDocument>? nextDocuments;
   Exception? nextDocumentsError;
   String? nextMcpToken;
@@ -238,6 +242,7 @@ class FakeSoliplexApi extends SoliplexApi {
   @override
   Future<List<Room>> getRooms({CancelToken? cancelToken}) async {
     getRoomsCallCount++;
+    if (roomsGate != null) await roomsGate!.future;
     if (nextError != null) throw nextError!;
     if (nextRooms != null) return nextRooms!;
     throw StateError(

--- a/test/helpers/test_server_entry.dart
+++ b/test/helpers/test_server_entry.dart
@@ -1,5 +1,6 @@
 import 'package:soliplex_agent/soliplex_agent.dart';
 import 'package:soliplex_frontend/src/modules/auth/auth_session.dart';
+import 'package:soliplex_frontend/src/modules/auth/auth_tokens.dart';
 import 'package:soliplex_frontend/src/modules/auth/server_entry.dart';
 
 import 'fakes.dart';
@@ -8,19 +9,40 @@ ServerEntry createTestServerEntry({
   FakeSoliplexApi? api,
   String serverId = 'http://test-server:8000',
   String alias = 'test-server-8000',
+  bool requiresAuth = false,
+  AuthSession? auth,
+  FakeHttpClient? httpClient,
 }) {
   final fakeApi = api ?? FakeSoliplexApi();
   return ServerEntry(
     serverId: serverId,
     alias: alias,
     serverUrl: Uri.parse(serverId),
-    auth: AuthSession(refreshService: FakeTokenRefreshService()),
-    httpClient: FakeHttpClient(),
+    auth: auth ?? AuthSession(refreshService: FakeTokenRefreshService()),
+    httpClient: httpClient ?? FakeHttpClient(),
     connection: ServerConnection(
       serverId: serverId,
       api: fakeApi,
       agUiStreamClient: FakeAgUiStreamClient(),
     ),
-    requiresAuth: false,
+    requiresAuth: requiresAuth,
   );
+}
+
+/// An [AuthSession] already in its [ActiveSession] state, for tests that need
+/// to exercise authenticated-only paths (e.g. the rail's account fetch).
+AuthSession authInActiveSession() {
+  final auth = AuthSession(refreshService: FakeTokenRefreshService());
+  auth.login(
+    provider: const OidcProvider(
+      discoveryUrl: 'https://auth.example.com/.well-known/openid-configuration',
+      clientId: 'test-client',
+    ),
+    tokens: AuthTokens(
+      accessToken: 'access',
+      refreshToken: 'refresh',
+      expiresAt: DateTime.now().add(const Duration(hours: 1)),
+    ),
+  );
+  return auth;
 }

--- a/test/modules/room/ui/account_from_json_test.dart
+++ b/test/modules/room/ui/account_from_json_test.dart
@@ -1,0 +1,58 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:soliplex_frontend/src/modules/room/ui/room_screen.dart';
+
+void main() {
+  group('accountFromJson', () {
+    test('prefers the full name from given + family', () {
+      final account = accountFromJson({
+        'given_name': 'Ada',
+        'family_name': 'Lovelace',
+        'preferred_username': 'ada',
+        'email': 'ada@example.com',
+      });
+      expect(account.name, 'Ada Lovelace');
+      expect(account.email, 'ada@example.com');
+    });
+
+    test('uses a lone given (or family) name, trimmed', () {
+      final account = accountFromJson({'given_name': 'Ada', 'family_name': ''});
+      expect(account.name, 'Ada');
+      expect(account.email, isNull);
+    });
+
+    test('falls back to preferred_username when no name is present', () {
+      final account = accountFromJson({
+        'preferred_username': 'ada',
+        'email': 'ada@example.com',
+      });
+      expect(account.name, 'ada');
+    });
+
+    test('falls back to email when only an email is present', () {
+      final account = accountFromJson({'email': 'ada@example.com'});
+      expect(account.name, 'ada@example.com');
+      expect(account.email, 'ada@example.com');
+    });
+
+    test('falls back to "Signed in" when the payload carries no label', () {
+      final account = accountFromJson(const {});
+      expect(account.name, 'Signed in');
+      expect(account.email, isNull);
+    });
+
+    test('treats whitespace-only name fields as absent', () {
+      final account = accountFromJson({
+        'given_name': '  ',
+        'family_name': '',
+        'preferred_username': 'ada',
+      });
+      expect(account.name, 'ada');
+    });
+
+    test('reports a blank email as null', () {
+      final account =
+          accountFromJson({'preferred_username': 'ada', 'email': ''});
+      expect(account.email, isNull);
+    });
+  });
+}

--- a/test/modules/room/ui/account_from_json_test.dart
+++ b/test/modules/room/ui/account_from_json_test.dart
@@ -49,9 +49,23 @@ void main() {
       expect(account.name, 'ada');
     });
 
+    test('treats a whitespace-only preferred_username as absent', () {
+      final account = accountFromJson({
+        'preferred_username': '  ',
+        'email': 'ada@example.com',
+      });
+      expect(account.name, 'ada@example.com');
+    });
+
     test('reports a blank email as null', () {
       final account =
           accountFromJson({'preferred_username': 'ada', 'email': ''});
+      expect(account.email, isNull);
+    });
+
+    test('treats a whitespace-only email as null', () {
+      final account =
+          accountFromJson({'preferred_username': 'ada', 'email': '  '});
       expect(account.email, isNull);
     });
   });

--- a/test/modules/room/ui/account_from_json_test.dart
+++ b/test/modules/room/ui/account_from_json_test.dart
@@ -28,10 +28,10 @@ void main() {
       expect(account.name, 'ada');
     });
 
-    test('falls back to email when only an email is present', () {
+    test('uses email as the name but drops the duplicate email line', () {
       final account = accountFromJson({'email': 'ada@example.com'});
       expect(account.name, 'ada@example.com');
-      expect(account.email, 'ada@example.com');
+      expect(account.email, isNull);
     });
 
     test('falls back to "Signed in" when the payload carries no label', () {

--- a/test/modules/room/ui/account_from_json_test.dart
+++ b/test/modules/room/ui/account_from_json_test.dart
@@ -68,5 +68,28 @@ void main() {
           accountFromJson({'preferred_username': 'ada', 'email': '  '});
       expect(account.email, isNull);
     });
+
+    test('treats a non-string field as absent without discarding siblings', () {
+      // A malformed claim (here a numeric given_name) must not take down the
+      // valid preferred_username and email alongside it.
+      final account = accountFromJson({
+        'given_name': 123,
+        'preferred_username': 'ada',
+        'email': 'ada@example.com',
+      });
+      expect(account.name, 'ada');
+      expect(account.email, 'ada@example.com');
+    });
+
+    test('falls back to "Signed in" when every claim is non-string', () {
+      final account = accountFromJson({
+        'given_name': 1,
+        'family_name': true,
+        'preferred_username': ['ada'],
+        'email': {'value': 'ada@example.com'},
+      });
+      expect(account.name, 'Signed in');
+      expect(account.email, isNull);
+    });
   });
 }

--- a/test/modules/room/ui/room_rail_test.dart
+++ b/test/modules/room/ui/room_rail_test.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:soliplex_client/soliplex_client.dart' show Room;
+import 'package:soliplex_client/soliplex_client.dart'
+    show PermissionDeniedException, Room;
 import 'package:soliplex_frontend/src/modules/room/ui/room_rail.dart';
 
 import '../../../helpers/test_server_entry.dart';
@@ -78,6 +79,24 @@ void main() {
       expect(find.byIcon(Icons.error_outline), findsOneWidget);
       await tester.tap(find.byIcon(Icons.error_outline));
       expect(retried, isTrue);
+    });
+
+    testWidgets('shows a non-retryable affordance for a permission denial',
+        (tester) async {
+      await tester.pumpWidget(_wrap(_rail(
+        rooms: null,
+        roomsError:
+            const PermissionDeniedException(statusCode: 403, message: 'no'),
+        onRetryRooms: () {},
+      )));
+
+      // A 403 is a steady state — re-trying won't help — so the lock glyph
+      // replaces the retry error glyph and the button is disabled.
+      expect(find.byIcon(Icons.lock_outline), findsOneWidget);
+      expect(find.byIcon(Icons.error_outline), findsNothing);
+      final button = tester.widget<IconButton>(
+          find.widgetWithIcon(IconButton, Icons.lock_outline));
+      expect(button.onPressed, isNull);
     });
 
     testWidgets('footer menu exposes the account, inspector, and versions',

--- a/test/modules/room/ui/room_rail_test.dart
+++ b/test/modules/room/ui/room_rail_test.dart
@@ -122,6 +122,14 @@ void main() {
       await tester.pumpAndSettle();
       expect(inspector, isTrue);
       expect(versions, isFalse);
+
+      // Each item carries its own onTap, so verify Versions is wired to its
+      // own callback and not to the inspector's.
+      await tester.tap(find.byIcon(Icons.more_vert));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('Versions'));
+      await tester.pumpAndSettle();
+      expect(versions, isTrue);
     });
   });
 

--- a/test/modules/room/ui/room_screen_test.dart
+++ b/test/modules/room/ui/room_screen_test.dart
@@ -818,6 +818,30 @@ void main() {
       await tester.pumpAndSettle();
       expect(api.getRoomsCallCount, 1);
     });
+
+    testWidgets('are refetched when the server changes', (tester) async {
+      Widget roomScreenFor(ServerEntry e) => MaterialApp(
+            home: RoomScreen(
+              serverEntry: e,
+              roomId: 'room-1',
+              threadId: null,
+              runtimeManager: runtimeManager,
+              registry: registry,
+              uploadRegistry: uploadRegistry,
+              documentSelections: DocumentSelections(),
+            ),
+          );
+
+      await tester.pumpWidget(roomScreenFor(
+          createTestServerEntry(api: api, serverId: 'http://server-a:8000')));
+      await tester.pumpAndSettle();
+      expect(api.getRoomsCallCount, 1);
+
+      await tester.pumpWidget(roomScreenFor(
+          createTestServerEntry(api: api, serverId: 'http://server-b:8000')));
+      await tester.pumpAndSettle();
+      expect(api.getRoomsCallCount, 2);
+    });
   });
 
   testWidgets('the room-info button navigates to the room info route',

--- a/test/modules/room/ui/room_screen_test.dart
+++ b/test/modules/room/ui/room_screen_test.dart
@@ -13,6 +13,7 @@ import 'package:soliplex_frontend/src/modules/room/run_registry.dart';
 import 'package:soliplex_frontend/src/modules/room/ui/room_screen.dart';
 import 'package:soliplex_frontend/src/modules/room/ui/thread_sidebar.dart';
 import 'package:soliplex_frontend/src/modules/room/upload_tracker_registry.dart';
+import 'package:soliplex_frontend/src/modules/auth/auth_tokens.dart';
 import 'package:soliplex_frontend/src/modules/auth/server_entry.dart';
 
 import '../../../helpers/fakes.dart';
@@ -44,6 +45,15 @@ class _StaleDocumentsApi extends FakeSoliplexApi {
     CancelToken? cancelToken,
   }) =>
       roomId == 'room-1' ? firstRoomDocuments.future : Future.value(const []);
+}
+
+/// A [FakeSoliplexApi] whose room-list fetch fails with an [AuthException],
+/// exercising the rail's session-expiry funnel.
+class _RoomsAuthErrorApi extends FakeSoliplexApi {
+  @override
+  Future<List<Room>> getRooms({CancelToken? cancelToken}) async {
+    throw const AuthException(message: 'expired');
+  }
 }
 
 Widget _buildRouted({
@@ -841,6 +851,45 @@ void main() {
           createTestServerEntry(api: api, serverId: 'http://server-b:8000')));
       await tester.pumpAndSettle();
       expect(api.getRoomsCallCount, 2);
+    });
+
+    testWidgets(
+        'an auth failure funnels to the session without an error affordance',
+        (tester) async {
+      final auth = authInActiveSession();
+      final authedEntry = createTestServerEntry(
+        api: _RoomsAuthErrorApi()
+          ..nextThreads = []
+          ..nextThreadHistory = ThreadHistory(messages: const []),
+        requiresAuth: true,
+        auth: auth,
+        httpClient: FakeHttpClient()
+          ..onRequest = (_, __) async => HttpResponse(
+                statusCode: 200,
+                bodyBytes: Uint8List.fromList(utf8.encode('{}')),
+              ),
+      );
+
+      await tester.pumpWidget(MaterialApp(
+        home: RoomScreen(
+          serverEntry: authedEntry,
+          roomId: 'room-1',
+          threadId: null,
+          runtimeManager: runtimeManager,
+          registry: registry,
+          uploadRegistry: uploadRegistry,
+          documentSelections: DocumentSelections(),
+        ),
+      ));
+      // Not pumpAndSettle: the rail's loading spinner never stops, since the
+      // auth funnel deliberately leaves the rooms fetch in its loading state.
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 100));
+
+      expect(auth.session.value, isA<ExpiredSession>());
+      // The rail leaves the loading state in place rather than surfacing its
+      // own retry affordance, so the route guard's redirect isn't pre-empted.
+      expect(find.byTooltip('Failed to load rooms'), findsNothing);
     });
   });
 

--- a/test/modules/room/ui/room_screen_test.dart
+++ b/test/modules/room/ui/room_screen_test.dart
@@ -83,6 +83,11 @@ Widget _buildRouted({
               documentSelections: DocumentSelections(),
             ),
           ),
+          GoRoute(
+            path: 'info',
+            builder: (ctx, state) =>
+                const Scaffold(body: Text('room info page')),
+          ),
         ],
       ),
     ],
@@ -713,11 +718,125 @@ void main() {
       expect(find.text('ada@example.com'), findsOneWidget);
     });
 
-    testWidgets('falls back to "Signed in" when the profile fetch fails',
+    testWidgets('falls back to "Signed in" when the profile fetch errors',
         (tester) async {
-      await pumpAuthedRoom(tester, profileClient(const {}, statusCode: 401));
+      await pumpAuthedRoom(tester, profileClient(const {}, statusCode: 500));
 
       expect(find.text('Signed in'), findsOneWidget);
     });
+
+    testWidgets('marks the session expired (Guest) on a 401', (tester) async {
+      await pumpAuthedRoom(tester, profileClient(const {}, statusCode: 401));
+
+      expect(find.text('Guest'), findsOneWidget);
+    });
+
+    testWidgets(
+        'a slow identity fetch from the previous server cannot overwrite '
+        'the current server identity', (tester) async {
+      HttpResponse profileResponse(Map<String, dynamic> profile) =>
+          HttpResponse(
+            statusCode: 200,
+            bodyBytes: Uint8List.fromList(utf8.encode(jsonEncode(profile))),
+          );
+
+      final heldA = Completer<HttpResponse>();
+      final entryA = createTestServerEntry(
+        api: api,
+        serverId: 'http://server-a:8000',
+        requiresAuth: true,
+        auth: authInActiveSession(),
+        httpClient: FakeHttpClient()..onRequest = (_, __) => heldA.future,
+      );
+      final entryB = createTestServerEntry(
+        api: api,
+        serverId: 'http://server-b:8000',
+        requiresAuth: true,
+        auth: authInActiveSession(),
+        httpClient: FakeHttpClient()
+          ..onRequest = (_, __) async =>
+              profileResponse({'given_name': 'Bob', 'family_name': 'Beta'}),
+      );
+
+      tester.view.physicalSize = const Size(1200, 800);
+      tester.view.devicePixelRatio = 1.0;
+      addTearDown(tester.view.resetPhysicalSize);
+
+      Widget roomScreen(ServerEntry e) => MaterialApp(
+            home: RoomScreen(
+              serverEntry: e,
+              roomId: 'room-1',
+              threadId: null,
+              runtimeManager: runtimeManager,
+              registry: registry,
+              uploadRegistry: uploadRegistry,
+              documentSelections: DocumentSelections(),
+            ),
+          );
+
+      // Server A's identity fetch is in flight, held open.
+      await tester.pumpWidget(roomScreen(entryA));
+      await tester.pumpAndSettle();
+
+      // Switch to server B, whose identity resolves immediately.
+      await tester.pumpWidget(roomScreen(entryB));
+      await tester.pumpAndSettle();
+
+      // Server A's now-stale fetch resolves; it must not overwrite B's
+      // identity.
+      heldA.complete(
+          profileResponse({'given_name': 'Alice', 'family_name': 'Alpha'}));
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.byTooltip('Account & more'));
+      await tester.pumpAndSettle();
+      expect(find.text('Bob Beta'), findsOneWidget);
+      expect(find.text('Alice Alpha'), findsNothing);
+    });
+  });
+
+  group('rail rooms', () {
+    Widget roomScreen(String roomId) => MaterialApp(
+          home: RoomScreen(
+            serverEntry: entry,
+            roomId: roomId,
+            threadId: null,
+            runtimeManager: runtimeManager,
+            registry: registry,
+            uploadRegistry: uploadRegistry,
+            documentSelections: DocumentSelections(),
+          ),
+        );
+
+    testWidgets('are not refetched on an in-server room switch',
+        (tester) async {
+      await tester.pumpWidget(roomScreen('room-1'));
+      await tester.pumpAndSettle();
+      expect(api.getRoomsCallCount, 1);
+
+      await tester.pumpWidget(roomScreen('room-2'));
+      await tester.pumpAndSettle();
+      expect(api.getRoomsCallCount, 1);
+    });
+  });
+
+  testWidgets('the room-info button navigates to the room info route',
+      (tester) async {
+    tester.view.physicalSize = const Size(1200, 800);
+    tester.view.devicePixelRatio = 1.0;
+    addTearDown(tester.view.resetPhysicalSize);
+
+    await tester.pumpWidget(_buildRouted(
+      entry: entry,
+      runtimeManager: runtimeManager,
+      registry: registry,
+      uploadRegistry: uploadRegistry,
+    ));
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.byTooltip('Room info'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('room info page'), findsOneWidget);
   });
 }

--- a/test/modules/room/ui/room_screen_test.dart
+++ b/test/modules/room/ui/room_screen_test.dart
@@ -1,4 +1,6 @@
 import 'dart:async';
+import 'dart:convert';
+import 'dart:typed_data';
 
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -652,6 +654,70 @@ void main() {
       await tester.pumpAndSettle();
 
       expect(find.byTooltip('Filter documents'), findsNothing);
+    });
+  });
+
+  group('rail account menu', () {
+    FakeHttpClient profileClient(
+      Map<String, dynamic> profile, {
+      int statusCode = 200,
+    }) =>
+        FakeHttpClient()
+          ..onRequest = (method, uri) async => HttpResponse(
+                statusCode: statusCode,
+                bodyBytes: Uint8List.fromList(utf8.encode(jsonEncode(profile))),
+              );
+
+    Future<void> pumpAuthedRoom(
+      WidgetTester tester,
+      FakeHttpClient httpClient,
+    ) async {
+      tester.view.physicalSize = const Size(1200, 800);
+      tester.view.devicePixelRatio = 1.0;
+      addTearDown(tester.view.resetPhysicalSize);
+
+      final authedEntry = createTestServerEntry(
+        api: api,
+        requiresAuth: true,
+        auth: authInActiveSession(),
+        httpClient: httpClient,
+      );
+      await tester.pumpWidget(MaterialApp(
+        home: RoomScreen(
+          serverEntry: authedEntry,
+          roomId: 'room-1',
+          threadId: null,
+          runtimeManager: runtimeManager,
+          registry: registry,
+          uploadRegistry: uploadRegistry,
+          documentSelections: DocumentSelections(),
+        ),
+      ));
+      await tester.pumpAndSettle();
+      await tester.tap(find.byTooltip('Account & more'));
+      await tester.pumpAndSettle();
+    }
+
+    testWidgets('shows the resolved name and email for a signed-in user',
+        (tester) async {
+      await pumpAuthedRoom(
+        tester,
+        profileClient({
+          'given_name': 'Ada',
+          'family_name': 'Lovelace',
+          'email': 'ada@example.com',
+        }),
+      );
+
+      expect(find.text('Ada Lovelace'), findsOneWidget);
+      expect(find.text('ada@example.com'), findsOneWidget);
+    });
+
+    testWidgets('falls back to "Signed in" when the profile fetch fails',
+        (tester) async {
+      await pumpAuthedRoom(tester, profileClient(const {}, statusCode: 401));
+
+      expect(find.text('Signed in'), findsOneWidget);
     });
   });
 }

--- a/test/modules/room/ui/room_screen_test.dart
+++ b/test/modules/room/ui/room_screen_test.dart
@@ -56,6 +56,16 @@ class _RoomsAuthErrorApi extends FakeSoliplexApi {
   }
 }
 
+/// A [FakeSoliplexApi] whose room-list fetch is denied with a 403, exercising
+/// the rail's inline permission affordance (not a re-auth funnel or a retry).
+class _RoomsPermissionDeniedApi extends FakeSoliplexApi {
+  @override
+  Future<List<Room>> getRooms({CancelToken? cancelToken}) async {
+    throw const PermissionDeniedException(
+        statusCode: 403, message: 'forbidden');
+  }
+}
+
 Widget _buildRouted({
   required ServerEntry entry,
   required AgentRuntimeManager runtimeManager,
@@ -890,6 +900,102 @@ void main() {
       // The rail leaves the loading state in place rather than surfacing its
       // own retry affordance, so the route guard's redirect isn't pre-empted.
       expect(find.byTooltip('Failed to load rooms'), findsNothing);
+    });
+
+    testWidgets(
+        'a permission denial surfaces inline without funneling to re-auth',
+        (tester) async {
+      tester.view.physicalSize = const Size(1200, 800);
+      tester.view.devicePixelRatio = 1.0;
+      addTearDown(tester.view.resetPhysicalSize);
+
+      final auth = authInActiveSession();
+      final deniedEntry = createTestServerEntry(
+        api: _RoomsPermissionDeniedApi()
+          ..nextThreads = []
+          ..nextThreadHistory = ThreadHistory(messages: const []),
+        requiresAuth: true,
+        auth: auth,
+        httpClient: FakeHttpClient()
+          ..onRequest = (_, __) async => HttpResponse(
+                statusCode: 200,
+                bodyBytes: Uint8List.fromList(utf8.encode('{}')),
+              ),
+      );
+
+      await tester.pumpWidget(MaterialApp(
+        home: RoomScreen(
+          serverEntry: deniedEntry,
+          roomId: 'room-1',
+          threadId: null,
+          runtimeManager: runtimeManager,
+          registry: registry,
+          uploadRegistry: uploadRegistry,
+          documentSelections: DocumentSelections(),
+        ),
+      ));
+      await tester.pumpAndSettle();
+
+      // A 403 is not an auth failure: the session stays active (no re-auth
+      // funnel) and the rail shows a distinct, non-retryable affordance
+      // rather than the generic "try again" error.
+      expect(auth.session.value, isA<ActiveSession>());
+      expect(
+        find.byTooltip("You don't have permission to view rooms"),
+        findsOneWidget,
+      );
+      expect(find.byTooltip('Failed to load rooms'), findsNothing);
+    });
+
+    testWidgets(
+        'a slow rooms fetch from the previous server cannot overwrite the '
+        'current server rooms', (tester) async {
+      tester.view.physicalSize = const Size(1200, 800);
+      tester.view.devicePixelRatio = 1.0;
+      addTearDown(tester.view.resetPhysicalSize);
+
+      final gateA = Completer<void>();
+      final apiA = FakeSoliplexApi()
+        ..nextRooms = [Room(id: 'a1', name: 'Xenon')]
+        ..nextThreads = []
+        ..nextThreadHistory = ThreadHistory(messages: const [])
+        ..roomsGate = gateA;
+      final apiB = FakeSoliplexApi()
+        ..nextRooms = [Room(id: 'b1', name: 'Yttrium')]
+        ..nextThreads = []
+        ..nextThreadHistory = ThreadHistory(messages: const []);
+
+      final entryA =
+          createTestServerEntry(api: apiA, serverId: 'http://server-a:8000');
+      final entryB =
+          createTestServerEntry(api: apiB, serverId: 'http://server-b:8000');
+
+      Widget roomScreenFor(ServerEntry e) => MaterialApp(
+            home: RoomScreen(
+              serverEntry: e,
+              roomId: 'room-1',
+              threadId: null,
+              runtimeManager: runtimeManager,
+              registry: registry,
+              uploadRegistry: uploadRegistry,
+              documentSelections: DocumentSelections(),
+            ),
+          );
+
+      // Server A's rooms fetch is in flight, held open.
+      await tester.pumpWidget(roomScreenFor(entryA));
+      await tester.pump();
+
+      // Switch to server B, whose rooms resolve immediately.
+      await tester.pumpWidget(roomScreenFor(entryB));
+      await tester.pumpAndSettle();
+
+      // Server A's now-stale fetch resolves; it must not overwrite B's rooms.
+      gateA.complete();
+      await tester.pumpAndSettle();
+
+      expect(find.text('Y'), findsOneWidget); // Yttrium
+      expect(find.text('X'), findsNothing); // Xenon must not appear
     });
   });
 

--- a/test/modules/room/ui/room_screen_test.dart
+++ b/test/modules/room/ui/room_screen_test.dart
@@ -751,6 +751,36 @@ void main() {
       expect(find.text('Guest'), findsOneWidget);
     });
 
+    testWidgets('marks the session expired (Guest) on a thrown AuthException',
+        (tester) async {
+      // The raw decorator chain usually surfaces a 401 as a response, but a
+      // thrown AuthException must funnel to the same session-expiry outcome.
+      await pumpAuthedRoom(
+        tester,
+        FakeHttpClient()
+          ..onRequest =
+              (_, __) async => throw const AuthException(message: 'expired'),
+      );
+
+      expect(find.text('Guest'), findsOneWidget);
+    });
+
+    testWidgets('falls back to "Signed in" on a malformed 200 body',
+        (tester) async {
+      // A 200 whose body isn't a JSON object trips the decode/cast; it must be
+      // caught and degrade to the generic label rather than crash the screen.
+      await pumpAuthedRoom(
+        tester,
+        FakeHttpClient()
+          ..onRequest = (_, __) async => HttpResponse(
+                statusCode: 200,
+                bodyBytes: Uint8List.fromList(utf8.encode('[1, 2, 3]')),
+              ),
+      );
+
+      expect(find.text('Signed in'), findsOneWidget);
+    });
+
     testWidgets(
         'a slow identity fetch from the previous server cannot overwrite '
         'the current server identity', (tester) async {


### PR DESCRIPTION
## What

Polishes and hardens the room rail's account-identity and rooms fetching.

### Behavior
- **Permission denials read as a steady state.** A 403 on the room list now shows a distinct, non-retryable lock glyph (disabled button, "You don't have permission to view rooms") instead of the generic retry error. The session stays active — a 403 is not an auth failure.
- **Auth errors funnel to login.** An `AuthException` (or a 401 on the raw `/api/user_info` decorator chain) during the rail's room or identity fetch marks the session expired so the route guard redirects to login, rather than flashing an error banner first.
- **Account identity resolves more robustly.** `accountFromJson` reads each OIDC claim independently — whitespace-only fields are treated as absent, a malformed (non-string) claim no longer discards its valid siblings, and an email standing in for a missing name no longer renders twice.

### Internal
- A generation counter guards a slow account fetch from a previous server overwriting the current server's identity (the raw request can't be cancelled).
- Server-scoped fetches (rooms, account, activity) refetch only on a server change, not on every in-server room switch — no more spinner flash or redundant requests.
- 403s are logged at debug rather than the severe channel reserved for genuine failures (and a denied rooms fetch now leaves a trace, matching the account path).
- `contrastingForeground` is exposed from `soliplex_design` and reused for hashed-tint avatars; the avatar-initial helper is shared.

## Testing
- `accountFromJson` unit tests cover the full label-resolution tree, whitespace trimming, and the non-string-claim guard.
- Widget tests cover the account fetch (200 / 500 / 401 / thrown `AuthException` / malformed body), both staleness guards through real async interleaving, the 403-vs-auth divergence on both the session signal and the rendered affordance, refetch-on-server-change vs. no-refetch-on-room-switch, and the rail menu wiring.
- `flutter analyze` clean; affected suites green.

## Review
Ran the PR review toolkit (code / silent-failure / comments / tests) — no Critical or Important blockers. Applied two findings: a `Versions` menu-wiring test and a debug log for denied rooms fetches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)