### PR TITLE
feat: keyed user-scoped device-local storage — foundation + per-user composer drafts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,13 @@ Versions follow the `version+build` scheme from `pubspec.yaml`, bumped via
   instead of leaking them until app exit — the runtime's timers and stream are
   disposed and any live run for the server is cancelled.
 
+### Security
+
+- Composer drafts are now scoped to the signed-in user: a different user signing
+  in on the same server no longer sees the previous user's unsent draft. A
+  by-server draft clear also no longer over-reaches a same-host server that
+  differs only by an explicit vs default port.
+
 ## [0.92.0+65] - 2026-07-02
 
 ### Added

--- a/lib/src/core/keyed_storage.dart
+++ b/lib/src/core/keyed_storage.dart
@@ -1,0 +1,26 @@
+/// Composite, percent-encoded SharedPreferences keys of the form
+/// `<prefix>:<enc(c0)>:<enc(c1)>:…`.
+///
+/// Every component is percent-encoded, so the `:` delimiter only ever appears
+/// between components — a component may itself contain `:` `/` `#`. This makes
+/// server-scoped prefix sweeps exact (a portless origin no longer prefix-matches
+/// the same host with an explicit port) and is what fixes the composer-draft
+/// colon-collision bug. By convention `serverId` is the first component.
+String encodeKey(String prefix, List<String> components) =>
+    [prefix, ...components.map(Uri.encodeComponent)].join(':');
+
+/// The decoded components of [key] if it belongs to [prefix], else `null`.
+List<String>? decodeKey(String prefix, String key) {
+  final head = '$prefix:';
+  if (!key.startsWith(head)) return null;
+  return key
+      .substring(head.length)
+      .split(':')
+      .map(Uri.decodeComponent)
+      .toList(growable: false);
+}
+
+/// The prefix for a server-scoped `startsWith` sweep, assuming `serverId` is the
+/// first component: `'<prefix>:<enc(serverId)>:'`.
+String serverKeyPrefix(String prefix, String serverId) =>
+    '$prefix:${Uri.encodeComponent(serverId)}:';

--- a/lib/src/modules/auth/access_token_identity.dart
+++ b/lib/src/modules/auth/access_token_identity.dart
@@ -1,0 +1,27 @@
+import 'dart:convert';
+
+/// Extracts a stable per-user identity from a JWT [accessToken].
+///
+/// Returns `"<iss>#<sub>"` when the token is a JWT whose payload carries
+/// non-empty `iss` and `sub` string claims, else `null`. `sub` is the IdP's
+/// stable subject id; `iss` disambiguates subjects across issuers on one server.
+///
+/// Decode-only: the backend already validated the token cryptographically, so
+/// this reads claims purely to bucket device-local state. Never throws.
+String? accessTokenIdentity(String accessToken) {
+  final segments = accessToken.split('.');
+  if (segments.length < 2) return null;
+  try {
+    final payload =
+        utf8.decode(base64Url.decode(base64Url.normalize(segments[1])));
+    final decoded = jsonDecode(payload);
+    if (decoded is! Map<String, dynamic>) return null;
+    final iss = decoded['iss'];
+    final sub = decoded['sub'];
+    if (iss is! String || iss.isEmpty) return null;
+    if (sub is! String || sub.isEmpty) return null;
+    return '$iss#$sub';
+  } on Object {
+    return null;
+  }
+}

--- a/lib/src/modules/auth/auth_session.dart
+++ b/lib/src/modules/auth/auth_session.dart
@@ -2,6 +2,7 @@ import 'dart:developer' as dev;
 
 import 'package:soliplex_agent/soliplex_agent.dart';
 
+import 'access_token_identity.dart';
 import 'auth_tokens.dart';
 
 /// Manages auth session and implements TokenRefresher for the HTTP client.
