### PR TITLE
Image preview zoom/rotate, wider form column, connect-rail centering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,9 +13,16 @@ Versions follow the `version+build` scheme from `pubspec.yaml`, bumped via
 - Lobby: an unread dot on each room card when the room has activity newer than
   the last time the user opened it. Read state is tracked per-device; there is
   no server-side read state or unread count.
+- Room: workdir file image previews are now zoomable and rotatable, with a
+  reset-to-original control that appears while zoomed. Zoom/rotate now share a
+  single viewer with the citation chunk visualization.
 
 ### Fixed
 
+- Room: image previews can be zoomed with a trackpad two-finger scroll, not
+  only mouse wheel and pinch (`InteractiveViewer.trackpadScrollCausesScale`).
+  Zoom is sized to the image's exact aspect ratio for every format, so scaling
+  no longer magnifies surrounding whitespace.
 - Lobby: a room's "last activity" now reflects the user's most recent run in
   that room (served by the backend stats API), not the newest thread's
   creation time — so a long-lived thread used minutes ago no longer reads as

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,9 @@ Versions follow the `version+build` scheme from `pubspec.yaml`, bumped via
   room. The width is now a single shared constant (`formColumnMaxWidth`).
   Narrower viewports are unaffected — the column still fills the available
   width.
+- Auth: the connect-flow rail now scrolls to keep the active step centered as
+  the flow advances. Early and final steps that can't be centered stay pinned
+  to the start/end.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,14 @@ Versions follow the `version+build` scheme from `pubspec.yaml`, bumped via
   reset-to-original control that appears while zoomed. Zoom/rotate now share a
   single viewer with the citation chunk visualization.
 
+### Changed
+
+- Auth/Quiz: widened the centered form/content column from 400 to 600 on
+  wide viewports so server URLs, the server list, and quiz content have more
+  room. The width is now a single shared constant (`formColumnMaxWidth`).
+  Narrower viewports are unaffected — the column still fills the available
+  width.
+
 ### Fixed
 
 - Room: image previews can be zoomed with a trackpad two-finger scroll, not

--- a/lib/src/core/layout.dart
+++ b/lib/src/core/layout.dart
@@ -1,0 +1,18 @@
+/// Shared layout constants for content sizing across feature modules.
+library;
+
+// REORG NEEDED: content-width caps are scattered across the app — this
+// form-column width, the chat timeline cap (840, `_maxContentWidth` in
+// room_screen.dart), and the preview dialog caps (800, chunk visualization /
+// workdir preview). They should be consolidated into one layout-token home so
+// the values are discoverable and managed together; a candidate is the
+// soliplex_design package alongside SoliplexBreakpoints.
+
+/// Maximum width of a centered form/content column on wide viewports, so forms
+/// and cards don't stretch edge-to-edge on desktop/web.
+///
+/// Shared by the onboarding/connect flow (HomeShell) and the quiz forms so the
+/// form surfaces stay visually aligned. This is deliberately independent of
+/// SoliplexBreakpoints — it's a content width, not a layout breakpoint, and the
+/// two should not drift together.
+const double formColumnMaxWidth = 600;

