### PR TITLE
fix(room): keep latest message visible when the keyboard opens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,15 @@ Versions follow the `version+build` scheme from `pubspec.yaml`, bumped via
 
 ## [Unreleased]
 
+### Fixed
+
+- Room: the on-screen keyboard no longer hides the most recent message. When
+  the keyboard opens while the conversation is resting at the bottom, the
+  message list re-pins to the bottom so the latest message stays visible above
+  the input bar. The trigger is the viewport shrinking (any near-bottom
+  reflow), not a platform check, so desktop — which has no software keyboard —
+  is unaffected.
+
 ## [0.90.3+63] - 2026-06-24
 
 ### Changed

--- a/lib/src/modules/room/ui/message_timeline.dart
+++ b/lib/src/modules/room/ui/message_timeline.dart
@@ -70,11 +70,11 @@ class _MessageTimelineState extends State<MessageTimeline> {
   /// Gap left above a message when it is revealed at the top of the viewport.
   static const _revealTopGap = 8.0;
 
-  /// Viewport height from the previous layout. Lets [build] notice the
-  /// viewport shrinking when the on-screen keyboard opens: the Scaffold
-  /// consumes the keyboard inset and hands the body a shorter constraint
-  /// (the inset itself is stripped before it reaches here). Null until the
-  /// first layout.
+  /// Viewport height from the previous layout pass. Compared in
+  /// [_maybeStickToBottomOnShrink] to detect the viewport shrinking when the
+  /// on-screen keyboard opens: the Scaffold consumes the keyboard inset and
+  /// hands the body a shorter constraint (the inset itself is stripped before
+  /// it reaches here). Null until the first layout.
   double? _lastViewportHeight;
 
   /// Distance from the bottom within which the list counts as "resting at the
@@ -184,20 +184,26 @@ class _MessageTimelineState extends State<MessageTimeline> {
     });
   }
 
-  /// Re-pins the list to the bottom when the viewport shrinks (e.g. the
-  /// keyboard opens) and the list was already resting at the bottom. The
-  /// Scaffold reflows the body shorter, but the scroll offset would otherwise
-  /// stay put and let the newest message slide below the fold. A user who has
-  /// scrolled up to read history is left in place. A no-op when the viewport
-  /// grows or is unchanged — and therefore on desktop, where no keyboard ever
-  /// shrinks it.
+  /// Re-pins the list to the bottom when the viewport shrinks while the list
+  /// is already resting at the bottom (within [_bottomStickThreshold]). The
+  /// motivating case is the on-screen keyboard opening: the Scaffold reflows
+  /// the body shorter, but the scroll offset would otherwise stay put and let
+  /// the newest message slide below the fold. The trigger is the shrink
+  /// itself, not the keyboard specifically — any Column sibling that claims
+  /// space (e.g. the reconnect banner appearing) shrinks the viewport too, and
+  /// re-pinning then is consistent with the near-bottom band the
+  /// scroll-to-bottom button already uses. A user who has scrolled meaningfully
+  /// up to read history (outside the band) is left in place. A no-op when the
+  /// viewport grows or is unchanged — and therefore on desktop, where no
+  /// keyboard ever shrinks it.
   void _maybeStickToBottomOnShrink(double viewportHeight) {
     final previous = _lastViewportHeight;
     _lastViewportHeight = viewportHeight;
     if (previous == null || viewportHeight >= previous) return;
     if (!_scrollController.hasClients) return;
     final pos = _scrollController.position;
-    // Sampled before the relayout, so these are the pre-shrink metrics.
+    // pos.pixels and pos.maxScrollExtent are from the previous frame —
+    // not yet reconciled to the shrunk viewport.
     if (pos.maxScrollExtent - pos.pixels >= _bottomStickThreshold) return;
     _scrollToBottom();
   }

