### PR TITLE
refactor(auth): drive server-removal cleanup off an explicit event

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,14 @@ Versions follow the `version+build` scheme from `pubspec.yaml`, bumped via
 - Lobby: an "Unread first" sort option groups a server's rooms into an Unread
   section above a Read section, each ordered by recent activity.
 
+### Changed
+
+- Device-local cleanup on server removal is driven by an explicit
+  `ServerManager.onServerRemoved` event instead of diffing the servers signal.
+  Only a genuine removal clears a server's read state, unread-divider anchors,
+  and composer drafts; a signal reset such as shell teardown no longer risks
+  wiping stored state, independent of module dispose order.
+
 ### Fixed
 
 - Removing a server now clears the rest of its device-local state, not just its

--- a/lib/src/core/removed_server_cleanup.dart
+++ b/lib/src/core/removed_server_cleanup.dart
@@ -1,10 +1,9 @@
 import 'dart:async' show unawaited;
 
-import 'package:soliplex_agent/soliplex_agent.dart' show ReadonlySignal;
 import 'package:soliplex_logging/soliplex_logging.dart';
 
 import '../modules/auth/return_to_storage.dart';
-import '../modules/auth/server_entry.dart';
+import '../modules/auth/server_manager.dart';
 import '../modules/lobby/lobby_read_markers.dart'
     show RoomReadMarkers, ServerReadMarkers;
 import '../modules/room/thread_anchor_storage.dart';
@@ -19,61 +18,40 @@ final Logger _logger =
 ///
 /// Owned by [RoomAppModule] (like [UploadTrackerRegistry]) rather than a screen
 /// because removal fires from surfaces that don't mount the lobby — notably the
-/// home screen's server list. Subscribing to [ServerManager.servers] at module
-/// scope runs the cleanup for every removal path across the whole app session.
-/// The shared in-memory read-marker models are the same instances the lobby and
-/// room screens watch, so clearing them updates a mounted screen reactively too.
+/// home screen's server list. Registering on [ServerManager.onServerRemoved] at
+/// module scope runs the cleanup for every removal path across the whole app
+/// session. The shared in-memory read-marker models are the same instances the
+/// lobby and room screens watch, so clearing them updates a mounted screen
+/// reactively too.
 ///
