### PR TITLE
feat(room): read markers cascade down a server/room/thread hierarchy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,13 @@ Versions follow the `version+build` scheme from `pubspec.yaml`, bumped via
   pinned first, then unread rooms newest-first, a divider, then read rooms
   newest-first, then idle rooms alphabetically — so a freshly-added server's
   backlog no longer reads as a wall of unread noise.
+- Room/Lobby: read markers now cascade down a server → room → thread hierarchy.
+  Each unread check floors an item's read state under its ancestors — a room
+  reads as read when its activity is at or before the later of its own marker
+  and its server's, and a thread under the later of its own, its room's, and its
+  server's — so a single higher-level marker can clear every dot beneath it with
+  no per-item write. Server-level markers persist per-device alongside the
+  existing room and thread markers.
 
 ### Changed
 

--- a/lib/src/core/activity_read.dart
+++ b/lib/src/core/activity_read.dart
@@ -11,3 +11,14 @@ bool isActivityUnread(DateTime? lastActivity, DateTime? seen) {
   if (lastActivity == null) return false;
   return seen == null || lastActivity.isAfter(seen);
 }
+
+/// The later of two "last seen" markers, treating null as never-seen (so it
+/// never wins). Used to floor an item's read state under its ancestors: an item
+/// reads as read when its activity is at or before the latest of its own marker
+/// and its ancestors' (a room's server marker; a thread's room and server
+/// markers).
+DateTime? latestSeen(DateTime? a, DateTime? b) {
+  if (a == null) return b;
+  if (b == null) return a;
+  return a.isAfter(b) ? a : b;
+}

--- a/lib/src/flavors/standard.dart
+++ b/lib/src/flavors/standard.dart
@@ -23,7 +23,8 @@ import '../modules/auth/server_storage.dart';
 import '../modules/diagnostics/diagnostics_module.dart';
 import '../modules/diagnostics/network_inspector.dart';
 import '../modules/lobby/lobby_module.dart';
-import '../modules/lobby/lobby_read_markers.dart' show RoomReadMarkers;
+import '../modules/lobby/lobby_read_markers.dart'
+    show RoomReadMarkers, ServerReadMarkers;
 import '../modules/quiz/quiz_module.dart';
 import '../modules/room/agent_runtime_manager.dart';
 import '../modules/room/execution_tracker_extension.dart';