--- a/lib/src/modules/room/ui/message_timeline.dart
+++ b/lib/src/modules/room/ui/message_timeline.dart
@@ -70,6 +70,18 @@ class _MessageTimelineState extends State<MessageTimeline> {
   /// Gap left above a message when it is revealed at the top of the viewport.
   static const _revealTopGap = 8.0;
 
+  /// Viewport height from the previous layout. Lets [build] notice the
+  /// viewport shrinking when the on-screen keyboard opens: the Scaffold
+  /// consumes the keyboard inset and hands the body a shorter constraint
+  /// (the inset itself is stripped before it reaches here). Null until the
+  /// first layout.
+  double? _lastViewportHeight;
+
+  /// Distance from the bottom within which the list counts as "resting at the
+  /// bottom" for keyboard re-pinning. Mirrors the scroll-to-bottom button's
+  /// near-bottom band so the two agree on what "at the bottom" means.
+  static const _bottomStickThreshold = 100.0;
+
   Map<String, String?> _runIdMap = const {};
   Map<String, List<SourceReference>> _sourceReferencesMap = const {};
 
@@ -170,6 +182,24 @@ class _MessageTimelineState extends State<MessageTimeline> {
       if (!_scrollController.hasClients) return;
       _scrollController.jumpTo(_scrollController.position.maxScrollExtent);
     });
