### PR TITLE
feat(lobby): add "Unread first" room grouping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ Versions follow the `version+build` scheme from `pubspec.yaml`, bumped via
 
 ## [Unreleased]
 
+### Added
+
+- Lobby: an "Unread first" sort option groups a server's rooms into an Unread
+  section above a Read section, each ordered by recent activity. Read rooms are
+  reordered below a divider, never hidden.
+
 ## [0.92.0+65] - 2026-07-02
 
 ### Added

--- a/lib/src/modules/lobby/lobby_sort_mode.dart
+++ b/lib/src/modules/lobby/lobby_sort_mode.dart
@@ -5,7 +5,11 @@ import 'package:shared_preferences/shared_preferences.dart';
 /// [recentActivity] sorts by the most recently *created* thread in each room
 /// (the only recency signal the backend exposes today — there is no
 /// last-access field). Rooms with no threads sort last.
-enum LobbySortMode { none, recentActivity }
+///
+/// [unreadFirst] groups rooms into an Unread section above a Read section,
+/// each ordered by recent activity. It groups by *attention status* rather
+/// than *time*; it is mutually exclusive with [recentActivity].
+enum LobbySortMode { none, recentActivity, unreadFirst }
 
 /// Persists the user's preferred [LobbySortMode] across launches.
 ///

--- a/lib/src/modules/lobby/room_grouping.dart
+++ b/lib/src/modules/lobby/room_grouping.dart
@@ -1,0 +1,49 @@
+import 'package:soliplex_agent/soliplex_agent.dart' show Room;
+
+/// Orders [rooms] by [activityFor] descending (newest activity first). Rooms
+/// with a null timestamp — none fetched, no threads, or a failed lookup —
+/// keep their original relative order at the end. Ties among dated rooms break
+/// by original index so equal timestamps stay in input order (`List.sort` is
+/// not guaranteed stable). Does not mutate [rooms].
+List<Room> sortRoomsByRecency(
+  List<Room> rooms,
+  DateTime? Function(Room) activityFor,
+) {
+  final dated = <(Room, DateTime, int)>[];
+  final undated = <Room>[];
+  for (var i = 0; i < rooms.length; i++) {
+    final time = activityFor(rooms[i]);
+    if (time != null) {
+      dated.add((rooms[i], time, i));
+    } else {
+      undated.add(rooms[i]);
+    }
+  }
+  dated.sort((a, b) {
+    final byTime = b.$2.compareTo(a.$2);
+    return byTime != 0 ? byTime : a.$3.compareTo(b.$3);
+  });
+  return [...dated.map((e) => e.$1), ...undated];
+}
+
+/// An unread/read split of a room list, each side already recency-ordered.
+typedef UnreadPartition = ({List<Room> unread, List<Room> read});
+
+/// Splits [rooms] into an unread section (where [isUnread] is true) and a read
+/// section (the rest), ordering each side newest-activity-first via
+/// [sortRoomsByRecency]. Does not mutate [rooms].
+UnreadPartition partitionByUnread(
+  List<Room> rooms,
+  bool Function(Room) isUnread,
+  DateTime? Function(Room) activityFor,
+) {
+  final unread = <Room>[];
+  final read = <Room>[];
+  for (final room in rooms) {
+    (isUnread(room) ? unread : read).add(room);
+  }
+  return (
+    unread: sortRoomsByRecency(unread, activityFor),
+    read: sortRoomsByRecency(read, activityFor),
+  );
+}

--- a/lib/src/modules/lobby/ui/lobby_screen.dart
+++ b/lib/src/modules/lobby/ui/lobby_screen.dart
@@ -17,6 +17,7 @@ import '../lobby_sort_mode.dart';
 import '../lobby_state.dart';
 import '../lobby_view_mode.dart';
 import '../room_activity_format.dart';
+import '../room_grouping.dart';
 import 'room_card.dart';
 import 'room_grid_card.dart';
 import 'room_grid_layout.dart';
@@ -665,18 +666,23 @@ class _LobbyControlsState extends State<_LobbyControls> {
           value: LobbySortMode.recentActivity,
           label: 'Recent activity',
         ),
