### PR TITLE
feat(room): scope thread read markers & anchors by user

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,11 @@ Versions follow the `version+build` scheme from `pubspec.yaml`, bumped via
   in on the same server no longer sees the previous user's unsent draft. A
   by-server draft clear also no longer over-reaches a same-host server that
   differs only by an explicit vs default port.
+- Thread read markers and unread-divider anchors are now scoped to the signed-in
+  user: a different user signing in on the same server no longer inherits the
+  previous user's read state or "New messages" dividers. As a one-time effect of
+  the storage-format change, existing thread read state resets on upgrade — every
+  thread reads as unread once and dividers are recomputed from that point.
 
 ## [0.92.0+65] - 2026-07-02
 

--- a/lib/src/core/keyed_storage.dart
+++ b/lib/src/core/keyed_storage.dart
@@ -24,3 +24,10 @@ List<String>? decodeKey(String prefix, String key) {
 /// first component: `'<prefix>:<enc(serverId)>:'`.
 String serverKeyPrefix(String prefix, String serverId) =>
     '$prefix:${Uri.encodeComponent(serverId)}:';
+
+/// The `userId` component used to bucket device-local state on a server that
+/// requires no sign-in, where there is no user identity. Real identities are
+/// `iss#sub` and always contain a `#`, so this `#`-free literal can never collide
+/// with one. State in this bucket is device-shared across everyone using that
+/// unauthenticated server — there is no identity to isolate it by.
+const unauthenticatedStorageUser = 'unauthenticated';

--- a/lib/src/modules/room/anchor_tracker.dart
+++ b/lib/src/modules/room/anchor_tracker.dart
@@ -2,7 +2,6 @@ import 'dart:async';
 
 import 'package:soliplex_logging/soliplex_logging.dart';
 
-import 'thread_anchor_storage.dart';
 import 'thread_read_markers.dart' show ThreadActivityKey;
 import 'unread_boundary.dart';
 
@@ -17,10 +16,10 @@ final Logger _logger = LogManager.instance.getLogger('soliplex.anchor_tracker');
 /// tested independently of the room screen.
 class AnchorTracker {
   AnchorTracker({
-    Future<Map<ThreadActivityKey, String>> Function()? load,
-    Future<void> Function(Map<ThreadActivityKey, String>)? save,
-  })  : _load = load ?? ThreadAnchorStorage.load,
-        _save = save ?? ThreadAnchorStorage.save;
+    required Future<Map<ThreadActivityKey, String>> Function() load,
+    required Future<void> Function(Map<ThreadActivityKey, String>) save,
+  })  : _load = load,
+        _save = save;
 
   final Future<Map<ThreadActivityKey, String>> Function() _load;
   final Future<void> Function(Map<ThreadActivityKey, String>) _save;

--- a/lib/src/modules/room/thread_anchor_storage.dart
+++ b/lib/src/modules/room/thread_anchor_storage.dart
@@ -3,7 +3,7 @@ import 'dart:convert';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:soliplex_logging/soliplex_logging.dart';
 
-import 'thread_read_markers.dart' show ThreadActivityKey;
+import '../../core/keyed_storage.dart';
 
 final Logger _logger =
     LogManager.instance.getLogger('soliplex.thread_anchor_storage');
@@ -12,100 +12,120 @@ final Logger _logger =
 /// "New messages" divider at the first unread message.
 ///
 /// The topological twin of [ThreadReadMarkerStorage]: that store keeps a
