### PR TITLE
Mark as read actions across lobby and room

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,7 +36,16 @@ Versions follow the `version+build` scheme from `pubspec.yaml`, bumped via
   and its server's, and a thread under the later of its own, its room's, and its
   server's — so a single higher-level marker can clear every dot beneath it with
   no per-item write. Server-level markers persist per-device alongside the
-  existing room and thread markers.
+  existing room and thread markers. Note: activating the hierarchy re-interprets
+  markers you already have, so some threads may show as read on upgrade with no
+  action on your part — the rule can only clear an unread dot, never light one.
+- Room/Lobby: you can now mark a thread, a room, or a whole server read on
+  demand — "Mark as read" in the thread tile menu, a long-press (touch) or
+  right-click (desktop) "Mark as read" on the rooms-rail circle and on the lobby
+  room cards, and "Mark all as read" in the server tile menu. Thanks to the
+  read-up hierarchy above, marking a room read also reads all its threads, and
+  marking a server read reads every room and thread on it — loaded or not — with
+  a single marker write and no per-item fan-out.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,11 @@ Versions follow the `version+build` scheme from `pubspec.yaml`, bumped via
 
 ### Fixed
 
+- Room/Lobby: removing a server now clears its per-device read markers (server,
+  room, and thread), so re-adding the same server no longer shows its rooms and
+  threads as already read. Markers are keyed by a URL-derived server id, which a
+  re-added server reuses, so a removed server's markers would otherwise floor
+  the fresh one.
 - Chat history: a malformed or out-of-range backend timestamp no longer aborts
   loading a thread's history or hangs an in-flight run; the affected message
   simply carries no timestamp. Naive (offset-less) backend timestamps are now

--- a/lib/src/modules/lobby/lobby_read_markers.dart
+++ b/lib/src/modules/lobby/lobby_read_markers.dart
@@ -132,9 +132,10 @@ class RoomReadMarkers {
   }
 
   /// Stamps [key] read as of [at] and persists. [at] is normalized to UTC so