@@ -132,7 +133,11 @@ Future<ShellConfig> standard({
 
   // Shared in-memory read-marker model so a room stamped read in the room
   // screen clears its lobby unread dot immediately, with no storage race.
-  final readMarkers = RoomReadMarkers();
+  final roomReadMarkers = RoomReadMarkers();
+
+  // Shared server-level read markers, watched by both modules so a server
+  // marker floors every room and thread on it across both surfaces.
+  final serverReadMarkers = ServerReadMarkers();
 
   final inactivityLogoutFlags = LocalInactivityLogoutFlagStorage();
 
@@ -174,13 +179,15 @@ Future<ShellConfig> standard({
         serverManager: serverManager,
         identity: effectiveIdentity,
         registry: registry,
-        readMarkers: readMarkers,
+        roomReadMarkers: roomReadMarkers,
+        serverReadMarkers: serverReadMarkers,
       ),
       RoomAppModule(
         serverManager: serverManager,
         runtimeManager: runtimeManager,
         registry: registry,
-        readMarkers: readMarkers,
+        roomReadMarkers: roomReadMarkers,
+        serverReadMarkers: serverReadMarkers,
         appName: effectiveIdentity.appName,
         logo: brandLogo,
         enableDocumentFilter: true,

--- a/lib/src/modules/lobby/lobby_module.dart
+++ b/lib/src/modules/lobby/lobby_module.dart
@@ -5,7 +5,7 @@ import '../../core/app_identity.dart';
 import '../../core/routes.dart';
 import '../auth/server_manager.dart';
 import '../room/run_registry.dart';
-import 'lobby_read_markers.dart' show RoomReadMarkers;
+import 'lobby_read_markers.dart' show RoomReadMarkers, ServerReadMarkers;
 import 'ui/lobby_screen.dart';
 
 class LobbyAppModule extends AppModule {
@@ -13,7 +13,8 @@ class LobbyAppModule extends AppModule {
     required this.serverManager,
     required this.identity,
     required this.registry,
-    required this.readMarkers,
+    required this.roomReadMarkers,
+    required this.serverReadMarkers,
   });
 
   final ServerManager serverManager;
@@ -27,7 +28,11 @@ class LobbyAppModule extends AppModule {
 
   /// Shared room read markers, also stamped by the room screen so a room read
   /// there clears its lobby unread dot immediately.
-  final RoomReadMarkers readMarkers;
+  final RoomReadMarkers roomReadMarkers;
+
+  /// Shared server read markers, also watched by the room screen. A server
+  /// marker floors every room's unread dot on the server.
+  final ServerReadMarkers serverReadMarkers;
 
   @override
   String get namespace => 'lobby';
@@ -42,7 +47,8 @@ class LobbyAppModule extends AppModule {
                 serverManager: serverManager,
                 identity: identity,
                 registry: registry,
-                readMarkers: readMarkers,
+                roomReadMarkers: roomReadMarkers,
+                serverReadMarkers: serverReadMarkers,
               ),
             ),
           ),

--- a/lib/src/modules/lobby/lobby_read_markers.dart
+++ b/lib/src/modules/lobby/lobby_read_markers.dart
@@ -149,3 +149,127 @@ class RoomReadMarkers {
 
   void dispose() => _markers.dispose();
 }
+
+/// Persists per-server "last seen" timestamps. A server marker floors every
+/// room and thread on that server: activity at or before it reads as read, so a
+/// single server-level write floors the whole server with no per-room fan-out.
+/// Mirrors [LobbyReadMarkerStorage] but keyed by a single server id, so rows are
+/// `{s, t}` (server id, ISO-8601 UTC instant).
+abstract final class ServerReadMarkerStorage {
+  static const _key = 'soliplex_server_read_markers';
+
+  static const _fieldServer = 's';
+  static const _fieldTime = 't';
+
+  static Future<Map<String, DateTime>> load() async {
+    final prefs = await SharedPreferences.getInstance();
+    final raw = prefs.getString(_key);
+    if (raw == null || raw.isEmpty) return {};
+
+    final result = <String, DateTime>{};
+    try {
+      final decoded = jsonDecode(raw);
+      if (decoded is! List) {
+        _logger.warning(
+            'Discarding corrupt server read markers (not a JSON array)');
+        return {};
+      }
+      var skipped = 0;
+      for (final entry in decoded) {
+        if (entry is! Map) {
+          skipped++;
+          continue;
+        }
+        final s = entry[_fieldServer];
+        final t = entry[_fieldTime];
+        if (s is! String || t is! String) {
+          skipped++;
+          continue;
+        }
+        final at = DateTime.tryParse(t);
+        if (at == null) {
+          skipped++;
+          continue;
+        }
+        result[s] = at.toUtc();
+      }
+      if (skipped > 0 && result.isEmpty) {
+        _logger
+            .error('Discarding all $skipped server read markers; none parsed');
+      } else if (skipped > 0) {
+        _logger.warning('Skipped $skipped malformed server read marker(s)');
+      }
+    } on FormatException catch (e, st) {
+      _logger.warning(
+        'Discarding corrupt server read markers',
+        error: e,
+        stackTrace: st,
+      );
+      return {};
+    }
+    return result;
+  }
+
+  static Future<void> save(Map<String, DateTime> markers) async {
+    final prefs = await SharedPreferences.getInstance();
+    final list = [
+      for (final entry in markers.entries)
+        {
+          _fieldServer: entry.key,
+          _fieldTime: entry.value.toUtc().toIso8601String(),
+        },
+    ];
+    await prefs.setString(_key, jsonEncode(list));
+  }
+}
+
+/// In-memory, reactive source of truth for per-server read markers, shared by
+/// the lobby and the room screen: a marker written to it is visible to both
+/// immediately, with no [ServerReadMarkerStorage] round-trip, so a server floor
+/// applies to every surface at once. Mirrors [RoomReadMarkers] one level up the
+/// hierarchy. Backed by [ServerReadMarkerStorage] for persistence across launches.
+class ServerReadMarkers {
+  final Signal<Map<String, DateTime>> _markers = Signal(const {});
+  ReadonlySignal<Map<String, DateTime>> get markers => _markers;
+
+  bool _loaded = false;
+
+  /// The current markers, for a non-reactive read.
+  Map<String, DateTime> get value => _markers.value;
+
+  /// Loads persisted markers once, merging them under any already stamped
+  /// in-memory (an early [markRead] before the disk read returned) so a
+  /// just-read server isn't clobbered back to unread by the slower load.
+  Future<void> ensureLoaded() async {
+    if (_loaded) return;
+    _loaded = true;
+    try {
+      final loaded = await ServerReadMarkerStorage.load();
+      _markers.value = {...loaded, ..._markers.value};
+    } catch (error, st) {
+      _logger.warning(
+        'Failed to load server read markers',
+        error: error,
+        stackTrace: st,
+      );
+    }
+  }
+
+  /// Stamps [serverId] read as of [at] and persists. The [markers] update is
+  /// synchronous, so a screen watching it reacts with no storage round-trip.
+  void markRead(String serverId, DateTime at) {
+    _markers.value = {..._markers.value, serverId: at};
+    unawaited(
+      ServerReadMarkerStorage.save(_markers.value)
+          .catchError((Object error, StackTrace st) {
+        _logger.warning(
+          'Failed to persist server read markers',
+          error: error,
+          stackTrace: st,
+        );
+      }),
+    );
+  }
+
+  void dispose() => _markers.dispose();
+}

--- a/lib/src/modules/lobby/lobby_state.dart
+++ b/lib/src/modules/lobby/lobby_state.dart
@@ -85,15 +85,18 @@ class LobbyState {
     required ServerManager serverManager,
     ApiResolver? apiResolver,
     RunRegistry? registry,
-    RoomReadMarkers? readMarkers,
+    RoomReadMarkers? roomReadMarkers,
+    ServerReadMarkers? serverReadMarkers,
   })  : _serverManager = serverManager,
         _apiResolver = apiResolver ?? _defaultResolver,
         _registry = registry,
-        _readMarkers = readMarkers ?? RoomReadMarkers() {
+        _roomReadMarkers = roomReadMarkers ?? RoomReadMarkers(),
+        _serverReadMarkers = serverReadMarkers ?? ServerReadMarkers() {
     _unsubscribe = _serverManager.servers.subscribe(_onServersChanged);
     unawaited(_loadViewMode());
     unawaited(_loadSortMode());
-    unawaited(_readMarkers.ensureLoaded());
+    unawaited(_roomReadMarkers.ensureLoaded());
+    unawaited(_serverReadMarkers.ensureLoaded());
     unawaited(_loadSelectedServer());
     _watchRunCompletions();
   }
@@ -105,7 +108,12 @@ class LobbyState {
   /// Shared in-memory read-marker model. A room is unread when [roomActivity]
   /// reports activity newer than this marker. Stamped by the room screen on
   /// leave; the lobby watches it so a just-read room clears immediately.
-  final RoomReadMarkers _readMarkers;
+  final RoomReadMarkers _roomReadMarkers;
+
+  /// Shared in-memory server read-marker model. A server marker floors every
+  /// room on it, so a room is unread only when its activity beats the later of
+  /// its own marker and this one. Shared with the room screen.
+  final ServerReadMarkers _serverReadMarkers;
 
   late final void Function() _unsubscribe;
 
@@ -220,8 +228,14 @@ class LobbyState {
   /// *unread* when [roomActivity] reports a last-activity time newer than its
   /// marker (or newer than the epoch, when never opened). Persisted per-device;
   /// there is no server-side read state and no unread count.
-  ReadonlySignal<Map<RoomActivityKey, DateTime>> get readMarkers =>
-      _readMarkers.markers;
+  ReadonlySignal<Map<RoomActivityKey, DateTime>> get roomReadMarkers =>
+      _roomReadMarkers.markers;
+
+  /// Per-server "last seen" timestamps, keyed by serverId. A room reads as read
+  /// when its activity is at or before the later of its room marker and its
+  /// server's marker here, so a server marker floors all its rooms.
+  ReadonlySignal<Map<String, DateTime>> get serverReadMarkers =>
+      _serverReadMarkers.markers;
 
   /// True while activity for the selected server is being fetched.
   final Signal<bool> _activityLoading = Signal(false);

--- a/lib/src/modules/lobby/ui/lobby_screen.dart
+++ b/lib/src/modules/lobby/ui/lobby_screen.dart
@@ -11,7 +11,7 @@ import '../../../core/routes.dart';
 import '../../auth/server_entry.dart';
 import '../../auth/server_manager.dart';
 import '../../room/run_registry.dart';
-import '../lobby_read_markers.dart' show RoomReadMarkers;
+import '../lobby_read_markers.dart' show RoomReadMarkers, ServerReadMarkers;
 import '../lobby_sort_mode.dart';
 import '../lobby_state.dart';
 import '../lobby_view_mode.dart';
@@ -34,7 +34,8 @@ class LobbyScreen extends StatefulWidget {
     required this.serverManager,
     required this.identity,
     this.registry,
-    this.readMarkers,
+    this.roomReadMarkers,
+    this.serverReadMarkers,
     this.apiResolver,
   });
 
@@ -50,7 +51,11 @@ class LobbyScreen extends StatefulWidget {
 
   /// Shared room read markers, forwarded to [LobbyState]. Null in tests, where
   /// each screen gets its own isolated store.
-  final RoomReadMarkers? readMarkers;
+  final RoomReadMarkers? roomReadMarkers;
+
+  /// Shared server read markers, forwarded to [LobbyState]. Null in tests, where
+  /// each screen gets its own isolated store.
+  final ServerReadMarkers? serverReadMarkers;
 
   /// Test seam forwarded to [LobbyState]; production uses the default
   /// per-entry API resolver.
@@ -71,7 +76,8 @@ class _LobbyScreenState extends State<LobbyScreen> {
       serverManager: widget.serverManager,
       apiResolver: widget.apiResolver,
       registry: widget.registry,
-      readMarkers: widget.readMarkers,
+      roomReadMarkers: widget.roomReadMarkers,
+      serverReadMarkers: widget.serverReadMarkers,
     );
   }
 
@@ -126,7 +132,8 @@ class _LobbyScreenState extends State<LobbyScreen> {
     final selectedServerId = _state.selectedServerId.watch(context);
     final sortMode = _state.sortMode.watch(context);
     final roomActivity = _state.roomActivity.watch(context);
-    final readMarkers = _state.readMarkers.watch(context);
+    final roomReadMarkers = _state.roomReadMarkers.watch(context);
+    final serverReadMarkers = _state.serverReadMarkers.watch(context);
     final activityLoading = _state.activityLoading.watch(context);
     return LayoutBuilder(
       builder: (context, constraints) {
@@ -146,7 +153,8 @@ class _LobbyScreenState extends State<LobbyScreen> {
                 sortMode: sortMode,
                 onSortModeChanged: _state.setSortMode,
                 roomActivity: roomActivity,
-                readMarkers: readMarkers,
+                roomReadMarkers: roomReadMarkers,
+                serverReadMarkers: serverReadMarkers,
                 activityLoading: activityLoading,
                 selectedServerId: selectedServerId,
                 onSelectServer: _state.selectServer,
@@ -170,7 +178,8 @@ class _LobbyScreenState extends State<LobbyScreen> {
                 sortMode: sortMode,
                 onSortModeChanged: _state.setSortMode,
                 roomActivity: roomActivity,
-                readMarkers: readMarkers,
+                roomReadMarkers: roomReadMarkers,
+                serverReadMarkers: serverReadMarkers,
                 activityLoading: activityLoading,
                 selectedServerId: selectedServerId,
                 onSelectServer: _state.selectServer,
@@ -200,7 +209,8 @@ class _WideLayout extends StatelessWidget {
     required this.sortMode,
     required this.onSortModeChanged,
     required this.roomActivity,
-    required this.readMarkers,
+    required this.roomReadMarkers,
+    required this.serverReadMarkers,
     required this.activityLoading,
     required this.selectedServerId,
     required this.onSelectServer,
@@ -224,7 +234,8 @@ class _WideLayout extends StatelessWidget {
   final LobbySortMode sortMode;
   final void Function(LobbySortMode) onSortModeChanged;
   final Map<RoomActivityKey, DateTime?> roomActivity;
-  final Map<RoomActivityKey, DateTime> readMarkers;
+  final Map<RoomActivityKey, DateTime> roomReadMarkers;
+  final Map<String, DateTime> serverReadMarkers;
   final bool activityLoading;
   final String? selectedServerId;
   final void Function(String serverId) onSelectServer;
@@ -271,7 +282,8 @@ class _WideLayout extends StatelessWidget {
                 sortMode: sortMode,
                 onSortModeChanged: onSortModeChanged,
                 roomActivity: roomActivity,
-                readMarkers: readMarkers,
+                roomReadMarkers: roomReadMarkers,
+                serverReadMarkers: serverReadMarkers,
                 activityLoading: activityLoading,
                 selectedServerId: selectedServerId,
                 onRoomTap: onRoomTap,
@@ -300,7 +312,8 @@ class _NarrowLayout extends StatelessWidget {
     required this.sortMode,
     required this.onSortModeChanged,
     required this.roomActivity,
-    required this.readMarkers,
+    required this.roomReadMarkers,
+    required this.serverReadMarkers,
     required this.activityLoading,
     required this.selectedServerId,
     required this.onSelectServer,
@@ -324,7 +337,8 @@ class _NarrowLayout extends StatelessWidget {
   final LobbySortMode sortMode;
   final void Function(LobbySortMode) onSortModeChanged;
   final Map<RoomActivityKey, DateTime?> roomActivity;
-  final Map<RoomActivityKey, DateTime> readMarkers;
+  final Map<RoomActivityKey, DateTime> roomReadMarkers;
+  final Map<String, DateTime> serverReadMarkers;
   final bool activityLoading;
   final String? selectedServerId;
   final void Function(String serverId) onSelectServer;
@@ -386,7 +400,8 @@ class _NarrowLayout extends StatelessWidget {
           sortMode: sortMode,
           onSortModeChanged: onSortModeChanged,
           roomActivity: roomActivity,
-          readMarkers: readMarkers,
+          roomReadMarkers: roomReadMarkers,
+          serverReadMarkers: serverReadMarkers,
           activityLoading: activityLoading,
           selectedServerId: selectedServerId,
           onRoomTap: onRoomTap,
@@ -410,7 +425,8 @@ class _RoomContent extends StatelessWidget {
     required this.sortMode,
     required this.onSortModeChanged,
     required this.roomActivity,
-    required this.readMarkers,
+    required this.roomReadMarkers,
+    required this.serverReadMarkers,
     required this.activityLoading,
     required this.selectedServerId,
     required this.onRoomTap,
@@ -428,7 +444,8 @@ class _RoomContent extends StatelessWidget {
   final LobbySortMode sortMode;
   final void Function(LobbySortMode) onSortModeChanged;
   final Map<RoomActivityKey, DateTime?> roomActivity;
-  final Map<RoomActivityKey, DateTime> readMarkers;
+  final Map<RoomActivityKey, DateTime> roomReadMarkers;
+  final Map<String, DateTime> serverReadMarkers;
   final bool activityLoading;
   final String? selectedServerId;
   final void Function(String serverId, String roomId) onRoomTap;
@@ -524,7 +541,8 @@ class _RoomContent extends StatelessWidget {
           searchQuery: searchQuery,
           sortMode: sortMode,
           roomActivity: roomActivity,
-          readMarkers: readMarkers,
+          roomReadMarkers: roomReadMarkers,
+          serverReadMarkers: serverReadMarkers,
           onRoomTap: onRoomTap,
           onInfoTap: onInfoTap,
           onSignIn: onSignIn,
@@ -714,7 +732,8 @@ class _ServerSection extends StatelessWidget {
     required this.searchQuery,
     required this.sortMode,
     required this.roomActivity,
-    required this.readMarkers,
+    required this.roomReadMarkers,
+    required this.serverReadMarkers,
     required this.onRoomTap,
     required this.onInfoTap,
     required this.onSignIn,
@@ -726,7 +745,8 @@ class _ServerSection extends StatelessWidget {
   final String searchQuery;
   final LobbySortMode sortMode;
   final Map<RoomActivityKey, DateTime?> roomActivity;
-  final Map<RoomActivityKey, DateTime> readMarkers;
+  final Map<RoomActivityKey, DateTime> roomReadMarkers;
+  final Map<String, DateTime> serverReadMarkers;
   final void Function(String serverId, String roomId) onRoomTap;
   final void Function(String serverId, String roomId) onInfoTap;
   final void Function(String serverId) onSignIn;
@@ -845,7 +865,10 @@ class _ServerSection extends StatelessWidget {
 
   bool _isUnread(Room room) {
     final key = (serverId: serverId, roomId: room.id);
-    return isActivityUnread(roomActivity[key], readMarkers[key]);
+    return isActivityUnread(
+      roomActivity[key],
+      latestSeen(roomReadMarkers[key], serverReadMarkers[serverId]),
+    );
   }
 
   /// Renders [rooms] in the active view mode (no grouping).

--- a/lib/src/modules/room/room_module.dart
+++ b/lib/src/modules/room/room_module.dart
@@ -4,7 +4,8 @@ import 'package:go_router/go_router.dart';
 import '../../core/app_module.dart';
 import '../auth/require_connected_server.dart';
 import '../auth/server_manager.dart';
-import '../lobby/lobby_read_markers.dart' show RoomReadMarkers;
+import '../lobby/lobby_read_markers.dart'
+    show RoomReadMarkers, ServerReadMarkers;
 import 'agent_runtime_manager.dart';
 import 'document_selections.dart';
 import 'message_expansions.dart';
@@ -19,7 +20,8 @@ class RoomAppModule extends AppModule {
     required this.serverManager,
     required this.runtimeManager,
     required this.registry,
-    required this.readMarkers,
+    required this.roomReadMarkers,
+    required this.serverReadMarkers,
     required this.appName,
     this.logo,
     this.enableDocumentFilter = false,
@@ -33,7 +35,11 @@ class RoomAppModule extends AppModule {
 
   /// Shared room read markers, also watched by the lobby so a room stamped read
   /// here clears its lobby unread dot immediately.
-  final RoomReadMarkers readMarkers;
+  final RoomReadMarkers roomReadMarkers;
+
+  /// Shared server read markers, also watched by the lobby. A server marker
+  /// floors every room and thread on the server for the rail's unread checks.
+  final ServerReadMarkers serverReadMarkers;
 
   /// Brand identity for the room-info screen's branded header.
   final String appName;
@@ -99,7 +105,8 @@ class RoomAppModule extends AppModule {
             uploadRegistry: _uploadRegistry,
             enableDocumentFilter: enableDocumentFilter,
             documentSelections: _documentSelections,
-            readMarkers: readMarkers,
+            roomReadMarkers: roomReadMarkers,
+            serverReadMarkers: serverReadMarkers,
           ),
         );
       },

--- a/lib/src/modules/room/room_unread.dart
+++ b/lib/src/modules/room/room_unread.dart
@@ -1,6 +1,7 @@
 import 'package:soliplex_client/soliplex_client.dart';
 
-import '../../core/activity_read.dart' show RoomActivityKey, isActivityUnread;
+import '../../core/activity_read.dart'
+    show RoomActivityKey, isActivityUnread, latestSeen;
 import 'thread_read_markers.dart' show ThreadActivityKey;
 
 export 'thread_read_markers.dart' show ThreadActivityKey;
@@ -10,10 +11,17 @@ export 'thread_read_markers.dart' show ThreadActivityKey;
 /// activity arriving while the user views it (e.g. their own reply) does not
 /// light its own rail dot. Mirrors the selected-thread exclusion in
 /// [unreadThreadIds].
+///
+/// [serverSeen] is the server-level marker: a room reads as read when its
+/// activity is at or before the later of its own marker and [serverSeen], so a
+/// server marker floors every room on it without a per-room write. It is
+/// required (pass null for "no server marker") so a caller can't silently drop
+/// the floor and leave a room's dot stale.
 Set<String> unreadRoomIds(
   Map<String, DateTime?> roomActivity,
   Map<RoomActivityKey, DateTime> markers, {
   required String serverId,
+  required DateTime? serverSeen,
   String? currentRoomId,
 }) {
   return {
@@ -21,7 +29,10 @@ Set<String> unreadRoomIds(
       if (entry.key != currentRoomId &&
           isActivityUnread(
             entry.value,
-            markers[(serverId: serverId, roomId: entry.key)],
+            latestSeen(
+              markers[(serverId: serverId, roomId: entry.key)],
+              serverSeen,
+            ),
           ))
         entry.key,
   };
@@ -34,34 +45,46 @@ Set<String> unreadRoomIds(
 ///
 /// Used both for the per-thread unread dots and to roll thread-unread up into
 /// the room's unread state.
+///
+/// [roomSeen] and [serverSeen] are the ancestor markers: a thread reads as read
+/// when its activity is at or before the later of its own marker and either
+/// ancestor, so a room (or server) marker floors every thread inside it without
+/// a per-thread write. Both are required (pass null for "no ancestor marker") so
+/// a caller can't silently drop a floor and leave a thread's dot stale.
 Set<String> unreadThreadIds(
   List<ThreadInfo> threads,
   Map<ThreadActivityKey, DateTime> threadMarkers, {
   required String serverId,
   required String roomId,
+  required DateTime? roomSeen,
+  required DateTime? serverSeen,
   String? selectedThreadId,
 }) {
+  final ancestorSeen = latestSeen(roomSeen, serverSeen);
   return {
     for (final thread in threads)
       if (thread.id != selectedThreadId &&
           isActivityUnread(
             thread.lastActivity,
-            threadMarkers[(
-              serverId: serverId,
-              roomId: roomId,
-              threadId: thread.id,
-            )],
+            latestSeen(
+              threadMarkers[(
+                serverId: serverId,
+                roomId: roomId,
+                threadId: thread.id,
+              )],
+              ancestorSeen,
+            ),
           ))
         thread.id,
   };
 }
 
 /// Whether to stamp the room read now: true only when no thread is unread AND
-/// the room still has activity newer than [roomSeen] (an unread→read transition
-/// worth persisting). Returns false when already caught up, so we don't re-stamp
-/// on every update.
+/// the room still has activity newer than the effective floor (an unread→read
+/// transition worth persisting). Returns false when already caught up, so we
+/// don't re-stamp on every update.
 ///
-/// "Activity newer than [roomSeen]" is the room-level dot signal, not the truth
+/// "Activity newer than the floor" is the room-level dot signal, not the truth
 /// of unread — the room marker and the per-thread markers are separate, so it
 /// can be a stale false positive (dot lit, yet every thread read). The unread
 /// truth is the first clause; we stamp only when the dot is lit but no thread is
@@ -71,12 +94,19 @@ Set<String> unreadThreadIds(
 /// the same source as the unread check — so a thread list that hasn't caught up
 /// to new activity can't mark the room read over a thread about to surface (the
 /// two inputs can never disagree).
+///
+/// [roomSeen] and [serverSeen] are the room's own marker and its server's; the
+/// effective floor is their max ([latestSeen]), which both gates the room-level
+/// dot and floors the per-thread check, keeping the two consistent. Both are
+/// required (pass null for "no marker"), matching [unreadThreadIds], so a caller
+/// can't silently drop a floor.
 bool shouldMarkRoomRead(
   List<ThreadInfo> threads,
-  Map<ThreadActivityKey, DateTime> threadMarkers,
-  DateTime? roomSeen, {
+  Map<ThreadActivityKey, DateTime> threadMarkers, {
   required String serverId,
   required String roomId,
+  required DateTime? roomSeen,
+  required DateTime? serverSeen,
   String? selectedThreadId,
 }) {
   final hasUnread = unreadThreadIds(
@@ -85,6 +115,8 @@ bool shouldMarkRoomRead(
     serverId: serverId,
     roomId: roomId,
     selectedThreadId: selectedThreadId,
+    roomSeen: roomSeen,
+    serverSeen: serverSeen,
   ).isNotEmpty;
   if (hasUnread) return false;
 
@@ -96,7 +128,7 @@ bool shouldMarkRoomRead(
       latestActivity = activity;
     }
   }
-  return isActivityUnread(latestActivity, roomSeen);
+  return isActivityUnread(latestActivity, latestSeen(roomSeen, serverSeen));
 }
 
 /// The rail's room order plus where the unread→read divider goes.

--- a/lib/src/modules/room/ui/room_screen.dart
+++ b/lib/src/modules/room/ui/room_screen.dart
@@ -158,7 +158,8 @@ class RoomScreen extends StatefulWidget {
     required this.uploadRegistry,
     this.enableDocumentFilter = false,
     required this.documentSelections,
-    this.readMarkers,
+    this.roomReadMarkers,
+    this.serverReadMarkers,
   });
 
   final ServerEntry serverEntry;
@@ -173,7 +174,12 @@ class RoomScreen extends StatefulWidget {
   /// Shared in-memory room read markers, also watched by the lobby. Stamping a
   /// room read here is visible to the lobby immediately, with no storage race.
   /// Null in tests, where each screen gets its own isolated store.
-  final RoomReadMarkers? readMarkers;
+  final RoomReadMarkers? roomReadMarkers;
+
+  /// Shared in-memory server read markers. A server marker floors every room
+  /// and thread on the server, so the rail's unread computations read up to it.
+  /// Null in tests, where each screen gets its own isolated store.
+  final ServerReadMarkers? serverReadMarkers;
 
   @override
   State<RoomScreen> createState() => _RoomScreenState();
@@ -195,7 +201,7 @@ class _RoomScreenState extends State<RoomScreen> {
   /// Last-activity per room id for the current server (from the room stats
   /// batch). Absent/empty when stats are unavailable — which simply shows no
   /// unread dots (graceful on a pre-stats backend). Drives [_unreadRoomIds]
-  /// together with [_readMarkers].
+  /// together with [_roomReadMarkers] and [_serverReadMarkers].
   Map<String, DateTime?> _roomActivity = const {};
   CancelToken? _activityCancelToken;
 
@@ -203,7 +209,12 @@ class _RoomScreenState extends State<RoomScreen> {
   /// also watched by the lobby. A room is unread when its last-activity is
   /// newer than its marker; opening a room here stamps "now", clearing its dot
   /// here and — immediately, no storage race — in the lobby.
-  late final RoomReadMarkers _readMarkers;
+  late final RoomReadMarkers _roomReadMarkers;
+
+  /// Shared in-memory model of per-`serverId` "last seen" markers, also watched
+  /// by the lobby. Floors every room and thread on the server: the rail's unread
+  /// checks read up to it, so a server marker suppresses their dots.
+  late final ServerReadMarkers _serverReadMarkers;
 
   /// Per-`(serverId, roomId, threadId)` "last seen" markers for threads,
   /// device-local. A thread is unread when its [ThreadInfo.lastActivity] is
@@ -389,8 +400,15 @@ class _RoomScreenState extends State<RoomScreen> {
 
   /// Loads the shared read markers once, then re-evaluates the room read state
   /// in case the thread list arrived before them.
-  Future<void> _loadReadMarkers() async {
-    await _readMarkers.ensureLoaded();
+  Future<void> _loadRoomReadMarkers() async {
+    await _roomReadMarkers.ensureLoaded();
+    if (mounted) _recomputeRoomRead();
+  }
+
+  /// Loads the shared server read markers once, then re-evaluates the room read
+  /// state in case the thread list arrived before them.
+  Future<void> _loadServerReadMarkers() async {
+    await _serverReadMarkers.ensureLoaded();
     if (mounted) _recomputeRoomRead();
   }
 
@@ -400,7 +418,7 @@ class _RoomScreenState extends State<RoomScreen> {
   /// calls this, and only once no thread is unread. The shared store both
   /// persists and notifies its watchers (this build and the lobby's).
   void _markRoomRead(String roomId) {
-    _readMarkers.markRead(
+    _roomReadMarkers.markRead(
       (serverId: widget.serverEntry.serverId, roomId: roomId),
       clock.now().toUtc(),
     );
@@ -427,9 +445,11 @@ class _RoomScreenState extends State<RoomScreen> {
       serverId: serverId,
       roomId: roomId,
       selectedThreadId: leavingThreadId,
+      roomSeen: _roomReadMarkers.value[(serverId: serverId, roomId: roomId)],
+      serverSeen: _serverReadMarkers.value[serverId],
     ).isNotEmpty;
     if (stillUnread) return;
-    _readMarkers.markRead(
+    _roomReadMarkers.markRead(
       (serverId: serverId, roomId: roomId),
       clock.now().toUtc(),
     );
@@ -450,9 +470,10 @@ class _RoomScreenState extends State<RoomScreen> {
     if (shouldMarkRoomRead(
       status.threads,
       _threadReadMarkers,
-      _readMarkers.value[key],
       serverId: widget.serverEntry.serverId,
       roomId: widget.roomId,
+      roomSeen: _roomReadMarkers.value[key],
+      serverSeen: _serverReadMarkers.value[widget.serverEntry.serverId],
       selectedThreadId: widget.threadId,
     )) {
       _markRoomRead(widget.roomId);
@@ -502,9 +523,10 @@ class _RoomScreenState extends State<RoomScreen> {
   Set<String> get _unreadRoomIds {
     final ids = unreadRoomIds(
       _roomActivity,
-      _readMarkers.value,
+      _roomReadMarkers.value,
       serverId: widget.serverEntry.serverId,
       currentRoomId: widget.roomId,
+      serverSeen: _serverReadMarkers.value[widget.serverEntry.serverId],
     );
     final openRoomUnread = _unreadThreadIds(
       _state.threadList.threads.value,
@@ -643,12 +665,16 @@ class _RoomScreenState extends State<RoomScreen> {
     String? selectedThreadId,
   ) {
     if (status is! ThreadsLoaded) return const {};
+    final serverId = widget.serverEntry.serverId;
     return unreadThreadIds(
       status.threads,
       _threadReadMarkers,
-      serverId: widget.serverEntry.serverId,
+      serverId: serverId,
       roomId: widget.roomId,
       selectedThreadId: selectedThreadId,
+      roomSeen:
+          _roomReadMarkers.value[(serverId: serverId, roomId: widget.roomId)],
+      serverSeen: _serverReadMarkers.value[serverId],
     );
   }
 
@@ -753,13 +779,15 @@ class _RoomScreenState extends State<RoomScreen> {
   void initState() {
     super.initState();
     HardwareKeyboard.instance.addHandler(_handleKey);
-    _readMarkers = widget.readMarkers ?? RoomReadMarkers();
+    _roomReadMarkers = widget.roomReadMarkers ?? RoomReadMarkers();
+    _serverReadMarkers = widget.serverReadMarkers ?? ServerReadMarkers();
     _state = _createRoomState();
     _workdirs = _createWorkdirController();
     _refreshFilterableDocuments();
     _fetchServerRooms();
     _fetchRoomActivity();
-    unawaited(_loadReadMarkers());
+    unawaited(_loadRoomReadMarkers());
+    unawaited(_loadServerReadMarkers());
     unawaited(_loadThreadReadMarkers());
     _anchorTracker = _createAnchorTracker();
     // Keep the room's unread dot derived from its threads: watch the thread
@@ -1139,7 +1167,8 @@ class _RoomScreenState extends State<RoomScreen> {
   Widget build(BuildContext context) {
     // Rebuild the rail's room dots when a read marker is stamped (here or by
     // the lobby). Marker writes go through the shared store, not setState.
-    _readMarkers.markers.watch(context);
+    _roomReadMarkers.markers.watch(context);
+    _serverReadMarkers.markers.watch(context);
     final threadListStatus = _state.threadList.threads.watch(context);
     final selectedThreadId = _state.activeThreadView?.threadId;
     final unreadThreadIds =

--- a/test/core/activity_read_test.dart
+++ b/test/core/activity_read_test.dart
@@ -1,0 +1,20 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:soliplex_frontend/src/core/activity_read.dart';
+
+void main() {
+  group('latestSeen', () {
+    final early = DateTime.utc(2026, 1, 1);
+    final later = DateTime.utc(2026, 6, 1);
+
+    test('returns the later of two markers', () {
+      expect(latestSeen(early, later), later);
+      expect(latestSeen(later, early), later);
+    });
+
+    test('null never wins (treated as never-seen)', () {
+      expect(latestSeen(null, later), later);
+      expect(latestSeen(later, null), later);
+      expect(latestSeen(null, null), isNull);
+    });
+  });
+}

--- a/test/modules/lobby/lobby_module_test.dart
+++ b/test/modules/lobby/lobby_module_test.dart
@@ -21,7 +21,8 @@ void main() {
         serverManager: _createManager(),
         identity: testIdentity(),
         registry: RunRegistry(),
-        readMarkers: RoomReadMarkers(),
+        roomReadMarkers: RoomReadMarkers(),
+        serverReadMarkers: ServerReadMarkers(),
       ).build();
       final paths =
           contribution.routes.whereType<GoRoute>().map((r) => r.path).toList();
@@ -33,7 +34,8 @@ void main() {
         serverManager: _createManager(),
         identity: testIdentity(),
         registry: RunRegistry(),
-        readMarkers: RoomReadMarkers(),
+        roomReadMarkers: RoomReadMarkers(),
+        serverReadMarkers: ServerReadMarkers(),
       ).build();
       expect(contribution.redirect, isNull);
     });

--- a/test/modules/lobby/server_read_markers_test.dart
+++ b/test/modules/lobby/server_read_markers_test.dart
@@ -1,0 +1,76 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:soliplex_frontend/src/modules/lobby/lobby_read_markers.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+  setUp(() => SharedPreferences.setMockInitialValues({}));
+
+  group('ServerReadMarkerStorage', () {
+    test('defaults to empty when nothing is persisted', () async {
+      expect(await ServerReadMarkerStorage.load(), isEmpty);
+    });
+
+    test('round-trips markers, normalizing to UTC', () async {
+      final markers = {
+        's1': DateTime.utc(2026, 6, 1, 12),
+        's2': DateTime.utc(2026, 1, 2, 3, 4),
+      };
+      await ServerReadMarkerStorage.save(markers);
+
+      final loaded = await ServerReadMarkerStorage.load();
+      expect(loaded, hasLength(2));
+      expect(loaded['s1'], DateTime.utc(2026, 6, 1, 12));
+      expect(loaded['s2']!.isUtc, isTrue);
+    });
+
+    test('a corrupt payload loads as empty rather than throwing', () async {
+      SharedPreferences.setMockInitialValues(
+        {'soliplex_server_read_markers': 'not json{'},
+      );
+      expect(await ServerReadMarkerStorage.load(), isEmpty);
+    });
+
+    test('skips malformed entries but keeps valid ones', () async {
+      // A partially-corrupt payload must drop only the bad rows, not reset the
+      // whole read model: a missing field, an unparseable time, and a non-object
+      // entry are each skipped while the one valid row survives.
+      SharedPreferences.setMockInitialValues({
+        'soliplex_server_read_markers': '['
+            '{"s":"s1","t":"2026-06-01T00:00:00Z"},'
+            '{"s":"s2","t":"not-a-date"},'
+            '{"t":"2026-06-01T00:00:00Z"},'
+            '"garbage"'
+            ']',
+      });
+      final loaded = await ServerReadMarkerStorage.load();
+      expect(loaded, hasLength(1));
+      expect(loaded['s1'], DateTime.utc(2026, 6));
+    });
+  });
+
+  group('ServerReadMarkers', () {
+    const serverId = 's';
+    final at = DateTime.utc(2026, 6, 1);
+
+    test('markRead stamps and exposes the marker synchronously', () {
+      final markers = ServerReadMarkers();
+      markers.markRead(serverId, at);
+      expect(markers.value[serverId], at);
+      markers.dispose();
+    });
+
+    test('ensureLoaded reads markers persisted by an earlier store', () async {
+      final seed = ServerReadMarkers()..markRead(serverId, at);
+      // Let the write-through persist before the next store loads.
+      await Future<void>.delayed(Duration.zero);
+      seed.dispose();
+
+      final store = ServerReadMarkers();
+      await store.ensureLoaded();
+
+      expect(store.markers.value[serverId], at);
+      store.dispose();
+    });
+  });
+}

--- a/test/modules/room/room_module_test.dart
+++ b/test/modules/room/room_module_test.dart
@@ -35,7 +35,8 @@ void main() {
       serverManager: _createManager(),
       runtimeManager: runtimeManager,
       registry: registry,
-      readMarkers: RoomReadMarkers(),
+      roomReadMarkers: RoomReadMarkers(),
+      serverReadMarkers: ServerReadMarkers(),
       appName: 'Soliplex',
     );
   });

--- a/test/modules/room/room_unread_test.dart
+++ b/test/modules/room/room_unread_test.dart
@@ -22,6 +22,8 @@ void main() {
           serverId: 's1',
           roomId: 'r1',
           selectedThreadId: selectedThreadId,
+          roomSeen: null,
+          serverSeen: null,
         );
 
     test('includes a thread with activity newer than its marker', () {
@@ -86,9 +88,10 @@ void main() {
         shouldMarkRoomRead(
           threads,
           markers,
-          roomSeen,
           serverId: 's1',
           roomId: 'r1',
+          roomSeen: roomSeen,
+          serverSeen: null,
           selectedThreadId: selectedThreadId,
         );
 
@@ -149,7 +152,7 @@ void main() {
         (serverId: 's1', roomId: 'r1'): DateTime.utc(2026, 6, 1),
       };
       expect(
-        unreadRoomIds(activity, markers, serverId: 's1'),
+        unreadRoomIds(activity, markers, serverId: 's1', serverSeen: null),
         {'r1'},
       );
     });
@@ -162,7 +165,8 @@ void main() {
         (serverId: 's1', roomId: 'r1'): DateTime.utc(2026, 6, 1),
       };
       expect(
-        unreadRoomIds(activity, markers, serverId: 's1', currentRoomId: 'r1'),
+        unreadRoomIds(activity, markers,
+            serverId: 's1', currentRoomId: 'r1', serverSeen: null),
         isEmpty,
       );
     });
@@ -177,9 +181,136 @@ void main() {
         (serverId: 's1', roomId: 'r2'): DateTime.utc(2026, 6, 1),
       };
       expect(
-        unreadRoomIds(activity, markers, serverId: 's1', currentRoomId: 'r1'),
+        unreadRoomIds(activity, markers,
+            serverId: 's1', currentRoomId: 'r1', serverSeen: null),
         {'r2'},
       );
+    });
+  });
+
+  group('read-up cascade', () {
+    final t1 = DateTime.utc(2026, 1, 1);
+    final t5 = DateTime.utc(2026, 1, 5);
+    final t9 = DateTime.utc(2026, 1, 9);
+
+    test('server floor marks every room read without a room marker', () {
+      // Rooms "a"/"b" have activity but no room marker; the server marker t9
+      // floors them so neither reads unread.
+      final unread = unreadRoomIds(
+        {'a': t5, 'b': t1},
+        const {},
+        serverId: 's',
+        serverSeen: t9,
+      );
+      expect(unread, isEmpty);
+    });
+
+    test('activity newer than the server floor still reads unread', () {
+      final unread = unreadRoomIds(
+        {'a': t9},
+        const {},
+        serverId: 's',
+        serverSeen: t5,
+      );
+      expect(unread, {'a'});
+    });
+
+    test('a room marker newer than the server floor still floors its activity',
+        () {
+      // The room's own marker t9 beats the older server floor t5, so activity
+      // at t5 reads as read.
+      final unread = unreadRoomIds(
+        {'a': t5},
+        {(serverId: 's', roomId: 'a'): t9},
+        serverId: 's',
+        serverSeen: t5,
+      );
+      expect(unread, isEmpty);
+    });
+
+    test('a newer server floor supersedes an older existing room marker', () {
+      // Room "a" already has a stale room marker t1; the newer server floor t9
+      // must win (the floor is the max of the two, not "prefer the room marker
+      // when present"), so activity at t5 reads as read. This is the mark-server-
+      // read-over-a-partially-read-room case.
+      final unread = unreadRoomIds(
+        {'a': t5},
+        {(serverId: 's', roomId: 'a'): t1},
+        serverId: 's',
+        serverSeen: t9,
+      );
+      expect(unread, isEmpty);
+    });
+
+    test('room floor marks every thread read without a thread marker', () {
+      final unread = unreadThreadIds(
+        [_thread('x', lastActivity: t5), _thread('y', lastActivity: t1)],
+        const {},
+        serverId: 's',
+        roomId: 'r1',
+        roomSeen: t9,
+        serverSeen: null,
+      );
+      expect(unread, isEmpty);
+    });
+
+    test('thread newer than its room/server floor reads unread', () {
+      final unread = unreadThreadIds(
+        [_thread('x', lastActivity: t9)],
+        const {},
+        serverId: 's',
+        roomId: 'r1',
+        roomSeen: t1,
+        serverSeen: t5,
+      );
+      expect(unread, {'x'});
+    });
+
+    test('a thread with its own newer marker beats the ancestor floor', () {
+      final unread = unreadThreadIds(
+        [_thread('x', lastActivity: t5)],
+        {(serverId: 's', roomId: 'r1', threadId: 'x'): t9},
+        serverId: 's',
+        roomId: 'r1',
+        roomSeen: t1,
+        serverSeen: null,
+      );
+      expect(unread, isEmpty);
+    });
+
+    test('a newer server floor supersedes an older existing thread marker', () {
+      // Thread "x" already has a stale thread marker t1 and there is no room
+      // marker; the newer server floor t9 must supersede the thread marker
+      // (max, not "prefer own marker") AND participate in the ancestor floor
+      // even when roomSeen is null, so activity at t5 reads as read.
+      final unread = unreadThreadIds(
+        [_thread('x', lastActivity: t5)],
+        {(serverId: 's', roomId: 'r1', threadId: 'x'): t1},
+        serverId: 's',
+        roomId: 'r1',
+        roomSeen: null,
+        serverSeen: t9,
+      );
+      expect(unread, isEmpty);
+    });
+
+    test('shouldMarkRoomRead floors its thread check by the server floor', () {
+      // Thread "b" has old activity (t5) and no thread marker, so without the
+      // floor it would read unread and block the stamp. The server floor
+      // (t7, supplied via serverSeen with no room marker) covers it, leaving no
+      // unread thread; thread "a" (read on its own marker) carries the room's
+      // latest activity (t9) past the floor, so the room genuinely transitions
+      // unread→read and should be stamped. Passing the floor through serverSeen
+      // guards that shouldMarkRoomRead folds it into the per-thread check.
+      final marked = shouldMarkRoomRead(
+        [_thread('a', lastActivity: t9), _thread('b', lastActivity: t5)],
+        {(serverId: 's', roomId: 'r1', threadId: 'a'): t9},
+        serverId: 's',
+        roomId: 'r1',
+        roomSeen: null,
+        serverSeen: DateTime.utc(2026, 1, 7),
+      );
+      expect(marked, isTrue);
     });
   });
 }


### PR DESCRIPTION
## What

Read markers now cascade down a **server → room → thread** hierarchy. Each unread check floors an item's read state under its ancestors:

- a **room** reads as read when its activity is at or before the later of its own marker and its **server's**;
- a **thread** reads as read under the later of its own, its **room's**, and its **server's** marker.

So a single higher-level marker can clear every unread dot beneath it with no per-item write.

## How

- New `latestSeen(a, b)` helper (`core/activity_read.dart`) — the later of two "last seen" markers, treating null as never-seen.
- New `ServerReadMarkers` / `ServerReadMarkerStorage` (`lobby/lobby_read_markers.dart`), mirroring the existing room-level types one level up — reactive in-memory model backed by per-device `SharedPreferences`.
- `unreadRoomIds` / `unreadThreadIds` / `shouldMarkRoomRead` take **required nullable** `serverSeen` / `roomSeen` floor params, so no call site can silently drop the floor.
- Server markers are shared through the lobby and room modules (renamed `readMarkers` → `roomReadMarkers` for clarity alongside the new `serverReadMarkers`), watched by both surfaces.

## Note — writer lands in a follow-up

This PR ships the **read path**. Nothing yet *writes* a server marker (`ServerReadMarkers.markRead` has no production caller), so in production the cascade currently collapses to the existing room/thread behavior. A "mark server read" action is a deliberate follow-up. UI-wiring tests for the server floor will follow with that writer, since injection is the only way to populate a marker until then.

## Tests

- `latestSeen` unit tests (max + null-never-wins).
- `ServerReadMarkerStorage` round-trip, corrupt-payload, and partial-corruption (drop-bad-rows-keep-good) tests.
- `read-up cascade` group in `room_unread_test.dart` covering server-floors-rooms, activity-newer-than-floor, own-marker-beats-floor, newer-floor-supersedes-stale-marker (room and thread), and `shouldMarkRoomRead` folding the floor into its per-thread check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)