### PR TITLE
feat(room): chat message timestamps and cross-bubble selection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,11 @@ Versions follow the `version+build` scheme from `pubspec.yaml`, bumped via
 - Design system: `BrandTint` and `TintSource` are re-exported from
   `soliplex_frontend`, so a facade-only consumer can build
   `BrandTheme(tint: ...)` without depending on `soliplex_design` directly.
+- Chat: messages now show a muted timestamp caption, and a centered day
+  divider marks each calendar-day group in the transcript. Both use the
+  viewer's local zone and stay correct across DST.
+- Chat: the transcript is selectable across message bubbles — one drag spans
+  user, assistant, error, and tool-output tiles at once.
 
 ### Changed
 

--- a/lib/src/modules/diagnostics/ui/json_tree_view.dart
+++ b/lib/src/modules/diagnostics/ui/json_tree_view.dart
@@ -5,9 +5,19 @@ import '../models/json_tree_model.dart';
 
 /// Renders a [List<JsonNode>] as an expandable tree with syntax coloring.
 class JsonTreeView extends StatelessWidget {
-  const JsonTreeView({required this.nodes, super.key});
+  const JsonTreeView({
+    required this.nodes,
+    this.selectable = true,
+    super.key,
+  });
 
   final List<JsonNode> nodes;
+
+  /// Whether the tree's text manages its own selection (via `SelectableText`).
+  /// Pass `false` when rendered inside a `SelectionArea` so the surrounding
+  /// area handles selection — a self-selecting widget nested in a
+  /// `SelectionArea` drops out of the area's selection.
+  final bool selectable;
 
   @override
   Widget build(BuildContext context) {
@@ -26,33 +36,44 @@ class JsonTreeView extends StatelessWidget {
     // lets the tree extend to its natural width and pan instead.
     return SingleChildScrollView(
       scrollDirection: Axis.horizontal,
-      child: _JsonNodeList(nodes: nodes, depth: 0),
+      child: _JsonNodeList(nodes: nodes, depth: 0, selectable: selectable),
     );
   }
 }
 
 class _JsonNodeList extends StatelessWidget {
-  const _JsonNodeList({required this.nodes, required this.depth});
+  const _JsonNodeList({
+    required this.nodes,
+    required this.depth,
+    required this.selectable,
+  });
 
   final List<JsonNode> nodes;
   final int depth;
+  final bool selectable;
 
   @override
   Widget build(BuildContext context) {
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
-        for (final node in nodes) _JsonNodeTile(node: node, depth: depth),
+        for (final node in nodes)
+          _JsonNodeTile(node: node, depth: depth, selectable: selectable),
       ],
     );
   }
 }
 
 class _JsonNodeTile extends StatefulWidget {
-  const _JsonNodeTile({required this.node, required this.depth});
+  const _JsonNodeTile({
+    required this.node,
+    required this.depth,
+    required this.selectable,
+  });
 
   final JsonNode node;
   final int depth;
+  final bool selectable;
 
   @override
   State<_JsonNodeTile> createState() => _JsonNodeTileState();
@@ -108,25 +129,25 @@ class _JsonNodeTileState extends State<_JsonNodeTile> {
 
     final baseStyle = context.monospaceOn(theme.textTheme.bodySmall);
 
+    final span = TextSpan(
+      children: [
+        if (node.key.isNotEmpty)
+          TextSpan(
+            text: '${node.key}: ',
+            style: baseStyle.copyWith(
+              color: colorScheme.onSurface,
+            ),
+          ),
+        TextSpan(
+          text: node.value,
+          style: baseStyle.copyWith(color: valueColor),
+        ),
+      ],
+    );
+
     return Padding(
       padding: EdgeInsets.only(left: indent),
-      child: SelectableText.rich(
-        TextSpan(
-          children: [
-            if (node.key.isNotEmpty)
-              TextSpan(
-                text: '${node.key}: ',
-                style: baseStyle.copyWith(
-                  color: colorScheme.onSurface,
-                ),
-              ),
-            TextSpan(
-              text: node.value,
-              style: baseStyle.copyWith(color: valueColor),
-            ),
-          ],
-        ),
-      ),
+      child: widget.selectable ? SelectableText.rich(span) : Text.rich(span),
     );
   }
 
@@ -159,19 +180,30 @@ class _JsonNodeTileState extends State<_JsonNodeTile> {
                   color: colorScheme.onSurfaceVariant,
                 ),
                 const SizedBox(width: SoliplexSpacing.s1),
-                SelectableText(
-                  _expanded ? expandedLabel : label,
-                  style: baseStyle,
-                ),
+                widget.selectable
+                    ? SelectableText(
+                        _expanded ? expandedLabel : label,
+                        style: baseStyle,
+                      )
+                    : Text(
+                        _expanded ? expandedLabel : label,
+                        style: baseStyle,
+                      ),
               ],
             ),
           ),
         ),
         if (_expanded) ...[
-          _JsonNodeList(nodes: children, depth: widget.depth + 1),
+          _JsonNodeList(
+            nodes: children,
+            depth: widget.depth + 1,
+            selectable: widget.selectable,
+          ),
           Padding(
             padding: EdgeInsets.only(left: indent),
-            child: SelectableText(closingLabel, style: baseStyle),
+            child: widget.selectable
+                ? SelectableText(closingLabel, style: baseStyle)
+                : Text(closingLabel, style: baseStyle),
           ),
         ],
       ],

