### PR TITLE
fix(auth): make the consent agreement row fully tappable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ Versions follow the `version+build` scheme from `pubspec.yaml`, bumped via
   (paragraphs, lists, emphasis, and external links) instead of literal text.
   Flavors can structure the notice; the body is treated as trusted,
   flavor-provided input.
+- Auth: the consent agreement is now toggled by tapping anywhere on its row,
+  not just the checkbox, giving it a full-width tap target.
 
 ## [0.90.0+60] - 2026-06-16
 

--- a/lib/src/modules/auth/ui/home_screen.dart
+++ b/lib/src/modules/auth/ui/home_screen.dart
@@ -425,28 +425,26 @@ class _HomeScreenState extends ConsumerState<HomeScreen> {
       // Pure-frontend agreement gate — the consent is the user ticking this,
       // no extra backend round-trip.
       Container(
-        padding: const EdgeInsets.all(SoliplexSpacing.s2),
         decoration: BoxDecoration(
           borderRadius: BorderRadius.circular(soliplexRadii.md),
           border: Border.all(
             color: _consentAgreed ? colors.primary : colors.outlineVariant,
           ),
         ),
-        child: Row(
-          crossAxisAlignment: CrossAxisAlignment.center,
-          children: [
-            Checkbox(
-              value: _consentAgreed,
-              onChanged: (v) => setState(() => _consentAgreed = v ?? false),
-            ),
-            const SizedBox(width: SoliplexSpacing.s1),
-            Expanded(
-              child: Text(
-                'I understand and agree to the usage terms.',
-                style: theme.textTheme.bodyMedium,
-              ),
-            ),
-          ],
+        child: CheckboxListTile(
+          value: _consentAgreed,
+          onChanged: (v) => setState(() => _consentAgreed = v ?? false),
+          controlAffinity: ListTileControlAffinity.leading,
+          contentPadding: const EdgeInsets.symmetric(
+            horizontal: SoliplexSpacing.s2,
+          ),
+          shape: RoundedRectangleBorder(
+            borderRadius: BorderRadius.circular(soliplexRadii.md),
+          ),
+          title: Text(
+            'I understand and agree to the usage terms.',
+            style: theme.textTheme.bodyMedium,
+          ),
         ),
       ),
       const SizedBox(height: SoliplexSpacing.s4),

--- a/test/modules/auth/ui/home_screen_test.dart
+++ b/test/modules/auth/ui/home_screen_test.dart
@@ -984,6 +984,30 @@ void main() {
       expect(find.text('Before you connect'), findsNothing);
     });
 
+    testWidgets('tapping the label text ticks the agreement gate',
+        (tester) async {
+      final serverManager = _createServerManager();
+      await tester.pumpWidget(_buildApp(
+        serverManager: serverManager,
+        discover: _multiProviderDiscover,
+        consentNotice: notice,
+      ));
+      await tester.pumpAndSettle();
+
+      await reachConsent(tester);
+
+      // Tap the label text, not the checkbox box itself.
+      await tester.tap(find.text('I understand and agree to the usage terms.'));
+      await tester.pumpAndSettle();
+
+      // The box is now ticked and the gate opens.
+      expect(tester.widget<Checkbox>(find.byType(Checkbox)).value, isTrue);
+      await tester.tap(find.text('Agree & continue'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Choose how you want to authenticate.'), findsOneWidget);
+    });
+
     testWidgets('leaving and re-entering consent re-arms the gate',
         (tester) async {
       final serverManager = _createServerManager();


### PR DESCRIPTION
## What

On the pre-sign-in consent gate, the agreement was toggled only by tapping the ~24px `Checkbox`. Tapping the label text or the surrounding box did nothing, leaving a small hit target (below the 48px Material/WCAG minimum) and a dead label that reads as broken.

This replaces the custom `Row(Checkbox + Text)` with a single `CheckboxListTile` inside the existing bordered box, so the **entire row** toggles consent.

## Why CheckboxListTile

It resolves four hazards for free that a hand-rolled `InkWell` wrapper would each require care:

- **Single source of truth** — no double-toggle from a row gesture firing alongside the checkbox's own `onChanged`.
- **Merged a11y semantics** — one node ("checkbox, unchecked, I understand and agree to the usage terms.") instead of separate checkbox + text nodes.
- **Keyboard focus + Space/Enter activation.**
- **Hover/pressed ink ripple and pointer cursor** on web/desktop.

The bordered box and its dynamic border color (`primary` when checked, `outlineVariant` otherwise) are preserved; the ripple is clipped to the rounded corners via `shape`, and the checkbox stays left-aligned (`controlAffinity: leading`).

## Tests

- New widget test: tapping the **label text** (not the checkbox) ticks the gate and lets the flow advance — written failing first, then passing (TDD).
- Existing consent-gate tests stay green (a single `Checkbox` still renders, so `find.byType(Checkbox)` resolves).
- `flutter analyze` clean; 45/45 in the consent-gate test file pass.

## Out of scope

Making the scrollable terms body selectable — a separate, agreed change tracked on its own branch (the `selectable: false` default lives on the shared `ProseMarkdown`, so it must be scoped locally).

🤖 Generated with [Claude Code](https://claude.com/claude-code)