+  }
+
+  /// Re-pins the list to the bottom when the viewport shrinks (e.g. the
+  /// keyboard opens) and the list was already resting at the bottom. The
+  /// Scaffold reflows the body shorter, but the scroll offset would otherwise
+  /// stay put and let the newest message slide below the fold. A user who has
+  /// scrolled up to read history is left in place. A no-op when the viewport
+  /// grows or is unchanged — and therefore on desktop, where no keyboard ever
+  /// shrinks it.
+  void _maybeStickToBottomOnShrink(double viewportHeight) {
+    final previous = _lastViewportHeight;
+    _lastViewportHeight = viewportHeight;
+    if (previous == null || viewportHeight >= previous) return;
+    if (!_scrollController.hasClients) return;
+    final pos = _scrollController.position;
+    // Sampled before the relayout, so these are the pre-shrink metrics.
+    if (pos.maxScrollExtent - pos.pixels >= _bottomStickThreshold) return;
+    _scrollToBottom();
   }
 
   void _scrollToUnread(String firstUnreadId, String? anchorId) {
@@ -295,71 +325,83 @@ class _MessageTimelineState extends State<MessageTimeline> {
           }
         : null;
 
-    return Stack(
-      children: [
-        CustomScrollView(
-          controller: _scrollController,
-          slivers: [
-            SliverPadding(
-              padding: const EdgeInsets.all(SoliplexSpacing.s4),
-              sliver: SliverList.builder(
-                itemCount: displayMessages.length,
-                itemBuilder: (context, index) {
-                  final message = displayMessages[index];
-                  final isLastItem = index == displayMessages.length - 1;
-                  // A distinct key for the loading sentinel forces a
-                  // remount at the AwaitingText → TextStreaming transition.
-                  // Children capture their MessageExpansion handle once in
-                  // initState; without the remount they would stay bound to
-                  // loadingMessageId (which forMessage rejects) and never
-                  // acquire a handle under the real messageId.
-                  final tile = MessageTile(
-                    roomId: widget.roomId,
-                    message: message,
-                    runId: _runIdMap[message.id] ??
-                        (message is TextMessage && message.user == ChatUser.user
-                            ? widget.messageStates[message.id]?.runId
-                            : null),
-                    sourceReferences: _sourceReferencesMap[message.id],
-                    onFeedbackSubmit: widget.onFeedbackSubmit,
-                    onInspect: widget.onInspect,
-                    onShowChunkVisualization: widget.onShowChunkVisualization,
-                    onFetchWorkdirFiles: widget.onFetchWorkdirFiles,
-                    onDownloadWorkdirFile: widget.onDownloadWorkdirFile,
-                    onPreviewWorkdirFile: widget.onPreviewWorkdirFile,
-                    executionTracker: widget.executionTrackers[message.id] ??
-                        (message is LoadingMessage
-                            ? widget.executionTrackers[awaitingTrackerKey]
-                            : null),
-                    streamingPhase: isLastItem ? streamingPhase : null,
-                  );
-                  return Padding(
-                    key: message is LoadingMessage
-                        ? const ValueKey('loading')
-                        : _keyFor(message.id),
-                    padding: const EdgeInsets.only(bottom: SoliplexSpacing.s4),
-                    child: message.id == _frozenFirstUnreadId
-                        ? Column(
-                            mainAxisSize: MainAxisSize.min,
-                            crossAxisAlignment: CrossAxisAlignment.stretch,
-                            children: [const UnreadDivider(), tile],
-                          )
-                        : tile,
-                  );
-                },
+    return LayoutBuilder(
+      builder: (context, constraints) {
+        // The viewport height drops when the keyboard opens (the Scaffold
+        // reflows the body shorter); keep the latest message pinned above the
+        // input bar when it does.
+        _maybeStickToBottomOnShrink(constraints.maxHeight);
+        return Stack(
+          children: [
+            CustomScrollView(
+              controller: _scrollController,
+              slivers: [
+                SliverPadding(
+                  padding: const EdgeInsets.all(SoliplexSpacing.s4),
+                  sliver: SliverList.builder(
+                    itemCount: displayMessages.length,
+                    itemBuilder: (context, index) {
+                      final message = displayMessages[index];
+                      final isLastItem = index == displayMessages.length - 1;
+                      // A distinct key for the loading sentinel forces a
+                      // remount at the AwaitingText → TextStreaming transition.
+                      // Children capture their MessageExpansion handle once in
+                      // initState; without the remount they would stay bound to
+                      // loadingMessageId (which forMessage rejects) and never
+                      // acquire a handle under the real messageId.
+                      final tile = MessageTile(
+                        roomId: widget.roomId,
+                        message: message,
+                        runId: _runIdMap[message.id] ??
+                            (message is TextMessage &&
+                                    message.user == ChatUser.user
+                                ? widget.messageStates[message.id]?.runId
+                                : null),
+                        sourceReferences: _sourceReferencesMap[message.id],
+                        onFeedbackSubmit: widget.onFeedbackSubmit,
+                        onInspect: widget.onInspect,
+                        onShowChunkVisualization:
+                            widget.onShowChunkVisualization,
+                        onFetchWorkdirFiles: widget.onFetchWorkdirFiles,
+                        onDownloadWorkdirFile: widget.onDownloadWorkdirFile,
+                        onPreviewWorkdirFile: widget.onPreviewWorkdirFile,
+                        executionTracker: widget
+                                .executionTrackers[message.id] ??
+                            (message is LoadingMessage
+                                ? widget.executionTrackers[awaitingTrackerKey]
+                                : null),
+                        streamingPhase: isLastItem ? streamingPhase : null,
+                      );
+                      return Padding(
+                        key: message is LoadingMessage
+                            ? const ValueKey('loading')
+                            : _keyFor(message.id),
+                        padding:
+                            const EdgeInsets.only(bottom: SoliplexSpacing.s4),
+                        child: message.id == _frozenFirstUnreadId
+                            ? Column(
+                                mainAxisSize: MainAxisSize.min,
+                                crossAxisAlignment: CrossAxisAlignment.stretch,
+                                children: [const UnreadDivider(), tile],
+                              )
+                            : tile,
+                      );
+                    },
+                  ),
+                ),
+              ],
+            ),
+            Positioned(
+              right: SoliplexSpacing.s4,
+              bottom: SoliplexSpacing.s4,
+              child: ScrollToBottomButton(
+                controller: _scrollToBottomController,
+                onPressed: _onScrollToBottom,
               ),
             ),
           ],
-        ),
-        Positioned(
-          right: SoliplexSpacing.s4,
-          bottom: SoliplexSpacing.s4,
-          child: ScrollToBottomButton(
-            controller: _scrollToBottomController,
-            onPressed: _onScrollToBottom,
-          ),
-        ),
-      ],
+        );
+      },
     );
   }
 }

--- a/test/modules/room/ui/message_timeline_keyboard_inset_test.dart
+++ b/test/modules/room/ui/message_timeline_keyboard_inset_test.dart
@@ -1,0 +1,80 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:soliplex_agent/soliplex_agent.dart';
+
+import 'package:soliplex_frontend/src/modules/room/message_expansions.dart';
+import 'package:soliplex_frontend/src/modules/room/room_providers.dart';
+import 'package:soliplex_frontend/src/modules/room/ui/message_timeline.dart';
+import 'package:soliplex_frontend/src/modules/room/unread_boundary.dart';
+
+/// Builds a timeline that rests at the bottom (caught-up, no unread divider)
+/// inside a Scaffold whose wrapping MediaQuery carries [bottomInset]. The
+/// Scaffold consumes the inset and shrinks the body, exactly as a real
+/// keyboard does; a fixed-height stand-in plays the role of the input bar.
+Widget _harness(List<ChatMessage> messages, double bottomInset) {
+  return ProviderScope(
+    overrides: [
+      messageExpansionsProvider.overrideWithValue(MessageExpansions()),
+    ],
+    child: MaterialApp(
+      home: MediaQuery(
+        data: MediaQueryData(
+          size: const Size(400, 800),
+          viewInsets: EdgeInsets.only(bottom: bottomInset),
+        ),
+        child: Scaffold(
+          body: Column(
+            children: [
+              Expanded(
+                child: MessageTimeline(
+                  roomId: 'r',
+                  messages: messages,
+                  messageStates: const {},
+                  unreadBoundary: const BoundaryResolved(null),
+                ),
+              ),
+              Container(height: 80, color: const Color(0xFF888888)),
+            ],
+          ),
+        ),
+      ),
+    ),
+  );
+}
+
+List<ChatMessage> _manyMessages() => [
+      for (var i = 0; i < 40; i++)
+        TextMessage(
+          id: 'msg-$i',
+          user: i.isEven ? ChatUser.user : ChatUser.assistant,
+          createdAt: DateTime(2026, 3, 1).add(Duration(minutes: i)),
+          text: 'Message number $i with some text to take vertical space',
+        ),
+    ];
+
+ScrollPosition _timelinePosition(WidgetTester tester) =>
+    tester.state<ScrollableState>(find.byType(Scrollable).first).position;
+
+void main() {
+  testWidgets('keeps the latest message visible when the keyboard opens',
+      (tester) async {
+    await tester.pumpWidget(_harness(_manyMessages(), 0));
+    await tester.pumpAndSettle();
+
+    final atRest = _timelinePosition(tester);
+    expect(atRest.pixels, closeTo(atRest.maxScrollExtent, 1.0),
+        reason: 'caught-up timeline rests at the bottom');
+
+    // Keyboard opens: the wrapping MediaQuery gains a bottom inset, the
+    // Scaffold shrinks the body, and the timeline's viewport shrinks with it.
+    await tester.pumpWidget(_harness(_manyMessages(), 300));
+    await tester.pumpAndSettle();
+
+    final afterKeyboard = _timelinePosition(tester);
+    expect(
+        afterKeyboard.maxScrollExtent - afterKeyboard.pixels, lessThan(100.0),
+        reason: 'list re-pins to the bottom so the latest message stays '
+            'visible above the input instead of hiding behind the keyboard');
+  });
+}

--- a/test/modules/room/ui/message_timeline_keyboard_inset_test.dart
+++ b/test/modules/room/ui/message_timeline_keyboard_inset_test.dart
@@ -34,7 +34,7 @@ Widget _harness(List<ChatMessage> messages, double bottomInset) {
                   unreadBoundary: const BoundaryResolved(null),
                 ),
               ),
-              Container(height: 80, color: const Color(0xFF888888)),
+              Container(height: 80),
             ],
           ),
         ),