+        SoliplexDropdownEntry(
+          value: LobbySortMode.unreadFirst,
+          label: 'Unread first',
+        ),
       ],
     );
-    final busy =
-        widget.sortLoading && widget.sortMode == LobbySortMode.recentActivity
-            ? const Padding(
-                padding: EdgeInsets.only(left: SoliplexSpacing.s2),
-                child: SizedBox.square(
-                  dimension: 16,
-                  child: CircularProgressIndicator(strokeWidth: 2),
-                ),
-              )
-            : const SizedBox.shrink();
+    final busy = widget.sortLoading &&
+            (widget.sortMode == LobbySortMode.recentActivity ||
+                widget.sortMode == LobbySortMode.unreadFirst)
+        ? const Padding(
+            padding: EdgeInsets.only(left: SoliplexSpacing.s2),
+            child: SizedBox.square(
+              dimension: 16,
+              child: CircularProgressIndicator(strokeWidth: 2),
+            ),
+          )
+        : const SizedBox.shrink();
 
     return LayoutBuilder(
       builder: (context, constraints) {
@@ -857,15 +863,17 @@ class _ServerSection extends StatelessWidget {
       );
     }
 
-    final ordered = _applySort(matches);
+    return switch (sortMode) {
+      LobbySortMode.none => _buildBlock(context, matches),
+      LobbySortMode.recentActivity => _buildRecencyGroups(context, matches),
+      LobbySortMode.unreadFirst => _buildUnreadGroups(context, matches),
+    };
+  }
 
-    // When sorting by recency, split the (already date-descending) list into
-    // "Today / Yesterday / ..." sections, each under a header + divider — like
-    // an LLM chat history. Otherwise render one flat block.
-    if (sortMode != LobbySortMode.recentActivity) {
-      return _buildBlock(context, ordered);
-    }
-
+  /// Sorts [rooms] by recency and groups them under "Today / Yesterday / …"
+  /// date-bucket headers, like an LLM chat history.
+  Widget _buildRecencyGroups(BuildContext context, List<Room> rooms) {
+    final ordered = sortRoomsByRecency(rooms, _activityFor);
     final groups = <ActivityBucket, List<Room>>{};
     for (final room in ordered) {
       (groups[bucketFor(_activityFor(room))] ??= []).add(room);
@@ -878,6 +886,26 @@ class _ServerSection extends StatelessWidget {
             _GroupHeader(label: bucket.label),
             _buildBlock(context, bucketRooms),
           ],
+      ],
+    );
+  }
+
+  /// Splits [rooms] into an Unread section above a Read section, each
+  /// recency-ordered. A section with no rooms renders no header, so an
+  /// all-read list shows only "Read" and an all-unread list only "Unread".
+  Widget _buildUnreadGroups(BuildContext context, List<Room> rooms) {
+    final parts = partitionByUnread(rooms, _isUnread, _activityFor);
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        if (parts.unread.isNotEmpty) ...[
+          const _GroupHeader(label: 'Unread'),
+          _buildBlock(context, parts.unread),
+        ],
+        if (parts.read.isNotEmpty) ...[
+          const _GroupHeader(label: 'Read'),
+          _buildBlock(context, parts.read),
+        ],
       ],
     );
   }
@@ -928,30 +956,6 @@ class _ServerSection extends StatelessWidget {
           onInfoTap: onInfoTap,
         ),
     };
-  }
-
-  /// Orders rooms by most-recent-thread activity (descending) when that sort
-  /// is active. Rooms without a known timestamp — none fetched, no threads,
-  /// or a failed lookup — keep their original relative order at the end. Ties
-  /// break by original index so equal timestamps stay in their input order
-  /// (`List.sort` is not guaranteed stable). Does not mutate the input list.
-  List<Room> _applySort(List<Room> rooms) {
-    if (sortMode != LobbySortMode.recentActivity) return rooms;
-    final dated = <(Room, DateTime, int)>[];
-    final undated = <Room>[];
-    for (var i = 0; i < rooms.length; i++) {
-      final time = _activityFor(rooms[i]);
-      if (time != null) {
-        dated.add((rooms[i], time, i));
-      } else {
-        undated.add(rooms[i]);
-      }
-    }
-    dated.sort((a, b) {
-      final byTime = b.$2.compareTo(a.$2);
-      return byTime != 0 ? byTime : a.$3.compareTo(b.$3);
-    });
-    return [...dated.map((e) => e.$1), ...undated];
   }
 }
 