--- a/lib/src/modules/room/compute_display_messages.dart
+++ b/lib/src/modules/room/compute_display_messages.dart
@@ -33,7 +33,10 @@ List<ChatMessage> computeDisplayMessages(
         TextMessage(
           id: messageId,
           user: user,
-          createdAt: DateTime.timestamp(),
+          // No server time exists mid-stream; the caption fills when the
+          // message commits with the backend's event time on TextMessageEnd,
+          // rather than flashing a client clock.
+          createdAt: null,
           text: text,
           thinkingText: thinkingText,
         ),

--- a/lib/src/modules/room/message_timestamp_format.dart
+++ b/lib/src/modules/room/message_timestamp_format.dart
@@ -1,0 +1,121 @@
+// Pure formatting for chat message time captions and day dividers.
+//
+// All inputs are converted to the viewer's local zone before any calendar
+// field is read. `now` is injectable for testing. No `intl` — the 12-hour
+// clock and weekday/month names are built by hand.
+
+enum _DayBucket { today, yesterday, weekday, thisYear, older }
+
+const _weekdayNames = [
+  'Monday',
+  'Tuesday',
+  'Wednesday',
+  'Thursday',
+  'Friday',
+  'Saturday',
+  'Sunday',
+];
+
+const _monthNames = [
+  'January',
+  'February',
+  'March',
+  'April',
+  'May',
+  'June',
+  'July',
+  'August',
+  'September',
+  'October',
+  'November',
+  'December',
+];
+
+/// Whole calendar days between two local dates, computed DST-immune by flooring
+/// each to a UTC midnight (UTC has no DST, so the diff is always whole days).
+/// Not `now.difference(t).inDays`, which counts 24-hour chunks and both
+/// misbuckets near midnight and truncates a 23-hour spring-forward day.
+int _daysAgo(DateTime localT, DateTime localNow) {
+  final t = DateTime.utc(localT.year, localT.month, localT.day);
+  final n = DateTime.utc(localNow.year, localNow.month, localNow.day);
+  return n.difference(t).inDays;
+}
+
+_DayBucket _bucketFor(DateTime localT, DateTime localNow) {
+  final daysAgo = _daysAgo(localT, localNow);
+  if (daysAgo <= 0) return _DayBucket.today;
+  if (daysAgo == 1) return _DayBucket.yesterday;
+  // Exactly 7 days ago is the same weekday as today, so the weekday bucket
+  // stops at 6; day 7+ falls through to the date.
+  if (daysAgo <= 6) return _DayBucket.weekday;
+  return localT.year == localNow.year ? _DayBucket.thisYear : _DayBucket.older;
+}
+
+/// 12-hour clock: midnight → `12:xx AM`, noon → `12:xx PM`, minute zero-padded,
+/// hour unpadded.
+String _clock(DateTime local) {
+  final h = local.hour;
+  final hour12 = h % 12 == 0 ? 12 : h % 12;
+  final period = h < 12 ? 'AM' : 'PM';
+  final mm = local.minute.toString().padLeft(2, '0');
+  return '$hour12:$mm $period';
+}
+
+String _weekdayAbbrev(DateTime local) =>
+    _weekdayNames[local.weekday - 1].substring(0, 3);
+
+String _monthAbbrev(DateTime local) =>
+    _monthNames[local.month - 1].substring(0, 3);
+
+/// Muted caption under a message bubble. Today shows just the time (the day
+/// divider carries the day); older buckets stay self-describing.
+///
+/// - same day → `2:14 PM`
+/// - previous day → `Yesterday · 4:12 PM`
+/// - 2–6 days ago → `Mon · 9:03 AM`
+/// - earlier this year → `Mar 3 · 9:03 AM`
+/// - older → `Mar 3, 2025 · 9:03 AM`
+String formatMessageCaption(DateTime time, {DateTime? now}) {
+  final local = time.toLocal();
+  final localNow = (now ?? DateTime.now()).toLocal();
+  final clock = _clock(local);
+  return switch (_bucketFor(local, localNow)) {
+    _DayBucket.today => clock,
+    _DayBucket.yesterday => 'Yesterday · $clock',
+    _DayBucket.weekday => '${_weekdayAbbrev(local)} · $clock',
+    _DayBucket.thisYear => '${_monthAbbrev(local)} ${local.day} · $clock',
+    _DayBucket.older =>
+      '${_monthAbbrev(local)} ${local.day}, ${local.year} · $clock',
+  };
+}
+
+/// Centered day-divider label. Uses full names (the divider is the prominent
+/// marker) and carries the date on the 2–6-day bucket so the literal date is
+/// visible once per group.
+///
+/// - today → `Today`
+/// - yesterday → `Yesterday`
+/// - 2–6 days ago → `Monday, June 23`
+/// - earlier this year → `March 3`
+/// - older → `March 3, 2025`
+String formatDayDivider(DateTime time, {DateTime? now}) {
+  final local = time.toLocal();
+  final localNow = (now ?? DateTime.now()).toLocal();
+  final weekday = _weekdayNames[local.weekday - 1];
+  final month = _monthNames[local.month - 1];
+  return switch (_bucketFor(local, localNow)) {
+    _DayBucket.today => 'Today',
+    _DayBucket.yesterday => 'Yesterday',
+    _DayBucket.weekday => '$weekday, $month ${local.day}',
+    _DayBucket.thisYear => '$month ${local.day}',
+    _DayBucket.older => '$month ${local.day}, ${local.year}',
+  };
+}
+
+/// Whether [a] and [b] fall on the same local calendar day. Component equality
+/// (no arithmetic), so it is DST-safe. Used for the day-divider boundary.
+bool isSameCalendarDay(DateTime a, DateTime b) {
+  final la = a.toLocal();
+  final lb = b.toLocal();
+  return la.year == lb.year && la.month == lb.month && la.day == lb.day;
+}

--- a/lib/src/modules/room/ui/citations_section.dart
+++ b/lib/src/modules/room/ui/citations_section.dart
@@ -271,6 +271,7 @@ class _SourceReferenceRow extends StatelessWidget {
               child: SingleChildScrollView(
                 child: FlutterMarkdownPlusRenderer(
                   data: sourceReference.content,
+                  selectable: false,
                 ),
               ),
             ),

--- a/lib/src/modules/room/ui/day_divider.dart
+++ b/lib/src/modules/room/ui/day_divider.dart
@@ -1,0 +1,33 @@
+import 'package:flutter/material.dart';
+import 'package:soliplex_design/soliplex_design.dart';
+
+/// A centered calendar-day separator drawn between message groups on different
+/// days (and above the first message). [label] comes from `formatDayDivider`
+/// (e.g. `Today`, `Monday, June 23`); it is uppercased here as a style choice.
+class DayDivider extends StatelessWidget {
+  const DayDivider({super.key, required this.label});
+
+  final String label;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final color = theme.colorScheme.onSurfaceVariant;
+    return Padding(
+      padding: const EdgeInsets.only(bottom: SoliplexSpacing.s4),
+      child: Row(
+        children: [
+          Expanded(child: Divider(color: color)),
+          Padding(
+            padding: const EdgeInsets.symmetric(horizontal: SoliplexSpacing.s2),
+            child: Text(
+              label.toUpperCase(),
+              style: theme.textTheme.labelSmall?.copyWith(color: color),
+            ),
+          ),
+          Expanded(child: Divider(color: color)),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/src/modules/room/ui/dropped_event_message_tile.dart
+++ b/lib/src/modules/room/ui/dropped_event_message_tile.dart
@@ -112,7 +112,7 @@ class _DroppedEventMessageTileState extends State<DroppedEventMessageTile> {
     if (raw is String) {
       // Top-level JSON parse failure: show the raw bytes the parser
       // rejected, so a developer can see the malformed wire content.
-      return SelectableText(raw, style: mono);
+      return Text(raw, style: mono);
     }
     return JsonTreeView(nodes: buildJsonTree(raw));
   }

--- a/lib/src/modules/room/ui/dropped_event_message_tile.dart
+++ b/lib/src/modules/room/ui/dropped_event_message_tile.dart
@@ -114,7 +114,9 @@ class _DroppedEventMessageTileState extends State<DroppedEventMessageTile> {
       // rejected, so a developer can see the malformed wire content.
       return Text(raw, style: mono);
     }
-    return JsonTreeView(nodes: buildJsonTree(raw));
+    // Non-selectable so the tile joins the transcript's SelectionArea rather
+    // than capturing the drag with its own selection.
+    return JsonTreeView(nodes: buildJsonTree(raw), selectable: false);
   }
 
   String _humanizeSource(DropSource source) {

--- a/lib/src/modules/room/ui/error_message_tile.dart
+++ b/lib/src/modules/room/ui/error_message_tile.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:soliplex_agent/soliplex_agent.dart';
 
 import 'copy_button.dart';
+import 'message_caption.dart';
 import 'package:soliplex_design/soliplex_design.dart';
 
 class ErrorMessageTile extends StatelessWidget {
@@ -29,6 +30,7 @@ class ErrorMessageTile extends StatelessWidget {
             ),
           ),
         ),
+        if (message.createdAt != null) MessageCaption(time: message.createdAt!),
         const SizedBox(height: SoliplexSpacing.s1),
         CopyButton(text: message.errorText),
       ],

--- a/lib/src/modules/room/ui/error_message_tile.dart
+++ b/lib/src/modules/room/ui/error_message_tile.dart
@@ -23,7 +23,7 @@ class ErrorMessageTile extends StatelessWidget {
             color: theme.colorScheme.errorContainer,
             borderRadius: BorderRadius.circular(context.radii.md),
           ),
-          child: SelectableText(
+          child: Text(
             message.errorText,
             style: theme.textTheme.bodyMedium?.copyWith(
               color: theme.colorScheme.onErrorContainer,

--- a/lib/src/modules/room/ui/execution/execution_timeline.dart
+++ b/lib/src/modules/room/ui/execution/execution_timeline.dart
@@ -312,7 +312,7 @@ class _ExecutionTimelineState extends ConsumerState<ExecutionTimeline> {
               alignment: Alignment.centerRight,
               child: CopyButton(text: source, iconSize: 14),
             ),
-            SelectableText(
+            Text(
               source,
               style: context
                   .monospaceOn(theme.textTheme.labelSmall)

--- a/lib/src/modules/room/ui/gen_ui_tile.dart
+++ b/lib/src/modules/room/ui/gen_ui_tile.dart
@@ -23,7 +23,7 @@ class GenUiTile extends StatelessWidget {
               ),
             ),
             const SizedBox(height: SoliplexSpacing.s2),
-            SelectableText(
+            Text(
               const JsonEncoder.withIndent('  ').convert(message.data),
               style: context.monospaceOn(theme.textTheme.bodySmall),
             ),

--- a/lib/src/modules/room/ui/markdown/flutter_markdown_plus_renderer.dart
+++ b/lib/src/modules/room/ui/markdown/flutter_markdown_plus_renderer.dart
@@ -26,7 +26,14 @@ class FlutterMarkdownPlusRenderer extends MarkdownRenderer {
     super.onLinkTap,
     super.onImageTap,
     super.key,
+    this.selectable = true,
   });
+
+  /// Whether the markdown manages its own selection (via `SelectableText`).
+  /// Pass `false` when rendered inside a `SelectionArea` so the surrounding
+  /// area handles selection — a self-selecting widget nested in a
+  /// `SelectionArea` conflicts.
+  final bool selectable;
 
   @override
   Widget build(BuildContext context) {
@@ -39,7 +46,7 @@ class FlutterMarkdownPlusRenderer extends MarkdownRenderer {
 
     return MarkdownBody(
       data: sanitizeMarkdown(data),
-      selectable: true,
+      selectable: selectable,
       styleSheet: markdownTheme?.toMarkdownStyleSheet(
         codeFontStyle: monoStyle,
       ),

--- a/lib/src/modules/room/ui/message_caption.dart
+++ b/lib/src/modules/room/ui/message_caption.dart
@@ -1,0 +1,29 @@
+import 'package:flutter/material.dart';
+import 'package:soliplex_design/soliplex_design.dart';
+
+import '../message_timestamp_format.dart';
+
+/// Muted timestamp caption shown under a message bubble or outcome tile.
+///
+/// Callers render this only for messages that have a known time (a non-null
+/// [time]); a message whose `createdAt` is null — the in-flight user echo —
+/// simply omits it. The enclosing tile's `Column` handles left/right alignment.
+class MessageCaption extends StatelessWidget {
+  const MessageCaption({super.key, required this.time});
+
+  final DateTime time;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Padding(
+      padding: const EdgeInsets.only(top: SoliplexSpacing.s1),
+      child: Text(
+        formatMessageCaption(time),
+        style: theme.textTheme.labelSmall?.copyWith(
+          color: theme.colorScheme.onSurfaceVariant,
+        ),
+      ),
+    );
+  }
+}

--- a/lib/src/modules/room/ui/message_caption.dart
+++ b/lib/src/modules/room/ui/message_caption.dart
@@ -6,8 +6,9 @@ import '../message_timestamp_format.dart';
 /// Muted timestamp caption shown under a message bubble or outcome tile.
 ///
 /// Callers render this only for messages that have a known time (a non-null
-/// [time]); a message whose `createdAt` is null — the in-flight user echo —
-/// simply omits it. The enclosing tile's `Column` handles left/right alignment.
+/// [time]); a message whose `createdAt` is null — the optimistic user echo or
+/// an assistant reply still streaming — simply omits it. The enclosing tile's
+/// `Column` handles left/right alignment.
 class MessageCaption extends StatelessWidget {
   const MessageCaption({super.key, required this.time});
 

--- a/lib/src/modules/room/ui/message_timeline.dart
+++ b/lib/src/modules/room/ui/message_timeline.dart
@@ -364,6 +364,13 @@ class _MessageTimelineState extends State<MessageTimeline> {
 
     _evaluateUnread(displayMessages);
 
+    // Messages with no known time yet — the streaming assistant reply and the
+    // optimistic user echo, both effectively "now" — group under the current
+    // day for the divider boundary (their captions are omitted until a server
+    // time arrives). Computed once per build so grouping is stable across
+    // items; UTC to match the backend-sourced createdAt values it stands in for.
+    final dayFallback = DateTime.timestamp();
+
     if (_needsInitialScroll) {
       _lastUserMessageId = _findLastUserMessage(widget.messages)?.id;
       // Defer the one-time initial scroll until we know where to land: follow a
@@ -436,9 +443,6 @@ class _MessageTimelineState extends State<MessageTimeline> {
                                   : null),
                           streamingPhase: isLastItem ? streamingPhase : null,
                         );
-                        // A null createdAt (the in-flight user echo) groups under
-                        // today for the boundary check.
-                        final dayFallback = DateTime.now();
                         final startsNewDay = index == 0 ||
                             !isSameCalendarDay(
                               message.createdAt ?? dayFallback,

--- a/lib/src/modules/room/ui/message_timeline.dart
+++ b/lib/src/modules/room/ui/message_timeline.dart
@@ -4,10 +4,12 @@ import 'package:soliplex_agent/soliplex_agent.dart' hide State;
 
 import '../compute_display_messages.dart';
 import '../execution_tracker.dart';
+import '../message_timestamp_format.dart';
 import '../tracker_registry.dart' show awaitingTrackerKey;
 import '../run_id_resolver.dart';
 import '../source_references_resolver.dart';
 import '../unread_boundary.dart';
+import 'day_divider.dart';
 import 'message_tile.dart';
 import 'scroll/anchored_scroll_controller.dart';
 import 'scroll/scroll_to_bottom.dart';
@@ -433,19 +435,37 @@ class _MessageTimelineState extends State<MessageTimeline> {
                                 : null),
                         streamingPhase: isLastItem ? streamingPhase : null,
                       );
+                      // A null createdAt (the in-flight user echo) groups under
+                      // today for the boundary check.
+                      final dayFallback = DateTime.now();
+                      final startsNewDay = index == 0 ||
+                          !isSameCalendarDay(
+                            message.createdAt ?? dayFallback,
+                            displayMessages[index - 1].createdAt ?? dayFallback,
+                          );
+                      final showUnread = message.id == _frozenFirstUnreadId;
+                      final leading = <Widget>[
+                        if (startsNewDay)
+                          DayDivider(
+                            label: formatDayDivider(
+                              message.createdAt ?? dayFallback,
+                            ),
+                          ),
+                        if (showUnread) const UnreadDivider(),
+                      ];
                       return Padding(
                         key: message is LoadingMessage
                             ? const ValueKey('loading')
                             : _keyFor(message.id),
                         padding:
                             const EdgeInsets.only(bottom: SoliplexSpacing.s4),
-                        child: message.id == _frozenFirstUnreadId
-                            ? Column(
+                        child: leading.isEmpty
+                            ? tile
+                            : Column(
                                 mainAxisSize: MainAxisSize.min,
                                 crossAxisAlignment: CrossAxisAlignment.stretch,
-                                children: [const UnreadDivider(), tile],
-                              )
-                            : tile,
+                                children: [...leading, tile],
+                              ),
                       );
                     },
                   ),

--- a/lib/src/modules/room/ui/message_timeline.dart
+++ b/lib/src/modules/room/ui/message_timeline.dart
@@ -396,81 +396,85 @@ class _MessageTimelineState extends State<MessageTimeline> {
         _maybeStickToBottomOnShrink(constraints.maxHeight);
         return Stack(
           children: [
-            CustomScrollView(
-              controller: _scrollController,
-              slivers: [
-                SliverPadding(
-                  padding: const EdgeInsets.all(SoliplexSpacing.s4),
-                  sliver: SliverList.builder(
-                    itemCount: displayMessages.length,
-                    itemBuilder: (context, index) {
-                      final message = displayMessages[index];
-                      final isLastItem = index == displayMessages.length - 1;
-                      // A distinct key for the loading sentinel forces a
-                      // remount at the AwaitingText → TextStreaming transition.
-                      // Children capture their MessageExpansion handle once in
-                      // initState; without the remount they would stay bound to
-                      // loadingMessageId (which forMessage rejects) and never
-                      // acquire a handle under the real messageId.
-                      final tile = MessageTile(
-                        roomId: widget.roomId,
-                        message: message,
-                        runId: _runIdMap[message.id] ??
-                            (message is TextMessage &&
-                                    message.user == ChatUser.user
-                                ? widget.messageStates[message.id]?.runId
-                                : null),
-                        sourceReferences: _sourceReferencesMap[message.id],
-                        onFeedbackSubmit: widget.onFeedbackSubmit,
-                        onInspect: widget.onInspect,
-                        onShowChunkVisualization:
-                            widget.onShowChunkVisualization,
-                        onFetchWorkdirFiles: widget.onFetchWorkdirFiles,
-                        onDownloadWorkdirFile: widget.onDownloadWorkdirFile,
-                        onPreviewWorkdirFile: widget.onPreviewWorkdirFile,
-                        executionTracker: widget
-                                .executionTrackers[message.id] ??
-                            (message is LoadingMessage
-                                ? widget.executionTrackers[awaitingTrackerKey]
-                                : null),
-                        streamingPhase: isLastItem ? streamingPhase : null,
-                      );
-                      // A null createdAt (the in-flight user echo) groups under
-                      // today for the boundary check.
-                      final dayFallback = DateTime.now();
-                      final startsNewDay = index == 0 ||
-                          !isSameCalendarDay(
-                            message.createdAt ?? dayFallback,
-                            displayMessages[index - 1].createdAt ?? dayFallback,
-                          );
-                      final showUnread = message.id == _frozenFirstUnreadId;
-                      final leading = <Widget>[
-                        if (startsNewDay)
-                          DayDivider(
-                            label: formatDayDivider(
+            SelectionArea(
+              child: CustomScrollView(
+                controller: _scrollController,
+                slivers: [
+                  SliverPadding(
+                    padding: const EdgeInsets.all(SoliplexSpacing.s4),
+                    sliver: SliverList.builder(
+                      itemCount: displayMessages.length,
+                      itemBuilder: (context, index) {
+                        final message = displayMessages[index];
+                        final isLastItem = index == displayMessages.length - 1;
+                        // A distinct key for the loading sentinel forces a
+                        // remount at the AwaitingText → TextStreaming transition.
+                        // Children capture their MessageExpansion handle once in
+                        // initState; without the remount they would stay bound to
+                        // loadingMessageId (which forMessage rejects) and never
+                        // acquire a handle under the real messageId.
+                        final tile = MessageTile(
+                          roomId: widget.roomId,
+                          message: message,
+                          runId: _runIdMap[message.id] ??
+                              (message is TextMessage &&
+                                      message.user == ChatUser.user
+                                  ? widget.messageStates[message.id]?.runId
+                                  : null),
+                          sourceReferences: _sourceReferencesMap[message.id],
+                          onFeedbackSubmit: widget.onFeedbackSubmit,
+                          onInspect: widget.onInspect,
+                          onShowChunkVisualization:
+                              widget.onShowChunkVisualization,
+                          onFetchWorkdirFiles: widget.onFetchWorkdirFiles,
+                          onDownloadWorkdirFile: widget.onDownloadWorkdirFile,
+                          onPreviewWorkdirFile: widget.onPreviewWorkdirFile,
+                          executionTracker: widget
+                                  .executionTrackers[message.id] ??
+                              (message is LoadingMessage
+                                  ? widget.executionTrackers[awaitingTrackerKey]
+                                  : null),
+                          streamingPhase: isLastItem ? streamingPhase : null,
+                        );
+                        // A null createdAt (the in-flight user echo) groups under
+                        // today for the boundary check.
+                        final dayFallback = DateTime.now();
+                        final startsNewDay = index == 0 ||
+                            !isSameCalendarDay(
                               message.createdAt ?? dayFallback,
-                            ),
-                          ),
-                        if (showUnread) const UnreadDivider(),
-                      ];
-                      return Padding(
-                        key: message is LoadingMessage
-                            ? const ValueKey('loading')
-                            : _keyFor(message.id),
-                        padding:
-                            const EdgeInsets.only(bottom: SoliplexSpacing.s4),
-                        child: leading.isEmpty
-                            ? tile
-                            : Column(
-                                mainAxisSize: MainAxisSize.min,
-                                crossAxisAlignment: CrossAxisAlignment.stretch,
-                                children: [...leading, tile],
+                              displayMessages[index - 1].createdAt ??
+                                  dayFallback,
+                            );
+                        final showUnread = message.id == _frozenFirstUnreadId;
+                        final leading = <Widget>[
+                          if (startsNewDay)
+                            DayDivider(
+                              label: formatDayDivider(
+                                message.createdAt ?? dayFallback,
                               ),
-                      );
-                    },
+                            ),
+                          if (showUnread) const UnreadDivider(),
+                        ];
+                        return Padding(
+                          key: message is LoadingMessage
+                              ? const ValueKey('loading')
+                              : _keyFor(message.id),
+                          padding:
+                              const EdgeInsets.only(bottom: SoliplexSpacing.s4),
+                          child: leading.isEmpty
+                              ? tile
+                              : Column(
+                                  mainAxisSize: MainAxisSize.min,
+                                  crossAxisAlignment:
+                                      CrossAxisAlignment.stretch,
+                                  children: [...leading, tile],
+                                ),
+                        );
+                      },
+                    ),
                   ),
-                ),
-              ],
+                ],
+              ),
             ),
             Positioned(
               right: SoliplexSpacing.s4,

--- a/lib/src/modules/room/ui/no_response_tile_widget.dart
+++ b/lib/src/modules/room/ui/no_response_tile_widget.dart
@@ -6,6 +6,7 @@ import 'execution/phase_indicator.dart';
 import 'execution/execution_timeline.dart';
 import 'execution/static_thinking_block.dart';
 import 'execution/thinking_block.dart';
+import 'message_caption.dart';
 import 'package:soliplex_design/soliplex_design.dart';
 
 class NoResponseTileWidget extends StatelessWidget {
@@ -60,6 +61,7 @@ class NoResponseTileWidget extends StatelessWidget {
           reason: message.reason,
           errorDetail: message.errorDetail,
         ),
+        if (message.createdAt != null) MessageCaption(time: message.createdAt!),
       ],
     );
   }

--- a/lib/src/modules/room/ui/room_screen.dart
+++ b/lib/src/modules/room/ui/room_screen.dart
@@ -78,15 +78,25 @@ final _modifierKeys = <LogicalKeyboardKey>{
 
 /// Whether a key press should pull focus into the chat composer
 /// ("type to focus"). Only real typing does — never a bare modifier, and never
-/// while [shortcutModifierActive] (a copy/select command modifier) is held, so
-/// shortcuts like copy and select-all leave the transcript's [SelectionArea]
-/// selection intact instead of clearing it by moving focus.
+/// while a copy/select command modifier is held (meta, or control on its own),
+/// so shortcuts like copy and select-all leave the transcript's
+/// [SelectionArea] selection intact instead of clearing it by moving focus.
+///
+/// Control *combined with* alt is treated as typing, not a shortcut: Windows
+/// synthesizes AltGr as Ctrl+Alt to compose special characters (`@`, `€`, `{`,
+/// …), so those keystrokes must still focus-and-type. Plain Alt/Option is
+/// likewise typing. A genuine Ctrl+Alt shortcut is rare and — since this only
+/// moves focus without consuming the event — harmless if it also focuses.
 bool shouldFocusChatInputOnKey(
   KeyEvent event, {
-  required bool shortcutModifierActive,
+  required bool isMetaPressed,
+  required bool isControlPressed,
+  required bool isAltPressed,
 }) {
   if (event is! KeyDownEvent) return false;
   if (_modifierKeys.contains(event.logicalKey)) return false;
+  final shortcutModifierActive =
+      isMetaPressed || (isControlPressed && !isAltPressed);
   if (shortcutModifierActive) return false;
   return true;
 }
@@ -972,15 +982,11 @@ class _RoomScreenState extends State<RoomScreen> {
     if (_chatFocusNode.hasFocus) return false;
     if (ModalRoute.of(context)?.isCurrent != true) return false;
     final keyboard = HardwareKeyboard.instance;
-    // Meta/control are the copy/select-all shortcut modifiers whose keystrokes
-    // must not clear the transcript selection. Alt is excluded: AltGr
-    // (Windows/Linux) and Option (macOS) type special characters, so those
-    // keystrokes should still focus-and-type.
-    final shortcutModifierActive =
-        keyboard.isMetaPressed || keyboard.isControlPressed;
     if (!shouldFocusChatInputOnKey(
       event,
-      shortcutModifierActive: shortcutModifierActive,
+      isMetaPressed: keyboard.isMetaPressed,
+      isControlPressed: keyboard.isControlPressed,
+      isAltPressed: keyboard.isAltPressed,
     )) {
       return false;
     }

--- a/lib/src/modules/room/ui/room_screen.dart
+++ b/lib/src/modules/room/ui/room_screen.dart
@@ -61,6 +61,36 @@ import 'package:soliplex_design/soliplex_design.dart';
 final Logger _logger =
     LogManager.instance.getLogger('soliplex_frontend.room_screen');
 
+final _modifierKeys = <LogicalKeyboardKey>{
+  LogicalKeyboardKey.meta,
+  LogicalKeyboardKey.metaLeft,
+  LogicalKeyboardKey.metaRight,
+  LogicalKeyboardKey.control,
+  LogicalKeyboardKey.controlLeft,
+  LogicalKeyboardKey.controlRight,
+  LogicalKeyboardKey.alt,
+  LogicalKeyboardKey.altLeft,
+  LogicalKeyboardKey.altRight,
+  LogicalKeyboardKey.shift,
+  LogicalKeyboardKey.shiftLeft,
+  LogicalKeyboardKey.shiftRight,
+};
+
+/// Whether a key press should pull focus into the chat composer
+/// ("type to focus"). Only real typing does — never a bare modifier, and never
+/// while [shortcutModifierActive] (a copy/select command modifier) is held, so
+/// shortcuts like copy and select-all leave the transcript's [SelectionArea]
+/// selection intact instead of clearing it by moving focus.
+bool shouldFocusChatInputOnKey(
+  KeyEvent event, {
+  required bool shortcutModifierActive,
+}) {
+  if (event is! KeyDownEvent) return false;
+  if (_modifierKeys.contains(event.logicalKey)) return false;
+  if (shortcutModifierActive) return false;
+  return true;
+}
+
 const double _sidebarWidth = 300;
 
 /// Caps the conversation column (message timeline + chat input) so it stays
@@ -940,8 +970,20 @@ class _RoomScreenState extends State<RoomScreen> {
 
   bool _handleKey(KeyEvent event) {
     if (_chatFocusNode.hasFocus) return false;
-    if (event is! KeyDownEvent) return false;
     if (ModalRoute.of(context)?.isCurrent != true) return false;
+    final keyboard = HardwareKeyboard.instance;
+    // Meta/control are the copy/select-all shortcut modifiers whose keystrokes
+    // must not clear the transcript selection. Alt is excluded: AltGr
+    // (Windows/Linux) and Option (macOS) type special characters, so those
+    // keystrokes should still focus-and-type.
+    final shortcutModifierActive =
+        keyboard.isMetaPressed || keyboard.isControlPressed;
+    if (!shouldFocusChatInputOnKey(
+      event,
+      shortcutModifierActive: shortcutModifierActive,
+    )) {
+      return false;
+    }
     _chatFocusNode.requestFocus();
     return false;
   }

--- a/lib/src/modules/room/ui/text_message_tile.dart
+++ b/lib/src/modules/room/ui/text_message_tile.dart
@@ -167,13 +167,16 @@ class _MessageBubble extends StatelessWidget {
         ),
       ),
       child: isUser
-          ? SelectableText(
+          ? Text(
               message.text,
               style: TextStyle(color: theme.colorScheme.onPrimaryContainer),
             )
           : message.text.isEmpty
               ? const Text('...')
-              : FlutterMarkdownPlusRenderer(data: message.text),
+              : FlutterMarkdownPlusRenderer(
+                  data: message.text,
+                  selectable: false,
+                ),
     );
   }
 }

--- a/lib/src/modules/room/ui/text_message_tile.dart
+++ b/lib/src/modules/room/ui/text_message_tile.dart
@@ -169,7 +169,9 @@ class _MessageBubble extends StatelessWidget {
       child: isUser
           ? Text(
               message.text,
-              style: TextStyle(color: theme.colorScheme.onPrimaryContainer),
+              style: theme.textTheme.bodyMedium?.copyWith(
+                color: theme.colorScheme.onPrimaryContainer,
+              ),
             )
           : message.text.isEmpty
               ? const Text('...')

--- a/lib/src/modules/room/ui/text_message_tile.dart
+++ b/lib/src/modules/room/ui/text_message_tile.dart
@@ -10,6 +10,7 @@ import 'execution/static_thinking_block.dart';
 import 'execution/thinking_block.dart';
 import 'feedback_buttons.dart';
 import 'markdown/flutter_markdown_plus_renderer.dart';
+import 'message_caption.dart';
 import 'workdir_files_section.dart';
 import 'package:soliplex_design/soliplex_design.dart';
 
@@ -81,6 +82,7 @@ class TextMessageTile extends StatelessWidget {
         ),
         const SizedBox(height: SoliplexSpacing.s1),
         _MessageBubble(message: message),
+        if (message.createdAt != null) MessageCaption(time: message.createdAt!),
         const SizedBox(height: SoliplexSpacing.s2),
         Row(
           mainAxisSize: MainAxisSize.min,

--- a/lib/src/modules/room/ui/tool_call_tile.dart
+++ b/lib/src/modules/room/ui/tool_call_tile.dart
@@ -82,7 +82,7 @@ class _CodeBlock extends StatelessWidget {
             ),
           ),
           const SizedBox(height: SoliplexSpacing.s1),
-          SelectableText(
+          Text(
             text,
             style: context.monospaceOn(theme.textTheme.bodySmall),
           ),

--- a/packages/soliplex_agent/lib/src/orchestration/run_orchestrator.dart
+++ b/packages/soliplex_agent/lib/src/orchestration/run_orchestrator.dart
@@ -787,11 +787,12 @@ class RunOrchestrator {
     Map<String, dynamic>? stateOverlay,
   ) {
     final priorMessages = cachedHistory?.messages ?? <ChatMessage>[];
-    // No authoritative time exists at submit — the backend hasn't created the
-    // run yet — so the optimistic echo carries no timestamp (createdAt: null,
-    // the default). It fills from the run's server `created` on replay; the
-    // frontend never displays a client-generated time. now() here is only for a
-    // unique id.
+    // No authoritative time exists at submit — the run has no server time yet —
+    // so the optimistic echo starts without one (createdAt: null, the default).
+    // It is stamped with the run's server start time when RunStartedEvent
+    // arrives, and fills from the run's server `created` on replay. The
+    // frontend never displays a client-generated time. now() here is only for
+    // a unique id.
     final userMsg = TextMessage.create(
       id: 'user-${DateTime.now().microsecondsSinceEpoch}',
       user: ChatUser.user,
@@ -991,6 +992,22 @@ class RunOrchestrator {
           reason: FailureReason.serverError,
           error: event.message,
           conversation: withCitations,
+        ),
+      );
+      return;
+    }
+    if (event is RunStartedEvent) {
+      // Stamp the optimistic user echo with the run's server start time, so its
+      // caption matches the backend `created` a reload would resolve.
+      final userMessageId = _userMessageId;
+      final startTime = _lastEventTime;
+      final conversation = userMessageId != null && startTime != null
+          ? result.conversation.withMessageTime(userMessageId, startTime)
+          : result.conversation;
+      _setState(
+        previous.copyWith(
+          conversation: conversation,
+          streaming: result.streaming,
         ),
       );
       return;

--- a/packages/soliplex_agent/lib/src/orchestration/run_orchestrator.dart
+++ b/packages/soliplex_agent/lib/src/orchestration/run_orchestrator.dart
@@ -998,7 +998,8 @@ class RunOrchestrator {
     }
     if (event is RunStartedEvent) {
       // Stamp the optimistic user echo with the run's server start time, so its
-      // caption matches the backend `created` a reload would resolve.
+      // caption matches the time a reload resolves it to (the `RUN_STARTED`
+      // timestamp, falling back to run `created`).
       final userMessageId = _userMessageId;
       final startTime = _lastEventTime;
       final conversation = userMessageId != null && startTime != null

--- a/packages/soliplex_agent/test/orchestration/run_orchestrator_test.dart
+++ b/packages/soliplex_agent/test/orchestration/run_orchestrator_test.dart
@@ -186,6 +186,36 @@ void main() {
       verifyNever(() => api.createRun(any(), any()));
       expect(orchestrator.currentState, isA<CompletedState>());
     });
+
+    test('stamps the user message with the run-start server time', () async {
+      const startMs = 1782922475841;
+      stubCreateRun();
+      stubRunAgent(
+        stream: Stream.fromIterable([
+          const RunStartedEvent(
+            threadId: 'thread-1',
+            runId: _runId,
+            timestamp: startMs,
+          ),
+          const TextMessageStartEvent(messageId: 'msg-1'),
+          const TextMessageContentEvent(messageId: 'msg-1', delta: 'Hello'),
+          const TextMessageEndEvent(messageId: 'msg-1'),
+          const RunFinishedEvent(threadId: 'thread-1', runId: _runId),
+        ]),
+      );
+
+      await orchestrator.startRun(key: _key, userMessage: 'Hi');
+      await Future<void>.delayed(Duration.zero);
+
+      final completed = orchestrator.currentState as CompletedState;
+      final userMessage = completed.conversation.messages
+          .whereType<TextMessage>()
+          .firstWhere((m) => m.user == ChatUser.user);
+      expect(
+        userMessage.createdAt,
+        DateTime.fromMillisecondsSinceEpoch(startMs, isUtc: true),
+      );
+    });
   });
 
   group('error', () {

--- a/packages/soliplex_client/lib/src/api/soliplex_api.dart
+++ b/packages/soliplex_client/lib/src/api/soliplex_api.dart
@@ -1107,21 +1107,21 @@ class SoliplexApi {
   }
 
   /// Resolves a create response's server [created] to a UTC [DateTime],
-  /// degrading to the client clock when it is absent or malformed. Unlike
-  /// [_runCreated] (replay, which has no acceptable client fallback for a
-  /// historical run), a freshly created run/thread can safely stamp `now()`
-  /// rather than fail the create call.
+  /// degrading to the client clock ([DateTime.timestamp], also UTC) when it is
+  /// absent or malformed. Unlike [_runCreated] (replay, which has no acceptable
+  /// client fallback for a historical run), a freshly created run/thread can
+  /// safely stamp the current time rather than fail the create call.
   static DateTime _createdOrNow(dynamic created) {
     // Absent is the documented fallback; a present-but-wrong-shaped value is
     // contract drift worth a signal (same warn-on-wrong-shape as [_runCreated],
     // which differs only in resolving a bad value to null instead of `now()`).
-    if (created == null) return DateTime.now();
+    if (created == null) return DateTime.timestamp();
     if (created is! String) {
       _logger.warning(
         'create: non-string `created` (${created.runtimeType}); using the '
         'client clock.',
       );
-      return DateTime.now();
+      return DateTime.timestamp();
     }
     try {
       return parseTimestamp(created);
@@ -1130,7 +1130,7 @@ class SoliplexApi {
         'create: malformed `created` ($created); using the client clock.',
         error: error,
       );
-      return DateTime.now();
+      return DateTime.timestamp();
     } on Object catch (error, stackTrace) {
       // parseTimestamp is documented to throw only FormatException; anything
       // else is an unexpected contract break worth a louder signal, but still
@@ -1141,7 +1141,7 @@ class SoliplexApi {
         error: error,
         stackTrace: stackTrace,
       );
-      return DateTime.now();
+      return DateTime.timestamp();
     }
   }
 

--- a/packages/soliplex_client/lib/src/api/soliplex_api.dart
+++ b/packages/soliplex_client/lib/src/api/soliplex_api.dart
@@ -436,16 +436,14 @@ class SoliplexApi {
     final metadata = response['metadata'] as Map<String, dynamic>?;
     final threadName = metadata?['name'] as String? ?? name ?? '';
 
-    // Prefer the backend's server `created`; fall back to the client clock
-    // only if the response omits it.
-    final createdRaw = response['created'];
+    // Prefer the backend's server `created`; fall back to the client clock if
+    // the response omits it or the value is malformed.
     final threadInfo = ThreadInfo(
       id: response['thread_id'] as String,
       roomId: roomId,
       initialRunId: initialRunId ?? '',
       name: threadName,
-      createdAt:
-          createdRaw is String ? parseTimestamp(createdRaw) : DateTime.now(),
+      createdAt: _createdOrNow(response['created']),
     );
 
     return (threadInfo, aguiState);
@@ -550,14 +548,12 @@ class SoliplexApi {
     );
 
     // Normalize response: backend returns run_id, we use id. Prefer the
-    // backend's server `created`; fall back to the client clock only if the
-    // response omits it.
-    final createdRaw = response['created'];
+    // backend's server `created`; fall back to the client clock if the response
+    // omits it or the value is malformed.
     return RunInfo(
       id: response['run_id'] as String,
       threadId: threadId,
-      createdAt:
-          createdRaw is String ? parseTimestamp(createdRaw) : DateTime.now(),
+      createdAt: _createdOrNow(response['created']),
     );
   }
 
@@ -985,7 +981,15 @@ class SoliplexApi {
         if (eventJson['type'] != 'RUN_STARTED') continue;
         final ts = eventJson['timestamp'];
         if (ts is int) {
-          runStartedAt = DateTime.fromMillisecondsSinceEpoch(ts, isUtc: true);
+          try {
+            runStartedAt = DateTime.fromMillisecondsSinceEpoch(ts, isUtc: true);
+          } on Object catch (error) {
+            _logger.warning(
+              'replay: invalid RUN_STARTED timestamp ($ts) in run $runId of '
+              'thread $threadId; falling back to run.created (or none).',
+              error: error,
+            );
+          }
         }
         break;
       }
@@ -1094,6 +1098,44 @@ class SoliplexApi {
       messageStates: messageStates,
       runs: runs,
     );
+  }
+
+  /// Resolves a create response's server [created] to a UTC [DateTime],
+  /// degrading to the client clock when it is absent or malformed. Unlike
+  /// [_runCreated] (replay, which has no acceptable client fallback for a
+  /// historical run), a freshly created run/thread can safely stamp `now()`
+  /// rather than fail the create call.
+  static DateTime _createdOrNow(dynamic created) {
+    // Absent is the documented fallback; a present-but-wrong-shaped value is
+    // contract drift worth a signal (mirrors [_runCreated]).
+    if (created == null) return DateTime.now();
+    if (created is! String) {
+      _logger.warning(
+        'create: non-string `created` (${created.runtimeType}); using the '
+        'client clock.',
+      );
+      return DateTime.now();
+    }
+    try {
+      return parseTimestamp(created);
+    } on FormatException catch (error) {
+      _logger.warning(
+        'create: malformed `created` ($created); using the client clock.',
+        error: error,
+      );
+      return DateTime.now();
+    } on Object catch (error, stackTrace) {
+      // parseTimestamp is documented to throw only FormatException; anything
+      // else is an unexpected contract break worth a louder signal, but still
+      // must not fail the create call.
+      _logger.error(
+        'create: unexpected error parsing `created` ($created); using the '
+        'client clock.',
+        error: error,
+        stackTrace: stackTrace,
+      );
+      return DateTime.now();
+    }
   }
 
   /// Resolves a run map's `created` to a UTC [DateTime] via [parseTimestamp]

--- a/packages/soliplex_client/lib/src/api/soliplex_api.dart
+++ b/packages/soliplex_client/lib/src/api/soliplex_api.dart
@@ -974,7 +974,7 @@ class SoliplexApi {
       // The run-start event carries the server time the run began. Messages
       // without a timestamp of their own — chiefly the user message — resolve
       // to it, matching the live path; run.created is the fallback when the
-      // run-start event is absent or carries no timestamp.
+      // run-start event is absent or carries no usable timestamp.
       DateTime? runStartedAt;
       for (final eventJson in events) {
         if (eventJson is! Map<String, dynamic>) continue;
@@ -990,6 +990,12 @@ class SoliplexApi {
               error: error,
             );
           }
+        } else if (ts != null) {
+          _logger.warning(
+            'replay: non-int RUN_STARTED timestamp (${ts.runtimeType}) in run '
+            '$runId of thread $threadId; falling back to run.created '
+            '(or none).',
+          );
         }
         break;
       }
@@ -1107,7 +1113,8 @@ class SoliplexApi {
   /// rather than fail the create call.
   static DateTime _createdOrNow(dynamic created) {
     // Absent is the documented fallback; a present-but-wrong-shaped value is
-    // contract drift worth a signal (mirrors [_runCreated]).
+    // contract drift worth a signal (same warn-on-wrong-shape as [_runCreated],
+    // which differs only in resolving a bad value to null instead of `now()`).
     if (created == null) return DateTime.now();
     if (created is! String) {
       _logger.warning(

--- a/packages/soliplex_client/lib/src/api/soliplex_api.dart
+++ b/packages/soliplex_client/lib/src/api/soliplex_api.dart
@@ -436,12 +436,16 @@ class SoliplexApi {
     final metadata = response['metadata'] as Map<String, dynamic>?;
     final threadName = metadata?['name'] as String? ?? name ?? '';
 
+    // Prefer the backend's server `created`; fall back to the client clock
+    // only if the response omits it.
+    final createdRaw = response['created'];
     final threadInfo = ThreadInfo(
       id: response['thread_id'] as String,
       roomId: roomId,
       initialRunId: initialRunId ?? '',
       name: threadName,
-      createdAt: DateTime.now(),
+      createdAt:
+          createdRaw is String ? parseTimestamp(createdRaw) : DateTime.now(),
     );
 
     return (threadInfo, aguiState);
@@ -545,11 +549,15 @@ class SoliplexApi {
       cancelToken: cancelToken,
     );
 
-    // Normalize response: backend returns run_id, we use id
+    // Normalize response: backend returns run_id, we use id. Prefer the
+    // backend's server `created`; fall back to the client clock only if the
+    // response omits it.
+    final createdRaw = response['created'];
     return RunInfo(
       id: response['run_id'] as String,
       threadId: threadId,
-      createdAt: DateTime.now(),
+      createdAt:
+          createdRaw is String ? parseTimestamp(createdRaw) : DateTime.now(),
     );
   }
 
@@ -967,6 +975,22 @@ class SoliplexApi {
         }
       }
 
+      // The run-start event carries the server time the run began. Messages
+      // without a timestamp of their own — chiefly the user message — resolve
+      // to it, matching the live path; run.created is the fallback when the
+      // run-start event is absent or carries no timestamp.
+      DateTime? runStartedAt;
+      for (final eventJson in events) {
+        if (eventJson is! Map<String, dynamic>) continue;
+        if (eventJson['type'] != 'RUN_STARTED') continue;
+        final ts = eventJson['timestamp'];
+        if (ts is int) {
+          runStartedAt = DateTime.fromMillisecondsSinceEpoch(ts, isUtc: true);
+        }
+        break;
+      }
+      final fallbackCreated = runStartedAt ?? created;
+
       // Per-event try/catch so one bad event can't abort replay.
       final decodedEvents = <BaseEvent>[];
       for (var i = 0; i < events.length; i++) {
@@ -992,7 +1016,7 @@ class SoliplexApi {
               reason: error.toString(),
               runId: runId,
               rawPayload: rawPayload,
-              createdAt: created,
+              createdAt: fallbackCreated,
             ),
           );
         }
@@ -1032,7 +1056,7 @@ class SoliplexApi {
                 conversation,
                 streaming,
                 event,
-                runCreated: created,
+                runCreated: fallbackCreated,
               );
               conversation = result.conversation;
               streaming = result.streaming;

--- a/packages/soliplex_client/lib/src/domain/conversation.dart
+++ b/packages/soliplex_client/lib/src/domain/conversation.dart
@@ -200,6 +200,24 @@ class Conversation {
     return copyWith(messageStates: {...messageStates, userMessageId: state});
   }
 
+  /// Returns a copy with [messageId]'s `createdAt` set to [createdAt] when that
+  /// message is present and has no time yet. Stamps the optimistic user echo
+  /// with the run's server start time once it is known; a no-op if the message
+  /// already carries a time or is absent.
+  Conversation withMessageTime(String messageId, DateTime createdAt) {
+    return copyWith(
+      messages: [
+        for (final message in messages)
+          if (message is TextMessage &&
+              message.id == messageId &&
+              message.createdAt == null)
+            message.copyWith(createdAt: createdAt)
+          else
+            message,
+      ],
+    );
+  }
+
   /// Creates a copy with the given fields replaced.
   Conversation copyWith({
     String? threadId,

--- a/packages/soliplex_client/lib/src/domain/run_info.dart
+++ b/packages/soliplex_client/lib/src/domain/run_info.dart
@@ -76,7 +76,7 @@ class RunInfo {
   /// Label for the run (empty string if not provided).
   final String label;
 
-  /// When the run was created.
+  /// When the run was created, in UTC.
   final DateTime createdAt;
 
   /// Completion status of the run.

--- a/packages/soliplex_client/lib/src/domain/thread_info.dart
+++ b/packages/soliplex_client/lib/src/domain/thread_info.dart
@@ -30,7 +30,7 @@ class ThreadInfo {
   /// Description of the thread (empty string if not provided).
   final String description;
 
-  /// When the thread was created.
+  /// When the thread was created, in UTC.
   final DateTime createdAt;
 
   /// Most recent message turn (AG-UI run) in the thread, in UTC, or `null`

--- a/packages/soliplex_client/test/api/soliplex_api_test.dart
+++ b/packages/soliplex_client/test/api/soliplex_api_test.dart
@@ -1168,6 +1168,29 @@ void main() {
         expect(run.createdAt.isUtc, isTrue);
       });
 
+      test('absent created degrades to a UTC client clock', () async {
+        when(
+          () => mockTransport.request<Map<String, dynamic>>(
+            'POST',
+            any(),
+            cancelToken: any(named: 'cancelToken'),
+            fromJson: any(named: 'fromJson'),
+            body: any(named: 'body'),
+            headers: any(named: 'headers'),
+            timeout: any(named: 'timeout'),
+          ),
+        ).thenAnswer(
+          (_) async => {'run_id': 'new-run'},
+        );
+
+        // Absent `created` is the documented primary fallback: stamp the client
+        // clock rather than fail the create, and keep it UTC to match the
+        // backend-parsed path.
+        final run = await api.createRun('room-123', 'thread-456');
+        expect(run.id, equals('new-run'));
+        expect(run.createdAt.isUtc, isTrue);
+      });
+
       test('validates non-empty roomId', () {
         expect(
           () => api.createRun('', 'thread-123'),
@@ -1510,6 +1533,67 @@ void main() {
               // Beyond the DateTime epoch-ms range: the conversion throws and
               // must not abort the whole replay.
               'timestamp': 8640000000000001,
+            },
+            {
+              'type': 'TEXT_MESSAGE_START',
+              'messageId': 'user-1',
+              'role': 'user',
+            },
+            {
+              'type': 'TEXT_MESSAGE_CONTENT',
+              'messageId': 'user-1',
+              'delta': 'Hi',
+            },
+            {'type': 'TEXT_MESSAGE_END', 'messageId': 'user-1'},
+          ],
+        });
+
+        final history = await api.getThreadHistory('room-123', 'thread-456');
+        final userMessage =
+            history.messages.firstWhere((m) => m.id == 'user-1');
+
+        expect(
+          userMessage.createdAt!.isAtSameMomentAs(DateTime.utc(2026, 1, 7, 1)),
+          isTrue,
+        );
+      });
+
+      test('non-int RUN_STARTED timestamp falls back to run.created', () async {
+        void stubGet(String path, Map<String, dynamic> response) {
+          when(
+            () => mockTransport.request<Map<String, dynamic>>(
+              'GET',
+              Uri.parse('https://api.example.com/api/v1/$path'),
+              cancelToken: any(named: 'cancelToken'),
+              fromJson: any(named: 'fromJson'),
+              body: any(named: 'body'),
+              headers: any(named: 'headers'),
+              timeout: any(named: 'timeout'),
+            ),
+          ).thenAnswer((_) async => response);
+        }
+
+        stubGet('rooms/room-123/agui/thread-456', {
+          'room_id': 'room-123',
+          'thread_id': 'thread-456',
+          'runs': {
+            'run-1': {
+              'run_id': 'run-1',
+              'created': '2026-01-07T01:00:00.000Z',
+              'finished': '2026-01-07T01:01:00.000Z',
+            },
+          },
+        });
+        stubGet('rooms/room-123/agui/thread-456/run-1', {
+          'run_id': 'run-1',
+          'events': [
+            {
+              'type': 'RUN_STARTED',
+              'threadId': 'thread-456',
+              'runId': 'run-1',
+              // Wrong-typed timestamp: the parse is skipped and the user
+              // message falls back to run.created rather than aborting replay.
+              'timestamp': '2026-01-07T01:00:05.000Z',
             },
             {
               'type': 'TEXT_MESSAGE_START',

--- a/packages/soliplex_client/test/api/soliplex_api_test.dart
+++ b/packages/soliplex_client/test/api/soliplex_api_test.dart
@@ -757,6 +757,33 @@ void main() {
         );
       });
 
+      test('createdAt comes from the backend created field', () async {
+        when(
+          () => mockTransport.request<Map<String, dynamic>>(
+            'POST',
+            any(),
+            cancelToken: any(named: 'cancelToken'),
+            fromJson: any(named: 'fromJson'),
+            body: any(named: 'body'),
+            headers: any(named: 'headers'),
+            timeout: any(named: 'timeout'),
+          ),
+        ).thenAnswer(
+          (_) async => {
+            'thread_id': 'new-thread',
+            'created': '2026-01-07T01:00:00.000Z',
+            'runs': <String, dynamic>{},
+          },
+        );
+
+        final (thread, _) = await api.createThread('room-123');
+
+        expect(
+          thread.createdAt.isAtSameMomentAs(DateTime.utc(2026, 1, 7, 1)),
+          isTrue,
+        );
+      });
+
       test('returns empty state when runs have no run_input', () async {
         when(
           () => mockTransport.request<Map<String, dynamic>>(
@@ -1071,6 +1098,32 @@ void main() {
         expect(run.threadId, equals('thread-456'));
       });
 
+      test('createdAt comes from the backend created field', () async {
+        when(
+          () => mockTransport.request<Map<String, dynamic>>(
+            'POST',
+            any(),
+            cancelToken: any(named: 'cancelToken'),
+            fromJson: any(named: 'fromJson'),
+            body: any(named: 'body'),
+            headers: any(named: 'headers'),
+            timeout: any(named: 'timeout'),
+          ),
+        ).thenAnswer(
+          (_) async => {
+            'run_id': 'new-run',
+            'created': '2026-01-07T01:00:00.000Z',
+          },
+        );
+
+        final run = await api.createRun('room-123', 'thread-456');
+
+        expect(
+          run.createdAt.isAtSameMomentAs(DateTime.utc(2026, 1, 7, 1)),
+          isTrue,
+        );
+      });
+
       test('validates non-empty roomId', () {
         expect(
           () => api.createRun('', 'thread-123'),
@@ -1312,6 +1365,68 @@ void main() {
         expect(byId['msg-3']!.createdAt, isNull);
         // Malformed run created → null, and the run still replayed.
         expect(byId['msg-4']!.createdAt, isNull);
+      });
+
+      test('user message resolves to RUN_STARTED timestamp over run.created',
+          () async {
+        // RUN_STARTED fires just after the run row is created, so its server
+        // timestamp differs from run.created; the user message (no timestamp of
+        // its own) should take the RUN_STARTED time, matching the live path.
+        final runStart = DateTime.utc(2026, 1, 7, 1, 0, 5);
+
+        void stubGet(String path, Map<String, dynamic> response) {
+          when(
+            () => mockTransport.request<Map<String, dynamic>>(
+              'GET',
+              Uri.parse('https://api.example.com/api/v1/$path'),
+              cancelToken: any(named: 'cancelToken'),
+              fromJson: any(named: 'fromJson'),
+              body: any(named: 'body'),
+              headers: any(named: 'headers'),
+              timeout: any(named: 'timeout'),
+            ),
+          ).thenAnswer((_) async => response);
+        }
+
+        stubGet('rooms/room-123/agui/thread-456', {
+          'room_id': 'room-123',
+          'thread_id': 'thread-456',
+          'runs': {
+            'run-1': {
+              'run_id': 'run-1',
+              'created': '2026-01-07T01:00:00.000Z',
+              'finished': '2026-01-07T01:01:00.000Z',
+            },
+          },
+        });
+        stubGet('rooms/room-123/agui/thread-456/run-1', {
+          'run_id': 'run-1',
+          'events': [
+            {
+              'type': 'RUN_STARTED',
+              'threadId': 'thread-456',
+              'runId': 'run-1',
+              'timestamp': runStart.millisecondsSinceEpoch,
+            },
+            {
+              'type': 'TEXT_MESSAGE_START',
+              'messageId': 'user-1',
+              'role': 'user',
+            },
+            {
+              'type': 'TEXT_MESSAGE_CONTENT',
+              'messageId': 'user-1',
+              'delta': 'Hi',
+            },
+            {'type': 'TEXT_MESSAGE_END', 'messageId': 'user-1'},
+          ],
+        });
+
+        final history = await api.getThreadHistory('room-123', 'thread-456');
+        final userMessage =
+            history.messages.firstWhere((m) => m.id == 'user-1');
+
+        expect(userMessage.createdAt!.isAtSameMomentAs(runStart), isTrue);
       });
 
       test('fetches multiple runs in parallel and orders by creation time',

--- a/packages/soliplex_client/test/api/soliplex_api_test.dart
+++ b/packages/soliplex_client/test/api/soliplex_api_test.dart
@@ -1124,6 +1124,27 @@ void main() {
         );
       });
 
+      test('malformed created does not abort the run creation', () async {
+        when(
+          () => mockTransport.request<Map<String, dynamic>>(
+            'POST',
+            any(),
+            cancelToken: any(named: 'cancelToken'),
+            fromJson: any(named: 'fromJson'),
+            body: any(named: 'body'),
+            headers: any(named: 'headers'),
+            timeout: any(named: 'timeout'),
+          ),
+        ).thenAnswer(
+          (_) async => {'run_id': 'new-run', 'created': 'not-a-date'},
+        );
+
+        // A malformed timestamp must degrade to the client clock, not throw
+        // out of the send path.
+        final run = await api.createRun('room-123', 'thread-456');
+        expect(run.id, equals('new-run'));
+      });
+
       test('validates non-empty roomId', () {
         expect(
           () => api.createRun('', 'thread-123'),
@@ -1427,6 +1448,68 @@ void main() {
             history.messages.firstWhere((m) => m.id == 'user-1');
 
         expect(userMessage.createdAt!.isAtSameMomentAs(runStart), isTrue);
+      });
+
+      test('out-of-range RUN_STARTED timestamp falls back to run.created',
+          () async {
+        void stubGet(String path, Map<String, dynamic> response) {
+          when(
+            () => mockTransport.request<Map<String, dynamic>>(
+              'GET',
+              Uri.parse('https://api.example.com/api/v1/$path'),
+              cancelToken: any(named: 'cancelToken'),
+              fromJson: any(named: 'fromJson'),
+              body: any(named: 'body'),
+              headers: any(named: 'headers'),
+              timeout: any(named: 'timeout'),
+            ),
+          ).thenAnswer((_) async => response);
+        }
+
+        stubGet('rooms/room-123/agui/thread-456', {
+          'room_id': 'room-123',
+          'thread_id': 'thread-456',
+          'runs': {
+            'run-1': {
+              'run_id': 'run-1',
+              'created': '2026-01-07T01:00:00.000Z',
+              'finished': '2026-01-07T01:01:00.000Z',
+            },
+          },
+        });
+        stubGet('rooms/room-123/agui/thread-456/run-1', {
+          'run_id': 'run-1',
+          'events': [
+            {
+              'type': 'RUN_STARTED',
+              'threadId': 'thread-456',
+              'runId': 'run-1',
+              // Beyond the DateTime epoch-ms range: the conversion throws and
+              // must not abort the whole replay.
+              'timestamp': 8640000000000001,
+            },
+            {
+              'type': 'TEXT_MESSAGE_START',
+              'messageId': 'user-1',
+              'role': 'user',
+            },
+            {
+              'type': 'TEXT_MESSAGE_CONTENT',
+              'messageId': 'user-1',
+              'delta': 'Hi',
+            },
+            {'type': 'TEXT_MESSAGE_END', 'messageId': 'user-1'},
+          ],
+        });
+
+        final history = await api.getThreadHistory('room-123', 'thread-456');
+        final userMessage =
+            history.messages.firstWhere((m) => m.id == 'user-1');
+
+        expect(
+          userMessage.createdAt!.isAtSameMomentAs(DateTime.utc(2026, 1, 7, 1)),
+          isTrue,
+        );
       });
 
       test('fetches multiple runs in parallel and orders by creation time',

--- a/packages/soliplex_client/test/api/soliplex_api_test.dart
+++ b/packages/soliplex_client/test/api/soliplex_api_test.dart
@@ -1143,6 +1143,29 @@ void main() {
         // out of the send path.
         final run = await api.createRun('room-123', 'thread-456');
         expect(run.id, equals('new-run'));
+        // The client-clock fallback stays UTC, matching the backend-parsed
+        // path so the field's zone is uniform however it was resolved.
+        expect(run.createdAt.isUtc, isTrue);
+      });
+
+      test('non-string created degrades to a UTC client clock', () async {
+        when(
+          () => mockTransport.request<Map<String, dynamic>>(
+            'POST',
+            any(),
+            cancelToken: any(named: 'cancelToken'),
+            fromJson: any(named: 'fromJson'),
+            body: any(named: 'body'),
+            headers: any(named: 'headers'),
+            timeout: any(named: 'timeout'),
+          ),
+        ).thenAnswer(
+          (_) async => {'run_id': 'new-run', 'created': 42},
+        );
+
+        final run = await api.createRun('room-123', 'thread-456');
+        expect(run.id, equals('new-run'));
+        expect(run.createdAt.isUtc, isTrue);
       });
 
       test('validates non-empty roomId', () {

--- a/packages/soliplex_client/test/domain/conversation_test.dart
+++ b/packages/soliplex_client/test/domain/conversation_test.dart
@@ -53,6 +53,45 @@ void main() {
       });
     });
 
+    group('withMessageTime', () {
+      test('sets createdAt on a matching message that has none', () {
+        final time = DateTime.utc(2026, 1, 2, 3, 4);
+        final base = conversation.withAppendedMessage(
+          TextMessage.create(id: 'u1', user: ChatUser.user, text: 'Hi'),
+        );
+
+        final updated = base.withMessageTime('u1', time);
+
+        expect(updated.messages.single.createdAt, time);
+      });
+
+      test('leaves a message that already has a time unchanged', () {
+        final existing = DateTime.utc(2026);
+        final base = conversation.withAppendedMessage(
+          TextMessage.create(
+            id: 'u1',
+            user: ChatUser.user,
+            text: 'Hi',
+            createdAt: existing,
+          ),
+        );
+
+        final updated = base.withMessageTime('u1', DateTime.utc(2027));
+
+        expect(updated.messages.single.createdAt, existing);
+      });
+
+      test('leaves other messages untouched when the id does not match', () {
+        final base = conversation.withAppendedMessage(
+          TextMessage.create(id: 'u1', user: ChatUser.user, text: 'Hi'),
+        );
+
+        final updated = base.withMessageTime('missing', DateTime.utc(2026));
+
+        expect(updated.messages.single.createdAt, isNull);
+      });
+    });
+
     group('withToolCall', () {
       test('adds tool call to empty list', () {
         const toolCall = ToolCallInfo(id: 'tool-1', name: 'search');

--- a/test/modules/room/compute_display_messages_test.dart
+++ b/test/modules/room/compute_display_messages_test.dart
@@ -91,6 +91,21 @@ void main() {
     expect((result.last as TextMessage).text, 'Response');
   });
 
+  test('streaming message carries no client-clock createdAt', () {
+    final result = computeDisplayMessages(
+      const [],
+      const TextStreaming(
+        messageId: 'msg-1',
+        user: ChatUser.assistant,
+        text: 'Response',
+      ),
+    );
+
+    // No server time exists mid-stream; the caption fills when the message
+    // commits with the backend's event time, not a client clock.
+    expect((result.single as TextMessage).createdAt, isNull);
+  });
+
   test('preserves thinkingText from streaming state', () {
     final result = computeDisplayMessages(
       const [],

--- a/test/modules/room/message_timestamp_format_test.dart
+++ b/test/modules/room/message_timestamp_format_test.dart
@@ -1,0 +1,111 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:soliplex_frontend/src/modules/room/message_timestamp_format.dart';
+
+void main() {
+  // Sunday 2026-03-15, noon, local. March avoids any DST transition.
+  final now = DateTime(2026, 3, 15, 12);
+
+  group('formatMessageCaption', () {
+    test('today shows time only', () {
+      expect(
+        formatMessageCaption(DateTime(2026, 3, 15, 14, 14), now: now),
+        '2:14 PM',
+      );
+    });
+
+    test('yesterday is day-qualified', () {
+      expect(
+        formatMessageCaption(DateTime(2026, 3, 14, 16, 12), now: now),
+        'Yesterday · 4:12 PM',
+      );
+    });
+
+    test('2–6 days ago uses the abbreviated weekday', () {
+      // 2026-03-12 is a Thursday, 3 days before Sunday the 15th.
+      expect(
+        formatMessageCaption(DateTime(2026, 3, 12, 9, 3), now: now),
+        'Thu · 9:03 AM',
+      );
+    });
+
+    test('earlier this year uses abbreviated month + day', () {
+      expect(
+        formatMessageCaption(DateTime(2026, 1, 5, 9, 3), now: now),
+        'Jan 5 · 9:03 AM',
+      );
+    });
+
+    test('older (prior year) includes the year', () {
+      expect(
+        formatMessageCaption(DateTime(2025, 3, 3, 9, 3), now: now),
+        'Mar 3, 2025 · 9:03 AM',
+      );
+    });
+  });
+
+  group('formatMessageCaption clock + boundary edges', () {
+    test('midnight is 12 AM, noon is 12 PM, minutes zero-padded', () {
+      expect(
+        formatMessageCaption(DateTime(2026, 3, 15, 0, 5), now: now),
+        '12:05 AM',
+      );
+      expect(
+        formatMessageCaption(DateTime(2026, 3, 15, 12), now: now),
+        '12:00 PM',
+      );
+      expect(
+        formatMessageCaption(DateTime(2026, 3, 15, 23, 59), now: now),
+        '11:59 PM',
+      );
+    });
+
+    test('day 6 is the weekday bucket, day 7 falls through to the date', () {
+      // 2026-03-09 (Mon) is 6 days before Sunday the 15th → weekday.
+      // 2026-03-08 (Sun) is 7 days ago → same weekday as today, so it shows
+      // the date instead of "Sun".
+      expect(
+        formatMessageCaption(DateTime(2026, 3, 9, 9, 3), now: now),
+        'Mon · 9:03 AM',
+      );
+      expect(
+        formatMessageCaption(DateTime(2026, 3, 8, 9, 3), now: now),
+        'Mar 8 · 9:03 AM',
+      );
+    });
+  });
+
+  group('formatDayDivider', () {
+    test('today / yesterday are relative words', () {
+      expect(formatDayDivider(DateTime(2026, 3, 15, 9), now: now), 'Today');
+      expect(formatDayDivider(DateTime(2026, 3, 14, 9), now: now), 'Yesterday');
+    });
+
+    test('2–6 days ago is full weekday + date', () {
+      expect(
+        formatDayDivider(DateTime(2026, 3, 12, 9), now: now),
+        'Thursday, March 12',
+      );
+    });
+
+    test('this year is full month + day; older includes the year', () {
+      expect(formatDayDivider(DateTime(2026, 1, 5, 9), now: now), 'January 5');
+      expect(
+        formatDayDivider(DateTime(2025, 3, 3, 9), now: now),
+        'March 3, 2025',
+      );
+    });
+  });
+
+  group('isSameCalendarDay', () {
+    test('true within a local calendar day, false across midnight', () {
+      expect(
+        isSameCalendarDay(DateTime(2026, 3, 15, 1), DateTime(2026, 3, 15, 23)),
+        isTrue,
+      );
+      expect(
+        isSameCalendarDay(DateTime(2026, 3, 15, 23), DateTime(2026, 3, 16, 1)),
+        isFalse,
+      );
+    });
+  });
+}

--- a/test/modules/room/message_timestamp_format_test.dart
+++ b/test/modules/room/message_timestamp_format_test.dart
@@ -59,6 +59,18 @@ void main() {
       );
     });
 
+    test('buckets by calendar day, not elapsed hours, across midnight', () {
+      // 1h05m apart but a calendar day apart: a naive now.difference(t).inDays
+      // reads 0 (today); the UTC-floored day math reads 1 (yesterday).
+      expect(
+        formatMessageCaption(
+          DateTime(2026, 3, 14, 23, 30),
+          now: DateTime(2026, 3, 15, 0, 35),
+        ),
+        'Yesterday · 11:30 PM',
+      );
+    });
+
     test('day 6 is the weekday bucket, day 7 falls through to the date', () {
       // 2026-03-09 (Mon) is 6 days before Sunday the 15th → weekday.
       // 2026-03-08 (Sun) is 7 days ago → same weekday as today, so it shows

--- a/test/modules/room/ui/citations_section_test.dart
+++ b/test/modules/room/ui/citations_section_test.dart
@@ -3,6 +3,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:soliplex_agent/soliplex_agent.dart' hide State;
 
 import 'package:soliplex_frontend/src/modules/room/ui/citations_section.dart';
+import 'package:soliplex_frontend/src/modules/room/ui/markdown/flutter_markdown_plus_renderer.dart';
 
 SourceReference _ref({
   required int index,
@@ -26,6 +27,38 @@ SourceReference _ref({
 Widget _wrap(Widget child) => MaterialApp(home: Scaffold(body: child));
 
 void main() {
+  testWidgets(
+      'expanded citation content renders non-selectable inside a SelectionArea',
+      (tester) async {
+    // Gate: a self-selecting (selectable:true) markdown nested in a
+    // SelectionArea throws; this proves the citation content renders
+    // selectable:false and so coexists with the surrounding area.
+    await tester.pumpWidget(MaterialApp(
+      home: Scaffold(
+        body: SelectionArea(
+          child: SingleChildScrollView(
+            child: CitationsSection(
+              sourceReferences: [
+                _ref(index: 1, title: 'Alpha', content: 'cited body'),
+              ],
+            ),
+          ),
+        ),
+      ),
+    ));
+
+    await tester.tap(find.text('1 source'));
+    await tester.pump();
+    await tester.tap(find.text('Alpha'));
+    await tester.pump();
+
+    expect(tester.takeException(), isNull);
+    final md = tester.widget<FlutterMarkdownPlusRenderer>(
+      find.byType(FlutterMarkdownPlusRenderer),
+    );
+    expect(md.selectable, isFalse);
+  });
+
   testWidgets('header shows source count', (tester) async {
     await tester.pumpWidget(_wrap(
       CitationsSection(sourceReferences: [_ref(index: 1), _ref(index: 2)]),

--- a/test/modules/room/ui/citations_section_test.dart
+++ b/test/modules/room/ui/citations_section_test.dart
@@ -30,9 +30,10 @@ void main() {
   testWidgets(
       'expanded citation content renders non-selectable inside a SelectionArea',
       (tester) async {
-    // Gate: a self-selecting (selectable:true) markdown nested in a
-    // SelectionArea throws; this proves the citation content renders
-    // selectable:false and so coexists with the surrounding area.
+    // A self-selecting (selectable:true) markdown nested in a SelectionArea
+    // captures the drag gesture itself and drops out of the transcript-wide
+    // selection; this proves the citation content renders selectable:false and
+    // so joins the surrounding area's selection.
     await tester.pumpWidget(MaterialApp(
       home: Scaffold(
         body: SelectionArea(

--- a/test/modules/room/ui/dropped_event_message_tile_test.dart
+++ b/test/modules/room/ui/dropped_event_message_tile_test.dart
@@ -126,4 +126,32 @@ void main() {
     // Belt-and-suspenders: not the unavailable fallback.
     expect(find.text('(payload unavailable)'), findsNothing);
   });
+
+  testWidgets('expanded JSON payload is non-selectable inside a SelectionArea',
+      (tester) async {
+    // The tile renders in the transcript's SelectionArea; a self-selecting
+    // JSON tree would capture the drag and drop out of the transcript-wide
+    // selection, so the tree must render its text non-selectable.
+    final msg = DroppedEventMessage.create(
+      id: 'dropped-run-1-3',
+      source: DropSource.decode,
+      reason: 'unknown event type',
+      runId: 'run-1',
+      rawPayload: const {'type': 'WIDGET', 'foo': 'bar'},
+    );
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: SelectionArea(child: DroppedEventMessageTile(message: msg)),
+        ),
+      ),
+    );
+    await tester.tap(find.byType(InkWell).first);
+    await tester.pump();
+
+    expect(tester.takeException(), isNull);
+    expect(find.textContaining('foo'), findsWidgets);
+    expect(find.byType(SelectableText), findsNothing);
+  });
 }

--- a/test/modules/room/ui/error_message_tile_test.dart
+++ b/test/modules/room/ui/error_message_tile_test.dart
@@ -4,6 +4,7 @@ import 'package:soliplex_agent/soliplex_agent.dart';
 
 import 'package:soliplex_frontend/src/modules/room/ui/copy_button.dart';
 import 'package:soliplex_frontend/src/modules/room/ui/error_message_tile.dart';
+import 'package:soliplex_frontend/src/modules/room/ui/message_caption.dart';
 
 void main() {
   testWidgets('shows copy button', (tester) async {
@@ -22,5 +23,24 @@ void main() {
     );
 
     expect(find.byType(CopyButton), findsOneWidget);
+  });
+
+  testWidgets('shows a timestamp caption', (tester) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: ErrorMessageTile(
+            message: ErrorMessage(
+              id: 'e1',
+              createdAt: DateTime(2020, 3, 3, 9, 3),
+              errorText: 'Boom',
+            ),
+          ),
+        ),
+      ),
+    );
+
+    expect(find.byType(MessageCaption), findsOneWidget);
+    expect(find.text('Mar 3, 2020 · 9:03 AM'), findsOneWidget);
   });
 }

--- a/test/modules/room/ui/markdown/markdown_selection_test.dart
+++ b/test/modules/room/ui/markdown/markdown_selection_test.dart
@@ -19,13 +19,4 @@ void main() {
     expect(tester.takeException(), isNull);
     expect(find.byType(FlutterMarkdownPlusRenderer), findsOneWidget);
   });
-
-  testWidgets('plain SelectableText inside a SelectionArea', (tester) async {
-    await tester.pumpWidget(MaterialApp(
-      home: Scaffold(body: SelectionArea(child: SelectableText('hello'))),
-    ));
-    await tester.pump();
-
-    expect(tester.takeException(), isNull);
-  });
 }

--- a/test/modules/room/ui/markdown/markdown_selection_test.dart
+++ b/test/modules/room/ui/markdown/markdown_selection_test.dart
@@ -1,0 +1,31 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:soliplex_frontend/src/modules/room/ui/markdown/flutter_markdown_plus_renderer.dart';
+
+Widget _inArea(Widget child) =>
+    MaterialApp(home: Scaffold(body: SelectionArea(child: child)));
+
+void main() {
+  testWidgets('selectable:false markdown renders inside a SelectionArea',
+      (tester) async {
+    await tester.pumpWidget(_inArea(
+      const FlutterMarkdownPlusRenderer(
+        data: '# Hi\n\nbody text',
+        selectable: false,
+      ),
+    ));
+    await tester.pump();
+
+    expect(tester.takeException(), isNull);
+    expect(find.byType(FlutterMarkdownPlusRenderer), findsOneWidget);
+  });
+
+  testWidgets('plain SelectableText inside a SelectionArea', (tester) async {
+    await tester.pumpWidget(MaterialApp(
+      home: Scaffold(body: SelectionArea(child: SelectableText('hello'))),
+    ));
+    await tester.pump();
+
+    expect(tester.takeException(), isNull);
+  });
+}

--- a/test/modules/room/ui/message_timeline_day_divider_test.dart
+++ b/test/modules/room/ui/message_timeline_day_divider_test.dart
@@ -12,6 +12,13 @@ TextMessage _msg(String id, DateTime createdAt) => TextMessage(
       text: 'body-$id',
     );
 
+TextMessage _pending(String id) => TextMessage(
+      id: id,
+      user: ChatUser.user,
+      createdAt: null,
+      text: 'body-$id',
+    );
+
 Widget _harness(List<ChatMessage> messages) => MaterialApp(
       home: Scaffold(
         body: MessageTimeline(
@@ -46,6 +53,21 @@ void main() {
     ]));
     await tester.pump();
 
+    expect(find.byType(DayDivider), findsOneWidget);
+  });
+
+  testWidgets('a pending message (null createdAt) groups under today',
+      (tester) async {
+    // The in-flight user echo carries no time until RUN_STARTED; it must not
+    // crash the day grouping and falls under today's group alongside a message
+    // already stamped today.
+    await tester.pumpWidget(_harness([
+      _msg('a', DateTime.now()),
+      _pending('b'),
+    ]));
+    await tester.pump();
+
+    expect(tester.takeException(), isNull);
     expect(find.byType(DayDivider), findsOneWidget);
   });
 }

--- a/test/modules/room/ui/message_timeline_day_divider_test.dart
+++ b/test/modules/room/ui/message_timeline_day_divider_test.dart
@@ -1,0 +1,51 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:soliplex_agent/soliplex_agent.dart';
+import 'package:soliplex_frontend/src/modules/room/ui/day_divider.dart';
+import 'package:soliplex_frontend/src/modules/room/ui/message_timeline.dart';
+import 'package:soliplex_frontend/src/modules/room/unread_boundary.dart';
+
+TextMessage _msg(String id, DateTime createdAt) => TextMessage(
+      id: id,
+      user: ChatUser.assistant,
+      createdAt: createdAt,
+      text: 'body-$id',
+    );
+
+Widget _harness(List<ChatMessage> messages) => MaterialApp(
+      home: Scaffold(
+        body: MessageTimeline(
+          roomId: 'room-1',
+          messages: messages,
+          messageStates: const {},
+          unreadBoundary: const BoundaryResolved(null),
+        ),
+      ),
+    );
+
+void main() {
+  testWidgets('a divider marks each calendar-day group (first + boundaries)',
+      (tester) async {
+    // Two messages on different days → a divider above the first, and one
+    // before the second where the day changes.
+    await tester.pumpWidget(_harness([
+      _msg('a', DateTime(2020, 3, 3, 9)),
+      _msg('b', DateTime(2020, 3, 4, 9)),
+    ]));
+    await tester.pump();
+
+    expect(find.byType(DayDivider), findsNWidgets(2));
+  });
+
+  testWidgets('no divider between two messages on the same calendar day',
+      (tester) async {
+    // Same day → only the leading divider above the first message.
+    await tester.pumpWidget(_harness([
+      _msg('a', DateTime(2020, 3, 3, 9)),
+      _msg('b', DateTime(2020, 3, 3, 15)),
+    ]));
+    await tester.pump();
+
+    expect(find.byType(DayDivider), findsOneWidget);
+  });
+}

--- a/test/modules/room/ui/no_response_tile_widget_test.dart
+++ b/test/modules/room/ui/no_response_tile_widget_test.dart
@@ -5,6 +5,7 @@ import 'package:soliplex_agent/soliplex_agent.dart';
 
 import 'package:soliplex_frontend/src/modules/room/message_expansions.dart';
 import 'package:soliplex_frontend/src/modules/room/room_providers.dart';
+import 'package:soliplex_frontend/src/modules/room/ui/message_caption.dart';
 import 'package:soliplex_frontend/src/modules/room/ui/no_response_tile_widget.dart';
 
 Widget _wrap(Widget child, {MessageExpansions? store}) => ProviderScope(
@@ -40,6 +41,22 @@ NoResponseTile _tile({
     };
 
 void main() {
+  testWidgets('shows a timestamp caption', (tester) async {
+    await tester.pumpWidget(_wrap(
+      NoResponseTileWidget(
+        roomId: 'r',
+        message: NoResponseTile.finished(
+          id: 'nr1',
+          createdAt: DateTime(2020, 3, 3, 9, 3),
+          thinkingText: 'thinking',
+        ),
+      ),
+    ));
+
+    expect(find.byType(MessageCaption), findsOneWidget);
+    expect(find.text('Mar 3, 2020 · 9:03 AM'), findsOneWidget);
+  });
+
   testWidgets('finished renders the info icon', (tester) async {
     await tester.pumpWidget(_wrap(
       NoResponseTileWidget(

--- a/test/modules/room/ui/room_screen_test.dart
+++ b/test/modules/room/ui/room_screen_test.dart
@@ -1,9 +1,9 @@
 import 'dart:async';
 import 'dart:convert';
-import 'dart:typed_data';
 
 import 'package:clock/clock.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:go_router/go_router.dart';
 import 'package:shared_preferences/shared_preferences.dart';
@@ -122,6 +122,73 @@ Widget _buildRouted({
 }
 
 void main() {
+  group('shouldFocusChatInputOnKey', () {
+    KeyDownEvent down(LogicalKeyboardKey key) => KeyDownEvent(
+          physicalKey: PhysicalKeyboardKey.keyA,
+          logicalKey: key,
+          timeStamp: Duration.zero,
+        );
+
+    test('a typed character pulls focus to the composer', () {
+      expect(
+        shouldFocusChatInputOnKey(
+          down(LogicalKeyboardKey.keyA),
+          shortcutModifierActive: false,
+        ),
+        isTrue,
+      );
+    });
+
+    test('a bare shift press does not steal focus', () {
+      // Shift is a modifier key, so pressing it alone is not typing — even
+      // though it is not a command modifier (Shift+letter still types, covered
+      // by the plain-character case above via shortcutModifierActive: false).
+      expect(
+        shouldFocusChatInputOnKey(
+          down(LogicalKeyboardKey.shiftLeft),
+          shortcutModifierActive: false,
+        ),
+        isFalse,
+      );
+    });
+
+    test('a character with a command modifier held does not steal focus', () {
+      // e.g. Cmd+C / Cmd+A — must leave the transcript selection intact.
+      expect(
+        shouldFocusChatInputOnKey(
+          down(LogicalKeyboardKey.keyC),
+          shortcutModifierActive: true,
+        ),
+        isFalse,
+      );
+    });
+
+    test('a bare modifier key does not steal focus', () {
+      // Pressing Cmd alone (before C) must not clear the selection.
+      expect(
+        shouldFocusChatInputOnKey(
+          down(LogicalKeyboardKey.metaLeft),
+          shortcutModifierActive: false,
+        ),
+        isFalse,
+      );
+    });
+
+    test('a key-up event does not steal focus', () {
+      expect(
+        shouldFocusChatInputOnKey(
+          KeyUpEvent(
+            physicalKey: PhysicalKeyboardKey.keyA,
+            logicalKey: LogicalKeyboardKey.keyA,
+            timeStamp: Duration.zero,
+          ),
+          shortcutModifierActive: false,
+        ),
+        isFalse,
+      );
+    });
+  });
+
   late FakeSoliplexApi api;
   late ServerEntry entry;
   late AgentRuntimeManager runtimeManager;

--- a/test/modules/room/ui/room_screen_test.dart
+++ b/test/modules/room/ui/room_screen_test.dart
@@ -129,60 +129,68 @@ void main() {
           timeStamp: Duration.zero,
         );
 
-    test('a typed character pulls focus to the composer', () {
-      expect(
+    bool shouldFocus(
+      KeyEvent event, {
+      bool meta = false,
+      bool control = false,
+      bool alt = false,
+    }) =>
         shouldFocusChatInputOnKey(
-          down(LogicalKeyboardKey.keyA),
-          shortcutModifierActive: false,
-        ),
-        isTrue,
-      );
+          event,
+          isMetaPressed: meta,
+          isControlPressed: control,
+          isAltPressed: alt,
+        );
+
+    test('a typed character pulls focus to the composer', () {
+      expect(shouldFocus(down(LogicalKeyboardKey.keyA)), isTrue);
     });
 
     test('a bare shift press does not steal focus', () {
       // Shift is a modifier key, so pressing it alone is not typing — even
       // though it is not a command modifier (Shift+letter still types, covered
-      // by the plain-character case above via shortcutModifierActive: false).
+      // by the plain-character case above).
+      expect(shouldFocus(down(LogicalKeyboardKey.shiftLeft)), isFalse);
+    });
+
+    test('a character with meta held does not steal focus', () {
+      // e.g. Cmd+C / Cmd+A — must leave the transcript selection intact.
+      expect(shouldFocus(down(LogicalKeyboardKey.keyC), meta: true), isFalse);
+    });
+
+    test('a character with control alone held does not steal focus', () {
+      // e.g. Ctrl+C / Ctrl+A on Windows/Linux — must leave the selection.
       expect(
-        shouldFocusChatInputOnKey(
-          down(LogicalKeyboardKey.shiftLeft),
-          shortcutModifierActive: false,
-        ),
-        isFalse,
+          shouldFocus(down(LogicalKeyboardKey.keyC), control: true), isFalse);
+    });
+
+    test('an AltGr (control+alt) character focuses the composer', () {
+      // Windows synthesizes AltGr as Ctrl+Alt to compose special characters;
+      // that composed keystroke must still focus-and-type, not read as a
+      // shortcut.
+      expect(
+        shouldFocus(down(LogicalKeyboardKey.keyQ), control: true, alt: true),
+        isTrue,
       );
     });
 
-    test('a character with a command modifier held does not steal focus', () {
-      // e.g. Cmd+C / Cmd+A — must leave the transcript selection intact.
-      expect(
-        shouldFocusChatInputOnKey(
-          down(LogicalKeyboardKey.keyC),
-          shortcutModifierActive: true,
-        ),
-        isFalse,
-      );
+    test('a plain alt/option character focuses the composer', () {
+      expect(shouldFocus(down(LogicalKeyboardKey.keyE), alt: true), isTrue);
     });
 
     test('a bare modifier key does not steal focus', () {
       // Pressing Cmd alone (before C) must not clear the selection.
-      expect(
-        shouldFocusChatInputOnKey(
-          down(LogicalKeyboardKey.metaLeft),
-          shortcutModifierActive: false,
-        ),
-        isFalse,
-      );
+      expect(shouldFocus(down(LogicalKeyboardKey.metaLeft)), isFalse);
     });
 
     test('a key-up event does not steal focus', () {
       expect(
-        shouldFocusChatInputOnKey(
+        shouldFocus(
           KeyUpEvent(
             physicalKey: PhysicalKeyboardKey.keyA,
             logicalKey: LogicalKeyboardKey.keyA,
             timeStamp: Duration.zero,
           ),
-          shortcutModifierActive: false,
         ),
         isFalse,
       );

--- a/test/modules/room/ui/text_message_tile_test.dart
+++ b/test/modules/room/ui/text_message_tile_test.dart
@@ -7,6 +7,7 @@ import 'package:soliplex_frontend/src/modules/room/message_expansions.dart';
 import 'package:soliplex_frontend/src/modules/room/room_providers.dart';
 import 'package:soliplex_frontend/src/modules/room/ui/copy_button.dart';
 import 'package:soliplex_frontend/src/modules/room/ui/feedback_buttons.dart';
+import 'package:soliplex_frontend/src/modules/room/ui/message_caption.dart';
 import 'package:soliplex_frontend/src/modules/room/ui/text_message_tile.dart';
 
 Widget _wrap(Widget child, {MessageExpansions? store}) => ProviderScope(
@@ -34,6 +35,40 @@ void main() {
 
     expect(find.byType(CopyButton), findsOneWidget);
     expect(find.byType(FeedbackButtons), findsNothing);
+  });
+
+  testWidgets('shows a timestamp caption when createdAt is set',
+      (tester) async {
+    await tester.pumpWidget(_wrap(
+      TextMessageTile(
+        roomId: 'r',
+        message: TextMessage(
+          id: 'cap-1',
+          user: ChatUser.user,
+          createdAt: DateTime(2020, 3, 3, 9, 3),
+          text: 'Hello',
+        ),
+      ),
+    ));
+
+    expect(find.byType(MessageCaption), findsOneWidget);
+    expect(find.text('Mar 3, 2020 · 9:03 AM'), findsOneWidget);
+  });
+
+  testWidgets('omits the caption when createdAt is null', (tester) async {
+    await tester.pumpWidget(_wrap(
+      TextMessageTile(
+        roomId: 'r',
+        message: TextMessage(
+          id: 'cap-2',
+          user: ChatUser.assistant,
+          createdAt: null,
+          text: 'Streaming…',
+        ),
+      ),
+    ));
+
+    expect(find.byType(MessageCaption), findsNothing);
   });
 
   testWidgets('assistant message shows copy button and feedback buttons',

--- a/test/modules/room/ui/text_message_tile_test.dart
+++ b/test/modules/room/ui/text_message_tile_test.dart
@@ -7,6 +7,7 @@ import 'package:soliplex_frontend/src/modules/room/message_expansions.dart';
 import 'package:soliplex_frontend/src/modules/room/room_providers.dart';
 import 'package:soliplex_frontend/src/modules/room/ui/copy_button.dart';
 import 'package:soliplex_frontend/src/modules/room/ui/feedback_buttons.dart';
+import 'package:soliplex_frontend/src/modules/room/ui/markdown/flutter_markdown_plus_renderer.dart';
 import 'package:soliplex_frontend/src/modules/room/ui/message_caption.dart';
 import 'package:soliplex_frontend/src/modules/room/ui/text_message_tile.dart';
 
@@ -69,6 +70,44 @@ void main() {
     ));
 
     expect(find.byType(MessageCaption), findsNothing);
+  });
+
+  testWidgets('assistant bubble markdown defers selection to the area',
+      (tester) async {
+    await tester.pumpWidget(_wrap(
+      TextMessageTile(
+        roomId: 'r',
+        message: TextMessage(
+          id: 'a1',
+          user: ChatUser.assistant,
+          createdAt: DateTime(2020),
+          text: 'reply',
+        ),
+      ),
+    ));
+
+    final md = tester.widget<FlutterMarkdownPlusRenderer>(
+      find.byType(FlutterMarkdownPlusRenderer),
+    );
+    expect(md.selectable, isFalse);
+  });
+
+  testWidgets('user bubble is a plain Text, not SelectableText',
+      (tester) async {
+    await tester.pumpWidget(_wrap(
+      TextMessageTile(
+        roomId: 'r',
+        message: TextMessage(
+          id: 'u1',
+          user: ChatUser.user,
+          createdAt: DateTime(2020),
+          text: 'Hello',
+        ),
+      ),
+    ));
+
+    expect(find.byType(SelectableText), findsNothing);
+    expect(find.text('Hello'), findsOneWidget);
   });
 
   testWidgets('assistant message shows copy button and feedback buttons',


### PR DESCRIPTION
## What

Two chat-transcript features:

1. **Message timestamps** — a muted timestamp caption under each message bubble/outcome tile, plus a centered day divider marking each calendar-day group. Times render in the viewer's local zone and stay correct across DST (day bucketing floors to UTC midnights rather than counting 24h chunks).
2. **Cross-bubble selection** — the whole transcript sits under one `SelectionArea`, so a single drag spans user, assistant, error, and tool-output tiles. Individual tiles switch from self-selecting widgets (`SelectableText`, `MarkdownBody(selectable:true)`) to plain `Text`/`selectable:false` so the enclosing area owns selection.

## Where times come from

The frontend never displays a client-generated time. Message captions read `createdAt`, which is always backend-sourced:

- **Live**: the optimistic user echo starts with no time and is stamped from the `RunStartedEvent` server timestamp when it arrives.
- **Replay**: a message resolves to its own event timestamp, falling back to `RUN_STARTED` time, then the run's `created`.
- **Streaming reply**: no caption until it commits with the backend event time on `TextMessageEnd`.

`RunInfo`/`ThreadInfo.createdAt` (run/thread metadata, not captions) degrade to a UTC client clock only when a create response omits or malforms `created` — never failing the create over a cosmetic timestamp.

## Review

Reviewed by parallel code-review agents (general quality, tests, silent-failure, comments): no critical or important issues. Follow-ups applied — added coverage for the absent-`created` and non-int-`RUN_STARTED` fallback branches, made the per-build day-group fallback deterministic (UTC), and corrected the null-`createdAt` docs.

## Testing

- `soliplex_client`, `soliplex_agent`, and room UI test suites pass.
- New pure-function coverage for bucket boundaries, the 12-hour clock, DST-immune day math, and the timestamp-resolution fallbacks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)