-  /// the in-memory value matches what a reload yields (storage round-trips in
-  /// UTC), keeping marker identity stable. The [markers] update is synchronous,
-  /// so a screen watching it reacts with no storage round-trip.
+  /// the in-memory value equals what a reload yields: DateTime equality compares
+  /// the isUtc flag, so a local stamp would be unequal to its own UTC-parsed
+  /// reload. The [markers] update is synchronous, so a screen watching it reacts
+  /// with no storage round-trip.
   void markRead(RoomActivityKey key, DateTime at) {
     _markers.value = {..._markers.value, key: at.toUtc()};
     unawaited(
@@ -160,8 +161,11 @@ class RoomReadMarkers {
     unawaited(
       LobbyReadMarkerStorage.save(_markers.value)
           .catchError((Object error, StackTrace st) {
-        _logger.warning(
-          'Failed to persist room read markers',
+        // Error, not warning: a failed clear leaves stale floors on disk, so a
+        // server re-added under the same id reads as already-read (hides unread
+        // content), a worse outcome than a missed stamp.
+        _logger.error(
+          'Failed to clear room read markers for removed server',
           error: error,
           stackTrace: st,
         );
@@ -278,9 +282,10 @@ class ServerReadMarkers {
   }
 
   /// Stamps [serverId] read as of [at] and persists. [at] is normalized to UTC
-  /// so the in-memory value matches what a reload yields (storage round-trips in
-  /// UTC), keeping marker identity stable. The [markers] update is synchronous,
-  /// so a screen watching it reacts with no storage round-trip.
+  /// so the in-memory value equals what a reload yields: DateTime equality
+  /// compares the isUtc flag, so a local stamp would be unequal to its own
+  /// UTC-parsed reload. The [markers] update is synchronous, so a screen
+  /// watching it reacts with no storage round-trip.
   void markRead(String serverId, DateTime at) {
     _markers.value = {..._markers.value, serverId: at.toUtc()};
     unawaited(
@@ -303,8 +308,11 @@ class ServerReadMarkers {
     unawaited(
       ServerReadMarkerStorage.save(_markers.value)
           .catchError((Object error, StackTrace st) {
-        _logger.warning(
-          'Failed to persist server read markers',
+        // Error, not warning: a failed clear leaves a stale floor on disk, so a
+        // server re-added under the same id reads as already-read (hides unread
+        // content), a worse outcome than a missed stamp.
+        _logger.error(
+          'Failed to clear server read marker for removed server',
           error: error,
           stackTrace: st,
         );

--- a/lib/src/modules/lobby/lobby_read_markers.dart
+++ b/lib/src/modules/lobby/lobby_read_markers.dart
@@ -147,6 +147,26 @@ class RoomReadMarkers {
     );
   }
 
+  /// Drops every marker for [serverId] and persists, so a removed server's
+  /// rooms don't read as read if the server is re-added under the same id.
+  /// No-op (and no write) when the server has no markers.
+  void clearServer(String serverId) {
+    final next = {..._markers.value}
+      ..removeWhere((key, _) => key.serverId == serverId);
+    if (next.length == _markers.value.length) return;
+    _markers.value = next;
+    unawaited(
+      LobbyReadMarkerStorage.save(_markers.value)
+          .catchError((Object error, StackTrace st) {
+        _logger.warning(
+          'Failed to persist room read markers',
+          error: error,
+          stackTrace: st,
+        );
+      }),
+    );
+  }
+
   void dispose() => _markers.dispose();
 }
 
@@ -259,6 +279,23 @@ class ServerReadMarkers {
   /// synchronous, so a screen watching it reacts with no storage round-trip.
   void markRead(String serverId, DateTime at) {
     _markers.value = {..._markers.value, serverId: at};
+    unawaited(
+      ServerReadMarkerStorage.save(_markers.value)
+          .catchError((Object error, StackTrace st) {
+        _logger.warning(
+          'Failed to persist server read markers',
+          error: error,
+          stackTrace: st,
+        );
+      }),
+    );
+  }
+
+  /// Drops [serverId]'s marker and persists, so a removed server doesn't floor
+  /// its rooms if re-added under the same id. No-op when there is no marker.
+  void clearServer(String serverId) {
+    if (!_markers.value.containsKey(serverId)) return;
+    _markers.value = {..._markers.value}..remove(serverId);
     unawaited(
       ServerReadMarkerStorage.save(_markers.value)
           .catchError((Object error, StackTrace st) {

--- a/lib/src/modules/lobby/lobby_read_markers.dart
+++ b/lib/src/modules/lobby/lobby_read_markers.dart
@@ -131,10 +131,12 @@ class RoomReadMarkers {
     }
   }
 
-  /// Stamps [key] read as of [at] and persists. The [markers] update is
-  /// synchronous, so a screen watching it reacts with no storage round-trip.
+  /// Stamps [key] read as of [at] and persists. [at] is normalized to UTC so
+  /// the in-memory value matches what a reload yields (storage round-trips in
+  /// UTC), keeping marker identity stable. The [markers] update is synchronous,
+  /// so a screen watching it reacts with no storage round-trip.
   void markRead(RoomActivityKey key, DateTime at) {
-    _markers.value = {..._markers.value, key: at};
+    _markers.value = {..._markers.value, key: at.toUtc()};
     unawaited(
       LobbyReadMarkerStorage.save(_markers.value)
           .catchError((Object error, StackTrace st) {
@@ -275,10 +277,12 @@ class ServerReadMarkers {
     }
   }
 
-  /// Stamps [serverId] read as of [at] and persists. The [markers] update is
-  /// synchronous, so a screen watching it reacts with no storage round-trip.
+  /// Stamps [serverId] read as of [at] and persists. [at] is normalized to UTC
+  /// so the in-memory value matches what a reload yields (storage round-trips in
+  /// UTC), keeping marker identity stable. The [markers] update is synchronous,
+  /// so a screen watching it reacts with no storage round-trip.
   void markRead(String serverId, DateTime at) {
-    _markers.value = {..._markers.value, serverId: at};
+    _markers.value = {..._markers.value, serverId: at.toUtc()};
     unawaited(
       ServerReadMarkerStorage.save(_markers.value)
           .catchError((Object error, StackTrace st) {

--- a/lib/src/modules/lobby/lobby_state.dart
+++ b/lib/src/modules/lobby/lobby_state.dart
@@ -248,6 +248,13 @@ class LobbyState {
     );
   }
 
+  /// Stamps [serverId] read as of now (from the server tile menu). Via the
+  /// read-up rule this reads every room and thread on the server — loaded or not
+  /// — as read, with a single marker write.
+  void markServerRead(String serverId) {
+    _serverReadMarkers.markRead(serverId, clock.now().toUtc());
+  }
+
   /// True while activity for the selected server is being fetched.
   final Signal<bool> _activityLoading = Signal(false);
   ReadonlySignal<bool> get activityLoading => _activityLoading;

--- a/lib/src/modules/lobby/lobby_state.dart
+++ b/lib/src/modules/lobby/lobby_state.dart
@@ -521,7 +521,10 @@ class LobbyState {
         unawaited(
           ThreadReadMarkerStorage.clearServer(id)
               .catchError((Object error, StackTrace st) {
-            _logger.warning(
+            // Error, not warning: a failed clear leaves stale thread floors on
+            // disk, so a server re-added under the same id reads as already-read
+            // (hides unread content), a worse outcome than a missed stamp.
+            _logger.error(
               'Failed to clear thread read markers for removed server',
               error: error,
               stackTrace: st,

--- a/lib/src/modules/lobby/lobby_state.dart
+++ b/lib/src/modules/lobby/lobby_state.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 import 'dart:convert';
 
+import 'package:clock/clock.dart';
 import 'package:soliplex_agent/soliplex_agent.dart' hide AuthException;
 import 'package:soliplex_client/soliplex_client.dart'
     show
@@ -236,6 +237,16 @@ class LobbyState {
   /// server's marker here, so a server marker floors all its rooms.
   ReadonlySignal<Map<String, DateTime>> get serverReadMarkers =>
       _serverReadMarkers.markers;
+
+  /// Stamps a room read as of now (from a lobby card's context menu). Writes
+  /// through the shared store, so the rail's dot clears too, and every thread in
+  /// the room reads as read via the read-up rule.
+  void markRoomRead(String serverId, String roomId) {
+    _roomReadMarkers.markRead(
+      (serverId: serverId, roomId: roomId),
+      clock.now().toUtc(),
+    );
+  }
 
   /// True while activity for the selected server is being fetched.
   final Signal<bool> _activityLoading = Signal(false);

--- a/lib/src/modules/lobby/lobby_state.dart
+++ b/lib/src/modules/lobby/lobby_state.dart
@@ -19,6 +19,7 @@ import '../auth/server_entry.dart';
 import '../auth/server_manager.dart';
 import '../room/room_run_activity.dart';
 import '../room/run_registry.dart';
+import '../room/thread_read_markers.dart';
 import 'lobby_read_markers.dart';
 import 'lobby_sort_mode.dart';
 import 'lobby_view_mode.dart';
@@ -512,6 +513,21 @@ class LobbyState {
         // Drop a stuck in-flight activity fetch for a removed server; otherwise
         // _activityFetchServerId would block a future fetch if the id returns.
         if (_activityFetchServerId == id) _cancelActivityFetch();
+        // Server ids are derived from the URL, so re-adding a removed server
+        // reuses its id. Drop its read markers at every level so the re-added
+        // server starts unread instead of inheriting the old floors.
+        _serverReadMarkers.clearServer(id);
+        _roomReadMarkers.clearServer(id);
+        unawaited(
+          ThreadReadMarkerStorage.clearServer(id)
+              .catchError((Object error, StackTrace st) {
+            _logger.warning(
+              'Failed to clear thread read markers for removed server',
+              error: error,
+              stackTrace: st,
+            );
+          }),
+        );
       }
       _roomsByServer.value = updatedRooms;
       _userProfiles.value = updatedProfiles;

--- a/lib/src/modules/lobby/ui/lobby_screen.dart
+++ b/lib/src/modules/lobby/ui/lobby_screen.dart
@@ -159,6 +159,7 @@ class _LobbyScreenState extends State<LobbyScreen> {
                 activityLoading: activityLoading,
                 selectedServerId: selectedServerId,
                 onSelectServer: _state.selectServer,
+                onMarkServerRead: _state.markServerRead,
                 serverManager: widget.serverManager,
                 onAddServer: _onAddServer,
                 onNetworkInspector: _onNetworkInspector,
@@ -185,6 +186,7 @@ class _LobbyScreenState extends State<LobbyScreen> {
                 activityLoading: activityLoading,
                 selectedServerId: selectedServerId,
                 onSelectServer: _state.selectServer,
+                onMarkServerRead: _state.markServerRead,
                 serverManager: widget.serverManager,
                 onAddServer: _onAddServer,
                 onNetworkInspector: _onNetworkInspector,
@@ -217,6 +219,7 @@ class _WideLayout extends StatelessWidget {
     required this.activityLoading,
     required this.selectedServerId,
     required this.onSelectServer,
+    required this.onMarkServerRead,
     required this.serverManager,
     required this.onAddServer,
     required this.onNetworkInspector,
@@ -243,6 +246,7 @@ class _WideLayout extends StatelessWidget {
   final bool activityLoading;
   final String? selectedServerId;
   final void Function(String serverId) onSelectServer;
+  final void Function(String serverId) onMarkServerRead;
   final ServerManager serverManager;
   final VoidCallback onAddServer;
   final VoidCallback onNetworkInspector;
@@ -270,6 +274,7 @@ class _WideLayout extends StatelessWidget {
                 selectedServerId: selectedServerId,
                 onSelectServer: onSelectServer,
                 onSignIn: onSignIn,
+                onMarkServerRead: onMarkServerRead,
                 onAddServer: onAddServer,
                 onNetworkInspector: onNetworkInspector,
                 onVersions: onVersions,
@@ -323,6 +328,7 @@ class _NarrowLayout extends StatelessWidget {
     required this.activityLoading,
     required this.selectedServerId,
     required this.onSelectServer,
+    required this.onMarkServerRead,
     required this.serverManager,
     required this.onAddServer,
     required this.onNetworkInspector,
@@ -349,6 +355,7 @@ class _NarrowLayout extends StatelessWidget {
   final bool activityLoading;
   final String? selectedServerId;
   final void Function(String serverId) onSelectServer;
+  final void Function(String serverId) onMarkServerRead;
   final ServerManager serverManager;
   final VoidCallback onAddServer;
   final VoidCallback onNetworkInspector;
@@ -387,6 +394,7 @@ class _NarrowLayout extends StatelessWidget {
                 Scaffold.of(drawerContext).closeDrawer();
               },
               onSignIn: onSignIn,
+              onMarkServerRead: onMarkServerRead,
               onAddServer: onAddServer,
               onNetworkInspector: onNetworkInspector,
               onVersions: onVersions,

--- a/lib/src/modules/lobby/ui/lobby_screen.dart
+++ b/lib/src/modules/lobby/ui/lobby_screen.dart
@@ -904,8 +904,9 @@ class _ServerSection extends StatelessWidget {
             children: [
               for (final room in rooms)
                 MarkReadContextMenu(
-                  enabled: _isUnread(room),
-                  onMarkRead: () => onMarkRoomRead(serverId, room.id),
+                  onMarkRead: _isUnread(room)
+                      ? () => onMarkRoomRead(serverId, room.id)
+                      : null,
                   child: RoomCard(
                     room: room,
                     activityTime: _activityFor(room),
@@ -1007,9 +1008,10 @@ class _RoomGrid extends StatelessWidget {
                       Expanded(
                         child: i < rowRooms.length
                             ? MarkReadContextMenu(
-                                enabled: isUnread(rowRooms[i]),
-                                onMarkRead: () =>
-                                    onMarkRoomRead(serverId, rowRooms[i].id),
+                                onMarkRead: isUnread(rowRooms[i])
+                                    ? () =>
+                                        onMarkRoomRead(serverId, rowRooms[i].id)
+                                    : null,
                                 child: RoomGridCard(
                                   room: rowRooms[i],
                                   activityTime: activityFor(rowRooms[i]),

--- a/lib/src/modules/lobby/ui/lobby_screen.dart
+++ b/lib/src/modules/lobby/ui/lobby_screen.dart
@@ -8,6 +8,7 @@ import 'package:soliplex_client/soliplex_client.dart'
 import '../../../core/activity_read.dart';
 import '../../../core/app_identity.dart';
 import '../../../core/routes.dart';
+import '../../../shared/mark_read_context_menu.dart';
 import '../../auth/server_entry.dart';
 import '../../auth/server_manager.dart';
 import '../../room/run_registry.dart';
@@ -163,6 +164,7 @@ class _LobbyScreenState extends State<LobbyScreen> {
                 onNetworkInspector: _onNetworkInspector,
                 onVersions: _onVersions,
                 onRoomTap: _onRoomTap,
+                onMarkRoomRead: _state.markRoomRead,
                 onInfoTap: _onInfoTap,
                 onSignIn: _onSignIn,
               )
@@ -188,6 +190,7 @@ class _LobbyScreenState extends State<LobbyScreen> {
                 onNetworkInspector: _onNetworkInspector,
                 onVersions: _onVersions,
                 onRoomTap: _onRoomTap,
+                onMarkRoomRead: _state.markRoomRead,
                 onInfoTap: _onInfoTap,
                 onSignIn: _onSignIn,
               );
@@ -219,6 +222,7 @@ class _WideLayout extends StatelessWidget {
     required this.onNetworkInspector,
     required this.onVersions,
     required this.onRoomTap,
+    required this.onMarkRoomRead,
     required this.onInfoTap,
     required this.onSignIn,
   });
@@ -244,6 +248,7 @@ class _WideLayout extends StatelessWidget {
   final VoidCallback onNetworkInspector;
   final VoidCallback onVersions;
   final void Function(String serverId, String roomId) onRoomTap;
+  final void Function(String serverId, String roomId) onMarkRoomRead;
   final void Function(String serverId, String roomId) onInfoTap;
   final void Function(String serverId) onSignIn;
 
@@ -287,6 +292,7 @@ class _WideLayout extends StatelessWidget {
                 activityLoading: activityLoading,
                 selectedServerId: selectedServerId,
                 onRoomTap: onRoomTap,
+                onMarkRoomRead: onMarkRoomRead,
                 onInfoTap: onInfoTap,
                 onAddServer: onAddServer,
                 onSignIn: onSignIn,
@@ -322,6 +328,7 @@ class _NarrowLayout extends StatelessWidget {
     required this.onNetworkInspector,
     required this.onVersions,
     required this.onRoomTap,
+    required this.onMarkRoomRead,
     required this.onInfoTap,
     required this.onSignIn,
   });
@@ -347,6 +354,7 @@ class _NarrowLayout extends StatelessWidget {
   final VoidCallback onNetworkInspector;
   final VoidCallback onVersions;
   final void Function(String serverId, String roomId) onRoomTap;
+  final void Function(String serverId, String roomId) onMarkRoomRead;
   final void Function(String serverId, String roomId) onInfoTap;
   final void Function(String serverId) onSignIn;
 
@@ -405,6 +413,7 @@ class _NarrowLayout extends StatelessWidget {
           activityLoading: activityLoading,
           selectedServerId: selectedServerId,
           onRoomTap: onRoomTap,
+          onMarkRoomRead: onMarkRoomRead,
           onInfoTap: onInfoTap,
           onAddServer: onAddServer,
           onSignIn: onSignIn,
@@ -430,6 +439,7 @@ class _RoomContent extends StatelessWidget {
     required this.activityLoading,
     required this.selectedServerId,
     required this.onRoomTap,
+    required this.onMarkRoomRead,
     required this.onInfoTap,
     required this.onAddServer,
     required this.onSignIn,
@@ -449,6 +459,7 @@ class _RoomContent extends StatelessWidget {
   final bool activityLoading;
   final String? selectedServerId;
   final void Function(String serverId, String roomId) onRoomTap;
+  final void Function(String serverId, String roomId) onMarkRoomRead;
   final void Function(String serverId, String roomId) onInfoTap;
   final VoidCallback onAddServer;
   final void Function(String serverId) onSignIn;
@@ -544,6 +555,7 @@ class _RoomContent extends StatelessWidget {
           roomReadMarkers: roomReadMarkers,
           serverReadMarkers: serverReadMarkers,
           onRoomTap: onRoomTap,
+          onMarkRoomRead: onMarkRoomRead,
           onInfoTap: onInfoTap,
           onSignIn: onSignIn,
         ),
@@ -735,6 +747,7 @@ class _ServerSection extends StatelessWidget {
     required this.roomReadMarkers,
     required this.serverReadMarkers,
     required this.onRoomTap,
+    required this.onMarkRoomRead,
     required this.onInfoTap,
     required this.onSignIn,
   });
@@ -748,6 +761,7 @@ class _ServerSection extends StatelessWidget {
   final Map<RoomActivityKey, DateTime> roomReadMarkers;
   final Map<String, DateTime> serverReadMarkers;
   final void Function(String serverId, String roomId) onRoomTap;
+  final void Function(String serverId, String roomId) onMarkRoomRead;
   final void Function(String serverId, String roomId) onInfoTap;
   final void Function(String serverId) onSignIn;
 
@@ -881,12 +895,16 @@ class _ServerSection extends StatelessWidget {
           child: Column(
             children: [
               for (final room in rooms)
-                RoomCard(
-                  room: room,
-                  activityTime: _activityFor(room),
-                  isUnread: _isUnread(room),
-                  onTap: () => onRoomTap(serverId, room.id),
-                  onInfoTap: () => onInfoTap(serverId, room.id),
+                MarkReadContextMenu(
+                  enabled: _isUnread(room),
+                  onMarkRead: () => onMarkRoomRead(serverId, room.id),
+                  child: RoomCard(
+                    room: room,
+                    activityTime: _activityFor(room),
+                    isUnread: _isUnread(room),
+                    onTap: () => onRoomTap(serverId, room.id),
+                    onInfoTap: () => onInfoTap(serverId, room.id),
+                  ),
                 ),
             ],
           ),
@@ -897,6 +915,7 @@ class _ServerSection extends StatelessWidget {
           activityFor: _activityFor,
           isUnread: _isUnread,
           onRoomTap: onRoomTap,
+          onMarkRoomRead: onMarkRoomRead,
           onInfoTap: onInfoTap,
         ),
     };
@@ -940,6 +959,7 @@ class _RoomGrid extends StatelessWidget {
     required this.activityFor,
     required this.isUnread,
     required this.onRoomTap,
+    required this.onMarkRoomRead,
     required this.onInfoTap,
   });
 
@@ -948,6 +968,7 @@ class _RoomGrid extends StatelessWidget {
   final DateTime? Function(Room) activityFor;
   final bool Function(Room) isUnread;
   final void Function(String serverId, String roomId) onRoomTap;
+  final void Function(String serverId, String roomId) onMarkRoomRead;
   final void Function(String serverId, String roomId) onInfoTap;
 
   @override
@@ -977,14 +998,19 @@ class _RoomGrid extends StatelessWidget {
                       if (i > 0) const SizedBox(width: spacing),
                       Expanded(
                         child: i < rowRooms.length
-                            ? RoomGridCard(
-                                room: rowRooms[i],
-                                activityTime: activityFor(rowRooms[i]),
-                                isUnread: isUnread(rowRooms[i]),
-                                onTap: () =>
-                                    onRoomTap(serverId, rowRooms[i].id),
-                                onInfoTap: () =>
-                                    onInfoTap(serverId, rowRooms[i].id),
+                            ? MarkReadContextMenu(
+                                enabled: isUnread(rowRooms[i]),
+                                onMarkRead: () =>
+                                    onMarkRoomRead(serverId, rowRooms[i].id),
+                                child: RoomGridCard(
+                                  room: rowRooms[i],
+                                  activityTime: activityFor(rowRooms[i]),
+                                  isUnread: isUnread(rowRooms[i]),
+                                  onTap: () =>
+                                      onRoomTap(serverId, rowRooms[i].id),
+                                  onInfoTap: () =>
+                                      onInfoTap(serverId, rowRooms[i].id),
+                                ),
                               )
                             : const SizedBox.shrink(),
                       ),

--- a/lib/src/modules/lobby/ui/server_sidebar.dart
+++ b/lib/src/modules/lobby/ui/server_sidebar.dart
@@ -25,6 +25,7 @@ class ServerSidebar extends StatelessWidget {
     required this.selectedServerId,
     required this.onSelectServer,
     required this.onSignIn,
+    required this.onMarkServerRead,
     required this.onAddServer,
     required this.onNetworkInspector,
     required this.onVersions,
@@ -47,6 +48,9 @@ class ServerSidebar extends StatelessWidget {
 
   /// Routes a disconnected server to its sign-in flow.
   final void Function(String serverId) onSignIn;
+
+  /// Marks every room (and thread) on a server read, from its tile menu.
+  final void Function(String serverId) onMarkServerRead;
   final VoidCallback onAddServer;
   final VoidCallback onNetworkInspector;
   final VoidCallback onVersions;
@@ -73,6 +77,7 @@ class ServerSidebar extends StatelessWidget {
               selectedServerId: selectedServerId,
               onSelectServer: onSelectServer,
               onSignIn: onSignIn,
+              onMarkServerRead: onMarkServerRead,
               onAddServer: onAddServer,
             ),
           ),
@@ -150,6 +155,7 @@ class _ServerList extends StatelessWidget {
     required this.selectedServerId,
     required this.onSelectServer,
     required this.onSignIn,
+    required this.onMarkServerRead,
     required this.onAddServer,
   });
 
@@ -158,6 +164,7 @@ class _ServerList extends StatelessWidget {
   final String? selectedServerId;
   final void Function(String serverId) onSelectServer;
   final void Function(String serverId) onSignIn;
+  final void Function(String serverId) onMarkServerRead;
   final VoidCallback onAddServer;
 
   @override
@@ -183,6 +190,7 @@ class _ServerList extends StatelessWidget {
             selected: entry.key == selectedServerId,
             onTap: () => onSelectServer(entry.key),
             onSignIn: () => onSignIn(entry.key),
+            onMarkAllRead: () => onMarkServerRead(entry.key),
           ),
         Padding(
           padding: const EdgeInsets.only(top: SoliplexSpacing.s2),
@@ -204,6 +212,7 @@ class _ServerTile extends StatefulWidget {
     required this.selected,
     required this.onTap,
     required this.onSignIn,
+    required this.onMarkAllRead,
   });
 
   final ServerEntry entry;
@@ -211,6 +220,7 @@ class _ServerTile extends StatefulWidget {
   final bool selected;
   final VoidCallback onTap;
   final VoidCallback onSignIn;
+  final VoidCallback onMarkAllRead;
 
   @override
   State<_ServerTile> createState() => _ServerTileState();
@@ -259,6 +269,7 @@ class _ServerTileState extends State<_ServerTile> {
             entry: widget.entry,
             serverManager: widget.serverManager,
             onSignIn: widget.onSignIn,
+            onMarkAllRead: widget.onMarkAllRead,
           ),
         ),
         dense: true,
@@ -316,7 +327,7 @@ String _signedInName(UserProfile? profile) {
 
 /// Per-server actions behind a tile's trailing ⋮ menu. The available set
 /// depends on the server's connection state (see [_ServerTileMenu]).
-enum _ServerTileAction { signIn, logOut, copyAddress, remove }
+enum _ServerTileAction { signIn, logOut, markAllRead, copyAddress, remove }
 
 /// What happens to the entry after a log-out attempt. The error-menu escape
 /// hatch (remove even when sign-out fails) is a third outcome beyond "keep"
@@ -348,11 +359,13 @@ class _ServerTileMenu extends ConsumerStatefulWidget {
     required this.entry,
     required this.serverManager,
     required this.onSignIn,
+    required this.onMarkAllRead,
   });
 
   final ServerEntry entry;
   final ServerManager serverManager;
   final VoidCallback onSignIn;
+  final VoidCallback onMarkAllRead;
 
   @override
   ConsumerState<_ServerTileMenu> createState() => _ServerTileMenuState();
@@ -368,6 +381,8 @@ class _ServerTileMenuState extends ConsumerState<_ServerTileMenu> {
         widget.onSignIn();
       case _ServerTileAction.logOut:
         await _runLogout(_AfterLogout.keep);
+      case _ServerTileAction.markAllRead:
+        widget.onMarkAllRead();
       case _ServerTileAction.copyAddress:
         await _copyAddress();
       case _ServerTileAction.remove:
@@ -493,6 +508,13 @@ class _ServerTileMenuState extends ConsumerState<_ServerTileMenu> {
             value: _ServerTileAction.logOut,
             child: _MenuRow(icon: Icons.logout, label: 'Log out'),
           ),
+        const PopupMenuItem(
+          value: _ServerTileAction.markAllRead,
+          child: _MenuRow(
+            icon: Icons.mark_chat_read_outlined,
+            label: 'Mark all as read',
+          ),
+        ),
         const PopupMenuItem(
           value: _ServerTileAction.copyAddress,
           child: _MenuRow(

--- a/lib/src/modules/room/room_state.dart
+++ b/lib/src/modules/room/room_state.dart
@@ -319,7 +319,7 @@ class RoomState {
           threadList.noteSpawnedThread(ThreadInfo(
             id: key.threadId,
             roomId: _roomId,
-            createdAt: DateTime.now(),
+            createdAt: DateTime.timestamp(),
           ));
           selectThread(key.threadId);
           _activeThreadView!.attachSession(session);

--- a/lib/src/modules/room/room_unread.dart
+++ b/lib/src/modules/room/room_unread.dart
@@ -49,8 +49,10 @@ Set<String> unreadRoomIds(
 /// [roomSeen] and [serverSeen] are the ancestor markers: a thread reads as read
 /// when its activity is at or before the later of its own marker and either
 /// ancestor, so a room (or server) marker floors every thread inside it without
-/// a per-thread write. Both are required (pass null for "no ancestor marker") so
-/// a caller can't silently drop a floor and leave a thread's dot stale.
+/// a per-thread write. This upward flooring is the "read-up rule" referenced
+/// elsewhere (e.g. the marker-stamping doc comments). Both are required (pass
+/// null for "no ancestor marker") so a caller can't silently drop a floor and
+/// leave a thread's dot stale.
 Set<String> unreadThreadIds(
   List<ThreadInfo> threads,
   Map<ThreadActivityKey, DateTime> threadMarkers, {

--- a/lib/src/modules/room/thread_read_markers.dart
+++ b/lib/src/modules/room/thread_read_markers.dart
@@ -97,6 +97,15 @@ abstract final class ThreadReadMarkerStorage {
   /// Drops every thread marker for [serverId], so a removed server's threads
   /// don't read as read if the server is re-added under the same id. No-op (and
   /// no write) when the server has no markers.
+  ///
+  /// Fire-and-forget with no retry: unlike the signal-backed room/server
+  /// stores, this has no in-memory owner to re-save a corrected map, so a
+  /// failed [save] leaves stale thread floors on disk (a re-added same-id
+  /// server reads as already-read). Accepted because a re-add after a write
+  /// failure is rare and the caller logs the failure at error level. A live
+  /// RoomScreen's marker flush, which persists its full cross-server map, can
+  /// likewise overwrite this clear — reachable only if lobby and room are ever
+  /// mounted at once, which the current navigation never does.
   static Future<void> clearServer(String serverId) async {
     final markers = await load();
     final next = {...markers}

--- a/lib/src/modules/room/thread_read_markers.dart
+++ b/lib/src/modules/room/thread_read_markers.dart
@@ -1,7 +1,10 @@
 import 'dart:convert';
-import 'dart:developer' as dev;
 
 import 'package:shared_preferences/shared_preferences.dart';
+import 'package:soliplex_logging/soliplex_logging.dart';
+
+final Logger _logger =
+    LogManager.instance.getLogger('soliplex.thread_read_markers');
 
 /// Identifies a thread across servers and rooms for the read model. Named
 /// fields (rather than a positional tuple) so the three ids can't be
@@ -31,10 +34,8 @@ abstract final class ThreadReadMarkerStorage {
     try {
       final decoded = jsonDecode(raw);
       if (decoded is! List) {
-        dev.log(
-          'Discarding corrupt thread read markers (not a JSON array)',
-          level: 900,
-        );
+        _logger.warning(
+            'Discarding corrupt thread read markers (not a JSON array)');
         return {};
       }
       var skipped = 0;
@@ -62,23 +63,17 @@ abstract final class ThreadReadMarkerStorage {
         // Every row dropped on a non-empty payload is a systemic serialization
         // break, not one stale row, and it silently resets the read model
         // (every thread flips to unread). Surface it loudly.
-        dev.log(
-          'Discarding all $skipped thread read markers; none parsed',
-          level: 1000,
-        );
+        _logger
+            .error('Discarding all $skipped thread read markers; none parsed');
       } else if (skipped > 0) {
-        dev.log(
-          'Skipped $skipped malformed thread read marker(s)',
-          level: 900,
-        );
+        _logger.warning('Skipped $skipped malformed thread read marker(s)');
       }
     } on FormatException catch (e, st) {
       // Corrupt payload: start fresh rather than wedging the room.
-      dev.log(
+      _logger.warning(
         'Discarding corrupt thread read markers',
         error: e,
         stackTrace: st,
-        level: 900,
       );
       return {};
     }

--- a/lib/src/modules/room/thread_read_markers.dart
+++ b/lib/src/modules/room/thread_read_markers.dart
@@ -98,4 +98,15 @@ abstract final class ThreadReadMarkerStorage {
     ];
     await prefs.setString(_key, jsonEncode(list));
   }
+
+  /// Drops every thread marker for [serverId], so a removed server's threads
+  /// don't read as read if the server is re-added under the same id. No-op (and
+  /// no write) when the server has no markers.
+  static Future<void> clearServer(String serverId) async {
+    final markers = await load();
+    final next = {...markers}
+      ..removeWhere((key, _) => key.serverId == serverId);
+    if (next.length == markers.length) return;
+    await save(next);
+  }
 }

--- a/lib/src/modules/room/ui/room_rail.dart
+++ b/lib/src/modules/room/ui/room_rail.dart
@@ -4,6 +4,7 @@ import 'package:soliplex_client/soliplex_client.dart'
     show PermissionDeniedException, Room;
 import 'package:soliplex_design/soliplex_design.dart';
 
+import '../../../shared/mark_read_context_menu.dart';
 import '../../auth/auth_tokens.dart';
 import '../../auth/server_entry.dart';
 import '../../lobby/ui/unread_dot.dart';
@@ -39,6 +40,7 @@ class RoomRail extends StatelessWidget {
     this.onRetryRooms,
     this.unreadRoomIds = const {},
     this.dividerIndex,
+    this.onMarkRoomRead,
   });
 
   /// The server's rooms, or `null` while loading.
@@ -70,6 +72,10 @@ class RoomRail extends StatelessWidget {
 
   final VoidCallback onNetworkInspector;
   final VoidCallback onVersions;
+
+  /// Marks a room read from its avatar's context menu (long-press /
+  /// secondary-tap). Offered only for unread rooms; null disables the menu.
+  final void Function(String roomId)? onMarkRoomRead;
 
   /// Fixed rail width — wide enough for a 44px avatar plus the selection bar
   /// and breathing room, narrow enough to stay a rail.
@@ -151,6 +157,8 @@ class RoomRail extends StatelessWidget {
           selected: room.id == selectedRoomId,
           unread: unreadRoomIds.contains(room.id),
           onTap: () => onSelectRoom(room.id),
+          onMarkRead:
+              onMarkRoomRead == null ? null : () => onMarkRoomRead!(room.id),
         );
       },
     );
@@ -165,12 +173,17 @@ class _RoomAvatarTile extends StatelessWidget {
     required this.selected,
     required this.unread,
     required this.onTap,
+    required this.onMarkRead,
   });
 
   final Room room;
   final bool selected;
   final bool unread;
   final VoidCallback onTap;
+
+  /// Stamps this room read from the context menu; null when marking is
+  /// unavailable. The menu is offered only when the room is [unread].
+  final VoidCallback? onMarkRead;
 
   static const double _avatar = 44;
 
@@ -180,61 +193,66 @@ class _RoomAvatarTile extends StatelessWidget {
     final bg = roomAvatarColor(room.name, theme.brightness);
     final fg = contrastingForeground(bg);
 
-    return Tooltip(
-      message: room.name,
-      child: Padding(
-        padding: const EdgeInsets.symmetric(vertical: SoliplexSpacing.s1),
-        child: SizedBox(
-          height: _avatar,
-          child: Stack(
-            alignment: Alignment.center,
-            children: [
-              // Leading selection bar, hugging the rail's left edge.
-              if (selected)
-                Align(
-                  alignment: Alignment.centerLeft,
-                  child: Container(
-                    width: SoliplexSpacing.s1,
-                    height: _avatar - SoliplexSpacing.s2,
-                    decoration: BoxDecoration(
-                      color: theme.colorScheme.primary,
-                      borderRadius: BorderRadius.circular(context.radii.sm),
+    return MarkReadContextMenu(
+      enabled: unread && onMarkRead != null,
+      onMarkRead: onMarkRead ?? () {},
+      child: Tooltip(
+        message: room.name,
+        child: Padding(
+          padding: const EdgeInsets.symmetric(vertical: SoliplexSpacing.s1),
+          child: SizedBox(
+            height: _avatar,
+            child: Stack(
+              alignment: Alignment.center,
+              children: [
+                // Leading selection bar, hugging the rail's left edge.
+                if (selected)
+                  Align(
+                    alignment: Alignment.centerLeft,
+                    child: Container(
+                      width: SoliplexSpacing.s1,
+                      height: _avatar - SoliplexSpacing.s2,
+                      decoration: BoxDecoration(
+                        color: theme.colorScheme.primary,
+                        borderRadius: BorderRadius.circular(context.radii.sm),
+                      ),
                     ),
                   ),
-                ),
-              // Fixed-size box so the unread badge anchors to the avatar's
-              // corner rather than the wider rail column.
-              SizedBox.square(
-                dimension: _avatar,
-                child: Stack(
-                  clipBehavior: Clip.none,
-                  children: [
-                    Positioned.fill(
-                      child: Material(
-                        color: bg,
-                        // A selected avatar squares off (smaller radius) so the
-                        // shape shift reinforces the leading bar.
-                        borderRadius: BorderRadius.circular(
-                            selected ? context.radii.md : _avatar / 2),
-                        clipBehavior: Clip.antiAlias,
-                        child: InkWell(
-                          onTap: onTap,
-                          child: Center(
-                            child: Text(
-                              _avatarInitial(room.name),
-                              style: theme.textTheme.titleMedium
-                                  ?.copyWith(color: fg),
+                // Fixed-size box so the unread badge anchors to the avatar's
+                // corner rather than the wider rail column.
+                SizedBox.square(
+                  dimension: _avatar,
+                  child: Stack(
+                    clipBehavior: Clip.none,
+                    children: [
+                      Positioned.fill(
+                        child: Material(
+                          color: bg,
+                          // A selected avatar squares off (smaller radius) so the
+                          // shape shift reinforces the leading bar.
+                          borderRadius: BorderRadius.circular(
+                              selected ? context.radii.md : _avatar / 2),
+                          clipBehavior: Clip.antiAlias,
+                          child: InkWell(
+                            onTap: onTap,
+                            child: Center(
+                              child: Text(
+                                _avatarInitial(room.name),
+                                style: theme.textTheme.titleMedium
+                                    ?.copyWith(color: fg),
+                              ),
                             ),
                           ),
                         ),
                       ),
-                    ),
-                    if (unread)
-                      const Positioned(top: 0, right: 0, child: _UnreadBadge()),
-                  ],
+                      if (unread)
+                        const Positioned(
+                            top: 0, right: 0, child: _UnreadBadge()),
+                    ],
+                  ),
                 ),
-              ),
-            ],
+              ],
+            ),
           ),
         ),
       ),

--- a/lib/src/modules/room/ui/room_rail.dart
+++ b/lib/src/modules/room/ui/room_rail.dart
@@ -193,11 +193,18 @@ class _RoomAvatarTile extends StatelessWidget {
     final bg = roomAvatarColor(room.name, theme.brightness);
     final fg = contrastingForeground(bg);
 
-    return MarkReadContextMenu(
-      enabled: unread && onMarkRead != null,
-      onMarkRead: onMarkRead ?? () {},
-      child: Tooltip(
-        message: room.name,
+    // Tooltip must wrap the context menu (not the other way round): the
+    // tooltip triggers on long-press for touch, so if it sat *inside* the
+    // menu's GestureDetector it would win the gesture arena and the long-press
+    // menu would never open. As the outer widget its recognizer is the ancestor
+    // one, so the menu's (descendant) long-press wins when a room is unread.
+    return Tooltip(
+      message: room.name,
+      child: MarkReadContextMenu(
+        onMarkRead: unread ? onMarkRead : null,
+        // The avatar is a single letter; surface the room name in the menu so a
+        // long-press still identifies the room where the tooltip can't fire.
+        title: room.name,
         child: Padding(
           padding: const EdgeInsets.symmetric(vertical: SoliplexSpacing.s1),
           child: SizedBox(

--- a/lib/src/modules/room/ui/room_screen.dart
+++ b/lib/src/modules/room/ui/room_screen.dart
@@ -414,9 +414,11 @@ class _RoomScreenState extends State<RoomScreen> {
 
   /// Stamps [roomId] on the current server read as of now. Uses "now" (not the
   /// cached activity time) so the marker is at or after any observed activity,
-  /// even if the activity batch is stale or pending. Only [_recomputeRoomRead]
-  /// calls this, and only once no thread is unread. The shared store both
-  /// persists and notifies its watchers (this build and the lobby's).
+  /// even if the activity batch is stale or pending. Called by
+  /// [_recomputeRoomRead] once no thread is unread, and directly from the rail's
+  /// context menu to mark a room read on demand (which floors its threads via
+  /// the read-up rule). The shared store both persists and notifies its
+  /// watchers (this build and the lobby's).
   void _markRoomRead(String roomId) {
     _roomReadMarkers.markRead(
       (serverId: widget.serverEntry.serverId, roomId: roomId),
@@ -1313,6 +1315,7 @@ class _RoomScreenState extends State<RoomScreen> {
       roomsError: _serverRoomsError,
       onRetryRooms: () => setState(_fetchServerRooms),
       unreadRoomIds: _unreadRoomIds,
+      onMarkRoomRead: _markRoomRead,
       selectedRoomId: widget.roomId,
       onSelectRoom: (roomId) {
         onNavigate?.call();

--- a/lib/src/modules/room/ui/room_screen.dart
+++ b/lib/src/modules/room/ui/room_screen.dart
@@ -1182,24 +1182,29 @@ class _RoomScreenState extends State<RoomScreen> {
       child: LayoutBuilder(
         builder: (context, constraints) {
           final isWide = constraints.maxWidth >= SoliplexBreakpoints.tablet;
-          final sidebar = ThreadSidebar(
-            threadListStatus: threadListStatus,
-            selectedThreadId: selectedThreadId,
-            onThreadSelected: _onThreadSelected,
-            onBackToLobby: _onBackToLobby,
-            onCreateThread: _state.createThread,
-            onRetryThreads: () => _state.threadList.refresh(),
-            onReauthenticate: _onReauthenticate,
-            quizzes: room?.quizzes ?? const {},
-            onQuizTapped: _onQuizTapped,
-            onRenameThread: _showRenameDialog,
-            onDeleteThread: _showDeleteDialog,
-            runningThreadIds: _state.runningThreadIds,
-            unreadThreadIds: unreadThreadIds,
-          );
           final content = _buildContent(room);
 
           if (isWide) {
+            final sidebar = ThreadSidebar(
+              threadListStatus: threadListStatus,
+              selectedThreadId: selectedThreadId,
+              onThreadSelected: _onThreadSelected,
+              onBackToLobby: _onBackToLobby,
+              onCreateThread: _state.createThread,
+              onRetryThreads: () => _state.threadList.refresh(),
+              onReauthenticate: _onReauthenticate,
+              quizzes: room?.quizzes ?? const {},
+              onQuizTapped: _onQuizTapped,
+              onRenameThread: _showRenameDialog,
+              onDeleteThread: _showDeleteDialog,
+              onMarkThreadRead: (threadId) => _stampThreadRead((
+                serverId: widget.serverEntry.serverId,
+                roomId: widget.roomId,
+                threadId: threadId,
+              )),
+              runningThreadIds: _state.runningThreadIds,
+              unreadThreadIds: unreadThreadIds,
+            );
             return Scaffold(
               // No AppBar here, so SafeArea guards every edge: the rail/sidebar
               // headers clear the status bar and side notches, and the chat
@@ -1269,6 +1274,11 @@ class _RoomScreenState extends State<RoomScreen> {
                             Navigator.pop(drawerContext);
                             _showDeleteDialog(id);
                           },
+                          onMarkThreadRead: (threadId) => _stampThreadRead((
+                            serverId: widget.serverEntry.serverId,
+                            roomId: widget.roomId,
+                            threadId: threadId,
+                          )),
                         ),
                       ),
                     ],

--- a/lib/src/modules/room/ui/thread_sidebar.dart
+++ b/lib/src/modules/room/ui/thread_sidebar.dart
@@ -22,6 +22,7 @@ class ThreadSidebar extends StatelessWidget {
     this.onQuizTapped,
     this.onRenameThread,
     this.onDeleteThread,
+    this.onMarkThreadRead,
   });
 
   final ThreadListStatus threadListStatus;
@@ -35,6 +36,7 @@ class ThreadSidebar extends StatelessWidget {
   final void Function(String quizId)? onQuizTapped;
   final void Function(String threadId, String currentName)? onRenameThread;
   final void Function(String threadId)? onDeleteThread;
+  final void Function(String threadId)? onMarkThreadRead;
   final ReadonlySignal<Set<String>> runningThreadIds;
 
   /// Ids of threads with activity newer than the user last saw — each gets an
@@ -122,6 +124,7 @@ class ThreadSidebar extends StatelessWidget {
                         onRename: () =>
                             onRenameThread?.call(thread.id, thread.name),
                         onDelete: () => onDeleteThread?.call(thread.id),
+                        onMarkRead: () => onMarkThreadRead?.call(thread.id),
                       );
                     },
                   );

--- a/lib/src/modules/room/ui/thread_tile.dart
+++ b/lib/src/modules/room/ui/thread_tile.dart
@@ -7,7 +7,7 @@ import 'package:soliplex_design/soliplex_design.dart';
 import '../../../shared/relative_time.dart';
 import '../../lobby/ui/unread_dot.dart';
 
-enum _ThreadAction { rename, delete }
+enum _ThreadAction { markRead, rename, delete }
 
 class ThreadTile extends StatefulWidget {
   const ThreadTile({
@@ -17,6 +17,7 @@ class ThreadTile extends StatefulWidget {
     required this.onTap,
     required this.onRename,
     required this.onDelete,
+    required this.onMarkRead,
     this.isRunning = false,
     this.unread = false,
   });
@@ -26,6 +27,9 @@ class ThreadTile extends StatefulWidget {
   final VoidCallback onTap;
   final VoidCallback onRename;
   final VoidCallback onDelete;
+
+  /// Stamps this thread read. Offered in the overflow menu only when [unread].
+  final VoidCallback onMarkRead;
   final bool isRunning;
 
   /// Whether the thread has activity newer than the user last saw — shows a
@@ -122,6 +126,8 @@ class _ThreadTileState extends State<ThreadTile> {
       onSelected: (action) {
         setState(() => _isMenuOpen = false);
         switch (action) {
+          case _ThreadAction.markRead:
+            widget.onMarkRead();
           case _ThreadAction.rename:
             widget.onRename();
           case _ThreadAction.delete:
@@ -129,6 +135,17 @@ class _ThreadTileState extends State<ThreadTile> {
         }
       },
       itemBuilder: (context) => [
+        if (widget.unread)
+          const PopupMenuItem(
+            value: _ThreadAction.markRead,
+            child: Row(
+              children: [
+                Icon(Icons.mark_chat_read_outlined, size: 18),
+                SizedBox(width: SoliplexSpacing.s3),
+                Text('Mark as read'),
+              ],
+            ),
+          ),
         const PopupMenuItem(
           value: _ThreadAction.rename,
           child: Row(

--- a/lib/src/shared/mark_read_context_menu.dart
+++ b/lib/src/shared/mark_read_context_menu.dart
@@ -4,31 +4,47 @@ import 'package:soliplex_design/soliplex_design.dart';
 /// Wraps [child] so a long-press (touch) or secondary-tap (right-click) offers
 /// a single "Mark as read" action at the pointer. Used by the rooms rail circle
 /// and the lobby room cards, which have no room for a persistent menu button.
-/// When [enabled] is false the gesture opens nothing (e.g. already read).
+/// A null [onMarkRead] disables the gesture (e.g. the item is already read).
 class MarkReadContextMenu extends StatelessWidget {
   const MarkReadContextMenu({
     super.key,
     required this.child,
-    required this.enabled,
     required this.onMarkRead,
+    this.title,
   });
 
   final Widget child;
-  final bool enabled;
-  final VoidCallback onMarkRead;
+
+  /// Marks the wrapped item read. Null disables the gesture — no menu opens.
+  final VoidCallback? onMarkRead;
+
+  /// Optional heading shown above the action, so a long-press still surfaces a
+  /// label where [child] has none visible — the rail's single-letter avatar
+  /// passes the room name here. Null shows just the action (the lobby cards,
+  /// which already show the room name, pass nothing).
+  final String? title;
 
   Future<void> _show(BuildContext context, Offset globalPosition) async {
-    if (!enabled) return;
+    final onMarkRead = this.onMarkRead;
+    if (onMarkRead == null) return;
     final overlay =
         Overlay.of(context).context.findRenderObject()! as RenderBox;
+    final title = this.title;
     final selected = await showMenu<bool>(
       context: context,
       position: RelativeRect.fromRect(
         globalPosition & Size.zero,
         Offset.zero & overlay.size,
       ),
-      items: const [
-        PopupMenuItem(
+      items: [
+        if (title != null) ...[
+          PopupMenuItem(
+            enabled: false,
+            child: Text(title, style: Theme.of(context).textTheme.titleSmall),
+          ),
+          const PopupMenuDivider(),
+        ],
+        const PopupMenuItem(
           value: true,
           child: Row(
             mainAxisSize: MainAxisSize.min,
@@ -46,6 +62,11 @@ class MarkReadContextMenu extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    // When disabled, add no gesture recognizer at all, so a long-press
+    // affordance on [child] (e.g. a Tooltip) still works. An always-present
+    // detector would also enter the gesture arena and could win the long-press
+    // over the child, suppressing it for nothing.
+    if (onMarkRead == null) return child;
     return GestureDetector(
       onLongPressStart: (d) => _show(context, d.globalPosition),
       onSecondaryTapDown: (d) => _show(context, d.globalPosition),

--- a/lib/src/shared/mark_read_context_menu.dart
+++ b/lib/src/shared/mark_read_context_menu.dart
@@ -1,0 +1,55 @@
+import 'package:flutter/material.dart';
+import 'package:soliplex_design/soliplex_design.dart';
+
+/// Wraps [child] so a long-press (touch) or secondary-tap (right-click) offers
+/// a single "Mark as read" action at the pointer. Used by the rooms rail circle
+/// and the lobby room cards, which have no room for a persistent menu button.
+/// When [enabled] is false the gesture opens nothing (e.g. already read).
+class MarkReadContextMenu extends StatelessWidget {
+  const MarkReadContextMenu({
+    super.key,
+    required this.child,
+    required this.enabled,
+    required this.onMarkRead,
+  });
+
+  final Widget child;
+  final bool enabled;
+  final VoidCallback onMarkRead;
+
+  Future<void> _show(BuildContext context, Offset globalPosition) async {
+    if (!enabled) return;
+    final overlay =
+        Overlay.of(context).context.findRenderObject()! as RenderBox;
+    final selected = await showMenu<bool>(
+      context: context,
+      position: RelativeRect.fromRect(
+        globalPosition & Size.zero,
+        Offset.zero & overlay.size,
+      ),
+      items: const [
+        PopupMenuItem(
+          value: true,
+          child: Row(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              Icon(Icons.mark_chat_read_outlined, size: 20),
+              SizedBox(width: SoliplexSpacing.s3),
+              Text('Mark as read'),
+            ],
+          ),
+        ),
+      ],
+    );
+    if (selected ?? false) onMarkRead();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return GestureDetector(
+      onLongPressStart: (d) => _show(context, d.globalPosition),
+      onSecondaryTapDown: (d) => _show(context, d.globalPosition),
+      child: child,
+    );
+  }
+}

--- a/lib/src/shared/mark_read_context_menu.dart
+++ b/lib/src/shared/mark_read_context_menu.dart
@@ -57,6 +57,10 @@ class MarkReadContextMenu extends StatelessWidget {
         ),
       ],
     );
+    // The menu awaits a selection, during which this element can unmount (the
+    // owning screen torn down). Bail if so, rather than stamp through an
+    // already-disposed marker store.
+    if (!context.mounted) return;
     if (selected ?? false) onMarkRead();
   }
 

--- a/packages/soliplex_client/lib/src/domain/thread_info.dart
+++ b/packages/soliplex_client/lib/src/domain/thread_info.dart
@@ -4,7 +4,7 @@ import 'package:meta/meta.dart';
 @immutable
 class ThreadInfo {
   /// Creates thread info.
-  const ThreadInfo({
+  ThreadInfo({
     required this.id,
     required this.roomId,
     required this.createdAt,
@@ -13,7 +13,10 @@ class ThreadInfo {
     this.description = '',
     this.metadata = const {},
     this.lastActivity,
-  });
+  }) : assert(
+          lastActivity == null || lastActivity.isUtc,
+          'lastActivity must be UTC',
+        );
 
   /// Unique identifier for the thread.
   final String id;

--- a/packages/soliplex_client/test/domain/thread_info_test.dart
+++ b/packages/soliplex_client/test/domain/thread_info_test.dart
@@ -23,6 +23,18 @@ void main() {
       expect(thread.hasDescription, isFalse);
     });
 
+    test('lastActivity must be UTC', () {
+      expect(
+        () => ThreadInfo(
+          id: 'thread-1',
+          roomId: 'room-1',
+          createdAt: DateTime.utc(2025),
+          lastActivity: DateTime(2025), // device-local — must be rejected
+        ),
+        throwsA(isA<AssertionError>()),
+      );
+    });
+
     test('creates with all fields', () {
       final createdAt = DateTime(2025);
       final thread = ThreadInfo(

--- a/test/modules/lobby/lobby_state_test.dart
+++ b/test/modules/lobby/lobby_state_test.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 import 'dart:convert';
 import 'dart:typed_data';
 
+import 'package:clock/clock.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:soliplex_agent/soliplex_agent.dart';
@@ -1122,6 +1123,20 @@ void main() {
         expect(state.roomActivity.value[key], DateTime.utc(2026, 6, 2));
 
         state.dispose();
+      });
+    });
+
+    group('mark as read', () {
+      test('markRoomRead stamps the room marker so it reads as read', () {
+        withClock(Clock.fixed(DateTime.utc(2026, 6, 1)), () {
+          final state = LobbyState(serverManager: _createManager());
+          state.markRoomRead('srv', 'roomA');
+          expect(
+            state.roomReadMarkers.value[(serverId: 'srv', roomId: 'roomA')],
+            DateTime.utc(2026, 6, 1),
+          );
+          state.dispose();
+        });
       });
     });
   });

--- a/test/modules/lobby/lobby_state_test.dart
+++ b/test/modules/lobby/lobby_state_test.dart
@@ -12,6 +12,7 @@ import 'package:soliplex_frontend/src/modules/auth/selected_server_storage.dart'
 import 'package:soliplex_frontend/src/modules/auth/server_manager.dart';
 import 'package:soliplex_frontend/src/core/activity_read.dart';
 import 'package:soliplex_frontend/src/modules/lobby/lobby_state.dart';
+import 'package:soliplex_frontend/src/modules/room/thread_read_markers.dart';
 
 import '../../helpers/fakes.dart';
 
@@ -1146,6 +1147,53 @@ void main() {
           expect(state.serverReadMarkers.value['s'], DateTime.utc(2026, 6, 1));
           state.dispose();
         });
+      });
+
+      test('removing a server clears its read markers at every level',
+          () async {
+        final at = DateTime.utc(2026, 6, 1);
+        final manager = _createManager();
+        manager.addServer(
+          serverId: 's1',
+          serverUrl: Uri.parse('http://s1.test'),
+          requiresAuth: false,
+        );
+        final state = LobbyState(
+          serverManager: manager,
+          apiResolver: (_) => FakeSoliplexApi(),
+        );
+        await pumpEventQueue();
+
+        state.markServerRead('s1');
+        state.markRoomRead('s1', 'r');
+        await ThreadReadMarkerStorage.save({
+          (serverId: 's1', roomId: 'r', threadId: 't'): at,
+          (serverId: 's2', roomId: 'r', threadId: 't'): at,
+        });
+
+        manager.removeServer('s1');
+        await pumpEventQueue();
+
+        expect(state.serverReadMarkers.value.containsKey('s1'), isFalse);
+        expect(
+          state.roomReadMarkers.value
+              .containsKey((serverId: 's1', roomId: 'r')),
+          isFalse,
+        );
+        // A re-added server (same URL → same id) must start unread: the
+        // persisted thread markers for the removed server are gone, while
+        // another server's survive.
+        final threads = await ThreadReadMarkerStorage.load();
+        expect(
+          threads.containsKey((serverId: 's1', roomId: 'r', threadId: 't')),
+          isFalse,
+        );
+        expect(
+          threads.containsKey((serverId: 's2', roomId: 'r', threadId: 't')),
+          isTrue,
+        );
+
+        state.dispose();
       });
     });
   });

--- a/test/modules/lobby/lobby_state_test.dart
+++ b/test/modules/lobby/lobby_state_test.dart
@@ -1138,6 +1138,15 @@ void main() {
           state.dispose();
         });
       });
+
+      test('markServerRead stamps the server marker', () {
+        withClock(Clock.fixed(DateTime.utc(2026, 6, 1)), () {
+          final state = LobbyState(serverManager: _createManager());
+          state.markServerRead('s');
+          expect(state.serverReadMarkers.value['s'], DateTime.utc(2026, 6, 1));
+          state.dispose();
+        });
+      });
     });
   });
 

--- a/test/modules/lobby/room_read_markers_test.dart
+++ b/test/modules/lobby/room_read_markers_test.dart
@@ -47,6 +47,16 @@ void main() {
       store.dispose();
     });
 
+    test('markRead normalizes a non-UTC timestamp to UTC', () {
+      final store = RoomReadMarkers();
+      final local = DateTime(2026, 6, 1, 12); // device-local
+      store.markRead(key, local);
+      final stored = store.value[key]!;
+      expect(stored.isUtc, isTrue);
+      expect(stored, local.toUtc());
+      store.dispose();
+    });
+
     test('clearServer drops only that server\'s markers and persists',
         () async {
       final store = RoomReadMarkers();

--- a/test/modules/lobby/room_read_markers_test.dart
+++ b/test/modules/lobby/room_read_markers_test.dart
@@ -46,5 +46,27 @@ void main() {
       expect(store.markers.value[key], at);
       store.dispose();
     });
+
+    test('clearServer drops only that server\'s markers and persists',
+        () async {
+      final store = RoomReadMarkers();
+      store.markRead((serverId: 's1', roomId: 'a'), at);
+      store.markRead((serverId: 's1', roomId: 'b'), at);
+      store.markRead((serverId: 's2', roomId: 'c'), at);
+      // Let the mark write-throughs settle before clearing, so the reload
+      // below observes clearServer's write rather than a racing stamp save.
+      await Future<void>.delayed(Duration.zero);
+
+      store.clearServer('s1');
+
+      expect(store.value.keys, {(serverId: 's2', roomId: 'c')});
+      // Persisted: a fresh store loads only the surviving server's marker.
+      await Future<void>.delayed(Duration.zero);
+      final reloaded = RoomReadMarkers();
+      await reloaded.ensureLoaded();
+      expect(reloaded.value.keys, {(serverId: 's2', roomId: 'c')});
+      store.dispose();
+      reloaded.dispose();
+    });
   });
 }

--- a/test/modules/lobby/server_read_markers_test.dart
+++ b/test/modules/lobby/server_read_markers_test.dart
@@ -72,5 +72,24 @@ void main() {
       expect(store.markers.value[serverId], at);
       store.dispose();
     });
+
+    test('clearServer drops only that server\'s marker and persists', () async {
+      final store = ServerReadMarkers();
+      store.markRead('s1', at);
+      store.markRead('s2', at);
+      // Let the mark write-throughs settle before clearing, so the reload
+      // below observes clearServer's write rather than a racing stamp save.
+      await Future<void>.delayed(Duration.zero);
+
+      store.clearServer('s1');
+
+      expect(store.value.keys, {'s2'});
+      await Future<void>.delayed(Duration.zero);
+      final reloaded = ServerReadMarkers();
+      await reloaded.ensureLoaded();
+      expect(reloaded.value.keys, {'s2'});
+      store.dispose();
+      reloaded.dispose();
+    });
   });
 }

--- a/test/modules/lobby/server_read_markers_test.dart
+++ b/test/modules/lobby/server_read_markers_test.dart
@@ -73,6 +73,16 @@ void main() {
       store.dispose();
     });
 
+    test('markRead normalizes a non-UTC timestamp to UTC', () {
+      final store = ServerReadMarkers();
+      final local = DateTime(2026, 6, 1, 12); // device-local
+      store.markRead(serverId, local);
+      final stored = store.value[serverId]!;
+      expect(stored.isUtc, isTrue);
+      expect(stored, local.toUtc());
+      store.dispose();
+    });
+
     test('clearServer drops only that server\'s marker and persists', () async {
       final store = ServerReadMarkers();
       store.markRead('s1', at);

--- a/test/modules/lobby/ui/lobby_screen_test.dart
+++ b/test/modules/lobby/ui/lobby_screen_test.dart
@@ -723,5 +723,100 @@ void main() {
       expect(find.text('Special'), findsOneWidget);
       expect(find.text('General'), findsNothing);
     });
+
+    testWidgets(
+        'unread room card long-press marks it read: persists the marker '
+        'and clears the dot', (tester) async {
+      tester.view.physicalSize = const Size(900, 600);
+      tester.view.devicePixelRatio = 1.0;
+      addTearDown(tester.view.resetPhysicalSize);
+
+      final manager = _createManager();
+      manager.addServer(
+        serverId: 'local',
+        serverUrl: Uri.parse('http://localhost:8000'),
+        requiresAuth: false,
+      );
+      final fakeApi = FakeSoliplexApi()
+        ..nextRooms = const [Room(id: 'r1', name: 'General')]
+        ..roomsStats = {'r1': RoomStats(lastActivity: DateTime.utc(2026, 6))};
+
+      await tester.pumpWidget(_buildApp(manager, apiResolver: (_) => fakeApi));
+      await tester.pumpAndSettle();
+
+      // Unread to begin with (activity, no marker).
+      expect(find.byType(UnreadDot), findsOneWidget);
+
+      await tester.longPress(find.byType(RoomCard));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('Mark as read'));
+      await tester.pumpAndSettle();
+
+      // The dot clears reactively, and the room's marker is persisted keyed by
+      // its id (so the gating wired the correct room, not just any room).
+      expect(find.byType(UnreadDot), findsNothing);
+      final prefs = await SharedPreferences.getInstance();
+      expect(prefs.getString('soliplex_lobby_read_markers'), contains('r1'));
+    });
+
+    testWidgets('a read room card offers no Mark as read menu', (tester) async {
+      tester.view.physicalSize = const Size(900, 600);
+      tester.view.devicePixelRatio = 1.0;
+      addTearDown(tester.view.resetPhysicalSize);
+
+      final manager = _createManager();
+      manager.addServer(
+        serverId: 'local',
+        serverUrl: Uri.parse('http://localhost:8000'),
+        requiresAuth: false,
+      );
+      // No activity => not unread => the gating passes a null callback, so the
+      // context menu adds no gesture and a long-press opens nothing.
+      final fakeApi = FakeSoliplexApi()
+        ..nextRooms = const [Room(id: 'r1', name: 'General')];
+
+      await tester.pumpWidget(_buildApp(manager, apiResolver: (_) => fakeApi));
+      await tester.pumpAndSettle();
+      expect(find.byType(UnreadDot), findsNothing);
+
+      await tester.longPress(find.byType(RoomCard));
+      await tester.pumpAndSettle();
+      expect(find.text('Mark as read'), findsNothing);
+    });
+
+    testWidgets(
+        'unread room grid card long-press marks it read (grid layout wires '
+        'the same gating)', (tester) async {
+      SharedPreferences.setMockInitialValues(
+        {'soliplex_lobby_view_mode': 'grid'},
+      );
+      tester.view.physicalSize = const Size(900, 600);
+      tester.view.devicePixelRatio = 1.0;
+      addTearDown(tester.view.resetPhysicalSize);
+
+      final manager = _createManager();
+      manager.addServer(
+        serverId: 'local',
+        serverUrl: Uri.parse('http://localhost:8000'),
+        requiresAuth: false,
+      );
+      final fakeApi = FakeSoliplexApi()
+        ..nextRooms = const [Room(id: 'r1', name: 'General')]
+        ..roomsStats = {'r1': RoomStats(lastActivity: DateTime.utc(2026, 6))};
+
+      await tester.pumpWidget(_buildApp(manager, apiResolver: (_) => fakeApi));
+      await tester.pumpAndSettle();
+      expect(find.byType(RoomGridCard), findsOneWidget);
+      expect(find.byType(UnreadDot), findsOneWidget);
+
+      await tester.longPress(find.byType(RoomGridCard));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('Mark as read'));
+      await tester.pumpAndSettle();
+
+      expect(find.byType(UnreadDot), findsNothing);
+      final prefs = await SharedPreferences.getInstance();
+      expect(prefs.getString('soliplex_lobby_read_markers'), contains('r1'));
+    });
   });
 }

--- a/test/modules/lobby/ui/server_sidebar_test.dart
+++ b/test/modules/lobby/ui/server_sidebar_test.dart
@@ -33,6 +33,7 @@ Widget _buildSidebar({
   String? selectedServerId,
   void Function(String serverId)? onSelectServer,
   void Function(String serverId)? onSignIn,
+  void Function(String serverId)? onMarkServerRead,
   VoidCallback? onAddServer,
   VoidCallback? onNetworkInspector,
   VoidCallback? onVersions,
@@ -54,6 +55,7 @@ Widget _buildSidebar({
           selectedServerId: selectedServerId,
           onSelectServer: onSelectServer ?? (_) {},
           onSignIn: onSignIn ?? (_) {},
+          onMarkServerRead: onMarkServerRead ?? (_) {},
           onAddServer: onAddServer ?? () {},
           onNetworkInspector: onNetworkInspector ?? () {},
           onVersions: onVersions ?? () {},
@@ -216,6 +218,33 @@ void main() {
     });
 
     group('tile ⋮ menu', () {
+      testWidgets('offers Mark all as read and fires onMarkServerRead',
+          (tester) async {
+        final manager = _createManager();
+        manager.addServer(
+          serverId: 'srv',
+          serverUrl: Uri.parse('http://localhost:8000'),
+          requiresAuth: false,
+        );
+
+        String? marked;
+        await tester.pumpWidget(_buildSidebar(
+          servers: manager.servers.value,
+          serverManager: manager,
+          // Selected so the hover-revealed ⋮ is shown (no mouse in the test).
+          selectedServerId: 'srv',
+          onMarkServerRead: (id) => marked = id,
+        ));
+
+        await tester.tap(find.byIcon(Icons.more_vert).first);
+        await tester.pumpAndSettle();
+        expect(find.text('Mark all as read'), findsOneWidget);
+
+        await tester.tap(find.text('Mark all as read'));
+        await tester.pumpAndSettle();
+        expect(marked, 'srv');
+      });
+
       testWidgets(
           'a disconnected server offers Sign in, Copy server address, '
           'and Remove', (tester) async {

--- a/test/modules/room/thread_read_markers_test.dart
+++ b/test/modules/room/thread_read_markers_test.dart
@@ -67,5 +67,18 @@ void main() {
         DateTime.utc(2026, 6, 1, 12),
       );
     });
+
+    test('clearServer prunes only that server\'s thread markers', () async {
+      final at = DateTime.utc(2026, 6, 1);
+      await ThreadReadMarkerStorage.save({
+        (serverId: 's1', roomId: 'r', threadId: 't1'): at,
+        (serverId: 's2', roomId: 'r', threadId: 't2'): at,
+      });
+
+      await ThreadReadMarkerStorage.clearServer('s1');
+
+      final loaded = await ThreadReadMarkerStorage.load();
+      expect(loaded.keys, {(serverId: 's2', roomId: 'r', threadId: 't2')});
+    });
   });
 }

--- a/test/modules/room/ui/room_rail_test.dart
+++ b/test/modules/room/ui/room_rail_test.dart
@@ -22,6 +22,7 @@ RoomRail _rail({
   Set<String> unreadRoomIds = const {},
   int? dividerIndex,
   void Function(String)? onSelectRoom,
+  void Function(String)? onMarkRoomRead,
   VoidCallback? onRetryRooms,
   RoomAccount? account,
   VoidCallback? onNetworkInspector,
@@ -35,6 +36,7 @@ RoomRail _rail({
       dividerIndex: dividerIndex,
       selectedRoomId: selectedRoomId,
       onSelectRoom: onSelectRoom ?? (_) {},
+      onMarkRoomRead: onMarkRoomRead,
       entry: createTestServerEntry(),
       account: account,
       onNetworkInspector: onNetworkInspector ?? () {},
@@ -64,6 +66,38 @@ void main() {
     testWidgets('marks only unread rooms with a dot', (tester) async {
       await tester.pumpWidget(_wrap(_rail(unreadRoomIds: const {'r2'})));
       expect(find.byTooltip('Unread activity'), findsOneWidget);
+    });
+
+    testWidgets(
+        'long-pressing an unread room offers Mark as read and fires with '
+        'its id', (tester) async {
+      String? marked;
+      await tester.pumpWidget(_wrap(_rail(
+        unreadRoomIds: const {'r2'},
+        onMarkRoomRead: (id) => marked = id,
+      )));
+
+      await tester.longPress(find.text('B')); // Beta = r2, unread
+      await tester.pumpAndSettle();
+      expect(find.text('Mark as read'), findsOneWidget);
+      // The menu surfaces the room name (the avatar shows only 'B').
+      expect(find.text('Beta'), findsOneWidget);
+
+      await tester.tap(find.text('Mark as read'));
+      await tester.pumpAndSettle();
+      expect(marked, 'r2');
+    });
+
+    testWidgets('long-pressing a read room offers no Mark as read',
+        (tester) async {
+      await tester.pumpWidget(_wrap(_rail(
+        unreadRoomIds: const {'r2'},
+        onMarkRoomRead: (_) {},
+      )));
+
+      await tester.longPress(find.text('A')); // Alpha = r1, read
+      await tester.pumpAndSettle();
+      expect(find.text('Mark as read'), findsNothing);
     });
 
     testWidgets('shows no dots when nothing is unread', (tester) async {

--- a/test/modules/room/ui/thread_tile_test.dart
+++ b/test/modules/room/ui/thread_tile_test.dart
@@ -28,6 +28,7 @@ void main() {
           onTap: () {},
           onRename: () {},
           onDelete: () {},
+          onMarkRead: () {},
         ),
       ),
     ));
@@ -45,6 +46,7 @@ void main() {
               onTap: () {},
               onRename: () {},
               onDelete: () {},
+              onMarkRead: () {},
             ),
           ),
         );
@@ -65,6 +67,7 @@ void main() {
           onTap: () {},
           onRename: () {},
           onDelete: () {},
+          onMarkRead: () {},
         ),
       ),
     ));
@@ -86,6 +89,7 @@ void main() {
           onTap: () {},
           onRename: () => renameCalled = true,
           onDelete: () {},
+          onMarkRead: () {},
         ),
       ),
     ));
@@ -109,6 +113,7 @@ void main() {
           onTap: () {},
           onRename: () {},
           onDelete: () => deleteCalled = true,
+          onMarkRead: () {},
         ),
       ),
     ));
@@ -142,6 +147,7 @@ void main() {
               onTap: () {},
               onRename: () => renameCalled = true,
               onDelete: () {},
+              onMarkRead: () {},
             ),
           ),
         ),
@@ -191,6 +197,7 @@ void main() {
               onTap: () {},
               onRename: () {},
               onDelete: () => deleteCalled = true,
+              onMarkRead: () {},
             ),
           ),
         ),
@@ -227,6 +234,7 @@ void main() {
           onTap: () {},
           onRename: () {},
           onDelete: () {},
+          onMarkRead: () {},
         ),
       ),
     ));
@@ -252,6 +260,7 @@ void main() {
               onTap: () {},
               onRename: () {},
               onDelete: () {},
+              onMarkRead: () {},
             ),
           ),
         ),
@@ -283,6 +292,7 @@ void main() {
           onTap: () {},
           onRename: () {},
           onDelete: () {},
+          onMarkRead: () {},
         ),
       ),
     ));
@@ -290,6 +300,51 @@ void main() {
     expect(find.byType(CircularProgressIndicator), findsNothing);
     expect(find.byIcon(Icons.more_vert), findsNothing);
     debugDefaultTargetPlatformOverride = null;
+  });
+
+  testWidgets('unread thread menu offers Mark as read and fires callback',
+      (tester) async {
+    var marked = false;
+    await tester.pumpWidget(MaterialApp(
+      home: Scaffold(
+        body: ThreadTile(
+          thread: thread,
+          isSelected: false,
+          unread: true,
+          onTap: () {},
+          onRename: () {},
+          onDelete: () {},
+          onMarkRead: () => marked = true,
+        ),
+      ),
+    ));
+
+    await tester.tap(find.byIcon(Icons.more_vert));
+    await tester.pumpAndSettle();
+    expect(find.text('Mark as read'), findsOneWidget);
+
+    await tester.tap(find.text('Mark as read'));
+    await tester.pumpAndSettle();
+    expect(marked, isTrue);
+  });
+
+  testWidgets('read thread menu omits Mark as read', (tester) async {
+    await tester.pumpWidget(MaterialApp(
+      home: Scaffold(
+        body: ThreadTile(
+          thread: thread,
+          isSelected: false,
+          onTap: () {},
+          onRename: () {},
+          onDelete: () {},
+          onMarkRead: () {},
+        ),
+      ),
+    ));
+
+    await tester.tap(find.byIcon(Icons.more_vert));
+    await tester.pumpAndSettle();
+    expect(find.text('Mark as read'), findsNothing);
   });
 
   testWidgets('Delete menu item uses error color', (tester) async {
@@ -301,6 +356,7 @@ void main() {
           onTap: () {},
           onRename: () {},
           onDelete: () {},
+          onMarkRead: () {},
         ),
       ),
     ));

--- a/test/shared/mark_read_context_menu_test.dart
+++ b/test/shared/mark_read_context_menu_test.dart
@@ -1,22 +1,26 @@
+import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:soliplex_frontend/src/shared/mark_read_context_menu.dart';
 
 void main() {
+  Widget host({required VoidCallback? onMarkRead, String? title}) =>
+      MaterialApp(
+        home: Scaffold(
+          body: Center(
+            child: MarkReadContextMenu(
+              onMarkRead: onMarkRead,
+              title: title,
+              child: const SizedBox(width: 44, height: 44, child: Text('R')),
+            ),
+          ),
+        ),
+      );
+
   testWidgets('long-press opens Mark as read and fires the callback',
       (tester) async {
     var marked = false;
-    await tester.pumpWidget(MaterialApp(
-      home: Scaffold(
-        body: Center(
-          child: MarkReadContextMenu(
-            enabled: true,
-            onMarkRead: () => marked = true,
-            child: const SizedBox(width: 44, height: 44, child: Text('R')),
-          ),
-        ),
-      ),
-    ));
+    await tester.pumpWidget(host(onMarkRead: () => marked = true));
 
     await tester.longPress(find.text('R'));
     await tester.pumpAndSettle();
@@ -27,18 +31,54 @@ void main() {
     expect(marked, isTrue);
   });
 
-  testWidgets('disabled: long-press opens no menu', (tester) async {
-    await tester.pumpWidget(MaterialApp(
-      home: Scaffold(
-        body: Center(
-          child: MarkReadContextMenu(
-            enabled: false,
-            onMarkRead: () {},
-            child: const SizedBox(width: 44, height: 44, child: Text('R')),
-          ),
-        ),
-      ),
-    ));
+  testWidgets('secondary-tap (right-click) opens the menu and fires',
+      (tester) async {
+    var marked = false;
+    await tester.pumpWidget(host(onMarkRead: () => marked = true));
+
+    final gesture = await tester.startGesture(
+      tester.getCenter(find.text('R')),
+      kind: PointerDeviceKind.mouse,
+      buttons: kSecondaryButton,
+    );
+    await gesture.up();
+    await tester.pumpAndSettle();
+    expect(find.text('Mark as read'), findsOneWidget);
+
+    await tester.tap(find.text('Mark as read'));
+    await tester.pumpAndSettle();
+    expect(marked, isTrue);
+  });
+
+  testWidgets('dismissing the menu without a selection does not fire',
+      (tester) async {
+    var marked = false;
+    await tester.pumpWidget(host(onMarkRead: () => marked = true));
+
+    await tester.longPress(find.text('R'));
+    await tester.pumpAndSettle();
+    expect(find.text('Mark as read'), findsOneWidget);
+
+    // Tap the modal barrier outside the menu to dismiss it (returns null).
+    await tester.tapAt(const Offset(5, 5));
+    await tester.pumpAndSettle();
+    expect(find.text('Mark as read'), findsNothing);
+    expect(marked, isFalse);
+  });
+
+  testWidgets('shows the title as a header above the action when provided',
+      (tester) async {
+    await tester.pumpWidget(host(onMarkRead: () {}, title: 'Beta'));
+
+    await tester.longPress(find.text('R'));
+    await tester.pumpAndSettle();
+    expect(find.text('Beta'), findsOneWidget);
+    expect(find.text('Mark as read'), findsOneWidget);
+  });
+
+  testWidgets('disabled (null callback): long-press opens no menu',
+      (tester) async {
+    await tester.pumpWidget(host(onMarkRead: null));
 
     await tester.longPress(find.text('R'));
     await tester.pumpAndSettle();

--- a/test/shared/mark_read_context_menu_test.dart
+++ b/test/shared/mark_read_context_menu_test.dart
@@ -1,0 +1,47 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:soliplex_frontend/src/shared/mark_read_context_menu.dart';
+
+void main() {
+  testWidgets('long-press opens Mark as read and fires the callback',
+      (tester) async {
+    var marked = false;
+    await tester.pumpWidget(MaterialApp(
+      home: Scaffold(
+        body: Center(
+          child: MarkReadContextMenu(
+            enabled: true,
+            onMarkRead: () => marked = true,
+            child: const SizedBox(width: 44, height: 44, child: Text('R')),
+          ),
+        ),
+      ),
+    ));
+
+    await tester.longPress(find.text('R'));
+    await tester.pumpAndSettle();
+    expect(find.text('Mark as read'), findsOneWidget);
+
+    await tester.tap(find.text('Mark as read'));
+    await tester.pumpAndSettle();
+    expect(marked, isTrue);
+  });
+
+  testWidgets('disabled: long-press opens no menu', (tester) async {
+    await tester.pumpWidget(MaterialApp(
+      home: Scaffold(
+        body: Center(
+          child: MarkReadContextMenu(
+            enabled: false,
+            onMarkRead: () {},
+            child: const SizedBox(width: 44, height: 44, child: Text('R')),
+          ),
+        ),
+      ),
+    ));
+
+    await tester.longPress(find.text('R'));
+    await tester.pumpAndSettle();
+    expect(find.text('Mark as read'), findsNothing);
+  });
+}


### PR DESCRIPTION
## Summary

Adds on-demand "Mark as read" actions across the read model, and fixes a marker-leak when a server is removed.

**New actions** (each writes through the shared marker store, so dots clear reactively everywhere they appear):

- **Thread tile menu** — "Mark as read" in the overflow menu, shown only when the thread is unread.
- **Rooms rail circle** — long-press (touch) or right-click (desktop) opens a "Mark as read" context menu, offered only for unread rooms. Surfaces the room name as a header since the avatar is a single letter.
- **Lobby room cards** (list and grid) — same long-press / right-click context menu, gated on unread.
- **Server tile menu** — "Mark all as read".

Thanks to the existing read-up hierarchy, marking a room read also reads all its threads, and marking a server read reads every room and thread on it — loaded or not — with a single marker write and no per-item fan-out.

**Shared widget:** `MarkReadContextMenu` wraps a child so a long-press / secondary-tap offers the action at the pointer. A null callback disables the gesture entirely (adds no recognizer), so a child's own long-press affordance — e.g. the rail avatar's `Tooltip` — still fires when the item is already read.

## Fix

- **Removing a server now clears its per-device read markers** (server, room, and thread). Markers are keyed by a URL-derived server id that a re-added server reuses, so a removed server's stale markers would otherwise floor the fresh one and hide unread content.

## Hardening

- `markRead` normalizes timestamps to UTC at the store boundary, so an in-memory stamp equals its own persisted-then-reloaded value (`DateTime` equality compares the `isUtc` flag).
- `ThreadInfo` asserts `lastActivity` is UTC.
- Thread-marker logging routed through `soliplex_logging` instead of `dart:developer`.

## Notes

- Failed `clearServer` writes are logged at error level and swallowed (fire-and-forget). The thread-level path has no in-memory self-heal; the accepted risk and a latent lobby/room concurrent-flush hazard (unreachable under current navigation) are documented on `ThreadReadMarkerStorage.clearServer`.

## Testing

- Unread-gating verified on all four surfaces (menu present iff unread), in both list and grid lobby layouts.
- UTC normalization asserted (both `isUtc` and value equality) for room and server markers; `ThreadInfo` UTC invariant has a dedicated test.
- Server-removal clears markers at all three levels while a second server's survive.
- `MarkReadContextMenu`: long-press, secondary-tap, dismiss-without-selection, title header, and disabled (no-gesture) branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)