### PR TITLE
fix: drain a removed server's device-local state and runtime caches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,10 +16,10 @@ Versions follow the `version+build` scheme from `pubspec.yaml`, bumped via
 ### Fixed
 
 - Removing a server now clears the rest of its device-local state, not just its
-  read markers: the thread unread-divider anchors, unsent composer drafts, and
-  the pending inactivity-logout flag are all dropped. Because server ids derive
-  from the URL, re-adding the same server reused the id and could resurrect a
-  stale divider, an old draft, or a spurious `prompt=login`.
+  read markers: the thread unread-divider anchors and unsent composer drafts are
+  dropped too, on every removal path. Because server ids derive from the URL,
+  re-adding the same server reused the id and could resurrect a stale divider or
+  an old draft.
 - Removing a server now evicts its in-memory agent runtime and tracked runs
   instead of leaking them until app exit — the runtime's timers and stream are
   disposed and any live run for the server is cancelled.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,17 @@ Versions follow the `version+build` scheme from `pubspec.yaml`, bumped via
 - Lobby: an "Unread first" sort option groups a server's rooms into an Unread
   section above a Read section, each ordered by recent activity.
 
+### Fixed
+
+- Removing a server now clears the rest of its device-local state, not just its
+  read markers: the thread unread-divider anchors, unsent composer drafts, and
+  the pending inactivity-logout flag are all dropped. Because server ids derive
+  from the URL, re-adding the same server reused the id and could resurrect a
+  stale divider, an old draft, or a spurious `prompt=login`.
+- Removing a server now evicts its in-memory agent runtime and tracked runs
+  instead of leaking them until app exit — the runtime's timers and stream are
+  disposed and any live run for the server is cancelled.
+
 ## [0.92.0+65] - 2026-07-02
 
 ### Added

--- a/lib/src/core/removed_server_cleanup.dart
+++ b/lib/src/core/removed_server_cleanup.dart
@@ -36,19 +36,19 @@ class RemovedServerCleanup {
     required RoomReadMarkers roomReadMarkers,
     required ServerReadMarkers serverReadMarkers,
   })  : _roomReadMarkers = roomReadMarkers,
