### PR TITLE
feat(room): cluster unread rooms at the top of the rooms rail

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,10 @@ Versions follow the `version+build` scheme from `pubspec.yaml`, bumped via
   viewer's local zone and stay correct across DST.
 - Chat: the transcript is selectable across message bubbles — one drag spans
   user, assistant, error, and tool-output tiles at once.
+- Room: the rooms rail clusters unread rooms at the top — the selected room is
+  pinned first, then unread rooms newest-first, a divider, then read rooms
+  newest-first, then idle rooms alphabetically — so a freshly-added server's
+  backlog no longer reads as a wall of unread noise.
 
 ### Changed
 

--- a/lib/src/modules/room/room_unread.dart
+++ b/lib/src/modules/room/room_unread.dart
@@ -110,7 +110,7 @@ typedef RoomRailOrder = ({List<Room> rooms, int? dividerIndex});
 ///   3. read rooms that have activity, newest first;
 ///   4. rooms with no activity, alphabetical (case-insensitive) by name.
 ///
-/// A grey divider separates the unread section (2) from the read sections
+/// A divider separates the unread section (2) from the read sections
 /// (3+4); [RoomRailOrder.dividerIndex] marks its position, or is null when
 /// either section is empty.
 ///
@@ -144,7 +144,8 @@ RoomRailOrder orderRoomsForRail(
       if (ta == null && tb == null) return byName(a, b);
       if (ta == null) return 1;
       if (tb == null) return -1;
-      return tb.compareTo(ta);
+      final byActivity = tb.compareTo(ta);
+      return byActivity != 0 ? byActivity : byName(a, b);
     });
 
   final firstReadIndex = ordered.indexWhere((room) => rankOf(room) >= 2);

--- a/lib/src/modules/room/room_unread.dart
+++ b/lib/src/modules/room/room_unread.dart
@@ -98,3 +98,59 @@ bool shouldMarkRoomRead(
   }
   return isActivityUnread(latestActivity, roomSeen);
 }
+
+/// The rail's room order plus where the unread→read divider goes.
+/// [dividerIndex] is the index in [rooms] of the first read-section room, or
+/// null when no divider should show (either section empty).
+typedef RoomRailOrder = ({List<Room> rooms, int? dividerIndex});
+
+/// Orders [rooms] for the rooms rail:
+///   1. the selected room (if present), pinned first regardless of its state;
+///   2. unread rooms, newest [activity] first;
+///   3. read rooms that have activity, newest first;
+///   4. rooms with no activity, alphabetical (case-insensitive) by name.
+///
+/// A grey divider separates the unread section (2) from the read sections
+/// (3+4); [RoomRailOrder.dividerIndex] marks its position, or is null when
+/// either section is empty.
+///
+/// [activity] maps room id to last-activity (null when the room has no runs).
+/// [unreadRoomIds] is the caller's already-computed unread set, so this only
+/// orders — it does not re-derive unread.
+RoomRailOrder orderRoomsForRail(
+  List<Room> rooms,
+  Map<String, DateTime?> activity,
+  Set<String> unreadRoomIds, {
+  String? selectedRoomId,
+}) {
+  int rankOf(Room room) {
+    if (room.id == selectedRoomId) return 0;
+    if (unreadRoomIds.contains(room.id)) return 1;
+    if (activity[room.id] != null) return 2;
+    return 3;
+  }
+
+  int byName(Room a, Room b) =>
+      a.name.toLowerCase().compareTo(b.name.toLowerCase());
+
+  final ordered = [...rooms]..sort((a, b) {
+      final ra = rankOf(a);
+      final rb = rankOf(b);
+      if (ra != rb) return ra.compareTo(rb);
+      if (ra == 3) return byName(a, b); // no-activity: alphabetical
+      // Unread and read-with-activity sections: newest activity first.
+      final ta = activity[a.id];
+      final tb = activity[b.id];
+      if (ta == null && tb == null) return byName(a, b);
+      if (ta == null) return 1;
+      if (tb == null) return -1;
+      return tb.compareTo(ta);
+    });
+
+  final firstReadIndex = ordered.indexWhere((room) => rankOf(room) >= 2);
+  final hasUnread = ordered.any((room) => rankOf(room) == 1);
+  final dividerIndex =
+      (hasUnread && firstReadIndex != -1) ? firstReadIndex : null;
+
+  return (rooms: ordered, dividerIndex: dividerIndex);
+}

