### PR TITLE
feat(client): resolve message timestamps from authoritative backend time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,21 @@ Versions follow the `version+build` scheme from `pubspec.yaml`, bumped via
 
 ## [Unreleased]
 
+### Changed
+
+- Chat: a message's timestamp now comes from the backend's authoritative time
+  — the AG-UI event timestamp, falling back to the run's server `created` —
+  instead of the device clock, and is absent until that time is known (e.g. an
+  optimistic user echo fills in on replay). Client-only tiles (cancellation,
+  loading, in-flight streaming, locally executed tool results) carry a UTC
+  client time.
+
 ### Fixed
 
+- Chat history: a malformed or out-of-range backend timestamp no longer aborts
+  loading a thread's history or hangs an in-flight run; the affected message
+  simply carries no timestamp. Naive (offset-less) backend timestamps are now
+  read as UTC instead of the device's local zone, fixing an off-by-hours error.
 - Consent notice: the full notice can now be selected and copied in one drag.
   The prose renderer no longer builds each markdown block as an isolated
   selectable, so a selection spans every paragraph and list at once.

--- a/lib/src/modules/room/compute_display_messages.dart
+++ b/lib/src/modules/room/compute_display_messages.dart
@@ -33,7 +33,7 @@ List<ChatMessage> computeDisplayMessages(
         TextMessage(
           id: messageId,
           user: user,
-          createdAt: DateTime.now(),
+          createdAt: DateTime.timestamp(),
           text: text,
           thinkingText: thinkingText,
         ),

--- a/packages/soliplex_agent/lib/src/orchestration/run_orchestrator.dart
+++ b/packages/soliplex_agent/lib/src/orchestration/run_orchestrator.dart
@@ -113,6 +113,12 @@ class RunOrchestrator {
   /// decoder produces.
   int _liveEventCounter = 0;
 
+  /// The backend timestamp of the most recent event received on the active
+  /// subscription, or null before any timestamped event arrives. Used to stamp
+  /// the partial reply committed on cancel with the last server time rather
+  /// than a client `now()`.
+  DateTime? _lastEventTime;
+
   // runToCompletion infrastructure
   Completer<RunState>? _terminalCompleter;
   int _subscriptionEpoch = 0;
@@ -251,11 +257,13 @@ class RunOrchestrator {
           streaming: streaming,
           runId: runId,
           terminalEvent: 'cancelRun',
+          createdAt: _lastEventTime,
         );
         final synthesisResult = synthesizeCancelledNoResponse(
           conversation: withPartial,
           streaming: streaming,
           runId: runId,
+          createdAt: DateTime.timestamp(),
         );
         final withCitations =
             _extractCitations(synthesisResult.conversation, runId);
@@ -851,6 +859,7 @@ class RunOrchestrator {
     _cancelToken ??= CancelToken();
     _receivedTerminalEvent = false;
     _liveEventCounter = 0;
+    _lastEventTime = null;
     _terminalCompleter = Completer<RunState>();
     _subscriptionEpoch++;
     final epoch = _subscriptionEpoch;
@@ -879,6 +888,11 @@ class RunOrchestrator {
       case DecodedEvent(:final event, :final rawJson):
         final running = _currentState;
         if (running is! RunningState) return;
+        final timestamp = event.timestamp;
+        if (timestamp != null) {
+          _lastEventTime =
+              DateTime.fromMillisecondsSinceEpoch(timestamp, isUtc: true);
+        }
         try {
           final result =
               processEvent(running.conversation, running.streaming, event);

--- a/packages/soliplex_agent/lib/src/orchestration/run_orchestrator.dart
+++ b/packages/soliplex_agent/lib/src/orchestration/run_orchestrator.dart
@@ -779,6 +779,11 @@ class RunOrchestrator {
     Map<String, dynamic>? stateOverlay,
   ) {
     final priorMessages = cachedHistory?.messages ?? <ChatMessage>[];
+    // No authoritative time exists at submit — the backend hasn't created the
+    // run yet — so the optimistic echo carries no timestamp (createdAt: null,
+    // the default). It fills from the run's server `created` on replay; the
+    // frontend never displays a client-generated time. now() here is only for a
+    // unique id.
     final userMsg = TextMessage.create(
       id: 'user-${DateTime.now().microsecondsSinceEpoch}',
       user: ChatUser.user,

--- a/packages/soliplex_agent/lib/src/orchestration/run_orchestrator.dart
+++ b/packages/soliplex_agent/lib/src/orchestration/run_orchestrator.dart
@@ -890,8 +890,16 @@ class RunOrchestrator {
         if (running is! RunningState) return;
         final timestamp = event.timestamp;
         if (timestamp != null) {
-          _lastEventTime =
-              DateTime.fromMillisecondsSinceEpoch(timestamp, isUtc: true);
+          try {
+            _lastEventTime =
+                DateTime.fromMillisecondsSinceEpoch(timestamp, isUtc: true);
+          } on Object catch (error) {
+            _logger.warning(
+              'Ignoring out-of-range event timestamp ($timestamp) on run '
+              '${running.runId}',
+              error: error,
+            );
+          }
         }
         try {
           final result =

--- a/packages/soliplex_agent/lib/src/orchestration/run_orchestrator.dart
+++ b/packages/soliplex_agent/lib/src/orchestration/run_orchestrator.dart
@@ -895,7 +895,7 @@ class RunOrchestrator {
                 DateTime.fromMillisecondsSinceEpoch(timestamp, isUtc: true);
           } on Object catch (error) {
             _logger.warning(
-              'Ignoring out-of-range event timestamp ($timestamp) on run '
+              'Ignoring invalid event timestamp ($timestamp) on run '
               '${running.runId}',
               error: error,
             );

--- a/packages/soliplex_agent/test/orchestration/run_orchestrator_test.dart
+++ b/packages/soliplex_agent/test/orchestration/run_orchestrator_test.dart
@@ -522,6 +522,7 @@ void main() {
       final controller = StreamController<BaseEvent>();
       stubRunAgent(stream: controller.stream);
 
+      final staleTs = DateTime.utc(2026).millisecondsSinceEpoch;
       await orchestrator.startRun(key: _key, userMessage: 'Hi');
       controller
         ..add(const RunStartedEvent(threadId: 'thread-1', runId: _runId))
@@ -532,7 +533,7 @@ void main() {
             delta: 'considering options',
           ),
         )
-        ..add(const ThinkingTextMessageEndEvent());
+        ..add(ThinkingTextMessageEndEvent(timestamp: staleTs));
       await Future<void>.delayed(Duration.zero);
 
       expect(orchestrator.currentState, isA<RunningState>());
@@ -545,6 +546,12 @@ void main() {
       expect(synthesized.id, equals(noResponseMessageId(_runId)));
       expect(synthesized.reason, equals(TerminalReason.cancelled));
       expect(synthesized.thinkingText, equals('considering options'));
+      // The cancel is a client action with no backend event, so the tile
+      // carries the cancel instant (client now) — not the stale last-event
+      // time.
+      expect(synthesized.createdAt, isNotNull);
+      expect(synthesized.createdAt!.isUtc, isTrue);
+      expect(synthesized.createdAt!.isAfter(DateTime.utc(2026, 1, 2)), isTrue);
 
       await controller.close();
     });
@@ -559,6 +566,7 @@ void main() {
       final controller = StreamController<BaseEvent>();
       stubRunAgent(stream: controller.stream);
 
+      final lastChunkTime = DateTime.utc(2026, 1, 1, 12);
       await orchestrator.startRun(key: _key, userMessage: 'Hi');
       controller
         ..add(const RunStartedEvent(threadId: 'thread-1', runId: _runId))
@@ -570,9 +578,10 @@ void main() {
           ),
         )
         ..add(
-          const TextMessageContentEvent(
+          TextMessageContentEvent(
             messageId: 'reply-1',
             delta: 'reply',
+            timestamp: lastChunkTime.millisecondsSinceEpoch,
           ),
         );
       await Future<void>.delayed(Duration.zero);
@@ -587,6 +596,10 @@ void main() {
           .singleWhere((m) => m.id == 'reply-1');
       expect(committed.text, equals('half-rendered reply'));
       expect(committed.user, equals(ChatUser.assistant));
+      // The committed partial is backend content, so it carries the last
+      // received backend event time — not a client now().
+      expect(committed.createdAt, isNotNull);
+      expect(committed.createdAt!.isAtSameMomentAs(lastChunkTime), isTrue);
       // No NoResponseTile — partial-commit is the user-visible signal,
       // and synthesis declines on TextStreaming by design.
       expect(

--- a/packages/soliplex_agent/test/orchestration/run_orchestrator_test.dart
+++ b/packages/soliplex_agent/test/orchestration/run_orchestrator_test.dart
@@ -432,6 +432,39 @@ void main() {
           as ErrorMessage;
       expect(surfaced.errorText, equals('connection lost'));
     });
+
+    test(
+        'event with out-of-range timestamp is tolerated; run completes '
+        'instead of hanging', () async {
+      // An absurd epoch must not throw out of the stream listener (where it
+      // would escape the per-event guard and leave the run hung). The
+      // timestamp is ignored; the event still processes.
+      stubCreateRun();
+      stubRunAgent(
+        stream: Stream.fromIterable([
+          const RunStartedEvent(threadId: 'thread-1', runId: _runId),
+          const TextMessageStartEvent(messageId: 'msg-1'),
+          const TextMessageContentEvent(
+            messageId: 'msg-1',
+            delta: 'hello',
+            // One past DateTime's max epoch-ms (kept under 2^53 for web).
+            timestamp: 8640000000000001,
+          ),
+          const TextMessageEndEvent(messageId: 'msg-1'),
+          const RunFinishedEvent(threadId: 'thread-1', runId: _runId),
+        ]),
+      );
+
+      await orchestrator.startRun(key: _key, userMessage: 'Hi');
+      await Future<void>.delayed(Duration.zero);
+
+      expect(orchestrator.currentState, isA<CompletedState>());
+      final completed = orchestrator.currentState as CompletedState;
+      final reply = completed.conversation.messages
+          .whereType<TextMessage>()
+          .firstWhere((m) => m.id == 'msg-1');
+      expect(reply.text, equals('hello'));
+    });
   });
 
   group('cancel', () {

--- a/packages/soliplex_client/lib/src/api/soliplex_api.dart
+++ b/packages/soliplex_client/lib/src/api/soliplex_api.dart
@@ -768,9 +768,14 @@ class SoliplexApi {
     //    position by walking the original sort once.
     final fetchByRunId = {for (final r in results) r.runId: r};
     final preFetchByRunKey = {for (final d in preFetchDrops) d.runId: d.error};
-    final eventsPerRun =
-        <({String runId, List<dynamic> events, Object? fetchError})>[];
+    final eventsPerRun = <({
+      String runId,
+      List<dynamic> events,
+      Object? fetchError,
+      DateTime? created,
+    })>[];
     for (final entry in _sortRunsByCreationTime(runs)) {
+      final created = _runCreated(entry.value);
       final preFetchError = preFetchByRunKey[entry.key];
       if (preFetchError != null) {
         eventsPerRun.add(
@@ -778,6 +783,7 @@ class SoliplexApi {
             runId: entry.key,
             events: const <dynamic>[],
             fetchError: preFetchError,
+            created: created,
           ),
         );
         continue;
@@ -794,6 +800,7 @@ class SoliplexApi {
           runId: rawRunId,
           events: fetched.events,
           fetchError: fetched.fetchError,
+          created: created,
         ),
       );
     }
@@ -900,7 +907,13 @@ class SoliplexApi {
   /// messages. Each run's citations are keyed by the user message ID that
   /// initiated that run.
   ThreadHistory _replayEventsToHistory(
-    List<({String runId, List<dynamic> events, Object? fetchError})>
+    List<
+            ({
+              String runId,
+              List<dynamic> events,
+              Object? fetchError,
+              DateTime? created,
+            })>
         eventsPerRun,
     String threadId,
   ) {
@@ -912,7 +925,7 @@ class SoliplexApi {
     final messageStates = <String, MessageState>{};
     final runs = <RunEventBundle>[];
 
-    for (final (:runId, :events, :fetchError) in eventsPerRun) {
+    for (final (:runId, :events, :fetchError, :created) in eventsPerRun) {
       // Run-level fetch failure (transient HTTP error or pre-fetch
       // shape-drift on the run entry) → mint one drop tile in place so
       // the run is visibly missing from the timeline rather than
@@ -929,6 +942,7 @@ class SoliplexApi {
             source: DropSource.decode,
             reason: fetchError.toString(),
             runId: runId,
+            createdAt: created,
           ),
         );
       }
@@ -978,6 +992,7 @@ class SoliplexApi {
               reason: error.toString(),
               runId: runId,
               rawPayload: rawPayload,
+              createdAt: created,
             ),
           );
         }
@@ -1013,7 +1028,12 @@ class SoliplexApi {
           case DecodedEvent(:final event):
             decodedEvents.add(event);
             try {
-              final result = processEvent(conversation, streaming, event);
+              final result = processEvent(
+                conversation,
+                streaming,
+                event,
+                runCreated: created,
+              );
               conversation = result.conversation;
               streaming = result.streaming;
             } on Object catch (error, stackTrace) {
@@ -1054,6 +1074,16 @@ class SoliplexApi {
 
   /// Sorts runs by creation time (oldest first). Non-Map run values
   /// sort to the end; the caller filters them out before fetching.
+  /// Parses a run map's UTC `created` ISO-8601 string to a UTC [DateTime], or
+  /// null when absent or malformed. Used to stamp replayed messages with their
+  /// run's server time; null leaves them without a displayed timestamp rather
+  /// than substituting a client `now()`.
+  static DateTime? _runCreated(dynamic runData) {
+    if (runData is! Map<String, dynamic>) return null;
+    final created = runData['created'];
+    return created is String ? DateTime.tryParse(created)?.toUtc() : null;
+  }
+
   List<MapEntry<String, dynamic>> _sortRunsByCreationTime(
     Map<String, dynamic> runs,
   ) {

--- a/packages/soliplex_client/lib/src/api/soliplex_api.dart
+++ b/packages/soliplex_client/lib/src/api/soliplex_api.dart
@@ -775,7 +775,7 @@ class SoliplexApi {
       DateTime? created,
     })>[];
     for (final entry in _sortRunsByCreationTime(runs)) {
-      final created = _runCreated(entry.value);
+      final created = _runCreated(entry.value, entry.key, threadId);
       final preFetchError = preFetchByRunKey[entry.key];
       if (preFetchError != null) {
         eventsPerRun.add(
@@ -1072,18 +1072,36 @@ class SoliplexApi {
     );
   }
 
-  /// Sorts runs by creation time (oldest first). Non-Map run values
-  /// sort to the end; the caller filters them out before fetching.
-  /// Parses a run map's UTC `created` ISO-8601 string to a UTC [DateTime], or
-  /// null when absent or malformed. Used to stamp replayed messages with their
-  /// run's server time; null leaves them without a displayed timestamp rather
-  /// than substituting a client `now()`.
-  static DateTime? _runCreated(dynamic runData) {
+  /// Resolves a run map's `created` to a UTC [DateTime] via [parseTimestamp]
+  /// (which reads a naive ISO-8601 string as UTC), or null when the field is
+  /// absent. A present-but-wrong-shaped or malformed value logs a warning and
+  /// resolves to null, leaving the run's replayed messages without a displayed
+  /// timestamp rather than substituting a client `now()`.
+  static DateTime? _runCreated(dynamic runData, String runId, String threadId) {
     if (runData is! Map<String, dynamic>) return null;
     final created = runData['created'];
-    return created is String ? DateTime.tryParse(created)?.toUtc() : null;
+    if (created == null) return null;
+    if (created is! String) {
+      _logger.warning(
+        'replay: run $runId in thread $threadId has a non-string `created` '
+        '(${created.runtimeType}); resolving to no timestamp.',
+      );
+      return null;
+    }
+    try {
+      return parseTimestamp(created);
+    } on FormatException catch (error) {
+      _logger.warning(
+        'replay: run $runId in thread $threadId has a malformed `created` '
+        'timestamp; resolving to no timestamp.',
+        error: error,
+      );
+      return null;
+    }
   }
 
+  /// Sorts runs by creation time (oldest first). Non-Map run values
+  /// sort to the end; the caller filters them out before fetching.
   List<MapEntry<String, dynamic>> _sortRunsByCreationTime(
     Map<String, dynamic> runs,
   ) {

--- a/packages/soliplex_client/lib/src/api/soliplex_api.dart
+++ b/packages/soliplex_client/lib/src/api/soliplex_api.dart
@@ -1091,10 +1091,23 @@ class SoliplexApi {
     try {
       return parseTimestamp(created);
     } on FormatException catch (error) {
+      // Expected shape drift: a malformed `created` string. Routine — warn
+      // and resolve to no timestamp.
       _logger.warning(
         'replay: run $runId in thread $threadId has a malformed `created` '
         'timestamp; resolving to no timestamp.',
         error: error,
+      );
+      return null;
+    } on Object catch (error, stackTrace) {
+      // parseTimestamp is documented to throw only FormatException; anything
+      // else is an unexpected contract break worth a louder signal. Still
+      // resolve to null so one run never aborts the whole history replay.
+      _logger.error(
+        'replay: run $runId in thread $threadId threw unexpectedly parsing '
+        '`created`; resolving to no timestamp.',
+        error: error,
+        stackTrace: stackTrace,
       );
       return null;
     }

--- a/packages/soliplex_client/lib/src/application/agui_event_processor.dart
+++ b/packages/soliplex_client/lib/src/application/agui_event_processor.dart
@@ -57,10 +57,18 @@ EventProcessingResult processEvent(
         conversation: conversation.withStatus(Running(runId: runId)),
         streaming: streaming,
       ),
-    RunFinishedEvent(:final runId) =>
-      _processRunFinished(conversation, streaming, runId),
-    RunErrorEvent(:final message) =>
-      _processRunError(conversation, streaming, message),
+    RunFinishedEvent(:final runId, :final timestamp) => _processRunFinished(
+        conversation,
+        streaming,
+        runId,
+        createdAt: _eventTime(timestamp) ?? runCreated,
+      ),
+    RunErrorEvent(:final message, :final timestamp) => _processRunError(
+        conversation,
+        streaming,
+        message,
+        createdAt: _eventTime(timestamp) ?? runCreated,
+      ),
 
     // Thinking / reasoning lifecycle — outer (Thinking/ReasoningStart/End),
     // inner thinking (ThinkingTextMessageStart/End), and reasoning message
@@ -552,8 +560,9 @@ StreamingState _withToolCallPhase(
 EventProcessingResult _processRunFinished(
   Conversation conversation,
   StreamingState streaming,
-  String runId,
-) {
+  String runId, {
+  DateTime? createdAt,
+}) {
   if (conversation.status is! Running) {
     _logger.warning(
       'RunFinishedEvent on non-Running status; preserving prior status. '
@@ -573,11 +582,13 @@ EventProcessingResult _processRunFinished(
     streaming: streaming,
     runId: runId,
     terminalEvent: 'RunFinishedEvent',
+    createdAt: createdAt,
   );
   final result = synthesizeFinishedNoResponse(
     conversation: withPartial,
     streaming: streaming,
     runId: runId,
+    createdAt: createdAt,
   );
   // RunFinished with no synthesized tile and no in-flight text produces
   // no message in the list at all — `AgentSession` will return
@@ -627,20 +638,23 @@ EventProcessingResult _processRunFinished(
 EventProcessingResult _processRunError(
   Conversation conversation,
   StreamingState streaming,
-  String message,
-) {
+  String message, {
+  DateTime? createdAt,
+}) {
   if (conversation.status case Running(:final runId)) {
     final withPartial = commitPartialTextOnTerminal(
       conversation: conversation,
       streaming: streaming,
       runId: runId,
       terminalEvent: 'RunErrorEvent',
+      createdAt: createdAt,
     );
     final result = synthesizeFailedNoResponse(
       conversation: withPartial,
       streaming: streaming,
       runId: runId,
       errorDetail: message,
+      createdAt: createdAt,
     );
     // The partial-text commit already produces a user-visible signal in
     // the messages list — synthesis declines on TextStreaming by design,
@@ -677,6 +691,7 @@ EventProcessingResult _processRunError(
             ErrorMessage.create(
               id: runErrorMessageId(runId),
               message: message,
+              createdAt: createdAt,
             ),
           );
     return EventProcessingResult(

--- a/packages/soliplex_client/lib/src/application/agui_event_processor.dart
+++ b/packages/soliplex_client/lib/src/application/agui_event_processor.dart
@@ -36,8 +36,10 @@ class EventProcessingResult {
 /// Processes a single AG-UI event, returning updated domain and streaming
 /// state.
 ///
-/// This is a pure function with no side effects. It takes the current state
-/// and an event, and returns the new state.
+/// A minted message's `createdAt` resolves to `event.timestamp ?? runCreated`,
+/// where [runCreated] is the run's server `created` (supplied during replay,
+/// null while live). Both may be null — the message then carries no timestamp
+/// rather than a client-generated one.
 ///
 /// Example usage:
 /// ```dart

--- a/packages/soliplex_client/lib/src/application/agui_event_processor.dart
+++ b/packages/soliplex_client/lib/src/application/agui_event_processor.dart
@@ -722,6 +722,7 @@ EventProcessingResult _processRunError(
             ErrorMessage.create(
               id: preRunErrorMessageId(conversation.threadId, message),
               message: message,
+              createdAt: createdAt,
             ),
           )
           .withStatus(Failed(error: message)),

--- a/packages/soliplex_client/lib/src/application/agui_event_processor.dart
+++ b/packages/soliplex_client/lib/src/application/agui_event_processor.dart
@@ -48,8 +48,9 @@ class EventProcessingResult {
 EventProcessingResult processEvent(
   Conversation conversation,
   StreamingState streaming,
-  BaseEvent event,
-) {
+  BaseEvent event, {
+  DateTime? runCreated,
+}) {
   return switch (event) {
     // Run lifecycle events
     RunStartedEvent(:final runId) => EventProcessingResult(
@@ -93,10 +94,11 @@ EventProcessingResult processEvent(
       ),
     TextMessageContentEvent(:final messageId, :final delta) =>
       _processTextContent(conversation, streaming, messageId, delta),
-    TextMessageEndEvent(:final messageId) => _processTextEnd(
+    TextMessageEndEvent(:final messageId, :final timestamp) => _processTextEnd(
         conversation,
         streaming,
         messageId,
+        createdAt: _eventTime(timestamp) ?? runCreated,
       ),
 
     // Tool call events — accumulate tool names on start, args via deltas,
@@ -309,11 +311,18 @@ EventProcessingResult _processTextContent(
       ),
     );
 
+/// Converts an AG-UI event's epoch-millisecond [timestamp] to a UTC [DateTime],
+/// or null when the event carries no timestamp.
+DateTime? _eventTime(int? timestamp) => timestamp == null
+    ? null
+    : DateTime.fromMillisecondsSinceEpoch(timestamp, isUtc: true);
+
 EventProcessingResult _processTextEnd(
   Conversation conversation,
   StreamingState streaming,
-  String messageId,
-) =>
+  String messageId, {
+  DateTime? createdAt,
+}) =>
     _onActiveTextStream(
       conversation,
       streaming,
@@ -337,6 +346,7 @@ EventProcessingResult _processTextEnd(
           user: active.user,
           text: active.text,
           thinkingText: active.thinkingText,
+          createdAt: createdAt,
         );
 
         return EventProcessingResult(

--- a/packages/soliplex_client/lib/src/application/no_response_synthesis.dart
+++ b/packages/soliplex_client/lib/src/application/no_response_synthesis.dart
@@ -42,6 +42,7 @@ NoResponseSynthesisResult synthesizeFinishedNoResponse({
   required Conversation conversation,
   required StreamingState streaming,
   required String runId,
+  DateTime? createdAt,
 }) =>
     _synthesize(
       conversation: conversation,
@@ -50,6 +51,7 @@ NoResponseSynthesisResult synthesizeFinishedNoResponse({
       buildTile: (id, thinking) => NoResponseTile.finished(
         id: id,
         thinkingText: thinking,
+        createdAt: createdAt,
       ),
     );
 
@@ -62,6 +64,7 @@ NoResponseSynthesisResult synthesizeFailedNoResponse({
   required StreamingState streaming,
   required String runId,
   required String errorDetail,
+  DateTime? createdAt,
 }) =>
     _synthesize(
       conversation: conversation,
@@ -71,6 +74,7 @@ NoResponseSynthesisResult synthesizeFailedNoResponse({
         id: id,
         thinkingText: thinking,
         errorDetail: errorDetail,
+        createdAt: createdAt,
       ),
     );
 
@@ -80,6 +84,7 @@ NoResponseSynthesisResult synthesizeCancelledNoResponse({
   required Conversation conversation,
   required StreamingState streaming,
   required String runId,
+  DateTime? createdAt,
 }) =>
     _synthesize(
       conversation: conversation,
@@ -88,6 +93,7 @@ NoResponseSynthesisResult synthesizeCancelledNoResponse({
       buildTile: (id, thinking) => NoResponseTile.cancelled(
         id: id,
         thinkingText: thinking,
+        createdAt: createdAt,
       ),
     );
 
@@ -137,6 +143,7 @@ Conversation commitPartialTextOnTerminal({
   required StreamingState streaming,
   required String runId,
   required String terminalEvent,
+  DateTime? createdAt,
 }) {
   if (streaming is! TextStreaming) return conversation;
   final messageId = streaming.messageId;
@@ -167,6 +174,7 @@ Conversation commitPartialTextOnTerminal({
       user: streaming.user,
       text: streaming.text,
       thinkingText: streaming.thinkingText,
+      createdAt: createdAt,
     ),
   );
 }

--- a/packages/soliplex_client/lib/src/domain/chat_message.dart
+++ b/packages/soliplex_client/lib/src/domain/chat_message.dart
@@ -217,8 +217,16 @@ class ErrorMessage extends ChatMessage {
   }) : super(user: ChatUser.system);
 
   /// Creates an error message with the given ID and auto-generated timestamp.
-  factory ErrorMessage.create({required String id, required String message}) {
-    return ErrorMessage(id: id, errorText: message, createdAt: DateTime.now());
+  factory ErrorMessage.create({
+    required String id,
+    required String message,
+    DateTime? createdAt,
+  }) {
+    return ErrorMessage(
+      id: id,
+      errorText: message,
+      createdAt: createdAt ?? DateTime.now(),
+    );
   }
 
   /// The error message text.

--- a/packages/soliplex_client/lib/src/domain/chat_message.dart
+++ b/packages/soliplex_client/lib/src/domain/chat_message.dart
@@ -28,11 +28,15 @@ sealed class ChatMessage {
   /// The user who sent this message.
   final ChatUser user;
 
-  /// When this message was created, per the backend (`event.timestamp` or the
-  /// run's `created`). Null when no authoritative time is known yet — e.g. the
-  /// live optimistic user echo before the run is persisted; it fills in from
-  /// the run's server `created` on replay. The frontend never invents a
-  /// displayed time, so this is never a client `DateTime.now()`.
+  /// When this message was created. Backend-event-driven messages (replayed or
+  /// terminal text, run finished/errored) carry the backend's time
+  /// (`event.timestamp`, falling back to the run's `created`). Client-event
+  /// messages carry the client clock at creation, because the event happened on
+  /// the client and has no backend counterpart — e.g. a user-cancelled tile
+  /// (the cancel instant), the loading placeholder, the in-flight streaming
+  /// tile, and locally executed tool results. Null when no authoritative time
+  /// is known yet — e.g. the optimistic user echo before the run is persisted,
+  /// which fills in from the run's `created` on replay.
   final DateTime? createdAt;
 
   @override
@@ -222,7 +226,9 @@ class ErrorMessage extends ChatMessage {
     required this.errorText,
   }) : super(user: ChatUser.system);
 
-  /// Creates an error message with the given ID and auto-generated timestamp.
+  /// Creates an error message with the given ID. [createdAt] is the
+  /// backend-sourced time (the error event's timestamp or the run's
+  /// `created`), or null when none is known yet.
   factory ErrorMessage.create({
     required String id,
     required String message,

--- a/packages/soliplex_client/lib/src/domain/chat_message.dart
+++ b/packages/soliplex_client/lib/src/domain/chat_message.dart
@@ -70,13 +70,14 @@ class TextMessage extends ChatMessage {
     this.thinkingText = '',
   });
 
-  /// Creates a text message with the given ID and auto-generated timestamp.
+  /// Creates a text message with the given ID, defaulting [createdAt] to now.
   factory TextMessage.create({
     required String id,
     required ChatUser user,
     required String text,
     bool isStreaming = false,
     String thinkingText = '',
+    DateTime? createdAt,
   }) {
     return TextMessage(
       id: id,
@@ -84,7 +85,7 @@ class TextMessage extends ChatMessage {
       text: text,
       isStreaming: isStreaming,
       thinkingText: thinkingText,
-      createdAt: DateTime.now(),
+      createdAt: createdAt ?? DateTime.now(),
     );
   }
 

--- a/packages/soliplex_client/lib/src/domain/chat_message.dart
+++ b/packages/soliplex_client/lib/src/domain/chat_message.dart
@@ -28,15 +28,16 @@ sealed class ChatMessage {
   /// The user who sent this message.
   final ChatUser user;
 
-  /// When this message was created. Backend-event-driven messages (replayed or
-  /// terminal text, run finished/errored) carry the backend's time
-  /// (`event.timestamp`, falling back to the run's `created`). Client-event
-  /// messages carry the client clock at creation, because the event happened on
-  /// the client and has no backend counterpart — e.g. a user-cancelled tile
-  /// (the cancel instant), the loading placeholder, the in-flight streaming
-  /// tile, and locally executed tool results. Null when no authoritative time
-  /// is known yet — e.g. the optimistic user echo before the run is persisted,
-  /// which fills in from the run's `created` on replay.
+  /// When this message was created. Backend-driven messages carry the backend's
+  /// time: replayed or terminal text and run finished/errored use
+  /// `event.timestamp` (falling back to the run's `created`), and a reply cut
+  /// off by a cancel keeps its last received backend event time. Client-only
+  /// artifacts carry the client clock at creation, since they have no backend
+  /// counterpart — the user-cancelled tile (the cancel instant), the loading
+  /// placeholder, the in-flight streaming tile, and locally executed tool
+  /// results. Null when no authoritative time is known yet — e.g. the
+  /// optimistic user echo before the run is persisted, which fills in from the
+  /// run's `created` on replay.
   final DateTime? createdAt;
 
   @override
@@ -258,8 +259,8 @@ class ToolCallMessage extends ChatMessage {
     required this.toolCalls,
   }) : super(user: ChatUser.assistant);
 
-  /// Creates a tool call message with the given ID and auto-generated
-  /// timestamp.
+  /// Creates a tool call message with the given ID, stamped with the client
+  /// clock at creation (created client-side; no backend time).
   factory ToolCallMessage.create({
     required String id,
     required List<ToolCallInfo> toolCalls,
@@ -267,7 +268,7 @@ class ToolCallMessage extends ChatMessage {
     return ToolCallMessage(
       id: id,
       toolCalls: toolCalls,
-      createdAt: DateTime.now(),
+      createdAt: DateTime.timestamp(),
     );
   }
 
@@ -292,7 +293,7 @@ class ToolCallMessage extends ChatMessage {
     return ToolCallMessage(
       id: id,
       toolCalls: toolCalls,
-      createdAt: DateTime.now(),
+      createdAt: DateTime.timestamp(),
     );
   }
 
@@ -314,7 +315,8 @@ class GenUiMessage extends ChatMessage {
     required this.data,
   }) : super(user: ChatUser.assistant);
 
-  /// Creates a genUI message with the given ID and auto-generated timestamp.
+  /// Creates a genUI message with the given ID, stamped with the client clock
+  /// at creation (created client-side; no backend time).
   factory GenUiMessage.create({
     required String id,
     required String widgetName,
@@ -324,7 +326,7 @@ class GenUiMessage extends ChatMessage {
       id: id,
       widgetName: widgetName,
       data: data,
-      createdAt: DateTime.now(),
+      createdAt: DateTime.timestamp(),
     );
   }
 
@@ -345,9 +347,10 @@ class LoadingMessage extends ChatMessage {
   const LoadingMessage({required super.id, required super.createdAt})
       : super(user: ChatUser.assistant);
 
-  /// Creates a loading message with the given ID and auto-generated timestamp.
+  /// Creates a loading message with the given ID, stamped with the client clock
+  /// at creation (a transient client-side placeholder with no backend time).
   factory LoadingMessage.create({required String id}) {
-    return LoadingMessage(id: id, createdAt: DateTime.now());
+    return LoadingMessage(id: id, createdAt: DateTime.timestamp());
   }
 
   @override

--- a/packages/soliplex_client/lib/src/domain/chat_message.dart
+++ b/packages/soliplex_client/lib/src/domain/chat_message.dart
@@ -381,14 +381,16 @@ class DroppedEventMessage extends ChatMessage {
     this.rawPayload,
   }) : super(user: ChatUser.system);
 
-  /// Creates a dropped-event message with the given id and auto-generated
-  /// timestamp.
+  /// Creates a dropped-event message with the given id. [createdAt] is the
+  /// run's `created` on replay, or null for a live drop (no authoritative
+  /// time yet); the model never substitutes a client `now()`.
   factory DroppedEventMessage.create({
     required String id,
     required DropSource source,
     required String reason,
     String? runId,
     Object? rawPayload,
+    DateTime? createdAt,
   }) {
     return DroppedEventMessage(
       id: id,
@@ -396,7 +398,7 @@ class DroppedEventMessage extends ChatMessage {
       reason: reason,
       runId: runId,
       rawPayload: rawPayload,
-      createdAt: DateTime.now(),
+      createdAt: createdAt,
     );
   }
 

--- a/packages/soliplex_client/lib/src/domain/chat_message.dart
+++ b/packages/soliplex_client/lib/src/domain/chat_message.dart
@@ -28,8 +28,12 @@ sealed class ChatMessage {
   /// The user who sent this message.
   final ChatUser user;
 
-  /// When this message was created.
-  final DateTime createdAt;
+  /// When this message was created, per the backend (`event.timestamp` or the
+  /// run's `created`). Null when no authoritative time is known yet — e.g. the
+  /// live optimistic user echo before the run is persisted; it fills in from
+  /// the run's server `created` on replay. The frontend never invents a
+  /// displayed time, so this is never a client `DateTime.now()`.
+  final DateTime? createdAt;
 
   @override
   bool operator ==(Object other) =>
@@ -70,14 +74,16 @@ class TextMessage extends ChatMessage {
     this.thinkingText = '',
   });
 
-  /// Creates a text message with the given ID, defaulting [createdAt] to now.
+  /// Creates a text message with the given ID. [createdAt] is the
+  /// backend-sourced time, or null when none is known yet (e.g. the live
+  /// optimistic echo). The model never substitutes a client `now()`.
   factory TextMessage.create({
     required String id,
     required ChatUser user,
     required String text,
+    DateTime? createdAt,
     bool isStreaming = false,
     String thinkingText = '',
-    DateTime? createdAt,
   }) {
     return TextMessage(
       id: id,
@@ -85,7 +91,7 @@ class TextMessage extends ChatMessage {
       text: text,
       isStreaming: isStreaming,
       thinkingText: thinkingText,
-      createdAt: createdAt ?? DateTime.now(),
+      createdAt: createdAt,
     );
   }
 
@@ -147,7 +153,7 @@ class NoResponseTile extends ChatMessage {
   }) =>
       NoResponseTile._(
         id: id,
-        createdAt: createdAt ?? DateTime.now(),
+        createdAt: createdAt,
         thinkingText: thinkingText,
         reason: TerminalReason.failed,
         errorDetail: errorDetail,
@@ -161,7 +167,7 @@ class NoResponseTile extends ChatMessage {
   }) =>
       NoResponseTile._(
         id: id,
-        createdAt: createdAt ?? DateTime.now(),
+        createdAt: createdAt,
         thinkingText: thinkingText,
         reason: TerminalReason.cancelled,
         errorDetail: null,
@@ -175,7 +181,7 @@ class NoResponseTile extends ChatMessage {
   }) =>
       NoResponseTile._(
         id: id,
-        createdAt: createdAt ?? DateTime.now(),
+        createdAt: createdAt,
         thinkingText: thinkingText,
         reason: TerminalReason.finished,
         errorDetail: null,
@@ -225,7 +231,7 @@ class ErrorMessage extends ChatMessage {
     return ErrorMessage(
       id: id,
       errorText: message,
-      createdAt: createdAt ?? DateTime.now(),
+      createdAt: createdAt,
     );
   }
 

--- a/packages/soliplex_client/lib/src/domain/chat_message.dart
+++ b/packages/soliplex_client/lib/src/domain/chat_message.dart
@@ -277,7 +277,8 @@ class ToolCallMessage extends ChatMessage {
   /// Used after client-side tool execution to append results to the
   /// conversation before starting a continuation run. The [toolCalls]
   /// should have `status: completed` or `status: failed` with results
-  /// populated.
+  /// populated. Stamped with the client clock at creation, since a locally
+  /// executed result has no backend time.
   factory ToolCallMessage.fromExecuted({
     required String id,
     required List<ToolCallInfo> toolCalls,

--- a/packages/soliplex_client/test/api/soliplex_api_test.dart
+++ b/packages/soliplex_client/test/api/soliplex_api_test.dart
@@ -1212,6 +1212,95 @@ void main() {
         );
       });
 
+      test(
+          'replayed message createdAt resolves event.timestamp ?? run.created '
+          '?? null', () async {
+        final eventTime = DateTime.utc(2026, 1, 7, 2, 0, 30);
+
+        List<Map<String, dynamic>> textEvents(String msgId, {int? timestamp}) =>
+            [
+              {
+                'type': 'TEXT_MESSAGE_START',
+                'messageId': msgId,
+                'role': 'assistant',
+              },
+              {
+                'type': 'TEXT_MESSAGE_CONTENT',
+                'messageId': msgId,
+                'delta': 'x',
+              },
+              {
+                'type': 'TEXT_MESSAGE_END',
+                'messageId': msgId,
+                if (timestamp != null) 'timestamp': timestamp,
+              },
+            ];
+
+        void stubGet(String path, Map<String, dynamic> response) {
+          when(
+            () => mockTransport.request<Map<String, dynamic>>(
+              'GET',
+              Uri.parse('https://api.example.com/api/v1/$path'),
+              cancelToken: any(named: 'cancelToken'),
+              fromJson: any(named: 'fromJson'),
+              body: any(named: 'body'),
+              headers: any(named: 'headers'),
+              timeout: any(named: 'timeout'),
+            ),
+          ).thenAnswer((_) async => response);
+        }
+
+        stubGet('rooms/room-123/agui/thread-456', {
+          'room_id': 'room-123',
+          'thread_id': 'thread-456',
+          'runs': {
+            'run-1': {
+              'run_id': 'run-1',
+              'created': '2026-01-07T01:00:00.000Z',
+              'finished': '2026-01-07T01:01:00.000Z',
+            },
+            'run-2': {
+              'run_id': 'run-2',
+              'created': '2026-01-07T02:00:00.000Z',
+              'finished': '2026-01-07T02:01:00.000Z',
+            },
+            // No 'created' → run.created resolves to null.
+            'run-3': {
+              'run_id': 'run-3',
+              'finished': '2026-01-07T03:01:00.000Z',
+            },
+          },
+        });
+        stubGet('rooms/room-123/agui/thread-456/run-1', {
+          'run_id': 'run-1',
+          'events': textEvents('msg-1'),
+        });
+        stubGet('rooms/room-123/agui/thread-456/run-2', {
+          'run_id': 'run-2',
+          'events':
+              textEvents('msg-2', timestamp: eventTime.millisecondsSinceEpoch),
+        });
+        stubGet('rooms/room-123/agui/thread-456/run-3', {
+          'run_id': 'run-3',
+          'events': textEvents('msg-3'),
+        });
+
+        final history = await api.getThreadHistory('room-123', 'thread-456');
+        final byId = {for (final m in history.messages) m.id: m};
+
+        // No event timestamp → falls back to the run's created.
+        expect(
+          byId['msg-1']!
+              .createdAt!
+              .isAtSameMomentAs(DateTime.utc(2026, 1, 7, 1)),
+          isTrue,
+        );
+        // Event timestamp present → wins over the run's created (02:00:00).
+        expect(byId['msg-2']!.createdAt!.isAtSameMomentAs(eventTime), isTrue);
+        // Neither event timestamp nor run created → null (no client now()).
+        expect(byId['msg-3']!.createdAt, isNull);
+      });
+
       test('fetches multiple runs in parallel and orders by creation time',
           () async {
         // Thread endpoint returns two completed runs

--- a/packages/soliplex_client/test/api/soliplex_api_test.dart
+++ b/packages/soliplex_client/test/api/soliplex_api_test.dart
@@ -1269,6 +1269,13 @@ void main() {
               'run_id': 'run-3',
               'finished': '2026-01-07T03:01:00.000Z',
             },
+            // Malformed 'created' → resolves to null without throwing, so the
+            // rest of the thread still loads.
+            'run-4': {
+              'run_id': 'run-4',
+              'created': 'not-a-date',
+              'finished': '2026-01-07T04:01:00.000Z',
+            },
           },
         });
         stubGet('rooms/room-123/agui/thread-456/run-1', {
@@ -1283,6 +1290,10 @@ void main() {
         stubGet('rooms/room-123/agui/thread-456/run-3', {
           'run_id': 'run-3',
           'events': textEvents('msg-3'),
+        });
+        stubGet('rooms/room-123/agui/thread-456/run-4', {
+          'run_id': 'run-4',
+          'events': textEvents('msg-4'),
         });
 
         final history = await api.getThreadHistory('room-123', 'thread-456');
@@ -1299,6 +1310,8 @@ void main() {
         expect(byId['msg-2']!.createdAt!.isAtSameMomentAs(eventTime), isTrue);
         // Neither event timestamp nor run created → null (no client now()).
         expect(byId['msg-3']!.createdAt, isNull);
+        // Malformed run created → null, and the run still replayed.
+        expect(byId['msg-4']!.createdAt, isNull);
       });
 
       test('fetches multiple runs in parallel and orders by creation time',
@@ -2706,6 +2719,9 @@ void main() {
           final drop = history.messages.whereType<DroppedEventMessage>().single;
           expect(drop.runId, 'run-1');
           expect(drop.reason, contains('Connection failed'));
+          // The drop tile carries the failed run's server `created`, not a
+          // client now().
+          expect(drop.createdAt, DateTime.utc(2026, 1, 7, 1));
         },
       );
 

--- a/packages/soliplex_client/test/application/agui_event_processor_test.dart
+++ b/packages/soliplex_client/test/application/agui_event_processor_test.dart
@@ -354,6 +354,77 @@ void main() {
         final surfaced = result.conversation.messages.last as ErrorMessage;
         expect(surfaced.errorText, equals('tool failure'));
       });
+
+      test(
+          'RunErrorEvent stamps surfaced ErrorMessage createdAt from '
+          'event.timestamp', () {
+        final runningConversation =
+            conversation.withStatus(const Running(runId: 'run-1')).withToolCall(
+                  const ToolCallInfo(id: 'tc1', name: 'search'),
+                );
+        const streamingWithThinking = app_streaming.AwaitingText(
+          bufferedThinkingText: 'planning the call',
+        );
+        final eventTime = DateTime.utc(2026, 3, 3, 9, 3);
+        final event = RunErrorEvent(
+          message: 'tool failure',
+          timestamp: eventTime.millisecondsSinceEpoch,
+        );
+
+        final result =
+            processEvent(runningConversation, streamingWithThinking, event);
+
+        final surfaced =
+            result.conversation.messages.whereType<ErrorMessage>().single;
+        expect(surfaced.createdAt.isAtSameMomentAs(eventTime), isTrue);
+      });
+
+      test(
+          'RunErrorEvent stamps committed partial text createdAt from '
+          'event.timestamp', () {
+        final runningConversation =
+            conversation.withStatus(const Running(runId: 'run-1'));
+        const streamingText = app_streaming.TextStreaming(
+          messageId: 'msg-1',
+          user: _defaultUser,
+          text: 'partial reply',
+        );
+        final eventTime = DateTime.utc(2026, 3, 3, 9, 3);
+        final event = RunErrorEvent(
+          message: 'boom',
+          timestamp: eventTime.millisecondsSinceEpoch,
+        );
+
+        final result = processEvent(runningConversation, streamingText, event);
+
+        final committed = result.conversation.messages
+            .whereType<TextMessage>()
+            .firstWhere((m) => m.id == 'msg-1');
+        expect(committed.createdAt.isAtSameMomentAs(eventTime), isTrue);
+      });
+
+      test(
+          'RunFinishedEvent stamps synthesized NoResponseTile createdAt from '
+          'event.timestamp', () {
+        final runningConversation =
+            conversation.withStatus(const Running(runId: 'run-1'));
+        const streamingWithThinking = app_streaming.AwaitingText(
+          bufferedThinkingText: 'thought process',
+        );
+        final eventTime = DateTime.utc(2026, 3, 3, 9, 3);
+        final event = RunFinishedEvent(
+          threadId: 'thread-1',
+          runId: 'run-1',
+          timestamp: eventTime.millisecondsSinceEpoch,
+        );
+
+        final result =
+            processEvent(runningConversation, streamingWithThinking, event);
+
+        final tile =
+            result.conversation.messages.whereType<NoResponseTile>().single;
+        expect(tile.createdAt.isAtSameMomentAs(eventTime), isTrue);
+      });
     });
 
     group('text message streaming', () {

--- a/packages/soliplex_client/test/application/agui_event_processor_test.dart
+++ b/packages/soliplex_client/test/application/agui_event_processor_test.dart
@@ -434,6 +434,46 @@ void main() {
         expect(message.id, equals('msg-1'));
       });
 
+      test('TextMessageEndEvent stamps createdAt from event.timestamp', () {
+        const streamingState = app_streaming.TextStreaming(
+          messageId: 'msg-1',
+          user: _defaultUser,
+          text: 'Hello world',
+        );
+        final eventTime = DateTime.utc(2026, 3, 3, 9, 3);
+        final event = TextMessageEndEvent(
+          messageId: 'msg-1',
+          timestamp: eventTime.millisecondsSinceEpoch,
+        );
+
+        final result = processEvent(conversation, streamingState, event);
+
+        final message = result.conversation.messages.first;
+        expect(message.createdAt.isAtSameMomentAs(eventTime), isTrue);
+        expect(message.createdAt.isUtc, isTrue);
+      });
+
+      test('TextMessageEndEvent uses runCreated when event has no timestamp',
+          () {
+        const streamingState = app_streaming.TextStreaming(
+          messageId: 'msg-1',
+          user: _defaultUser,
+          text: 'Hello world',
+        );
+        const event = TextMessageEndEvent(messageId: 'msg-1');
+        final runCreated = DateTime.utc(2026, 3, 3, 9);
+
+        final result = processEvent(
+          conversation,
+          streamingState,
+          event,
+          runCreated: runCreated,
+        );
+
+        final message = result.conversation.messages.first;
+        expect(message.createdAt, runCreated);
+      });
+
       test('TextMessageEndEvent preserves user role from streaming state', () {
         // Verify role propagation: user from streaming state goes into message
         const streamingState = app_streaming.TextStreaming(

--- a/packages/soliplex_client/test/application/agui_event_processor_test.dart
+++ b/packages/soliplex_client/test/application/agui_event_processor_test.dart
@@ -376,7 +376,7 @@ void main() {
 
         final surfaced =
             result.conversation.messages.whereType<ErrorMessage>().single;
-        expect(surfaced.createdAt.isAtSameMomentAs(eventTime), isTrue);
+        expect(surfaced.createdAt!.isAtSameMomentAs(eventTime), isTrue);
       });
 
       test(
@@ -400,7 +400,7 @@ void main() {
         final committed = result.conversation.messages
             .whereType<TextMessage>()
             .firstWhere((m) => m.id == 'msg-1');
-        expect(committed.createdAt.isAtSameMomentAs(eventTime), isTrue);
+        expect(committed.createdAt!.isAtSameMomentAs(eventTime), isTrue);
       });
 
       test(
@@ -423,7 +423,7 @@ void main() {
 
         final tile =
             result.conversation.messages.whereType<NoResponseTile>().single;
-        expect(tile.createdAt.isAtSameMomentAs(eventTime), isTrue);
+        expect(tile.createdAt!.isAtSameMomentAs(eventTime), isTrue);
       });
     });
 
@@ -520,8 +520,8 @@ void main() {
         final result = processEvent(conversation, streamingState, event);
 
         final message = result.conversation.messages.first;
-        expect(message.createdAt.isAtSameMomentAs(eventTime), isTrue);
-        expect(message.createdAt.isUtc, isTrue);
+        expect(message.createdAt!.isAtSameMomentAs(eventTime), isTrue);
+        expect(message.createdAt!.isUtc, isTrue);
       });
 
       test('TextMessageEndEvent uses runCreated when event has no timestamp',

--- a/packages/soliplex_client/test/domain/chat_message_test.dart
+++ b/packages/soliplex_client/test/domain/chat_message_test.dart
@@ -223,8 +223,8 @@ void main() {
       expect(message.createdAt, isNotNull);
     });
 
-    test('fromExecuted sets auto-generated timestamp', () {
-      final before = DateTime.now();
+    test('fromExecuted stamps the client clock at creation', () {
+      final before = DateTime.timestamp();
       final message = ToolCallMessage.fromExecuted(
         id: 'tc-exec-2',
         toolCalls: const [
@@ -236,7 +236,7 @@ void main() {
           ),
         ],
       );
-      final after = DateTime.now();
+      final after = DateTime.timestamp();
 
       expect(
         message.createdAt!.isAfter(before.subtract(const Duration(seconds: 1))),

--- a/packages/soliplex_client/test/domain/chat_message_test.dart
+++ b/packages/soliplex_client/test/domain/chat_message_test.dart
@@ -14,7 +14,9 @@ void main() {
       expect(message.text, equals('Hello'));
       expect(message.isStreaming, isFalse);
       expect(message.id, equals('msg-1'));
-      expect(message.createdAt, isNotNull);
+      // createdAt is omitted, so it defaults to null — the model never
+      // substitutes a client-generated time.
+      expect(message.createdAt, isNull);
     });
 
     test('create with all fields', () {
@@ -237,11 +239,11 @@ void main() {
       final after = DateTime.now();
 
       expect(
-        message.createdAt.isAfter(before.subtract(const Duration(seconds: 1))),
+        message.createdAt!.isAfter(before.subtract(const Duration(seconds: 1))),
         isTrue,
       );
       expect(
-        message.createdAt.isBefore(after.add(const Duration(seconds: 1))),
+        message.createdAt!.isBefore(after.add(const Duration(seconds: 1))),
         isTrue,
       );
     });


### PR DESCRIPTION
## What

A `ChatMessage`'s `createdAt` now resolves from the backend's **authoritative** time instead of a client `DateTime.now()`:

- **Resolution order:** the AG-UI `event.timestamp` (epoch-ms), falling back to the run's server `created` (ISO-8601). When neither is known yet, `createdAt` is **null** (the field is now nullable) — e.g. the optimistic user echo before the run is persisted, which fills in from the run's `created` on replay.
- **Client-only tiles** that have no backend counterpart — cancellation, loading, in-flight streaming, locally executed tool results — carry a **UTC** client time (`DateTime.timestamp()`), consistent with the UTC backend times.

This threads the resolved time through the event processor, no-response synthesis, history replay, and the orchestrator's cancel path.

> Note: nothing in the UI renders `createdAt` yet — this is the correctness groundwork for a future per-message timestamp display, plus the resilience fixes below which are user-visible today.

## Fixes

- **Off-by-hours on naive timestamps.** Replay parsed the run's `created` with a bare `DateTime.tryParse(...).toUtc()`, which reads an offset-less (UTC-but-unmarked) backend timestamp as *local* and then shifts it. It now delegates to the shared `parseTimestamp` helper (the same one `RunInfo` uses), which normalizes naive timestamps to UTC.
- **Run hang on a bad event timestamp.** An out-of-range `event.timestamp` made `DateTime.fromMillisecondsSinceEpoch` throw `RangeError` in the stream listener's `onData` — escaping the per-event guard so the run never reached a terminal state (UI spun forever). The conversion is now guarded; a bad epoch is logged and ignored while the event still processes.
- **History-load abort on a malformed `created`.** A malformed/wrong-shaped run `created` now logs and resolves to null instead of being silently swallowed or throwing out of `getThreadHistory`. `FormatException` (routine malformed input) logs at `warning`; any other throw (a `parseTimestamp` contract break) logs at `error`; both resolve to null so one run never aborts the whole replay.

## Testing

- New tests cover the resolution precedence (`event.timestamp ?? run.created ?? null`), malformed-`created` resilience, drop-tile stamping, the cancel-path split (committed partial → last backend event time; cancelled tile → cancel instant), and the run-hang regression.
- Full unit suites pass: `soliplex_agent` +478, `soliplex_client` +1505 (integration suites excluded — they require a live backend). Analyzer clean; formatted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)