@@ -76,5 +76,48 @@ void main() {
         afterKeyboard.maxScrollExtent - afterKeyboard.pixels, lessThan(100.0),
         reason: 'list re-pins to the bottom so the latest message stays '
             'visible above the input instead of hiding behind the keyboard');
+  });
+
+  testWidgets('does not move a scrolled-up list when the inset stays zero',
+      (tester) async {
+    await tester.pumpWidget(_harness(_manyMessages(), 0));
+    await tester.pumpAndSettle();
+
+    // User scrolls up to read history.
+    final position = _timelinePosition(tester);
+    position.jumpTo(0);
+    await tester.pump();
+    expect(position.pixels, 0.0);
+
+    // A rebuild with the inset still zero (no keyboard — i.e. desktop) must
+    // not shrink the viewport, so the fix stays a no-op and the user's
+    // position is preserved.
+    await tester.pumpWidget(_harness(_manyMessages(), 0));
+    await tester.pumpAndSettle();
+
+    expect(_timelinePosition(tester).pixels, 0.0,
+        reason: 'no viewport shrink => fix is a no-op; scroll position kept');
+  });
+
+  testWidgets(
+      'leaves a list scrolled beyond the band in place when the '
+      'keyboard opens', (tester) async {
+    await tester.pumpWidget(_harness(_manyMessages(), 0));
+    await tester.pumpAndSettle();
+
+    // Scroll up well beyond the near-bottom band to read history.
+    final position = _timelinePosition(tester);
+    position.jumpTo(position.maxScrollExtent - 300);
+    await tester.pump();
+    final scrolledUp = _timelinePosition(tester).pixels;
+
+    // Keyboard opens — the viewport shrinks — but the user is outside the
+    // near-bottom band, so the re-pin guard must leave them where they are.
+    await tester.pumpWidget(_harness(_manyMessages(), 300));
+    await tester.pumpAndSettle();
+
+    expect(_timelinePosition(tester).pixels, closeTo(scrolledUp, 1.0),
+        reason: 'a list scrolled beyond the band is not yanked to the bottom '
+            'when the keyboard opens');
   });
 }