@@ -17,6 +18,21 @@ class AuthSession implements TokenRefresher {
 
   final Signal<SessionState> _session = Signal<SessionState>(const NoSession());
   ReadonlySignal<SessionState> get session => _session;
+
+  /// The live user's stable identity (`iss#sub`) for this server, or `null`
+  /// when signed out or the access token can't be decoded. Resolves the token
+  /// from ActiveSession AND ExpiredSession — a draft persisted on auth-expiry
+  /// must still be attributable to the user. Re-evaluates only when the session
+  /// changes and yields the same value across a same-user refresh, so watchers
+  /// don't churn. Raw (un-encoded); key builders percent-encode it downstream.
+  late final ReadonlySignal<String?> currentUserId = computed(() {
+    final token = switch (_session.value) {
+      ActiveSession(:final tokens) => tokens.accessToken,
+      ExpiredSession(:final tokens) => tokens.accessToken,
+      NoSession() => null,
+    };
+    return token == null ? null : accessTokenIdentity(token);
+  });
 
   /// Sync read for the HTTP client's getToken callback.
   ///

--- a/lib/src/modules/auth/return_to_storage.dart
+++ b/lib/src/modules/auth/return_to_storage.dart
@@ -3,41 +3,46 @@ import 'dart:convert';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:soliplex_logging/soliplex_logging.dart';
 
+import '../../core/keyed_storage.dart';
+
 final Logger _logger =
     LogManager.instance.getLogger('soliplex.return_to_storage');
 
-/// Per-screen snapshot store for state that needs to survive an
-/// auth-failure round-trip (composer drafts, quiz progress).
+/// Per-user composer-draft store, keyed by (serverId, userId, roomId).
 ///
 /// Backed by `shared_preferences` rather than `flutter_secure_storage`
 /// because none of the persisted state is sensitive — tokens go
 /// through the secure store.
 ///
-/// Entries expire after 24 hours so drafts survive multi-minute OIDC
+/// Entries expire after [maxAge] so drafts survive multi-minute OIDC
 /// roundtrips with retries while still bounding staleness.
 abstract final class ReturnToStorage {
-  static const _prefix = 'soliplex_return_to';
+  static const _prefix = 'soliplex_return_to:composer';
 
   /// Entries older than this are treated as missing and lazily cleared
   /// on the next read.
   static const maxAge = Duration(hours: 24);
 
-  static String _composerKey(String serverId, String roomId) =>
-      '$_prefix:composer:$serverId:$roomId';
+  static String _key(String serverId, String userId, String roomId) =>
+      encodeKey(_prefix, [serverId, userId, roomId]);
 
-  /// Stores the unsent composer text for a `(serverId, roomId)` pair.
+  /// Stores the unsent composer text for a `(serverId, userId, roomId)`
+  /// triple. A `null` [userId] means the user can't be attributed (signed
+  /// out) and is a no-op — there's no scope to save under.
   ///
   /// Empty / whitespace-only text is treated as "no draft" and clears
   /// any existing entry — there's nothing meaningful to restore.
   static Future<void> saveComposer({
     required String serverId,
+    required String? userId,
     required String roomId,
     required String unsentText,
     DateTime? now,
   }) async {
+    if (userId == null) return;
     final trimmed = unsentText.trim();
     if (trimmed.isEmpty) {
-      await clearComposer(serverId: serverId, roomId: roomId);
+      await clearComposer(serverId: serverId, userId: userId, roomId: roomId);
       return;
     }
     final prefs = await SharedPreferences.getInstance();
@@ -45,19 +50,22 @@ abstract final class ReturnToStorage {
       'unsentText': unsentText,
       'createdAt': (now ?? DateTime.timestamp()).toUtc().toIso8601String(),
     };
-    await prefs.setString(_composerKey(serverId, roomId), jsonEncode(entry));
+    await prefs.setString(_key(serverId, userId, roomId), jsonEncode(entry));
   }
 
-  /// Returns the previously persisted composer text for the pair, or
-  /// `null` when missing, expired, or corrupted. Expired or corrupted
-  /// entries are removed from storage as a side effect.
+  /// Returns the previously persisted composer text for the triple, or
+  /// `null` when missing, expired, corrupted, or [userId] is `null`.
+  /// Expired or corrupted entries are removed from storage as a side
+  /// effect.
   static Future<String?> loadComposer({
     required String serverId,
+    required String? userId,
     required String roomId,
     DateTime? now,
   }) async {
+    if (userId == null) return null;
     final prefs = await SharedPreferences.getInstance();
-    final raw = prefs.getString(_composerKey(serverId, roomId));
+    final raw = prefs.getString(_key(serverId, userId, roomId));
     if (raw == null) return null;
 
     try {
@@ -65,7 +73,7 @@ abstract final class ReturnToStorage {
       final createdAt = DateTime.parse(json['createdAt'] as String).toUtc();
       final currentTime = now ?? DateTime.timestamp();
       if (currentTime.difference(createdAt) > maxAge) {
-        await clearComposer(serverId: serverId, roomId: roomId);
+        await clearComposer(serverId: serverId, userId: userId, roomId: roomId);
         return null;
       }
       return json['unsentText'] as String?;
@@ -75,34 +83,44 @@ abstract final class ReturnToStorage {
         error: e,
         stackTrace: st,
       );
-      await clearComposer(serverId: serverId, roomId: roomId);
+      await clearComposer(serverId: serverId, userId: userId, roomId: roomId);
       return null;
     }
   }
 
   static Future<void> clearComposer({
     required String serverId,
+    required String userId,
     required String roomId,
   }) async {
     final prefs = await SharedPreferences.getInstance();
-    await prefs.remove(_composerKey(serverId, roomId));
+    await prefs.remove(_key(serverId, userId, roomId));
   }
 
-  /// Removes every composer draft belonging to [serverId], so a removed
-  /// server's unsent text can't resurface in a re-added room.
-  ///
-  /// Matches by key prefix. This is exact for the common case, but the key
-  /// joins [serverId] and roomId with an unescaped `:`, and a server id is a
-  /// `Uri.origin` (which omits the default port). So a portless origin is a
-  /// prefix of the same host with an explicit port — `clearServer` for
-  /// `https://foo.com` also sweeps `https://foo.com:8443`'s drafts. Bounded and
-  /// rare (both servers on one host, one with an unsent draft); the unambiguous
-  /// fix is the keyed-store migration tracked in issue #393.
+  /// Removes every user's draft belonging to [serverId], so a removed
+  /// server's unsent text can't resurface in a re-added room. Matches the
+  /// percent-encoded key format; pre-userId (legacy) raw-key drafts are
+  /// abandoned by the one-time launch sweep, not handled here.
   static Future<void> clearServer(String serverId) async {
     final prefs = await SharedPreferences.getInstance();
-    final prefix = '$_prefix:composer:$serverId:';
+    final prefix = serverKeyPrefix(_prefix, serverId);
     final keys = prefs.getKeys().where((key) => key.startsWith(prefix));
     for (final key in keys) {
+      await prefs.remove(key);
+    }
+  }
+
+  /// Removes every user's draft for `(serverId, roomId)`.
+  static Future<void> clearRoom(String serverId, String roomId) async {
+    final prefs = await SharedPreferences.getInstance();
+    final dead = prefs.getKeys().where((key) {
+      final components = decodeKey(_prefix, key);
+      return components != null &&
+          components.length == 3 &&
+          components[0] == serverId &&
+          components[2] == roomId;
+    });
+    for (final key in dead) {
       await prefs.remove(key);
     }
   }

--- a/lib/src/modules/room/composer_persistence.dart
+++ b/lib/src/modules/room/composer_persistence.dart
@@ -11,6 +11,7 @@ import '../auth/return_to_storage.dart';
 /// redirect still proceeds.
 void persistComposerDraft({
   required String serverId,
+  required String? userId,
   required String roomId,
   required String prompt,
 }) {
@@ -18,6 +19,7 @@ void persistComposerDraft({
   unawaited(
     ReturnToStorage.saveComposer(
       serverId: serverId,
+      userId: userId,
       roomId: roomId,
       unsentText: prompt,
     ).catchError((Object e, StackTrace st) {

--- a/lib/src/modules/room/room_state.dart
+++ b/lib/src/modules/room/room_state.dart
@@ -302,6 +302,7 @@ class RoomState {
         isDisposed: () => _isDisposed,
         onAuthExpired: (text) => persistComposerDraft(
           serverId: _connection.serverId,
+          userId: _auth.currentUserId.value,
           roomId: _roomId,
           prompt: text,
         ),

--- a/lib/src/modules/room/thread_view_state.dart
+++ b/lib/src/modules/room/thread_view_state.dart
@@ -505,6 +505,7 @@ class ThreadViewState {
     if (_isDisposed) return;
     persistComposerDraft(
       serverId: _connection.serverId,
+      userId: _auth.currentUserId.value,
       roomId: _roomId,
       prompt: prompt,
     );

--- a/lib/src/modules/room/ui/room_screen.dart
+++ b/lib/src/modules/room/ui/room_screen.dart
@@ -819,8 +819,11 @@ class _RoomScreenState extends State<RoomScreen> {
   /// composer is the safe fallback.
   Future<void> _restorePersistedComposer() async {
     try {
+      final userId = widget.serverEntry.auth.currentUserId.value;
+      if (userId == null) return; // no signed-in user → nothing to restore
       final text = await ReturnToStorage.loadComposer(
         serverId: widget.serverEntry.serverId,
+        userId: userId,
         roomId: widget.roomId,
       );
       if (!mounted || text == null) return;
@@ -832,6 +835,7 @@ class _RoomScreenState extends State<RoomScreen> {
       // room don't re-pre-fill the box with stale content.
       await ReturnToStorage.clearComposer(
         serverId: widget.serverEntry.serverId,
+        userId: userId,
         roomId: widget.roomId,
       );
     } catch (e, st) {

--- a/test/core/keyed_storage_test.dart
+++ b/test/core/keyed_storage_test.dart
@@ -1,0 +1,48 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:soliplex_frontend/src/core/keyed_storage.dart';
+
+void main() {
+  const p = 'soliplex_thread_read_marker';
+
+  test('round-trips simple components', () {
+    final key = encodeKey(p, ['s1', 'u1', 'r1', 't1']);
+    expect(decodeKey(p, key), ['s1', 'u1', 'r1', 't1']);
+  });
+
+  test('round-trips components containing :, /, and #', () {
+    final server = 'https://foo.com';
+    final user = 'https://sso/realm#alice';
+    final key = encodeKey(p, [server, user, 'r1']);
+    // No raw delimiter leaks into the encoded key.
+    expect(key.contains('https://'), isFalse);
+    expect(decodeKey(p, key), [server, user, 'r1']);
+  });
+
+  test('decodeKey returns null for a different prefix', () {
+    final key = encodeKey(p, ['s1']);
+    expect(decodeKey('other_prefix', key), isNull);
+  });
+
+  test('decodeKey is not fooled by a prefix that is a substring', () {
+    // 'pre' must not decode a 'prefix:...' key.
+    final key = encodeKey('prefix', ['s1']);
+    expect(decodeKey('pre', key), isNull);
+  });
+
+  test('serverKeyPrefix disambiguates a portless origin from an explicit port',
+      () {
+    // The colon-collision bug: origins omit default ports, so
+    // "https://foo.com" is a raw-string prefix of "https://foo.com:8443".
+    final portless = encodeKey(p, ['https://foo.com', 'r1']);
+    final withPort = encodeKey(p, ['https://foo.com:8443', 'r1']);
+    final sweep = serverKeyPrefix(p, 'https://foo.com');
+
+    expect(portless.startsWith(sweep), isTrue);
+    expect(withPort.startsWith(sweep), isFalse); // the fix
+  });
+
+  test('serverKeyPrefix matches encodeKey with serverId first', () {
+    final key = encodeKey(p, ['s1', 'u1', 'r1']);
+    expect(key.startsWith(serverKeyPrefix(p, 's1')), isTrue);
+  });
+}

--- a/test/core/removed_server_cleanup_test.dart
+++ b/test/core/removed_server_cleanup_test.dart
@@ -94,11 +94,13 @@ void main() {
       });
       await ReturnToStorage.saveComposer(
         serverId: 's1',
+        userId: 'u',
         roomId: 'r',
         unsentText: 's1 draft',
       );
       await ReturnToStorage.saveComposer(
         serverId: 's2',
+        userId: 'u',
         roomId: 'r',
         unsentText: 's2 draft',
       );
@@ -116,11 +118,13 @@ void main() {
         isTrue,
       );
       expect(
-        await ReturnToStorage.loadComposer(serverId: 's1', roomId: 'r'),
+        await ReturnToStorage.loadComposer(
+            serverId: 's1', userId: 'u', roomId: 'r'),
         isNull,
       );
       expect(
-        await ReturnToStorage.loadComposer(serverId: 's2', roomId: 'r'),
+        await ReturnToStorage.loadComposer(
+            serverId: 's2', userId: 'u', roomId: 'r'),
         's2 draft',
       );
     });

--- a/test/modules/auth/access_token_identity_test.dart
+++ b/test/modules/auth/access_token_identity_test.dart
@@ -1,0 +1,43 @@
+import 'dart:convert';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:soliplex_frontend/src/modules/auth/access_token_identity.dart';
+
+// Builds a JWT-shaped string (header.payload.signature) with the given payload.
+String _jwt(Map<String, dynamic> payload) {
+  String seg(Map<String, dynamic> m) =>
+      base64Url.encode(utf8.encode(jsonEncode(m))).replaceAll('=', '');
+  return '${seg({'alg': 'RS256'})}.${seg(payload)}.sig';
+}
+
+void main() {
+  test('extracts iss#sub from a well-formed token', () {
+    final token = _jwt({'iss': 'https://idp.example/realm', 'sub': 'user-123'});
+    expect(accessTokenIdentity(token), 'https://idp.example/realm#user-123');
+  });
+
+  test('returns null when sub is missing', () {
+    expect(accessTokenIdentity(_jwt({'iss': 'https://idp.example'})), isNull);
+  });
+
+  test('returns null when iss is missing', () {
+    expect(accessTokenIdentity(_jwt({'sub': 'user-123'})), isNull);
+  });
+
+  test('returns null when a claim is blank', () {
+    expect(accessTokenIdentity(_jwt({'iss': '', 'sub': 'user-123'})), isNull);
+  });
+
+  test('returns null for a non-JWT string', () {
+    expect(accessTokenIdentity('not-a-jwt'), isNull);
+    expect(accessTokenIdentity(''), isNull);
+  });
+
+  test('returns null for an undecodable payload segment', () {
+    expect(accessTokenIdentity('aaa.!!!not-base64!!!.sig'), isNull);
+  });
+
+  test('tolerates base64url payloads without padding', () {
+    expect(accessTokenIdentity(_jwt({'iss': 'i', 'sub': 's'})), 'i#s');
+  });
+}

--- a/test/modules/auth/auth_session_test.dart
+++ b/test/modules/auth/auth_session_test.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+import 'dart:convert';
 
 import 'package:flutter_test/flutter_test.dart';
 import 'package:soliplex_agent/soliplex_agent.dart';
@@ -20,6 +21,18 @@ AuthTokens _tokens({Duration expiresIn = const Duration(hours: 1)}) {
     expiresAt: DateTime.now().add(expiresIn),
   );
 }
+
+String _jwt(String iss, String sub) {
+  String seg(Map<String, dynamic> m) =>
+      base64Url.encode(utf8.encode(jsonEncode(m))).replaceAll('=', '');
+  return '${seg({'alg': 'RS256'})}.${seg({'iss': iss, 'sub': sub})}.sig';
+}
+
+AuthTokens _identityTokens(String accessToken) => AuthTokens(
+      accessToken: accessToken,
+      refreshToken: 'r',
+      expiresAt: DateTime.utc(2100),
+    );
 
 void main() {
   late FakeTokenRefreshService refreshService;
@@ -123,6 +136,62 @@ void main() {
     test('is a no-op when state is NoSession', () {
       session.markSessionExpired();
       expect(session.session.value, isA<NoSession>());
+    });
+  });
+
+  group('AuthSession.currentUserId', () {
+    test('null before any login (NoSession)', () {
+      expect(session.currentUserId.value, isNull);
+    });
+
+    test('yields iss#sub after login', () {
+      session.login(
+        provider: _provider,
+        tokens: _identityTokens(_jwt('iss-a', 'alice')),
+      );
+      expect(session.currentUserId.value, 'iss-a#alice');
+    });
+
+    test('still yields iss#sub while ExpiredSession (critical for draft save)',
+        () {
+      session.login(
+        provider: _provider,
+        tokens: _identityTokens(_jwt('iss-a', 'alice')),
+      );
+      session.markSessionExpired();
+      expect(session.currentUserId.value, 'iss-a#alice');
+    });
+
+    test('null after logout', () {
+      session.login(
+        provider: _provider,
+        tokens: _identityTokens(_jwt('iss-a', 'alice')),
+      );
+      session.logout();
+      expect(session.currentUserId.value, isNull);
+    });
+
+    test('null when the access token is not a decodable JWT', () {
+      session.login(
+        provider: _provider,
+        tokens: _identityTokens('opaque-token'),
+      );
+      expect(session.currentUserId.value, isNull);
+    });
+
+    test('value is stable across a same-user token refresh', () {
+      session.login(
+        provider: _provider,
+        tokens: _identityTokens(_jwt('iss-a', 'alice')),
+      );
+      final first = session.currentUserId.value;
+      // Simulate a refresh: same user, new token string.
+      session.login(
+        provider: _provider,
+        tokens: _identityTokens(_jwt('iss-a', 'alice')),
+      );
+      expect(session.currentUserId.value, first);
+      expect(session.currentUserId.value, 'iss-a#alice');
     });
   });
 

--- a/test/modules/auth/return_to_storage_test.dart
+++ b/test/modules/auth/return_to_storage_test.dart
@@ -1,11 +1,14 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:shared_preferences/shared_preferences.dart';
+import 'package:soliplex_frontend/src/core/keyed_storage.dart';
 import 'package:soliplex_frontend/src/modules/auth/return_to_storage.dart';
 
 final _baseTime = DateTime.utc(2026, 5, 20, 12);
 
 void main() {
   group('ReturnToStorage composer', () {
+    const u = 'iss#user';
+
     setUp(() {
       SharedPreferences.setMockInitialValues({});
     });
@@ -13,6 +16,7 @@ void main() {
     test('save and load round-trip', () async {
       await ReturnToStorage.saveComposer(
         serverId: 'server-a',
+        userId: u,
         roomId: 'room-1',
         unsentText: 'half-written message',
         now: _baseTime,
@@ -20,6 +24,7 @@ void main() {
 
       final loaded = await ReturnToStorage.loadComposer(
         serverId: 'server-a',
+        userId: u,
         roomId: 'room-1',
         now: _baseTime,
       );
@@ -30,6 +35,7 @@ void main() {
     test('load returns null when nothing saved', () async {
       final loaded = await ReturnToStorage.loadComposer(
         serverId: 'server-a',
+        userId: u,
         roomId: 'room-1',
       );
       expect(loaded, isNull);
@@ -39,18 +45,21 @@ void main() {
         () async {
       await ReturnToStorage.saveComposer(
         serverId: 'a',
+        userId: u,
         roomId: 'r',
         unsentText: 'previous draft',
       );
 
       await ReturnToStorage.saveComposer(
         serverId: 'a',
+        userId: u,
         roomId: 'r',
         unsentText: '   ',
       );
 
       expect(
-        await ReturnToStorage.loadComposer(serverId: 'a', roomId: 'r'),
+        await ReturnToStorage.loadComposer(
+            serverId: 'a', userId: u, roomId: 'r'),
         isNull,
       );
     });
@@ -58,18 +67,21 @@ void main() {
     test('per-(serverId, roomId) isolation', () async {
       await ReturnToStorage.saveComposer(
         serverId: 'a',
+        userId: u,
         roomId: 'r1',
         unsentText: 'A/r1 draft',
         now: _baseTime,
       );
       await ReturnToStorage.saveComposer(
         serverId: 'b',
+        userId: u,
         roomId: 'r1',
         unsentText: 'B/r1 draft',
         now: _baseTime,
       );
       await ReturnToStorage.saveComposer(
         serverId: 'a',
+        userId: u,
         roomId: 'r2',
         unsentText: 'A/r2 draft',
         now: _baseTime,
@@ -78,6 +90,7 @@ void main() {
       expect(
         await ReturnToStorage.loadComposer(
           serverId: 'a',
+          userId: u,
           roomId: 'r1',
           now: _baseTime,
         ),
@@ -86,6 +99,7 @@ void main() {
       expect(
         await ReturnToStorage.loadComposer(
           serverId: 'b',
+          userId: u,
           roomId: 'r1',
           now: _baseTime,
         ),
@@ -94,6 +108,7 @@ void main() {
       expect(
         await ReturnToStorage.loadComposer(
           serverId: 'a',
+          userId: u,
           roomId: 'r2',
           now: _baseTime,
         ),
@@ -104,6 +119,7 @@ void main() {
     test('load returns null and clears entry past the 24h TTL', () async {
       await ReturnToStorage.saveComposer(
         serverId: 'a',
+        userId: u,
         roomId: 'r',
         unsentText: 'old draft',
         now: _baseTime,
@@ -113,6 +129,7 @@ void main() {
       final later = _baseTime.add(const Duration(hours: 24, seconds: 1));
       final loaded = await ReturnToStorage.loadComposer(
         serverId: 'a',
+        userId: u,
         roomId: 'r',
         now: later,
       );
@@ -126,12 +143,13 @@ void main() {
     test('load returns null and clears corrupted entry', () async {
       final prefs = await SharedPreferences.getInstance();
       await prefs.setString(
-        'soliplex_return_to:composer:a:r',
+        encodeKey('soliplex_return_to:composer', ['a', u, 'r']),
         '{not valid json',
       );
 
       final loaded = await ReturnToStorage.loadComposer(
         serverId: 'a',
+        userId: u,
         roomId: 'r',
       );
       expect(loaded, isNull);
@@ -141,13 +159,16 @@ void main() {
     test('clearComposer removes a stored entry', () async {
       await ReturnToStorage.saveComposer(
         serverId: 'a',
+        userId: u,
         roomId: 'r',
         unsentText: 'draft',
       );
-      await ReturnToStorage.clearComposer(serverId: 'a', roomId: 'r');
+      await ReturnToStorage.clearComposer(
+          serverId: 'a', userId: u, roomId: 'r');
 
       expect(
-        await ReturnToStorage.loadComposer(serverId: 'a', roomId: 'r'),
+        await ReturnToStorage.loadComposer(
+            serverId: 'a', userId: u, roomId: 'r'),
         isNull,
       );
     });
@@ -155,18 +176,21 @@ void main() {
     test('clearServer removes every room draft for that server only', () async {
       await ReturnToStorage.saveComposer(
         serverId: 'a',
+        userId: u,
         roomId: 'r1',
         unsentText: 'A/r1',
         now: _baseTime,
       );
       await ReturnToStorage.saveComposer(
         serverId: 'a',
+        userId: u,
         roomId: 'r2',
         unsentText: 'A/r2',
         now: _baseTime,
       );
       await ReturnToStorage.saveComposer(
         serverId: 'b',
+        userId: u,
         roomId: 'r1',
         unsentText: 'B/r1',
         now: _baseTime,
@@ -177,6 +201,7 @@ void main() {
       expect(
         await ReturnToStorage.loadComposer(
           serverId: 'a',
+          userId: u,
           roomId: 'r1',
           now: _baseTime,
         ),
@@ -185,6 +210,7 @@ void main() {
       expect(
         await ReturnToStorage.loadComposer(
           serverId: 'a',
+          userId: u,
           roomId: 'r2',
           now: _baseTime,
         ),
@@ -193,6 +219,7 @@ void main() {
       expect(
         await ReturnToStorage.loadComposer(
           serverId: 'b',
+          userId: u,
           roomId: 'r1',
           now: _baseTime,
         ),
@@ -200,67 +227,104 @@ void main() {
       );
     });
 
-    // The key joins ids with a `:`, so the trailing `:` on the prefix keeps a
-    // clear from reaching an id that merely shares a leading substring but not a
-    // whole `:`-delimited segment (`a` vs `ab`).
-    test('clearServer keeps drafts of an id sharing only a non-boundary prefix',
+    const s = 'https://foo.com', u1 = 'iss#alice', u2 = 'iss#bob', r = 'r1';
+
+    test('a draft saved as one user is not visible to another (isolation)',
         () async {
       await ReturnToStorage.saveComposer(
-        serverId: 'a',
-        roomId: 'r',
-        unsentText: 'A/r',
-        now: _baseTime,
-      );
-      await ReturnToStorage.saveComposer(
-        serverId: 'ab',
-        roomId: 'r',
-        unsentText: 'AB/r',
-        now: _baseTime,
-      );
-
-      await ReturnToStorage.clearServer('a');
-
+          serverId: s, userId: u1, roomId: r, unsentText: 'hi from alice');
       expect(
-        await ReturnToStorage.loadComposer(
-          serverId: 'ab',
-          roomId: 'r',
-          now: _baseTime,
-        ),
-        'AB/r',
-      );
+          await ReturnToStorage.loadComposer(
+              serverId: s, userId: u2, roomId: r),
+          isNull);
+      expect(
+          await ReturnToStorage.loadComposer(
+              serverId: s, userId: u1, roomId: r),
+          'hi from alice');
     });
 
-    // Characterizes a known, accepted over-sweep (issue #393): a server id is a
-    // `Uri.origin`, which omits the default port, so a portless origin is a full
-    // prefix of the same host with an explicit port. Clearing the portless
-    // origin therefore also sweeps the explicit-port sibling's drafts. This
-    // pins the current behavior so the keyed-store fix is a deliberate,
-    // test-breaking change rather than a silent one.
-    test('clearServer over-sweeps a portless origin onto its port sibling',
+    test('null userId no-ops save and returns null on load', () async {
+      await ReturnToStorage.saveComposer(
+          serverId: s, userId: null, roomId: r, unsentText: 'x');
+      expect(
+          await ReturnToStorage.loadComposer(
+              serverId: s, userId: u1, roomId: r),
+          isNull);
+      expect(
+          await ReturnToStorage.loadComposer(
+              serverId: s, userId: null, roomId: r),
+          isNull);
+    });
+
+    test('clearServer removes every user\'s draft for the server', () async {
+      await ReturnToStorage.saveComposer(
+          serverId: s, userId: u1, roomId: r, unsentText: 'a');
+      await ReturnToStorage.saveComposer(
+          serverId: s, userId: u2, roomId: r, unsentText: 'b');
+      await ReturnToStorage.clearServer(s);
+      expect(
+          await ReturnToStorage.loadComposer(
+              serverId: s, userId: u1, roomId: r),
+          isNull);
+      expect(
+          await ReturnToStorage.loadComposer(
+              serverId: s, userId: u2, roomId: r),
+          isNull);
+    });
+
+    test('clearServer does not touch a same-host different-port server',
+        () async {
+      const s2 = 'https://foo.com:8443';
+      await ReturnToStorage.saveComposer(
+          serverId: s, userId: u1, roomId: r, unsentText: 'a');
+      await ReturnToStorage.saveComposer(
+          serverId: s2, userId: u1, roomId: r, unsentText: 'b');
+      await ReturnToStorage.clearServer(s);
+      expect(
+          await ReturnToStorage.loadComposer(
+              serverId: s, userId: u1, roomId: r),
+          isNull);
+      expect(
+          await ReturnToStorage.loadComposer(
+              serverId: s2, userId: u1, roomId: r),
+          'b');
+    });
+
+    test('clearRoom removes every user\'s draft for that room, keeps siblings',
         () async {
       await ReturnToStorage.saveComposer(
-        serverId: 'https://foo.com',
-        roomId: 'r',
-        unsentText: 'default port',
-        now: _baseTime,
-      );
+          serverId: s, userId: u1, roomId: r, unsentText: 'a');
       await ReturnToStorage.saveComposer(
-        serverId: 'https://foo.com:8443',
-        roomId: 'r',
-        unsentText: 'explicit port',
-        now: _baseTime,
-      );
-
-      await ReturnToStorage.clearServer('https://foo.com');
-
+          serverId: s, userId: u2, roomId: r, unsentText: 'b');
+      await ReturnToStorage.saveComposer(
+          serverId: s, userId: u1, roomId: 'r2', unsentText: 'c');
+      await ReturnToStorage.clearRoom(s, r);
       expect(
-        await ReturnToStorage.loadComposer(
-          serverId: 'https://foo.com:8443',
-          roomId: 'r',
-          now: _baseTime,
-        ),
-        isNull,
-      );
+          await ReturnToStorage.loadComposer(
+              serverId: s, userId: u1, roomId: r),
+          isNull);
+      expect(
+          await ReturnToStorage.loadComposer(
+              serverId: s, userId: u2, roomId: r),
+          isNull);
+      expect(
+          await ReturnToStorage.loadComposer(
+              serverId: s, userId: u1, roomId: 'r2'),
+          'c');
+    });
+
+    test(
+        'ignores a pre-userId (legacy) raw-key draft — abandoned, not migrated',
+        () async {
+      SharedPreferences.setMockInitialValues({
+        'soliplex_return_to:composer:$s:$r':
+            '{"unsentText":"legacy draft","createdAt":"2999-01-01T00:00:00Z"}',
+      });
+      // The legacy key is not read; a load under the user-scoped key misses.
+      expect(
+          await ReturnToStorage.loadComposer(
+              serverId: s, userId: u1, roomId: r),
+          isNull);
     });
   });
 }

--- a/test/modules/room/room_state_test.dart
+++ b/test/modules/room/room_state_test.dart
@@ -1,3 +1,5 @@
+import 'dart:convert';
+
 import 'package:flutter_test/flutter_test.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:soliplex_agent/soliplex_agent.dart';
@@ -63,6 +65,16 @@ class _StubRuntimeManager extends AgentRuntimeManager {
   AgentRuntime getRuntime(ServerConnection connection) => _runtime;
 }
 
+/// Builds a minimal unsigned JWT with `iss`/`sub` claims so
+/// [AuthSession.currentUserId] can decode a stable identity from it.
+String _jwt(String iss, String sub) {
+  String seg(Map<String, dynamic> m) =>
+      base64Url.encode(utf8.encode(jsonEncode(m))).replaceAll('=', '');
+  return '${seg({'alg': 'RS256'})}.${seg({'iss': iss, 'sub': sub})}.sig';
+}
+
+const _testUserId = 'iss-test#user';
+
 void _activate(AuthSession auth) {
   auth.login(
     provider: const OidcProvider(
@@ -70,7 +82,7 @@ void _activate(AuthSession auth) {
       clientId: 'test-client',
     ),
     tokens: AuthTokens(
-      accessToken: 'access',
+      accessToken: _jwt('iss-test', 'user'),
       refreshToken: 'refresh',
       expiresAt: DateTime.now().add(const Duration(hours: 1)),
     ),
@@ -924,6 +936,7 @@ void main() {
 
       final restored = await ReturnToStorage.loadComposer(
         serverId: 'test-server',
+        userId: _testUserId,
         roomId: 'room-1',
       );
       expect(

--- a/test/modules/room/thread_view_state_test.dart
+++ b/test/modules/room/thread_view_state_test.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+import 'dart:convert';
 
 import 'package:flutter_test/flutter_test.dart';
 import 'package:shared_preferences/shared_preferences.dart';
@@ -20,6 +21,16 @@ ServerConnection _fakeConnection(FakeSoliplexApi api) => ServerConnection(
       api: api,
       agUiStreamClient: FakeAgUiStreamClient(),
     );
+
+/// Builds a minimal unsigned JWT with `iss`/`sub` claims so
+/// [AuthSession.currentUserId] can decode a stable identity from it.
+String _jwt(String iss, String sub) {
+  String seg(Map<String, dynamic> m) =>
+      base64Url.encode(utf8.encode(jsonEncode(m))).replaceAll('=', '');
+  return '${seg({'alg': 'RS256'})}.${seg({'iss': iss, 'sub': sub})}.sig';
+}
+
+const _testUserId = 'iss-test#user';
 
 /// FakeSoliplexApi variant that holds getThreadHistory open until the
 /// test resolves it. Used to assert observable behavior on an in-flight
@@ -1140,6 +1151,17 @@ void main() {
         // to ReturnToStorage so the composer survives the route guard
         // redirect and reload.
         api.nextThreadHistory = ThreadHistory(messages: const []);
+        auth.login(
+          provider: const OidcProvider(
+            discoveryUrl: 'https://sso/.well-known/openid-configuration',
+            clientId: 'c',
+          ),
+          tokens: AuthTokens(
+            accessToken: _jwt('iss-test', 'user'),
+            refreshToken: 'r',
+            expiresAt: DateTime.now().add(const Duration(hours: 1)),
+          ),
+        );
 
         final state = ThreadViewState(
           connection: connection,
@@ -1159,6 +1181,7 @@ void main() {
 
         final restored = await ReturnToStorage.loadComposer(
           serverId: 'test-server',
+          userId: _testUserId,
           roomId: 'room-1',
         );
         expect(


### PR DESCRIPTION
Foundation for keyed, **user-scoped** device-local storage — the start of closing the shared-device cross-user leak by *partitioning* state per user instead of wiping it. Lands the substrate plus the first (highest-sensitivity) store cutover.

## What's here

- **Identity resolver** — `accessTokenIdentity` decodes a stable `iss#sub` from the access-token JWT (decode-only; no signature verification). `AuthSession.currentUserId` exposes it as a computed signal that resolves **both `ActiveSession` and `ExpiredSession`**, so a draft persisted on auth-expiry still attributes the user.
- **Key codec** — `encodeKey`/`decodeKey`/`serverKeyPrefix` build composite, percent-encoded SharedPreferences keys. Percent-encoding makes the `:` delimiter unambiguous and structurally **fixes the origin/port colon-collision** in by-server sweeps.
- **Composer drafts → per-user** — `ReturnToStorage` is now keyed by `(serverId, userId, roomId)`, so a different user on the same server no longer inherits the prior user's unsent draft. Adds `clearRoom` (all users); `clearServer` spans all users. Old key-less drafts are abandoned (swept on launch in a later change), not migrated.

## Scope / follow-ups

The identity resolver and key codec have no consumers beyond the drafts store yet — they're the shared base for the remaining store cutovers (thread / room / server read markers) and the cross-store cleanup, which land in follow-up PRs. So the cross-user leak is only *partially* closed here (drafts); read-state scoping follows.

## Testing

Full suite green; analyzer clean. New unit coverage for the decoder, the `currentUserId` signal (incl. the Expired-session case), the key codec (incl. the colon-collision fix), and draft user-isolation / `clearServer` / `clearRoom`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