--- a/lib/src/modules/room/ui/room_rail.dart
+++ b/lib/src/modules/room/ui/room_rail.dart
@@ -38,6 +38,7 @@ class RoomRail extends StatelessWidget {
     this.roomsError,
     this.onRetryRooms,
     this.unreadRoomIds = const {},
+    this.dividerIndex,
   });
 
   /// The server's rooms, or `null` while loading.
@@ -48,6 +49,10 @@ class RoomRail extends StatelessWidget {
   /// the lobby reads here too (and vice versa). Empty when stats are
   /// unavailable (e.g. a pre-stats backend), which simply shows no dots.
   final Set<String> unreadRoomIds;
+
+  /// Index in [rooms] of the first read-section room; a grey divider is drawn
+  /// above it to separate unread rooms from read ones. Null draws no divider.
+  final int? dividerIndex;
 
   /// Non-null when the room list failed to load.
   final Object? roomsError;
@@ -120,8 +125,26 @@ class RoomRail extends StatelessWidget {
     }
     return ListView.builder(
       padding: const EdgeInsets.symmetric(vertical: SoliplexSpacing.s2),
-      itemCount: rooms.length,
+      // One extra item for the divider row when present.
+      itemCount: rooms.length + (dividerIndex == null ? 0 : 1),
       itemBuilder: (context, index) {
+        final divider = dividerIndex;
+        if (divider != null) {
+          if (index == divider) {
+            return Padding(
+              key: const ValueKey('rail-unread-divider'),
+              padding: const EdgeInsets.symmetric(
+                horizontal: SoliplexSpacing.s3,
+                vertical: SoliplexSpacing.s1,
+              ),
+              child: Divider(
+                height: 1,
+                color: Theme.of(context).colorScheme.outlineVariant,
+              ),
+            );
+          }
+          if (index > divider) index -= 1;
+        }
         final room = rooms[index];
         return _RoomAvatarTile(
           room: room,

--- a/lib/src/modules/room/ui/room_screen.dart
+++ b/lib/src/modules/room/ui/room_screen.dart
@@ -1259,8 +1259,18 @@ class _RoomScreenState extends State<RoomScreen> {
   /// Builds the always-visible rooms rail. [onNavigate] (the drawer pop) runs
   /// before any navigation when the rail lives inside the narrow drawer.
   Widget _buildRail({VoidCallback? onNavigate}) {
+    final rooms = _serverRooms;
+    final order = rooms == null
+        ? null
+        : orderRoomsForRail(
+            rooms,
+            _roomActivity,
+            _unreadRoomIds,
+            selectedRoomId: widget.roomId,
+          );
     return RoomRail(
-      rooms: _serverRooms,
+      rooms: order?.rooms,
+      dividerIndex: order?.dividerIndex,
       roomsError: _serverRoomsError,
       onRetryRooms: () => setState(_fetchServerRooms),
       unreadRoomIds: _unreadRoomIds,

--- a/test/modules/room/room_rail_order_test.dart
+++ b/test/modules/room/room_rail_order_test.dart
@@ -40,20 +40,6 @@ void main() {
       expect(order.rooms.map((r) => r.id).toList(), ['a', 'new', 'old']);
     });
 
-    test('a room that just got activity lands right below the selected room',
-        () {
-      // The "new activity slots below current room" behaviour falls out of
-      // unread-newest-first + selected-pinned-top.
-      final rooms = [_room('sel', 'Sel'), _room('x', 'X'), _room('y', 'Y')];
-      final order = orderRoomsForRail(
-        rooms,
-        {'sel': _t(1), 'x': _t(3), 'y': _t(20)}, // y just pinged
-        {'x', 'y'},
-        selectedRoomId: 'sel',
-      );
-      expect(order.rooms[1].id, 'y');
-    });
-
     test(
         'read rooms follow unread, newest first; no-activity rooms last '
         'alphabetically', () {

--- a/test/modules/room/ui/room_rail_test.dart
+++ b/test/modules/room/ui/room_rail_test.dart
@@ -20,6 +20,7 @@ RoomRail _rail({
   Object? roomsError,
   String selectedRoomId = 'r1',
   Set<String> unreadRoomIds = const {},
+  int? dividerIndex,
   void Function(String)? onSelectRoom,
   VoidCallback? onRetryRooms,
   RoomAccount? account,
@@ -31,6 +32,7 @@ RoomRail _rail({
       roomsError: roomsError,
       onRetryRooms: onRetryRooms,
       unreadRoomIds: unreadRoomIds,
+      dividerIndex: dividerIndex,
       selectedRoomId: selectedRoomId,
       onSelectRoom: onSelectRoom ?? (_) {},
       entry: createTestServerEntry(),
@@ -67,6 +69,29 @@ void main() {
     testWidgets('shows no dots when nothing is unread', (tester) async {
       await tester.pumpWidget(_wrap(_rail()));
       expect(find.byTooltip('Unread activity'), findsNothing);
+    });
+
+    testWidgets('renders a divider at dividerIndex', (tester) async {
+      await tester.pumpWidget(_wrap(_rail(
+        rooms: const [
+          Room(id: 'r1', name: 'Alpha'),
+          Room(id: 'r2', name: 'Beta'),
+        ],
+        dividerIndex: 1,
+      )));
+      expect(
+        find.byKey(const ValueKey('rail-unread-divider')),
+        findsOneWidget,
+      );
+      // Both rooms still render — the divider is an extra row, not a
+      // replacement.
+      expect(find.text('A'), findsOneWidget);
+      expect(find.text('B'), findsOneWidget);
+    });
+
+    testWidgets('renders no divider when dividerIndex is null', (tester) async {
+      await tester.pumpWidget(_wrap(_rail()));
+      expect(find.byKey(const ValueKey('rail-unread-divider')), findsNothing);
     });
 
     testWidgets('shows an error affordance that retries', (tester) async {

--- a/test/modules/room/ui/room_rail_test.dart
+++ b/test/modules/room/ui/room_rail_test.dart
@@ -71,7 +71,8 @@ void main() {
       expect(find.byTooltip('Unread activity'), findsNothing);
     });
 
-    testWidgets('renders a divider at dividerIndex', (tester) async {
+    testWidgets('renders the divider between the rooms at dividerIndex',
+        (tester) async {
       await tester.pumpWidget(_wrap(_rail(
         rooms: const [
           Room(id: 'r1', name: 'Alpha'),
@@ -79,14 +80,15 @@ void main() {
         ],
         dividerIndex: 1,
       )));
-      expect(
-        find.byKey(const ValueKey('rail-unread-divider')),
-        findsOneWidget,
-      );
-      // Both rooms still render — the divider is an extra row, not a
-      // replacement.
-      expect(find.text('A'), findsOneWidget);
-      expect(find.text('B'), findsOneWidget);
+      final divider = find.byKey(const ValueKey('rail-unread-divider'));
+      expect(divider, findsOneWidget);
+      // The divider sits below the first room and above the second — the one
+      // thing the index-shift in _buildList encodes.
+      final alphaY = tester.getTopLeft(find.text('A')).dy;
+      final dividerY = tester.getTopLeft(divider).dy;
+      final betaY = tester.getTopLeft(find.text('B')).dy;
+      expect(alphaY, lessThan(dividerY));
+      expect(dividerY, lessThan(betaY));
     });
 
     testWidgets('renders no divider when dividerIndex is null', (tester) async {

--- a/test/src/modules/room/room_rail_order_test.dart
+++ b/test/src/modules/room/room_rail_order_test.dart
@@ -1,0 +1,123 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:soliplex_client/soliplex_client.dart';
+import 'package:soliplex_frontend/src/modules/room/room_unread.dart';
+
+// Minimal Room builder — only id/name matter to the ordering.
+Room _room(String id, String name) => Room(id: id, name: name);
+
+DateTime _t(int day) => DateTime.utc(2026, 1, day);
+
+void main() {
+  group('orderRoomsForRail', () {
+    test('pins the selected room first regardless of its activity', () {
+      final rooms = [
+        _room('a', 'Alpha'),
+        _room('b', 'Bravo'),
+        _room('c', 'Cee')
+      ];
+      final order = orderRoomsForRail(
+        rooms,
+        {'a': _t(1), 'b': _t(5), 'c': null},
+        {'b'}, // b is unread
+        selectedRoomId: 'a',
+      );
+      expect(order.rooms.first.id, 'a');
+    });
+
+    test('orders unread rooms newest activity first, below the selected room',
+        () {
+      final rooms = [
+        _room('a', 'Sel'),
+        _room('old', 'Old'),
+        _room('new', 'New')
+      ];
+      final order = orderRoomsForRail(
+        rooms,
+        {'a': _t(1), 'old': _t(2), 'new': _t(9)},
+        {'old', 'new'},
+        selectedRoomId: 'a',
+      );
+      expect(order.rooms.map((r) => r.id).toList(), ['a', 'new', 'old']);
+    });
+
+    test('a room that just got activity lands right below the selected room',
+        () {
+      // The "new activity slots below current room" behaviour falls out of
+      // unread-newest-first + selected-pinned-top.
+      final rooms = [_room('sel', 'Sel'), _room('x', 'X'), _room('y', 'Y')];
+      final order = orderRoomsForRail(
+        rooms,
+        {'sel': _t(1), 'x': _t(3), 'y': _t(20)}, // y just pinged
+        {'x', 'y'},
+        selectedRoomId: 'sel',
+      );
+      expect(order.rooms[1].id, 'y');
+    });
+
+    test(
+        'read rooms follow unread, newest first; no-activity rooms last '
+        'alphabetically', () {
+      final rooms = [
+        _room('z', 'Zeta'),
+        _room('m', 'Mid'),
+        _room('u', 'Unread'),
+        _room('a', 'Aardvark'),
+      ];
+      final order = orderRoomsForRail(
+        rooms,
+        {'z': _t(4), 'm': _t(8), 'u': _t(9), 'a': null},
+        {'u'},
+        selectedRoomId: null,
+      );
+      // unread(u) | read-by-activity: m(8) then z(4) | no-activity: a
+      expect(order.rooms.map((r) => r.id).toList(), ['u', 'm', 'z', 'a']);
+    });
+
+    test(
+        'divider index is the first read-section room when both sections '
+        'are non-empty', () {
+      final rooms = [_room('s', 'Sel'), _room('u', 'U'), _room('r', 'R')];
+      final order = orderRoomsForRail(
+        rooms,
+        {'s': _t(1), 'u': _t(5), 'r': _t(2)},
+        {'u'},
+        selectedRoomId: 's',
+      );
+      // ['s'(0), 'u'(1), 'r'(2)] -> read starts at index 2
+      expect(order.dividerIndex, 2);
+    });
+
+    test('no divider when there are no unread rooms', () {
+      final rooms = [_room('s', 'Sel'), _room('r', 'R')];
+      final order = orderRoomsForRail(
+        rooms,
+        {'s': _t(1), 'r': _t(2)},
+        const {},
+        selectedRoomId: 's',
+      );
+      expect(order.dividerIndex, isNull);
+    });
+
+    test('no divider when there are no read rooms', () {
+      final rooms = [_room('s', 'Sel'), _room('u', 'U')];
+      final order = orderRoomsForRail(
+        rooms,
+        {'s': _t(1), 'u': _t(9)},
+        {'u'},
+        selectedRoomId: 's',
+      );
+      expect(order.dividerIndex, isNull);
+    });
+
+    test('no-activity rooms tie-break alphabetically, case-insensitively', () {
+      final rooms = [_room('b', 'bravo'), _room('a', 'Alpha')];
+      final order = orderRoomsForRail(
+        rooms,
+        {'a': null, 'b': null},
+        const {},
+        selectedRoomId: null,
+      );
+      expect(order.rooms.map((r) => r.id).toList(), ['a', 'b']);
+    });
+  });
+}


### PR DESCRIPTION
## What

The rooms rail now orders rooms so a freshly-added server's backlog stops reading as a wall of unread noise. Order is:

1. **Selected room** — pinned first, regardless of its state.
2. **Unread rooms** — newest activity first.
3. *(grey divider)*
4. **Read rooms with activity** — newest first.
5. **Idle rooms** (no activity) — alphabetical, case-insensitive.

Equal-timestamp rooms fall back to alphabetical order, so the sort is deterministic.

This is the first slice (Tasks 1–2) of the room read/unread UX plan — the pure ordering function plus the rail render. The mark-as-read affordances (rail circle, room card, thread menu, server menu) are separate follow-up tasks and are **not** in this PR.

## How

- `orderRoomsForRail(...)` in `room_unread.dart` — a pure function returning the ordered list plus a `dividerIndex`, kept out of the widget so it's unit-testable.
- `RoomRail` gains a `dividerIndex` param and renders a divider row at that position; `room_screen.dart`'s `_buildRail` computes the order from the rooms, activity map, unread set, and selected room. Live reshuffle is automatic — the existing marker/activity rebuilds already re-order the rail.

## Tests

- 7 unit tests for the ordering function (rank tiers, sort direction, both divider-suppression cases, alphabetical tie-break).
- 2 widget tests for the rail divider (renders between the correct rooms; absent when null).

All green; analyzer and format clean; changelog updated.