### PR DESCRIPTION
## Problem

On any platform with a software keyboard (iOS, Android, mobile web), opening the keyboard in the chat room hid the most recent message behind it instead of keeping it visible above the input bar.

## Root cause

The `Scaffold` already does the right thing — `resizeToAvoidBottomInset` (default `true`) shrinks the body when the keyboard opens, so the input bar stays above it, and it *strips* the inset from the body's `MediaQuery`. But `MessageTimeline`'s `CustomScrollView` never re-scrolled on the resulting viewport shrink: its offset stayed put while `maxScrollExtent` grew by the inset, so the bottom (latest message) slid below the fold. Autoscroll only fired on initial mount, a new user message, and the one-time unread evaluation — nothing watched the viewport resize.

## Fix

`MessageTimeline` wraps its output in a `LayoutBuilder`; when the viewport shrinks while the list is resting within the near-bottom band, it re-pins to the bottom. The trigger is the viewport reflow (caused by the Scaffold consuming the keyboard inset), **not** a `Platform.is*` check — so it's a natural no-op on desktop, where no keyboard ever shrinks the viewport. A user who has scrolled meaningfully up to read history is left in place.

## Tests

- Keyboard opens while at the bottom → latest message stays visible (fails pre-fix at a ~300px gap).
- No keyboard inset → no-op; a scrolled-up list is not moved (desktop case).
- A list scrolled beyond the near-bottom band → not yanked to the bottom when the keyboard opens (guards the history-reader contract).

Full suite green (1787 tests); analyzer clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)