--- a/test/modules/lobby/lobby_sort_mode_test.dart
+++ b/test/modules/lobby/lobby_sort_mode_test.dart
@@ -52,6 +52,12 @@ void main() {
       );
       expect(await LobbySortModeStorage.load(), LobbySortMode.none);
     });
+
+    test('round-trips unreadFirst', () async {
+      SharedPreferences.setMockInitialValues({});
+      await LobbySortModeStorage.save(LobbySortMode.unreadFirst);
+      expect(await LobbySortModeStorage.load(), LobbySortMode.unreadFirst);
+    });
   });
 
   group('LobbyState sorting', () {

--- a/test/modules/lobby/room_grouping_test.dart
+++ b/test/modules/lobby/room_grouping_test.dart
@@ -1,0 +1,75 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:soliplex_agent/soliplex_agent.dart' show Room;
+import 'package:soliplex_frontend/src/modules/lobby/room_grouping.dart';
+
+void main() {
+  const alpha = Room(id: 'r1', name: 'Alpha');
+  const bravo = Room(id: 'r2', name: 'Bravo');
+  const charlie = Room(id: 'r3', name: 'Charlie');
+  const delta = Room(id: 'r4', name: 'Delta');
+
+  final activity = <String, DateTime?>{
+    'r1': null,
+    'r2': DateTime.utc(2026, 6, 1),
+    'r3': null,
+    'r4': DateTime.utc(2026, 1, 1),
+  };
+  DateTime? activityFor(Room r) => activity[r.id];
+
+  group('sortRoomsByRecency', () {
+    test('orders dated rooms newest-first, undated last in input order', () {
+      final ordered =
+          sortRoomsByRecency([alpha, bravo, charlie, delta], activityFor);
+      expect(
+          ordered.map((r) => r.name), ['Bravo', 'Delta', 'Alpha', 'Charlie']);
+    });
+
+    test('does not mutate the input list', () {
+      final input = [alpha, bravo, charlie, delta];
+      sortRoomsByRecency(input, activityFor);
+      expect(input, [alpha, bravo, charlie, delta]);
+    });
+
+    test('breaks equal timestamps by original order (stable)', () {
+      final same = DateTime.utc(2026, 3, 1);
+      final ordered = sortRoomsByRecency(
+        [alpha, bravo],
+        (r) => same,
+      );
+      expect(ordered.map((r) => r.name), ['Alpha', 'Bravo']);
+    });
+  });
+
+  group('partitionByUnread', () {
+    bool isUnread(Room r) => r.id == 'r2' || r.id == 'r4';
+
+    test('splits unread from read, each recency-ordered', () {
+      final parts = partitionByUnread(
+          [alpha, bravo, charlie, delta], isUnread, activityFor);
+      // Unread: Bravo (Jun) before Delta (Jan).
+      expect(parts.unread.map((r) => r.name), ['Bravo', 'Delta']);
+      // Read: both undated, original order.
+      expect(parts.read.map((r) => r.name), ['Alpha', 'Charlie']);
+    });
+
+    test('all-read input yields an empty unread side', () {
+      final parts = partitionByUnread(
+        [alpha, charlie],
+        (_) => false,
+        activityFor,
+      );
+      expect(parts.unread, isEmpty);
+      expect(parts.read.map((r) => r.name), ['Alpha', 'Charlie']);
+    });
+
+    test('all-unread input yields an empty read side', () {
+      final parts = partitionByUnread(
+        [bravo, delta],
+        (_) => true,
+        activityFor,
+      );
+      expect(parts.unread.map((r) => r.name), ['Bravo', 'Delta']);
+      expect(parts.read, isEmpty);
+    });
+  });
+}

--- a/test/modules/lobby/ui/lobby_screen_test.dart
+++ b/test/modules/lobby/ui/lobby_screen_test.dart
@@ -638,6 +638,54 @@ void main() {
     });
 
     testWidgets(
+        'unread-first sort groups unread rooms above read rooms with headers',
+        (tester) async {
+      tester.view.physicalSize = const Size(900, 600);
+      tester.view.devicePixelRatio = 1.0;
+      addTearDown(tester.view.resetPhysicalSize);
+
+      final manager = _createManager();
+      manager.addServer(
+        serverId: 'local',
+        serverUrl: Uri.parse('http://localhost:8000'),
+        requiresAuth: false,
+      );
+      // 'Fresh' has activity and no read marker -> unread. 'Quiet' has no
+      // activity -> read. Backend lists the read room first, so the grouping
+      // (not the input order) is what pulls 'Fresh' to the top.
+      final fakeApi = FakeSoliplexApi()
+        ..nextRooms = const [
+          Room(id: 'r1', name: 'Quiet'),
+          Room(id: 'r2', name: 'Fresh'),
+        ]
+        ..roomsStats = {
+          'r1': RoomStats(),
+          'r2': RoomStats(lastActivity: DateTime.utc(2026, 6)),
+        };
+
+      await tester.pumpWidget(_buildApp(manager, apiResolver: (_) => fakeApi));
+      await tester.pumpAndSettle();
+
+      // No section headers under the default 'None' sort.
+      expect(find.text('Unread'), findsNothing);
+      expect(find.text('Read'), findsNothing);
+
+      await tester.tap(find.byType(DropdownMenu<LobbySortMode>));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('Unread first').hitTestable());
+      await tester.pumpAndSettle();
+
+      // Both section headers present.
+      expect(find.text('Unread'), findsOneWidget);
+      expect(find.text('Read'), findsOneWidget);
+
+      // The unread room card sits above the read room card.
+      final freshY = tester.getTopLeft(find.text('Fresh')).dy;
+      final quietY = tester.getTopLeft(find.text('Quiet')).dy;
+      expect(freshY, lessThan(quietY));
+    });
+
+    testWidgets(
         'shows only the selected server, and switching the sidebar '
         'selection swaps the shown rooms', (tester) async {
       tester.view.physicalSize = const Size(900, 600);


### PR DESCRIPTION
## What

Adds an **"Unread first"** sort option to the lobby room list. When selected, a
server's rooms are grouped into an **Unread** section above a **Read** section —
each ordered by recent activity — under labeled headers.

It joins the existing sort dropdown as a third, mutually-exclusive mode:

- **None** — flat list, backend order
- **Recent activity** — Today / Yesterday / … day buckets
- **Unread first** — Unread / Read sections *(new)*

## Why

The lobby already computes per-room unread state (the unread dot) but offered no
way to bring unread rooms to the top. This is a triage view — "what still needs
my attention" first — distinct from the time-based "Recent activity" view.

## Design notes

- **Grouping, not a filter.** Read rooms stay visible below the divider. This is
  an ordering axis, so it lives in the sort dropdown rather than as a hide filter.
- **Flat sections.** Each section is recency-ordered with no nested day
  sub-buckets — attention-status grouping and time grouping are mutually
  exclusive, and each room card already shows a relative timestamp.
- **Empty sections render no header** (all-read shows only "Read"; all-unread
  only "Unread").
- **No new network calls or models** — reuses the existing activity batch and the
  `_isUnread` predicate.
- **DRY extraction.** The recency ordering that was inline in `_ServerSection`
  (`_applySort`, serving only "Recent activity") is now the pure, unit-tested
  `sortRoomsByRecency` in `room_grouping.dart`, shared by both grouped modes.
  `partitionByUnread` builds the unread/read split on top of it. `_applySort` is
  deleted.

## Testing

- New unit tests for `sortRoomsByRecency` / `partitionByUnread` (recency order,
  no-mutation, stable ties, partition split, all-read, all-unread).
- New widget test: selecting "Unread first" renders unread rooms under an
  "Unread" header above a "Read" header — the fake API lists the read room first,
  so the assertion proves the grouping, not input-order coincidence.
- Storage round-trip test for the new `unreadFirst` enum value.
- Full suite: 1897 passing, `flutter analyze` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