--- a/lib/src/modules/auth/ui/connect_flow_rail.dart
+++ b/lib/src/modules/auth/ui/connect_flow_rail.dart
@@ -41,11 +41,45 @@ ConnectStep stepForConnectState(ConnectState state) => switch (state) {
 /// [SoliplexBreakpoints.desktop]); on narrow screens the per-state heading
 /// carries the context instead. The strip scrolls horizontally when it's
 /// wider than its column, so every label stays legible rather than being
-/// squeezed.
-class ConnectFlowRail extends StatelessWidget {
+/// squeezed. As the flow advances the active node is scrolled to the centre of
+/// the strip; early steps that can't be centred stay pinned at the start (the
+/// scroll clamps to its bounds).
+class ConnectFlowRail extends StatefulWidget {
   const ConnectFlowRail({super.key, required this.current});
 
   final ConnectStep current;
+
+  @override
+  State<ConnectFlowRail> createState() => _ConnectFlowRailState();
+}
+
+class _ConnectFlowRailState extends State<ConnectFlowRail> {
+  final GlobalKey _activeKey = GlobalKey();
+
+  @override
+  void initState() {
+    super.initState();
+    _centerActiveAfterFrame();
+  }
+
+  @override
+  void didUpdateWidget(ConnectFlowRail old) {
+    super.didUpdateWidget(old);
+    if (old.current != widget.current) _centerActiveAfterFrame();
+  }
+
+  void _centerActiveAfterFrame() {
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      final ctx = _activeKey.currentContext;
+      if (ctx == null) return;
+      Scrollable.ensureVisible(
+        ctx,
+        alignment: 0.5,
+        duration: const Duration(milliseconds: 250),
+        curve: Curves.easeOut,
+      );
+    });
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -74,7 +108,12 @@ class ConnectFlowRail extends StatelessWidget {
           mainAxisSize: MainAxisSize.min,
           children: [
             for (final step in ConnectStep.values) ...[
-              _RailNode(step: step, current: current, baseStyle: baseStyle),
+              _RailNode(
+                key: step == widget.current ? _activeKey : null,
+                step: step,
+                current: widget.current,
+                baseStyle: baseStyle,
+              ),
               if (step != ConnectStep.values.last)
                 Padding(
                   padding: const EdgeInsets.symmetric(
@@ -98,6 +137,7 @@ class _RailNode extends StatelessWidget {
     required this.step,
     required this.current,
     required this.baseStyle,
+    super.key,
   });
 
   final ConnectStep step;

--- a/lib/src/modules/auth/ui/home_shell.dart
+++ b/lib/src/modules/auth/ui/home_shell.dart
@@ -3,6 +3,7 @@ import 'package:go_router/go_router.dart';
 import 'package:soliplex_design/soliplex_design.dart';
 
 import '../../../../version.dart';
+import '../../../core/layout.dart';
 import '../../../core/routes.dart';
 
 /// Shared chrome for the unauthenticated onboarding surfaces (home /
@@ -18,7 +19,7 @@ class HomeShell extends StatelessWidget {
     required this.appName,
     required this.child,
     this.logo,
-    this.maxContentWidth = 400,
+    this.maxContentWidth = formColumnMaxWidth,
   });
 
   final String appName;

--- a/lib/src/modules/quiz/ui/quiz_results.dart
+++ b/lib/src/modules/quiz/ui/quiz_results.dart
@@ -1,7 +1,8 @@
 import 'package:flutter/material.dart';
 
-import '../quiz_session.dart';
 import 'package:soliplex_design/soliplex_design.dart';
+import '../../../core/layout.dart';
+import '../quiz_session.dart';
 
 class QuizResultsView extends StatelessWidget {
   const QuizResultsView({
@@ -28,7 +29,7 @@ class QuizResultsView extends StatelessWidget {
 
     return Center(
       child: ConstrainedBox(
-        constraints: const BoxConstraints(maxWidth: 400),
+        constraints: const BoxConstraints(maxWidth: formColumnMaxWidth),
         child: Padding(
           padding: const EdgeInsets.all(SoliplexSpacing.s4),
           child: Column(

--- a/lib/src/modules/quiz/ui/quiz_start.dart
+++ b/lib/src/modules/quiz/ui/quiz_start.dart
@@ -2,6 +2,8 @@ import 'package:flutter/material.dart';
 import 'package:soliplex_client/soliplex_client.dart';
 import 'package:soliplex_design/soliplex_design.dart';
 
+import '../../../core/layout.dart';
+
 class QuizStartView extends StatelessWidget {
   const QuizStartView({
     super.key,
@@ -17,7 +19,7 @@ class QuizStartView extends StatelessWidget {
     final theme = Theme.of(context);
     return Center(
       child: ConstrainedBox(
-        constraints: const BoxConstraints(maxWidth: 400),
+        constraints: const BoxConstraints(maxWidth: formColumnMaxWidth),
         child: Padding(
           padding: const EdgeInsets.all(SoliplexSpacing.s4),
           child: Column(

--- a/lib/src/modules/room/ui/chunk_visualization_page.dart
+++ b/lib/src/modules/room/ui/chunk_visualization_page.dart
@@ -1,5 +1,4 @@
 import 'dart:convert';
-import 'dart:math' show min;
 import 'dart:typed_data';
 
 import 'package:flutter/material.dart';
@@ -8,6 +7,7 @@ import 'package:soliplex_logging/soliplex_logging.dart';
 
 import 'package:soliplex_design/soliplex_design.dart';
 import '../../../shared/failed_image.dart';
+import '../../../shared/zoomable_image.dart';
 import 'pager_dots.dart';
 
 final _logger =
@@ -18,23 +18,14 @@ sealed class PageImage {
   const PageImage();
 }
 
-/// A successfully decoded page image with its raw PNG bytes and dimensions.
-/// [hasDimensions] is false when [readPngDimensions] could not parse an IHDR
-/// chunk — the bytes are still valid base64 but may not be a PNG; rendering
-/// uses [InteractiveViewer] without computed sizing from IHDR.
+/// A page whose base64 payload decoded to bytes. Codec-time failures (bytes
+/// were valid base64 but not a valid image) are not represented here — they
+/// happen during paint and are surfaced by [ZoomableImage]'s decode fallback.
 @visibleForTesting
 final class PageImageDecoded extends PageImage {
-  const PageImageDecoded({
-    required this.bytes,
-    required this.width,
-    required this.height,
-  });
+  const PageImageDecoded({required this.bytes});
 
   final Uint8List bytes;
-  final int width;
-  final int height;
-
-  bool get hasDimensions => width > 0 && height > 0;
 }
 
 /// A page whose base64 payload could not be decoded. Codec-time failures
@@ -45,32 +36,6 @@ final class PageImageBroken extends PageImage {
   const PageImageBroken({required this.reason});
 
   final String reason;
-}
-
-/// Reads dimensions from a PNG IHDR chunk (bytes 16–23).
-/// Returns (0, 0) for non-PNG, missing IHDR, or truncated data.
-@visibleForTesting
-(int, int) readPngDimensions(Uint8List bytes) {
-  // Full 8-byte PNG signature + 4-byte chunk length + 4-byte "IHDR" + 8 bytes
-  // for width and height = 24 bytes minimum.
-  if (bytes.length < 24) return (0, 0);
-
-  // PNG signature: 137 80 78 71 13 10 26 10
-  const sig = [0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A];
-  for (var i = 0; i < sig.length; i++) {
-    if (bytes[i] != sig[i]) return (0, 0);
-  }
-
-  // First chunk must be IHDR (bytes 12–15: 0x49 0x48 0x44 0x52).
-  if (bytes[12] != 0x49 ||
-      bytes[13] != 0x48 ||
-      bytes[14] != 0x44 ||
-      bytes[15] != 0x52) {
-    return (0, 0);
-  }
-
-  final data = ByteData.sublistView(bytes);
-  return (data.getUint32(16), data.getUint32(20));
 }
 
 class ChunkVisualizationPage extends StatefulWidget {
@@ -180,9 +145,7 @@ class _ChunkVisualizationPageState extends State<ChunkVisualizationPage> {
   /// image doesn't collapse the entire visualization.
   static PageImage _decodePageImage(String b64) {
     try {
-      final bytes = base64Decode(b64);
-      final (w, h) = readPngDimensions(bytes);
-      return PageImageDecoded(bytes: bytes, width: w, height: h);
+      return PageImageDecoded(bytes: base64Decode(b64));
     } on FormatException catch (error, stack) {
       _logger.warning(
         'chunk image base64 decode failed',
@@ -316,7 +279,7 @@ class _ChunkVisualizationPageState extends State<ChunkVisualizationPage> {
     );
   }
 
-  Widget _buildPageImage(PageImage page, int rotation) {
+  Widget _buildPageImage(PageImage page, int index) {
     return switch (page) {
       PageImageBroken(:final reason) => Center(
           // FormatException messages are usually short but uncapped; bound
@@ -327,59 +290,15 @@ class _ChunkVisualizationPageState extends State<ChunkVisualizationPage> {
                 '${reason.length <= 80 ? reason : '${reason.substring(0, 80)}…'}',
           ),
         ),
-      PageImageDecoded() => _buildDecodedPageImage(page, rotation),
-    };
-  }
-
-  Widget _buildDecodedPageImage(PageImageDecoded page, int rotation) {
-    final image = RotatedBox(
-      quarterTurns: rotation,
-      child: Image.memory(
-        page.bytes,
-        fit: BoxFit.contain,
-        errorBuilder: (_, error, stack) {
-          _logger.warning(
-            'chunk image bytes failed to render',
-            error: error,
-            stackTrace: stack,
-          );
-          return const FailedImage(label: 'Page image failed to render');
-        },
-      ),
-    );
-
-    if (!page.hasDimensions) {
-      return Center(
-        child: InteractiveViewer(
-          minScale: 1.0,
-          maxScale: 4.0,
-          child: image,
-        ),
-      );
-    }
-
-    return LayoutBuilder(
-      builder: (context, constraints) {
-        final effW = rotation.isOdd ? page.height : page.width;
-        final effH = rotation.isOdd ? page.width : page.height;
-        final scale = min(
-          constraints.maxWidth / effW,
-          constraints.maxHeight / effH,
-        );
-        return Center(
-          child: InteractiveViewer(
-            constrained: false,
-            minScale: 1.0,
-            maxScale: 4.0,
-            child: SizedBox(
-              width: effW * scale,
-              height: effH * scale,
-              child: image,
-            ),
+      PageImageDecoded(:final bytes) => ZoomableImage(
+          bytes: bytes,
+          rotationQuarterTurns: _rotations[index] ?? 0,
+          onRotate: () => _rotate(index),
+          decodeFailureChild: const Center(
+            child: FailedImage(label: 'Page image failed to render'),
           ),
-        );
-      },
-    );
+        ),
+    };
   }
 
   Widget _buildImages(BuildContext context, List<PageImage> pages) {
@@ -394,24 +313,8 @@ class _ChunkVisualizationPageState extends State<ChunkVisualizationPage> {
             controller: _pageController,
             itemCount: pages.length,
             onPageChanged: (index) => setState(() => _currentPage = index),
-            itemBuilder: (context, index) {
-              final page = pages[index];
-              final rotation = _rotations[index] ?? 0;
-              return Stack(
-                children: [
-                  _buildPageImage(page, rotation),
-                  Positioned(
-                    right: SoliplexSpacing.s2,
-                    top: SoliplexSpacing.s2,
-                    child: IconButton.filledTonal(
-                      onPressed: () => _rotate(index),
-                      icon: const Icon(Icons.rotate_right),
-                      tooltip: 'Rotate',
-                    ),
-                  ),
-                ],
-              );
-            },
+            itemBuilder: (context, index) =>
+                _buildPageImage(pages[index], index),
           ),
         ),
         Padding(

--- a/lib/src/modules/room/ui/workdir_files_section.dart
+++ b/lib/src/modules/room/ui/workdir_files_section.dart
@@ -8,6 +8,7 @@ import 'package:soliplex_design/soliplex_design.dart';
 import 'package:soliplex_logging/soliplex_logging.dart';
 
 import '../../../shared/preview_icon_button.dart';
+import '../../../shared/zoomable_image.dart';
 import 'pager_dots.dart';
 import 'workdir_preview/code_preview.dart';
 import 'workdir_preview/download_feedback_button.dart';
@@ -383,6 +384,10 @@ class _WorkdirPreviewPageState extends State<WorkdirPreviewPage> {
   /// future when the user hits Retry on a failed slide.
   final _retryTokens = <WorkdirFile, int>{};
 
+  /// Per-file image rotation in quarter turns. Keyed by [WorkdirFile] so
+  /// rotation persists while paging between files.
+  final _rotations = <WorkdirFile, int>{};
+
   @override
   void dispose() {
     _controller.dispose();
@@ -398,6 +403,12 @@ class _WorkdirPreviewPageState extends State<WorkdirPreviewPage> {
     setState(() {
       _bytesCache.remove(file);
       _retryTokens[file] = (_retryTokens[file] ?? 0) + 1;
+    });
+  }
+
+  void _rotate(WorkdirFile file) {
+    setState(() {
+      _rotations[file] = ((_rotations[file] ?? 0) + 1) % 4;
     });
   }
 
@@ -485,6 +496,8 @@ class _WorkdirPreviewPageState extends State<WorkdirPreviewPage> {
           kind: kind,
           filename: file.filename,
           onDownload: () => widget.onDownload(file),
+          rotationQuarterTurns: _rotations[file] ?? 0,
+          onRotate: () => _rotate(file),
         );
       },
     );
@@ -687,12 +700,16 @@ class _PreviewBody extends StatelessWidget {
     required this.kind,
     required this.filename,
     required this.onDownload,
+    required this.rotationQuarterTurns,
+    required this.onRotate,
   }) : assert(kind.canRender, 'pdf/unknown must be guarded before this point');
 
   final Uint8List bytes;
   final PreviewKind kind;
   final String filename;
   final Future<DownloadOutcome> Function() onDownload;
+  final int rotationQuarterTurns;
+  final VoidCallback onRotate;
 
   Widget _fallback({required IconData icon, required String message}) =>
       _CannotPreview(
@@ -705,9 +722,11 @@ class _PreviewBody extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     if (kind == PreviewKind.image) {
-      return _ImageOrFallback(
+      return ZoomableImage(
         bytes: bytes,
-        fallback: _fallback(
+        rotationQuarterTurns: rotationQuarterTurns,
+        onRotate: onRotate,
+        decodeFailureChild: _fallback(
           icon: Icons.broken_image_outlined,
           message: 'This image looks corrupt',
         ),
@@ -751,66 +770,6 @@ class _PreviewBody extends StatelessWidget {
           message: "Can't preview this file",
         ),
     };
-  }
-}
-
-/// Renders [bytes] in an [InteractiveViewer]. If [Image.memory]'s
-/// decoder rejects the bytes, swaps in [fallback] as a peer of (not a
-/// descendant of) the viewer so its controls aren't pannable/zoomable.
-///
-/// Decode-failure state is owned here, not on the parent, so that a
-/// fresh widget instance (different bytes) starts clean.
-class _ImageOrFallback extends StatefulWidget {
-  const _ImageOrFallback({required this.bytes, required this.fallback});
-
-  final Uint8List bytes;
-  final Widget fallback;
-
-  @override
-  State<_ImageOrFallback> createState() => _ImageOrFallbackState();
-}
-
-class _ImageOrFallbackState extends State<_ImageOrFallback> {
-  bool _failed = false;
-
-  @override
-  void didUpdateWidget(_ImageOrFallback old) {
-    super.didUpdateWidget(old);
-    if (!identical(old.bytes, widget.bytes)) {
-      _failed = false;
-    }
-  }
-
-  void _markFailed(Object? error, StackTrace? stackTrace) {
-    if (_failed) return;
-    _logger.warning(
-      'image bytes failed to decode',
-      error: error,
-      stackTrace: stackTrace,
-      attributes: {'byteLength': widget.bytes.length},
-    );
-    WidgetsBinding.instance.addPostFrameCallback((_) {
-      if (mounted) setState(() => _failed = true);
-    });
-  }
-
-  @override
-  Widget build(BuildContext context) {
-    if (_failed) return widget.fallback;
-    return Center(
-      child: InteractiveViewer(
-        minScale: 1.0,
-        maxScale: 4.0,
-        child: Image.memory(
-          widget.bytes,
-          fit: BoxFit.contain,
-          errorBuilder: (_, error, stack) {
-            _markFailed(error, stack);
-            return const SizedBox.shrink();
-          },
-        ),
-      ),
-    );
   }
 }
 

--- a/lib/src/shared/zoomable_image.dart
+++ b/lib/src/shared/zoomable_image.dart
@@ -1,0 +1,219 @@
+import 'dart:math' show min;
+import 'dart:typed_data';
+
+import 'package:flutter/material.dart';
+import 'package:soliplex_design/soliplex_design.dart';
+import 'package:soliplex_logging/soliplex_logging.dart';
+
+final _logger =
+    LogManager.instance.getLogger('soliplex_frontend.zoomable_image');
+
+/// Pan/zoom/rotate viewer for a single decoded image, shared by the chunk
+/// visualization and workdir file previews.
+///
+/// Zoom works for mouse wheel, trackpad pinch, and — via
+/// [InteractiveViewer.trackpadScrollCausesScale] — trackpad two-finger scroll,
+/// which Flutter would otherwise route to a (clamped, invisible) pan.
+///
+/// Intrinsic dimensions are read from the decoded image so the image is sized
+/// to its exact aspect ratio under `constrained: false`; zoom then scales only
+/// image content, never surrounding whitespace. Works for every format the
+/// engine decodes, not just PNG.
+///
+/// Rotation state is owned by the caller ([rotationQuarterTurns] / [onRotate])
+/// so it can persist across paging. When the bytes can't be decoded,
+/// [decodeFailureChild] is shown in place of the viewer and the rotate control
+/// is hidden.
+class ZoomableImage extends StatefulWidget {
+  const ZoomableImage({
+    required this.bytes,
+    required this.rotationQuarterTurns,
+    required this.onRotate,
+    required this.decodeFailureChild,
+    super.key,
+  });
+
+  final Uint8List bytes;
+  final int rotationQuarterTurns;
+  final VoidCallback onRotate;
+  final Widget decodeFailureChild;
+
+  @override
+  State<ZoomableImage> createState() => _ZoomableImageState();
+}
+
+class _ZoomableImageState extends State<ZoomableImage> {
+  final TransformationController _controller = TransformationController();
+  late MemoryImage _provider;
+  ImageStream? _stream;
+  ImageStreamListener? _listener;
+  Size? _intrinsicSize;
+  bool _failed = false;
+  bool _zoomed = false;
+
+  @override
+  void initState() {
+    super.initState();
+    _provider = MemoryImage(widget.bytes);
+    _controller.addListener(_onTransformChanged);
+  }
+
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    _resolveDimensions();
+  }
+
+  @override
+  void didUpdateWidget(ZoomableImage old) {
+    super.didUpdateWidget(old);
+    if (!identical(old.bytes, widget.bytes)) {
+      _detachStream();
+      _provider = MemoryImage(widget.bytes);
+      _intrinsicSize = null;
+      _failed = false;
+      _controller.value = Matrix4.identity();
+      _resolveDimensions();
+    }
+  }
+
+  @override
+  void dispose() {
+    _detachStream();
+    _controller
+      ..removeListener(_onTransformChanged)
+      ..dispose();
+    super.dispose();
+  }
+
+  void _onTransformChanged() {
+    final zoomed = _controller.value.getMaxScaleOnAxis() > 1.001;
+    if (zoomed != _zoomed && mounted) setState(() => _zoomed = zoomed);
+  }
+
+  void _resolveDimensions() {
+    _detachStream();
+    final stream = _provider.resolve(createLocalImageConfiguration(context));
+    final listener = ImageStreamListener(
+      (info, _) {
+        final size = Size(
+          info.image.width.toDouble(),
+          info.image.height.toDouble(),
+        );
+        info.dispose();
+        if (mounted) setState(() => _intrinsicSize = size);
+      },
+      onError: _markFailed,
+    );
+    _stream = stream..addListener(listener);
+    _listener = listener;
+  }
+
+  void _detachStream() {
+    if (_stream != null && _listener != null) {
+      _stream!.removeListener(_listener!);
+    }
+    _stream = null;
+    _listener = null;
+  }
+
+  void _reset() => _controller.value = Matrix4.identity();
+
+  void _markFailed(Object error, StackTrace? stackTrace) {
+    if (_failed) return;
+    _logger.warning(
+      'image bytes failed to decode',
+      error: error,
+      stackTrace: stackTrace,
+      attributes: {'byteLength': widget.bytes.length},
+    );
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (mounted) setState(() => _failed = true);
+    });
+  }
+
+  Widget _interactive({required bool constrained, required Widget child}) {
+    return InteractiveViewer(
+      transformationController: _controller,
+      constrained: constrained,
+      trackpadScrollCausesScale: true,
+      minScale: 1.0,
+      maxScale: 4.0,
+      child: child,
+    );
+  }
+
+  Widget _viewer() {
+    final rotation = widget.rotationQuarterTurns;
+    final image = RotatedBox(
+      quarterTurns: rotation,
+      child: Image(
+        image: _provider,
+        fit: BoxFit.contain,
+        errorBuilder: (_, error, stack) {
+          _markFailed(error, stack);
+          return const SizedBox.shrink();
+        },
+      ),
+    );
+
+    final size = _intrinsicSize;
+    if (size == null) {
+      return Center(child: _interactive(constrained: true, child: image));
+    }
+
+    return LayoutBuilder(
+      builder: (context, constraints) {
+        final effW = rotation.isOdd ? size.height : size.width;
+        final effH = rotation.isOdd ? size.width : size.height;
+        final scale = min(
+          constraints.maxWidth / effW,
+          constraints.maxHeight / effH,
+        );
+        return Center(
+          child: _interactive(
+            constrained: false,
+            child: SizedBox(
+              width: effW * scale,
+              height: effH * scale,
+              child: image,
+            ),
+          ),
+        );
+      },
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    if (_failed) return widget.decodeFailureChild;
+
+    return Stack(
+      children: [
+        Positioned.fill(child: _viewer()),
+        // With constrained:false zoom, scrolling back out clamps scale but
+        // leaves a residual offset, so there's otherwise no reliable way back
+        // to the starting view. The reset control appears only while zoomed.
+        if (_zoomed)
+          Positioned(
+            left: SoliplexSpacing.s2,
+            top: SoliplexSpacing.s2,
+            child: IconButton.filledTonal(
+              onPressed: _reset,
+              icon: const Icon(Icons.zoom_out_map),
+              tooltip: 'Reset zoom',
+            ),
+          ),
+        Positioned(
+          right: SoliplexSpacing.s2,
+          top: SoliplexSpacing.s2,
+          child: IconButton.filledTonal(
+            onPressed: widget.onRotate,
+            icon: const Icon(Icons.rotate_right),
+            tooltip: 'Rotate',
+          ),
+        ),
+      ],
+    );
+  }
+}

--- a/test/modules/auth/ui/connect_flow_rail_test.dart
+++ b/test/modules/auth/ui/connect_flow_rail_test.dart
@@ -82,23 +82,50 @@ void main() {
       expect(find.byIcon(Icons.check), findsNothing);
     });
 
-    // Confirms the rail actually scrolls once its content is wider than the
-    // visible space, rather than overflowing or shrinking to fit.
-    testWidgets('scrolls horizontally when wider than its column',
-        (tester) async {
-      // A column far narrower than the seven-node strip's intrinsic width.
-      await tester.pumpWidget(
-        const MaterialApp(
+    Widget narrowHost(ConnectStep current) => MaterialApp(
           home: Scaffold(
             body: Center(
               child: SizedBox(
                 width: 120,
-                child: ConnectFlowRail(current: ConnectStep.connected),
+                child: ConnectFlowRail(current: current),
               ),
             ),
           ),
-        ),
-      );
+        );
+
+    ScrollPosition railPosition(WidgetTester tester) => tester
+        .state<ScrollableState>(
+          find.descendant(
+            of: find.byType(ConnectFlowRail),
+            matching: find.byType(Scrollable),
+          ),
+        )
+        .position;
+
+    testWidgets('scrolls to center the active step as the flow advances',
+        (tester) async {
+      await tester.pumpWidget(narrowHost(ConnectStep.url));
+      await tester.pumpAndSettle();
+      // The first step can't be centered (nothing to its left), so it stays
+      // pinned at the start.
+      expect(railPosition(tester).pixels, 0);
+
+      // Advancing rebuilds the rail with a later `current`; it should scroll
+      // to bring the now-active step into view.
+      await tester.pumpWidget(narrowHost(ConnectStep.connected));
+      await tester.pumpAndSettle();
+      expect(railPosition(tester).pixels, greaterThan(0));
+    });
+
+    // Confirms the rail actually scrolls once its content is wider than the
+    // visible space, rather than overflowing or shrinking to fit.
+    testWidgets('scrolls horizontally when wider than its column',
+        (tester) async {
+      // A column far narrower than the seven-node strip's intrinsic width. Uses
+      // the first step so the auto-centring leaves it pinned at the start —
+      // this test is about scrollability, not the centring behaviour.
+      await tester.pumpWidget(narrowHost(ConnectStep.url));
+      await tester.pumpAndSettle();
 
       // No RenderFlex overflow was thrown while laying the strip out.
       expect(tester.takeException(), isNull);

--- a/test/modules/room/ui/chunk_visualization_page_test.dart
+++ b/test/modules/room/ui/chunk_visualization_page_test.dart
@@ -1,5 +1,4 @@
 import 'dart:convert';
-import 'dart:typed_data' show Uint8List;
 
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -36,6 +35,14 @@ class _ChunkVizApi extends FakeSoliplexApi {
 Widget _wrap(Widget child) => MaterialApp(home: Scaffold(body: child));
 
 void main() {
+  // Decoded page bytes are a shared imageCache key; clear it between tests so a
+  // decode result from one test can't poison the next.
+  tearDown(() {
+    PaintingBinding.instance.imageCache
+      ..clear()
+      ..clearLiveImages();
+  });
+
   testWidgets('shows loading indicator while fetching', (tester) async {
     final api = _ChunkVizApi()
       ..nextVisualization = ChunkVisualization(
@@ -232,59 +239,6 @@ void main() {
     expect(find.byType(Dialog), findsOneWidget);
     expect(find.text('My Report'), findsOneWidget);
     expect(find.byIcon(Icons.close), findsOneWidget);
-  });
-
-  group('readPngDimensions', () {
-    test('reads width and height from valid PNG', () {
-      final (w, h) = readPngDimensions(_pngBytes);
-      expect(w, 1);
-      expect(h, 1);
-    });
-
-    test('returns (0, 0) for non-PNG bytes', () {
-      final bytes = Uint8List.fromList([0xFF, 0xD8, 0xFF, 0xE0, 0, 0, 0, 0]);
-      final (w, h) = readPngDimensions(bytes);
-      expect(w, 0);
-      expect(h, 0);
-    });
-
-    test('returns (0, 0) for truncated data', () {
-      final (w, h) = readPngDimensions(Uint8List.fromList([0x89, 0x50]));
-      expect(w, 0);
-      expect(h, 0);
-    });
-
-    test('returns (0, 0) for empty bytes', () {
-      final (w, h) = readPngDimensions(Uint8List(0));
-      expect(w, 0);
-      expect(h, 0);
-    });
-  });
-
-  group('PageImageDecoded.hasDimensions', () {
-    test('true when both dimensions are positive', () {
-      expect(
-        PageImageDecoded(bytes: Uint8List(0), width: 100, height: 200)
-            .hasDimensions,
-        isTrue,
-      );
-    });
-
-    test('false when width is zero', () {
-      expect(
-        PageImageDecoded(bytes: Uint8List(0), width: 0, height: 200)
-            .hasDimensions,
-        isFalse,
-      );
-    });
-
-    test('false when both are zero', () {
-      expect(
-        PageImageDecoded(bytes: Uint8List(0), width: 0, height: 0)
-            .hasDimensions,
-        isFalse,
-      );
-    });
   });
 
   testWidgets(

--- a/test/modules/room/ui/workdir_files_section_test.dart
+++ b/test/modules/room/ui/workdir_files_section_test.dart
@@ -388,6 +388,27 @@ void main() {
     expect(find.byType(Dialog), findsNothing);
   });
 
+  testWidgets('tapping rotate turns the previewed image a quarter turn',
+      (tester) async {
+    await tester.pumpWidget(_wrap(WorkdirFilesSection(
+      runId: 'run-1',
+      fetchFiles: (_) async => [_file('plot.png')],
+      onDownload: (_, __) async => DownloadOutcome.success,
+      onPreview: (_, __) async => _tinyPng,
+    )));
+    await tester.pump();
+
+    await tester.tap(find.byIcon(Icons.visibility_outlined));
+    await tester.pumpAndSettle();
+
+    expect(tester.widget<RotatedBox>(find.byType(RotatedBox)).quarterTurns, 0);
+
+    await tester.tap(find.byTooltip('Rotate'));
+    await tester.pump();
+
+    expect(tester.widget<RotatedBox>(find.byType(RotatedBox)).quarterTurns, 1);
+  });
+
   testWidgets('preview shows generic error + Retry when fetch fails',
       (tester) async {
     var fetchCalls = 0;

--- a/test/shared/zoomable_image_test.dart
+++ b/test/shared/zoomable_image_test.dart
@@ -1,0 +1,132 @@
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:soliplex_frontend/src/shared/zoomable_image.dart';
+
+// 1x1 red PNG pixel (minimal valid PNG).
+final _pngBytes = base64Decode(
+  'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR4'
+  '2mP8/58BAwAI/AL+hc2rNAAAAABJRU5ErkJggg==',
+);
+
+Widget _wrap(Widget child) => MaterialApp(
+      home: Scaffold(
+        // A bounded box mirroring the dialog/preview host so InteractiveViewer
+        // has finite constraints and the image fills the viewport.
+        body: Center(child: SizedBox(width: 400, height: 300, child: child)),
+      ),
+    );
+
+void main() {
+  // The same bytes are a shared imageCache key; clear it between tests so a
+  // decode result from one test can't poison the next.
+  tearDown(() {
+    PaintingBinding.instance.imageCache
+      ..clear()
+      ..clearLiveImages();
+  });
+
+  testWidgets('enables trackpad-scroll zoom within scale bounds',
+      (tester) async {
+    await tester.pumpWidget(_wrap(
+      ZoomableImage(
+        bytes: _pngBytes,
+        rotationQuarterTurns: 0,
+        onRotate: () {},
+        decodeFailureChild: const Text('failed'),
+      ),
+    ));
+    await tester.pump();
+
+    // On the web, Flutter routes Mac trackpad two-finger scroll to a pan; with
+    // the image filling the viewport that pan is clamped and nothing happens.
+    // trackpadScrollCausesScale makes the gesture zoom instead.
+    final viewer = tester.widget<InteractiveViewer>(
+      find.byType(InteractiveViewer),
+    );
+    expect(viewer.trackpadScrollCausesScale, isTrue);
+    expect(viewer.minScale, 1.0);
+    expect(viewer.maxScale, 4.0);
+  });
+
+  testWidgets('reset control appears only while zoomed and restores fit',
+      (tester) async {
+    await tester.pumpWidget(_wrap(
+      ZoomableImage(
+        bytes: _pngBytes,
+        rotationQuarterTurns: 0,
+        onRotate: () {},
+        decodeFailureChild: const Text('failed'),
+      ),
+    ));
+    await tester.pump();
+
+    // Not zoomed: no reset control.
+    expect(find.byTooltip('Reset zoom'), findsNothing);
+
+    final controller = tester
+        .widget<InteractiveViewer>(find.byType(InteractiveViewer))
+        .transformationController!;
+    controller.value = Matrix4.diagonal3Values(2.5, 2.5, 1.0);
+    await tester.pump();
+
+    // Zoomed: reset control shows; tapping it returns to the original fit.
+    expect(find.byTooltip('Reset zoom'), findsOneWidget);
+    await tester.tap(find.byTooltip('Reset zoom'));
+    await tester.pump();
+
+    expect(controller.value, Matrix4.identity());
+    expect(find.byTooltip('Reset zoom'), findsNothing);
+  });
+
+  testWidgets('rotate button invokes onRotate', (tester) async {
+    var rotations = 0;
+    await tester.pumpWidget(_wrap(
+      ZoomableImage(
+        bytes: _pngBytes,
+        rotationQuarterTurns: 0,
+        onRotate: () => rotations++,
+        decodeFailureChild: const Text('failed'),
+      ),
+    ));
+    await tester.pump();
+
+    await tester.tap(find.byTooltip('Rotate'));
+    expect(rotations, 1);
+  });
+
+  testWidgets('applies the given quarter-turn rotation', (tester) async {
+    await tester.pumpWidget(_wrap(
+      ZoomableImage(
+        bytes: _pngBytes,
+        rotationQuarterTurns: 3,
+        onRotate: () {},
+        decodeFailureChild: const Text('failed'),
+      ),
+    ));
+    await tester.pump();
+
+    final rotated = tester.widget<RotatedBox>(find.byType(RotatedBox));
+    expect(rotated.quarterTurns, 3);
+  });
+
+  testWidgets('shows fallback and hides rotate button on decode failure',
+      (tester) async {
+    await tester.pumpWidget(_wrap(
+      ZoomableImage(
+        bytes: Uint8List.fromList(const [1, 2, 3, 4, 5]),
+        rotationQuarterTurns: 0,
+        onRotate: () {},
+        decodeFailureChild: const Text('failed'),
+      ),
+    ));
+    await tester.pumpAndSettle();
+
+    expect(find.text('failed'), findsOneWidget);
+    expect(find.byTooltip('Rotate'), findsNothing);
+    expect(find.byType(InteractiveViewer), findsNothing);
+  });
+}


### PR DESCRIPTION
A few onboarding/room-preview UX regressions and polish, each as its own commit.

## Changes

### `feat(room)`: zoomable/rotatable image previews via shared viewer
- New shared `ZoomableImage` (`lib/src/shared/zoomable_image.dart`) used by both the workdir file preview and the citation chunk visualization.
- Fixes the workdir images "can't zoom" report: enables `InteractiveViewer.trackpadScrollCausesScale` so previews zoom on a Mac trackpad two-finger scroll (mouse wheel and pinch already worked).
- Intrinsic size is read from the decoded image so zoom scales the image content (not whitespace) for every format, not just PNG.
- Adds quarter-turn rotation to workdir previews and a reset-to-original control that appears while zoomed.
- Chunk visualization drops its now-redundant PNG-IHDR layout code; keeps base64 broken-image handling. Workdir keeps its download-capable corrupt-image placeholder.

### `feat(auth,quiz)`: widen form column to 600 via shared constant
- New `formColumnMaxWidth` (`lib/src/core/layout.dart`) replaces the per-screen 400 caps in the connect flow, OAuth callback, and quiz start/results.
- Wider viewports get a roomier column for server URLs / the server list / quiz content; narrower viewports still fill the available width.
- A note flags the scattered content-width caps (this column, the chat timeline cap, the preview dialog caps) for later consolidation.

### `feat(auth)`: center the active step in the connect-flow rail
- The rail scrolls to keep the active step centered as the flow advances; early/final steps that can't be centered clamp to the start/end.

## Testing
- `flutter analyze`: zero issues.
- Full suite: 1692 tests pass (incl. new `ZoomableImage`, connect-rail centering, and workdir rotation tests).
- Verified on web (Chrome): trackpad/mouse zoom, reset-to-original, rotation, 400-vs-600 form width, and rail centering at each step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)