-/// [dispose] must run before [ServerManager.dispose] empties the servers signal
-/// on shell teardown: that empty-out is a set transition this class would
-/// otherwise read as a mass removal and wipe every server's state, even though
-/// teardown keeps stored sessions for the next launch. [RoomAppModule] is
-/// disposed before the auth module (reverse registration order), so its
-/// `onDispose` unsubscribes in time.
+/// Keying off the removal event — not the [ServerManager.servers] signal —
+/// means only a genuine [ServerManager.removeServer] clears disk state.
+/// Teardown's signal empty-out never fires the event, so stored sessions
+/// survive to the next launch regardless of module dispose ordering.
 class RemovedServerCleanup {
   RemovedServerCleanup({
-    required ReadonlySignal<Map<String, ServerEntry>> servers,
+    required ServerManager serverManager,
     required RoomReadMarkers roomReadMarkers,
     required ServerReadMarkers serverReadMarkers,
   })  : _roomReadMarkers = roomReadMarkers,
-        _serverReadMarkers = serverReadMarkers,
-        // Seed the baseline (initializer list) before subscribing below: the
-        // signals library fires the callback synchronously with the current
-        // value, and _onServersChanged diffs against _knownIds on that first
-        // fire. Seeding it to the current ids makes that fire a no-op (nothing
-        // diffs as removed).
-        _knownIds = servers.value.keys.toSet() {
-    _unsubscribe = servers.subscribe(_onServersChanged);
+        _serverReadMarkers = serverReadMarkers {
+    _unsubscribe = serverManager.onServerRemoved(_clearServer);
   }
 
   final RoomReadMarkers _roomReadMarkers;
   final ServerReadMarkers _serverReadMarkers;
-  Set<String> _knownIds;
   late final void Function() _unsubscribe;
   bool _isDisposed = false;
 
-  void _onServersChanged(Map<String, ServerEntry> servers) {
-    if (_isDisposed) return;
-    final nextIds = servers.keys.toSet();
-    final removed = _knownIds.difference(nextIds);
-    _knownIds = nextIds;
-    // No "skip when nextIds is empty" shortcut: a user removing their last
-    // server also drops to `{}` and must still be cleared, so the empty-out is
-    // indistinguishable here from a real removal. The dispose ordering
-    // documented on this class — not a guard in this method — is what keeps
-    // teardown's empty-out from wiping every server.
-    for (final id in removed) {
-      _clearServer(id);
-    }
-  }
-
-  /// Runs synchronously inside the servers-signal write (the subscription fires
-  /// during [ServerManager.removeServer]). Every clear is isolated so one
-  /// failure can neither strand the others nor unwind that write: a synchronous
-  /// throw from an in-memory clear would propagate out of this callback and
-  /// unwind the write, so each runs guarded, and the static stores run
-  /// fire-and-forget with their throws caught and logged per store.
+  /// Runs synchronously inside [ServerManager.removeServer] via the
+  /// onServerRemoved dispatch. Every clear is isolated so one failure can't
+  /// strand the others: the in-memory clears run guarded and the static stores
+  /// run fire-and-forget with their throws caught and logged per store.
   void _clearServer(String id) {
+    // onServerRemoved dispatches over a snapshot, so if a preceding listener
+    // synchronously tore down this cleanup, this callback still fires from that
+    // snapshot. A disposed cleanup does no work; the silent return is expected.
+    if (_isDisposed) return;
     _clearInMemory(
         () => _serverReadMarkers.clearServer(id), 'server read marker', id);
     _clearInMemory(
@@ -124,8 +102,8 @@ class RemovedServerCleanup {
     // under the same id reuse a silent IdP session and skip the forced re-login.
   }
 
-  /// Runs a synchronous in-memory clear, logging any throw instead of letting
-  /// it unwind the servers-signal write this executes inside.
+  /// Runs a synchronous in-memory clear, logging any throw so it can't strand
+  /// the sibling clears that follow it in [_clearServer].
   void _clearInMemory(void Function() clear, String what, String id) {
     try {
       clear();

--- a/lib/src/core/removed_server_cleanup.dart
+++ b/lib/src/core/removed_server_cleanup.dart
@@ -24,10 +24,10 @@ final Logger _logger =
 /// lobby and room screens watch, so clearing them updates a mounted screen
 /// reactively too.
 ///
-/// Keying off the removal event — not the [ServerManager.servers] signal —
-/// means only a genuine [ServerManager.removeServer] clears disk state.
-/// Teardown's signal empty-out never fires the event, so stored sessions
-/// survive to the next launch regardless of module dispose ordering.
+/// Only a genuine [ServerManager.removeServer] clears disk state. Shell
+/// teardown empties the servers signal without firing the removal event, so
+/// stored sessions survive to the next launch regardless of module dispose
+/// ordering.
 class RemovedServerCleanup {
   RemovedServerCleanup({
     required ServerManager serverManager,

--- a/lib/src/modules/auth/server_manager.dart
+++ b/lib/src/modules/auth/server_manager.dart
@@ -18,6 +18,8 @@ typedef HttpClientFactory = SoliplexHttpClient Function({
 
 typedef AuthSessionFactory = AuthSession Function();
 
+typedef ServerRemovedListener = void Function(String serverId);
+
 /// Owns the collection of per-server resources and shared infrastructure.
 /// Keeps [ServerRegistry] in sync internally.
 class ServerManager {
@@ -49,11 +51,10 @@ class ServerManager {
   final Set<String> _aliases = {};
 
   /// Listeners notified when a server is permanently removed via
-  /// [removeServer]. Carries the removal *intent* that the [servers] signal
-  /// cannot: an empty-out from [dispose] shrinks the signal identically but
-  /// must not notify, so persistent device-local cleanup keys off this event
-  /// rather than diffing the signal.
-  final List<void Function(String serverId)> _onRemoved = [];
+  /// [removeServer]. Carries the removal *intent* the [servers] signal cannot:
+  /// [dispose] empties the signal identically but must not notify, so
+  /// persistent device-local cleanup keys off this event.
+  final List<ServerRemovedListener> _onRemoved = [];
 
   bool _restoring = false;
 
@@ -157,9 +158,14 @@ class ServerManager {
   /// unregisters another mid-dispatch does not retract it from the in-flight
   /// round — the unregistered listener still receives the current event.
   /// Subscribers must guard against running after their own disposal.
-  void Function() onServerRemoved(void Function(String serverId) listener) {
+  void Function() onServerRemoved(ServerRemovedListener listener) {
     _onRemoved.add(listener);
-    return () => _onRemoved.remove(listener);
+    var active = true;
+    return () {
+      if (!active) return;
+      active = false;
+      _onRemoved.remove(listener);
+    };
   }
 
   void removeServer(String serverId) {

--- a/lib/src/modules/auth/server_manager.dart
+++ b/lib/src/modules/auth/server_manager.dart
@@ -152,6 +152,11 @@ class ServerManager {
 
   /// Registers a listener fired synchronously when [removeServer] permanently
   /// removes a server. Returns a disposer that unregisters it.
+  ///
+  /// Dispatch runs over a snapshot of the listeners, so a listener that
+  /// unregisters another mid-dispatch does not retract it from the in-flight
+  /// round — the unregistered listener still receives the current event.
+  /// Subscribers must guard against running after their own disposal.
   void Function() onServerRemoved(void Function(String serverId) listener) {
     _onRemoved.add(listener);
     return () => _onRemoved.remove(listener);
@@ -175,7 +180,8 @@ class ServerManager {
 
     // Snapshot so a listener that unsubscribes itself can't mutate the list
     // mid-iteration. Each dispatch is guarded so one throwing listener can
-    // neither strand the others nor unwind this removal write.
+    // neither strand the others nor abort the rest of removeServer (the storage
+    // delete below).
     for (final listener in List.of(_onRemoved)) {
       try {
         listener(serverId);

--- a/lib/src/modules/auth/server_manager.dart
+++ b/lib/src/modules/auth/server_manager.dart
@@ -48,6 +48,13 @@ class ServerManager {
   /// Tracks in-use aliases to ensure uniqueness.
   final Set<String> _aliases = {};
 
+  /// Listeners notified when a server is permanently removed via
+  /// [removeServer]. Carries the removal *intent* that the [servers] signal
+  /// cannot: an empty-out from [dispose] shrinks the signal identically but
+  /// must not notify, so persistent device-local cleanup keys off this event
+  /// rather than diffing the signal.
+  final List<void Function(String serverId)> _onRemoved = [];
+
   bool _restoring = false;
 
   /// Aggregate auth state derived from all server sessions.
@@ -143,6 +150,13 @@ class ServerManager {
     return entry;
   }
 
+  /// Registers a listener fired synchronously when [removeServer] permanently
+  /// removes a server. Returns a disposer that unregisters it.
+  void Function() onServerRemoved(void Function(String serverId) listener) {
+    _onRemoved.add(listener);
+    return () => _onRemoved.remove(listener);
+  }
+
   void removeServer(String serverId) {
     final entry = _servers.value[serverId];
     if (entry == null) {
@@ -158,6 +172,22 @@ class ServerManager {
 
     final updated = {..._servers.value}..remove(serverId);
     _servers.value = updated;
+
+    // Snapshot so a listener that unsubscribes itself can't mutate the list
+    // mid-iteration. Each dispatch is guarded so one throwing listener can
+    // neither strand the others nor unwind this removal write.
+    for (final listener in List.of(_onRemoved)) {
+      try {
+        listener(serverId);
+      } on Object catch (e, st) {
+        _logger.error(
+          'server-removed listener threw',
+          error: e,
+          stackTrace: st,
+          attributes: {'serverId': serverId},
+        );
+      }
+    }
 
     _persistQueue[serverId] = (_persistQueue[serverId] ?? Future.value())
         .then((_) => _storage.delete(serverId))

--- a/lib/src/modules/room/room_module.dart
+++ b/lib/src/modules/room/room_module.dart
@@ -30,7 +30,7 @@ class RoomAppModule extends AppModule {
         _messageExpansions = MessageExpansions(),
         _uploadRegistry = UploadTrackerRegistry(servers: serverManager.servers),
         _removedServerCleanup = RemovedServerCleanup(
-          servers: serverManager.servers,
+          serverManager: serverManager,
           roomReadMarkers: roomReadMarkers,
           serverReadMarkers: serverReadMarkers,
         );
@@ -122,9 +122,6 @@ class RoomAppModule extends AppModule {
 
   @override
   Future<void> onDispose() async {
-    // Before the auth module disposes ServerManager (reverse registration
-    // order), so the cleanup stops observing before ServerManager empties the
-    // servers signal — an empty-out it would otherwise read as a mass removal.
     _removedServerCleanup.dispose();
     await runtimeManager.dispose();
     registry.dispose();

--- a/test/core/removed_server_cleanup_test.dart
+++ b/test/core/removed_server_cleanup_test.dart
@@ -1,17 +1,10 @@
-import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:shared_preferences/shared_preferences.dart';
-import 'package:soliplex_agent/soliplex_agent.dart';
 import 'package:soliplex_frontend/src/core/removed_server_cleanup.dart';
-import 'package:soliplex_frontend/src/core/shell_config.dart';
-import 'package:soliplex_frontend/src/modules/auth/auth_module.dart';
 import 'package:soliplex_frontend/src/modules/auth/auth_session.dart';
 import 'package:soliplex_frontend/src/modules/auth/return_to_storage.dart';
 import 'package:soliplex_frontend/src/modules/auth/server_manager.dart';
 import 'package:soliplex_frontend/src/modules/lobby/lobby_read_markers.dart';
-import 'package:soliplex_frontend/src/modules/room/agent_runtime_manager.dart';
-import 'package:soliplex_frontend/src/modules/room/room_module.dart';
-import 'package:soliplex_frontend/src/modules/room/run_registry.dart';
 import 'package:soliplex_frontend/src/modules/room/thread_anchor_storage.dart';
 import 'package:soliplex_frontend/src/modules/room/thread_read_markers.dart';
 
@@ -47,7 +40,7 @@ void main() {
     final room = RoomReadMarkers();
     final server = ServerReadMarkers();
     final cleanup = RemovedServerCleanup(
-      servers: manager.servers,
+      serverManager: manager,
       roomReadMarkers: room,
       serverReadMarkers: server,
     );
@@ -132,12 +125,29 @@ void main() {
       );
     });
 
-    // Disposing must stop the cleanup observing. On shell teardown
-    // ServerManager empties the servers signal, and a still-subscribed cleanup
-    // would read that as a mass removal and wipe every server's state — even
-    // though teardown keeps stored sessions for the next launch. Its owning
-    // module disposes it before that empty-out; this pins the guard that makes
-    // that ordering safe.
+    // A signal empty-out is not a removal: ServerManager.dispose() empties the
+    // servers signal on shell teardown, but that state is meant to survive to
+    // the next launch. The cleanup keys off the removeServer event, so a bare
+    // dispose must not wipe anything.
+    test('ServerManager.dispose does not clear device-local state', () async {
+      final at = DateTime.utc(2026, 6, 1);
+      final wired = wire();
+      wired.server.markRead('s1', at);
+      wired.room.markRead((serverId: 's1', roomId: 'r'), at);
+
+      wired.manager.dispose();
+      await pumpEventQueue();
+
+      expect(wired.server.value.containsKey('s1'), isTrue);
+      expect(
+        wired.room.value.containsKey((serverId: 's1', roomId: 'r')),
+        isTrue,
+      );
+    });
+
+    // dispose() unsubscribes from the removal event, so a removal after dispose
+    // is a no-op. The owning module disposes the cleanup on teardown; this pins
+    // that a disposed cleanup no longer reacts.
     test('a disposed cleanup ignores later server removals', () async {
       final at = DateTime.utc(2026, 6, 1);
       final wired = wire();
@@ -152,86 +162,6 @@ void main() {
       expect(
         wired.room.value.containsKey((serverId: 's1', roomId: 'r')),
         isTrue,
-      );
-    });
-  });
-
-  // Guards that RoomAppModule.onDispose stops the cleanup before ServerManager
-  // empties the servers signal. If onDispose ever drops the
-  // _removedServerCleanup.dispose() call, the still-subscribed cleanup reads the
-  // teardown empty-out as a mass removal and wipes every server's state; this
-  // drives the real modules through the real ShellConfig teardown to catch that.
-  // It does not pin the production registration order itself (this list is built
-  // here, not read from the flavor) — that ordering is a cross-module contract.
-  group('teardown ordering (shell composition)', () {
-    final at = DateTime.utc(2026, 6, 1);
-    const roomKey = (serverId: 's1', roomId: 'r');
-    const threadKey = (serverId: 's1', roomId: 'r', threadId: 't');
-
-    test('teardown leaves a surviving session\'s device-local state intact',
-        () async {
-      final manager = _createManager();
-      manager.addServer(
-        serverId: 's1',
-        serverUrl: Uri.parse('http://s1.test'),
-        requiresAuth: false,
-      );
-      final room = RoomReadMarkers();
-      final server = ServerReadMarkers();
-      final runtimeManager = AgentRuntimeManager(
-        platform: TestPlatformConstraints(),
-        toolRegistryResolver: (_) async => const ToolRegistry(),
-        logger: testLogger(),
-        servers: manager.servers,
-      );
-      final registry = RunRegistry(servers: manager.servers);
-      final authMod = AuthAppModule(
-        serverManager: manager,
-        probeClient: FakeHttpClient(),
-        authFlow: FakeAuthFlow(),
-        appName: 'Soliplex',
-        inactivityLogoutFlags: InMemoryInactivityLogoutFlagStorage(),
-      );
-      // RoomAppModule builds its own RemovedServerCleanup over these markers.
-      final roomMod = RoomAppModule(
-        serverManager: manager,
-        runtimeManager: runtimeManager,
-        registry: registry,
-        roomReadMarkers: room,
-        serverReadMarkers: server,
-        appName: 'Soliplex',
-      );
-      // Auth before room, matching the flavor: reverse-order teardown disposes
-      // room (stopping the cleanup) before auth empties the signal.
-      final config = await ShellConfig.fromModules(
-        appName: 'Soliplex',
-        lightTheme: ThemeData(),
-        modules: [authMod, roomMod],
-      );
-
-      server.markRead('s1', at);
-      room.markRead(roomKey, at);
-      await ThreadReadMarkerStorage.save({threadKey: at});
-      await ThreadAnchorStorage.save({threadKey: 'm1'});
-      await ReturnToStorage.saveComposer(
-        serverId: 's1',
-        roomId: 'r',
-        unsentText: 'draft',
-      );
-
-      await config.dispose?.call();
-      await pumpEventQueue();
-
-      expect(server.value.containsKey('s1'), isTrue);
-      expect(room.value.containsKey(roomKey), isTrue);
-      expect(
-        (await ThreadReadMarkerStorage.load()).containsKey(threadKey),
-        isTrue,
-      );
-      expect((await ThreadAnchorStorage.load()).containsKey(threadKey), isTrue);
-      expect(
-        await ReturnToStorage.loadComposer(serverId: 's1', roomId: 'r'),
-        'draft',
       );
     });
   });

--- a/test/modules/auth/server_manager_test.dart
+++ b/test/modules/auth/server_manager_test.dart
@@ -1,4 +1,5 @@
 import 'package:flutter_test/flutter_test.dart';
+import 'package:soliplex_logging/soliplex_logging.dart';
 
 import 'package:soliplex_frontend/src/interfaces/auth_state.dart';
 import 'package:soliplex_frontend/src/modules/auth/auth_session.dart';
@@ -155,6 +156,81 @@ void main() {
         () => manager.removeServer('nonexistent'),
         throwsStateError,
       );
+    });
+  });
+
+  group('onServerRemoved', () {
+    test('fires with the removed id on removeServer', () {
+      final manager = _createManager();
+      manager.addServer(
+        serverId: 'test',
+        serverUrl: Uri.parse('https://api.example.com'),
+      );
+      final removed = <String>[];
+      manager.onServerRemoved(removed.add);
+
+      manager.removeServer('test');
+
+      expect(removed, ['test']);
+    });
+
+    test('does not fire on dispose', () {
+      final manager = _createManager();
+      manager.addServer(
+        serverId: 'test',
+        serverUrl: Uri.parse('https://api.example.com'),
+      );
+      final removed = <String>[];
+      manager.onServerRemoved(removed.add);
+
+      manager.dispose();
+
+      expect(removed, isEmpty);
+    });
+
+    test('returned disposer stops delivery', () {
+      final manager = _createManager();
+      manager.addServer(
+        serverId: 'a',
+        serverUrl: Uri.parse('https://a.example.com'),
+      );
+      manager.addServer(
+        serverId: 'b',
+        serverUrl: Uri.parse('https://b.example.com'),
+      );
+      final removed = <String>[];
+      final unsubscribe = manager.onServerRemoved(removed.add);
+
+      unsubscribe();
+      manager.removeServer('a');
+
+      expect(removed, isEmpty);
+    });
+
+    test('a throwing listener is isolated and does not unwind removeServer',
+        () {
+      final sink = MemorySink();
+      LogManager.instance.addSink(sink);
+      addTearDown(() => LogManager.instance.removeSink(sink));
+
+      final manager = _createManager();
+      manager.addServer(
+        serverId: 'test',
+        serverUrl: Uri.parse('https://api.example.com'),
+      );
+      final removed = <String>[];
+      manager.onServerRemoved((_) => throw StateError('listener boom'));
+      manager.onServerRemoved(removed.add);
+
+      // The throwing listener must not unwind the removal write.
+      manager.removeServer('test');
+
+      expect(manager.servers.value, isEmpty);
+      // Later listeners still run despite the earlier throw.
+      expect(removed, ['test']);
+      final errors = sink.records.where((r) => r.level == LogLevel.error);
+      expect(errors, hasLength(1));
+      expect(errors.single.error, isA<StateError>());
     });
   });
 

--- a/test/modules/auth/server_manager_test.dart
+++ b/test/modules/auth/server_manager_test.dart
@@ -208,29 +208,77 @@ void main() {
     });
 
     test('a throwing listener is isolated and does not unwind removeServer',
-        () {
+        () async {
       final sink = MemorySink();
       LogManager.instance.addSink(sink);
       addTearDown(() => LogManager.instance.removeSink(sink));
 
-      final manager = _createManager();
+      final storage = InMemoryServerStorage();
+      final manager = _createManager(storage: storage);
       manager.addServer(
         serverId: 'test',
         serverUrl: Uri.parse('https://api.example.com'),
+      );
+      await storage.save(
+        'test',
+        KnownServer(serverUrl: Uri.parse('https://api.example.com')),
       );
       final removed = <String>[];
       manager.onServerRemoved((_) => throw StateError('listener boom'));
       manager.onServerRemoved(removed.add);
 
-      // The throwing listener must not unwind the removal write.
       manager.removeServer('test');
+      await pumpEventQueue();
 
       expect(manager.servers.value, isEmpty);
       // Later listeners still run despite the earlier throw.
       expect(removed, ['test']);
+      // The work after the dispatch loop still runs: the stored session is
+      // deleted despite the throw.
+      expect(await storage.loadAll(), isEmpty);
       final errors = sink.records.where((r) => r.level == LogLevel.error);
       expect(errors, hasLength(1));
       expect(errors.single.error, isA<StateError>());
+    });
+
+    test('calling a disposer twice does not retract a live subscription', () {
+      final manager = _createManager();
+      manager.addServer(
+        serverId: 'test',
+        serverUrl: Uri.parse('https://api.example.com'),
+      );
+      final delivered = <String>[];
+      void listener(String _) => delivered.add('hit');
+      // The same listener registered twice yields two independent
+      // subscriptions. Disposing one twice must retract only its own entry.
+      final disposeFirst = manager.onServerRemoved(listener);
+      manager.onServerRemoved(listener);
+
+      disposeFirst();
+      disposeFirst();
+
+      manager.removeServer('test');
+
+      expect(delivered, ['hit']);
+    });
+
+    test('dispatch snapshots listeners so one can unregister another mid-round',
+        () {
+      final manager = _createManager();
+      manager.addServer(
+        serverId: 'test',
+        serverUrl: Uri.parse('https://api.example.com'),
+      );
+      final delivered = <String>[];
+      late void Function() disposeSecond;
+      // The first listener unregisters the second while dispatch is in flight.
+      // Dispatch runs over a snapshot, so the second still receives this event.
+      manager.onServerRemoved((_) => disposeSecond());
+      disposeSecond = manager.onServerRemoved((_) => delivered.add('second'));
+
+      manager.removeServer('test');
+
+      expect(delivered, ['second']);
     });
   });
 


### PR DESCRIPTION
## What

Device-local cleanup on server removal is now driven by an explicit `ServerManager.onServerRemoved` event instead of diffing the `servers` signal.

Previously `RemovedServerCleanup` subscribed to the `servers` signal and treated any set-shrink as a removal. That made a signal *reset* — e.g. `ServerManager.dispose()` emptying the signal on shell teardown — indistinguishable from a real removal, so cleanup could wipe stored state that was meant to survive to the next launch. The old design avoided this only through a fragile cross-module dispose-ordering contract (RoomAppModule had to dispose before the auth module emptied the signal).

The event carries the removal *intent* the signal cannot: only a genuine `removeServer` fires it; `dispose()` never does. This removes the dispose-ordering dependency entirely.

## Changes

- **`ServerManager.onServerRemoved`** — synchronous listener registration returning an idempotent disposer. Dispatch runs over a snapshot (`List.of`) so a listener unsubscribing another mid-round doesn't corrupt iteration; each listener is guarded so one throw can neither strand siblings nor abort the storage delete that follows.
- **`RemovedServerCleanup`** — keys off the event instead of the signal; drops the `_knownIds` diffing and the dispose-ordering rationale.
- **`RoomAppModule`** — wiring updated; obsolete dispose-ordering comment removed.

## Tests

- `onServerRemoved`: fires with the id on removal, does **not** fire on dispose, disposer stops delivery, idempotent disposer doesn't retract a sibling subscription, snapshot dispatch survives mid-round unsubscribe, throwing listener is isolated + logged and the storage delete still runs.
- `RemovedServerCleanup`: genuine removal clears all device-local stores; `ServerManager.dispose` clears nothing.
- Removed the shell-composition teardown group — it guarded the dispose-ordering contract this change eliminates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)