-/// timestamp for the unread dot (computed before history loads); this one
-/// keeps a message id for the in-thread line (computed after history loads).
-/// Separate stores because the two values have different mutation lifecycles.
-/// Device-local; stored as a JSON array of `{s, r, th, id}` objects so the
-/// ids needn't be escaped into a composite key.
+/// timestamp for the unread dot (computed before history loads); this one keeps a
+/// message id for the in-thread line (computed after history loads). Separate
+/// stores because the two values have different mutation lifecycles.
+///
+/// Backed by `shared_preferences`, grained to one blob per `(serverId, userId,
+/// roomId)` — the room screen reads one room at a time. The value is a JSON
+/// object `{threadId: messageId}`. Keyed via the shared codec so component
+/// separators are unambiguous.
 abstract final class ThreadAnchorStorage {
-  static const _key = 'soliplex_thread_unread_anchors';
+  static const _prefix = 'soliplex_thread_anchor';
 
-  // Row field names, shared by load and save so the read/write contract can't
-  // drift: a typo in one half alone would silently drop every row.
-  static const _fieldServer = 's';
-  static const _fieldRoom = 'r';
-  static const _fieldThread = 'th';
-  static const _fieldId = 'id';
+  static String _key(String serverId, String userId, String roomId) =>
+      encodeKey(_prefix, [serverId, userId, roomId]);
 
-  /// Returns the stored anchors, dropping corrupt rows. Throws on an
-  /// underlying storage I/O failure; callers must handle it.
-  static Future<Map<ThreadActivityKey, String>> load() async {
+  /// The anchors (threadId → last-read message id) for one room and user, or
+  /// empty when [userId] is null (signed out) or nothing is stored.
+  static Future<Map<String, String>> loadRoom({
+    required String serverId,
+    required String? userId,
+    required String roomId,
+  }) async {
+    if (userId == null) return {};
     final prefs = await SharedPreferences.getInstance();
-    final raw = prefs.getString(_key);
+    final raw = prefs.getString(_key(serverId, userId, roomId));
     if (raw == null || raw.isEmpty) return {};
 
-    final result = <ThreadActivityKey, String>{};
+    final result = <String, String>{};
     try {
       final decoded = jsonDecode(raw);
-      if (decoded is! List) {
-        _logger.warning('Discarding corrupt thread anchors (not a JSON array)');
+      if (decoded is! Map) {
+        _logger
+            .warning('Discarding corrupt thread anchors (not a JSON object)');
         return {};
       }
       var skipped = 0;
-      for (final entry in decoded) {
-        if (entry is! Map) {
+      decoded.forEach((key, value) {
+        if (key is! String || value is! String) {
           skipped++;
-          continue;
+          return;
         }
-        final s = entry[_fieldServer];
-        final r = entry[_fieldRoom];
-        final th = entry[_fieldThread];
-        final id = entry[_fieldId];
-        if (s is! String || r is! String || th is! String || id is! String) {
-          skipped++;
-          continue;
-        }
-        result[(serverId: s, roomId: r, threadId: th)] = id;
-      }
-      // Every row dropped on a non-empty payload is a systemic serialization
-      // break, not one stale row, and it silently resets the read model. Surface
-      // it loudly.
+        result[key] = value;
+      });
       if (skipped > 0 && result.isEmpty) {
+        // Every entry dropped on a non-empty payload is a systemic
+        // serialization break, not one stale row, and it silently resets this
+        // room's dividers. Surface it loudly.
         _logger.error('Discarding all $skipped thread anchors; none parsed');
       } else if (skipped > 0) {
         _logger.warning('Skipped $skipped malformed thread anchor(s)');
       }
     } on FormatException catch (e, st) {
-      // Corrupt payload: start fresh rather than wedging the room.
-      _logger.warning(
-        'Discarding corrupt thread anchors',
-        error: e,
-        stackTrace: st,
-      );
+      _logger.warning('Discarding corrupt thread anchors',
+          error: e, stackTrace: st);
       return {};
     }
     return result;
   }
 
-  /// Throws on an underlying storage I/O failure; callers must handle it.
-  static Future<void> save(Map<ThreadActivityKey, String> anchors) async {
+  /// Persists [anchors] (threadId → message id) as the whole blob for the room.
+  /// No-op when [userId] is null.
+  static Future<void> saveRoom({
+    required String serverId,
+    required String? userId,
+    required String roomId,
+    required Map<String, String> anchors,
+  }) async {
+    if (userId == null) return;
     final prefs = await SharedPreferences.getInstance();
-    final list = [
-      for (final entry in anchors.entries)
-        {
-          _fieldServer: entry.key.serverId,
-          _fieldRoom: entry.key.roomId,
-          _fieldThread: entry.key.threadId,
-          _fieldId: entry.value,
-        },
-    ];
-    await prefs.setString(_key, jsonEncode(list));
+    await prefs.setString(_key(serverId, userId, roomId), jsonEncode(anchors));
   }
 
-  /// Drops every anchor for [serverId], so a removed server's threads don't
-  /// restore a stale "New messages" divider if the server is re-added under the
-  /// same id. No-op (and no write) when the server has no anchors.
-  ///
-  /// Propagates I/O failures from [load]/[save] to the caller (like the thread
-  /// read-marker store); callers run it fire-and-forget and log. A failed [save]
-  /// leaves stale anchors on disk — accepted because an anchor only positions a
-  /// divider (it never floors unread state), so a surviving stale anchor is a
-  /// cosmetic misplacement, not a correctness break.
+  /// Drops every user's anchors for [serverId] (keyed format). Legacy pre-keyed
+  /// anchors are swept once by the first-launch migration (PR 6), not here.
   static Future<void> clearServer(String serverId) async {
-    final anchors = await load();
-    final next = {...anchors}
-      ..removeWhere((key, _) => key.serverId == serverId);
-    if (next.length == anchors.length) return;
-    await save(next);
+    final prefs = await SharedPreferences.getInstance();
+    final sweep = serverKeyPrefix(_prefix, serverId);
+    for (final k
+        in prefs.getKeys().where((k) => k.startsWith(sweep)).toList()) {
+      await prefs.remove(k);
+    }
   }
+
+  /// Drops every user's anchors for [roomId] on [serverId].
+  static Future<void> clearRoom(String serverId, String roomId) async {
+    final prefs = await SharedPreferences.getInstance();
+    for (final k in _roomKeys(prefs, serverId, roomId)) {
+      await prefs.remove(k);
+    }
+  }
+
+  /// Removes [threadId]'s anchor from every user's blob for [roomId] on
+  /// [serverId], leaving sibling threads intact.
+  static Future<void> clearThread(
+      String serverId, String roomId, String threadId) async {
+    final prefs = await SharedPreferences.getInstance();
+    for (final k in _roomKeys(prefs, serverId, roomId)) {
+      final raw = prefs.getString(k);
+      if (raw == null || raw.isEmpty) continue;
+      try {
+        final decoded = jsonDecode(raw);
+        if (decoded is! Map || !decoded.containsKey(threadId)) continue;
+        decoded.remove(threadId);
+        await prefs.setString(k, jsonEncode(decoded));
+      } on FormatException {
+        continue;
+      }
+    }
+  }
+
+  /// Every stored key (any user) for [roomId] on [serverId].
+  static List<String> _roomKeys(
+          SharedPreferences prefs, String serverId, String roomId) =>
+      prefs.getKeys().where((k) {
+        final c = decodeKey(_prefix, k);
+        return c != null && c.length == 3 && c[0] == serverId && c[2] == roomId;
+      }).toList();
 }

--- a/lib/src/modules/room/thread_anchor_storage.dart
+++ b/lib/src/modules/room/thread_anchor_storage.dart
@@ -27,15 +27,16 @@ abstract final class ThreadAnchorStorage {
       encodeKey(_prefix, [serverId, userId, roomId]);
 
   /// The anchors (threadId → last-read message id) for one room and user, or
-  /// empty when [userId] is null (signed out) or nothing is stored.
+  /// empty when nothing is stored. A null [userId] (a server requiring no
+  /// sign-in) resolves to the shared [unauthenticatedStorageUser] bucket.
   static Future<Map<String, String>> loadRoom({
     required String serverId,
     required String? userId,
     required String roomId,
   }) async {
-    if (userId == null) return {};
     final prefs = await SharedPreferences.getInstance();
-    final raw = prefs.getString(_key(serverId, userId, roomId));
+    final raw = prefs.getString(
+        _key(serverId, userId ?? unauthenticatedStorageUser, roomId));
     if (raw == null || raw.isEmpty) return {};
 
     final result = <String, String>{};
@@ -70,17 +71,19 @@ abstract final class ThreadAnchorStorage {
     return result;
   }
 
-  /// Persists [anchors] (threadId → message id) as the whole blob for the room.
-  /// No-op when [userId] is null.
+  /// Persists [anchors] (threadId → message id) as the whole blob for the room. A
+  /// null [userId] (a server requiring no sign-in) resolves to the shared
+  /// [unauthenticatedStorageUser] bucket.
   static Future<void> saveRoom({
     required String serverId,
     required String? userId,
     required String roomId,
     required Map<String, String> anchors,
   }) async {
-    if (userId == null) return;
     final prefs = await SharedPreferences.getInstance();
-    await prefs.setString(_key(serverId, userId, roomId), jsonEncode(anchors));
+    await prefs.setString(
+        _key(serverId, userId ?? unauthenticatedStorageUser, roomId),
+        jsonEncode(anchors));
   }
 
   /// Drops every user's anchors for [serverId] (keyed format). Legacy pre-keyed

--- a/lib/src/modules/room/thread_anchor_storage.dart
+++ b/lib/src/modules/room/thread_anchor_storage.dart
@@ -86,8 +86,8 @@ abstract final class ThreadAnchorStorage {
         jsonEncode(anchors));
   }
 
-  /// Drops every user's anchors for [serverId] (keyed format). Legacy pre-keyed
-  /// anchors are swept once by the first-launch migration (PR 6), not here.
+  /// Drops every user's anchors for [serverId] (keyed format). Only keyed entries
+  /// are removed; any pre-keyed entry under the old key name is left untouched.
   static Future<void> clearServer(String serverId) async {
     final prefs = await SharedPreferences.getInstance();
     final sweep = serverKeyPrefix(_prefix, serverId);

--- a/lib/src/modules/room/thread_read_markers.dart
+++ b/lib/src/modules/room/thread_read_markers.dart
@@ -101,9 +101,9 @@ abstract final class ThreadReadMarkerStorage {
         jsonEncode(obj));
   }
 
-  /// Drops every user's thread markers for [serverId] (keyed format). Legacy
-  /// pre-keyed markers are swept once by the first-launch migration (PR 6), not
-  /// here.
+  /// Drops every user's thread markers for [serverId] (keyed format). Only keyed
+  /// entries are removed; any pre-keyed entry under the old key name is left
+  /// untouched.
   static Future<void> clearServer(String serverId) async {
     final prefs = await SharedPreferences.getInstance();
     final sweep = serverKeyPrefix(_prefix, serverId);

--- a/lib/src/modules/room/thread_read_markers.dart
+++ b/lib/src/modules/room/thread_read_markers.dart
@@ -33,15 +33,16 @@ abstract final class ThreadReadMarkerStorage {
       encodeKey(_prefix, [serverId, userId, roomId]);
 
   /// The read markers (threadId → last-seen instant) for one room and user, or
-  /// empty when [userId] is null (signed out) or nothing is stored.
+  /// empty when nothing is stored. A null [userId] (a server requiring no
+  /// sign-in) resolves to the shared [unauthenticatedStorageUser] bucket.
   static Future<Map<String, DateTime>> loadRoom({
     required String serverId,
     required String? userId,
     required String roomId,
   }) async {
-    if (userId == null) return {};
     final prefs = await SharedPreferences.getInstance();
-    final raw = prefs.getString(_key(serverId, userId, roomId));
+    final raw = prefs.getString(
+        _key(serverId, userId ?? unauthenticatedStorageUser, roomId));
     if (raw == null || raw.isEmpty) return {};
 
     final result = <String, DateTime>{};
@@ -82,20 +83,22 @@ abstract final class ThreadReadMarkerStorage {
     return result;
   }
 
-  /// Persists [markers] (threadId → instant) as the whole blob for the room.
-  /// No-op when [userId] is null.
+  /// Persists [markers] (threadId → instant) as the whole blob for the room. A
+  /// null [userId] (a server requiring no sign-in) resolves to the shared
+  /// [unauthenticatedStorageUser] bucket.
   static Future<void> saveRoom({
     required String serverId,
     required String? userId,
     required String roomId,
     required Map<String, DateTime> markers,
   }) async {
-    if (userId == null) return;
     final prefs = await SharedPreferences.getInstance();
     final obj = {
       for (final e in markers.entries) e.key: e.value.toUtc().toIso8601String(),
     };
-    await prefs.setString(_key(serverId, userId, roomId), jsonEncode(obj));
+    await prefs.setString(
+        _key(serverId, userId ?? unauthenticatedStorageUser, roomId),
+        jsonEncode(obj));
   }
 
   /// Drops every user's thread markers for [serverId] (keyed format). Legacy

--- a/lib/src/modules/room/thread_read_markers.dart
+++ b/lib/src/modules/room/thread_read_markers.dart
@@ -3,6 +3,8 @@ import 'dart:convert';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:soliplex_logging/soliplex_logging.dart';
 
+import '../../core/keyed_storage.dart';
+
 final Logger _logger =
     LogManager.instance.getLogger('soliplex.thread_read_markers');
 
@@ -11,106 +13,135 @@ final Logger _logger =
 /// transposed at a lookup or insertion site.
 typedef ThreadActivityKey = ({String serverId, String roomId, String threadId});
 
-/// Persists per-thread "last seen" timestamps so the room can mark threads
-/// with newer activity as unread.
+/// Persists per-thread "last seen" timestamps so the room can mark threads with
+/// newer activity as unread.
 ///
-/// The thread-level twin of the lobby's room read model: a thread is unread
-/// when its last-message time is newer than the moment the user last opened
-/// it on this device. There is no server-side read state and no count — just
-/// a boolean affordance. Read markers are therefore per-device.
+/// The thread-level twin of the lobby's room read model: a thread is unread when
+/// its last-message time is newer than the moment the user last opened it on this
+/// device. There is no server-side read state and no count — just a boolean
+/// affordance, per device and per user.
 ///
-/// Backed by `shared_preferences` (non-sensitive UI state). Stored as a JSON
-/// array of `{s, r, th, t}` objects (server id, room id, thread id, ISO-8601
-/// UTC instant) so ids needn't be escaped into a composite key.
+/// Backed by `shared_preferences` (non-sensitive UI state), grained to one blob
+/// per `(serverId, userId, roomId)` — the room screen reads one room at a time,
+/// so the blob matches the read-unit. The value is a JSON object `{threadId:
+/// ISO-8601 UTC instant}`. Keyed via the shared codec so component separators are
+/// unambiguous.
 abstract final class ThreadReadMarkerStorage {
-  static const _key = 'soliplex_thread_read_markers';
+  static const _prefix = 'soliplex_thread_read_marker';
 
-  static Future<Map<ThreadActivityKey, DateTime>> load() async {
+  static String _key(String serverId, String userId, String roomId) =>
+      encodeKey(_prefix, [serverId, userId, roomId]);
+
+  /// The read markers (threadId → last-seen instant) for one room and user, or
+  /// empty when [userId] is null (signed out) or nothing is stored.
+  static Future<Map<String, DateTime>> loadRoom({
+    required String serverId,
+    required String? userId,
+    required String roomId,
+  }) async {
+    if (userId == null) return {};
     final prefs = await SharedPreferences.getInstance();
-    final raw = prefs.getString(_key);
+    final raw = prefs.getString(_key(serverId, userId, roomId));
     if (raw == null || raw.isEmpty) return {};
 
-    final result = <ThreadActivityKey, DateTime>{};
+    final result = <String, DateTime>{};
     try {
       final decoded = jsonDecode(raw);
-      if (decoded is! List) {
+      if (decoded is! Map) {
         _logger.warning(
-            'Discarding corrupt thread read markers (not a JSON array)');
+            'Discarding corrupt thread read markers (not a JSON object)');
         return {};
       }
       var skipped = 0;
-      for (final entry in decoded) {
-        if (entry is! Map) {
+      decoded.forEach((key, value) {
+        if (key is! String || value is! String) {
           skipped++;
-          continue;
+          return;
         }
-        final s = entry['s'];
-        final r = entry['r'];
-        final th = entry['th'];
-        final t = entry['t'];
-        if (s is! String || r is! String || th is! String || t is! String) {
-          skipped++;
-          continue;
-        }
-        final at = DateTime.tryParse(t);
+        final at = DateTime.tryParse(value);
         if (at == null) {
           skipped++;
-          continue;
+          return;
         }
-        result[(serverId: s, roomId: r, threadId: th)] = at.toUtc();
-      }
+        result[key] = at.toUtc();
+      });
       if (skipped > 0 && result.isEmpty) {
-        // Every row dropped on a non-empty payload is a systemic serialization
-        // break, not one stale row, and it silently resets the read model
-        // (every thread flips to unread). Surface it loudly.
+        // Every entry dropped on a non-empty payload is a systemic
+        // serialization break, not one stale row, and it silently resets this
+        // room's read model. Surface it loudly.
         _logger
             .error('Discarding all $skipped thread read markers; none parsed');
       } else if (skipped > 0) {
         _logger.warning('Skipped $skipped malformed thread read marker(s)');
       }
     } on FormatException catch (e, st) {
-      // Corrupt payload: start fresh rather than wedging the room.
-      _logger.warning(
-        'Discarding corrupt thread read markers',
-        error: e,
-        stackTrace: st,
-      );
+      _logger.warning('Discarding corrupt thread read markers',
+          error: e, stackTrace: st);
       return {};
     }
     return result;
   }
 
-  static Future<void> save(Map<ThreadActivityKey, DateTime> markers) async {
+  /// Persists [markers] (threadId → instant) as the whole blob for the room.
+  /// No-op when [userId] is null.
+  static Future<void> saveRoom({
+    required String serverId,
+    required String? userId,
+    required String roomId,
+    required Map<String, DateTime> markers,
+  }) async {
+    if (userId == null) return;
     final prefs = await SharedPreferences.getInstance();
-    final list = [
-      for (final entry in markers.entries)
-        {
-          's': entry.key.serverId,
-          'r': entry.key.roomId,
-          'th': entry.key.threadId,
-          't': entry.value.toUtc().toIso8601String(),
-        },
-    ];
-    await prefs.setString(_key, jsonEncode(list));
+    final obj = {
+      for (final e in markers.entries) e.key: e.value.toUtc().toIso8601String(),
+    };
+    await prefs.setString(_key(serverId, userId, roomId), jsonEncode(obj));
   }
 
-  /// Drops every thread marker for [serverId], so a removed server's threads
-  /// don't read as read if the server is re-added under the same id. No-op (and
-  /// no write) when the server has no markers.
-  ///
-  /// Fire-and-forget with no retry: unlike the signal-backed room/server
-  /// stores, this has no in-memory owner to re-save a corrected map, so a
-  /// failed [save] leaves stale thread floors on disk (a re-added same-id
-  /// server reads as already-read). Accepted because a re-add after a write
-  /// failure is rare and the caller logs the failure at error level. A live
-  /// RoomScreen's marker flush, which persists its full cross-server map, can
-  /// likewise overwrite this clear — reachable only if lobby and room are ever
-  /// mounted at once, which the current navigation never does.
+  /// Drops every user's thread markers for [serverId] (keyed format). Legacy
+  /// pre-keyed markers are swept once by the first-launch migration (PR 6), not
+  /// here.
   static Future<void> clearServer(String serverId) async {
-    final markers = await load();
-    final next = {...markers}
-      ..removeWhere((key, _) => key.serverId == serverId);
-    if (next.length == markers.length) return;
-    await save(next);
+    final prefs = await SharedPreferences.getInstance();
+    final sweep = serverKeyPrefix(_prefix, serverId);
+    for (final k
+        in prefs.getKeys().where((k) => k.startsWith(sweep)).toList()) {
+      await prefs.remove(k);
+    }
   }
+
+  /// Drops every user's thread markers for [roomId] on [serverId].
+  static Future<void> clearRoom(String serverId, String roomId) async {
+    final prefs = await SharedPreferences.getInstance();
+    for (final k in _roomKeys(prefs, serverId, roomId)) {
+      await prefs.remove(k);
+    }
+  }
+
+  /// Removes [threadId]'s marker from every user's blob for [roomId] on
+  /// [serverId], leaving sibling threads intact.
+  static Future<void> clearThread(
+      String serverId, String roomId, String threadId) async {
+    final prefs = await SharedPreferences.getInstance();
+    for (final k in _roomKeys(prefs, serverId, roomId)) {
+      final raw = prefs.getString(k);
+      if (raw == null || raw.isEmpty) continue;
+      try {
+        final decoded = jsonDecode(raw);
+        if (decoded is! Map || !decoded.containsKey(threadId)) continue;
+        decoded.remove(threadId);
+        await prefs.setString(k, jsonEncode(decoded));
+      } on FormatException {
+        continue;
+      }
+    }
+  }
+
+  /// Every stored key (any user) for [roomId] on [serverId].
+  static List<String> _roomKeys(
+          SharedPreferences prefs, String serverId, String roomId) =>
+      prefs.getKeys().where((k) {
+        final c = decodeKey(_prefix, k);
+        return c != null && c.length == 3 && c[0] == serverId && c[2] == roomId;
+      }).toList();
 }

--- a/lib/src/modules/room/thread_read_tracker.dart
+++ b/lib/src/modules/room/thread_read_tracker.dart
@@ -1,0 +1,149 @@
+import 'dart:async';
+
+import 'package:soliplex_logging/soliplex_logging.dart';
+
+import 'thread_read_markers.dart' show ThreadActivityKey;
+
+final Logger _logger =
+    LogManager.instance.getLogger('soliplex.thread_read_tracker');
+
+/// Owns the current room's per-thread "last seen" read markers: loads them,
+/// stamps a thread read, and persists the room's blob.
+///
+/// The topological twin of [AnchorTracker] for the read-dot store — same
+/// load/merge/flush lifecycle, minus the divider concept (no frozen boundary).
+/// One instance per room, recreated on room change (like the anchor tracker), so
+/// its coordinates are captured at construction and never shift under an
+/// in-flight write when the widget advances to a new room.
+class ThreadReadTracker {
+  ThreadReadTracker({
+    required Future<Map<ThreadActivityKey, DateTime>> Function() load,
+    required Future<void> Function(Map<ThreadActivityKey, DateTime>) save,
+  })  : _load = load,
+        _save = save;
+
+  final Future<Map<ThreadActivityKey, DateTime>> Function() _load;
+  final Future<void> Function(Map<ThreadActivityKey, DateTime>) _save;
+
+  /// Escalates persistence logging from warning to error once this many
+  /// consecutive writes have failed, so a systemic storage break (disk full,
+  /// platform channel down) surfaces instead of degrading silently.
+  static const _failureEscalationThreshold = 3;
+
+  Map<ThreadActivityKey, DateTime> _markers = const {};
+  _LoadState _loadState = _LoadState.pending;
+
+  /// Whether [_markers] holds a change not yet written to disk. Survives a failed
+  /// write so the pending change is retried on the next flush instead of lost.
+  bool _dirty = false;
+
+  /// Guards [_flush] so only one write is ever in flight: overlapping saves
+  /// against the shared [_markers] map could otherwise persist a stale snapshot
+  /// after a newer one.
+  bool _flushing = false;
+
+  int _consecutiveFailures = 0;
+
+  /// The current in-memory markers, for the room-read rollup queries. All keys
+  /// share this tracker's captured (serverId, roomId).
+  Map<ThreadActivityKey, DateTime> get markers => _markers;
+
+  /// Loads markers from storage, merging UNDER any value stamped in-memory before
+  /// the load completed (so a pre-load stamp isn't dropped and the other threads'
+  /// markers are preserved). Flushes the merged map if a pre-load stamp left it
+  /// dirty.
+  ///
+  /// On a load failure persistence stays disabled: we read nothing, so writing
+  /// the partial in-memory map would clobber the threads we never read.
+  Future<void> loadFromDisk() async {
+    final Map<ThreadActivityKey, DateTime> loaded;
+    try {
+      loaded = await _load();
+    } catch (error, stackTrace) {
+      _logger.warning(
+        'Failed to load thread read markers',
+        error: error,
+        stackTrace: stackTrace,
+      );
+      // A pre-load stamp leaves [_dirty] true with no path to flush — intentional,
+      // not a lost write: writing it without the other threads' markers is the
+      // clobber we are avoiding.
+      _loadState = _LoadState.failed;
+      return;
+    }
+    _markers = {...loaded, ..._markers};
+    _loadState = _LoadState.loaded;
+    // A stamp before the load completed left us dirty; flush the merged map now
+    // so it is written without dropping the other threads.
+    if (_dirty) unawaited(_flush());
+  }
+
+  /// Stamps [key]'s read marker to [at]. Persists only once markers are loaded —
+  /// a partial map written earlier would clobber the other threads — and
+  /// re-flushes any change a prior write failed to persist.
+  void stamp(ThreadActivityKey key, DateTime at) {
+    if (_markers[key] == at) return;
+    _markers = {..._markers, key: at};
+    _dirty = true;
+    // Until the disk load completes, [loadFromDisk]'s flush owns persistence; a
+    // write here would clobber the threads we haven't read yet.
+    if (_loadState != _LoadState.loaded) return;
+    unawaited(_flush());
+  }
+
+  /// Writes [_markers] while any change is pending, one write at a time. Keeps
+  /// [_dirty] set on failure so the change is retried by the next flush rather
+  /// than lost, and escalates the log once failures persist.
+  Future<void> _flush() async {
+    if (_flushing) return;
+    _flushing = true;
+    try {
+      while (_dirty) {
+        _dirty = false;
+        final snapshot = Map.of(_markers);
+        try {
+          await _save(snapshot);
+          _consecutiveFailures = 0;
+        } catch (error, stackTrace) {
+          _dirty = true;
+          _consecutiveFailures++;
+          _logPersistFailure(error, stackTrace);
+          return;
+        }
+      }
+    } finally {
+      _flushing = false;
+    }
+  }
+
+  /// Best-effort persist of any pending stamp before the tracker is discarded, so
+  /// a write the retry loop was about to re-attempt survives a room change.
+  /// Callers fire this without awaiting (a [State.dispose] has no async gap).
+  /// Guarded to the loaded state: a pending or failed load must never write a
+  /// partial map, which would clobber the threads it never read. When a stamp
+  /// lands before the load resolves and the tracker is disposed mid-load, the
+  /// orphaned [loadFromDisk] still merges and flushes it.
+  Future<void> dispose() async {
+    if (_loadState == _LoadState.loaded && _dirty) await _flush();
+  }
+
+  void _logPersistFailure(Object error, StackTrace stackTrace) {
+    if (_consecutiveFailures >= _failureEscalationThreshold) {
+      _logger.error(
+        'Failed to persist thread read markers '
+        '($_consecutiveFailures consecutive failures; unread dots may be stale '
+        'until a write succeeds)',
+        error: error,
+        stackTrace: stackTrace,
+      );
+    } else {
+      _logger.warning(
+        'Failed to persist thread read markers',
+        error: error,
+        stackTrace: stackTrace,
+      );
+    }
+  }
+}
+
+enum _LoadState { pending, loaded, failed }

--- a/lib/src/modules/room/ui/room_screen.dart
+++ b/lib/src/modules/room/ui/room_screen.dart
@@ -888,18 +888,21 @@ class _RoomScreenState extends State<RoomScreen> {
       );
 
   ThreadReadTracker _createThreadReadTracker() {
-    // Capture the entry so the tracker's (serverId, userId) stay bound to the
-    // room it was created for: on a server switch the old tracker flushes after
-    // `widget` has advanced, and reading userId off `widget` then would misfile
-    // the old server's markers under the new server's user.
-    final serverEntry = widget.serverEntry;
-    final serverId = serverEntry.serverId;
+    // Capture all three coordinates at creation so the tracker stays bound to the
+    // room and user it was created for. Reading userId off the session at
+    // flush time would misfile markers: a server switch flushes the old tracker
+    // after `widget` has advanced, and a logout drops the session to NoSession
+    // (userId null) before the dispose flush — either would write the room's
+    // markers to the wrong bucket. The route guard guarantees a signed-in session
+    // before the room mounts, so userId is non-null here for auth-required servers.
+    final serverId = widget.serverEntry.serverId;
+    final userId = widget.serverEntry.auth.currentUserId.value;
     final roomId = widget.roomId;
     final tracker = ThreadReadTracker(
       load: () async {
         final markers = await ThreadReadMarkerStorage.loadRoom(
           serverId: serverId,
-          userId: serverEntry.auth.currentUserId.value,
+          userId: userId,
           roomId: roomId,
         );
         return {
@@ -909,7 +912,7 @@ class _RoomScreenState extends State<RoomScreen> {
       },
       save: (markers) => ThreadReadMarkerStorage.saveRoom(
         serverId: serverId,
-        userId: serverEntry.auth.currentUserId.value,
+        userId: userId,
         roomId: roomId,
         markers: {for (final e in markers.entries) e.key.threadId: e.value},
       ),
@@ -926,17 +929,17 @@ class _RoomScreenState extends State<RoomScreen> {
   }
 
   AnchorTracker _createAnchorTracker() {
-    // Capture the entry (see [_createThreadReadTracker]) so the anchor tracker's
-    // (serverId, userId) stay bound to the room it was created for across a
-    // server switch.
-    final serverEntry = widget.serverEntry;
-    final serverId = serverEntry.serverId;
+    // Capture all three coordinates at creation (see [_createThreadReadTracker])
+    // so the anchor tracker stays bound to the room and user it was created for
+    // across a server switch or a logout before its dispose flush.
+    final serverId = widget.serverEntry.serverId;
+    final userId = widget.serverEntry.auth.currentUserId.value;
     final roomId = widget.roomId;
     final tracker = AnchorTracker(
       load: () async {
         final anchors = await ThreadAnchorStorage.loadRoom(
           serverId: serverId,
-          userId: serverEntry.auth.currentUserId.value,
+          userId: userId,
           roomId: roomId,
         );
         return {
@@ -946,7 +949,7 @@ class _RoomScreenState extends State<RoomScreen> {
       },
       save: (anchors) => ThreadAnchorStorage.saveRoom(
         serverId: serverId,
-        userId: serverEntry.auth.currentUserId.value,
+        userId: userId,
         roomId: roomId,
         anchors: {for (final e in anchors.entries) e.key.threadId: e.value},
       ),

--- a/lib/src/modules/room/ui/room_screen.dart
+++ b/lib/src/modules/room/ui/room_screen.dart
@@ -31,7 +31,9 @@ import '../../lobby/lobby_read_markers.dart';
 import '../anchor_tracker.dart';
 import '../room_run_activity.dart';
 import '../room_unread.dart';
+import '../thread_anchor_storage.dart';
 import '../thread_read_markers.dart';
+import '../thread_read_tracker.dart';
 import '../unread_boundary.dart';
 import '../document_selections.dart';
 import '../pick_file.dart';
@@ -216,11 +218,12 @@ class _RoomScreenState extends State<RoomScreen> {
   /// checks read up to it, so a server marker suppresses their dots.
   late final ServerReadMarkers _serverReadMarkers;
 
-  /// Per-`(serverId, roomId, threadId)` "last seen" markers for threads,
-  /// device-local. A thread is unread when its [ThreadInfo.lastActivity] is
-  /// newer than its marker; opening a thread stamps "now". Distinct store from
-  /// the room markers (different granularity), but the same pattern.
-  Map<ThreadActivityKey, DateTime> _threadReadMarkers = const {};
+  /// Owns the current room's per-thread "last seen" read markers. Recreated on
+  /// room change (like [_anchorTracker]) so its captured coordinates never shift
+  /// under an in-flight write. A thread is unread when its
+  /// [ThreadInfo.lastActivity] is newer than its marker; opening a thread stamps
+  /// "now".
+  late ThreadReadTracker _threadReadTracker;
 
   /// Recreated on room change so a fresh room starts with no frozen boundary
   /// (the divider never carries over from the previous room) and a transient
@@ -259,13 +262,6 @@ class _RoomScreenState extends State<RoomScreen> {
   /// `/api/user_info` request can't be cancelled, so we guard the result
   /// against the latest generation instead.
   int _accountFetchGeneration = 0;
-
-  /// Whether [_threadReadMarkers] holds a change not yet written to disk.
-  /// Survives a failed write so the next stamp retries it instead of losing it.
-  bool _threadMarkersDirty = false;
-
-  /// Guards [_flushThreadReadMarkers] so only one write runs at a time.
-  bool _flushingThreadMarkers = false;
 
   bool get _filterEnabled => widget.enableDocumentFilter;
 
@@ -443,7 +439,7 @@ class _RoomScreenState extends State<RoomScreen> {
     if (status is! ThreadsLoaded) return;
     final stillUnread = unreadThreadIds(
       status.threads,
-      _threadReadMarkers,
+      _threadReadTracker.markers,
       serverId: serverId,
       roomId: roomId,
       selectedThreadId: leavingThreadId,
@@ -471,7 +467,7 @@ class _RoomScreenState extends State<RoomScreen> {
     // thread about to surface as unread.
     if (shouldMarkRoomRead(
       status.threads,
-      _threadReadMarkers,
+      _threadReadTracker.markers,
       serverId: widget.serverEntry.serverId,
       roomId: widget.roomId,
       roomSeen: _roomReadMarkers.value[key],
@@ -537,25 +533,6 @@ class _RoomScreenState extends State<RoomScreen> {
     return openRoomUnread ? {...ids, widget.roomId} : ids;
   }
 
-  /// Loads the thread read markers from disk, merging under any already set
-  /// in-memory (an early [_markThreadRead] on mount).
-  Future<void> _loadThreadReadMarkers() async {
-    try {
-      final loaded = await ThreadReadMarkerStorage.load();
-      if (!mounted) return;
-      setState(() => _threadReadMarkers = {...loaded, ..._threadReadMarkers});
-      // Markers just loaded; re-evaluate the room read state in case the thread
-      // list arrived before them.
-      _recomputeRoomRead();
-    } catch (error, stackTrace) {
-      _logger.warning(
-        'Failed to load thread read markers',
-        error: error,
-        stackTrace: stackTrace,
-      );
-    }
-  }
-
   /// Marks [threadId] on the current room as read as of now, clearing its
   /// unread dot. No-op when [threadId] is null (no thread open yet).
   void _markThreadRead(String? threadId) {
@@ -572,46 +549,9 @@ class _RoomScreenState extends State<RoomScreen> {
   /// callers that stamp before the room's thread list and coordinates line up
   /// pass false and let a later recompute on matching state do the rollup.
   void _stampThreadRead(ThreadActivityKey key, {bool recompute = true}) {
-    setState(() {
-      _threadReadMarkers = {..._threadReadMarkers, key: clock.now().toUtc()};
-    });
-    _persistThreadReadMarkers();
+    _threadReadTracker.stamp(key, clock.now().toUtc());
+    if (mounted) setState(() {});
     if (recompute) _recomputeRoomRead();
-  }
-
-  /// Serializes thread-read-marker writes so only one is ever in flight:
-  /// overlapping saves (rapid thread switches, or a switch immediately followed
-  /// by dispose) race on the shared store, and a stale snapshot could otherwise
-  /// land last and drop a just-stamped marker. Mirrors [AnchorTracker]'s flush.
-  void _persistThreadReadMarkers() {
-    _threadMarkersDirty = true;
-    unawaited(_flushThreadReadMarkers());
-  }
-
-  Future<void> _flushThreadReadMarkers() async {
-    if (_flushingThreadMarkers) return;
-    _flushingThreadMarkers = true;
-    try {
-      while (_threadMarkersDirty) {
-        _threadMarkersDirty = false;
-        try {
-          // Reads the latest map each pass; stamps replace [_threadReadMarkers]
-          // rather than mutating it, so the newest snapshot always wins.
-          await ThreadReadMarkerStorage.save(_threadReadMarkers);
-        } catch (error, stackTrace) {
-          // Keep the change pending so the next stamp retries it.
-          _threadMarkersDirty = true;
-          _logger.warning(
-            'Failed to persist thread read markers',
-            error: error,
-            stackTrace: stackTrace,
-          );
-          return;
-        }
-      }
-    } finally {
-      _flushingThreadMarkers = false;
-    }
   }
 
   /// Stamps the thread that was open before this update as read. Activity that
@@ -670,7 +610,7 @@ class _RoomScreenState extends State<RoomScreen> {
     final serverId = widget.serverEntry.serverId;
     return unreadThreadIds(
       status.threads,
-      _threadReadMarkers,
+      _threadReadTracker.markers,
       serverId: serverId,
       roomId: widget.roomId,
       selectedThreadId: selectedThreadId,
@@ -790,7 +730,7 @@ class _RoomScreenState extends State<RoomScreen> {
     _fetchRoomActivity();
     unawaited(_loadRoomReadMarkers());
     unawaited(_loadServerReadMarkers());
-    unawaited(_loadThreadReadMarkers());
+    _threadReadTracker = _createThreadReadTracker();
     _anchorTracker = _createAnchorTracker();
     // Keep the room's unread dot derived from its threads: watch the thread
     // list and mark the room read only once no thread is unread.
@@ -871,10 +811,12 @@ class _RoomScreenState extends State<RoomScreen> {
       _anchorAdvanceUnsub = null;
       _state.dispose();
       unawaited(_anchorTracker.dispose());
+      unawaited(_threadReadTracker.dispose());
       _chatController.clear();
       _state = _createRoomState();
       _workdirs = _createWorkdirController();
       _anchorTracker = _createAnchorTracker();
+      _threadReadTracker = _createThreadReadTracker();
       _hasFilterableDocuments = false;
       _filterDocsLoadFailed = false;
       _refreshFilterableDocuments();
@@ -945,8 +887,70 @@ class _RoomScreenState extends State<RoomScreen> {
         roomId: widget.roomId,
       );
 
+  ThreadReadTracker _createThreadReadTracker() {
+    // Capture the entry so the tracker's (serverId, userId) stay bound to the
+    // room it was created for: on a server switch the old tracker flushes after
+    // `widget` has advanced, and reading userId off `widget` then would misfile
+    // the old server's markers under the new server's user.
+    final serverEntry = widget.serverEntry;
+    final serverId = serverEntry.serverId;
+    final roomId = widget.roomId;
+    final tracker = ThreadReadTracker(
+      load: () async {
+        final markers = await ThreadReadMarkerStorage.loadRoom(
+          serverId: serverId,
+          userId: serverEntry.auth.currentUserId.value,
+          roomId: roomId,
+        );
+        return {
+          for (final e in markers.entries)
+            (serverId: serverId, roomId: roomId, threadId: e.key): e.value,
+        };
+      },
+      save: (markers) => ThreadReadMarkerStorage.saveRoom(
+        serverId: serverId,
+        userId: serverEntry.auth.currentUserId.value,
+        roomId: roomId,
+        markers: {for (final e in markers.entries) e.key.threadId: e.value},
+      ),
+    );
+    unawaited(tracker.loadFromDisk().then((_) {
+      // Markers just loaded; re-evaluate the room read state in case the thread
+      // list arrived before them.
+      if (mounted) {
+        setState(() {});
+        _recomputeRoomRead();
+      }
+    }));
+    return tracker;
+  }
+
   AnchorTracker _createAnchorTracker() {
-    final tracker = AnchorTracker();
+    // Capture the entry (see [_createThreadReadTracker]) so the anchor tracker's
+    // (serverId, userId) stay bound to the room it was created for across a
+    // server switch.
+    final serverEntry = widget.serverEntry;
+    final serverId = serverEntry.serverId;
+    final roomId = widget.roomId;
+    final tracker = AnchorTracker(
+      load: () async {
+        final anchors = await ThreadAnchorStorage.loadRoom(
+          serverId: serverId,
+          userId: serverEntry.auth.currentUserId.value,
+          roomId: roomId,
+        );
+        return {
+          for (final e in anchors.entries)
+            (serverId: serverId, roomId: roomId, threadId: e.key): e.value,
+        };
+      },
+      save: (anchors) => ThreadAnchorStorage.saveRoom(
+        serverId: serverId,
+        userId: serverEntry.auth.currentUserId.value,
+        roomId: roomId,
+        anchors: {for (final e in anchors.entries) e.key.threadId: e.value},
+      ),
+    );
     unawaited(tracker.loadFromDisk().then((_) {
       if (mounted) setState(() {});
     }));
@@ -979,15 +983,14 @@ class _RoomScreenState extends State<RoomScreen> {
     // unread dot when they return. Save-only — no setState while disposing.
     final threadId = widget.threadId;
     if (threadId != null) {
-      _threadReadMarkers = {
-        ..._threadReadMarkers,
+      _threadReadTracker.stamp(
         (
           serverId: widget.serverEntry.serverId,
           roomId: widget.roomId,
           threadId: threadId,
-        ): clock.now().toUtc(),
-      };
-      _persistThreadReadMarkers();
+        ),
+        clock.now().toUtc(),
+      );
     }
     // Bring the room-level marker up to now too, so the lobby reflects that the
     // user caught up here. Reads _state before it is disposed below.
@@ -1007,6 +1010,7 @@ class _RoomScreenState extends State<RoomScreen> {
     HardwareKeyboard.instance.removeHandler(_handleKey);
     _state.dispose();
     unawaited(_anchorTracker.dispose());
+    unawaited(_threadReadTracker.dispose());
     _chatController.dispose();
     _chatFocusNode.dispose();
     super.dispose();

--- a/test/core/removed_server_cleanup_test.dart
+++ b/test/core/removed_server_cleanup_test.dart
@@ -57,10 +57,10 @@ void main() {
       wired.server.markRead('s2', at);
       wired.room.markRead((serverId: 's1', roomId: 'r'), at);
       wired.room.markRead((serverId: 's2', roomId: 'r'), at);
-      await ThreadReadMarkerStorage.save({
-        (serverId: 's1', roomId: 'r', threadId: 't'): at,
-        (serverId: 's2', roomId: 'r', threadId: 't'): at,
-      });
+      await ThreadReadMarkerStorage.saveRoom(
+          serverId: 's1', userId: 'u', roomId: 'r', markers: {'t': at});
+      await ThreadReadMarkerStorage.saveRoom(
+          serverId: 's2', userId: 'u', roomId: 'r', markers: {'t': at});
 
       wired.manager.removeServer('s1');
       await pumpEventQueue();
@@ -75,23 +75,24 @@ void main() {
         wired.room.value.containsKey((serverId: 's2', roomId: 'r')),
         isTrue,
       );
-      final threads = await ThreadReadMarkerStorage.load();
       expect(
-        threads.containsKey((serverId: 's1', roomId: 'r', threadId: 't')),
-        isFalse,
+        await ThreadReadMarkerStorage.loadRoom(
+            serverId: 's1', userId: 'u', roomId: 'r'),
+        isEmpty,
       );
       expect(
-        threads.containsKey((serverId: 's2', roomId: 'r', threadId: 't')),
-        isTrue,
+        await ThreadReadMarkerStorage.loadRoom(
+            serverId: 's2', userId: 'u', roomId: 'r'),
+        {'t': at},
       );
     });
 
     test('clears the removed server\'s thread anchors and drafts', () async {
       final wired = wire();
-      await ThreadAnchorStorage.save({
-        (serverId: 's1', roomId: 'r', threadId: 't'): 'm1',
-        (serverId: 's2', roomId: 'r', threadId: 't'): 'm2',
-      });
+      await ThreadAnchorStorage.saveRoom(
+          serverId: 's1', userId: 'u', roomId: 'r', anchors: {'t': 'm1'});
+      await ThreadAnchorStorage.saveRoom(
+          serverId: 's2', userId: 'u', roomId: 'r', anchors: {'t': 'm2'});
       await ReturnToStorage.saveComposer(
         serverId: 's1',
         userId: 'u',
@@ -108,14 +109,15 @@ void main() {
       wired.manager.removeServer('s1');
       await pumpEventQueue();
 
-      final anchors = await ThreadAnchorStorage.load();
       expect(
-        anchors.containsKey((serverId: 's1', roomId: 'r', threadId: 't')),
-        isFalse,
+        await ThreadAnchorStorage.loadRoom(
+            serverId: 's1', userId: 'u', roomId: 'r'),
+        isEmpty,
       );
       expect(
-        anchors.containsKey((serverId: 's2', roomId: 'r', threadId: 't')),
-        isTrue,
+        await ThreadAnchorStorage.loadRoom(
+            serverId: 's2', userId: 'u', roomId: 'r'),
+        {'t': 'm2'},
       );
       expect(
         await ReturnToStorage.loadComposer(

--- a/test/helpers/test_server_entry.dart
+++ b/test/helpers/test_server_entry.dart
@@ -1,3 +1,5 @@
+import 'dart:convert';
+
 import 'package:soliplex_agent/soliplex_agent.dart';
 import 'package:soliplex_frontend/src/modules/auth/auth_session.dart';
 import 'package:soliplex_frontend/src/modules/auth/auth_tokens.dart';
@@ -47,4 +49,41 @@ AuthSession authInActiveSession() {
     ),
   );
   return auth;
+}
+
+/// The `iss#sub` identity embedded in the access token of [authWithIdentity],
+/// i.e. the value its `currentUserId` resolves to — use it as the `userId` when
+/// asserting against user-scoped device-local storage.
+const testUserIdentity = 'https://idp.test#test-user';
+
+/// The identity (`iss#sub`) that [authWithIdentity] embeds for a given [sub],
+/// under the default `iss`. Use as the `userId` when asserting against
+/// user-scoped storage.
+String testIdentityFor(String sub) => 'https://idp.test#$sub';
+
+/// An [AuthSession] in [ActiveSession] whose access token is a decodable JWT
+/// carrying `iss#`[sub], so `currentUserId` resolves to a stable user and
+/// user-scoped stores (thread markers, anchors, drafts) actually persist. Pass a
+/// distinct [sub] to model a different user on another server.
+AuthSession authWithIdentity({String sub = 'test-user'}) {
+  final auth = AuthSession(refreshService: FakeTokenRefreshService());
+  auth.login(
+    provider: const OidcProvider(
+      discoveryUrl: 'https://auth.example.com/.well-known/openid-configuration',
+      clientId: 'test-client',
+    ),
+    tokens: AuthTokens(
+      accessToken: _jwt('https://idp.test', sub),
+      refreshToken: 'refresh',
+      expiresAt: DateTime.now().add(const Duration(hours: 1)),
+    ),
+  );
+  return auth;
+}
+
+/// Builds a JWT-shaped `header.payload.signature` string embedding [iss]/[sub].
+String _jwt(String iss, String sub) {
+  String seg(Map<String, dynamic> m) =>
+      base64Url.encode(utf8.encode(jsonEncode(m))).replaceAll('=', '');
+  return '${seg({'alg': 'RS256'})}.${seg({'iss': iss, 'sub': sub})}.sig';
 }

--- a/test/modules/room/thread_anchor_storage_test.dart
+++ b/test/modules/room/thread_anchor_storage_test.dart
@@ -39,16 +39,20 @@ void main() {
           isEmpty);
     });
 
-    test('null userId no-ops save and returns empty on load', () async {
+    test(
+        'null userId persists to the shared unauthenticated bucket, isolated '
+        'from real users', () async {
       await ThreadAnchorStorage.saveRoom(
           serverId: s, userId: null, roomId: r, anchors: {'th1': 'm1'});
-      expect(
-          await ThreadAnchorStorage.loadRoom(
-              serverId: s, userId: u1, roomId: r),
-          isEmpty);
+      // Persisted and re-readable under the unauthenticated (null) bucket.
       expect(
           await ThreadAnchorStorage.loadRoom(
               serverId: s, userId: null, roomId: r),
+          {'th1': 'm1'});
+      // A signed-in user does not see the unauthenticated bucket.
+      expect(
+          await ThreadAnchorStorage.loadRoom(
+              serverId: s, userId: u1, roomId: r),
           isEmpty);
     });
 

--- a/test/modules/room/thread_anchor_storage_test.dart
+++ b/test/modules/room/thread_anchor_storage_test.dart
@@ -6,73 +6,140 @@ void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
   setUp(() => SharedPreferences.setMockInitialValues({}));
 
+  const s = 'https://foo.com', u1 = 'iss#alice', u2 = 'iss#bob', r = 'r1';
+
   group('ThreadAnchorStorage', () {
-    test('defaults to empty when nothing is persisted', () async {
-      expect(await ThreadAnchorStorage.load(), isEmpty);
-    });
-
-    test('round-trips anchors', () async {
-      final anchors = {
-        (serverId: 'a', roomId: 'r1', threadId: 't1'): 'msg-1',
-        (serverId: 'b', roomId: 'r2', threadId: 't2'): 'msg-2',
-      };
-      await ThreadAnchorStorage.save(anchors);
-
-      final loaded = await ThreadAnchorStorage.load();
-      expect(loaded, hasLength(2));
-      expect(loaded[(serverId: 'a', roomId: 'r1', threadId: 't1')], 'msg-1');
-      expect(loaded[(serverId: 'b', roomId: 'r2', threadId: 't2')], 'msg-2');
+    test('round-trips a room\'s anchors per user', () async {
+      await ThreadAnchorStorage.saveRoom(
+          serverId: s, userId: u1, roomId: r, anchors: {'th1': 'm1'});
+      expect(
+          await ThreadAnchorStorage.loadRoom(
+              serverId: s, userId: u1, roomId: r),
+          {'th1': 'm1'});
     });
 
     test('preserves ids that would collide under a naive composite key',
         () async {
-      final anchors = {
-        (serverId: 'a:b', roomId: 'r/1', threadId: 't|2'): 'm',
-      };
-      await ThreadAnchorStorage.save(anchors);
-
-      final loaded = await ThreadAnchorStorage.load();
-      expect(loaded[(serverId: 'a:b', roomId: 'r/1', threadId: 't|2')], 'm');
+      const server = 'a:b', user = 'iss#u/1', room = 'r|2';
+      await ThreadAnchorStorage.saveRoom(
+          serverId: server, userId: user, roomId: room, anchors: {'t|3': 'm'});
+      expect(
+          await ThreadAnchorStorage.loadRoom(
+              serverId: server, userId: user, roomId: room),
+          {'t|3': 'm'});
     });
 
-    test('discards a corrupt (non-array) payload', () async {
-      SharedPreferences.setMockInitialValues({
-        'soliplex_thread_unread_anchors': '{"not":"an array"}',
-      });
-      expect(await ThreadAnchorStorage.load(), isEmpty);
-    });
-
-    test('skips malformed rows but keeps valid ones', () async {
-      SharedPreferences.setMockInitialValues({
-        'soliplex_thread_unread_anchors':
-            '[{"s":"a","r":"r1","th":"t1","id":"m1"},'
-                '{"s":"a","r":"r1"},'
-                '{"s":"a","r":"r1","th":"t2","id":123}]',
-      });
-      final loaded = await ThreadAnchorStorage.load();
-      expect(loaded, hasLength(1));
-      expect(loaded[(serverId: 'a', roomId: 'r1', threadId: 't1')], 'm1');
-    });
-
-    test('degrades to empty when every row of a non-empty payload is malformed',
+    test('anchors saved as one user are invisible to another (isolation)',
         () async {
-      SharedPreferences.setMockInitialValues({
-        'soliplex_thread_unread_anchors':
-            '[{"s":"a","r":"r1"},{"th":"t2","id":123}]',
-      });
-      expect(await ThreadAnchorStorage.load(), isEmpty);
+      await ThreadAnchorStorage.saveRoom(
+          serverId: s, userId: u1, roomId: r, anchors: {'th1': 'm1'});
+      expect(
+          await ThreadAnchorStorage.loadRoom(
+              serverId: s, userId: u2, roomId: r),
+          isEmpty);
     });
 
-    test('clearServer prunes only that server\'s anchors', () async {
-      await ThreadAnchorStorage.save({
-        (serverId: 's1', roomId: 'r', threadId: 't1'): 'm1',
-        (serverId: 's2', roomId: 'r', threadId: 't2'): 'm2',
+    test('null userId no-ops save and returns empty on load', () async {
+      await ThreadAnchorStorage.saveRoom(
+          serverId: s, userId: null, roomId: r, anchors: {'th1': 'm1'});
+      expect(
+          await ThreadAnchorStorage.loadRoom(
+              serverId: s, userId: u1, roomId: r),
+          isEmpty);
+      expect(
+          await ThreadAnchorStorage.loadRoom(
+              serverId: s, userId: null, roomId: r),
+          isEmpty);
+    });
+
+    test('clearServer removes every user, spares a different-port peer',
+        () async {
+      const s2 = 'https://foo.com:8443';
+      await ThreadAnchorStorage.saveRoom(
+          serverId: s, userId: u1, roomId: r, anchors: {'th1': 'm1'});
+      await ThreadAnchorStorage.saveRoom(
+          serverId: s, userId: u2, roomId: r, anchors: {'th1': 'm1'});
+      await ThreadAnchorStorage.saveRoom(
+          serverId: s2, userId: u1, roomId: r, anchors: {'th1': 'm1'});
+      await ThreadAnchorStorage.clearServer(s);
+      expect(
+          await ThreadAnchorStorage.loadRoom(
+              serverId: s, userId: u1, roomId: r),
+          isEmpty);
+      expect(
+          await ThreadAnchorStorage.loadRoom(
+              serverId: s, userId: u2, roomId: r),
+          isEmpty);
+      expect(
+          await ThreadAnchorStorage.loadRoom(
+              serverId: s2, userId: u1, roomId: r),
+          {'th1': 'm1'});
+    });
+
+    test('clearRoom removes every user for the room, keeps sibling rooms',
+        () async {
+      await ThreadAnchorStorage.saveRoom(
+          serverId: s, userId: u1, roomId: r, anchors: {'th1': 'm1'});
+      await ThreadAnchorStorage.saveRoom(
+          serverId: s, userId: u2, roomId: r, anchors: {'th1': 'm1'});
+      await ThreadAnchorStorage.saveRoom(
+          serverId: s, userId: u1, roomId: 'r2', anchors: {'th9': 'm9'});
+      await ThreadAnchorStorage.clearRoom(s, r);
+      expect(
+          await ThreadAnchorStorage.loadRoom(
+              serverId: s, userId: u1, roomId: r),
+          isEmpty);
+      expect(
+          await ThreadAnchorStorage.loadRoom(
+              serverId: s, userId: u2, roomId: r),
+          isEmpty);
+      expect(
+          await ThreadAnchorStorage.loadRoom(
+              serverId: s, userId: u1, roomId: 'r2'),
+          {'th9': 'm9'});
+    });
+
+    test('clearThread removes one thread across users, keeps siblings',
+        () async {
+      await ThreadAnchorStorage.saveRoom(
+          serverId: s,
+          userId: u1,
+          roomId: r,
+          anchors: {'th1': 'm1', 'th2': 'm2'});
+      await ThreadAnchorStorage.saveRoom(
+          serverId: s, userId: u2, roomId: r, anchors: {'th1': 'm1'});
+      await ThreadAnchorStorage.clearThread(s, r, 'th1');
+      expect(
+          await ThreadAnchorStorage.loadRoom(
+              serverId: s, userId: u1, roomId: r),
+          {'th2': 'm2'});
+      expect(
+          await ThreadAnchorStorage.loadRoom(
+              serverId: s, userId: u2, roomId: r),
+          isEmpty);
+    });
+
+    test('discards a corrupt blob and returns empty', () async {
+      SharedPreferences.setMockInitialValues({
+        'soliplex_thread_anchor:${Uri.encodeComponent(s)}:'
+            '${Uri.encodeComponent(u1)}:${Uri.encodeComponent(r)}': 'not json',
       });
+      expect(
+          await ThreadAnchorStorage.loadRoom(
+              serverId: s, userId: u1, roomId: r),
+          isEmpty);
+    });
 
-      await ThreadAnchorStorage.clearServer('s1');
-
-      final loaded = await ThreadAnchorStorage.load();
-      expect(loaded.keys, {(serverId: 's2', roomId: 'r', threadId: 't2')});
+    test('skips malformed entries but keeps valid ones', () async {
+      SharedPreferences.setMockInitialValues({
+        'soliplex_thread_anchor:${Uri.encodeComponent(s)}:'
+                '${Uri.encodeComponent(u1)}:${Uri.encodeComponent(r)}':
+            '{"th1":"m1","th2":123}',
+      });
+      expect(
+          await ThreadAnchorStorage.loadRoom(
+              serverId: s, userId: u1, roomId: r),
+          {'th1': 'm1'});
     });
   });
 }

--- a/test/modules/room/thread_read_markers_test.dart
+++ b/test/modules/room/thread_read_markers_test.dart
@@ -6,79 +6,147 @@ void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
   setUp(() => SharedPreferences.setMockInitialValues({}));
 
+  const s = 'https://foo.com', u1 = 'iss#alice', u2 = 'iss#bob', r = 'r1';
+  final t = DateTime.utc(2026, 1, 1);
+
   group('ThreadReadMarkerStorage', () {
-    test('defaults to empty when nothing is persisted', () async {
-      expect(await ThreadReadMarkerStorage.load(), isEmpty);
+    test('round-trips a room\'s markers per user', () async {
+      await ThreadReadMarkerStorage.saveRoom(
+          serverId: s, userId: u1, roomId: r, markers: {'th1': t});
+      expect(
+          await ThreadReadMarkerStorage.loadRoom(
+              serverId: s, userId: u1, roomId: r),
+          {'th1': t});
     });
 
-    test('round-trips markers, normalizing to UTC', () async {
-      final markers = {
-        (serverId: 'a', roomId: 'r1', threadId: 't1'):
-            DateTime.utc(2026, 6, 1, 12),
-        (serverId: 'b', roomId: 'r2', threadId: 't2'):
-            DateTime.utc(2026, 1, 2, 3, 4),
-      };
-      await ThreadReadMarkerStorage.save(markers);
-
-      final loaded = await ThreadReadMarkerStorage.load();
-      expect(loaded, hasLength(2));
-      expect(
-        loaded[(serverId: 'a', roomId: 'r1', threadId: 't1')],
-        DateTime.utc(2026, 6, 1, 12),
-      );
-      expect(
-        loaded[(serverId: 'b', roomId: 'r2', threadId: 't2')]!.isUtc,
-        isTrue,
-      );
+    test('normalizes a local instant to UTC', () async {
+      final local = DateTime(2026, 6, 1, 12); // local zone, not .utc
+      await ThreadReadMarkerStorage.saveRoom(
+          serverId: s, userId: u1, roomId: r, markers: {'th1': local});
+      final loaded = (await ThreadReadMarkerStorage.loadRoom(
+          serverId: s, userId: u1, roomId: r))['th1']!;
+      expect(loaded.isUtc, isTrue);
+      expect(loaded, local.toUtc());
     });
 
     test('preserves ids that would collide under a naive composite key',
         () async {
-      final markers = {
-        (serverId: 'a:b', roomId: 'r/1', threadId: 't|2'): DateTime.utc(2026),
-      };
-      await ThreadReadMarkerStorage.save(markers);
-
-      final loaded = await ThreadReadMarkerStorage.load();
+      const server = 'a:b', user = 'iss#u/1', room = 'r|2';
+      await ThreadReadMarkerStorage.saveRoom(
+          serverId: server, userId: user, roomId: room, markers: {'t|3': t});
       expect(
-        loaded[(serverId: 'a:b', roomId: 'r/1', threadId: 't|2')],
-        DateTime.utc(2026),
-      );
+          await ThreadReadMarkerStorage.loadRoom(
+              serverId: server, userId: user, roomId: room),
+          {'t|3': t});
     });
 
-    test('discards a corrupt (non-array) payload', () async {
-      SharedPreferences.setMockInitialValues({
-        'soliplex_thread_read_markers': '{"not":"an array"}',
-      });
-      expect(await ThreadReadMarkerStorage.load(), isEmpty);
-    });
-
-    test('skips malformed rows but keeps valid ones', () async {
-      SharedPreferences.setMockInitialValues({
-        'soliplex_thread_read_markers':
-            '[{"s":"a","r":"r1","th":"t1","t":"2026-06-01T12:00:00Z"},'
-                '{"s":"a","r":"r1"},'
-                '{"s":"a","r":"r1","th":"t2","t":"not-a-date"}]',
-      });
-      final loaded = await ThreadReadMarkerStorage.load();
-      expect(loaded, hasLength(1));
+    test('markers saved as one user are invisible to another (isolation)',
+        () async {
+      await ThreadReadMarkerStorage.saveRoom(
+          serverId: s, userId: u1, roomId: r, markers: {'th1': t});
       expect(
-        loaded[(serverId: 'a', roomId: 'r1', threadId: 't1')],
-        DateTime.utc(2026, 6, 1, 12),
-      );
+          await ThreadReadMarkerStorage.loadRoom(
+              serverId: s, userId: u2, roomId: r),
+          isEmpty);
     });
 
-    test('clearServer prunes only that server\'s thread markers', () async {
-      final at = DateTime.utc(2026, 6, 1);
-      await ThreadReadMarkerStorage.save({
-        (serverId: 's1', roomId: 'r', threadId: 't1'): at,
-        (serverId: 's2', roomId: 'r', threadId: 't2'): at,
+    test('null userId no-ops save and returns empty on load', () async {
+      await ThreadReadMarkerStorage.saveRoom(
+          serverId: s, userId: null, roomId: r, markers: {'th1': t});
+      expect(
+          await ThreadReadMarkerStorage.loadRoom(
+              serverId: s, userId: u1, roomId: r),
+          isEmpty);
+      expect(
+          await ThreadReadMarkerStorage.loadRoom(
+              serverId: s, userId: null, roomId: r),
+          isEmpty);
+    });
+
+    test('clearServer removes every user, spares a different-port peer',
+        () async {
+      const s2 = 'https://foo.com:8443';
+      await ThreadReadMarkerStorage.saveRoom(
+          serverId: s, userId: u1, roomId: r, markers: {'th1': t});
+      await ThreadReadMarkerStorage.saveRoom(
+          serverId: s, userId: u2, roomId: r, markers: {'th1': t});
+      await ThreadReadMarkerStorage.saveRoom(
+          serverId: s2, userId: u1, roomId: r, markers: {'th1': t});
+      await ThreadReadMarkerStorage.clearServer(s);
+      expect(
+          await ThreadReadMarkerStorage.loadRoom(
+              serverId: s, userId: u1, roomId: r),
+          isEmpty);
+      expect(
+          await ThreadReadMarkerStorage.loadRoom(
+              serverId: s, userId: u2, roomId: r),
+          isEmpty);
+      expect(
+          await ThreadReadMarkerStorage.loadRoom(
+              serverId: s2, userId: u1, roomId: r),
+          {'th1': t});
+    });
+
+    test('clearRoom removes every user for the room, keeps sibling rooms',
+        () async {
+      await ThreadReadMarkerStorage.saveRoom(
+          serverId: s, userId: u1, roomId: r, markers: {'th1': t});
+      await ThreadReadMarkerStorage.saveRoom(
+          serverId: s, userId: u2, roomId: r, markers: {'th1': t});
+      await ThreadReadMarkerStorage.saveRoom(
+          serverId: s, userId: u1, roomId: 'r2', markers: {'th9': t});
+      await ThreadReadMarkerStorage.clearRoom(s, r);
+      expect(
+          await ThreadReadMarkerStorage.loadRoom(
+              serverId: s, userId: u1, roomId: r),
+          isEmpty);
+      expect(
+          await ThreadReadMarkerStorage.loadRoom(
+              serverId: s, userId: u2, roomId: r),
+          isEmpty);
+      expect(
+          await ThreadReadMarkerStorage.loadRoom(
+              serverId: s, userId: u1, roomId: 'r2'),
+          {'th9': t});
+    });
+
+    test('clearThread removes one thread across users, keeps siblings',
+        () async {
+      await ThreadReadMarkerStorage.saveRoom(
+          serverId: s, userId: u1, roomId: r, markers: {'th1': t, 'th2': t});
+      await ThreadReadMarkerStorage.saveRoom(
+          serverId: s, userId: u2, roomId: r, markers: {'th1': t});
+      await ThreadReadMarkerStorage.clearThread(s, r, 'th1');
+      expect(
+          await ThreadReadMarkerStorage.loadRoom(
+              serverId: s, userId: u1, roomId: r),
+          {'th2': t});
+      expect(
+          await ThreadReadMarkerStorage.loadRoom(
+              serverId: s, userId: u2, roomId: r),
+          isEmpty);
+    });
+
+    test('discards a corrupt blob and returns empty', () async {
+      SharedPreferences.setMockInitialValues({
+        'soliplex_thread_read_marker:${Uri.encodeComponent(s)}:'
+            '${Uri.encodeComponent(u1)}:${Uri.encodeComponent(r)}': 'not json',
       });
+      expect(
+          await ThreadReadMarkerStorage.loadRoom(
+              serverId: s, userId: u1, roomId: r),
+          isEmpty);
+    });
 
-      await ThreadReadMarkerStorage.clearServer('s1');
-
-      final loaded = await ThreadReadMarkerStorage.load();
-      expect(loaded.keys, {(serverId: 's2', roomId: 'r', threadId: 't2')});
+    test('skips malformed entries but keeps valid ones', () async {
+      SharedPreferences.setMockInitialValues({
+        'soliplex_thread_read_marker:${Uri.encodeComponent(s)}:'
+                '${Uri.encodeComponent(u1)}:${Uri.encodeComponent(r)}':
+            '{"th1":"2026-06-01T12:00:00Z","th2":"not-a-date","th3":5}',
+      });
+      final loaded = await ThreadReadMarkerStorage.loadRoom(
+          serverId: s, userId: u1, roomId: r);
+      expect(loaded, {'th1': DateTime.utc(2026, 6, 1, 12)});
     });
   });
 }

--- a/test/modules/room/thread_read_markers_test.dart
+++ b/test/modules/room/thread_read_markers_test.dart
@@ -50,16 +50,22 @@ void main() {
           isEmpty);
     });
 
-    test('null userId no-ops save and returns empty on load', () async {
+    test(
+        'null userId persists to the shared unauthenticated bucket, isolated '
+        'from real users', () async {
       await ThreadReadMarkerStorage.saveRoom(
           serverId: s, userId: null, roomId: r, markers: {'th1': t});
-      expect(
-          await ThreadReadMarkerStorage.loadRoom(
-              serverId: s, userId: u1, roomId: r),
-          isEmpty);
+      // Persisted and re-readable under the unauthenticated (null) bucket — a
+      // server requiring no sign-in has no identity to isolate by, so its read
+      // state is device-shared rather than dropped.
       expect(
           await ThreadReadMarkerStorage.loadRoom(
               serverId: s, userId: null, roomId: r),
+          {'th1': t});
+      // A signed-in user does not see the unauthenticated bucket.
+      expect(
+          await ThreadReadMarkerStorage.loadRoom(
+              serverId: s, userId: u1, roomId: r),
           isEmpty);
     });
 

--- a/test/modules/room/thread_read_tracker_test.dart
+++ b/test/modules/room/thread_read_tracker_test.dart
@@ -1,0 +1,189 @@
+import 'dart:async';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:soliplex_frontend/src/modules/room/thread_read_markers.dart'
+    show ThreadActivityKey;
+import 'package:soliplex_frontend/src/modules/room/thread_read_tracker.dart';
+
+ThreadActivityKey _key(String t) => (serverId: 's', roomId: 'r', threadId: t);
+
+DateTime _at(int minute) => DateTime.utc(2026, 1, 1, 0, minute);
+
+void main() {
+  group('ThreadReadTracker', () {
+    late List<Map<ThreadActivityKey, DateTime>> saves;
+    Map<ThreadActivityKey, DateTime> disk = {};
+
+    ThreadReadTracker make() => ThreadReadTracker(
+          load: () async => Map.of(disk),
+          save: (m) async {
+            saves.add(Map.of(m));
+          },
+        );
+
+    setUp(() {
+      saves = [];
+      disk = {};
+    });
+
+    test('stamp after load persists the marker', () async {
+      final t = make();
+      await t.loadFromDisk();
+      t.stamp(_key('a'), _at(3));
+      await pumpEventQueue();
+      expect(saves.last[_key('a')], _at(3));
+      expect(t.markers[_key('a')], _at(3));
+    });
+
+    test('stamp before load does not persist and does not wipe other threads',
+        () async {
+      disk = {_key('a'): _at(1), _key('b'): _at(2)};
+      final t = make();
+
+      // A stamp fires before the disk load completes.
+      t.stamp(_key('a'), _at(3));
+      expect(saves, isEmpty, reason: 'must not persist before markers loaded');
+
+      await t.loadFromDisk();
+      // The flush contains the in-memory stamp AND the other thread from disk.
+      expect(saves, isNotEmpty);
+      expect(saves.last[_key('a')], _at(3));
+      expect(saves.last[_key('b')], _at(2));
+      expect(t.markers[_key('b')], _at(2));
+    });
+
+    test('load failure never persists (no clobber)', () async {
+      disk = {_key('a'): _at(1), _key('b'): _at(2)};
+      final t = ThreadReadTracker(
+        load: () async => throw StateError('disk unavailable'),
+        save: (m) async {
+          saves.add(Map.of(m));
+        },
+      );
+      await t.loadFromDisk();
+      // A failed load read nothing, so writing the partial in-memory map would
+      // clobber the threads we never read. It must stay silent.
+      t.stamp(_key('a'), _at(3));
+      await pumpEventQueue();
+      expect(saves, isEmpty);
+    });
+
+    test('a failed persist is retried on the next stamp', () async {
+      disk = {_key('a'): _at(1)};
+      var failSave = false;
+      final t = ThreadReadTracker(
+        load: () async => Map.of(disk),
+        save: (m) async {
+          if (failSave) throw StateError('write failed');
+          saves.add(Map.of(m));
+        },
+      );
+      await t.loadFromDisk();
+      saves.clear();
+
+      failSave = true;
+      t.stamp(_key('a'), _at(5));
+      await pumpEventQueue();
+      expect(saves, isEmpty, reason: 'the persist threw');
+
+      failSave = false;
+      t.stamp(_key('a'), _at(6));
+      await pumpEventQueue();
+      expect(saves.last[_key('a')], _at(6));
+    });
+
+    test('serializes overlapping writes so the latest stamp wins', () async {
+      disk = {_key('a'): _at(1)};
+      final gates = <Completer<void>>[];
+      final t = ThreadReadTracker(
+        load: () async => Map.of(disk),
+        save: (m) async {
+          final gate = Completer<void>();
+          gates.add(gate);
+          await gate.future;
+          saves.add(Map.of(m));
+        },
+      );
+      await t.loadFromDisk();
+
+      t.stamp(_key('a'), _at(2)); // starts a save; held open by its gate.
+      t.stamp(_key('a'), _at(3)); // must not open a second concurrent save.
+      expect(gates, hasLength(1), reason: 'only one write in flight');
+
+      gates[0].complete();
+      await pumpEventQueue();
+      expect(gates, hasLength(2), reason: 'the pending change re-flushes');
+
+      gates[1].complete();
+      await pumpEventQueue();
+      expect(saves.last[_key('a')], _at(3));
+    });
+
+    test('dispose flushes a stamp a failed write left pending', () async {
+      disk = {_key('a'): _at(1)};
+      var failSave = true;
+      final t = ThreadReadTracker(
+        load: () async => Map.of(disk),
+        save: (m) async {
+          if (failSave) throw StateError('write failed');
+          saves.add(Map.of(m));
+        },
+      );
+      await t.loadFromDisk();
+      saves.clear();
+
+      t.stamp(_key('a'), _at(5));
+      await pumpEventQueue();
+      expect(saves, isEmpty, reason: 'the persist threw');
+
+      failSave = false;
+      await t.dispose();
+      expect(saves.last[_key('a')], _at(5));
+    });
+
+    test('dispose after a failed load never persists (no clobber)', () async {
+      disk = {_key('a'): _at(1), _key('b'): _at(2)};
+      final t = ThreadReadTracker(
+        load: () async => throw StateError('disk unavailable'),
+        save: (m) async {
+          saves.add(Map.of(m));
+        },
+      );
+      await t.loadFromDisk();
+      t.stamp(_key('a'), _at(5));
+
+      await t.dispose();
+      expect(saves, isEmpty);
+    });
+
+    test('dispose before load completes still flushes via the orphaned load',
+        () async {
+      // The fast room-switch case: the tracker is disposed while its load is
+      // still in flight. The orphaned load must still merge the pending stamp
+      // and flush it, so the leaving room's read marker survives.
+      disk = {_key('a'): _at(1)};
+      final loadGate = Completer<void>();
+      final t = ThreadReadTracker(
+        load: () async {
+          await loadGate.future;
+          return Map.of(disk);
+        },
+        save: (m) async {
+          saves.add(Map.of(m));
+        },
+      );
+
+      final loadFuture = t.loadFromDisk();
+      t.stamp(_key('b'), _at(9)); // stamp before load resolves
+      await t.dispose(); // dispose before load resolves: skips its own flush
+      expect(saves, isEmpty, reason: 'load has not resolved yet');
+
+      loadGate.complete();
+      await loadFuture;
+      await pumpEventQueue();
+      // The orphaned load merged the pending stamp and flushed it.
+      expect(saves.last[_key('b')], _at(9));
+      expect(saves.last[_key('a')], _at(1));
+    });
+  });
+}

--- a/test/modules/room/ui/room_screen_test.dart
+++ b/test/modules/room/ui/room_screen_test.dart
@@ -1444,6 +1444,73 @@ void main() {
         expect(markers['thread-1'], leave);
       });
     });
+
+    testWidgets(
+        'a logout while in a room stamps the open thread under the logged-in '
+        'user, not the unauthenticated bucket', (tester) async {
+      tester.view.physicalSize = const Size(1200, 800);
+      tester.view.devicePixelRatio = 1.0;
+      addTearDown(tester.view.resetPhysicalSize);
+      SharedPreferences.setMockInitialValues(const {});
+
+      final open = DateTime.utc(2026, 6, 1, 10);
+      final leave = DateTime.utc(2026, 6, 1, 10, 1);
+      var now = open;
+
+      api.nextThreads = [
+        ThreadInfo(
+          id: 'thread-1',
+          roomId: 'room-1',
+          name: 'First thread',
+          createdAt: DateTime(2026, 3, 2),
+          lastActivity: DateTime.utc(2026, 6, 1, 10, 0, 30),
+        ),
+      ];
+
+      final aliceEntry =
+          createTestServerEntry(api: api, auth: authWithIdentity(sub: 'alice'));
+
+      await withClock(Clock(() => now), () async {
+        await tester.pumpWidget(MaterialApp(
+          home: RoomScreen(
+            serverEntry: aliceEntry,
+            roomId: 'room-1',
+            threadId: 'thread-1',
+            runtimeManager: runtimeManager,
+            registry: registry,
+            uploadRegistry: uploadRegistry,
+            documentSelections: DocumentSelections(),
+          ),
+        ));
+        await tester.pumpAndSettle();
+
+        // Log out while the room is still mounted, then let it dispose. The
+        // dispose stamp must use the userId captured at tracker creation
+        // (alice), not the now-null live session — otherwise alice's read state
+        // leaks into the shared unauthenticated bucket.
+        now = leave;
+        aliceEntry.auth.logout();
+        await tester.pumpWidget(const SizedBox());
+        await tester.pumpAndSettle();
+
+        expect(
+          await ThreadReadMarkerStorage.loadRoom(
+            serverId: aliceEntry.serverId,
+            userId: testIdentityFor('alice'),
+            roomId: 'room-1',
+          ),
+          containsPair('thread-1', leave),
+        );
+        expect(
+          await ThreadReadMarkerStorage.loadRoom(
+            serverId: aliceEntry.serverId,
+            userId: null,
+            roomId: 'room-1',
+          ),
+          isEmpty,
+        );
+      });
+    });
   });
 
   group('room unread rollup', () {

--- a/test/modules/room/ui/room_screen_test.dart
+++ b/test/modules/room/ui/room_screen_test.dart
@@ -1390,6 +1390,60 @@ void main() {
         );
       });
     });
+
+    testWidgets(
+        'an unauthenticated server persists read state to the shared bucket',
+        (tester) async {
+      tester.view.physicalSize = const Size(1200, 800);
+      tester.view.devicePixelRatio = 1.0;
+      addTearDown(tester.view.resetPhysicalSize);
+      SharedPreferences.setMockInitialValues(const {});
+
+      final open = DateTime.utc(2026, 6, 1, 10);
+      final leave = DateTime.utc(2026, 6, 1, 10, 1);
+      var now = open;
+
+      api.nextThreads = [
+        ThreadInfo(
+          id: 'thread-1',
+          roomId: 'room-1',
+          name: 'First thread',
+          createdAt: DateTime(2026, 3, 2),
+          lastActivity: DateTime.utc(2026, 6, 1, 10, 0, 30),
+        ),
+      ];
+
+      // The default entry has no signed-in user (currentUserId == null) — a
+      // server requiring no sign-in. Its read state must still persist, under
+      // the shared unauthenticated bucket, rather than being silently dropped.
+      final anonEntry = createTestServerEntry(api: api);
+
+      await withClock(Clock(() => now), () async {
+        await tester.pumpWidget(MaterialApp(
+          home: RoomScreen(
+            serverEntry: anonEntry,
+            roomId: 'room-1',
+            threadId: 'thread-1',
+            runtimeManager: runtimeManager,
+            registry: registry,
+            uploadRegistry: uploadRegistry,
+            documentSelections: DocumentSelections(),
+          ),
+        ));
+        await tester.pumpAndSettle();
+
+        now = leave;
+        await tester.pumpWidget(const SizedBox());
+        await tester.pumpAndSettle();
+
+        final markers = await ThreadReadMarkerStorage.loadRoom(
+          serverId: anonEntry.serverId,
+          userId: null,
+          roomId: 'room-1',
+        );
+        expect(markers['thread-1'], leave);
+      });
+    });
   });
 
   group('room unread rollup', () {

--- a/test/modules/room/ui/room_screen_test.dart
+++ b/test/modules/room/ui/room_screen_test.dart
@@ -1229,10 +1229,13 @@ void main() {
         ),
       ];
 
+      final signedInEntry =
+          createTestServerEntry(api: api, auth: authWithIdentity());
+
       await withClock(Clock(() => now), () async {
         await tester.pumpWidget(MaterialApp(
           home: RoomScreen(
-            serverEntry: entry,
+            serverEntry: signedInEntry,
             roomId: 'room-1',
             threadId: 'thread-1',
             runtimeManager: runtimeManager,
@@ -1248,15 +1251,12 @@ void main() {
         await tester.pumpWidget(const SizedBox());
         await tester.pumpAndSettle();
 
-        final markers = await ThreadReadMarkerStorage.load();
-        expect(
-          markers[(
-            serverId: entry.serverId,
-            roomId: 'room-1',
-            threadId: 'thread-1',
-          )],
-          leave,
+        final markers = await ThreadReadMarkerStorage.loadRoom(
+          serverId: signedInEntry.serverId,
+          userId: testUserIdentity,
+          roomId: 'room-1',
         );
+        expect(markers['thread-1'], leave);
       });
     });
 
@@ -1281,9 +1281,12 @@ void main() {
         ),
       ];
 
+      final signedInEntry =
+          createTestServerEntry(api: api, auth: authWithIdentity());
+
       Widget roomScreen(String roomId) => MaterialApp(
             home: RoomScreen(
-              serverEntry: entry,
+              serverEntry: signedInEntry,
               roomId: roomId,
               threadId: roomId == 'room-1' ? 'thread-1' : null,
               runtimeManager: runtimeManager,
@@ -1303,14 +1306,87 @@ void main() {
         await tester.pumpWidget(roomScreen('room-2'));
         await tester.pumpAndSettle();
 
-        final markers = await ThreadReadMarkerStorage.load();
+        final markers = await ThreadReadMarkerStorage.loadRoom(
+          serverId: signedInEntry.serverId,
+          userId: testUserIdentity,
+          roomId: 'room-1',
+        );
+        expect(markers['thread-1'], leave);
+      });
+    });
+
+    testWidgets(
+        'a server switch stamps the left server under its own user, not the '
+        'incoming one', (tester) async {
+      tester.view.physicalSize = const Size(1200, 800);
+      tester.view.devicePixelRatio = 1.0;
+      addTearDown(tester.view.resetPhysicalSize);
+      SharedPreferences.setMockInitialValues(const {});
+
+      final open = DateTime.utc(2026, 6, 1, 10);
+      final leave = DateTime.utc(2026, 6, 1, 10, 1);
+      var now = open;
+
+      api.nextThreads = [
+        ThreadInfo(
+          id: 'thread-1',
+          roomId: 'room-1',
+          name: 'First thread',
+          createdAt: DateTime(2026, 3, 2),
+          lastActivity: DateTime.utc(2026, 6, 1, 10, 0, 30),
+        ),
+      ];
+
+      const serverA = 'http://server-a:8000';
+      final entryAlice = createTestServerEntry(
+        api: api,
+        serverId: serverA,
+        auth: authWithIdentity(sub: 'alice'),
+      );
+      final entryBob = createTestServerEntry(
+        api: FakeSoliplexApi(),
+        serverId: 'http://server-b:8000',
+        auth: authWithIdentity(sub: 'bob'),
+      );
+
+      Widget roomScreen(ServerEntry e) => MaterialApp(
+            home: RoomScreen(
+              serverEntry: e,
+              roomId: 'room-1',
+              threadId: 'thread-1',
+              runtimeManager: runtimeManager,
+              registry: registry,
+              uploadRegistry: uploadRegistry,
+              documentSelections: DocumentSelections(),
+            ),
+          );
+
+      await withClock(Clock(() => now), () async {
+        await tester.pumpWidget(roomScreen(entryAlice));
+        await tester.pumpAndSettle();
+
+        // Switch servers (alice -> bob) in place. The left server's stamp must
+        // be filed under alice, never bob — reading userId off the (advanced)
+        // widget at flush time would misfile it under bob.
+        now = leave;
+        await tester.pumpWidget(roomScreen(entryBob));
+        await tester.pumpAndSettle();
+
         expect(
-          markers[(
-            serverId: entry.serverId,
+          await ThreadReadMarkerStorage.loadRoom(
+            serverId: serverA,
+            userId: testIdentityFor('alice'),
             roomId: 'room-1',
-            threadId: 'thread-1',
-          )],
-          leave,
+          ),
+          containsPair('thread-1', leave),
+        );
+        expect(
+          await ThreadReadMarkerStorage.loadRoom(
+            serverId: serverA,
+            userId: testIdentityFor('bob'),
+            roomId: 'room-1',
+          ),
+          isEmpty,
         );
       });
     });


### PR DESCRIPTION
Continues the keyed, user-scoped device-local storage stack (after #401, which
did the identity resolver, key codec, and composer drafts). This slice closes
the cross-user leak of **thread-level** read state on a shared device.

## What changed

- **Thread read markers & unread-divider anchors are keyed by
  `(serverId, userId, roomId)`** via the shared percent-encoded codec, so a
  different user signing into the same server no longer inherits the previous
  user's read dots or "New messages" dividers. Each store is a per-room blob
  `{threadId: value}`; deletes span all users (`clearServer`/`clearRoom`/
  `clearThread`).
- **New `ThreadReadTracker`**, mirroring the existing `AnchorTracker`: the room
  screen owns per-room read markers through a tracker that captures its
  coordinates at creation, load-merges, and flushes on a serialized queue. This
  replaces the widget's ad-hoc flush/dirty state and makes the two twin stores
  symmetric. Both trackers are recreated per room switch and flush the leaving
  room on dispose, binding `userId` to the room they were created for so a
  server switch can't misfile the left server's markers under the incoming user.
- **Unauthenticated servers** (no signed-in user, `currentUserId == null`) fall
  back to a shared `unauthenticatedStorageUser` bucket instead of dropping their
  read state — there's no identity to isolate by, so it stays device-shared as
  before, while signed-in users remain isolated.

## Behavior note

Existing un-keyed thread read state is abandoned on the format change and
re-derives: **every thread reads as unread once after upgrade**, and dividers
recompute from that point. Noted in the CHANGELOG.

## Testing

- Full suite green (`flutter test --exclude-tags golden`), analyzer clean.
- New unit tests for both stores (isolation, per-user clears, corrupt handling,
  unauthenticated bucket) and for `ThreadReadTracker` (load-merge, clobber
  guard, retry, serialized flush, dispose paths).
- Widget regression guards: a room switch files the left room's stamp correctly,
  and a **server switch files the left server under its own user** (guards a
  cross-user misfiling bug caught and fixed during review).

## Not in this PR

Room- and server-level (lobby) read markers are still un-keyed — that's the next
slice in the stack and fully closes the leak.

🤖 Generated with [Claude Code](https://claude.com/claude-code)