### PR TITLE
fix: select consent notice as one block; shorten sidebar label to "New"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ Versions follow the `version+build` scheme from `pubspec.yaml`, bumped via
 - Consent notice: the full notice can now be selected and copied in one drag.
   The prose renderer no longer builds each markdown block as an isolated
   selectable, so a selection spans every paragraph and list at once.
+- Room: the sidebar create-thread button is now labelled "New" instead of
+  "New Thread".
 - Room: the on-screen keyboard no longer hides the most recent message. When
   the keyboard opens while the conversation is resting at the bottom, the
   message list re-pins to the bottom so the latest message stays visible above

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ Versions follow the `version+build` scheme from `pubspec.yaml`, bumped via
 
 ### Fixed
 
+- Consent notice: the full notice can now be selected and copied in one drag.
+  The prose renderer no longer builds each markdown block as an isolated
+  selectable, so a selection spans every paragraph and list at once.
 - Room: the on-screen keyboard no longer hides the most recent message. When
   the keyboard opens while the conversation is resting at the bottom, the
   message list re-pins to the bottom so the latest message stays visible above

--- a/lib/src/modules/room/ui/thread_sidebar.dart
+++ b/lib/src/modules/room/ui/thread_sidebar.dart
@@ -64,7 +64,7 @@ class ThreadSidebar extends StatelessWidget {
                 child: SoliplexButton.filled(
                   onPressed: onCreateThread,
                   icon: const Icon(Icons.add, size: 16),
-                  child: const Text('New Thread'),
+                  child: const Text('New'),
                 ),
               ),
             ],

--- a/lib/src/shared/markdown/prose_markdown.dart
+++ b/lib/src/shared/markdown/prose_markdown.dart
@@ -33,20 +33,22 @@ class ProseMarkdown extends MarkdownRenderer {
         MarkdownStyleSheet.fromTheme(Theme.of(context));
     final styleSheet = textStyle == null ? base : base.copyWith(p: textStyle);
 
-    return MarkdownBody(
-      data: sanitizeMarkdown(data),
-      selectable: true,
-      styleSheet: styleSheet,
-      extensionSet: md.ExtensionSet.gitHubFlavored,
-      onTapLink: (_, href, title) {
-        if (href == null) return;
-        final handleTap = onLinkTap;
-        if (handleTap != null) {
-          handleTap(href, title);
-        } else {
-          launchMarkdownLink(href);
-        }
-      },
+    return SelectionArea(
+      child: MarkdownBody(
+        data: sanitizeMarkdown(data),
+        selectable: false,
+        styleSheet: styleSheet,
+        extensionSet: md.ExtensionSet.gitHubFlavored,
+        onTapLink: (_, href, title) {
+          if (href == null) return;
+          final handleTap = onLinkTap;
+          if (handleTap != null) {
+            handleTap(href, title);
+          } else {
+            launchMarkdownLink(href);
+          }
+        },
+      ),
     );
   }
 }

--- a/test/modules/room/ui/room_screen_test.dart
+++ b/test/modules/room/ui/room_screen_test.dart
@@ -407,7 +407,7 @@ void main() {
     ));
     await tester.pumpAndSettle();
 
-    await tester.tap(find.text('New Thread'));
+    await tester.tap(find.text('New'));
     await tester.pumpAndSettle();
 
     expect(find.byIcon(Icons.error_outline), findsOneWidget);

--- a/test/modules/room/ui/thread_sidebar_test.dart
+++ b/test/modules/room/ui/thread_sidebar_test.dart
@@ -25,6 +25,25 @@ void main() {
     expect(find.byType(CircularProgressIndicator), findsOneWidget);
   });
 
+  testWidgets('labels the create-thread action "New"', (tester) async {
+    await tester.pumpWidget(MaterialApp(
+      home: Scaffold(
+        body: ThreadSidebar(
+          threadListStatus: ThreadsLoading(),
+          selectedThreadId: null,
+          onThreadSelected: (_) {},
+          onBackToLobby: () {},
+          onCreateThread: () {},
+          runningThreadIds: _emptyRunning,
+          onRetryThreads: () async {},
+        ),
+      ),
+    ));
+
+    expect(find.text('New'), findsOneWidget);
+    expect(find.text('New Thread'), findsNothing);
+  });
+
   testWidgets('shows thread names when loaded', (tester) async {
     final threads = [
       ThreadInfo(

--- a/test/shared/markdown/prose_markdown_test.dart
+++ b/test/shared/markdown/prose_markdown_test.dart
@@ -57,18 +57,29 @@ void main() {
       expect(body.styleSheet?.p?.color, Colors.purple);
     });
 
-    testWidgets('renders selectable text so the prose can be copied',
-        (tester) async {
+    testWidgets(
+        'wraps non-selectable blocks in a SelectionArea so a single '
+        'selection spans the whole notice', (tester) async {
       await tester.pumpWidget(
         const MaterialApp(
           home: Scaffold(
-            body: ProseMarkdown(data: 'selectable paragraph'),
+            body: ProseMarkdown(
+              data: 'first paragraph\n\nsecond paragraph',
+            ),
           ),
         ),
       );
 
+      expect(
+        find.ancestor(
+          of: find.byType(MarkdownBody),
+          matching: find.byType(SelectionArea),
+        ),
+        findsOneWidget,
+      );
+
       final body = tester.widget<MarkdownBody>(find.byType(MarkdownBody));
-      expect(body.selectable, isTrue);
+      expect(body.selectable, isFalse);
     });
 
     testWidgets('does not render LaTeX (no math builder wired)',


### PR DESCRIPTION
Two small, unrelated UI fixes.

## Fix 1 — Consent notice can't be selected as a whole (#382)

`ProseMarkdown` rendered the consent notice with `MarkdownBody(selectable: true)`. In `flutter_markdown_plus`, `selectable: true` builds each markdown block as its own isolated `SelectableText.rich`, so a drag-selection can't cross block boundaries — the full multi-block notice couldn't be selected in one go.

Now the `MarkdownBody` is wrapped in a `SelectionArea` with `selectable: false`, so every block is a plain `Text.rich` under one selection registry and a single drag spans the whole notice. Link taps still work alongside `SelectionArea` (covered by existing tests).

## Fix 2 — Sidebar "+ New Thread" → "+ New"

The sidebar create-thread button text is shortened from "New Thread" to "New"; the add icon already conveys the action.

## Tests

- Updated `prose_markdown_test.dart` to assert the `SelectionArea` + non-selectable `MarkdownBody` structure (doubles as the regression test for #382).
- Added a label-assertion test in `thread_sidebar_test.dart`; updated the create-thread tap finder in `room_screen_test.dart`.
- All affected tests pass; `flutter analyze` clean; markdown lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)