### PR TITLE
feat(auth): make the consent notice terms selectable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ Versions follow the `version+build` scheme from `pubspec.yaml`, bumped via
   flavor-provided input.
 - Auth: the consent agreement is now toggled by tapping anywhere on its row,
   not just the checkbox, giving it a full-width tap target.
+- Auth: the consent notice terms are now selectable, so users can copy the
+  text they're agreeing to.
 
 ## [0.90.0+60] - 2026-06-16
 

--- a/lib/src/shared/markdown/prose_markdown.dart
+++ b/lib/src/shared/markdown/prose_markdown.dart
@@ -10,9 +10,10 @@ import 'sanitize_markdown.dart';
 
 /// Renders trusted, author-provided prose markdown — paragraphs, lists,
 /// emphasis, and external links — for static copy surfaces such as the consent
-/// notice. Deliberately excludes the chat renderer's LaTeX, code, and image
-/// builders; `onImageTap` (inherited from [MarkdownRenderer]) is unused because
-/// prose renders no images.
+/// notice. The text is selectable so it can be copied. Deliberately excludes
+/// the chat renderer's LaTeX, code, and image builders; `onImageTap`
+/// (inherited from [MarkdownRenderer]) is unused because prose renders no
+/// images.
 class ProseMarkdown extends MarkdownRenderer {
   const ProseMarkdown({
     required super.data,
@@ -34,7 +35,7 @@ class ProseMarkdown extends MarkdownRenderer {
 
     return MarkdownBody(
       data: sanitizeMarkdown(data),
-      selectable: false,
+      selectable: true,
       styleSheet: styleSheet,
       extensionSet: md.ExtensionSet.gitHubFlavored,
       onTapLink: (_, href, title) {

--- a/test/shared/markdown/prose_markdown_test.dart
+++ b/test/shared/markdown/prose_markdown_test.dart
@@ -57,6 +57,20 @@ void main() {
       expect(body.styleSheet?.p?.color, Colors.purple);
     });
 
+    testWidgets('renders selectable text so the prose can be copied',
+        (tester) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Scaffold(
+            body: ProseMarkdown(data: 'selectable paragraph'),
+          ),
+        ),
+      );
+
+      final body = tester.widget<MarkdownBody>(find.byType(MarkdownBody));
+      expect(body.selectable, isTrue);
+    });
+
     testWidgets('does not render LaTeX (no math builder wired)',
         (tester) async {
       await tester.pumpWidget(


### PR DESCRIPTION
## What

The pre-sign-in consent terms render via `ProseMarkdown`, which hardcoded `MarkdownBody(selectable: false)` — users couldn't select or copy the terms they were agreeing to. This flips it to `selectable: true`.

For legal/consent text, being able to copy what you're agreeing to (for your records, translation, or a dictionary lookup) is the better default.

## Why flip the flag (not a param or SelectionArea)

- `ProseMarkdown` exists solely for "static copy surfaces such as the consent notice" and has exactly **one** consumer in `lib/` (the consent gate), so a `bool selectable` parameter would be unused configuration (YAGNI).
- It matches the established codebase pattern: every other markdown surface (chat messages, room welcome, citations, workdir previews) already renders with `selectable: true` via the chat renderer. `ProseMarkdown` was the lone `selectable: false` holdout.
- `SelectionArea`/`SelectableRegion` appears nowhere in `lib/` — introducing it here would be a novel pattern for no benefit.

`selectable: true` and `onTapLink` coexist in production today (the chat renderer runs both with tappable citation links), so links in the terms body still open. Markdown parsing, sanitization, the style sheet, and the GitHub-flavored extension set are untouched.

## Tests

- New widget test asserts `MarkdownBody.selectable == true` (written failing first, then passing — TDD).
- The existing `onTapLink`/link-launch tests pass **unmodified** — selectable mode did not change how link taps resolve.
- Manually verified in the app: terms can be drag-selected and copied, markdown still renders, and the body link still opens.
- `flutter analyze` clean; 51/51 across `prose_markdown_test.dart` + the consent-gate tests.

## Out of scope

Other markdown surfaces (already selectable); no `SelectionArea`; no `ConsentNotice` model change; no change to the consent checkbox/gate (shipped in #368).

🤖 Generated with [Claude Code](https://claude.com/claude-code)