### PR TITLE
chore: version 0.91.0+64

### DIFF
--- a/lib/version.dart
+++ b/lib/version.dart
@@ -2,4 +2,4 @@
 ///
 /// Generated from pubspec.yaml. Run `dart run tool/update_version.dart` after
 /// changing the version in pubspec.yaml.
-const String soliplexVersion = '0.90.3+63';
+const String soliplexVersion = '0.91.0+64';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,7 +3,7 @@ description: Modular Flutter frontend framework for Soliplex
 publish_to: none
 # To update version, run:
 # dart run tool/bump_version.dart <major|minor|patch|build>
-version: 0.90.3+63
+version: 0.91.0+64
 
 environment:
   sdk: ^3.6.0


### PR DESCRIPTION
Bumps version to `0.91.0+64` (minor).

- `pubspec.yaml`
- `lib/version.dart`

🤖 Generated with [Claude Code](https://claude.com/claude-code)