### PR TITLE
feat(auth): human-readable server names and descriptions

### DIFF
--- a/lib/src/modules/auth/connect_flow.dart
+++ b/lib/src/modules/auth/connect_flow.dart
@@ -228,6 +228,8 @@ class ConnectFlow {
       serverId: serverId,
       serverUrl: probeResult.serverUrl,
       requiresAuth: false,
+      name: probeResult.info?.name,
+      description: probeResult.info?.description,
     );
     DefaultBackendUrlStorage.save(probeResult.serverUrl.toString());
     await SelectedServerStorage.save(serverId);
@@ -251,6 +253,8 @@ class ConnectFlow {
       clientId: provider.clientId,
       createdAt: DateTime.timestamp(),
       frontendReturnTo: _pendingReturnTo,
+      serverName: probeResult.info?.name,
+      serverDescription: probeResult.info?.description,
     ));
 
     final serverId = serverIdFromUrl(probeResult.serverUrl);
@@ -270,6 +274,8 @@ class ConnectFlow {
       final entry = serverManager.addServer(
         serverId: serverId,
         serverUrl: probeResult.serverUrl,
+        name: probeResult.info?.name,
+        description: probeResult.info?.description,
       );
 
       entry.auth.login(

--- a/lib/src/modules/auth/connection_probe.dart
+++ b/lib/src/modules/auth/connection_probe.dart
@@ -11,6 +11,16 @@ typedef DiscoverProviders = Future<List<AuthProviderConfig>> Function(
   SoliplexHttpClient httpClient,
 );
 
+/// Signature for fetching a server's human-readable identity.
+///
+/// Defaults to [discoverServerInfo] from soliplex_agent. Returns `null` when
+/// the server configures no name/description (404) or is unreachable for the
+/// metadata call — server info is best-effort and never fails a probe.
+typedef DiscoverServerInfo = Future<ServerInfo?> Function(
+  Uri serverUrl,
+  SoliplexHttpClient httpClient,
+);
+
 /// Result of probing a backend URL for connectivity.
 sealed class ConnectionProbeResult {
   const ConnectionProbeResult();
@@ -21,10 +31,16 @@ class ConnectionSuccess extends ConnectionProbeResult {
   const ConnectionSuccess({
     required this.serverUrl,
     required this.providers,
+    this.info,
   });
 
   final Uri serverUrl;
   final List<AuthProviderConfig> providers;
+
+  /// The server's human-readable identity, or `null` when the server
+  /// configures none (or the metadata call failed). Callers fall back to the
+  /// raw [serverUrl] when this is absent.
+  final ServerInfo? info;
 
   /// Whether the connection uses HTTP (not HTTPS).
   bool get isInsecure => serverUrl.scheme == 'http';
@@ -53,6 +69,7 @@ Future<ConnectionProbeResult> probeConnection({
   required String input,
   required SoliplexHttpClient httpClient,
   DiscoverProviders discover = _defaultDiscover,
+  DiscoverServerInfo discoverInfo = _defaultDiscoverInfo,
   Duration probeTimeout = const Duration(seconds: 5),
 }) async {
   final List<Uri> candidates;
@@ -68,7 +85,20 @@ Future<ConnectionProbeResult> probeConnection({
     tried.add(uri);
     try {
       final providers = await discover(uri, httpClient).timeout(probeTimeout);
-      return ConnectionSuccess(serverUrl: uri, providers: providers);
+      // Server identity is best-effort enrichment: a failure here (404, slow
+      // response, network blip) must not turn a successful probe into a
+      // failure, so swallow everything and fall back to null.
+      ServerInfo? info;
+      try {
+        info = await discoverInfo(uri, httpClient).timeout(probeTimeout);
+      } on Object {
+        info = null;
+      }
+      return ConnectionSuccess(
+        serverUrl: uri,
+        providers: providers,
+        info: info,
+      );
     } on NetworkException catch (e) {
       lastNetworkError = e;
     } on TimeoutException {
@@ -132,3 +162,9 @@ Future<List<AuthProviderConfig>> _defaultDiscover(
   SoliplexHttpClient httpClient,
 ) =>
     discoverAuthProviders(serverUrl: serverUrl, httpClient: httpClient);
+
+Future<ServerInfo?> _defaultDiscoverInfo(
+  Uri serverUrl,
+  SoliplexHttpClient httpClient,
+) =>
+    discoverServerInfo(serverUrl: serverUrl, httpClient: httpClient);

--- a/lib/src/modules/auth/connection_probe.dart
+++ b/lib/src/modules/auth/connection_probe.dart
@@ -1,6 +1,10 @@
 import 'dart:async';
 
 import 'package:soliplex_agent/soliplex_agent.dart';
+import 'package:soliplex_logging/soliplex_logging.dart';
+
+final Logger _logger =
+    LogManager.instance.getLogger('soliplex.connection_probe');
 
 /// Signature for the auth provider discovery function.
 ///
@@ -13,9 +17,10 @@ typedef DiscoverProviders = Future<List<AuthProviderConfig>> Function(
 
 /// Signature for fetching a server's human-readable identity.
 ///
-/// Defaults to [discoverServerInfo] from soliplex_agent. Returns `null` when
-/// the server configures no name/description (404) or is unreachable for the
-/// metadata call — server info is best-effort and never fails a probe.
+/// Defaults to [discoverServerInfo] from soliplex_agent, which returns `null`
+/// only for a 404 (server configures no name/description) and otherwise throws.
+/// [probeConnection] treats any failure here as best-effort and falls back to
+/// `null`, so server info never fails a probe.
 typedef DiscoverServerInfo = Future<ServerInfo?> Function(
   Uri serverUrl,
   SoliplexHttpClient httpClient,
@@ -85,13 +90,17 @@ Future<ConnectionProbeResult> probeConnection({
     tried.add(uri);
     try {
       final providers = await discover(uri, httpClient).timeout(probeTimeout);
-      // Server identity is best-effort enrichment: a failure here (404, slow
-      // response, network blip) must not turn a successful probe into a
-      // failure, so swallow everything and fall back to null.
+      // Server identity is best-effort enrichment: any failure here (404, slow
+      // response, network blip, malformed or empty body) must not turn a
+      // successful probe into a failure, so log it and fall back to null.
       ServerInfo? info;
       try {
         info = await discoverInfo(uri, httpClient).timeout(probeTimeout);
-      } on Object {
+      } on Object catch (e) {
+        _logger.warning(
+          'Server info fetch failed for $uri; using raw address',
+          error: e,
+        );
         info = null;
       }
       return ConnectionSuccess(

--- a/lib/src/modules/auth/pre_auth_state.dart
+++ b/lib/src/modules/auth/pre_auth_state.dart
@@ -23,6 +23,8 @@ class PreAuthState {
     required this.clientId,
     required this.createdAt,
     this.frontendReturnTo,
+    this.serverName,
+    this.serverDescription,
   }) {
     if (frontendReturnTo != null && !_isSafeReturnTo(frontendReturnTo!)) {
       throw ArgumentError.value(
@@ -41,6 +43,8 @@ class PreAuthState {
       clientId: json['clientId'] as String,
       createdAt: DateTime.parse(json['createdAt'] as String).toUtc(),
       frontendReturnTo: json['frontendReturnTo'] as String?,
+      serverName: json['serverName'] as String?,
+      serverDescription: json['serverDescription'] as String?,
     );
   }
 
@@ -65,6 +69,15 @@ class PreAuthState {
   /// values throw [ArgumentError] before they can be persisted.
   final String? frontendReturnTo;
 
+  /// Cached human-readable server name probed before redirect, carried across
+  /// the OAuth roundtrip so the web callback can persist it. Null when the
+  /// server provides none.
+  final String? serverName;
+
+  /// Cached brief server description, carried across the OAuth roundtrip.
+  /// Null when the server provides none.
+  final String? serverDescription;
+
   /// Covers typical OIDC roundtrips: password reset, MFA prompts,
   /// email magic links.
   static const maxAge = Duration(minutes: 30);
@@ -81,6 +94,8 @@ class PreAuthState {
         'clientId': clientId,
         'createdAt': createdAt.toUtc().toIso8601String(),
         if (frontendReturnTo != null) 'frontendReturnTo': frontendReturnTo,
+        if (serverName != null) 'serverName': serverName,
+        if (serverDescription != null) 'serverDescription': serverDescription,
       };
 
   @override
@@ -91,7 +106,9 @@ class PreAuthState {
       other.discoveryUrl == discoveryUrl &&
       other.clientId == clientId &&
       other.createdAt == createdAt &&
-      other.frontendReturnTo == frontendReturnTo;
+      other.frontendReturnTo == frontendReturnTo &&
+      other.serverName == serverName &&
+      other.serverDescription == serverDescription;
 
   @override
   int get hashCode => Object.hash(
@@ -101,6 +118,8 @@ class PreAuthState {
         clientId,
         createdAt,
         frontendReturnTo,
+        serverName,
+        serverDescription,
       );
 
   @override

--- a/lib/src/modules/auth/server_entry.dart
+++ b/lib/src/modules/auth/server_entry.dart
@@ -30,6 +30,8 @@ class ServerEntry {
     required this.httpClient,
     required this.connection,
     this.requiresAuth = true,
+    this.name,
+    this.description,
   });
 
   final String serverId;
@@ -39,6 +41,17 @@ class ServerEntry {
   final SoliplexHttpClient httpClient;
   final ServerConnection connection;
   final bool requiresAuth;
+
+  /// Human-readable server name (e.g., "Demo Server"), or `null` when the
+  /// server provides none. Display sites fall back to [formatServerUrl].
+  final String? name;
+
+  /// Brief server description, or `null` when the server provides none.
+  final String? description;
+
+  /// Preferred display label: the human-readable [name] when available,
+  /// otherwise the formatted server address.
+  String get displayName => name ?? formatServerUrl(serverUrl);
 
   bool get isConnected => !requiresAuth || auth.isAuthenticated;
 }

--- a/lib/src/modules/auth/server_manager.dart
+++ b/lib/src/modules/auth/server_manager.dart
@@ -89,6 +89,8 @@ class ServerManager {
     required Uri serverUrl,
     bool requiresAuth = true,
     String? alias,
+    String? name,
+    String? description,
   }) {
     final existing = _servers.value[serverId];
     if (existing != null) return existing;
@@ -127,6 +129,8 @@ class ServerManager {
       httpClient: httpClient,
       connection: connection,
       requiresAuth: requiresAuth,
+      name: name,
+      description: description,
     );
 
     registry.add(connection);
@@ -184,6 +188,8 @@ class ServerManager {
             serverUrl: entry.value.serverUrl,
             requiresAuth: entry.value.requiresAuth,
             alias: entry.value.alias,
+            name: entry.value.name,
+            description: entry.value.description,
           );
           if (entry.value
               case AuthenticatedServer(:final provider, :final tokens)) {
@@ -225,6 +231,8 @@ class ServerManager {
               serverUrl: entry.serverUrl,
               alias: entry.alias,
               requiresAuth: entry.requiresAuth,
+              name: entry.name,
+              description: entry.description,
               provider: provider,
               tokens: tokens,
             ),
@@ -236,6 +244,8 @@ class ServerManager {
               serverUrl: entry.serverUrl,
               alias: entry.alias,
               requiresAuth: entry.requiresAuth,
+              name: entry.name,
+              description: entry.description,
             ),
           );
       }

--- a/lib/src/modules/auth/server_storage.dart
+++ b/lib/src/modules/auth/server_storage.dart
@@ -10,12 +10,16 @@ sealed class PersistedServer {
     required this.serverUrl,
     this.alias,
     this.requiresAuth = true,
+    this.name,
+    this.description,
   });
 
   factory PersistedServer.fromJson(Map<String, dynamic> json) {
     final serverUrl = Uri.parse(json['serverUrl'] as String);
     final alias = json['alias'] as String?;
     final requiresAuth = json['requiresAuth'] as bool? ?? true;
+    final name = json['name'] as String?;
+    final description = json['description'] as String?;
     final providerJson = json['provider'] as Map<String, dynamic>?;
     final tokensJson = json['tokens'] as Map<String, dynamic>?;
     if (providerJson != null && tokensJson != null) {
@@ -23,6 +27,8 @@ sealed class PersistedServer {
         serverUrl: serverUrl,
         alias: alias,
         requiresAuth: requiresAuth,
+        name: name,
+        description: description,
         provider: OidcProvider.fromJson(providerJson),
         tokens: AuthTokens.fromJson(tokensJson),
       );
@@ -31,12 +37,23 @@ sealed class PersistedServer {
       dev.log('Partial auth data for $serverUrl — treating as unauthenticated');
     }
     return KnownServer(
-        serverUrl: serverUrl, alias: alias, requiresAuth: requiresAuth);
+      serverUrl: serverUrl,
+      alias: alias,
+      requiresAuth: requiresAuth,
+      name: name,
+      description: description,
+    );
   }
 
   final Uri serverUrl;
   final String? alias;
   final bool requiresAuth;
+
+  /// Cached human-readable server name, or `null` when unknown.
+  final String? name;
+
+  /// Cached brief server description, or `null` when unknown.
+  final String? description;
 
   Map<String, dynamic> toJson();
 }
@@ -47,6 +64,8 @@ class AuthenticatedServer extends PersistedServer {
     required super.serverUrl,
     super.alias,
     super.requiresAuth,
+    super.name,
+    super.description,
     required this.provider,
     required this.tokens,
   });
@@ -59,6 +78,8 @@ class AuthenticatedServer extends PersistedServer {
         'serverUrl': serverUrl.toString(),
         if (alias != null) 'alias': alias,
         'requiresAuth': requiresAuth,
+        if (name != null) 'name': name,
+        if (description != null) 'description': description,
         'provider': provider.toJson(),
         'tokens': tokens.toJson(),
       };
@@ -66,14 +87,21 @@ class AuthenticatedServer extends PersistedServer {
 
 /// A known server without auth credentials.
 class KnownServer extends PersistedServer {
-  const KnownServer(
-      {required super.serverUrl, super.alias, super.requiresAuth});
+  const KnownServer({
+    required super.serverUrl,
+    super.alias,
+    super.requiresAuth,
+    super.name,
+    super.description,
+  });
 
   @override
   Map<String, dynamic> toJson() => {
         'serverUrl': serverUrl.toString(),
         if (alias != null) 'alias': alias,
         'requiresAuth': requiresAuth,
+        if (name != null) 'name': name,
+        if (description != null) 'description': description,
       };
 }
 

--- a/lib/src/modules/auth/ui/auth_callback_screen.dart
+++ b/lib/src/modules/auth/ui/auth_callback_screen.dart
@@ -79,6 +79,8 @@ class _AuthCallbackScreenState extends ConsumerState<AuthCallbackScreen> {
       final entry = widget.serverManager.addServer(
         serverId: serverId,
         serverUrl: preAuth.serverUrl,
+        name: preAuth.serverName,
+        description: preAuth.serverDescription,
       );
 
       entry.auth.login(

--- a/lib/src/modules/auth/ui/home_screen.dart
+++ b/lib/src/modules/auth/ui/home_screen.dart
@@ -473,11 +473,14 @@ class _HomeScreenState extends ConsumerState<HomeScreen> {
     ConnectionSuccess probeResult,
     List<AuthProviderConfig> providers,
   ) {
+    final info = probeResult.info;
     return [
       _titleBlock(
         context,
-        'Sign in to ${probeResult.serverUrl.host}',
-        'Choose how you want to authenticate.',
+        'Sign in to ${info?.name ?? probeResult.serverUrl.host}',
+        // Surface the server's own description when it provides one; otherwise
+        // keep the generic prompt.
+        info?.description ?? 'Choose how you want to authenticate.',
       ),
       const SizedBox(height: SoliplexSpacing.s6),
       for (final provider in providers) ...[
@@ -581,7 +584,16 @@ class _HomeScreenState extends ConsumerState<HomeScreen> {
         ),
       for (final entry in visibleServers)
         ListTile(
-          title: Text(formatServerUrl(entry.serverUrl)),
+          // Friendly name when known; raw address otherwise. The address
+          // drops to a subtitle only when a name is shown.
+          title: Text(entry.displayName),
+          subtitle: entry.name != null
+              ? Text(
+                  formatServerUrl(entry.serverUrl),
+                  maxLines: 1,
+                  overflow: TextOverflow.ellipsis,
+                )
+              : null,
           trailing: IconButton(
             icon: Icon(
               Icons.delete_outline,

--- a/lib/src/modules/lobby/ui/server_sidebar.dart
+++ b/lib/src/modules/lobby/ui/server_sidebar.dart
@@ -1,6 +1,7 @@
 import 'dart:developer' as dev;
 
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:signals_flutter/signals_flutter.dart';
 
@@ -241,7 +242,10 @@ class _ServerTileState extends State<_ServerTile> {
         minLeadingWidth: 0,
         horizontalTitleGap: SoliplexSpacing.s3,
         selected: widget.selected,
-        title: Text(formatServerUrl(widget.entry.serverUrl)),
+        // Prefer the server's human-readable name; fall back to the raw
+        // address. The tile shows only the name — the full address is reachable
+        // (and copyable) from the ⋮ menu's "Copy server address" action.
+        title: Text(widget.entry.displayName),
         trailing: Visibility(
           visible: showMenu,
           maintainSize: true,
@@ -308,7 +312,7 @@ String _signedInName(UserProfile? profile) {
 
 /// Per-server actions behind a tile's trailing ⋮ menu. The available set
 /// depends on the server's connection state (see [_ServerTileMenu]).
-enum _ServerTileAction { signIn, logOut, remove }
+enum _ServerTileAction { signIn, logOut, copyAddress, remove }
 
 /// What happens to the entry after a log-out attempt. The error-menu escape
 /// hatch (remove even when sign-out fails) is a third outcome beyond "keep"
@@ -360,6 +364,8 @@ class _ServerTileMenuState extends ConsumerState<_ServerTileMenu> {
         widget.onSignIn();
       case _ServerTileAction.logOut:
         await _runLogout(_AfterLogout.keep);
+      case _ServerTileAction.copyAddress:
+        await _copyAddress();
       case _ServerTileAction.remove:
         // A connected, authenticated server logs out first so the IdP session
         // doesn't outlive the removed entry; everything else removes outright.
@@ -369,6 +375,26 @@ class _ServerTileMenuState extends ConsumerState<_ServerTileMenu> {
           widget.serverManager.removeServer(widget.entry.serverId);
         }
     }
+  }
+
+  /// Copies the server's full address to the clipboard and confirms with a
+  /// SnackBar. Captures the messenger before the async gap so the post-await
+  /// use doesn't depend on a possibly-unmounted context.
+  Future<void> _copyAddress() async {
+    final messenger = ScaffoldMessenger.of(context);
+    final address = formatServerUrl(widget.entry.serverUrl);
+    try {
+      await Clipboard.setData(ClipboardData(text: address));
+    } on Exception catch (e, st) {
+      dev.log('Clipboard.setData failed', error: e, stackTrace: st);
+      messenger.showSnackBar(
+        const SnackBar(content: Text('Could not copy server address')),
+      );
+      return;
+    }
+    messenger.showSnackBar(
+      SnackBar(content: Text('Copied $address')),
+    );
   }
 
   Future<void> _runLogout(_AfterLogout then) async {
@@ -463,6 +489,13 @@ class _ServerTileMenuState extends ConsumerState<_ServerTileMenu> {
             value: _ServerTileAction.logOut,
             child: _MenuRow(icon: Icons.logout, label: 'Log out'),
           ),
+        const PopupMenuItem(
+          value: _ServerTileAction.copyAddress,
+          child: _MenuRow(
+            icon: Icons.content_copy,
+            label: 'Copy server address',
+          ),
+        ),
         PopupMenuItem(
           value: _ServerTileAction.remove,
           child: _MenuRow(

--- a/lib/src/modules/versions/server_versions_screen.dart
+++ b/lib/src/modules/versions/server_versions_screen.dart
@@ -117,9 +117,27 @@ class _ServerVersionsScreenState extends State<ServerVersionsScreen> {
           ),
           child: Align(
             alignment: Alignment.centerLeft,
-            child: SelectableText(
-              url,
-              style: Theme.of(context).textTheme.titleMedium,
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                SelectableText(
+                  widget.serverEntry.displayName,
+                  style: Theme.of(context).textTheme.titleMedium,
+                ),
+                // Show the raw address beneath the name only when a friendly
+                // name is present, so it stays available without duplicating
+                // the title for unnamed servers.
+                if (widget.serverEntry.name != null) ...[
+                  const SizedBox(height: SoliplexSpacing.s1),
+                  SelectableText(
+                    url,
+                    style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                          color: Theme.of(context).colorScheme.onSurfaceVariant,
+                        ),
+                  ),
+                ],
+              ],
             ),
           ),
         ),

--- a/packages/soliplex_agent/lib/soliplex_agent.dart
+++ b/packages/soliplex_agent/lib/soliplex_agent.dart
@@ -43,6 +43,7 @@ export 'src/host/web_platform_constraints.dart';
 // ── HTTP ──
 export 'src/http/create_agent_http_client.dart';
 export 'src/http/discover_auth_providers.dart';
+export 'src/http/discover_server_info.dart';
 // ── Models ──
 export 'src/models/agent_result.dart';
 export 'src/models/failure_reason.dart';

--- a/packages/soliplex_agent/lib/src/http/discover_server_info.dart
+++ b/packages/soliplex_agent/lib/src/http/discover_server_info.dart
@@ -1,0 +1,20 @@
+import 'package:soliplex_client/soliplex_client.dart';
+
+/// Fetches a Soliplex server's human-readable identity.
+///
+/// Wraps the underlying [fetchServerInfo] call so consumers don't need to
+/// create an [HttpTransport] directly.
+///
+/// [serverUrl] is the backend base URL (e.g., `https://api.example.com`).
+/// [httpClient] should come from `createAgentHttpClient` — valid with or
+/// without auth parameters.
+///
+/// Returns `null` when the server configures no name/description (the backend
+/// responds 404), so callers can fall back to the raw server address.
+Future<ServerInfo?> discoverServerInfo({
+  required Uri serverUrl,
+  required SoliplexHttpClient httpClient,
+}) {
+  final transport = HttpTransport(client: httpClient);
+  return fetchServerInfo(transport: transport, baseUrl: serverUrl);
+}

--- a/packages/soliplex_agent/test/http/discover_server_info_test.dart
+++ b/packages/soliplex_agent/test/http/discover_server_info_test.dart
@@ -1,0 +1,97 @@
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:mocktail/mocktail.dart';
+import 'package:soliplex_agent/soliplex_agent.dart';
+import 'package:test/test.dart';
+
+class _MockHttpClient extends Mock implements SoliplexHttpClient {}
+
+void main() {
+  late _MockHttpClient mockClient;
+
+  setUpAll(() {
+    registerFallbackValue(Uri());
+  });
+
+  setUp(() {
+    mockClient = _MockHttpClient();
+  });
+
+  void stub({required int statusCode, required String body}) {
+    when(
+      () => mockClient.request(
+        any(),
+        any(),
+        headers: any(named: 'headers'),
+        body: any(named: 'body'),
+        timeout: any(named: 'timeout'),
+      ),
+    ).thenAnswer(
+      (_) async => HttpResponse(
+        statusCode: statusCode,
+        bodyBytes: Uint8List.fromList(utf8.encode(body)),
+        headers: const {'content-type': 'application/json'},
+      ),
+    );
+  }
+
+  group('discoverServerInfo', () {
+    test('returns parsed ServerInfo', () async {
+      stub(
+        statusCode: 200,
+        body: jsonEncode({
+          'installation_id': 'soliplex-conf-minimal',
+          'name': 'Demo Server',
+          'description': 'A friendly demo instance',
+        }),
+      );
+
+      final info = await discoverServerInfo(
+        serverUrl: Uri.parse('https://api.example.com'),
+        httpClient: mockClient,
+      );
+
+      expect(info, isNotNull);
+      expect(info!.name, 'Demo Server');
+      expect(info.description, 'A friendly demo instance');
+    });
+
+    test('returns null on 404', () async {
+      stub(statusCode: 404, body: '{"detail":"server info not configured"}');
+
+      final info = await discoverServerInfo(
+        serverUrl: Uri.parse('https://api.example.com'),
+        httpClient: mockClient,
+      );
+
+      expect(info, isNull);
+    });
+
+    test('calls GET /api/v1/installation/identity on the server URL', () async {
+      stub(
+        statusCode: 200,
+        body: jsonEncode({'installation_id': 'id', 'name': 'X'}),
+      );
+
+      await discoverServerInfo(
+        serverUrl: Uri.parse('https://api.example.com'),
+        httpClient: mockClient,
+      );
+
+      final captured = verify(
+        () => mockClient.request(
+          'GET',
+          captureAny(),
+          headers: any(named: 'headers'),
+          body: any(named: 'body'),
+          timeout: any(named: 'timeout'),
+        ),
+      ).captured;
+      expect(
+        captured.single,
+        Uri.parse('https://api.example.com/api/v1/installation/identity'),
+      );
+    });
+  });
+}

--- a/packages/soliplex_client/lib/src/api/api.dart
+++ b/packages/soliplex_client/lib/src/api/api.dart
@@ -1,3 +1,4 @@
 export 'agui_message_mapper.dart';
 export 'fetch_auth_providers.dart';
+export 'fetch_server_info.dart';
 export 'soliplex_api.dart';

--- a/packages/soliplex_client/lib/src/api/fetch_server_info.dart
+++ b/packages/soliplex_client/lib/src/api/fetch_server_info.dart
@@ -1,0 +1,28 @@
+import 'package:soliplex_client/src/domain/server_info.dart';
+import 'package:soliplex_client/src/errors/exceptions.dart';
+import 'package:soliplex_client/src/http/http_transport.dart';
+
+/// Fetches the server's human-readable identity from the backend.
+///
+/// Calls `GET /api/v1/installation/identity` to retrieve the server's
+/// configured name and description.
+///
+/// Returns `null` when the server has no identity configured (the backend
+/// responds 404) so callers can fall back to displaying the raw address.
+///
+/// Parameters:
+/// - [transport]: HTTP transport for making the request.
+/// - [baseUrl]: Backend base URL (e.g., "https://api.example.com").
+Future<ServerInfo?> fetchServerInfo({
+  required HttpTransport transport,
+  required Uri baseUrl,
+}) async {
+  final uri = baseUrl.resolve('/api/v1/installation/identity');
+  try {
+    final response = await transport.request<Map<String, dynamic>>('GET', uri);
+    return ServerInfo.fromJson(response);
+  } on NotFoundException {
+    // Server configured no name/description — fall back to the raw address.
+    return null;
+  }
+}

--- a/packages/soliplex_client/lib/src/domain/domain.dart
+++ b/packages/soliplex_client/lib/src/domain/domain.dart
@@ -18,6 +18,7 @@ export 'room_skill.dart';
 export 'room_stats.dart';
 export 'room_tool.dart';
 export 'run_info.dart';
+export 'server_info.dart';
 export 'skill_tool_call_activity.dart';
 export 'source_reference.dart';
 export 'surface.dart';

--- a/packages/soliplex_client/lib/src/domain/server_info.dart
+++ b/packages/soliplex_client/lib/src/domain/server_info.dart
@@ -1,0 +1,52 @@
+import 'package:meta/meta.dart';
+
+/// Human-readable identity for a Soliplex server, from
+/// `GET /api/v1/installation/identity`.
+///
+/// Lets frontends show a friendly name and description in place of the raw
+/// server address. The backend responds 404 when neither field is configured,
+/// so this is always optional metadata — callers must fall back to the raw
+/// address when it is absent.
+@immutable
+class ServerInfo {
+  /// Creates server identity metadata.
+  const ServerInfo({
+    required this.installationId,
+    this.name,
+    this.description,
+  });
+
+  /// Parses a `GET /api/v1/installation/identity` response body.
+  factory ServerInfo.fromJson(Map<String, dynamic> json) {
+    return ServerInfo(
+      installationId: json['installation_id'] as String,
+      name: json['name'] as String?,
+      description: json['description'] as String?,
+    );
+  }
+
+  /// The server's installation identifier.
+  final String installationId;
+
+  /// Human-readable server name (e.g., "Demo Server"), if configured.
+  final String? name;
+
+  /// Brief server description, if configured.
+  final String? description;
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    return other is ServerInfo &&
+        other.installationId == installationId &&
+        other.name == name &&
+        other.description == description;
+  }
+
+  @override
+  int get hashCode => Object.hash(installationId, name, description);
+
+  @override
+  String toString() =>
+      'ServerInfo(installationId: $installationId, name: $name)';
+}

--- a/packages/soliplex_client/lib/src/domain/server_info.dart
+++ b/packages/soliplex_client/lib/src/domain/server_info.dart
@@ -1,4 +1,5 @@
 import 'package:meta/meta.dart';
+import 'package:soliplex_client/src/errors/exceptions.dart';
 
 /// Human-readable identity for a Soliplex server, from
 /// `GET /api/v1/installation/identity`.
@@ -17,11 +18,22 @@ class ServerInfo {
   });
 
   /// Parses a `GET /api/v1/installation/identity` response body.
+  ///
+  /// Blank or whitespace-only `name`/`description` are treated as absent so the
+  /// `null` fallback contract holds for every display site. Throws
+  /// [MalformedResponseException] when `installation_id` is missing or not a
+  /// string.
   factory ServerInfo.fromJson(Map<String, dynamic> json) {
+    final id = json['installation_id'];
+    if (id is! String) {
+      throw const MalformedResponseException(
+        message: 'identity response missing string installation_id',
+      );
+    }
     return ServerInfo(
-      installationId: json['installation_id'] as String,
-      name: json['name'] as String?,
-      description: json['description'] as String?,
+      installationId: id,
+      name: _blankToNull(json['name']),
+      description: _blankToNull(json['description']),
     );
   }
 
@@ -49,4 +61,10 @@ class ServerInfo {
   @override
   String toString() =>
       'ServerInfo(installationId: $installationId, name: $name)';
+}
+
+String? _blankToNull(Object? value) {
+  final text = value as String?;
+  if (text == null || text.trim().isEmpty) return null;
+  return text;
 }

--- a/packages/soliplex_client/test/api/fetch_server_info_test.dart
+++ b/packages/soliplex_client/test/api/fetch_server_info_test.dart
@@ -1,0 +1,119 @@
+import 'package:mocktail/mocktail.dart';
+import 'package:soliplex_client/soliplex_client.dart';
+import 'package:test/test.dart';
+
+class MockHttpTransport extends Mock implements HttpTransport {}
+
+void main() {
+  late MockHttpTransport mockTransport;
+
+  setUpAll(() {
+    registerFallbackValue(Uri.parse('https://example.com'));
+  });
+
+  setUp(() {
+    mockTransport = MockHttpTransport();
+  });
+
+  tearDown(() {
+    reset(mockTransport);
+  });
+
+  void stubResponse(Map<String, dynamic> body) {
+    when(
+      () => mockTransport.request<Map<String, dynamic>>(
+        'GET',
+        any(),
+        body: any(named: 'body'),
+        headers: any(named: 'headers'),
+        timeout: any(named: 'timeout'),
+        cancelToken: any(named: 'cancelToken'),
+        fromJson: any(named: 'fromJson'),
+      ),
+    ).thenAnswer((_) async => body);
+  }
+
+  group('fetchServerInfo', () {
+    test('returns parsed ServerInfo from backend response', () async {
+      stubResponse(const {
+        'installation_id': 'soliplex-conf-minimal',
+        'name': 'Demo Server',
+        'description': 'A friendly demo instance',
+      });
+
+      final info = await fetchServerInfo(
+        transport: mockTransport,
+        baseUrl: Uri.parse('https://api.example.com'),
+      );
+
+      expect(info, isNotNull);
+      expect(info!.installationId, 'soliplex-conf-minimal');
+      expect(info.name, 'Demo Server');
+      expect(info.description, 'A friendly demo instance');
+    });
+
+    test('calls correct endpoint /api/v1/installation/identity', () async {
+      stubResponse(const {'installation_id': 'id', 'name': 'X'});
+
+      await fetchServerInfo(
+        transport: mockTransport,
+        baseUrl: Uri.parse('https://api.example.com'),
+      );
+
+      verify(
+        () => mockTransport.request<Map<String, dynamic>>(
+          'GET',
+          Uri.parse('https://api.example.com/api/v1/installation/identity'),
+          body: any(named: 'body'),
+          headers: any(named: 'headers'),
+          timeout: any(named: 'timeout'),
+          cancelToken: any(named: 'cancelToken'),
+          fromJson: any(named: 'fromJson'),
+        ),
+      ).called(1);
+    });
+
+    test('returns null when the server has no identity (404)', () async {
+      when(
+        () => mockTransport.request<Map<String, dynamic>>(
+          'GET',
+          any(),
+          body: any(named: 'body'),
+          headers: any(named: 'headers'),
+          timeout: any(named: 'timeout'),
+          cancelToken: any(named: 'cancelToken'),
+          fromJson: any(named: 'fromJson'),
+        ),
+      ).thenThrow(const NotFoundException(message: 'Not found'));
+
+      final info = await fetchServerInfo(
+        transport: mockTransport,
+        baseUrl: Uri.parse('https://api.example.com'),
+      );
+
+      expect(info, isNull);
+    });
+
+    test('propagates non-404 errors', () async {
+      when(
+        () => mockTransport.request<Map<String, dynamic>>(
+          'GET',
+          any(),
+          body: any(named: 'body'),
+          headers: any(named: 'headers'),
+          timeout: any(named: 'timeout'),
+          cancelToken: any(named: 'cancelToken'),
+          fromJson: any(named: 'fromJson'),
+        ),
+      ).thenThrow(const NetworkException(message: 'Connection failed'));
+
+      await expectLater(
+        fetchServerInfo(
+          transport: mockTransport,
+          baseUrl: Uri.parse('https://api.example.com'),
+        ),
+        throwsA(isA<NetworkException>()),
+      );
+    });
+  });
+}

--- a/packages/soliplex_client/test/domain/server_info_test.dart
+++ b/packages/soliplex_client/test/domain/server_info_test.dart
@@ -1,0 +1,53 @@
+import 'package:soliplex_client/soliplex_client.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('ServerInfo.fromJson', () {
+    test('parses all fields', () {
+      final info = ServerInfo.fromJson(const {
+        'installation_id': 'soliplex-conf-minimal',
+        'name': 'Demo Server',
+        'description': 'A friendly demo instance',
+      });
+
+      expect(info.installationId, 'soliplex-conf-minimal');
+      expect(info.name, 'Demo Server');
+      expect(info.description, 'A friendly demo instance');
+    });
+
+    test('treats missing name/description as null', () {
+      final info = ServerInfo.fromJson(const {
+        'installation_id': 'soliplex-conf-minimal',
+      });
+
+      expect(info.installationId, 'soliplex-conf-minimal');
+      expect(info.name, isNull);
+      expect(info.description, isNull);
+    });
+  });
+
+  group('ServerInfo equality', () {
+    test('equal when all fields match', () {
+      const a = ServerInfo(
+        installationId: 'id',
+        name: 'Demo',
+        description: 'desc',
+      );
+      const b = ServerInfo(
+        installationId: 'id',
+        name: 'Demo',
+        description: 'desc',
+      );
+
+      expect(a, equals(b));
+      expect(a.hashCode, equals(b.hashCode));
+    });
+
+    test('differs when a field differs', () {
+      const a = ServerInfo(installationId: 'id', name: 'Demo');
+      const b = ServerInfo(installationId: 'id', name: 'Other');
+
+      expect(a, isNot(equals(b)));
+    });
+  });
+}

--- a/packages/soliplex_client/test/domain/server_info_test.dart
+++ b/packages/soliplex_client/test/domain/server_info_test.dart
@@ -24,6 +24,28 @@ void main() {
       expect(info.name, isNull);
       expect(info.description, isNull);
     });
+
+    test('treats blank/whitespace name/description as null', () {
+      final info = ServerInfo.fromJson(const {
+        'installation_id': 'soliplex-conf-minimal',
+        'name': '',
+        'description': '   ',
+      });
+
+      expect(info.name, isNull);
+      expect(info.description, isNull);
+    });
+
+    test('throws when installation_id is missing or not a string', () {
+      expect(
+        () => ServerInfo.fromJson(const {'name': 'Demo Server'}),
+        throwsA(isA<MalformedResponseException>()),
+      );
+      expect(
+        () => ServerInfo.fromJson(const {'installation_id': 42}),
+        throwsA(isA<MalformedResponseException>()),
+      );
+    });
   });
 
   group('ServerInfo equality', () {

--- a/test/helpers/test_server_entry.dart
+++ b/test/helpers/test_server_entry.dart
@@ -12,6 +12,7 @@ ServerEntry createTestServerEntry({
   bool requiresAuth = false,
   AuthSession? auth,
   FakeHttpClient? httpClient,
+  String? name,
 }) {
   final fakeApi = api ?? FakeSoliplexApi();
   return ServerEntry(
@@ -26,6 +27,7 @@ ServerEntry createTestServerEntry({
       agUiStreamClient: FakeAgUiStreamClient(),
     ),
     requiresAuth: requiresAuth,
+    name: name,
   );
 }
 

--- a/test/modules/auth/connection_probe_test.dart
+++ b/test/modules/auth/connection_probe_test.dart
@@ -224,5 +224,65 @@ void main() {
       final success = result as ConnectionSuccess;
       expect(success.serverUrl, Uri.parse('https://example.com'));
     });
+
+    test('attaches server info to a successful probe', () async {
+      const info = ServerInfo(
+        installationId: 'demo',
+        name: 'Demo Server',
+        description: 'A friendly demo instance',
+      );
+      final result = await probeConnection(
+        input: 'example.com',
+        httpClient: httpClient,
+        discover: (serverUrl, _) async => [_provider],
+        discoverInfo: (serverUrl, _) async => info,
+      );
+
+      final success = result as ConnectionSuccess;
+      expect(success.info, info);
+    });
+
+    test('leaves info null when server has no identity', () async {
+      final result = await probeConnection(
+        input: 'example.com',
+        httpClient: httpClient,
+        discover: (serverUrl, _) async => [_provider],
+        discoverInfo: (serverUrl, _) async => null,
+      );
+
+      final success = result as ConnectionSuccess;
+      expect(success.info, isNull);
+    });
+
+    test('a failing info fetch never fails the probe', () async {
+      final result = await probeConnection(
+        input: 'example.com',
+        httpClient: httpClient,
+        discover: (serverUrl, _) async => [_provider],
+        discoverInfo: (serverUrl, _) async =>
+            throw const NetworkException(message: 'metadata unreachable'),
+      );
+
+      expect(result, isA<ConnectionSuccess>());
+      final success = result as ConnectionSuccess;
+      expect(success.providers, [_provider]);
+      expect(success.info, isNull);
+    });
+
+    test('a hanging info fetch times out without failing the probe', () async {
+      final result = await probeConnection(
+        input: 'https://example.com',
+        httpClient: httpClient,
+        probeTimeout: const Duration(milliseconds: 100),
+        discover: (serverUrl, _) async => [_provider],
+        discoverInfo: (serverUrl, _) async {
+          await Future<void>.delayed(const Duration(seconds: 10));
+          throw StateError('should have timed out');
+        },
+      );
+
+      expect(result, isA<ConnectionSuccess>());
+      expect((result as ConnectionSuccess).info, isNull);
+    });
   });
 }

--- a/test/modules/auth/pre_auth_state_test.dart
+++ b/test/modules/auth/pre_auth_state_test.dart
@@ -4,7 +4,12 @@ import 'package:soliplex_frontend/src/modules/auth/pre_auth_state.dart';
 
 final _baseTime = DateTime.utc(2026, 3, 19, 12, 0);
 
-PreAuthState _makeState({DateTime? createdAt, String? frontendReturnTo}) =>
+PreAuthState _makeState({
+  DateTime? createdAt,
+  String? frontendReturnTo,
+  String? serverName,
+  String? serverDescription,
+}) =>
     PreAuthState(
       serverUrl: Uri.parse('https://api.example.com'),
       providerId: 'keycloak',
@@ -12,6 +17,8 @@ PreAuthState _makeState({DateTime? createdAt, String? frontendReturnTo}) =>
       clientId: 'soliplex',
       createdAt: createdAt ?? _baseTime,
       frontendReturnTo: frontendReturnTo,
+      serverName: serverName,
+      serverDescription: serverDescription,
     );
 
 void main() {
@@ -51,6 +58,26 @@ void main() {
       final now = _baseTime.add(const Duration(minutes: 30, seconds: 1));
 
       expect(state.isExpired(now: now), isTrue);
+    });
+
+    test('server name and description round-trip through JSON', () {
+      final state = _makeState(
+        serverName: 'Demo Server',
+        serverDescription: 'A friendly demo instance',
+      );
+
+      final restored = PreAuthState.fromJson(state.toJson());
+
+      expect(restored.serverName, 'Demo Server');
+      expect(restored.serverDescription, 'A friendly demo instance');
+      expect(restored, equals(state));
+    });
+
+    test('omits server name/description from JSON when null', () {
+      final json = _makeState().toJson();
+
+      expect(json.containsKey('serverName'), isFalse);
+      expect(json.containsKey('serverDescription'), isFalse);
     });
 
     test('frontendReturnTo round-trips through JSON', () {

--- a/test/modules/auth/secure_server_storage_test.dart
+++ b/test/modules/auth/secure_server_storage_test.dart
@@ -122,5 +122,57 @@ void main() {
       expect(result['srv-1']!.serverUrl.host, 'one.example.com');
       expect(result['srv-2']!.serverUrl.host, 'two.example.com');
     });
+
+    test('restores cached name and description for a KnownServer', () {
+      final raw = {
+        '${prefix}srv-1': encode({
+          ...knownServerJson(),
+          'name': 'Demo Server',
+          'description': 'A friendly demo instance',
+        }),
+      };
+
+      final result = deserializeStorageEntries(raw, prefix: prefix);
+      final server = result['srv-1']!;
+      expect(server.name, 'Demo Server');
+      expect(server.description, 'A friendly demo instance');
+    });
+
+    test('leaves name/description null when absent', () {
+      final raw = {
+        '${prefix}srv-1': encode(knownServerJson()),
+      };
+
+      final result = deserializeStorageEntries(raw, prefix: prefix);
+      final server = result['srv-1']!;
+      expect(server.name, isNull);
+      expect(server.description, isNull);
+    });
+  });
+
+  group('PersistedServer JSON round-trip with identity', () {
+    test('KnownServer preserves name and description', () {
+      final original = KnownServer(
+        serverUrl: Uri.parse('https://example.com'),
+        alias: 'example',
+        name: 'Demo Server',
+        description: 'A friendly demo instance',
+      );
+
+      final restored = PersistedServer.fromJson(original.toJson());
+
+      expect(restored, isA<KnownServer>());
+      expect(restored.name, 'Demo Server');
+      expect(restored.description, 'A friendly demo instance');
+    });
+
+    test('omits name/description from JSON when null', () {
+      final original = KnownServer(serverUrl: Uri.parse('https://example.com'));
+
+      final json = original.toJson();
+
+      expect(json.containsKey('name'), isFalse);
+      expect(json.containsKey('description'), isFalse);
+    });
   });
 }

--- a/test/modules/auth/server_entry_test.dart
+++ b/test/modules/auth/server_entry_test.dart
@@ -1,7 +1,24 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:soliplex_frontend/src/modules/auth/server_entry.dart';
 
+import '../../helpers/test_server_entry.dart';
+
 void main() {
+  group('displayName', () {
+    test('uses the human-readable name when present', () {
+      final entry = createTestServerEntry(
+        serverId: 'https://api.example.com',
+        name: 'Demo Server',
+      );
+      expect(entry.displayName, 'Demo Server');
+    });
+
+    test('falls back to the formatted address when name is null', () {
+      final entry = createTestServerEntry(serverId: 'https://api.example.com');
+      expect(entry.displayName, 'https://api.example.com');
+    });
+  });
+
   group('aliasFromUrl', () {
     test('localhost with explicit port', () {
       expect(

--- a/test/modules/lobby/ui/server_sidebar_test.dart
+++ b/test/modules/lobby/ui/server_sidebar_test.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 
 import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_riverpod/misc.dart' show Override;
 import 'package:flutter_test/flutter_test.dart';
@@ -179,8 +180,9 @@ void main() {
     });
 
     group('tile ⋮ menu', () {
-      testWidgets('a disconnected server offers Sign in and Remove',
-          (tester) async {
+      testWidgets(
+          'a disconnected server offers Sign in, Copy server address, '
+          'and Remove', (tester) async {
         final manager = _createManager();
         // requiresAuth + NoSession => not connected.
         manager.addServer(
@@ -200,6 +202,7 @@ void main() {
         await tester.tap(find.byIcon(Icons.more_vert).first);
         await tester.pumpAndSettle();
         expect(find.text('Sign in'), findsOneWidget);
+        expect(find.text('Copy server address'), findsOneWidget);
         expect(find.text('Remove'), findsOneWidget);
         expect(find.text('Log out'), findsNothing);
 
@@ -208,7 +211,8 @@ void main() {
         expect(signedIn, 'srv');
       });
 
-      testWidgets('a connected no-auth server offers only Remove',
+      testWidgets(
+          'a connected no-auth server offers Copy server address and Remove',
           (tester) async {
         final manager = _createManager();
         manager.addServer(
@@ -226,6 +230,7 @@ void main() {
 
         await tester.tap(find.byIcon(Icons.more_vert).first);
         await tester.pumpAndSettle();
+        expect(find.text('Copy server address'), findsOneWidget);
         expect(find.text('Remove'), findsOneWidget);
         expect(find.text('Sign in'), findsNothing);
         expect(find.text('Log out'), findsNothing);
@@ -263,8 +268,51 @@ void main() {
         await tester.tap(find.byIcon(Icons.more_vert).first);
         await tester.pumpAndSettle();
         expect(find.text('Log out'), findsOneWidget);
+        expect(find.text('Copy server address'), findsOneWidget);
         expect(find.text('Remove'), findsOneWidget);
         expect(find.text('Sign in'), findsNothing);
+      });
+
+      testWidgets('Copy server address copies the full URL and confirms',
+          (tester) async {
+        final manager = _createManager();
+        manager.addServer(
+          serverId: 'srv',
+          serverUrl: Uri.parse('https://api.example.com'),
+          requiresAuth: false,
+        );
+
+        String? copied;
+        TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+            .setMockMethodCallHandler(SystemChannels.platform, (call) async {
+          if (call.method == 'Clipboard.setData') {
+            copied = (call.arguments as Map)['text'] as String?;
+          }
+          return null;
+        });
+        addTearDown(
+          () => TestDefaultBinaryMessengerBinding
+              .instance.defaultBinaryMessenger
+              .setMockMethodCallHandler(SystemChannels.platform, null),
+        );
+
+        await tester.pumpWidget(_buildSidebar(
+          servers: manager.servers.value,
+          serverManager: manager,
+          // Selected so the hover-revealed ⋮ is shown (no mouse in the test).
+          selectedServerId: 'srv',
+        ));
+
+        await tester.tap(find.byIcon(Icons.more_vert).first);
+        await tester.pumpAndSettle();
+        expect(find.text('Copy server address'), findsOneWidget);
+
+        await tester.tap(find.text('Copy server address'));
+        await tester.pumpAndSettle();
+
+        // The full scheme://host address is copied, and a SnackBar confirms it.
+        expect(copied, 'https://api.example.com');
+        expect(find.text('Copied https://api.example.com'), findsOneWidget);
       });
 
       testWidgets('the tile ⋮ is hidden until the tile is hovered',

--- a/test/modules/lobby/ui/server_sidebar_test.dart
+++ b/test/modules/lobby/ui/server_sidebar_test.dart
@@ -91,6 +91,22 @@ void main() {
       expect(find.text('http://srv2.test:9000'), findsOneWidget);
     });
 
+    testWidgets('a server with a name shows the name, not the raw address',
+        (tester) async {
+      final manager = _createManager();
+      manager.addServer(
+        serverId: 'https://api.example.com',
+        serverUrl: Uri.parse('https://api.example.com'),
+        requiresAuth: false,
+        name: 'Demo Server',
+      );
+
+      await tester.pumpWidget(_buildSidebar(servers: manager.servers.value));
+
+      expect(find.text('Demo Server'), findsOneWidget);
+      expect(find.text('https://api.example.com'), findsNothing);
+    });
+
     testWidgets('the more menu routes Network Inspector / Versions',
         (tester) async {
       var inspector = 0;


### PR DESCRIPTION
## What

Shows a human-readable server **name** (e.g. "Demo Server") and a brief **description** in place of the raw server address (e.g. `demo.toughserv.com`), sourced from the backend.

Pairs with the backend PR adding `GET /api/server` (soliplex/soliplex).

## How

- **Fetch**: new `ServerInfo` model + `fetchServerInfo()` in `soliplex_client`, `discoverServerInfo()` in `soliplex_agent`. Fetched during the connect probe alongside auth providers; a 404/timeout/network error never fails the probe (best-effort enrichment → `null`).
- **Plumb**: threaded through `ConnectionSuccess`, `ServerEntry` (+ `displayName` getter), `ServerManager`, and `PreAuthState` (so the web OAuth-redirect path keeps the name across page reload). Cached in secure storage, so the friendly name shows on launch before any network call.
- **Display** (all fall back to the raw address when absent):
  - Connect / provider-selection screen — name as title, description as subtitle
  - Server sidebar tile
  - "Your Servers" list
  - Versions header

## Testing

- New unit tests for `ServerInfo`, `fetchServerInfo` (incl. 404 → null), `discoverServerInfo`, probe `info` threading, storage round-trip, and `PreAuthState` round-trip.
- Full suite green: **1795** app tests + **642** client + **17** agent; `flutter analyze` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)