-        _serverReadMarkers = serverReadMarkers {
-    // Seed the baseline before subscribing: the signals library fires the
-    // callback synchronously with the current value, and _onServersChanged
-    // reads _knownIds on that first fire. Seeding it to the current ids makes
-    // that fire a no-op (nothing diffs as removed) and avoids reading the late
-    // field before it is assigned.
-    _knownIds = servers.value.keys.toSet();
+        _serverReadMarkers = serverReadMarkers,
+        // Seed the baseline (initializer list) before subscribing below: the
+        // signals library fires the callback synchronously with the current
+        // value, and _onServersChanged diffs against _knownIds on that first
+        // fire. Seeding it to the current ids makes that fire a no-op (nothing
+        // diffs as removed).
+        _knownIds = servers.value.keys.toSet() {
     _unsubscribe = servers.subscribe(_onServersChanged);
   }
 
   final RoomReadMarkers _roomReadMarkers;
   final ServerReadMarkers _serverReadMarkers;
-  late Set<String> _knownIds;
+  Set<String> _knownIds;
   late final void Function() _unsubscribe;
   bool _isDisposed = false;
 
@@ -57,16 +57,11 @@ class RemovedServerCleanup {
     final nextIds = servers.keys.toSet();
     final removed = _knownIds.difference(nextIds);
     _knownIds = nextIds;
-    // Every departed id is cleared unconditionally — there is deliberately no
-    // "skip when nextIds is empty" guard against the teardown empty-out. That
-    // empty-out is indistinguishable here from a user removing their last
-    // server: both drop the final id to `{}`, and the last-server removal must
-    // still clear its state. The only reliable separator is the code path
-    // (teardown keeps stored sessions; removeServer deletes them), which the
-    // signal transition doesn't carry. What keeps teardown safe is the dispose
-    // ordering documented on this class: [dispose] unsubscribes before
-    // [ServerManager.dispose] empties the signal, so this callback never sees
-    // the empty-out.
+    // No "skip when nextIds is empty" shortcut: a user removing their last
+    // server also drops to `{}` and must still be cleared, so the empty-out is
+    // indistinguishable here from a real removal. The dispose ordering
+    // documented on this class — not a guard in this method — is what keeps
+    // teardown's empty-out from wiping every server.
     for (final id in removed) {
       _clearServer(id);
     }

--- a/lib/src/core/removed_server_cleanup.dart
+++ b/lib/src/core/removed_server_cleanup.dart
@@ -63,14 +63,16 @@ class RemovedServerCleanup {
   }
 
   /// Runs synchronously inside the servers-signal write (the subscription fires
-  /// during [ServerManager.removeServer]). The in-memory model clears are
-  /// synchronous map/signal updates that also persist themselves fire-and-forget
-  /// with their own failure logging; the static stores are awaited off the
-  /// microtask queue with their throws caught here so one failure can't strand
-  /// the others or unwind the signal write.
+  /// during [ServerManager.removeServer]). Every clear is isolated so one
+  /// failure can neither strand the others nor unwind that write: the in-memory
+  /// clears run guarded (their `value =` writes notify watchers synchronously,
+  /// so a throwing watcher would otherwise escape), and the static stores run
+  /// fire-and-forget with their throws caught and logged per store.
   void _clearServer(String id) {
-    _serverReadMarkers.clearServer(id);
-    _roomReadMarkers.clearServer(id);
+    _clearInMemory(
+        () => _serverReadMarkers.clearServer(id), 'server read marker', id);
+    _clearInMemory(
+        () => _roomReadMarkers.clearServer(id), 'room read markers', id);
     unawaited(
       ThreadReadMarkerStorage.clearServer(id)
           .catchError((Object error, StackTrace st) {
@@ -115,6 +117,21 @@ class RemovedServerCleanup {
     // prompt=login on the next connect (see ConnectFlow), so a server removed
     // while inactivity-logged-out must keep it: clearing it would let a re-add
     // under the same id reuse a silent IdP session and skip the forced re-login.
+  }
+
+  /// Runs a synchronous in-memory clear, logging any throw instead of letting
+  /// it unwind the servers-signal write this executes inside.
+  void _clearInMemory(void Function() clear, String what, String id) {
+    try {
+      clear();
+    } on Object catch (error, st) {
+      _logger.error(
+        'Failed to clear $what for removed server',
+        error: error,
+        stackTrace: st,
+        attributes: {'serverId': id},
+      );
+    }
   }
 
   void dispose() {

--- a/lib/src/core/removed_server_cleanup.dart
+++ b/lib/src/core/removed_server_cleanup.dart
@@ -90,10 +90,10 @@ class RemovedServerCleanup {
     unawaited(
       ThreadAnchorStorage.clearServer(id)
           .catchError((Object error, StackTrace st) {
-        // Error to match the thread-marker clear it mirrors: a stale anchor
-        // only misplaces a divider, but a systemic write failure here would
-        // also fail that clear, so surface both at the same level.
-        _logger.error(
+        // Warning, not error: a stale anchor only misplaces a "New messages"
+        // divider (cosmetic), unlike the thread-marker clear above whose
+        // failure hides unread content.
+        _logger.warning(
           'Failed to clear thread anchors for removed server',
           error: error,
           stackTrace: st,

--- a/lib/src/core/removed_server_cleanup.dart
+++ b/lib/src/core/removed_server_cleanup.dart
@@ -1,0 +1,125 @@
+import 'dart:async' show unawaited;
+
+import 'package:soliplex_agent/soliplex_agent.dart' show ReadonlySignal;
+import 'package:soliplex_logging/soliplex_logging.dart';
+
+import '../modules/auth/return_to_storage.dart';
+import '../modules/auth/server_entry.dart';
+import '../modules/lobby/lobby_read_markers.dart'
+    show RoomReadMarkers, ServerReadMarkers;
+import '../modules/room/thread_anchor_storage.dart';
+import '../modules/room/thread_read_markers.dart';
+
+final Logger _logger =
+    LogManager.instance.getLogger('soliplex.removed_server_cleanup');
+
+/// Drops a removed server's device-local state so re-adding it under the same
+/// id doesn't resurrect stale read state, a misplaced thread divider, or an
+/// unsent draft. Server ids derive from the URL, so a re-add reuses the id.
+///
+/// Owned by [RoomAppModule] (like [UploadTrackerRegistry]) rather than a screen
+/// because removal fires from surfaces that don't mount the lobby — notably the
+/// home screen's server list. Subscribing to [ServerManager.servers] at module
+/// scope runs the cleanup for every removal path across the whole app session.
+/// The shared in-memory read-marker models are the same instances the lobby and
+/// room screens watch, so clearing them updates a mounted screen reactively too.
+///
+/// [dispose] must run before [ServerManager.dispose] empties the servers signal
+/// on shell teardown: that empty-out is a set transition this class would
+/// otherwise read as a mass removal and wipe every server's state, even though
+/// teardown keeps stored sessions for the next launch. [RoomAppModule] is
+/// disposed before the auth module (reverse registration order), so its
+/// `onDispose` unsubscribes in time.
+class RemovedServerCleanup {
+  RemovedServerCleanup({
+    required ReadonlySignal<Map<String, ServerEntry>> servers,
+    required RoomReadMarkers roomReadMarkers,
+    required ServerReadMarkers serverReadMarkers,
+  })  : _roomReadMarkers = roomReadMarkers,
+        _serverReadMarkers = serverReadMarkers {
+    // Seed the baseline before subscribing: the signals library fires the
+    // callback synchronously with the current value, and _onServersChanged
+    // reads _knownIds on that first fire. Seeding it to the current ids makes
+    // that fire a no-op (nothing diffs as removed) and avoids reading the late
+    // field before it is assigned.
+    _knownIds = servers.value.keys.toSet();
+    _unsubscribe = servers.subscribe(_onServersChanged);
+  }
+
+  final RoomReadMarkers _roomReadMarkers;
+  final ServerReadMarkers _serverReadMarkers;
+  late Set<String> _knownIds;
+  late final void Function() _unsubscribe;
+  bool _isDisposed = false;
+
+  void _onServersChanged(Map<String, ServerEntry> servers) {
+    if (_isDisposed) return;
+    final nextIds = servers.keys.toSet();
+    final removed = _knownIds.difference(nextIds);
+    _knownIds = nextIds;
+    for (final id in removed) {
+      _clearServer(id);
+    }
+  }
+
+  /// Runs synchronously inside the servers-signal write (the subscription fires
+  /// during [ServerManager.removeServer]). The in-memory model clears are
+  /// synchronous map/signal updates that also persist themselves fire-and-forget
+  /// with their own failure logging; the static stores are awaited off the
+  /// microtask queue with their throws caught here so one failure can't strand
+  /// the others or unwind the signal write.
+  void _clearServer(String id) {
+    _serverReadMarkers.clearServer(id);
+    _roomReadMarkers.clearServer(id);
+    unawaited(
+      ThreadReadMarkerStorage.clearServer(id)
+          .catchError((Object error, StackTrace st) {
+        // Error, not warning: a failed clear leaves stale thread floors on
+        // disk, so a server re-added under the same id reads as already-read
+        // (hides unread content), a worse outcome than a missed stamp.
+        _logger.error(
+          'Failed to clear thread read markers for removed server',
+          error: error,
+          stackTrace: st,
+          attributes: {'serverId': id},
+        );
+      }),
+    );
+    unawaited(
+      ThreadAnchorStorage.clearServer(id)
+          .catchError((Object error, StackTrace st) {
+        // Error to match the thread-marker clear it mirrors: a stale anchor
+        // only misplaces a divider, but a systemic write failure here would
+        // also fail that clear, so surface both at the same level.
+        _logger.error(
+          'Failed to clear thread anchors for removed server',
+          error: error,
+          stackTrace: st,
+          attributes: {'serverId': id},
+        );
+      }),
+    );
+    unawaited(
+      ReturnToStorage.clearServer(id).catchError((Object error, StackTrace st) {
+        // Warning: a surviving draft self-expires after 24h and can only
+        // resurface in a re-added room, so it's lower stakes than a marker.
+        _logger.warning(
+          'Failed to clear composer drafts for removed server',
+          error: error,
+          stackTrace: st,
+          attributes: {'serverId': id},
+        );
+      }),
+    );
+    // The inactivity-logout flag is deliberately not cleared. It forces
+    // prompt=login on the next connect (see ConnectFlow), so a server removed
+    // while inactivity-logged-out must keep it: clearing it would let a re-add
+    // under the same id reuse a silent IdP session and skip the forced re-login.
+  }
+
+  void dispose() {
+    if (_isDisposed) return;
+    _isDisposed = true;
+    _unsubscribe();
+  }
+}

--- a/lib/src/core/removed_server_cleanup.dart
+++ b/lib/src/core/removed_server_cleanup.dart
@@ -57,6 +57,16 @@ class RemovedServerCleanup {
     final nextIds = servers.keys.toSet();
     final removed = _knownIds.difference(nextIds);
     _knownIds = nextIds;
+    // Every departed id is cleared unconditionally — there is deliberately no
+    // "skip when nextIds is empty" guard against the teardown empty-out. That
+    // empty-out is indistinguishable here from a user removing their last
+    // server: both drop the final id to `{}`, and the last-server removal must
+    // still clear its state. The only reliable separator is the code path
+    // (teardown keeps stored sessions; removeServer deletes them), which the
+    // signal transition doesn't carry. What keeps teardown safe is the dispose
+    // ordering documented on this class: [dispose] unsubscribes before
+    // [ServerManager.dispose] empties the signal, so this callback never sees
+    // the empty-out.
     for (final id in removed) {
       _clearServer(id);
     }
@@ -64,9 +74,9 @@ class RemovedServerCleanup {
 
   /// Runs synchronously inside the servers-signal write (the subscription fires
   /// during [ServerManager.removeServer]). Every clear is isolated so one
-  /// failure can neither strand the others nor unwind that write: the in-memory
-  /// clears run guarded (their `value =` writes notify watchers synchronously,
-  /// so a throwing watcher would otherwise escape), and the static stores run
+  /// failure can neither strand the others nor unwind that write: a synchronous
+  /// throw from an in-memory clear would propagate out of this callback and
+  /// unwind the write, so each runs guarded, and the static stores run
   /// fire-and-forget with their throws caught and logged per store.
   void _clearServer(String id) {
     _clearInMemory(

--- a/lib/src/flavors/standard.dart
+++ b/lib/src/flavors/standard.dart
@@ -181,6 +181,7 @@ Future<ShellConfig> standard({
         registry: registry,
         roomReadMarkers: roomReadMarkers,
         serverReadMarkers: serverReadMarkers,
+        inactivityLogoutFlags: inactivityLogoutFlags,
       ),
       RoomAppModule(
         serverManager: serverManager,

--- a/lib/src/flavors/standard.dart
+++ b/lib/src/flavors/standard.dart
@@ -127,9 +127,10 @@ Future<ShellConfig> standard({
       ToolCallsExtension(),
       HumanApprovalExtension(),
     ],
+    servers: serverManager.servers,
   );
 
-  final registry = RunRegistry();
+  final registry = RunRegistry(servers: serverManager.servers);
 
   // Shared in-memory read-marker model so a room stamped read in the room
   // screen clears its lobby unread dot immediately, with no storage race.

--- a/lib/src/flavors/standard.dart
+++ b/lib/src/flavors/standard.dart
@@ -182,7 +182,6 @@ Future<ShellConfig> standard({
         registry: registry,
         roomReadMarkers: roomReadMarkers,
         serverReadMarkers: serverReadMarkers,
-        inactivityLogoutFlags: inactivityLogoutFlags,
       ),
       RoomAppModule(
         serverManager: serverManager,

--- a/lib/src/modules/auth/inactivity_logout_storage.dart
+++ b/lib/src/modules/auth/inactivity_logout_storage.dart
@@ -1,6 +1,8 @@
-import 'dart:developer' as dev;
-
 import 'package:shared_preferences/shared_preferences.dart';
+import 'package:soliplex_logging/soliplex_logging.dart';
+
+final Logger _logger =
+    LogManager.instance.getLogger('soliplex.inactivity_logout_storage');
 
 /// Per-server flag recording that the most recent logout was triggered by
 /// the inactivity monitor.
@@ -32,7 +34,7 @@ abstract class InactivityLogoutFlagStorage {
 ///
 /// Every method degrades gracefully if the storage layer throws: writes
 /// and clears become no-ops and reads default to not-marked, each logged
-/// at SEVERE. Storage is best-effort here precisely because a thrown
+/// at error level. Storage is best-effort here precisely because a thrown
 /// `PlatformException` must not wedge the auth flow ([isMarked] runs
 /// before sign-in) or mask a completed sign-in as a failure ([clear]
 /// runs after it). The two write failures fail safe in opposite
@@ -56,11 +58,10 @@ class LocalInactivityLogoutFlagStorage implements InactivityLogoutFlagStorage {
       final prefs = await _prefsFactory();
       await prefs.setBool(_key(serverId), true);
     } catch (e, st) {
-      dev.log(
+      _logger.error(
         'Failed to persist inactivity-logout flag for $serverId',
         error: e,
         stackTrace: st,
-        level: 1000,
       );
     }
   }
@@ -71,12 +72,11 @@ class LocalInactivityLogoutFlagStorage implements InactivityLogoutFlagStorage {
       final prefs = await _prefsFactory();
       return prefs.getBool(_key(serverId)) ?? false;
     } catch (e, st) {
-      dev.log(
+      _logger.error(
         'Failed to read inactivity-logout flag for $serverId; '
         'defaulting to not-marked',
         error: e,
         stackTrace: st,
-        level: 1000,
       );
       return false;
     }
@@ -88,11 +88,10 @@ class LocalInactivityLogoutFlagStorage implements InactivityLogoutFlagStorage {
       final prefs = await _prefsFactory();
       await prefs.remove(_key(serverId));
     } catch (e, st) {
-      dev.log(
+      _logger.error(
         'Failed to clear inactivity-logout flag for $serverId',
         error: e,
         stackTrace: st,
-        level: 1000,
       );
     }
   }

--- a/lib/src/modules/auth/return_to_storage.dart
+++ b/lib/src/modules/auth/return_to_storage.dart
@@ -84,4 +84,16 @@ abstract final class ReturnToStorage {
     final prefs = await SharedPreferences.getInstance();
     await prefs.remove(_composerKey(serverId, roomId));
   }
+
+  /// Removes every composer draft belonging to [serverId], so a removed
+  /// server's unsent text can't resurface in a re-added room. The trailing
+  /// `:` bounds the match so `serverId: 'a'` does not also sweep `'ab'`.
+  static Future<void> clearServer(String serverId) async {
+    final prefs = await SharedPreferences.getInstance();
+    final prefix = '$_prefix:composer:$serverId:';
+    final keys = prefs.getKeys().where((key) => key.startsWith(prefix));
+    for (final key in keys) {
+      await prefs.remove(key);
+    }
+  }
 }

--- a/lib/src/modules/auth/return_to_storage.dart
+++ b/lib/src/modules/auth/return_to_storage.dart
@@ -86,8 +86,15 @@ abstract final class ReturnToStorage {
   }
 
   /// Removes every composer draft belonging to [serverId], so a removed
-  /// server's unsent text can't resurface in a re-added room. The trailing
-  /// `:` bounds the match so `serverId: 'a'` does not also sweep `'ab'`.
+  /// server's unsent text can't resurface in a re-added room.
+  ///
+  /// Matches by key prefix. This is exact for the common case, but the key
+  /// joins [serverId] and roomId with an unescaped `:`, and a server id is a
+  /// `Uri.origin` (which omits the default port). So a portless origin is a
+  /// prefix of the same host with an explicit port — `clearServer` for
+  /// `https://foo.com` also sweeps `https://foo.com:8443`'s drafts. Bounded and
+  /// rare (both servers on one host, one with an unsent draft); the unambiguous
+  /// fix is the keyed-store migration tracked in issue #393.
   static Future<void> clearServer(String serverId) async {
     final prefs = await SharedPreferences.getInstance();
     final prefix = '$_prefix:composer:$serverId:';

--- a/lib/src/modules/auth/return_to_storage.dart
+++ b/lib/src/modules/auth/return_to_storage.dart
@@ -1,7 +1,10 @@
 import 'dart:convert';
-import 'dart:developer' as dev;
 
 import 'package:shared_preferences/shared_preferences.dart';
+import 'package:soliplex_logging/soliplex_logging.dart';
+
+final Logger _logger =
+    LogManager.instance.getLogger('soliplex.return_to_storage');
 
 /// Per-screen snapshot store for state that needs to survive an
 /// auth-failure round-trip (composer drafts, quiz progress).
@@ -67,8 +70,8 @@ abstract final class ReturnToStorage {
       }
       return json['unsentText'] as String?;
     } catch (e, st) {
-      dev.log(
-        'ReturnToStorage: corrupted composer entry; clearing',
+      _logger.warning(
+        'Corrupted composer entry; clearing',
         error: e,
         stackTrace: st,
       );

--- a/lib/src/modules/lobby/lobby_module.dart
+++ b/lib/src/modules/lobby/lobby_module.dart
@@ -3,7 +3,6 @@ import 'package:go_router/go_router.dart';
 import '../../core/app_module.dart';
 import '../../core/app_identity.dart';
 import '../../core/routes.dart';
-import '../auth/inactivity_logout_storage.dart';
 import '../auth/server_manager.dart';
 import '../room/run_registry.dart';
 import 'lobby_read_markers.dart' show RoomReadMarkers, ServerReadMarkers;
@@ -16,7 +15,6 @@ class LobbyAppModule extends AppModule {
     required this.registry,
     required this.roomReadMarkers,
     required this.serverReadMarkers,
-    required this.inactivityLogoutFlags,
   });
 
   final ServerManager serverManager;
@@ -36,10 +34,6 @@ class LobbyAppModule extends AppModule {
   /// marker floors every room's unread dot on the server.
   final ServerReadMarkers serverReadMarkers;
 
-  /// Clears a removed server's pending inactivity-logout flag, so re-adding a
-  /// server under the same id doesn't inherit a stale forced `prompt=login`.
-  final InactivityLogoutFlagStorage inactivityLogoutFlags;
-
   @override
   String get namespace => 'lobby';
 
@@ -55,7 +49,6 @@ class LobbyAppModule extends AppModule {
                 registry: registry,
                 roomReadMarkers: roomReadMarkers,
                 serverReadMarkers: serverReadMarkers,
-                inactivityLogoutFlags: inactivityLogoutFlags,
               ),
             ),
           ),

--- a/lib/src/modules/lobby/lobby_module.dart
+++ b/lib/src/modules/lobby/lobby_module.dart
@@ -3,6 +3,7 @@ import 'package:go_router/go_router.dart';
 import '../../core/app_module.dart';
 import '../../core/app_identity.dart';
 import '../../core/routes.dart';
+import '../auth/inactivity_logout_storage.dart';
 import '../auth/server_manager.dart';
 import '../room/run_registry.dart';
 import 'lobby_read_markers.dart' show RoomReadMarkers, ServerReadMarkers;
@@ -15,6 +16,7 @@ class LobbyAppModule extends AppModule {
     required this.registry,
     required this.roomReadMarkers,
     required this.serverReadMarkers,
+    required this.inactivityLogoutFlags,
   });
 
   final ServerManager serverManager;
@@ -34,6 +36,10 @@ class LobbyAppModule extends AppModule {
   /// marker floors every room's unread dot on the server.
   final ServerReadMarkers serverReadMarkers;
 
+  /// Clears a removed server's pending inactivity-logout flag, so re-adding a
+  /// server under the same id doesn't inherit a stale forced `prompt=login`.
+  final InactivityLogoutFlagStorage inactivityLogoutFlags;
+
   @override
   String get namespace => 'lobby';
 
@@ -49,6 +55,7 @@ class LobbyAppModule extends AppModule {
                 registry: registry,
                 roomReadMarkers: roomReadMarkers,
                 serverReadMarkers: serverReadMarkers,
+                inactivityLogoutFlags: inactivityLogoutFlags,
               ),
             ),
           ),

--- a/lib/src/modules/lobby/lobby_read_markers.dart
+++ b/lib/src/modules/lobby/lobby_read_markers.dart
@@ -168,6 +168,7 @@ class RoomReadMarkers {
           'Failed to clear room read markers for removed server',
           error: error,
           stackTrace: st,
+          attributes: {'serverId': serverId},
         );
       }),
     );
@@ -315,6 +316,7 @@ class ServerReadMarkers {
           'Failed to clear server read marker for removed server',
           error: error,
           stackTrace: st,
+          attributes: {'serverId': serverId},
         );
       }),
     );

--- a/lib/src/modules/lobby/lobby_state.dart
+++ b/lib/src/modules/lobby/lobby_state.dart
@@ -14,11 +14,14 @@ import 'package:soliplex_logging/soliplex_logging.dart';
 import '../../core/activity_read.dart';
 import '../../core/util/debouncer.dart';
 import '../auth/auth_tokens.dart';
+import '../auth/inactivity_logout_storage.dart';
+import '../auth/return_to_storage.dart';
 import '../auth/selected_server_storage.dart';
 import '../auth/server_entry.dart';
 import '../auth/server_manager.dart';
 import '../room/room_run_activity.dart';
 import '../room/run_registry.dart';
+import '../room/thread_anchor_storage.dart';
 import '../room/thread_read_markers.dart';
 import 'lobby_read_markers.dart';
 import 'lobby_sort_mode.dart';
@@ -89,11 +92,13 @@ class LobbyState {
     RunRegistry? registry,
     RoomReadMarkers? roomReadMarkers,
     ServerReadMarkers? serverReadMarkers,
+    InactivityLogoutFlagStorage? inactivityLogoutFlags,
   })  : _serverManager = serverManager,
         _apiResolver = apiResolver ?? _defaultResolver,
         _registry = registry,
         _roomReadMarkers = roomReadMarkers ?? RoomReadMarkers(),
-        _serverReadMarkers = serverReadMarkers ?? ServerReadMarkers() {
+        _serverReadMarkers = serverReadMarkers ?? ServerReadMarkers(),
+        _inactivityLogoutFlags = inactivityLogoutFlags {
     _unsubscribe = _serverManager.servers.subscribe(_onServersChanged);
     unawaited(_loadViewMode());
     unawaited(_loadSortMode());
@@ -116,6 +121,11 @@ class LobbyState {
   /// room on it, so a room is unread only when its activity beats the later of
   /// its own marker and this one. Shared with the room screen.
   final ServerReadMarkers _serverReadMarkers;
+
+  /// Clears a removed server's pending inactivity-logout flag so a re-add under
+  /// the same id doesn't inherit a stale forced `prompt=login`. Null in
+  /// contexts that don't wire it (the flag then self-heals on next sign-in).
+  final InactivityLogoutFlagStorage? _inactivityLogoutFlags;
 
   late final void Function() _unsubscribe;
 
@@ -531,6 +541,34 @@ class LobbyState {
             );
           }),
         );
+        unawaited(
+          ThreadAnchorStorage.clearServer(id)
+              .catchError((Object error, StackTrace st) {
+            // Error to match the thread-marker clear it shadows: a stale anchor
+            // only misplaces a divider, but a systemic write failure here would
+            // also fail that clear, so surface both at the same level.
+            _logger.error(
+              'Failed to clear thread anchors for removed server',
+              error: error,
+              stackTrace: st,
+            );
+          }),
+        );
+        unawaited(
+          ReturnToStorage.clearServer(id)
+              .catchError((Object error, StackTrace st) {
+            // Warning: a surviving draft self-expires after 24h and can only
+            // resurface in a re-added room, so it's lower stakes than a marker.
+            _logger.warning(
+              'Failed to clear composer drafts for removed server',
+              error: error,
+              stackTrace: st,
+            );
+          }),
+        );
+        // The impl swallows and logs its own storage failures, so a missed
+        // clear only forces a harmless extra prompt=login on a same-id re-add.
+        unawaited(_inactivityLogoutFlags?.clear(id) ?? Future<void>.value());
       }
       _roomsByServer.value = updatedRooms;
       _userProfiles.value = updatedProfiles;

--- a/lib/src/modules/lobby/lobby_state.dart
+++ b/lib/src/modules/lobby/lobby_state.dart
@@ -14,15 +14,11 @@ import 'package:soliplex_logging/soliplex_logging.dart';
 import '../../core/activity_read.dart';
 import '../../core/util/debouncer.dart';
 import '../auth/auth_tokens.dart';
-import '../auth/inactivity_logout_storage.dart';
-import '../auth/return_to_storage.dart';
 import '../auth/selected_server_storage.dart';
 import '../auth/server_entry.dart';
 import '../auth/server_manager.dart';
 import '../room/room_run_activity.dart';
 import '../room/run_registry.dart';
-import '../room/thread_anchor_storage.dart';
-import '../room/thread_read_markers.dart';
 import 'lobby_read_markers.dart';
 import 'lobby_sort_mode.dart';
 import 'lobby_view_mode.dart';
@@ -92,13 +88,11 @@ class LobbyState {
     RunRegistry? registry,
     RoomReadMarkers? roomReadMarkers,
     ServerReadMarkers? serverReadMarkers,
-    InactivityLogoutFlagStorage? inactivityLogoutFlags,
   })  : _serverManager = serverManager,
         _apiResolver = apiResolver ?? _defaultResolver,
         _registry = registry,
         _roomReadMarkers = roomReadMarkers ?? RoomReadMarkers(),
-        _serverReadMarkers = serverReadMarkers ?? ServerReadMarkers(),
-        _inactivityLogoutFlags = inactivityLogoutFlags {
+        _serverReadMarkers = serverReadMarkers ?? ServerReadMarkers() {
     _unsubscribe = _serverManager.servers.subscribe(_onServersChanged);
     unawaited(_loadViewMode());
     unawaited(_loadSortMode());
@@ -121,11 +115,6 @@ class LobbyState {
   /// room on it, so a room is unread only when its activity beats the later of
   /// its own marker and this one. Shared with the room screen.
   final ServerReadMarkers _serverReadMarkers;
-
-  /// Clears a removed server's pending inactivity-logout flag so a re-add under
-  /// the same id doesn't inherit a stale forced `prompt=login`. Null in
-  /// contexts that don't wire it (the flag then self-heals on next sign-in).
-  final InactivityLogoutFlagStorage? _inactivityLogoutFlags;
 
   late final void Function() _unsubscribe;
 
@@ -523,52 +512,6 @@ class LobbyState {
         // Drop a stuck in-flight activity fetch for a removed server; otherwise
         // _activityFetchServerId would block a future fetch if the id returns.
         if (_activityFetchServerId == id) _cancelActivityFetch();
-        // Server ids are derived from the URL, so re-adding a removed server
-        // reuses its id. Drop its read markers at every level so the re-added
-        // server starts unread instead of inheriting the old floors.
-        _serverReadMarkers.clearServer(id);
-        _roomReadMarkers.clearServer(id);
-        unawaited(
-          ThreadReadMarkerStorage.clearServer(id)
-              .catchError((Object error, StackTrace st) {
-            // Error, not warning: a failed clear leaves stale thread floors on
-            // disk, so a server re-added under the same id reads as already-read
-            // (hides unread content), a worse outcome than a missed stamp.
-            _logger.error(
-              'Failed to clear thread read markers for removed server',
-              error: error,
-              stackTrace: st,
-            );
-          }),
-        );
-        unawaited(
-          ThreadAnchorStorage.clearServer(id)
-              .catchError((Object error, StackTrace st) {
-            // Error to match the thread-marker clear it shadows: a stale anchor
-            // only misplaces a divider, but a systemic write failure here would
-            // also fail that clear, so surface both at the same level.
-            _logger.error(
-              'Failed to clear thread anchors for removed server',
-              error: error,
-              stackTrace: st,
-            );
-          }),
-        );
-        unawaited(
-          ReturnToStorage.clearServer(id)
-              .catchError((Object error, StackTrace st) {
-            // Warning: a surviving draft self-expires after 24h and can only
-            // resurface in a re-added room, so it's lower stakes than a marker.
-            _logger.warning(
-              'Failed to clear composer drafts for removed server',
-              error: error,
-              stackTrace: st,
-            );
-          }),
-        );
-        // The impl swallows and logs its own storage failures, so a missed
-        // clear only forces a harmless extra prompt=login on a same-id re-add.
-        unawaited(_inactivityLogoutFlags?.clear(id) ?? Future<void>.value());
       }
       _roomsByServer.value = updatedRooms;
       _userProfiles.value = updatedProfiles;

--- a/lib/src/modules/lobby/ui/lobby_screen.dart
+++ b/lib/src/modules/lobby/ui/lobby_screen.dart
@@ -9,7 +9,6 @@ import '../../../core/activity_read.dart';
 import '../../../core/app_identity.dart';
 import '../../../core/routes.dart';
 import '../../../shared/mark_read_context_menu.dart';
-import '../../auth/inactivity_logout_storage.dart';
 import '../../auth/server_entry.dart';
 import '../../auth/server_manager.dart';
 import '../../room/run_registry.dart';
@@ -39,7 +38,6 @@ class LobbyScreen extends StatefulWidget {
     this.registry,
     this.roomReadMarkers,
     this.serverReadMarkers,
-    this.inactivityLogoutFlags,
     this.apiResolver,
   });
 
@@ -60,10 +58,6 @@ class LobbyScreen extends StatefulWidget {
   /// Shared server read markers, forwarded to [LobbyState]. Null in tests, where
   /// each screen gets its own isolated store.
   final ServerReadMarkers? serverReadMarkers;
-
-  /// Clears a removed server's pending inactivity-logout flag, forwarded to
-  /// [LobbyState]. Null in tests that don't exercise the flag.
-  final InactivityLogoutFlagStorage? inactivityLogoutFlags;
 
   /// Test seam forwarded to [LobbyState]; production uses the default
   /// per-entry API resolver.
@@ -86,7 +80,6 @@ class _LobbyScreenState extends State<LobbyScreen> {
       registry: widget.registry,
       roomReadMarkers: widget.roomReadMarkers,
       serverReadMarkers: widget.serverReadMarkers,
-      inactivityLogoutFlags: widget.inactivityLogoutFlags,
     );
   }
 

--- a/lib/src/modules/lobby/ui/lobby_screen.dart
+++ b/lib/src/modules/lobby/ui/lobby_screen.dart
@@ -9,6 +9,7 @@ import '../../../core/activity_read.dart';
 import '../../../core/app_identity.dart';
 import '../../../core/routes.dart';
 import '../../../shared/mark_read_context_menu.dart';
+import '../../auth/inactivity_logout_storage.dart';
 import '../../auth/server_entry.dart';
 import '../../auth/server_manager.dart';
 import '../../room/run_registry.dart';
@@ -38,6 +39,7 @@ class LobbyScreen extends StatefulWidget {
     this.registry,
     this.roomReadMarkers,
     this.serverReadMarkers,
+    this.inactivityLogoutFlags,
     this.apiResolver,
   });
 
@@ -58,6 +60,10 @@ class LobbyScreen extends StatefulWidget {
   /// Shared server read markers, forwarded to [LobbyState]. Null in tests, where
   /// each screen gets its own isolated store.
   final ServerReadMarkers? serverReadMarkers;
+
+  /// Clears a removed server's pending inactivity-logout flag, forwarded to
+  /// [LobbyState]. Null in tests that don't exercise the flag.
+  final InactivityLogoutFlagStorage? inactivityLogoutFlags;
 
   /// Test seam forwarded to [LobbyState]; production uses the default
   /// per-entry API resolver.
@@ -80,6 +86,7 @@ class _LobbyScreenState extends State<LobbyScreen> {
       registry: widget.registry,
       roomReadMarkers: widget.roomReadMarkers,
       serverReadMarkers: widget.serverReadMarkers,
+      inactivityLogoutFlags: widget.inactivityLogoutFlags,
     );
   }
 

--- a/lib/src/modules/room/agent_runtime_manager.dart
+++ b/lib/src/modules/room/agent_runtime_manager.dart
@@ -1,4 +1,8 @@
+import 'dart:async';
+
 import 'package:soliplex_agent/soliplex_agent.dart';
+
+import '../auth/server_entry.dart';
 
 /// Factory and cache for [AgentRuntime] instances, keyed by server ID.
 ///
@@ -10,10 +14,13 @@ class AgentRuntimeManager {
     required Future<ToolRegistry> Function(String roomId) toolRegistryResolver,
     required Logger logger,
     SessionExtensionFactory? extensionFactory,
+    ReadonlySignal<Map<String, ServerEntry>>? servers,
   })  : _platform = platform,
         _toolRegistryResolver = toolRegistryResolver,
         _extensionFactory = extensionFactory,
-        _logger = logger;
+        _logger = logger {
+    _unsubscribe = servers?.subscribe(_evictRemoved);
+  }
 
   final PlatformConstraints _platform;
   final Future<ToolRegistry> Function(String roomId) _toolRegistryResolver;
@@ -21,6 +28,7 @@ class AgentRuntimeManager {
   final Logger _logger;
   final Map<String, ({ServerConnection connection, AgentRuntime runtime})>
       _cache = {};
+  void Function()? _unsubscribe;
   bool _isDisposed = false;
 
   /// Resolves the [ToolRegistry] for a given room ID.
@@ -57,9 +65,33 @@ class AgentRuntimeManager {
     );
   }
 
+  /// Disposes and drops the cached runtime for every server no longer present
+  /// in [snapshot], so a removed server's runtime doesn't linger until the
+  /// whole manager is disposed. Disposal is fire-and-forget: it may make
+  /// teardown calls over a connection [ServerManager] has already closed, so a
+  /// throw is logged, not propagated.
+  void _evictRemoved(Map<String, ServerEntry> snapshot) {
+    if (_isDisposed) return;
+    final liveIds = snapshot.keys.toSet();
+    final dead = _cache.entries.where((e) => !liveIds.contains(e.key)).toList();
+    for (final entry in dead) {
+      _cache.remove(entry.key);
+      unawaited(_disposeRuntime(entry.key, entry.value.runtime));
+    }
+  }
+
+  Future<void> _disposeRuntime(String serverId, AgentRuntime runtime) async {
+    try {
+      await runtime.dispose();
+    } on Object catch (e) {
+      _logger.warning('Failed to dispose runtime $serverId: $e');
+    }
+  }
+
   /// Disposes all cached runtimes and clears the cache.
   Future<void> dispose() async {
     _isDisposed = true;
+    _unsubscribe?.call();
     final entries = _cache.values.toList();
     _cache.clear();
     for (final entry in entries) {

--- a/lib/src/modules/room/agent_runtime_manager.dart
+++ b/lib/src/modules/room/agent_runtime_manager.dart
@@ -83,8 +83,12 @@ class AgentRuntimeManager {
   Future<void> _disposeRuntime(String serverId, AgentRuntime runtime) async {
     try {
       await runtime.dispose();
-    } on Object catch (e) {
-      _logger.warning('Failed to dispose runtime $serverId: $e');
+    } on Object catch (e, st) {
+      _logger.error(
+        'Failed to dispose runtime for removed server $serverId',
+        error: e,
+        stackTrace: st,
+      );
     }
   }
 

--- a/lib/src/modules/room/agent_runtime_manager.dart
+++ b/lib/src/modules/room/agent_runtime_manager.dart
@@ -11,19 +11,19 @@ import '../auth/server_entry.dart';
 class AgentRuntimeManager {
   /// [servers] wires the removal-eviction path: when a server disappears from
   /// the signal, its cached runtime is disposed and dropped so it doesn't
-  /// linger until the whole manager is disposed. Null in tests that don't
-  /// exercise eviction.
+  /// linger until the whole manager is disposed. Tests that don't exercise
+  /// eviction pass a never-changing `Signal({})`.
   AgentRuntimeManager({
     required PlatformConstraints platform,
     required Future<ToolRegistry> Function(String roomId) toolRegistryResolver,
     required Logger logger,
+    required ReadonlySignal<Map<String, ServerEntry>> servers,
     SessionExtensionFactory? extensionFactory,
-    ReadonlySignal<Map<String, ServerEntry>>? servers,
   })  : _platform = platform,
         _toolRegistryResolver = toolRegistryResolver,
         _extensionFactory = extensionFactory,
         _logger = logger {
-    _unsubscribe = servers?.subscribe(_evictRemoved);
+    _unsubscribe = servers.subscribe(_evictRemoved);
   }
 
   final PlatformConstraints _platform;
@@ -32,7 +32,7 @@ class AgentRuntimeManager {
   final Logger _logger;
   final Map<String, ({ServerConnection connection, AgentRuntime runtime})>
       _cache = {};
-  void Function()? _unsubscribe;
+  late final void Function() _unsubscribe;
   bool _isDisposed = false;
 
   /// Resolves the [ToolRegistry] for a given room ID.
@@ -99,7 +99,7 @@ class AgentRuntimeManager {
   /// Disposes all cached runtimes and clears the cache.
   Future<void> dispose() async {
     _isDisposed = true;
-    _unsubscribe?.call();
+    _unsubscribe();
     final entries = _cache.values.toList();
     _cache.clear();
     for (final entry in entries) {

--- a/lib/src/modules/room/agent_runtime_manager.dart
+++ b/lib/src/modules/room/agent_runtime_manager.dart
@@ -11,8 +11,8 @@ import '../auth/server_entry.dart';
 class AgentRuntimeManager {
   /// [servers] wires the removal-eviction path: when a server disappears from
   /// the signal, its cached runtime is disposed and dropped so it doesn't
-  /// linger until the whole manager is disposed. A caller that never mutates
-  /// the signal opts out of eviction.
+  /// linger until the whole manager is disposed. Eviction is driven entirely by
+  /// the signal, so a signal that never changes simply never evicts.
   AgentRuntimeManager({
     required PlatformConstraints platform,
     required Future<ToolRegistry> Function(String roomId) toolRegistryResolver,

--- a/lib/src/modules/room/agent_runtime_manager.dart
+++ b/lib/src/modules/room/agent_runtime_manager.dart
@@ -85,7 +85,7 @@ class AgentRuntimeManager {
       await runtime.dispose();
     } on Object catch (e, st) {
       _logger.error(
-        'Failed to dispose runtime for removed server $serverId',
+        'Failed to dispose runtime $serverId',
         error: e,
         stackTrace: st,
       );
@@ -99,12 +99,7 @@ class AgentRuntimeManager {
     final entries = _cache.values.toList();
     _cache.clear();
     for (final entry in entries) {
-      try {
-        await entry.runtime.dispose();
-      } on Object catch (e) {
-        _logger.warning(
-            'Failed to dispose runtime ${entry.connection.serverId}: $e');
-      }
+      await _disposeRuntime(entry.connection.serverId, entry.runtime);
     }
   }
 }

--- a/lib/src/modules/room/agent_runtime_manager.dart
+++ b/lib/src/modules/room/agent_runtime_manager.dart
@@ -9,6 +9,10 @@ import '../auth/server_entry.dart';
 /// Create one manager per app session and pass it to modules that need to
 /// spawn agent sessions. Calling [dispose] shuts down all cached runtimes.
 class AgentRuntimeManager {
+  /// [servers] wires the removal-eviction path: when a server disappears from
+  /// the signal, its cached runtime is disposed and dropped so it doesn't
+  /// linger until the whole manager is disposed. Null in tests that don't
+  /// exercise eviction.
   AgentRuntimeManager({
     required PlatformConstraints platform,
     required Future<ToolRegistry> Function(String roomId) toolRegistryResolver,

--- a/lib/src/modules/room/agent_runtime_manager.dart
+++ b/lib/src/modules/room/agent_runtime_manager.dart
@@ -11,8 +11,8 @@ import '../auth/server_entry.dart';
 class AgentRuntimeManager {
   /// [servers] wires the removal-eviction path: when a server disappears from
   /// the signal, its cached runtime is disposed and dropped so it doesn't
-  /// linger until the whole manager is disposed. Tests that don't exercise
-  /// eviction pass a never-changing `Signal({})`.
+  /// linger until the whole manager is disposed. A caller that never mutates
+  /// the signal opts out of eviction.
   AgentRuntimeManager({
     required PlatformConstraints platform,
     required Future<ToolRegistry> Function(String roomId) toolRegistryResolver,
@@ -71,9 +71,9 @@ class AgentRuntimeManager {
 
   /// Disposes and drops the cached runtime for every server no longer present
   /// in [snapshot], so a removed server's runtime doesn't linger until the
-  /// whole manager is disposed. Disposal is fire-and-forget: it may make
-  /// teardown calls over a connection [ServerManager] has already closed, so a
-  /// throw is logged, not propagated.
+  /// whole manager is disposed. Disposal is fire-and-forget: it runs teardown
+  /// that can throw, and this eviction must not strand the other disposals or
+  /// propagate, so a throw is logged.
   void _evictRemoved(Map<String, ServerEntry> snapshot) {
     if (_isDisposed) return;
     final liveIds = snapshot.keys.toSet();
@@ -96,8 +96,9 @@ class AgentRuntimeManager {
     }
   }
 
-  /// Disposes all cached runtimes and clears the cache.
+  /// Disposes all cached runtimes and clears the cache. Idempotent.
   Future<void> dispose() async {
+    if (_isDisposed) return;
     _isDisposed = true;
     _unsubscribe();
     final entries = _cache.values.toList();

--- a/lib/src/modules/room/room_module.dart
+++ b/lib/src/modules/room/room_module.dart
@@ -2,6 +2,7 @@ import 'package:flutter/widgets.dart';
 import 'package:go_router/go_router.dart';
 
 import '../../core/app_module.dart';
+import '../../core/removed_server_cleanup.dart';
 import '../auth/require_connected_server.dart';
 import '../auth/server_manager.dart';
 import '../lobby/lobby_read_markers.dart'
@@ -27,7 +28,12 @@ class RoomAppModule extends AppModule {
     this.enableDocumentFilter = false,
   })  : _documentSelections = DocumentSelections(),
         _messageExpansions = MessageExpansions(),
-        _uploadRegistry = UploadTrackerRegistry(servers: serverManager.servers);
+        _uploadRegistry = UploadTrackerRegistry(servers: serverManager.servers),
+        _removedServerCleanup = RemovedServerCleanup(
+          servers: serverManager.servers,
+          roomReadMarkers: roomReadMarkers,
+          serverReadMarkers: serverReadMarkers,
+        );
 
   final ServerManager serverManager;
   final AgentRuntimeManager runtimeManager;
@@ -49,6 +55,7 @@ class RoomAppModule extends AppModule {
   final DocumentSelections _documentSelections;
   final MessageExpansions _messageExpansions;
   final UploadTrackerRegistry _uploadRegistry;
+  final RemovedServerCleanup _removedServerCleanup;
 
   @override
   String get namespace => 'room';
@@ -115,6 +122,10 @@ class RoomAppModule extends AppModule {
 
   @override
   Future<void> onDispose() async {
+    // Before the auth module disposes ServerManager (reverse registration
+    // order), so the cleanup stops observing before ServerManager empties the
+    // servers signal — an empty-out it would otherwise read as a mass removal.
+    _removedServerCleanup.dispose();
     await runtimeManager.dispose();
     registry.dispose();
     _uploadRegistry.dispose();

--- a/lib/src/modules/room/run_registry.dart
+++ b/lib/src/modules/room/run_registry.dart
@@ -133,20 +133,7 @@ class RunRegistry {
     if (dead.isEmpty) return;
     for (final key in dead) {
       final session = _runs.remove(key)?.session;
-      if (session == null) continue;
-      // This runs inside the servers-signal batch: a throwing cancel would
-      // otherwise abort the loop and unwind removeServer before it deletes the
-      // stored session. Log and keep evicting the rest.
-      try {
-        session.cancel();
-      } on Object catch (error, stackTrace) {
-        _logger.error(
-          'Failed to cancel run for removed server',
-          error: error,
-          stackTrace: stackTrace,
-          attributes: {'key': key.toString()},
-        );
-      }
+      if (session != null) _cancelQuietly(key, session);
     }
     final nextActive = _activeKeys.value
         .where((key) => liveIds.contains(key.serverId))
@@ -156,13 +143,32 @@ class RunRegistry {
     }
   }
 
+  /// Cancels [session], swallowing and logging any throw. [cancel] runs real
+  /// teardown that can throw; both callers cancel in a loop where one throw must
+  /// not strand the rest. Eviction also runs synchronously inside the
+  /// servers-signal write, where an escape would unwind removeServer before it
+  /// deletes the stored session.
+  void _cancelQuietly(ThreadKey key, AgentSession session) {
+    try {
+      session.cancel();
+    } on Object catch (error, stackTrace) {
+      _logger.error(
+        'Failed to cancel run',
+        error: error,
+        stackTrace: stackTrace,
+        attributes: {'key': key.toString()},
+      );
+    }
+  }
+
   /// Cancels all active sessions and releases resources. Idempotent.
   void dispose() {
     if (_isDisposed) return;
     _isDisposed = true;
     _unsubscribe?.call();
-    for (final run in _runs.values) {
-      run.session?.cancel();
+    for (final entry in _runs.entries) {
+      final session = entry.value.session;
+      if (session != null) _cancelQuietly(entry.key, session);
     }
     _runs.clear();
     _activeKeys.dispose();

--- a/lib/src/modules/room/run_registry.dart
+++ b/lib/src/modules/room/run_registry.dart
@@ -42,8 +42,8 @@ class CancelledRun extends RunOutcome {
 class RunRegistry {
   /// [servers] wires the removal-eviction path: when a server disappears from
   /// the signal, its tracked runs are cancelled and dropped so they don't
-  /// linger until the whole registry is disposed. Tests that don't exercise
-  /// eviction pass a never-changing `Signal({})`.
+  /// linger until the whole registry is disposed. A caller that never mutates
+  /// the signal opts out of eviction.
   RunRegistry({required ReadonlySignal<Map<String, ServerEntry>> servers}) {
     _unsubscribe = servers.subscribe(_evictRemoved);
   }

--- a/lib/src/modules/room/run_registry.dart
+++ b/lib/src/modules/room/run_registry.dart
@@ -3,6 +3,8 @@ import 'dart:async' show unawaited;
 import 'package:soliplex_agent/soliplex_agent.dart';
 import 'package:soliplex_logging/soliplex_logging.dart';
 
+import '../auth/server_entry.dart';
+
 final Logger _logger = LogManager.instance.getLogger('soliplex.run_registry');
 
 /// Terminal outcome of an agent run.
@@ -38,8 +40,17 @@ class CancelledRun extends RunOutcome {
 /// to a thread, [ThreadViewState] checks the registry for an active
 /// session to reattach to or a completed outcome to display.
 class RunRegistry {
+  /// [servers] wires the removal-eviction path: when a server disappears from
+  /// the signal, its tracked runs are cancelled and dropped so they don't
+  /// linger until the whole registry is disposed. Null in tests that don't
+  /// exercise eviction.
+  RunRegistry({ReadonlySignal<Map<String, ServerEntry>>? servers}) {
+    _unsubscribe = servers?.subscribe(_evictRemoved);
+  }
+
   final Map<ThreadKey, _TrackedRun> _runs = {};
   final Signal<Set<ThreadKey>> _activeKeys = Signal({});
+  void Function()? _unsubscribe;
   bool _isDisposed = false;
 
   /// Reactive set of keys that currently have an active (non-terminal) session.
@@ -111,10 +122,31 @@ class RunRegistry {
     return _runs[key]?.outcome;
   }
 
+  /// Cancels and drops every tracked run for a server no longer present in
+  /// [snapshot], so a removed server's live session is cancelled and its
+  /// captured outcome released instead of lingering until [dispose].
+  void _evictRemoved(Map<String, ServerEntry> snapshot) {
+    if (_isDisposed) return;
+    final liveIds = snapshot.keys.toSet();
+    final dead =
+        _runs.keys.where((key) => !liveIds.contains(key.serverId)).toList();
+    if (dead.isEmpty) return;
+    for (final key in dead) {
+      _runs.remove(key)?.session?.cancel();
+    }
+    final nextActive = _activeKeys.value
+        .where((key) => liveIds.contains(key.serverId))
+        .toSet();
+    if (nextActive.length != _activeKeys.value.length) {
+      _activeKeys.value = nextActive;
+    }
+  }
+
   /// Cancels all active sessions and releases resources. Idempotent.
   void dispose() {
     if (_isDisposed) return;
     _isDisposed = true;
+    _unsubscribe?.call();
     for (final run in _runs.values) {
       run.session?.cancel();
     }

--- a/lib/src/modules/room/run_registry.dart
+++ b/lib/src/modules/room/run_registry.dart
@@ -42,8 +42,8 @@ class CancelledRun extends RunOutcome {
 class RunRegistry {
   /// [servers] wires the removal-eviction path: when a server disappears from
   /// the signal, its tracked runs are cancelled and dropped so they don't
-  /// linger until the whole registry is disposed. A caller that never mutates
-  /// the signal opts out of eviction.
+  /// linger until the whole registry is disposed. Eviction is driven entirely by
+  /// the signal, so a signal that never changes simply never evicts.
   RunRegistry({required ReadonlySignal<Map<String, ServerEntry>> servers}) {
     _unsubscribe = servers.subscribe(_evictRemoved);
   }

--- a/lib/src/modules/room/run_registry.dart
+++ b/lib/src/modules/room/run_registry.dart
@@ -42,15 +42,15 @@ class CancelledRun extends RunOutcome {
 class RunRegistry {
   /// [servers] wires the removal-eviction path: when a server disappears from
   /// the signal, its tracked runs are cancelled and dropped so they don't
-  /// linger until the whole registry is disposed. Null in tests that don't
-  /// exercise eviction.
-  RunRegistry({ReadonlySignal<Map<String, ServerEntry>>? servers}) {
-    _unsubscribe = servers?.subscribe(_evictRemoved);
+  /// linger until the whole registry is disposed. Tests that don't exercise
+  /// eviction pass a never-changing `Signal({})`.
+  RunRegistry({required ReadonlySignal<Map<String, ServerEntry>> servers}) {
+    _unsubscribe = servers.subscribe(_evictRemoved);
   }
 
   final Map<ThreadKey, _TrackedRun> _runs = {};
   final Signal<Set<ThreadKey>> _activeKeys = Signal({});
-  void Function()? _unsubscribe;
+  late final void Function() _unsubscribe;
   bool _isDisposed = false;
 
   /// Reactive set of keys that currently have an active (non-terminal) session.
@@ -165,7 +165,7 @@ class RunRegistry {
   void dispose() {
     if (_isDisposed) return;
     _isDisposed = true;
-    _unsubscribe?.call();
+    _unsubscribe();
     for (final entry in _runs.entries) {
       final session = entry.value.session;
       if (session != null) _cancelQuietly(entry.key, session);

--- a/lib/src/modules/room/run_registry.dart
+++ b/lib/src/modules/room/run_registry.dart
@@ -132,7 +132,21 @@ class RunRegistry {
         _runs.keys.where((key) => !liveIds.contains(key.serverId)).toList();
     if (dead.isEmpty) return;
     for (final key in dead) {
-      _runs.remove(key)?.session?.cancel();
+      final session = _runs.remove(key)?.session;
+      if (session == null) continue;
+      // This runs inside the servers-signal batch: a throwing cancel would
+      // otherwise abort the loop and unwind removeServer before it deletes the
+      // stored session. Log and keep evicting the rest.
+      try {
+        session.cancel();
+      } on Object catch (error, stackTrace) {
+        _logger.error(
+          'Failed to cancel run for removed server',
+          error: error,
+          stackTrace: stackTrace,
+          attributes: {'key': key.toString()},
+        );
+      }
     }
     final nextActive = _activeKeys.value
         .where((key) => liveIds.contains(key.serverId))

--- a/lib/src/modules/room/thread_anchor_storage.dart
+++ b/lib/src/modules/room/thread_anchor_storage.dart
@@ -96,10 +96,11 @@ abstract final class ThreadAnchorStorage {
   /// restore a stale "New messages" divider if the server is re-added under the
   /// same id. No-op (and no write) when the server has no anchors.
   ///
-  /// Fire-and-forget with no retry, like the thread read-marker store: a failed
-  /// [save] leaves stale anchors on disk. Accepted because an anchor only
-  /// positions a divider (it never floors unread state), so a surviving stale
-  /// anchor is a cosmetic misplacement, not a correctness break.
+  /// Propagates I/O failures from [load]/[save] to the caller (like the thread
+  /// read-marker store); callers run it fire-and-forget and log. A failed [save]
+  /// leaves stale anchors on disk — accepted because an anchor only positions a
+  /// divider (it never floors unread state), so a surviving stale anchor is a
+  /// cosmetic misplacement, not a correctness break.
   static Future<void> clearServer(String serverId) async {
     final anchors = await load();
     final next = {...anchors}

--- a/lib/src/modules/room/thread_anchor_storage.dart
+++ b/lib/src/modules/room/thread_anchor_storage.dart
@@ -91,4 +91,20 @@ abstract final class ThreadAnchorStorage {
     ];
     await prefs.setString(_key, jsonEncode(list));
   }
+
+  /// Drops every anchor for [serverId], so a removed server's threads don't
+  /// restore a stale "New messages" divider if the server is re-added under the
+  /// same id. No-op (and no write) when the server has no anchors.
+  ///
+  /// Fire-and-forget with no retry, like the thread read-marker store: a failed
+  /// [save] leaves stale anchors on disk. Accepted because an anchor only
+  /// positions a divider (it never floors unread state), so a surviving stale
+  /// anchor is a cosmetic misplacement, not a correctness break.
+  static Future<void> clearServer(String serverId) async {
+    final anchors = await load();
+    final next = {...anchors}
+      ..removeWhere((key, _) => key.serverId == serverId);
+    if (next.length == anchors.length) return;
+    await save(next);
+  }
 }

--- a/test/core/removed_server_cleanup_test.dart
+++ b/test/core/removed_server_cleanup_test.dart
@@ -1,10 +1,17 @@
+import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:shared_preferences/shared_preferences.dart';
+import 'package:soliplex_agent/soliplex_agent.dart';
 import 'package:soliplex_frontend/src/core/removed_server_cleanup.dart';
+import 'package:soliplex_frontend/src/core/shell_config.dart';
+import 'package:soliplex_frontend/src/modules/auth/auth_module.dart';
 import 'package:soliplex_frontend/src/modules/auth/auth_session.dart';
 import 'package:soliplex_frontend/src/modules/auth/return_to_storage.dart';
 import 'package:soliplex_frontend/src/modules/auth/server_manager.dart';
 import 'package:soliplex_frontend/src/modules/lobby/lobby_read_markers.dart';
+import 'package:soliplex_frontend/src/modules/room/agent_runtime_manager.dart';
+import 'package:soliplex_frontend/src/modules/room/room_module.dart';
+import 'package:soliplex_frontend/src/modules/room/run_registry.dart';
 import 'package:soliplex_frontend/src/modules/room/thread_anchor_storage.dart';
 import 'package:soliplex_frontend/src/modules/room/thread_read_markers.dart';
 
@@ -145,6 +152,86 @@ void main() {
       expect(
         wired.room.value.containsKey((serverId: 's1', roomId: 'r')),
         isTrue,
+      );
+    });
+  });
+
+  // Guards that RoomAppModule.onDispose stops the cleanup before ServerManager
+  // empties the servers signal. If onDispose ever drops the
+  // _removedServerCleanup.dispose() call, the still-subscribed cleanup reads the
+  // teardown empty-out as a mass removal and wipes every server's state; this
+  // drives the real modules through the real ShellConfig teardown to catch that.
+  // It does not pin the production registration order itself (this list is built
+  // here, not read from the flavor) — that ordering is a cross-module contract.
+  group('teardown ordering (shell composition)', () {
+    final at = DateTime.utc(2026, 6, 1);
+    const roomKey = (serverId: 's1', roomId: 'r');
+    const threadKey = (serverId: 's1', roomId: 'r', threadId: 't');
+
+    test('teardown leaves a surviving session\'s device-local state intact',
+        () async {
+      final manager = _createManager();
+      manager.addServer(
+        serverId: 's1',
+        serverUrl: Uri.parse('http://s1.test'),
+        requiresAuth: false,
+      );
+      final room = RoomReadMarkers();
+      final server = ServerReadMarkers();
+      final runtimeManager = AgentRuntimeManager(
+        platform: TestPlatformConstraints(),
+        toolRegistryResolver: (_) async => const ToolRegistry(),
+        logger: testLogger(),
+        servers: manager.servers,
+      );
+      final registry = RunRegistry(servers: manager.servers);
+      final authMod = AuthAppModule(
+        serverManager: manager,
+        probeClient: FakeHttpClient(),
+        authFlow: FakeAuthFlow(),
+        appName: 'Soliplex',
+        inactivityLogoutFlags: InMemoryInactivityLogoutFlagStorage(),
+      );
+      // RoomAppModule builds its own RemovedServerCleanup over these markers.
+      final roomMod = RoomAppModule(
+        serverManager: manager,
+        runtimeManager: runtimeManager,
+        registry: registry,
+        roomReadMarkers: room,
+        serverReadMarkers: server,
+        appName: 'Soliplex',
+      );
+      // Auth before room, matching the flavor: reverse-order teardown disposes
+      // room (stopping the cleanup) before auth empties the signal.
+      final config = await ShellConfig.fromModules(
+        appName: 'Soliplex',
+        lightTheme: ThemeData(),
+        modules: [authMod, roomMod],
+      );
+
+      server.markRead('s1', at);
+      room.markRead(roomKey, at);
+      await ThreadReadMarkerStorage.save({threadKey: at});
+      await ThreadAnchorStorage.save({threadKey: 'm1'});
+      await ReturnToStorage.saveComposer(
+        serverId: 's1',
+        roomId: 'r',
+        unsentText: 'draft',
+      );
+
+      await config.dispose?.call();
+      await pumpEventQueue();
+
+      expect(server.value.containsKey('s1'), isTrue);
+      expect(room.value.containsKey(roomKey), isTrue);
+      expect(
+        (await ThreadReadMarkerStorage.load()).containsKey(threadKey),
+        isTrue,
+      );
+      expect((await ThreadAnchorStorage.load()).containsKey(threadKey), isTrue);
+      expect(
+        await ReturnToStorage.loadComposer(serverId: 's1', roomId: 'r'),
+        'draft',
       );
     });
   });

--- a/test/core/removed_server_cleanup_test.dart
+++ b/test/core/removed_server_cleanup_test.dart
@@ -1,0 +1,151 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:soliplex_frontend/src/core/removed_server_cleanup.dart';
+import 'package:soliplex_frontend/src/modules/auth/auth_session.dart';
+import 'package:soliplex_frontend/src/modules/auth/return_to_storage.dart';
+import 'package:soliplex_frontend/src/modules/auth/server_manager.dart';
+import 'package:soliplex_frontend/src/modules/lobby/lobby_read_markers.dart';
+import 'package:soliplex_frontend/src/modules/room/thread_anchor_storage.dart';
+import 'package:soliplex_frontend/src/modules/room/thread_read_markers.dart';
+
+import '../helpers/fakes.dart';
+
+ServerManager _createManager() => ServerManager(
+      authFactory: () => AuthSession(refreshService: FakeTokenRefreshService()),
+      clientFactory: ({getToken, tokenRefresher}) => FakeHttpClient(),
+      storage: InMemoryServerStorage(),
+    );
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+  setUp(() => SharedPreferences.setMockInitialValues({}));
+
+  ({
+    ServerManager manager,
+    RoomReadMarkers room,
+    ServerReadMarkers server,
+    RemovedServerCleanup cleanup,
+  }) wire() {
+    final manager = _createManager();
+    manager.addServer(
+      serverId: 's1',
+      serverUrl: Uri.parse('http://s1.test'),
+      requiresAuth: false,
+    );
+    manager.addServer(
+      serverId: 's2',
+      serverUrl: Uri.parse('http://s2.test'),
+      requiresAuth: false,
+    );
+    final room = RoomReadMarkers();
+    final server = ServerReadMarkers();
+    final cleanup = RemovedServerCleanup(
+      servers: manager.servers,
+      roomReadMarkers: room,
+      serverReadMarkers: server,
+    );
+    addTearDown(cleanup.dispose);
+    return (manager: manager, room: room, server: server, cleanup: cleanup);
+  }
+
+  group('RemovedServerCleanup', () {
+    test('clears the removed server\'s read markers, keeping a survivor\'s',
+        () async {
+      final at = DateTime.utc(2026, 6, 1);
+      final wired = wire();
+      wired.server.markRead('s1', at);
+      wired.server.markRead('s2', at);
+      wired.room.markRead((serverId: 's1', roomId: 'r'), at);
+      wired.room.markRead((serverId: 's2', roomId: 'r'), at);
+      await ThreadReadMarkerStorage.save({
+        (serverId: 's1', roomId: 'r', threadId: 't'): at,
+        (serverId: 's2', roomId: 'r', threadId: 't'): at,
+      });
+
+      wired.manager.removeServer('s1');
+      await pumpEventQueue();
+
+      expect(wired.server.value.containsKey('s1'), isFalse);
+      expect(wired.server.value.containsKey('s2'), isTrue);
+      expect(
+        wired.room.value.containsKey((serverId: 's1', roomId: 'r')),
+        isFalse,
+      );
+      expect(
+        wired.room.value.containsKey((serverId: 's2', roomId: 'r')),
+        isTrue,
+      );
+      final threads = await ThreadReadMarkerStorage.load();
+      expect(
+        threads.containsKey((serverId: 's1', roomId: 'r', threadId: 't')),
+        isFalse,
+      );
+      expect(
+        threads.containsKey((serverId: 's2', roomId: 'r', threadId: 't')),
+        isTrue,
+      );
+    });
+
+    test('clears the removed server\'s thread anchors and drafts', () async {
+      final wired = wire();
+      await ThreadAnchorStorage.save({
+        (serverId: 's1', roomId: 'r', threadId: 't'): 'm1',
+        (serverId: 's2', roomId: 'r', threadId: 't'): 'm2',
+      });
+      await ReturnToStorage.saveComposer(
+        serverId: 's1',
+        roomId: 'r',
+        unsentText: 's1 draft',
+      );
+      await ReturnToStorage.saveComposer(
+        serverId: 's2',
+        roomId: 'r',
+        unsentText: 's2 draft',
+      );
+
+      wired.manager.removeServer('s1');
+      await pumpEventQueue();
+
+      final anchors = await ThreadAnchorStorage.load();
+      expect(
+        anchors.containsKey((serverId: 's1', roomId: 'r', threadId: 't')),
+        isFalse,
+      );
+      expect(
+        anchors.containsKey((serverId: 's2', roomId: 'r', threadId: 't')),
+        isTrue,
+      );
+      expect(
+        await ReturnToStorage.loadComposer(serverId: 's1', roomId: 'r'),
+        isNull,
+      );
+      expect(
+        await ReturnToStorage.loadComposer(serverId: 's2', roomId: 'r'),
+        's2 draft',
+      );
+    });
+
+    // Disposing must stop the cleanup observing. On shell teardown
+    // ServerManager empties the servers signal, and a still-subscribed cleanup
+    // would read that as a mass removal and wipe every server's state — even
+    // though teardown keeps stored sessions for the next launch. Its owning
+    // module disposes it before that empty-out; this pins the guard that makes
+    // that ordering safe.
+    test('a disposed cleanup ignores later server removals', () async {
+      final at = DateTime.utc(2026, 6, 1);
+      final wired = wire();
+      wired.server.markRead('s1', at);
+      wired.room.markRead((serverId: 's1', roomId: 'r'), at);
+
+      wired.cleanup.dispose();
+      wired.manager.removeServer('s1');
+      await pumpEventQueue();
+
+      expect(wired.server.value.containsKey('s1'), isTrue);
+      expect(
+        wired.room.value.containsKey((serverId: 's1', roomId: 'r')),
+        isTrue,
+      );
+    });
+  });
+}

--- a/test/helpers/fakes.dart
+++ b/test/helpers/fakes.dart
@@ -16,7 +16,13 @@ import 'package:flutter/material.dart';
 import 'package:soliplex_frontend/src/core/app_identity.dart';
 import 'package:soliplex_frontend/src/modules/auth/inactivity_logout_storage.dart';
 import 'package:soliplex_frontend/src/modules/auth/platform/auth_flow.dart';
+import 'package:soliplex_frontend/src/modules/auth/server_entry.dart';
 import 'package:soliplex_frontend/src/modules/auth/server_storage.dart';
+
+/// A servers signal that never changes, for constructing eviction-aware
+/// managers and registries in tests that don't exercise eviction.
+ReadonlySignal<Map<String, ServerEntry>> emptyServers() =>
+    Signal<Map<String, ServerEntry>>({});
 
 /// Minimal app identity for widget tests: a trivial inline logo (no asset
 /// loading) plus a placeholder name.

--- a/test/modules/auth/return_to_storage_test.dart
+++ b/test/modules/auth/return_to_storage_test.dart
@@ -200,7 +200,10 @@ void main() {
       );
     });
 
-    test('clearServer does not sweep a server whose id is a prefix match',
+    // The key joins ids with a `:`, so the trailing `:` on the prefix keeps a
+    // clear from reaching an id that merely shares a leading substring but not a
+    // whole `:`-delimited segment (`a` vs `ab`).
+    test('clearServer keeps drafts of an id sharing only a non-boundary prefix',
         () async {
       await ReturnToStorage.saveComposer(
         serverId: 'a',
@@ -224,6 +227,39 @@ void main() {
           now: _baseTime,
         ),
         'AB/r',
+      );
+    });
+
+    // Characterizes a known, accepted over-sweep (issue #393): a server id is a
+    // `Uri.origin`, which omits the default port, so a portless origin is a full
+    // prefix of the same host with an explicit port. Clearing the portless
+    // origin therefore also sweeps the explicit-port sibling's drafts. This
+    // pins the current behavior so the keyed-store fix is a deliberate,
+    // test-breaking change rather than a silent one.
+    test('clearServer over-sweeps a portless origin onto its port sibling',
+        () async {
+      await ReturnToStorage.saveComposer(
+        serverId: 'https://foo.com',
+        roomId: 'r',
+        unsentText: 'default port',
+        now: _baseTime,
+      );
+      await ReturnToStorage.saveComposer(
+        serverId: 'https://foo.com:8443',
+        roomId: 'r',
+        unsentText: 'explicit port',
+        now: _baseTime,
+      );
+
+      await ReturnToStorage.clearServer('https://foo.com');
+
+      expect(
+        await ReturnToStorage.loadComposer(
+          serverId: 'https://foo.com:8443',
+          roomId: 'r',
+          now: _baseTime,
+        ),
+        isNull,
       );
     });
   });

--- a/test/modules/auth/return_to_storage_test.dart
+++ b/test/modules/auth/return_to_storage_test.dart
@@ -151,5 +151,80 @@ void main() {
         isNull,
       );
     });
+
+    test('clearServer removes every room draft for that server only', () async {
+      await ReturnToStorage.saveComposer(
+        serverId: 'a',
+        roomId: 'r1',
+        unsentText: 'A/r1',
+        now: _baseTime,
+      );
+      await ReturnToStorage.saveComposer(
+        serverId: 'a',
+        roomId: 'r2',
+        unsentText: 'A/r2',
+        now: _baseTime,
+      );
+      await ReturnToStorage.saveComposer(
+        serverId: 'b',
+        roomId: 'r1',
+        unsentText: 'B/r1',
+        now: _baseTime,
+      );
+
+      await ReturnToStorage.clearServer('a');
+
+      expect(
+        await ReturnToStorage.loadComposer(
+          serverId: 'a',
+          roomId: 'r1',
+          now: _baseTime,
+        ),
+        isNull,
+      );
+      expect(
+        await ReturnToStorage.loadComposer(
+          serverId: 'a',
+          roomId: 'r2',
+          now: _baseTime,
+        ),
+        isNull,
+      );
+      expect(
+        await ReturnToStorage.loadComposer(
+          serverId: 'b',
+          roomId: 'r1',
+          now: _baseTime,
+        ),
+        'B/r1',
+      );
+    });
+
+    test('clearServer does not sweep a server whose id is a prefix match',
+        () async {
+      await ReturnToStorage.saveComposer(
+        serverId: 'a',
+        roomId: 'r',
+        unsentText: 'A/r',
+        now: _baseTime,
+      );
+      await ReturnToStorage.saveComposer(
+        serverId: 'ab',
+        roomId: 'r',
+        unsentText: 'AB/r',
+        now: _baseTime,
+      );
+
+      await ReturnToStorage.clearServer('a');
+
+      expect(
+        await ReturnToStorage.loadComposer(
+          serverId: 'ab',
+          roomId: 'r',
+          now: _baseTime,
+        ),
+        'AB/r',
+      );
+    });
   });
 }

--- a/test/modules/lobby/lobby_module_test.dart
+++ b/test/modules/lobby/lobby_module_test.dart
@@ -1,7 +1,6 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:go_router/go_router.dart';
 import 'package:soliplex_frontend/src/modules/auth/auth_session.dart';
-import 'package:soliplex_frontend/src/modules/auth/inactivity_logout_storage.dart';
 import 'package:soliplex_frontend/src/modules/auth/server_manager.dart';
 import 'package:soliplex_frontend/src/modules/lobby/lobby_module.dart';
 import 'package:soliplex_frontend/src/modules/lobby/lobby_read_markers.dart';
@@ -24,7 +23,6 @@ void main() {
         registry: RunRegistry(),
         roomReadMarkers: RoomReadMarkers(),
         serverReadMarkers: ServerReadMarkers(),
-        inactivityLogoutFlags: LocalInactivityLogoutFlagStorage(),
       ).build();
       final paths =
           contribution.routes.whereType<GoRoute>().map((r) => r.path).toList();
@@ -38,7 +36,6 @@ void main() {
         registry: RunRegistry(),
         roomReadMarkers: RoomReadMarkers(),
         serverReadMarkers: ServerReadMarkers(),
-        inactivityLogoutFlags: LocalInactivityLogoutFlagStorage(),
       ).build();
       expect(contribution.redirect, isNull);
     });

--- a/test/modules/lobby/lobby_module_test.dart
+++ b/test/modules/lobby/lobby_module_test.dart
@@ -1,6 +1,7 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:go_router/go_router.dart';
 import 'package:soliplex_frontend/src/modules/auth/auth_session.dart';
+import 'package:soliplex_frontend/src/modules/auth/inactivity_logout_storage.dart';
 import 'package:soliplex_frontend/src/modules/auth/server_manager.dart';
 import 'package:soliplex_frontend/src/modules/lobby/lobby_module.dart';
 import 'package:soliplex_frontend/src/modules/lobby/lobby_read_markers.dart';
@@ -23,6 +24,7 @@ void main() {
         registry: RunRegistry(),
         roomReadMarkers: RoomReadMarkers(),
         serverReadMarkers: ServerReadMarkers(),
+        inactivityLogoutFlags: LocalInactivityLogoutFlagStorage(),
       ).build();
       final paths =
           contribution.routes.whereType<GoRoute>().map((r) => r.path).toList();
@@ -36,6 +38,7 @@ void main() {
         registry: RunRegistry(),
         roomReadMarkers: RoomReadMarkers(),
         serverReadMarkers: ServerReadMarkers(),
+        inactivityLogoutFlags: LocalInactivityLogoutFlagStorage(),
       ).build();
       expect(contribution.redirect, isNull);
     });

--- a/test/modules/lobby/lobby_module_test.dart
+++ b/test/modules/lobby/lobby_module_test.dart
@@ -20,7 +20,7 @@ void main() {
       final contribution = LobbyAppModule(
         serverManager: _createManager(),
         identity: testIdentity(),
-        registry: RunRegistry(),
+        registry: RunRegistry(servers: emptyServers()),
         roomReadMarkers: RoomReadMarkers(),
         serverReadMarkers: ServerReadMarkers(),
       ).build();
@@ -33,7 +33,7 @@ void main() {
       final contribution = LobbyAppModule(
         serverManager: _createManager(),
         identity: testIdentity(),
-        registry: RunRegistry(),
+        registry: RunRegistry(servers: emptyServers()),
         roomReadMarkers: RoomReadMarkers(),
         serverReadMarkers: ServerReadMarkers(),
       ).build();

--- a/test/modules/lobby/lobby_state_test.dart
+++ b/test/modules/lobby/lobby_state_test.dart
@@ -8,14 +8,10 @@ import 'package:shared_preferences/shared_preferences.dart';
 import 'package:soliplex_agent/soliplex_agent.dart';
 import 'package:soliplex_frontend/src/modules/auth/auth_session.dart';
 import 'package:soliplex_frontend/src/modules/auth/auth_tokens.dart';
-import 'package:soliplex_frontend/src/modules/auth/inactivity_logout_storage.dart';
-import 'package:soliplex_frontend/src/modules/auth/return_to_storage.dart';
 import 'package:soliplex_frontend/src/modules/auth/selected_server_storage.dart';
 import 'package:soliplex_frontend/src/modules/auth/server_manager.dart';
 import 'package:soliplex_frontend/src/core/activity_read.dart';
 import 'package:soliplex_frontend/src/modules/lobby/lobby_state.dart';
-import 'package:soliplex_frontend/src/modules/room/thread_anchor_storage.dart';
-import 'package:soliplex_frontend/src/modules/room/thread_read_markers.dart';
 
 import '../../helpers/fakes.dart';
 
@@ -1150,112 +1146,6 @@ void main() {
           expect(state.serverReadMarkers.value['s'], DateTime.utc(2026, 6, 1));
           state.dispose();
         });
-      });
-
-      test('removing a server clears its read markers at every level',
-          () async {
-        final at = DateTime.utc(2026, 6, 1);
-        final manager = _createManager();
-        manager.addServer(
-          serverId: 's1',
-          serverUrl: Uri.parse('http://s1.test'),
-          requiresAuth: false,
-        );
-        final state = LobbyState(
-          serverManager: manager,
-          apiResolver: (_) => FakeSoliplexApi(),
-        );
-        await pumpEventQueue();
-
-        state.markServerRead('s1');
-        state.markRoomRead('s1', 'r');
-        await ThreadReadMarkerStorage.save({
-          (serverId: 's1', roomId: 'r', threadId: 't'): at,
-          (serverId: 's2', roomId: 'r', threadId: 't'): at,
-        });
-
-        manager.removeServer('s1');
-        await pumpEventQueue();
-
-        expect(state.serverReadMarkers.value.containsKey('s1'), isFalse);
-        expect(
-          state.roomReadMarkers.value
-              .containsKey((serverId: 's1', roomId: 'r')),
-          isFalse,
-        );
-        // A re-added server (same URL → same id) must start unread: the
-        // persisted thread markers for the removed server are gone, while
-        // another server's survive.
-        final threads = await ThreadReadMarkerStorage.load();
-        expect(
-          threads.containsKey((serverId: 's1', roomId: 'r', threadId: 't')),
-          isFalse,
-        );
-        expect(
-          threads.containsKey((serverId: 's2', roomId: 'r', threadId: 't')),
-          isTrue,
-        );
-
-        state.dispose();
-      });
-
-      test('removing a server purges its anchors, drafts, and inactivity flag',
-          () async {
-        final manager = _createManager();
-        manager.addServer(
-          serverId: 's1',
-          serverUrl: Uri.parse('http://s1.test'),
-          requiresAuth: false,
-        );
-        final inactivityFlags = LocalInactivityLogoutFlagStorage();
-        final state = LobbyState(
-          serverManager: manager,
-          apiResolver: (_) => FakeSoliplexApi(),
-          inactivityLogoutFlags: inactivityFlags,
-        );
-        await pumpEventQueue();
-
-        await ThreadAnchorStorage.save({
-          (serverId: 's1', roomId: 'r', threadId: 't'): 'm1',
-          (serverId: 's2', roomId: 'r', threadId: 't'): 'm2',
-        });
-        await ReturnToStorage.saveComposer(
-          serverId: 's1',
-          roomId: 'r',
-          unsentText: 's1 draft',
-        );
-        await ReturnToStorage.saveComposer(
-          serverId: 's2',
-          roomId: 'r',
-          unsentText: 's2 draft',
-        );
-        await inactivityFlags.mark('s1');
-        await inactivityFlags.mark('s2');
-
-        manager.removeServer('s1');
-        await pumpEventQueue();
-
-        final anchors = await ThreadAnchorStorage.load();
-        expect(
-          anchors.containsKey((serverId: 's1', roomId: 'r', threadId: 't')),
-          isFalse,
-        );
-        expect(
-          anchors.containsKey((serverId: 's2', roomId: 'r', threadId: 't')),
-          isTrue,
-        );
-        expect(
-          await ReturnToStorage.loadComposer(serverId: 's1', roomId: 'r'),
-          isNull,
-        );
-        expect(
-          await ReturnToStorage.loadComposer(serverId: 's2', roomId: 'r'),
-          's2 draft',
-        );
-        expect(await inactivityFlags.isMarked('s1'), isFalse);
-        expect(await inactivityFlags.isMarked('s2'), isTrue);
-
-        state.dispose();
       });
     });
   });

--- a/test/modules/lobby/lobby_state_test.dart
+++ b/test/modules/lobby/lobby_state_test.dart
@@ -8,10 +8,13 @@ import 'package:shared_preferences/shared_preferences.dart';
 import 'package:soliplex_agent/soliplex_agent.dart';
 import 'package:soliplex_frontend/src/modules/auth/auth_session.dart';
 import 'package:soliplex_frontend/src/modules/auth/auth_tokens.dart';
+import 'package:soliplex_frontend/src/modules/auth/inactivity_logout_storage.dart';
+import 'package:soliplex_frontend/src/modules/auth/return_to_storage.dart';
 import 'package:soliplex_frontend/src/modules/auth/selected_server_storage.dart';
 import 'package:soliplex_frontend/src/modules/auth/server_manager.dart';
 import 'package:soliplex_frontend/src/core/activity_read.dart';
 import 'package:soliplex_frontend/src/modules/lobby/lobby_state.dart';
+import 'package:soliplex_frontend/src/modules/room/thread_anchor_storage.dart';
 import 'package:soliplex_frontend/src/modules/room/thread_read_markers.dart';
 
 import '../../helpers/fakes.dart';
@@ -1192,6 +1195,65 @@ void main() {
           threads.containsKey((serverId: 's2', roomId: 'r', threadId: 't')),
           isTrue,
         );
+
+        state.dispose();
+      });
+
+      test('removing a server purges its anchors, drafts, and inactivity flag',
+          () async {
+        final manager = _createManager();
+        manager.addServer(
+          serverId: 's1',
+          serverUrl: Uri.parse('http://s1.test'),
+          requiresAuth: false,
+        );
+        final inactivityFlags = LocalInactivityLogoutFlagStorage();
+        final state = LobbyState(
+          serverManager: manager,
+          apiResolver: (_) => FakeSoliplexApi(),
+          inactivityLogoutFlags: inactivityFlags,
+        );
+        await pumpEventQueue();
+
+        await ThreadAnchorStorage.save({
+          (serverId: 's1', roomId: 'r', threadId: 't'): 'm1',
+          (serverId: 's2', roomId: 'r', threadId: 't'): 'm2',
+        });
+        await ReturnToStorage.saveComposer(
+          serverId: 's1',
+          roomId: 'r',
+          unsentText: 's1 draft',
+        );
+        await ReturnToStorage.saveComposer(
+          serverId: 's2',
+          roomId: 'r',
+          unsentText: 's2 draft',
+        );
+        await inactivityFlags.mark('s1');
+        await inactivityFlags.mark('s2');
+
+        manager.removeServer('s1');
+        await pumpEventQueue();
+
+        final anchors = await ThreadAnchorStorage.load();
+        expect(
+          anchors.containsKey((serverId: 's1', roomId: 'r', threadId: 't')),
+          isFalse,
+        );
+        expect(
+          anchors.containsKey((serverId: 's2', roomId: 'r', threadId: 't')),
+          isTrue,
+        );
+        expect(
+          await ReturnToStorage.loadComposer(serverId: 's1', roomId: 'r'),
+          isNull,
+        );
+        expect(
+          await ReturnToStorage.loadComposer(serverId: 's2', roomId: 'r'),
+          's2 draft',
+        );
+        expect(await inactivityFlags.isMarked('s1'), isFalse);
+        expect(await inactivityFlags.isMarked('s2'), isTrue);
 
         state.dispose();
       });

--- a/test/modules/room/agent_runtime_manager_test.dart
+++ b/test/modules/room/agent_runtime_manager_test.dart
@@ -30,6 +30,7 @@ void main() {
       platform: TestPlatformConstraints(),
       toolRegistryResolver: (_) async => const ToolRegistry(),
       logger: testLogger(),
+      servers: emptyServers(),
     );
   });
 

--- a/test/modules/room/agent_runtime_manager_test.dart
+++ b/test/modules/room/agent_runtime_manager_test.dart
@@ -84,7 +84,7 @@ void main() {
     expect(registry, isA<ToolRegistry>());
   });
 
-  test('evicts a runtime when its server is removed from the signal', () {
+  test('evicts a runtime when its server is removed from the signal', () async {
     final servers = Signal<Map<String, ServerEntry>>({});
     final evicting = AgentRuntimeManager(
       platform: TestPlatformConstraints(),
@@ -103,8 +103,14 @@ void main() {
 
     servers.value = {};
 
-    // The stale runtime was disposed and dropped, so re-requesting the same
-    // connection builds a fresh one instead of returning the evicted cache hit.
+    // The stale runtime is actually disposed, not just dropped from the cache:
+    // a disposed runtime rejects spawn. This catches a regression that evicts
+    // the cache entry but skips disposal (the leak this eviction path fixes).
+    await expectLater(
+      rt1.spawn(roomId: 'r', prompt: 'p', threadId: 't'),
+      throwsA(isA<StateError>()),
+    );
+    // And re-requesting the same connection builds a fresh runtime.
     expect(identical(evicting.getRuntime(conn), rt1), isFalse);
   });
 

--- a/test/modules/room/agent_runtime_manager_test.dart
+++ b/test/modules/room/agent_runtime_manager_test.dart
@@ -1,9 +1,26 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:soliplex_agent/soliplex_agent.dart';
 
+import 'package:soliplex_frontend/src/modules/auth/auth_session.dart';
+import 'package:soliplex_frontend/src/modules/auth/server_entry.dart';
 import 'package:soliplex_frontend/src/modules/room/agent_runtime_manager.dart';
 
 import '../../helpers/fakes.dart';
+
+ServerConnection _connection(String serverId) => ServerConnection(
+      serverId: serverId,
+      api: FakeSoliplexApi(),
+      agUiStreamClient: FakeAgUiStreamClient(),
+    );
+
+ServerEntry _entry(String serverId) => ServerEntry(
+      serverId: serverId,
+      alias: serverId,
+      serverUrl: Uri.parse('https://$serverId.example.com'),
+      auth: AuthSession(refreshService: FakeTokenRefreshService()),
+      httpClient: FakeHttpClient(),
+      connection: _connection(serverId),
+    );
 
 void main() {
   late AgentRuntimeManager manager;
@@ -65,6 +82,58 @@ void main() {
       () async {
     final registry = await manager.toolRegistryResolver('any-room');
     expect(registry, isA<ToolRegistry>());
+  });
+
+  test('evicts a runtime when its server is removed from the signal', () {
+    final servers = Signal<Map<String, ServerEntry>>({});
+    final evicting = AgentRuntimeManager(
+      platform: TestPlatformConstraints(),
+      toolRegistryResolver: (_) async => const ToolRegistry(),
+      logger: testLogger(),
+      servers: servers,
+    );
+    addTearDown(() async {
+      await evicting.dispose();
+      servers.dispose();
+    });
+
+    final conn = _connection('server-1');
+    servers.value = {'server-1': _entry('server-1')};
+    final rt1 = evicting.getRuntime(conn);
+
+    servers.value = {};
+
+    // The stale runtime was disposed and dropped, so re-requesting the same
+    // connection builds a fresh one instead of returning the evicted cache hit.
+    expect(identical(evicting.getRuntime(conn), rt1), isFalse);
+  });
+
+  test('keeps runtimes for servers that remain', () {
+    final servers = Signal<Map<String, ServerEntry>>({});
+    final evicting = AgentRuntimeManager(
+      platform: TestPlatformConstraints(),
+      toolRegistryResolver: (_) async => const ToolRegistry(),
+      logger: testLogger(),
+      servers: servers,
+    );
+    addTearDown(() async {
+      await evicting.dispose();
+      servers.dispose();
+    });
+
+    final conn1 = _connection('server-1');
+    final conn2 = _connection('server-2');
+    servers.value = {
+      'server-1': _entry('server-1'),
+      'server-2': _entry('server-2')
+    };
+    final rt1 = evicting.getRuntime(conn1);
+    final rt2 = evicting.getRuntime(conn2);
+
+    servers.value = {'server-2': _entry('server-2')};
+
+    expect(identical(evicting.getRuntime(conn2), rt2), isTrue);
+    expect(identical(evicting.getRuntime(conn1), rt1), isFalse);
   });
 
   test('replaces runtime when connection changes for same serverId', () {

--- a/test/modules/room/agent_runtime_manager_test.dart
+++ b/test/modules/room/agent_runtime_manager_test.dart
@@ -108,7 +108,10 @@ void main() {
     // the cache entry but skips disposal (the leak this eviction path fixes).
     await expectLater(
       rt1.spawn(roomId: 'r', prompt: 'p', threadId: 't'),
-      throwsA(isA<StateError>()),
+      throwsA(
+        isA<StateError>()
+            .having((e) => e.toString(), 'message', contains('disposed')),
+      ),
     );
     // And re-requesting the same connection builds a fresh runtime.
     expect(identical(evicting.getRuntime(conn), rt1), isFalse);

--- a/test/modules/room/room_module_test.dart
+++ b/test/modules/room/room_module_test.dart
@@ -29,8 +29,9 @@ void main() {
       platform: TestPlatformConstraints(),
       toolRegistryResolver: (_) async => const ToolRegistry(),
       logger: testLogger(),
+      servers: emptyServers(),
     );
-    registry = RunRegistry();
+    registry = RunRegistry(servers: emptyServers());
     module = RoomAppModule(
       serverManager: _createManager(),
       runtimeManager: runtimeManager,

--- a/test/modules/room/room_state_test.dart
+++ b/test/modules/room/room_state_test.dart
@@ -54,6 +54,7 @@ class _StubRuntimeManager extends AgentRuntimeManager {
           platform: TestPlatformConstraints(),
           toolRegistryResolver: (_) async => const ToolRegistry(),
           logger: testLogger(),
+          servers: emptyServers(),
         );
 
   final AgentRuntime _runtime;
@@ -108,8 +109,9 @@ void main() {
       platform: TestPlatformConstraints(),
       toolRegistryResolver: (_) async => const ToolRegistry(),
       logger: testLogger(),
+      servers: emptyServers(),
     );
-    registry = RunRegistry();
+    registry = RunRegistry(servers: emptyServers());
     servers = Signal({serverEntry.serverId: serverEntry});
     uploadRegistry = UploadTrackerRegistry(servers: servers);
   });

--- a/test/modules/room/run_registry_test.dart
+++ b/test/modules/room/run_registry_test.dart
@@ -55,9 +55,10 @@ void main() {
       platform: TestPlatformConstraints(),
       toolRegistryResolver: (_) async => const ToolRegistry(),
       logger: testLogger(),
+      servers: emptyServers(),
     );
     runtime = runtimeManager.getRuntime(connection);
-    registry = RunRegistry();
+    registry = RunRegistry(servers: emptyServers());
   });
 
   tearDown(() async {

--- a/test/modules/room/run_registry_test.dart
+++ b/test/modules/room/run_registry_test.dart
@@ -331,4 +331,60 @@ void main() {
     expect(evicting.activeSession(keyS2), same(s2Session));
     expect(evicting.activeKeys.value, contains(keyS2));
   });
+
+  test('evicts the removed server\'s completed outcome, not just live runs',
+      () async {
+    final servers = Signal<Map<String, ServerEntry>>({});
+    final evicting = RunRegistry(servers: servers);
+    addTearDown(() {
+      evicting.dispose();
+      servers.dispose();
+    });
+
+    const key = (serverId: 's1', roomId: 'r', threadId: 't');
+    final session = ManualAgentSession(key);
+    servers.value = {'s1': _entry('s1')};
+    evicting.register(key, session);
+    session.completeAsCancelled();
+    await Future<void>.delayed(Duration.zero);
+    expect(evicting.completedOutcome(key), isNotNull);
+
+    servers.value = <String, ServerEntry>{};
+
+    expect(evicting.completedOutcome(key), isNull);
+  });
+
+  test('eviction survives a session whose cancel throws', () async {
+    final servers = Signal<Map<String, ServerEntry>>({});
+    final evicting = RunRegistry(servers: servers);
+    addTearDown(() {
+      evicting.dispose();
+      servers.dispose();
+    });
+
+    const throwingKey = (serverId: 's1', roomId: 'r', threadId: 't1');
+    const normalKey = (serverId: 's1', roomId: 'r', threadId: 't2');
+    final throwing = _ThrowingCancelSession(throwingKey);
+    final normal = ManualAgentSession(normalKey);
+    servers.value = {'s1': _entry('s1')};
+    evicting.register(throwingKey, throwing);
+    evicting.register(normalKey, normal);
+
+    // A throwing cancel must not abort the eviction fan-out (which runs inside
+    // the servers-signal batch and would otherwise unwind removeServer).
+    expect(() => servers.value = <String, ServerEntry>{}, returnsNormally);
+
+    expect(evicting.activeSession(throwingKey), isNull);
+    expect(evicting.activeSession(normalKey), isNull);
+    expect(normal.cancelCalled, isTrue);
+    expect(evicting.activeKeys.value, isEmpty);
+  });
+}
+
+/// Session whose [cancel] throws, to exercise the eviction guard.
+class _ThrowingCancelSession extends ManualAgentSession {
+  _ThrowingCancelSession(super.threadKey);
+
+  @override
+  void cancel() => throw StateError('cancel boom');
 }

--- a/test/modules/room/run_registry_test.dart
+++ b/test/modules/room/run_registry_test.dart
@@ -342,16 +342,23 @@ void main() {
     });
 
     const key = (serverId: 's1', roomId: 'r', threadId: 't');
+    const survivorKey = (serverId: 's2', roomId: 'r', threadId: 't');
     final session = ManualAgentSession(key);
-    servers.value = {'s1': _entry('s1')};
+    final survivor = ManualAgentSession(survivorKey);
+    servers.value = {'s1': _entry('s1'), 's2': _entry('s2')};
     evicting.register(key, session);
+    evicting.register(survivorKey, survivor);
     session.completeAsCancelled();
+    survivor.completeAsCancelled();
     await Future<void>.delayed(Duration.zero);
     expect(evicting.completedOutcome(key), isNotNull);
+    expect(evicting.completedOutcome(survivorKey), isNotNull);
 
-    servers.value = <String, ServerEntry>{};
+    servers.value = {'s2': _entry('s2')};
 
     expect(evicting.completedOutcome(key), isNull);
+    // A surviving server's completed outcome is retained.
+    expect(evicting.completedOutcome(survivorKey), isNotNull);
   });
 
   test('eviction survives a session whose cancel throws', () async {
@@ -367,11 +374,16 @@ void main() {
     final throwing = _ThrowingCancelSession(throwingKey);
     final normal = ManualAgentSession(normalKey);
     servers.value = {'s1': _entry('s1')};
+    // Register the throwing session first so it is iterated first (insertion
+    // order): that is what proves the surviving session is still evicted after
+    // the throw, and catches a guard that wraps the whole loop instead of the
+    // single cancel.
     evicting.register(throwingKey, throwing);
     evicting.register(normalKey, normal);
 
-    // A throwing cancel must not abort the eviction fan-out (which runs inside
-    // the servers-signal batch and would otherwise unwind removeServer).
+    // A throwing cancel must not abort the eviction fan-out (which runs
+    // synchronously inside the servers-signal write and would otherwise unwind
+    // removeServer).
     expect(() => servers.value = <String, ServerEntry>{}, returnsNormally);
 
     expect(evicting.activeSession(throwingKey), isNull);

--- a/test/modules/room/run_registry_test.dart
+++ b/test/modules/room/run_registry_test.dart
@@ -3,6 +3,8 @@ import 'dart:async';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:soliplex_agent/soliplex_agent.dart';
 
+import 'package:soliplex_frontend/src/modules/auth/auth_session.dart';
+import 'package:soliplex_frontend/src/modules/auth/server_entry.dart';
 import 'package:soliplex_frontend/src/modules/room/agent_runtime_manager.dart';
 import 'package:soliplex_frontend/src/modules/room/run_registry.dart';
 
@@ -12,6 +14,19 @@ ServerConnection _fakeConnection(FakeSoliplexApi api) => ServerConnection(
       serverId: 'test-server',
       api: api,
       agUiStreamClient: FakeAgUiStreamClient(),
+    );
+
+ServerEntry _entry(String serverId) => ServerEntry(
+      serverId: serverId,
+      alias: serverId,
+      serverUrl: Uri.parse('https://$serverId.example.com'),
+      auth: AuthSession(refreshService: FakeTokenRefreshService()),
+      httpClient: FakeHttpClient(),
+      connection: ServerConnection(
+        serverId: serverId,
+        api: FakeSoliplexApi(),
+        agUiStreamClient: FakeAgUiStreamClient(),
+      ),
     );
 
 const _key = (
@@ -289,5 +304,31 @@ void main() {
     );
     expect(session.cancelCalled, isTrue);
     expect(registry.activeSession(_key), isNull);
+  });
+
+  test('evicts runs whose server is removed from the signal', () async {
+    final servers = Signal<Map<String, ServerEntry>>({});
+    final evicting = RunRegistry(servers: servers);
+    addTearDown(() {
+      evicting.dispose();
+      servers.dispose();
+    });
+
+    const keyS1 = (serverId: 's1', roomId: 'r', threadId: 't');
+    const keyS2 = (serverId: 's2', roomId: 'r', threadId: 't');
+    final s1Session = ManualAgentSession(keyS1);
+    final s2Session = ManualAgentSession(keyS2);
+    servers.value = {'s1': _entry('s1'), 's2': _entry('s2')};
+    evicting.register(keyS1, s1Session);
+    evicting.register(keyS2, s2Session);
+
+    servers.value = {'s2': _entry('s2')};
+
+    expect(s1Session.cancelCalled, isTrue);
+    expect(evicting.activeSession(keyS1), isNull);
+    expect(evicting.activeKeys.value, isNot(contains(keyS1)));
+    // A surviving server's run is untouched.
+    expect(evicting.activeSession(keyS2), same(s2Session));
+    expect(evicting.activeKeys.value, contains(keyS2));
   });
 }

--- a/test/modules/room/thread_anchor_storage_test.dart
+++ b/test/modules/room/thread_anchor_storage_test.dart
@@ -74,16 +74,5 @@ void main() {
       final loaded = await ThreadAnchorStorage.load();
       expect(loaded.keys, {(serverId: 's2', roomId: 'r', threadId: 't2')});
     });
-
-    test('clearServer leaves storage untouched when nothing matches', () async {
-      await ThreadAnchorStorage.save({
-        (serverId: 's1', roomId: 'r', threadId: 't1'): 'm1',
-      });
-
-      await ThreadAnchorStorage.clearServer('absent');
-
-      final loaded = await ThreadAnchorStorage.load();
-      expect(loaded.keys, {(serverId: 's1', roomId: 'r', threadId: 't1')});
-    });
   });
 }

--- a/test/modules/room/thread_anchor_storage_test.dart
+++ b/test/modules/room/thread_anchor_storage_test.dart
@@ -62,5 +62,28 @@ void main() {
       });
       expect(await ThreadAnchorStorage.load(), isEmpty);
     });
+
+    test('clearServer prunes only that server\'s anchors', () async {
+      await ThreadAnchorStorage.save({
+        (serverId: 's1', roomId: 'r', threadId: 't1'): 'm1',
+        (serverId: 's2', roomId: 'r', threadId: 't2'): 'm2',
+      });
+
+      await ThreadAnchorStorage.clearServer('s1');
+
+      final loaded = await ThreadAnchorStorage.load();
+      expect(loaded.keys, {(serverId: 's2', roomId: 'r', threadId: 't2')});
+    });
+
+    test('clearServer leaves storage untouched when nothing matches', () async {
+      await ThreadAnchorStorage.save({
+        (serverId: 's1', roomId: 'r', threadId: 't1'): 'm1',
+      });
+
+      await ThreadAnchorStorage.clearServer('absent');
+
+      final loaded = await ThreadAnchorStorage.load();
+      expect(loaded.keys, {(serverId: 's1', roomId: 'r', threadId: 't1')});
+    });
   });
 }

--- a/test/modules/room/thread_view_state_test.dart
+++ b/test/modules/room/thread_view_state_test.dart
@@ -150,7 +150,7 @@ void main() {
     api = FakeSoliplexApi();
     connection = _fakeConnection(api);
     auth = AuthSession(refreshService: FakeTokenRefreshService());
-    registry = RunRegistry();
+    registry = RunRegistry(servers: emptyServers());
   });
 
   tearDown(() {
@@ -451,6 +451,7 @@ void main() {
         platform: TestPlatformConstraints(),
         toolRegistryResolver: (_) async => const ToolRegistry(),
         logger: testLogger(),
+        servers: emptyServers(),
       );
       runtime = runtimeManager.getRuntime(connection);
     });

--- a/test/modules/room/ui/room_screen_test.dart
+++ b/test/modules/room/ui/room_screen_test.dart
@@ -225,8 +225,9 @@ void main() {
       platform: TestPlatformConstraints(),
       toolRegistryResolver: (_) async => const ToolRegistry(),
       logger: testLogger(),
+      servers: emptyServers(),
     );
-    registry = RunRegistry();
+    registry = RunRegistry(servers: emptyServers());
     servers = Signal({entry.serverId: entry});
     uploadRegistry = UploadTrackerRegistry(servers: servers);
   });


### PR DESCRIPTION
## Summary

Closes part of #393. Removing a server left per-server device-local state
orphaned. Because server ids are derived from the URL, re-adding an identical
server reuses the id and can resurrect stale cached state. The removal hook
already cleared read markers at every level; this drains the rest.

Scope is deliberately **server removal only** (the correctness-critical part —
URL-derived ids are reused). Room/thread disappearance pruning and the other
#393 notes are tracked as follow-ups.

## What changed

A new `RemovedServerCleanup` (`lib/src/core/removed_server_cleanup.dart`), owned
by `RoomAppModule` and subscribed to `ServerManager.servers`, drains a departed
server's device-local state on every removal path. It supersedes the read-marker
clears that were inlined in `LobbyState._onServersChanged`, moved to module
scope so removal fires from surfaces that don't mount the lobby — notably the
home screen's server list.

**Persistent stores** cleared on removal:
- `ThreadReadMarkerStorage.clearServer` — thread read floors (pre-existing).
- `ThreadAnchorStorage.clearServer` — drops unread-divider anchors.
- `ReturnToStorage.clearServer` — sweeps composer drafts by key prefix (trailing
  `:` bounds the match so `a` doesn't sweep `ab`; a known portless-origin
  over-sweep is characterized by a test and tracked in #393).

The inactivity-logout flag is deliberately **not** cleared. It forces
`prompt=login` on the next connect (see `ConnectFlow`), so a server removed
while inactivity-logged-out must keep it — clearing it would let a re-add under
the same id reuse a silent IdP session and skip the forced re-login.

**Runtime caches** — self-evict off the server signal, matching
`UploadTrackerRegistry`:
- `AgentRuntimeManager` disposes and drops the runtime for a departed server
  (previously leaked its timers/stream until app exit).
- `RunRegistry` cancels live sessions and drops tracked outcomes for a departed
  server.

**Teardown safety.** `RemovedServerCleanup` unsubscribes in
`RoomAppModule.onDispose`, which runs before the auth module empties the servers
signal (reverse registration order). Otherwise the empty-out would read as a
mass removal and wipe every server's state on a clean exit.

## Testing

- Unit tests for `clearServer` on both static stores (prefix-boundary and no-op
  cases, plus the characterized #393 over-sweep).
- `RemovedServerCleanup` tests: a removed server's read markers, anchors, and
  drafts are cleared while a survivor's are kept; a disposed cleanup ignores
  later removals.
- Shell-composition teardown-ordering tests pinning both directions of the
  dispose-order contract: auth-before-room preserves device-local state, the
  reverse wipes it.
- Eviction + survivor-untouched tests for `AgentRuntimeManager` and
  `RunRegistry`, including a throwing-cancel case.
- Full suite green (golden tag excluded); analyze and markdown lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
