### PR TITLE
feat(lobby): scope room + server read markers by user, per server

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,12 @@ Versions follow the `version+build` scheme from `pubspec.yaml`, bumped via
   previous user's read state or "New messages" dividers. As a one-time effect of
   the storage-format change, existing thread read state resets on upgrade — every
   thread reads as unread once and dividers are recomputed from that point.
+- Lobby room and server read markers are now scoped to the signed-in user, per
+  server: a different user signing in on a shared device no longer inherits the
+  previous user's unread state, and the multi-server lobby resolves each server's
+  own signed-in user. This closes the last device-local read-state leak between
+  users. As a one-time effect of the storage-format change, existing lobby
+  read state resets on upgrade — every room reads as unread once.
 
 ## [0.92.0+65] - 2026-07-02
 

--- a/lib/src/core/activity_read.dart
+++ b/lib/src/core/activity_read.dart
@@ -3,6 +3,47 @@
 /// be transposed at a lookup or insertion site.
 typedef RoomActivityKey = ({String serverId, String roomId});
 
+/// Identifies a room read marker, scoped to the user who owns it so a different
+/// user signing in on the same device sees their own read state. `userId` is the
+/// non-null, sentinel-substituted identity (see `keyed_storage.dart`).
+typedef RoomMarkerKey = ({String serverId, String userId, String roomId});
+
+/// Identifies a server read marker, scoped to the user who owns it.
+typedef ServerMarkerKey = ({String serverId, String userId});
+
+/// Projects the user-scoped room markers down to the current user per server:
+/// keeps each entry whose `userId` equals [userFor] for its server, re-keyed to
+/// the user-agnostic [RoomActivityKey] the unread helpers and lobby consume.
+///
+/// [userFor] returns the non-null identity currently signed into that server (a
+/// signed-out or no-auth server resolves to the `unauthenticatedStorageUser`
+/// sentinel), letting the multi-server lobby resolve a different user per server.
+Map<RoomActivityKey, DateTime> currentUserRoomMarkers(
+  Map<RoomMarkerKey, DateTime> markers,
+  String Function(String serverId) userFor,
+) {
+  final result = <RoomActivityKey, DateTime>{};
+  markers.forEach((key, at) {
+    if (key.userId == userFor(key.serverId)) {
+      result[(serverId: key.serverId, roomId: key.roomId)] = at;
+    }
+  });
+  return result;
+}
+
+/// Projects the user-scoped server markers down to the current user per server,
+/// re-keyed to bare `serverId`. The server twin of [currentUserRoomMarkers].
+Map<String, DateTime> currentUserServerMarkers(
+  Map<ServerMarkerKey, DateTime> markers,
+  String Function(String serverId) userFor,
+) {
+  final result = <String, DateTime>{};
+  markers.forEach((key, at) {
+    if (key.userId == userFor(key.serverId)) result[key.serverId] = at;
+  });
+  return result;
+}
+
 /// Whether activity is unread: a known [lastActivity] strictly newer than the
 /// user's last-[seen] marker (or it has never been seen). No known activity
 /// means there is nothing to be unread about. The tie case ([lastActivity]

--- a/lib/src/core/keyed_storage.dart
+++ b/lib/src/core/keyed_storage.dart
@@ -31,3 +31,8 @@ String serverKeyPrefix(String prefix, String serverId) =>
 /// with one. State in this bucket is device-shared across everyone using that
 /// unauthenticated server — there is no identity to isolate it by.
 const unauthenticatedStorageUser = 'unauthenticated';
+
+/// The `userId` key component for [userId], substituting [unauthenticatedStorageUser]
+/// for a null identity (a signed-out or no-auth server). The single choke point
+/// for that substitution, so every key-construction site buckets the same way.
+String storageUser(String? userId) => userId ?? unauthenticatedStorageUser;

--- a/lib/src/modules/auth/auth_session.dart
+++ b/lib/src/modules/auth/auth_session.dart
@@ -25,6 +25,11 @@ class AuthSession implements TokenRefresher {
   /// must still be attributable to the user. Re-evaluates only when the session
   /// changes and yields the same value across a same-user refresh, so watchers
   /// don't churn. Raw (un-encoded); key builders percent-encode it downstream.
+  ///
+  /// A `null` on an *authenticated* session (an opaque, non-JWT access token
+  /// carrying no `iss`/`sub`) is expected, not an error: user-scoped
+  /// device-local state then shares this server's unauthenticated bucket, since
+  /// there is no identity claim to isolate it by.
   late final ReadonlySignal<String?> currentUserId = computed(() {
     final token = switch (_session.value) {
       ActiveSession(:final tokens) => tokens.accessToken,

--- a/lib/src/modules/lobby/lobby_read_markers.dart
+++ b/lib/src/modules/lobby/lobby_read_markers.dart
@@ -41,19 +41,22 @@ abstract final class LobbyReadMarkerStorage {
     required String? userId,
   }) async {
     final prefs = await SharedPreferences.getInstance();
-    final raw =
-        prefs.getString(_key(serverId, userId ?? unauthenticatedStorageUser));
+    final raw = prefs.getString(_key(serverId, storageUser(userId)));
     if (raw == null || raw.isEmpty) return {};
 
     final result = <String, DateTime>{};
     try {
       final decoded = jsonDecode(raw);
       if (decoded is! Map) {
-        _logger.warning(
+        // A non-empty payload that isn't a JSON object wipes this server's whole
+        // read model (every room flips to unread) — a systemic serialization
+        // break, not one stale row. Same severity as the all-entries-dropped
+        // case below.
+        _logger.error(
           'Discarding corrupt room read markers (not a JSON object)',
           attributes: {
             'serverId': serverId,
-            'userId': userId ?? unauthenticatedStorageUser,
+            'userId': storageUser(userId),
           },
         );
         return {};
@@ -76,7 +79,7 @@ abstract final class LobbyReadMarkerStorage {
       // model (every room flips to unread). Surface it loudly.
       final attributes = {
         'serverId': serverId,
-        'userId': userId ?? unauthenticatedStorageUser,
+        'userId': storageUser(userId),
       };
       if (skipped > 0 && result.isEmpty) {
         _logger.error('Discarding all $skipped room read markers; none parsed',
@@ -86,13 +89,15 @@ abstract final class LobbyReadMarkerStorage {
             attributes: attributes);
       }
     } on FormatException catch (e, st) {
-      _logger.warning(
+      // Unparseable JSON wipes this server's whole read model; surface as loudly
+      // as the all-entries-dropped case (raw is non-empty here).
+      _logger.error(
         'Discarding corrupt room read markers',
         error: e,
         stackTrace: st,
         attributes: {
           'serverId': serverId,
-          'userId': userId ?? unauthenticatedStorageUser,
+          'userId': storageUser(userId),
         },
       );
       return {};
@@ -110,8 +115,7 @@ abstract final class LobbyReadMarkerStorage {
     final obj = {
       for (final e in markers.entries) e.key: e.value.toUtc().toIso8601String(),
     };
-    await prefs.setString(
-        _key(serverId, userId ?? unauthenticatedStorageUser), jsonEncode(obj));
+    await prefs.setString(_key(serverId, storageUser(userId)), jsonEncode(obj));
   }
 
   /// Drops every user's room markers for [serverId]. Sweeps only keys under this
@@ -150,6 +154,14 @@ class RoomReadMarkers {
   /// same disk read instead of each racing a partial in-memory view onto disk.
   final Map<ServerMarkerKey, Future<void>> _loadTasks = {};
 
+  /// Per-server clear epoch, bumped by [clearServer]. A suspended [_load] or
+  /// [_persist] captures it before its `await` and, on resume, discards its work
+  /// if the epoch moved — so a clear that lands mid-flight can't be undone by the
+  /// op re-inserting a swept blob into memory or rewriting it to disk (which
+  /// would hide unread content on a same-id re-add). Keyed per server so clearing
+  /// one server never invalidates another's in-flight write.
+  final Map<String, int> _generation = {};
+
   bool _disposed = false;
 
   /// The current markers, for a non-reactive read.
@@ -164,18 +176,20 @@ class RoomReadMarkers {
     required String serverId,
     required String? userId,
   }) {
-    final key =
-        (serverId: serverId, userId: userId ?? unauthenticatedStorageUser);
+    final key = (serverId: serverId, userId: storageUser(userId));
     if (_loaded.contains(key)) return Future<void>.value();
     return _loadTasks[key] ??= _load(serverId, userId, key);
   }
 
   Future<void> _load(
       String serverId, String? userId, ServerMarkerKey key) async {
+    final gen = _generation[serverId] ?? 0;
     try {
       final loaded = await LobbyReadMarkerStorage.loadServer(
           serverId: serverId, userId: userId);
-      if (_disposed) return;
+      // A clear (or dispose) landed while this load was in flight; its blob was
+      // swept, so committing it now would resurrect the cleared state.
+      if (_disposed || gen != (_generation[serverId] ?? 0)) return;
       _markers.value = {
         for (final e in loaded.entries)
           (serverId: serverId, userId: key.userId, roomId: e.key): e.value,
@@ -189,7 +203,9 @@ class RoomReadMarkers {
         stackTrace: st,
       );
     } finally {
-      _loadTasks.remove(key);
+      // Only clear our own task slot: a stale epoch's [clearServer] already
+      // removed it, and a re-add may have registered a newer load under this key.
+      if (gen == (_generation[serverId] ?? 0)) _loadTasks.remove(key);
     }
   }
 
@@ -205,7 +221,7 @@ class RoomReadMarkers {
     required String roomId,
     required DateTime at,
   }) {
-    final u = userId ?? unauthenticatedStorageUser;
+    final u = storageUser(userId);
     _markers.value = {
       ..._markers.value,
       (serverId: serverId, userId: u, roomId: roomId): at.toUtc(),
@@ -218,11 +234,22 @@ class RoomReadMarkers {
   /// full on-disk set rather than shrinking it to the just-stamped room. When
   /// the load didn't complete (a storage failure), the write is skipped: the
   /// in-memory view is missing rooms that are still on disk, so rewriting it
-  /// would drop them.
+  /// would drop them. The just-stamped room then stays read in memory for this
+  /// session but does not survive a restart until a later load succeeds and a
+  /// subsequent stamp re-persists the blob.
   Future<void> _persist(String serverId, String u, String? userId) async {
+    final gen = _generation[serverId] ?? 0;
     try {
       await ensureLoaded(serverId: serverId, userId: userId);
-      if (_disposed || !_loaded.contains((serverId: serverId, userId: u))) {
+      // Disposed or cleared out from under this write: the in-memory state is
+      // already gone, so there is nothing left to persist.
+      if (_disposed || gen != (_generation[serverId] ?? 0)) return;
+      if (!_loaded.contains((serverId: serverId, userId: u))) {
+        _logger.debug(
+          'Skipped room read marker persist; blob not loaded (a prior load '
+          'failed). The stamp holds in memory but is not yet on disk.',
+          attributes: {'serverId': serverId, 'userId': u},
+        );
         return;
       }
       final blob = <String, DateTime>{
@@ -249,6 +276,9 @@ class RoomReadMarkers {
   /// id. The disk sweep runs unconditionally: the in-memory view can't see
   /// another user's (or an unloaded) blob that may still be on disk.
   void clearServer(String serverId) {
+    // Move the epoch first so any in-flight load/persist for this server sees
+    // the change and discards its result (see [_generation]).
+    _generation[serverId] = (_generation[serverId] ?? 0) + 1;
     final next = {..._markers.value}
       ..removeWhere((key, _) => key.serverId == serverId);
     // Reassign only on a real change, to avoid a spurious watcher notification.
@@ -296,8 +326,7 @@ abstract final class ServerReadMarkerStorage {
     required String? userId,
   }) async {
     final prefs = await SharedPreferences.getInstance();
-    final raw =
-        prefs.getString(_key(serverId, userId ?? unauthenticatedStorageUser));
+    final raw = prefs.getString(_key(serverId, storageUser(userId)));
     if (raw == null || raw.isEmpty) return null;
     final at = DateTime.tryParse(raw);
     if (at == null) {
@@ -305,7 +334,7 @@ abstract final class ServerReadMarkerStorage {
         'Discarding corrupt server read marker (unparseable)',
         attributes: {
           'serverId': serverId,
-          'userId': userId ?? unauthenticatedStorageUser,
+          'userId': storageUser(userId),
         },
       );
       return null;
@@ -321,7 +350,7 @@ abstract final class ServerReadMarkerStorage {
   }) async {
     final prefs = await SharedPreferences.getInstance();
     await prefs.setString(
-      _key(serverId, userId ?? unauthenticatedStorageUser),
+      _key(serverId, storageUser(userId)),
       at.toUtc().toIso8601String(),
     );
   }
@@ -353,6 +382,12 @@ class ServerReadMarkers {
   /// same disk read instead of one resolving before the marker is in memory.
   final Map<ServerMarkerKey, Future<void>> _loadTasks = {};
 
+  /// Per-server clear epoch, bumped by [clearServer]; see
+  /// [RoomReadMarkers._generation]. Only [_load] needs it here — [markRead]
+  /// persists with no `await` before its write, so a synchronously-following
+  /// [clearServer] sweep always lands after it in storage order.
+  final Map<String, int> _generation = {};
+
   bool _disposed = false;
 
   /// The current markers, for a non-reactive read.
@@ -365,18 +400,20 @@ class ServerReadMarkers {
     required String serverId,
     required String? userId,
   }) {
-    final key =
-        (serverId: serverId, userId: userId ?? unauthenticatedStorageUser);
+    final key = (serverId: serverId, userId: storageUser(userId));
     if (_loaded.contains(key)) return Future<void>.value();
     return _loadTasks[key] ??= _load(serverId, userId, key);
   }
 
   Future<void> _load(
       String serverId, String? userId, ServerMarkerKey key) async {
+    final gen = _generation[serverId] ?? 0;
     try {
       final at = await ServerReadMarkerStorage.loadServer(
           serverId: serverId, userId: userId);
-      if (_disposed) return;
+      // A clear (or dispose) landed while this load was in flight; its marker
+      // was swept, so committing it now would resurrect the cleared floor.
+      if (_disposed || gen != (_generation[serverId] ?? 0)) return;
       if (at != null && !_markers.value.containsKey(key)) {
         _markers.value = {..._markers.value, key: at};
       }
@@ -388,7 +425,8 @@ class ServerReadMarkers {
         stackTrace: st,
       );
     } finally {
-      _loadTasks.remove(key);
+      // Only clear our own task slot (see [RoomReadMarkers._load]).
+      if (gen == (_generation[serverId] ?? 0)) _loadTasks.remove(key);
     }
   }
 
@@ -400,7 +438,7 @@ class ServerReadMarkers {
     required String? userId,
     required DateTime at,
   }) {
-    final u = userId ?? unauthenticatedStorageUser;
+    final u = storageUser(userId);
     _markers.value = {
       ..._markers.value,
       (serverId: serverId, userId: u): at.toUtc(),
@@ -424,6 +462,9 @@ class ServerReadMarkers {
   /// removed server doesn't floor its rooms if re-added under the same id. The
   /// disk sweep runs unconditionally (see [RoomReadMarkers.clearServer]).
   void clearServer(String serverId) {
+    // Move the epoch first so any in-flight load for this server discards its
+    // result (see [_generation]).
+    _generation[serverId] = (_generation[serverId] ?? 0) + 1;
     final next = {..._markers.value}
       ..removeWhere((key, _) => key.serverId == serverId);
     // Reassign only on a real change, to avoid a spurious watcher notification.

--- a/lib/src/modules/lobby/lobby_read_markers.dart
+++ b/lib/src/modules/lobby/lobby_read_markers.dart
@@ -50,7 +50,12 @@ abstract final class LobbyReadMarkerStorage {
       final decoded = jsonDecode(raw);
       if (decoded is! Map) {
         _logger.warning(
-            'Discarding corrupt room read markers (not a JSON object)');
+          'Discarding corrupt room read markers (not a JSON object)',
+          attributes: {
+            'serverId': serverId,
+            'userId': userId ?? unauthenticatedStorageUser,
+          },
+        );
         return {};
       }
       var skipped = 0;
@@ -69,14 +74,27 @@ abstract final class LobbyReadMarkerStorage {
       // Every entry dropped on a non-empty payload is a systemic serialization
       // break, not one stale row, and it silently resets this server's read
       // model (every room flips to unread). Surface it loudly.
+      final attributes = {
+        'serverId': serverId,
+        'userId': userId ?? unauthenticatedStorageUser,
+      };
       if (skipped > 0 && result.isEmpty) {
-        _logger.error('Discarding all $skipped room read markers; none parsed');
+        _logger.error('Discarding all $skipped room read markers; none parsed',
+            attributes: attributes);
       } else if (skipped > 0) {
-        _logger.warning('Skipped $skipped malformed room read marker(s)');
+        _logger.warning('Skipped $skipped malformed room read marker(s)',
+            attributes: attributes);
       }
     } on FormatException catch (e, st) {
-      _logger.warning('Discarding corrupt room read markers',
-          error: e, stackTrace: st);
+      _logger.warning(
+        'Discarding corrupt room read markers',
+        error: e,
+        stackTrace: st,
+        attributes: {
+          'serverId': serverId,
+          'userId': userId ?? unauthenticatedStorageUser,
+        },
+      );
       return {};
     }
     return result;
@@ -96,8 +114,8 @@ abstract final class LobbyReadMarkerStorage {
         _key(serverId, userId ?? unauthenticatedStorageUser), jsonEncode(obj));
   }
 
-  /// Drops every user's room markers for [serverId]. Only keyed entries are
-  /// removed; any pre-keyed entry under the old flat key name is left untouched.
+  /// Drops every user's room markers for [serverId]. Sweeps only keys under this
+  /// class's `(serverId, userId)` prefix; unrelated keys are untouched.
   static Future<void> clearServer(String serverId) async {
     final prefs = await SharedPreferences.getInstance();
     final sweep = serverKeyPrefix(_prefix, serverId);
@@ -123,9 +141,14 @@ class RoomReadMarkers {
   final Signal<Map<RoomMarkerKey, DateTime>> _markers = Signal(const {});
   ReadonlySignal<Map<RoomMarkerKey, DateTime>> get markers => _markers;
 
-  /// The `(serverId, userId)` blobs already merged in from disk. Guards against
-  /// a re-entrant load clobbering an optimistic in-memory stamp.
-  final Set<(String, String)> _loaded = {};
+  /// `(serverId, userId)` blobs whose disk load has completed. A completed key
+  /// means the in-memory map already holds that blob's full on-disk set, so a
+  /// rewrite of it (see [_persist]) can't shrink what's on disk.
+  final Set<ServerMarkerKey> _loaded = {};
+
+  /// In-flight loads per `(serverId, userId)`, so concurrent callers await the
+  /// same disk read instead of each racing a partial in-memory view onto disk.
+  final Map<ServerMarkerKey, Future<void>> _loadTasks = {};
 
   bool _disposed = false;
 
@@ -135,34 +158,39 @@ class RoomReadMarkers {
   /// Loads the `(serverId, userId)` blob once, merging it *under* anything
   /// already stamped in-memory (an early [markRead] before the disk read
   /// returned) so a just-read room isn't clobbered back to unread by the slower
-  /// load. Idempotent per `(serverId, userId)`; on failure the guard is released
-  /// so a later mount can retry rather than leaving the blob permanently unread.
+  /// load. Concurrent calls await the same in-flight load; a failed load leaves
+  /// the key unloaded so a later mount retries rather than wedging it unread.
   Future<void> ensureLoaded({
     required String serverId,
     required String? userId,
-  }) async {
-    final u = userId ?? unauthenticatedStorageUser;
-    if (!_loaded.add((serverId, u))) return;
-    final Map<String, DateTime> loaded;
+  }) {
+    final key =
+        (serverId: serverId, userId: userId ?? unauthenticatedStorageUser);
+    if (_loaded.contains(key)) return Future<void>.value();
+    return _loadTasks[key] ??= _load(serverId, userId, key);
+  }
+
+  Future<void> _load(
+      String serverId, String? userId, ServerMarkerKey key) async {
     try {
-      loaded = await LobbyReadMarkerStorage.loadServer(
+      final loaded = await LobbyReadMarkerStorage.loadServer(
           serverId: serverId, userId: userId);
+      if (_disposed) return;
+      _markers.value = {
+        for (final e in loaded.entries)
+          (serverId: serverId, userId: key.userId, roomId: e.key): e.value,
+        ..._markers.value,
+      };
+      _loaded.add(key);
     } catch (error, st) {
-      // Release the guard so a later mount can retry a transient storage error.
-      _loaded.remove((serverId, u));
       _logger.warning(
         'Failed to load room read markers',
         error: error,
         stackTrace: st,
       );
-      return;
+    } finally {
+      _loadTasks.remove(key);
     }
-    if (_disposed) return;
-    _markers.value = {
-      for (final e in loaded.entries)
-        (serverId: serverId, userId: u, roomId: e.key): e.value,
-      ..._markers.value,
-    };
   }
 
   /// Stamps `(serverId, userId, roomId)` read as of [at] and persists. [at] is
@@ -185,42 +213,48 @@ class RoomReadMarkers {
     unawaited(_persist(serverId, u, userId));
   }
 
-  /// Rewrites the whole `(serverId, userId)` blob. Loads the blob first
-  /// (idempotent) so a stamp made before the server's markers were loaded
-  /// rewrites the full on-disk set rather than clobbering it down to the single
-  /// just-stamped room.
+  /// Rewrites the whole `(serverId, userId)` blob. Waits for the blob's load to
+  /// complete first, so a stamp made before or during the load rewrites the
+  /// full on-disk set rather than shrinking it to the just-stamped room. When
+  /// the load didn't complete (a storage failure), the write is skipped: the
+  /// in-memory view is missing rooms that are still on disk, so rewriting it
+  /// would drop them.
   Future<void> _persist(String serverId, String u, String? userId) async {
-    await ensureLoaded(serverId: serverId, userId: userId);
-    if (_disposed) return;
-    final blob = <String, DateTime>{
-      for (final e in _markers.value.entries)
-        if (e.key.serverId == serverId && e.key.userId == u)
-          e.key.roomId: e.value,
-    };
-    await LobbyReadMarkerStorage.saveServer(
-      serverId: serverId,
-      userId: userId,
-      markers: blob,
-    ).catchError((Object error, StackTrace st) {
+    try {
+      await ensureLoaded(serverId: serverId, userId: userId);
+      if (_disposed || !_loaded.contains((serverId: serverId, userId: u))) {
+        return;
+      }
+      final blob = <String, DateTime>{
+        for (final e in _markers.value.entries)
+          if (e.key.serverId == serverId && e.key.userId == u)
+            e.key.roomId: e.value,
+      };
+      await LobbyReadMarkerStorage.saveServer(
+        serverId: serverId,
+        userId: userId,
+        markers: blob,
+      );
+    } catch (error, st) {
       _logger.warning(
         'Failed to persist room read markers',
         error: error,
         stackTrace: st,
       );
-    });
+    }
   }
 
   /// Drops every user's markers for [serverId] from memory and disk, so a
   /// removed server's rooms don't read as read if it's re-added under the same
-  /// id. The disk sweep runs unconditionally: the in-memory view holds only the
-  /// current user's blob per server, so it can't tell whether another user's
-  /// (or an unloaded) blob is still on disk.
+  /// id. The disk sweep runs unconditionally: the in-memory view can't see
+  /// another user's (or an unloaded) blob that may still be on disk.
   void clearServer(String serverId) {
     final next = {..._markers.value}
       ..removeWhere((key, _) => key.serverId == serverId);
     // Reassign only on a real change, to avoid a spurious watcher notification.
     if (next.length != _markers.value.length) _markers.value = next;
-    _loaded.removeWhere((pair) => pair.$1 == serverId);
+    _loaded.removeWhere((key) => key.serverId == serverId);
+    _loadTasks.removeWhere((key, _) => key.serverId == serverId);
     unawaited(
       LobbyReadMarkerStorage.clearServer(serverId)
           .catchError((Object error, StackTrace st) {
@@ -267,7 +301,13 @@ abstract final class ServerReadMarkerStorage {
     if (raw == null || raw.isEmpty) return null;
     final at = DateTime.tryParse(raw);
     if (at == null) {
-      _logger.warning('Discarding corrupt server read marker (unparseable)');
+      _logger.warning(
+        'Discarding corrupt server read marker (unparseable)',
+        attributes: {
+          'serverId': serverId,
+          'userId': userId ?? unauthenticatedStorageUser,
+        },
+      );
       return null;
     }
     return at.toUtc();
@@ -286,7 +326,7 @@ abstract final class ServerReadMarkerStorage {
     );
   }
 
-  /// Drops every user's marker for [serverId] (keyed format).
+  /// Drops every user's marker for [serverId].
   static Future<void> clearServer(String serverId) async {
     final prefs = await SharedPreferences.getInstance();
     final sweep = serverKeyPrefix(_prefix, serverId);
@@ -307,7 +347,11 @@ class ServerReadMarkers {
   final Signal<Map<ServerMarkerKey, DateTime>> _markers = Signal(const {});
   ReadonlySignal<Map<ServerMarkerKey, DateTime>> get markers => _markers;
 
-  final Set<(String, String)> _loaded = {};
+  final Set<ServerMarkerKey> _loaded = {};
+
+  /// In-flight loads per `(serverId, userId)`, so concurrent callers await the
+  /// same disk read instead of one resolving before the marker is in memory.
+  final Map<ServerMarkerKey, Future<void>> _loadTasks = {};
 
   bool _disposed = false;
 
@@ -315,32 +359,37 @@ class ServerReadMarkers {
   Map<ServerMarkerKey, DateTime> get value => _markers.value;
 
   /// Loads the `(serverId, userId)` marker once, merging it *under* any stamp
-  /// already in-memory. Idempotent per `(serverId, userId)`; releases the guard
-  /// on failure so a later mount can retry.
+  /// already in-memory. Concurrent calls await the same in-flight load; a failed
+  /// load leaves the key unloaded so a later mount retries.
   Future<void> ensureLoaded({
     required String serverId,
     required String? userId,
-  }) async {
-    final u = userId ?? unauthenticatedStorageUser;
-    if (!_loaded.add((serverId, u))) return;
-    final DateTime? at;
+  }) {
+    final key =
+        (serverId: serverId, userId: userId ?? unauthenticatedStorageUser);
+    if (_loaded.contains(key)) return Future<void>.value();
+    return _loadTasks[key] ??= _load(serverId, userId, key);
+  }
+
+  Future<void> _load(
+      String serverId, String? userId, ServerMarkerKey key) async {
     try {
-      at = await ServerReadMarkerStorage.loadServer(
+      final at = await ServerReadMarkerStorage.loadServer(
           serverId: serverId, userId: userId);
+      if (_disposed) return;
+      if (at != null && !_markers.value.containsKey(key)) {
+        _markers.value = {..._markers.value, key: at};
+      }
+      _loaded.add(key);
     } catch (error, st) {
-      // Release the guard so a later mount can retry a transient storage error.
-      _loaded.remove((serverId, u));
       _logger.warning(
         'Failed to load server read marker',
         error: error,
         stackTrace: st,
       );
-      return;
+    } finally {
+      _loadTasks.remove(key);
     }
-    if (at == null || _disposed) return;
-    final key = (serverId: serverId, userId: u);
-    if (_markers.value.containsKey(key)) return;
-    _markers.value = {..._markers.value, key: at};
   }
 
   /// Stamps [serverId] read as of [at] for [userId] and persists. [at] is
@@ -379,7 +428,8 @@ class ServerReadMarkers {
       ..removeWhere((key, _) => key.serverId == serverId);
     // Reassign only on a real change, to avoid a spurious watcher notification.
     if (next.length != _markers.value.length) _markers.value = next;
-    _loaded.removeWhere((pair) => pair.$1 == serverId);
+    _loaded.removeWhere((key) => key.serverId == serverId);
+    _loadTasks.removeWhere((key, _) => key.serverId == serverId);
     unawaited(
       ServerReadMarkerStorage.clearServer(serverId)
           .catchError((Object error, StackTrace st) {

--- a/lib/src/modules/lobby/lobby_read_markers.dart
+++ b/lib/src/modules/lobby/lobby_read_markers.dart
@@ -245,7 +245,7 @@ class RoomReadMarkers {
       // already gone, so there is nothing left to persist.
       if (_disposed || gen != (_generation[serverId] ?? 0)) return;
       if (!_loaded.contains((serverId: serverId, userId: u))) {
-        _logger.debug(
+        _logger.warning(
           'Skipped room read marker persist; blob not loaded (a prior load '
           'failed). The stamp holds in memory but is not yet on disk.',
           attributes: {'serverId': serverId, 'userId': u},
@@ -384,8 +384,9 @@ class ServerReadMarkers {
 
   /// Per-server clear epoch, bumped by [clearServer]; see
   /// [RoomReadMarkers._generation]. Only [_load] needs it here — [markRead]
-  /// persists with no `await` before its write, so a synchronously-following
-  /// [clearServer] sweep always lands after it in storage order.
+  /// schedules its write without first awaiting a load (unlike
+  /// [RoomReadMarkers._persist]), so a [clearServer] sweep enqueued right after
+  /// it is ordered behind the write and wins.
   final Map<String, int> _generation = {};
 
   bool _disposed = false;

--- a/lib/src/modules/lobby/lobby_read_markers.dart
+++ b/lib/src/modules/lobby/lobby_read_markers.dart
@@ -5,7 +5,10 @@ import 'package:shared_preferences/shared_preferences.dart';
 import 'package:soliplex_agent/soliplex_agent.dart' show ReadonlySignal, Signal;
 import 'package:soliplex_logging/soliplex_logging.dart';
 
-import '../../core/activity_read.dart' show RoomActivityKey;
+import '../../core/activity_read.dart' show RoomMarkerKey, ServerMarkerKey;
+import '../../core/keyed_storage.dart';
+
+export '../../core/activity_read.dart' show RoomMarkerKey, ServerMarkerKey;
 
 final Logger _logger =
     LogManager.instance.getLogger('soliplex.lobby_read_markers');
@@ -16,85 +19,92 @@ final Logger _logger =
 /// This is a deliberately simple, *client-side* read model: a room is unread
 /// when its last-message time is newer than the moment the user last opened
 /// it on this device. There is no server-side read state and no count — just
-/// a boolean affordance. Read markers are therefore per-device.
+/// a boolean affordance. Read markers are therefore per-device, and per user:
+/// a different user signing in on a shared device sees their own read state.
 ///
-/// Backed by `shared_preferences` (non-sensitive UI state). Stored as a JSON
-/// array of `{s, r, t}` objects (server id, room id, ISO-8601 UTC instant) so
-/// ids needn't be escaped into a composite key.
+/// Backed by `shared_preferences` (non-sensitive UI state), grained to one blob
+/// per `(serverId, userId)` — the lobby loads all of a server's rooms at once,
+/// so the blob matches the read-unit. The value is a JSON object `{roomId:
+/// ISO-8601 UTC instant}`. Keyed via the shared codec so component separators
+/// are unambiguous. A null [userId] (a signed-out or no-auth server) resolves to
+/// the shared [unauthenticatedStorageUser] bucket.
 abstract final class LobbyReadMarkerStorage {
-  static const _key = 'soliplex_lobby_read_markers';
+  static const _prefix = 'soliplex_room_read_marker';
 
-  // Row field names, shared by load and save so the read/write contract can't
-  // drift: a typo in one half alone would silently drop every row.
-  static const _fieldServer = 's';
-  static const _fieldRoom = 'r';
-  static const _fieldTime = 't';
+  static String _key(String serverId, String userId) =>
+      encodeKey(_prefix, [serverId, userId]);
 
-  static Future<Map<RoomActivityKey, DateTime>> load() async {
+  /// The read markers (roomId → last-seen instant) for one server and user, or
+  /// empty when nothing is stored.
+  static Future<Map<String, DateTime>> loadServer({
+    required String serverId,
+    required String? userId,
+  }) async {
     final prefs = await SharedPreferences.getInstance();
-    final raw = prefs.getString(_key);
+    final raw =
+        prefs.getString(_key(serverId, userId ?? unauthenticatedStorageUser));
     if (raw == null || raw.isEmpty) return {};
 
-    final result = <RoomActivityKey, DateTime>{};
+    final result = <String, DateTime>{};
     try {
       final decoded = jsonDecode(raw);
-      if (decoded is! List) {
+      if (decoded is! Map) {
         _logger.warning(
-            'Discarding corrupt lobby read markers (not a JSON array)');
+            'Discarding corrupt room read markers (not a JSON object)');
         return {};
       }
       var skipped = 0;
-      for (final entry in decoded) {
-        if (entry is! Map) {
+      decoded.forEach((key, value) {
+        if (key is! String || value is! String) {
           skipped++;
-          continue;
+          return;
         }
-        final s = entry[_fieldServer];
-        final r = entry[_fieldRoom];
-        final t = entry[_fieldTime];
-        if (s is! String || r is! String || t is! String) {
-          skipped++;
-          continue;
-        }
-        final at = DateTime.tryParse(t);
+        final at = DateTime.tryParse(value);
         if (at == null) {
           skipped++;
-          continue;
+          return;
         }
-        result[(serverId: s, roomId: r)] = at.toUtc();
-      }
-      // Every row dropped on a non-empty payload is a systemic serialization
-      // break, not one stale row, and it silently resets the read model (every
-      // room flips to unread). Surface it loudly.
+        result[key] = at.toUtc();
+      });
+      // Every entry dropped on a non-empty payload is a systemic serialization
+      // break, not one stale row, and it silently resets this server's read
+      // model (every room flips to unread). Surface it loudly.
       if (skipped > 0 && result.isEmpty) {
-        _logger
-            .error('Discarding all $skipped lobby read markers; none parsed');
+        _logger.error('Discarding all $skipped room read markers; none parsed');
       } else if (skipped > 0) {
-        _logger.warning('Skipped $skipped malformed lobby read marker(s)');
+        _logger.warning('Skipped $skipped malformed room read marker(s)');
       }
     } on FormatException catch (e, st) {
-      // Corrupt payload: start fresh rather than wedging the lobby.
-      _logger.warning(
-        'Discarding corrupt lobby read markers',
-        error: e,
-        stackTrace: st,
-      );
+      _logger.warning('Discarding corrupt room read markers',
+          error: e, stackTrace: st);
       return {};
     }
     return result;
   }
 
-  static Future<void> save(Map<RoomActivityKey, DateTime> markers) async {
+  /// Persists [markers] (roomId → instant) as the whole blob for the server.
+  static Future<void> saveServer({
+    required String serverId,
+    required String? userId,
+    required Map<String, DateTime> markers,
+  }) async {
     final prefs = await SharedPreferences.getInstance();
-    final list = [
-      for (final entry in markers.entries)
-        {
-          _fieldServer: entry.key.serverId,
-          _fieldRoom: entry.key.roomId,
-          _fieldTime: entry.value.toUtc().toIso8601String(),
-        },
-    ];
-    await prefs.setString(_key, jsonEncode(list));
+    final obj = {
+      for (final e in markers.entries) e.key: e.value.toUtc().toIso8601String(),
+    };
+    await prefs.setString(
+        _key(serverId, userId ?? unauthenticatedStorageUser), jsonEncode(obj));
+  }
+
+  /// Drops every user's room markers for [serverId]. Only keyed entries are
+  /// removed; any pre-keyed entry under the old flat key name is left untouched.
+  static Future<void> clearServer(String serverId) async {
+    final prefs = await SharedPreferences.getInstance();
+    final sweep = serverKeyPrefix(_prefix, serverId);
+    for (final k
+        in prefs.getKeys().where((k) => k.startsWith(sweep)).toList()) {
+      await prefs.remove(k);
+    }
   }
 }
 
@@ -104,62 +114,115 @@ abstract final class LobbyReadMarkerStorage {
 /// no [LobbyReadMarkerStorage] round-trip to race the screens' mount/dispose
 /// ordering (which is what let a just-read room show a stale unread dot in the
 /// lobby). Backed by [LobbyReadMarkerStorage] for persistence across launches.
+///
+/// Keys carry the `userId` dimension so multiple servers — each potentially
+/// signed in as a different user — coexist in the one signal. The projection to
+/// the current user per server lives in the consumers (see
+/// `currentUserRoomMarkers`); this model is a dumb, auth-agnostic store.
 class RoomReadMarkers {
-  final Signal<Map<RoomActivityKey, DateTime>> _markers = Signal(const {});
-  ReadonlySignal<Map<RoomActivityKey, DateTime>> get markers => _markers;
+  final Signal<Map<RoomMarkerKey, DateTime>> _markers = Signal(const {});
+  ReadonlySignal<Map<RoomMarkerKey, DateTime>> get markers => _markers;
 
-  bool _loaded = false;
+  /// The `(serverId, userId)` blobs already merged in from disk. Guards against
+  /// a re-entrant load clobbering an optimistic in-memory stamp.
+  final Set<(String, String)> _loaded = {};
+
+  bool _disposed = false;
 
   /// The current markers, for a non-reactive read.
-  Map<RoomActivityKey, DateTime> get value => _markers.value;
+  Map<RoomMarkerKey, DateTime> get value => _markers.value;
 
-  /// Loads persisted markers once, merging them under any already stamped
-  /// in-memory (an early [markRead] before the disk read returned) so a
-  /// just-read room isn't clobbered back to unread by the slower load.
-  Future<void> ensureLoaded() async {
-    if (_loaded) return;
-    _loaded = true;
+  /// Loads the `(serverId, userId)` blob once, merging it *under* anything
+  /// already stamped in-memory (an early [markRead] before the disk read
+  /// returned) so a just-read room isn't clobbered back to unread by the slower
+  /// load. Idempotent per `(serverId, userId)`; on failure the guard is released
+  /// so a later mount can retry rather than leaving the blob permanently unread.
+  Future<void> ensureLoaded({
+    required String serverId,
+    required String? userId,
+  }) async {
+    final u = userId ?? unauthenticatedStorageUser;
+    if (!_loaded.add((serverId, u))) return;
+    final Map<String, DateTime> loaded;
     try {
-      final loaded = await LobbyReadMarkerStorage.load();
-      _markers.value = {...loaded, ..._markers.value};
+      loaded = await LobbyReadMarkerStorage.loadServer(
+          serverId: serverId, userId: userId);
     } catch (error, st) {
+      // Release the guard so a later mount can retry a transient storage error.
+      _loaded.remove((serverId, u));
       _logger.warning(
         'Failed to load room read markers',
         error: error,
         stackTrace: st,
       );
+      return;
     }
+    if (_disposed) return;
+    _markers.value = {
+      for (final e in loaded.entries)
+        (serverId: serverId, userId: u, roomId: e.key): e.value,
+      ..._markers.value,
+    };
   }
 
-  /// Stamps [key] read as of [at] and persists. [at] is normalized to UTC so
-  /// the in-memory value equals what a reload yields: DateTime equality compares
-  /// the isUtc flag, so a local stamp would be unequal to its own UTC-parsed
-  /// reload. The [markers] update is synchronous, so a screen watching it reacts
-  /// with no storage round-trip.
-  void markRead(RoomActivityKey key, DateTime at) {
-    _markers.value = {..._markers.value, key: at.toUtc()};
-    unawaited(
-      LobbyReadMarkerStorage.save(_markers.value)
-          .catchError((Object error, StackTrace st) {
-        _logger.warning(
-          'Failed to persist room read markers',
-          error: error,
-          stackTrace: st,
-        );
-      }),
-    );
+  /// Stamps `(serverId, userId, roomId)` read as of [at] and persists. [at] is
+  /// normalized to UTC so the in-memory value equals what a reload yields:
+  /// DateTime equality compares the isUtc flag, so a local stamp would be
+  /// unequal to its own UTC-parsed reload. The [markers] update is synchronous,
+  /// so a screen watching it reacts with no storage round-trip. A null [userId]
+  /// resolves to the [unauthenticatedStorageUser] bucket.
+  void markRead({
+    required String serverId,
+    required String? userId,
+    required String roomId,
+    required DateTime at,
+  }) {
+    final u = userId ?? unauthenticatedStorageUser;
+    _markers.value = {
+      ..._markers.value,
+      (serverId: serverId, userId: u, roomId: roomId): at.toUtc(),
+    };
+    unawaited(_persist(serverId, u, userId));
   }
 
-  /// Drops every marker for [serverId] and persists, so a removed server's
-  /// rooms don't read as read if the server is re-added under the same id.
-  /// No-op (and no write) when the server has no markers.
+  /// Rewrites the whole `(serverId, userId)` blob. Loads the blob first
+  /// (idempotent) so a stamp made before the server's markers were loaded
+  /// rewrites the full on-disk set rather than clobbering it down to the single
+  /// just-stamped room.
+  Future<void> _persist(String serverId, String u, String? userId) async {
+    await ensureLoaded(serverId: serverId, userId: userId);
+    if (_disposed) return;
+    final blob = <String, DateTime>{
+      for (final e in _markers.value.entries)
+        if (e.key.serverId == serverId && e.key.userId == u)
+          e.key.roomId: e.value,
+    };
+    await LobbyReadMarkerStorage.saveServer(
+      serverId: serverId,
+      userId: userId,
+      markers: blob,
+    ).catchError((Object error, StackTrace st) {
+      _logger.warning(
+        'Failed to persist room read markers',
+        error: error,
+        stackTrace: st,
+      );
+    });
+  }
+
+  /// Drops every user's markers for [serverId] from memory and disk, so a
+  /// removed server's rooms don't read as read if it's re-added under the same
+  /// id. The disk sweep runs unconditionally: the in-memory view holds only the
+  /// current user's blob per server, so it can't tell whether another user's
+  /// (or an unloaded) blob is still on disk.
   void clearServer(String serverId) {
     final next = {..._markers.value}
       ..removeWhere((key, _) => key.serverId == serverId);
-    if (next.length == _markers.value.length) return;
-    _markers.value = next;
+    // Reassign only on a real change, to avoid a spurious watcher notification.
+    if (next.length != _markers.value.length) _markers.value = next;
+    _loaded.removeWhere((pair) => pair.$1 == serverId);
     unawaited(
-      LobbyReadMarkerStorage.save(_markers.value)
+      LobbyReadMarkerStorage.clearServer(serverId)
           .catchError((Object error, StackTrace st) {
         // Error, not warning: a failed clear leaves stale floors on disk, so a
         // server re-added under the same id reads as already-read (hides unread
@@ -174,79 +237,63 @@ class RoomReadMarkers {
     );
   }
 
-  void dispose() => _markers.dispose();
+  void dispose() {
+    _disposed = true;
+    _markers.dispose();
+  }
 }
 
 /// Persists per-server "last seen" timestamps. A server marker floors every
 /// room and thread on that server: activity at or before it reads as read, so a
 /// single server-level write floors the whole server with no per-room fan-out.
-/// Mirrors [LobbyReadMarkerStorage] but keyed by a single server id, so rows are
-/// `{s, t}` (server id, ISO-8601 UTC instant).
+/// Keyed per `(serverId, userId)` so a different user sees their own floor; the
+/// value is a single ISO-8601 UTC instant. A null [userId] resolves to the
+/// shared [unauthenticatedStorageUser] bucket.
 abstract final class ServerReadMarkerStorage {
-  static const _key = 'soliplex_server_read_markers';
+  static const _prefix = 'soliplex_server_read_marker';
 
-  static const _fieldServer = 's';
-  static const _fieldTime = 't';
+  static String _key(String serverId, String userId) =>
+      encodeKey(_prefix, [serverId, userId]);
 
-  static Future<Map<String, DateTime>> load() async {
+  /// The server's last-seen instant for [userId], or null when nothing is
+  /// stored (or the stored value is unparseable).
+  static Future<DateTime?> loadServer({
+    required String serverId,
+    required String? userId,
+  }) async {
     final prefs = await SharedPreferences.getInstance();
-    final raw = prefs.getString(_key);
-    if (raw == null || raw.isEmpty) return {};
-
-    final result = <String, DateTime>{};
-    try {
-      final decoded = jsonDecode(raw);
-      if (decoded is! List) {
-        _logger.warning(
-            'Discarding corrupt server read markers (not a JSON array)');
-        return {};
-      }
-      var skipped = 0;
-      for (final entry in decoded) {
-        if (entry is! Map) {
-          skipped++;
-          continue;
-        }
-        final s = entry[_fieldServer];
-        final t = entry[_fieldTime];
-        if (s is! String || t is! String) {
-          skipped++;
-          continue;
-        }
-        final at = DateTime.tryParse(t);
-        if (at == null) {
-          skipped++;
-          continue;
-        }
-        result[s] = at.toUtc();
-      }
-      if (skipped > 0 && result.isEmpty) {
-        _logger
-            .error('Discarding all $skipped server read markers; none parsed');
-      } else if (skipped > 0) {
-        _logger.warning('Skipped $skipped malformed server read marker(s)');
-      }
-    } on FormatException catch (e, st) {
-      _logger.warning(
-        'Discarding corrupt server read markers',
-        error: e,
-        stackTrace: st,
-      );
-      return {};
+    final raw =
+        prefs.getString(_key(serverId, userId ?? unauthenticatedStorageUser));
+    if (raw == null || raw.isEmpty) return null;
+    final at = DateTime.tryParse(raw);
+    if (at == null) {
+      _logger.warning('Discarding corrupt server read marker (unparseable)');
+      return null;
     }
-    return result;
+    return at.toUtc();
   }
 
-  static Future<void> save(Map<String, DateTime> markers) async {
+  /// Persists [at] as the server's last-seen instant for [userId].
+  static Future<void> saveServer({
+    required String serverId,
+    required String? userId,
+    required DateTime at,
+  }) async {
     final prefs = await SharedPreferences.getInstance();
-    final list = [
-      for (final entry in markers.entries)
-        {
-          _fieldServer: entry.key,
-          _fieldTime: entry.value.toUtc().toIso8601String(),
-        },
-    ];
-    await prefs.setString(_key, jsonEncode(list));
+    await prefs.setString(
+      _key(serverId, userId ?? unauthenticatedStorageUser),
+      at.toUtc().toIso8601String(),
+    );
+  }
+
+  /// Drops every user's marker for [serverId] (keyed format).
+  static Future<void> clearServer(String serverId) async {
+    final prefs = await SharedPreferences.getInstance();
+    final sweep = serverKeyPrefix(_prefix, serverId);
+    for (final k
+        in prefs.getKeys().where((k) => k.startsWith(sweep)).toList()) {
+      await prefs.remove(k);
+    }
   }
 }
 
@@ -254,46 +301,69 @@ abstract final class ServerReadMarkerStorage {
 /// the lobby and the room screen: a marker written to it is visible to both
 /// immediately, with no [ServerReadMarkerStorage] round-trip, so a server floor
 /// applies to every surface at once. Mirrors [RoomReadMarkers] one level up the
-/// hierarchy. Backed by [ServerReadMarkerStorage] for persistence across launches.
+/// hierarchy, keyed `(serverId, userId)`. Backed by [ServerReadMarkerStorage]
+/// for persistence across launches.
 class ServerReadMarkers {
-  final Signal<Map<String, DateTime>> _markers = Signal(const {});
-  ReadonlySignal<Map<String, DateTime>> get markers => _markers;
+  final Signal<Map<ServerMarkerKey, DateTime>> _markers = Signal(const {});
+  ReadonlySignal<Map<ServerMarkerKey, DateTime>> get markers => _markers;
 
-  bool _loaded = false;
+  final Set<(String, String)> _loaded = {};
+
+  bool _disposed = false;
 
   /// The current markers, for a non-reactive read.
-  Map<String, DateTime> get value => _markers.value;
+  Map<ServerMarkerKey, DateTime> get value => _markers.value;
 
-  /// Loads persisted markers once, merging them under any already stamped
-  /// in-memory (an early [markRead] before the disk read returned) so a
-  /// just-read server isn't clobbered back to unread by the slower load.
-  Future<void> ensureLoaded() async {
-    if (_loaded) return;
-    _loaded = true;
+  /// Loads the `(serverId, userId)` marker once, merging it *under* any stamp
+  /// already in-memory. Idempotent per `(serverId, userId)`; releases the guard
+  /// on failure so a later mount can retry.
+  Future<void> ensureLoaded({
+    required String serverId,
+    required String? userId,
+  }) async {
+    final u = userId ?? unauthenticatedStorageUser;
+    if (!_loaded.add((serverId, u))) return;
+    final DateTime? at;
     try {
-      final loaded = await ServerReadMarkerStorage.load();
-      _markers.value = {...loaded, ..._markers.value};
+      at = await ServerReadMarkerStorage.loadServer(
+          serverId: serverId, userId: userId);
     } catch (error, st) {
+      // Release the guard so a later mount can retry a transient storage error.
+      _loaded.remove((serverId, u));
       _logger.warning(
-        'Failed to load server read markers',
+        'Failed to load server read marker',
         error: error,
         stackTrace: st,
       );
+      return;
     }
+    if (at == null || _disposed) return;
+    final key = (serverId: serverId, userId: u);
+    if (_markers.value.containsKey(key)) return;
+    _markers.value = {..._markers.value, key: at};
   }
 
-  /// Stamps [serverId] read as of [at] and persists. [at] is normalized to UTC
-  /// so the in-memory value equals what a reload yields: DateTime equality
-  /// compares the isUtc flag, so a local stamp would be unequal to its own
-  /// UTC-parsed reload. The [markers] update is synchronous, so a screen
-  /// watching it reacts with no storage round-trip.
-  void markRead(String serverId, DateTime at) {
-    _markers.value = {..._markers.value, serverId: at.toUtc()};
+  /// Stamps [serverId] read as of [at] for [userId] and persists. [at] is
+  /// normalized to UTC (see [RoomReadMarkers.markRead]). A null [userId]
+  /// resolves to the [unauthenticatedStorageUser] bucket.
+  void markRead({
+    required String serverId,
+    required String? userId,
+    required DateTime at,
+  }) {
+    final u = userId ?? unauthenticatedStorageUser;
+    _markers.value = {
+      ..._markers.value,
+      (serverId: serverId, userId: u): at.toUtc(),
+    };
     unawaited(
-      ServerReadMarkerStorage.save(_markers.value)
-          .catchError((Object error, StackTrace st) {
+      ServerReadMarkerStorage.saveServer(
+        serverId: serverId,
+        userId: userId,
+        at: at.toUtc(),
+      ).catchError((Object error, StackTrace st) {
         _logger.warning(
-          'Failed to persist server read markers',
+          'Failed to persist server read marker',
           error: error,
           stackTrace: st,
         );
@@ -301,13 +371,17 @@ class ServerReadMarkers {
     );
   }
 
-  /// Drops [serverId]'s marker and persists, so a removed server doesn't floor
-  /// its rooms if re-added under the same id. No-op when there is no marker.
+  /// Drops every user's marker for [serverId] from memory and disk, so a
+  /// removed server doesn't floor its rooms if re-added under the same id. The
+  /// disk sweep runs unconditionally (see [RoomReadMarkers.clearServer]).
   void clearServer(String serverId) {
-    if (!_markers.value.containsKey(serverId)) return;
-    _markers.value = {..._markers.value}..remove(serverId);
+    final next = {..._markers.value}
+      ..removeWhere((key, _) => key.serverId == serverId);
+    // Reassign only on a real change, to avoid a spurious watcher notification.
+    if (next.length != _markers.value.length) _markers.value = next;
+    _loaded.removeWhere((pair) => pair.$1 == serverId);
     unawaited(
-      ServerReadMarkerStorage.save(_markers.value)
+      ServerReadMarkerStorage.clearServer(serverId)
           .catchError((Object error, StackTrace st) {
         // Error, not warning: a failed clear leaves a stale floor on disk, so a
         // server re-added under the same id reads as already-read (hides unread
@@ -322,5 +396,8 @@ class ServerReadMarkers {
     );
   }
 
-  void dispose() => _markers.dispose();
+  void dispose() {
+    _disposed = true;
+    _markers.dispose();
+  }
 }

--- a/lib/src/modules/lobby/lobby_state.dart
+++ b/lib/src/modules/lobby/lobby_state.dart
@@ -12,7 +12,7 @@ import 'package:soliplex_client/soliplex_client.dart'
 import 'package:soliplex_logging/soliplex_logging.dart';
 
 import '../../core/activity_read.dart';
-import '../../core/keyed_storage.dart' show unauthenticatedStorageUser;
+import '../../core/keyed_storage.dart' show storageUser;
 import '../../core/util/debouncer.dart';
 import '../auth/auth_tokens.dart';
 import '../auth/selected_server_storage.dart';
@@ -239,7 +239,7 @@ class LobbyState {
     final userFor = _currentUserByServer();
     return currentUserRoomMarkers(
       _roomReadMarkers.markers.value,
-      (serverId) => userFor[serverId] ?? unauthenticatedStorageUser,
+      (serverId) => storageUser(userFor[serverId]),
     );
   });
 
@@ -253,7 +253,7 @@ class LobbyState {
     final userFor = _currentUserByServer();
     return currentUserServerMarkers(
       _serverReadMarkers.markers.value,
-      (serverId) => userFor[serverId] ?? unauthenticatedStorageUser,
+      (serverId) => storageUser(userFor[serverId]),
     );
   });
 
@@ -264,8 +264,7 @@ class LobbyState {
   Map<String, String> _currentUserByServer() {
     final result = <String, String>{};
     for (final entry in _serverManager.servers.value.values) {
-      result[entry.serverId] =
-          entry.auth.currentUserId.value ?? unauthenticatedStorageUser;
+      result[entry.serverId] = storageUser(entry.auth.currentUserId.value);
     }
     return result;
   }

--- a/lib/src/modules/lobby/lobby_state.dart
+++ b/lib/src/modules/lobby/lobby_state.dart
@@ -12,6 +12,7 @@ import 'package:soliplex_client/soliplex_client.dart'
 import 'package:soliplex_logging/soliplex_logging.dart';
 
 import '../../core/activity_read.dart';
+import '../../core/keyed_storage.dart' show unauthenticatedStorageUser;
 import '../../core/util/debouncer.dart';
 import '../auth/auth_tokens.dart';
 import '../auth/selected_server_storage.dart';
@@ -96,8 +97,6 @@ class LobbyState {
     _unsubscribe = _serverManager.servers.subscribe(_onServersChanged);
     unawaited(_loadViewMode());
     unawaited(_loadSortMode());
-    unawaited(_roomReadMarkers.ensureLoaded());
-    unawaited(_serverReadMarkers.ensureLoaded());
     unawaited(_loadSelectedServer());
     _watchRunCompletions();
   }
@@ -225,26 +224,77 @@ class LobbyState {
   ReadonlySignal<Map<RoomActivityKey, DateTime?>> get roomActivity =>
       _roomActivity;
 
-  /// Per-room "last seen" timestamps, keyed by (serverId, roomId). A room is
-  /// *unread* when [roomActivity] reports a last-activity time newer than its
-  /// marker (or newer than the epoch, when never opened). Persisted per-device;
-  /// there is no server-side read state and no unread count.
-  ReadonlySignal<Map<RoomActivityKey, DateTime>> get roomReadMarkers =>
-      _roomReadMarkers.markers;
+  /// Per-room "last seen" timestamps for the current user of each server, keyed
+  /// by (serverId, roomId). A room is *unread* when [roomActivity] reports a
+  /// last-activity time newer than its marker (or newer than the epoch, when
+  /// never opened). Persisted per-device and per-user; there is no server-side
+  /// read state and no unread count.
+  ///
+  /// The shared store keys by `(serverId, userId, roomId)` so servers signed in
+  /// as different users coexist; this projects to each server's current user.
+  /// Every visible server's `currentUserId` is read up front so a marker-less
+  /// server still subscribes and a later sign-in re-runs the projection.
+  late final ReadonlySignal<Map<RoomActivityKey, DateTime>> roomReadMarkers =
+      computed(() {
+    final userFor = _currentUserByServer();
+    return currentUserRoomMarkers(
+      _roomReadMarkers.markers.value,
+      (serverId) => userFor[serverId] ?? unauthenticatedStorageUser,
+    );
+  });
 
-  /// Per-server "last seen" timestamps, keyed by serverId. A room reads as read
-  /// when its activity is at or before the later of its room marker and its
-  /// server's marker here, so a server marker floors all its rooms.
-  ReadonlySignal<Map<String, DateTime>> get serverReadMarkers =>
-      _serverReadMarkers.markers;
+  /// Per-server "last seen" timestamps for the current user of each server,
+  /// keyed by serverId. A room reads as read when its activity is at or before
+  /// the later of its room marker and its server's marker here, so a server
+  /// marker floors all its rooms. Projects the shared `(serverId, userId)` store
+  /// to each server's current user, mirroring [roomReadMarkers].
+  late final ReadonlySignal<Map<String, DateTime>> serverReadMarkers =
+      computed(() {
+    final userFor = _currentUserByServer();
+    return currentUserServerMarkers(
+      _serverReadMarkers.markers.value,
+      (serverId) => userFor[serverId] ?? unauthenticatedStorageUser,
+    );
+  });
+
+  /// The current user identity per visible server (sentinel-substituted). Read
+  /// inside the projection computeds so every server's `currentUserId` is a
+  /// tracked dependency — otherwise a server with no markers yet would never be
+  /// read, and a later sign-in on it wouldn't invalidate the projection.
+  Map<String, String> _currentUserByServer() {
+    final result = <String, String>{};
+    for (final entry in _serverManager.servers.value.values) {
+      result[entry.serverId] =
+          entry.auth.currentUserId.value ?? unauthenticatedStorageUser;
+    }
+    return result;
+  }
+
+  String? _currentUserId(String serverId) =>
+      _serverManager.servers.value[serverId]?.auth.currentUserId.value;
+
+  /// Loads the current user's room + server marker blobs for [entry] into the
+  /// shared stores. Idempotent per `(serverId, userId)`, so calling it on every
+  /// auth change reloads only when the user actually changed (Alice → Bob), not
+  /// on a same-user token refresh.
+  void _ensureMarkersLoaded(ServerEntry entry) {
+    final userId = entry.auth.currentUserId.value;
+    unawaited(_roomReadMarkers.ensureLoaded(
+        serverId: entry.serverId, userId: userId));
+    unawaited(_serverReadMarkers.ensureLoaded(
+        serverId: entry.serverId, userId: userId));
+  }
 
   /// Stamps a room read as of now (from a lobby card's context menu). Writes
   /// through the shared store, so the rail's dot clears too, and every thread in
-  /// the room reads as read via the read-up rule.
+  /// the room reads as read via the read-up rule. Resolves the current user for
+  /// [serverId] live — a menu tap is immediate, so the signed-in user is right.
   void markRoomRead(String serverId, String roomId) {
     _roomReadMarkers.markRead(
-      (serverId: serverId, roomId: roomId),
-      clock.now().toUtc(),
+      serverId: serverId,
+      userId: _currentUserId(serverId),
+      roomId: roomId,
+      at: clock.now().toUtc(),
     );
   }
 
@@ -252,7 +302,11 @@ class LobbyState {
   /// read-up rule this reads every room and thread on the server — loaded or not
   /// — as read, with a single marker write.
   void markServerRead(String serverId) {
-    _serverReadMarkers.markRead(serverId, clock.now().toUtc());
+    _serverReadMarkers.markRead(
+      serverId: serverId,
+      userId: _currentUserId(serverId),
+      at: clock.now().toUtc(),
+    );
   }
 
   /// True while activity for the selected server is being fetched.
@@ -536,6 +590,7 @@ class LobbyState {
       _authSubscriptions[id] = entry.auth.session.subscribe((_) {
         _onAuthChanged(id, entry);
       });
+      _ensureMarkersLoaded(entry);
       if (entry.isConnected) {
         _fetchRooms(id, entry);
         _fetchUserProfile(id, entry);
@@ -549,6 +604,11 @@ class LobbyState {
     final previous = _lastSessionState[serverId];
     final current = entry.auth.session.value;
     _lastSessionState[serverId] = current;
+
+    // Load this server's markers for whoever is now signed in. Idempotent per
+    // (server, user): a same-user token rotation is a no-op, an Alice → Bob
+    // switch loads Bob's blob. Keyed on identity, not the session transition.
+    _ensureMarkersLoaded(entry);
 
     if (entry.isConnected) {
       // Refetch only on transitions INTO ActiveSession (silent

--- a/lib/src/modules/room/thread_anchor_storage.dart
+++ b/lib/src/modules/room/thread_anchor_storage.dart
@@ -35,8 +35,7 @@ abstract final class ThreadAnchorStorage {
     required String roomId,
   }) async {
     final prefs = await SharedPreferences.getInstance();
-    final raw = prefs.getString(
-        _key(serverId, userId ?? unauthenticatedStorageUser, roomId));
+    final raw = prefs.getString(_key(serverId, storageUser(userId), roomId));
     if (raw == null || raw.isEmpty) return {};
 
     final result = <String, String>{};
@@ -82,8 +81,7 @@ abstract final class ThreadAnchorStorage {
   }) async {
     final prefs = await SharedPreferences.getInstance();
     await prefs.setString(
-        _key(serverId, userId ?? unauthenticatedStorageUser, roomId),
-        jsonEncode(anchors));
+        _key(serverId, storageUser(userId), roomId), jsonEncode(anchors));
   }
 
   /// Drops every user's anchors for [serverId] (keyed format). Only keyed entries

--- a/lib/src/modules/room/thread_read_markers.dart
+++ b/lib/src/modules/room/thread_read_markers.dart
@@ -41,8 +41,7 @@ abstract final class ThreadReadMarkerStorage {
     required String roomId,
   }) async {
     final prefs = await SharedPreferences.getInstance();
-    final raw = prefs.getString(
-        _key(serverId, userId ?? unauthenticatedStorageUser, roomId));
+    final raw = prefs.getString(_key(serverId, storageUser(userId), roomId));
     if (raw == null || raw.isEmpty) return {};
 
     final result = <String, DateTime>{};
@@ -97,8 +96,7 @@ abstract final class ThreadReadMarkerStorage {
       for (final e in markers.entries) e.key: e.value.toUtc().toIso8601String(),
     };
     await prefs.setString(
-        _key(serverId, userId ?? unauthenticatedStorageUser, roomId),
-        jsonEncode(obj));
+        _key(serverId, storageUser(userId), roomId), jsonEncode(obj));
   }
 
   /// Drops every user's thread markers for [serverId] (keyed format). Only keyed

--- a/lib/src/modules/room/ui/room_screen.dart
+++ b/lib/src/modules/room/ui/room_screen.dart
@@ -23,6 +23,8 @@ import 'package:soliplex_client/soliplex_client.dart'
         buildDocumentFilter;
 import 'package:soliplex_logging/soliplex_logging.dart';
 
+import '../../../core/activity_read.dart' show currentUserRoomMarkers;
+import '../../../core/keyed_storage.dart' show unauthenticatedStorageUser;
 import '../../../core/util/debouncer.dart';
 import '../../../core/routes.dart';
 import '../../auth/return_to_storage.dart';
@@ -213,10 +215,19 @@ class _RoomScreenState extends State<RoomScreen> {
   /// here and — immediately, no storage race — in the lobby.
   late final RoomReadMarkers _roomReadMarkers;
 
-  /// Shared in-memory model of per-`serverId` "last seen" markers, also watched
-  /// by the lobby. Floors every room and thread on the server: the rail's unread
-  /// checks read up to it, so a server marker suppresses their dots.
+  /// Shared in-memory model of per-`(serverId, userId)` "last seen" markers,
+  /// also watched by the lobby. Floors every room and thread on the server: the
+  /// rail's unread checks read up to it, so a server marker suppresses their dots.
   late final ServerReadMarkers _serverReadMarkers;
+
+  /// The identity the open room's read markers are scoped to, captured at mount
+  /// and re-captured on every room change (like the trackers' coordinates); the
+  /// value only differs on a server switch. Read and write sites resolve it from
+  /// this field rather than live off the session so a deferred write after a
+  /// switch or logout can't misfile a marker into the wrong user's bucket. Null
+  /// (a signed-out or no-auth server) resolves to the shared unauthenticated
+  /// bucket in the stores.
+  String? _userId;
 
   /// Owns the current room's per-thread "last seen" read markers. Recreated on
   /// room change (like [_anchorTracker]) so its captured coordinates never shift
@@ -394,17 +405,19 @@ class _RoomScreenState extends State<RoomScreen> {
     });
   }
 
-  /// Loads the shared read markers once, then re-evaluates the room read state
-  /// in case the thread list arrived before them.
+  /// Loads the current user's room markers for this server once, then
+  /// re-evaluates the room read state in case the thread list arrived first.
   Future<void> _loadRoomReadMarkers() async {
-    await _roomReadMarkers.ensureLoaded();
+    await _roomReadMarkers.ensureLoaded(
+        serverId: widget.serverEntry.serverId, userId: _userId);
     if (mounted) _recomputeRoomRead();
   }
 
-  /// Loads the shared server read markers once, then re-evaluates the room read
-  /// state in case the thread list arrived before them.
+  /// Loads the current user's server marker for this server once, then
+  /// re-evaluates the room read state in case the thread list arrived first.
   Future<void> _loadServerReadMarkers() async {
-    await _serverReadMarkers.ensureLoaded();
+    await _serverReadMarkers.ensureLoaded(
+        serverId: widget.serverEntry.serverId, userId: _userId);
     if (mounted) _recomputeRoomRead();
   }
 
@@ -417,10 +430,28 @@ class _RoomScreenState extends State<RoomScreen> {
   /// watchers (this build and the lobby's).
   void _markRoomRead(String roomId) {
     _roomReadMarkers.markRead(
-      (serverId: widget.serverEntry.serverId, roomId: roomId),
-      clock.now().toUtc(),
+      serverId: widget.serverEntry.serverId,
+      userId: _userId,
+      roomId: roomId,
+      at: clock.now().toUtc(),
     );
   }
+
+  /// The current user's room-level "last seen" for [roomId] on [serverId], via
+  /// the shared store's user-scoped key.
+  DateTime? _roomSeen(String serverId, String? userId, String roomId) =>
+      _roomReadMarkers.value[(
+        serverId: serverId,
+        userId: userId ?? unauthenticatedStorageUser,
+        roomId: roomId,
+      )];
+
+  /// The current user's server-level "last seen" for [serverId].
+  DateTime? _serverSeen(String serverId, String? userId) =>
+      _serverReadMarkers.value[(
+        serverId: serverId,
+        userId: userId ?? unauthenticatedStorageUser,
+      )];
 
   /// Marks the room being left read when none of its threads remains unread,
   /// stamping the room-level marker the lobby reads (it has no per-thread
@@ -433,6 +464,7 @@ class _RoomScreenState extends State<RoomScreen> {
   void _markRoomReadOnLeave({
     required String serverId,
     required String roomId,
+    required String? userId,
     required String? leavingThreadId,
   }) {
     final status = _state.threadList.threads.value;
@@ -443,13 +475,15 @@ class _RoomScreenState extends State<RoomScreen> {
       serverId: serverId,
       roomId: roomId,
       selectedThreadId: leavingThreadId,
-      roomSeen: _roomReadMarkers.value[(serverId: serverId, roomId: roomId)],
-      serverSeen: _serverReadMarkers.value[serverId],
+      roomSeen: _roomSeen(serverId, userId, roomId),
+      serverSeen: _serverSeen(serverId, userId),
     ).isNotEmpty;
     if (stillUnread) return;
     _roomReadMarkers.markRead(
-      (serverId: serverId, roomId: roomId),
-      clock.now().toUtc(),
+      serverId: serverId,
+      userId: userId,
+      roomId: roomId,
+      at: clock.now().toUtc(),
     );
   }
 
@@ -460,7 +494,7 @@ class _RoomScreenState extends State<RoomScreen> {
   void _recomputeRoomRead() {
     final status = _state.threadList.threads.value;
     if (status is! ThreadsLoaded) return;
-    final key = (serverId: widget.serverEntry.serverId, roomId: widget.roomId);
+    final serverId = widget.serverEntry.serverId;
     // Judge "mark read" from the thread list's own latest activity, not the
     // separately-fetched room-activity batch: when the batch refreshes before
     // the thread list does, a stale list must not mark the room read over a
@@ -468,10 +502,10 @@ class _RoomScreenState extends State<RoomScreen> {
     if (shouldMarkRoomRead(
       status.threads,
       _threadReadTracker.markers,
-      serverId: widget.serverEntry.serverId,
+      serverId: serverId,
       roomId: widget.roomId,
-      roomSeen: _roomReadMarkers.value[key],
-      serverSeen: _serverReadMarkers.value[widget.serverEntry.serverId],
+      roomSeen: _roomSeen(serverId, _userId, widget.roomId),
+      serverSeen: _serverSeen(serverId, _userId),
       selectedThreadId: widget.threadId,
     )) {
       _markRoomRead(widget.roomId);
@@ -519,12 +553,16 @@ class _RoomScreenState extends State<RoomScreen> {
   /// whereas the thread-unread set excludes the open thread and surfaces only a
   /// genuinely unread sibling thread. Empty when activity is unavailable.
   Set<String> get _unreadRoomIds {
+    final serverId = widget.serverEntry.serverId;
     final ids = unreadRoomIds(
       _roomActivity,
-      _roomReadMarkers.value,
-      serverId: widget.serverEntry.serverId,
+      currentUserRoomMarkers(
+        _roomReadMarkers.value,
+        (_) => _userId ?? unauthenticatedStorageUser,
+      ),
+      serverId: serverId,
       currentRoomId: widget.roomId,
-      serverSeen: _serverReadMarkers.value[widget.serverEntry.serverId],
+      serverSeen: _serverSeen(serverId, _userId),
     );
     final openRoomUnread = _unreadThreadIds(
       _state.threadList.threads.value,
@@ -614,9 +652,8 @@ class _RoomScreenState extends State<RoomScreen> {
       serverId: serverId,
       roomId: widget.roomId,
       selectedThreadId: selectedThreadId,
-      roomSeen:
-          _roomReadMarkers.value[(serverId: serverId, roomId: widget.roomId)],
-      serverSeen: _serverReadMarkers.value[serverId],
+      roomSeen: _roomSeen(serverId, _userId, widget.roomId),
+      serverSeen: _serverSeen(serverId, _userId),
     );
   }
 
@@ -723,6 +760,7 @@ class _RoomScreenState extends State<RoomScreen> {
     HardwareKeyboard.instance.addHandler(_handleKey);
     _roomReadMarkers = widget.roomReadMarkers ?? RoomReadMarkers();
     _serverReadMarkers = widget.serverReadMarkers ?? ServerReadMarkers();
+    _userId = widget.serverEntry.auth.currentUserId.value;
     _state = _createRoomState();
     _workdirs = _createWorkdirController();
     _refreshFilterableDocuments();
@@ -799,9 +837,14 @@ class _RoomScreenState extends State<RoomScreen> {
     if (roomChanged) {
       // Mark the room being left read (under its own coordinates) before its
       // _state is torn down, so the lobby agrees the user caught up there.
+      // _userId still holds the leaving room's captured identity here (it is
+      // re-captured further below), so the leave stamp files under the user who
+      // read the room — not a live session read that a mid-flight logout could
+      // flip to null and misfile into the unauthenticated bucket.
       _markRoomReadOnLeave(
         serverId: oldWidget.serverEntry.serverId,
         roomId: oldWidget.roomId,
+        userId: _userId,
         leavingThreadId: oldWidget.threadId,
       );
       _cancelAutoSelect();
@@ -813,6 +856,10 @@ class _RoomScreenState extends State<RoomScreen> {
       unawaited(_anchorTracker.dispose());
       unawaited(_threadReadTracker.dispose());
       _chatController.clear();
+      // Re-capture the identity for the entered room/server before _watchRoomRead
+      // below fires the initial recompute, so it reads the right user's markers.
+      // A same-server room switch keeps the same user; a server switch changes it.
+      _userId = widget.serverEntry.auth.currentUserId.value;
       _state = _createRoomState();
       _workdirs = _createWorkdirController();
       _anchorTracker = _createAnchorTracker();
@@ -831,6 +878,11 @@ class _RoomScreenState extends State<RoomScreen> {
         _fetchServerRooms();
         _fetchRoomActivity();
         _fetchAccount();
+        // The read markers are keyed per (server, user); load the entered
+        // server's blobs for the current user. Idempotent — a no-op if the
+        // lobby already loaded them into the shared store.
+        unawaited(_loadRoomReadMarkers());
+        unawaited(_loadServerReadMarkers());
       }
       if (widget.threadId != null) {
         _state.selectThread(widget.threadId!);
@@ -1000,6 +1052,7 @@ class _RoomScreenState extends State<RoomScreen> {
     _markRoomReadOnLeave(
       serverId: widget.serverEntry.serverId,
       roomId: widget.roomId,
+      userId: _userId,
       leavingThreadId: threadId,
     );
     _cancelAutoSelect();

--- a/lib/src/modules/room/ui/room_screen.dart
+++ b/lib/src/modules/room/ui/room_screen.dart
@@ -24,7 +24,7 @@ import 'package:soliplex_client/soliplex_client.dart'
 import 'package:soliplex_logging/soliplex_logging.dart';
 
 import '../../../core/activity_read.dart' show currentUserRoomMarkers;
-import '../../../core/keyed_storage.dart' show unauthenticatedStorageUser;
+import '../../../core/keyed_storage.dart' show storageUser;
 import '../../../core/util/debouncer.dart';
 import '../../../core/routes.dart';
 import '../../auth/return_to_storage.dart';
@@ -221,12 +221,13 @@ class _RoomScreenState extends State<RoomScreen> {
   late final ServerReadMarkers _serverReadMarkers;
 
   /// The identity the open room's read markers are scoped to, captured at mount
-  /// and re-captured on every room change (like the trackers' coordinates); the
-  /// value only differs on a server switch. Read and write sites resolve it from
-  /// this field rather than live off the session so a deferred write after a
-  /// switch or logout can't misfile a marker into the wrong user's bucket. Null
-  /// (a signed-out or no-auth server) resolves to the shared unauthenticated
-  /// bucket in the stores.
+  /// and re-captured on every room change (like the trackers' coordinates). It
+  /// normally changes only on a server switch, but is re-read on every room
+  /// change, so an identity change on the same server (a logout/re-login) is
+  /// picked up too. Read and write sites resolve it from this field rather than
+  /// live off the session so a deferred write after a switch or logout can't
+  /// misfile a marker into the wrong user's bucket. Null (a signed-out or no-auth
+  /// server) resolves to the shared unauthenticated bucket in the stores.
   String? _userId;
 
   /// Owns the current room's per-thread "last seen" read markers. Recreated on
@@ -442,7 +443,7 @@ class _RoomScreenState extends State<RoomScreen> {
   DateTime? _roomSeen(String serverId, String? userId, String roomId) =>
       _roomReadMarkers.value[(
         serverId: serverId,
-        userId: userId ?? unauthenticatedStorageUser,
+        userId: storageUser(userId),
         roomId: roomId,
       )];
 
@@ -450,7 +451,7 @@ class _RoomScreenState extends State<RoomScreen> {
   DateTime? _serverSeen(String serverId, String? userId) =>
       _serverReadMarkers.value[(
         serverId: serverId,
-        userId: userId ?? unauthenticatedStorageUser,
+        userId: storageUser(userId),
       )];
 
   /// Marks the room being left read when none of its threads remains unread,
@@ -558,7 +559,7 @@ class _RoomScreenState extends State<RoomScreen> {
       _roomActivity,
       currentUserRoomMarkers(
         _roomReadMarkers.value,
-        (_) => _userId ?? unauthenticatedStorageUser,
+        (_) => storageUser(_userId),
       ),
       serverId: serverId,
       currentRoomId: widget.roomId,
@@ -858,7 +859,8 @@ class _RoomScreenState extends State<RoomScreen> {
       _chatController.clear();
       // Re-capture the identity for the entered room/server before _watchRoomRead
       // below fires the initial recompute, so it reads the right user's markers.
-      // A same-server room switch keeps the same user; a server switch changes it.
+      // Normally only a server switch changes it; re-reading also picks up an
+      // identity change on the same server (a logout/re-login).
       _userId = widget.serverEntry.auth.currentUserId.value;
       _state = _createRoomState();
       _workdirs = _createWorkdirController();

--- a/test/core/activity_read_test.dart
+++ b/test/core/activity_read_test.dart
@@ -17,4 +17,47 @@ void main() {
       expect(latestSeen(null, null), isNull);
     });
   });
+
+  group('currentUserRoomMarkers', () {
+    final t1 = DateTime.utc(2026, 1, 1);
+    final t2 = DateTime.utc(2026, 2, 2);
+
+    test('keeps only entries whose userId matches userFor for that server', () {
+      final markers = {
+        (serverId: 'A', userId: 'alice', roomId: 'r1'): t1,
+        (serverId: 'A', userId: 'bob', roomId: 'r2'): t2,
+      };
+      final view = currentUserRoomMarkers(markers, (_) => 'alice');
+      expect(view, {(serverId: 'A', roomId: 'r1'): t1});
+    });
+
+    test('resolves a different current user per server', () {
+      final markers = {
+        (serverId: 'A', userId: 'alice', roomId: 'r1'): t1,
+        (serverId: 'B', userId: 'bob', roomId: 'r2'): t2,
+      };
+      final userFor = {'A': 'alice', 'B': 'bob'};
+      final view = currentUserRoomMarkers(markers, (s) => userFor[s]!);
+      expect(view, {
+        (serverId: 'A', roomId: 'r1'): t1,
+        (serverId: 'B', roomId: 'r2'): t2,
+      });
+    });
+  });
+
+  group('currentUserServerMarkers', () {
+    final t1 = DateTime.utc(2026, 1, 1);
+    final t2 = DateTime.utc(2026, 2, 2);
+
+    test('keeps only the current user per server', () {
+      final markers = {
+        (serverId: 'A', userId: 'alice'): t1,
+        (serverId: 'A', userId: 'bob'): t2,
+        (serverId: 'B', userId: 'bob'): t2,
+      };
+      final userFor = {'A': 'alice', 'B': 'bob'};
+      final view = currentUserServerMarkers(markers, (s) => userFor[s]!);
+      expect(view, {'A': t1, 'B': t2});
+    });
+  });
 }

--- a/test/core/removed_server_cleanup_test.dart
+++ b/test/core/removed_server_cleanup_test.dart
@@ -49,14 +49,17 @@ void main() {
   }
 
   group('RemovedServerCleanup', () {
-    test('clears the removed server\'s read markers, keeping a survivor\'s',
+    test('clears the removed server for every user, keeping a survivor\'s',
         () async {
       final at = DateTime.utc(2026, 6, 1);
       final wired = wire();
-      wired.server.markRead('s1', at);
-      wired.server.markRead('s2', at);
-      wired.room.markRead((serverId: 's1', roomId: 'r'), at);
-      wired.room.markRead((serverId: 's2', roomId: 'r'), at);
+      // Two users signed into s1 on this device: removal must clear both.
+      wired.server.markRead(serverId: 's1', userId: 'alice', at: at);
+      wired.server.markRead(serverId: 's1', userId: 'bob', at: at);
+      wired.server.markRead(serverId: 's2', userId: 'alice', at: at);
+      wired.room.markRead(serverId: 's1', userId: 'alice', roomId: 'r', at: at);
+      wired.room.markRead(serverId: 's1', userId: 'bob', roomId: 'r', at: at);
+      wired.room.markRead(serverId: 's2', userId: 'alice', roomId: 'r', at: at);
       await ThreadReadMarkerStorage.saveRoom(
           serverId: 's1', userId: 'u', roomId: 'r', markers: {'t': at});
       await ThreadReadMarkerStorage.saveRoom(
@@ -65,16 +68,9 @@ void main() {
       wired.manager.removeServer('s1');
       await pumpEventQueue();
 
-      expect(wired.server.value.containsKey('s1'), isFalse);
-      expect(wired.server.value.containsKey('s2'), isTrue);
-      expect(
-        wired.room.value.containsKey((serverId: 's1', roomId: 'r')),
-        isFalse,
-      );
-      expect(
-        wired.room.value.containsKey((serverId: 's2', roomId: 'r')),
-        isTrue,
-      );
+      expect(wired.server.value.keys, {(serverId: 's2', userId: 'alice')});
+      expect(wired.room.value.keys,
+          {(serverId: 's2', userId: 'alice', roomId: 'r')});
       expect(
         await ThreadReadMarkerStorage.loadRoom(
             serverId: 's1', userId: 'u', roomId: 'r'),
@@ -138,15 +134,17 @@ void main() {
     test('ServerManager.dispose does not clear device-local state', () async {
       final at = DateTime.utc(2026, 6, 1);
       final wired = wire();
-      wired.server.markRead('s1', at);
-      wired.room.markRead((serverId: 's1', roomId: 'r'), at);
+      wired.server.markRead(serverId: 's1', userId: 'u', at: at);
+      wired.room.markRead(serverId: 's1', userId: 'u', roomId: 'r', at: at);
 
       wired.manager.dispose();
       await pumpEventQueue();
 
-      expect(wired.server.value.containsKey('s1'), isTrue);
+      expect(wired.server.value.containsKey((serverId: 's1', userId: 'u')),
+          isTrue);
       expect(
-        wired.room.value.containsKey((serverId: 's1', roomId: 'r')),
+        wired.room.value
+            .containsKey((serverId: 's1', userId: 'u', roomId: 'r')),
         isTrue,
       );
     });
@@ -157,16 +155,18 @@ void main() {
     test('a disposed cleanup ignores later server removals', () async {
       final at = DateTime.utc(2026, 6, 1);
       final wired = wire();
-      wired.server.markRead('s1', at);
-      wired.room.markRead((serverId: 's1', roomId: 'r'), at);
+      wired.server.markRead(serverId: 's1', userId: 'u', at: at);
+      wired.room.markRead(serverId: 's1', userId: 'u', roomId: 'r', at: at);
 
       wired.cleanup.dispose();
       wired.manager.removeServer('s1');
       await pumpEventQueue();
 
-      expect(wired.server.value.containsKey('s1'), isTrue);
+      expect(wired.server.value.containsKey((serverId: 's1', userId: 'u')),
+          isTrue);
       expect(
-        wired.room.value.containsKey((serverId: 's1', roomId: 'r')),
+        wired.room.value
+            .containsKey((serverId: 's1', userId: 'u', roomId: 'r')),
         isTrue,
       );
     });

--- a/test/helpers/test_server_entry.dart
+++ b/test/helpers/test_server_entry.dart
@@ -73,13 +73,19 @@ AuthSession authWithIdentity({String sub = 'test-user'}) {
       clientId: 'test-client',
     ),
     tokens: AuthTokens(
-      accessToken: _jwt('https://idp.test', sub),
+      accessToken: testAccessToken(sub: sub),
       refreshToken: 'refresh',
       expiresAt: DateTime.now().add(const Duration(hours: 1)),
     ),
   );
   return auth;
 }
+
+/// A decodable JWT access token embedding `https://idp.test#`[sub], for logging
+/// a [ServerManager] entry into a specific identity (`entry.auth.login`) so its
+/// `currentUserId` resolves to [testIdentityFor]`(sub)`.
+String testAccessToken({String sub = 'test-user'}) =>
+    _jwt('https://idp.test', sub);
 
 /// Builds a JWT-shaped `header.payload.signature` string embedding [iss]/[sub].
 String _jwt(String iss, String sub) {

--- a/test/modules/lobby/lobby_read_markers_test.dart
+++ b/test/modules/lobby/lobby_read_markers_test.dart
@@ -1,71 +1,101 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:shared_preferences/shared_preferences.dart';
+import 'package:soliplex_frontend/src/core/keyed_storage.dart';
 import 'package:soliplex_frontend/src/modules/lobby/lobby_read_markers.dart';
 
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
   setUp(() => SharedPreferences.setMockInitialValues({}));
 
+  const s = 'https://foo.com', u1 = 'iss#alice', u2 = 'iss#bob';
+  final t = DateTime.utc(2026, 6, 1, 12);
+
   group('LobbyReadMarkerStorage', () {
     test('defaults to empty when nothing is persisted', () async {
-      expect(await LobbyReadMarkerStorage.load(), isEmpty);
+      expect(await LobbyReadMarkerStorage.loadServer(serverId: s, userId: u1),
+          isEmpty);
     });
 
-    test('round-trips markers, normalizing to UTC', () async {
-      final markers = {
-        (serverId: 'a', roomId: 'r1'): DateTime.utc(2026, 6, 1, 12),
-        (serverId: 'b', roomId: 'r2'): DateTime.utc(2026, 1, 2, 3, 4),
-      };
-      await LobbyReadMarkerStorage.save(markers);
-
-      final loaded = await LobbyReadMarkerStorage.load();
-      expect(loaded, hasLength(2));
-      expect(
-          loaded[(serverId: 'a', roomId: 'r1')], DateTime.utc(2026, 6, 1, 12));
-      expect(loaded[(serverId: 'b', roomId: 'r2')]!.isUtc, isTrue);
-    });
-
-    test('preserves ids that would collide under a naive composite key',
+    test('round-trips a server\'s room markers per user, normalizing to UTC',
         () async {
-      // Ids with separators must survive the JSON round-trip intact.
-      final markers = {
-        (serverId: 'a|b', roomId: 'r'): DateTime.utc(2026),
-        (serverId: 'a', roomId: 'b|r'): DateTime.utc(2025),
-      };
-      await LobbyReadMarkerStorage.save(markers);
-
-      final loaded = await LobbyReadMarkerStorage.load();
+      await LobbyReadMarkerStorage.saveServer(
+        serverId: s,
+        userId: u1,
+        markers: {'r1': t, 'r2': DateTime.utc(2026, 1, 2, 3, 4)},
+      );
+      final loaded =
+          await LobbyReadMarkerStorage.loadServer(serverId: s, userId: u1);
       expect(loaded, hasLength(2));
-      expect(loaded[(serverId: 'a|b', roomId: 'r')], DateTime.utc(2026));
-      expect(loaded[(serverId: 'a', roomId: 'b|r')], DateTime.utc(2025));
+      expect(loaded['r1'], t);
+      expect(loaded['r2']!.isUtc, isTrue);
     });
 
-    test('a corrupt payload loads as empty rather than throwing', () async {
-      SharedPreferences.setMockInitialValues(
-        {'soliplex_lobby_read_markers': 'not json{'},
-      );
-      expect(await LobbyReadMarkerStorage.load(), isEmpty);
+    test('markers saved as one user are invisible to another (isolation)',
+        () async {
+      await LobbyReadMarkerStorage.saveServer(
+          serverId: s, userId: u1, markers: {'r1': t});
+      expect(await LobbyReadMarkerStorage.loadServer(serverId: s, userId: u2),
+          isEmpty);
+    });
+
+    test('a null userId resolves to the shared unauthenticated bucket',
+        () async {
+      await LobbyReadMarkerStorage.saveServer(
+          serverId: s, userId: null, markers: {'r1': t});
+      expect(
+          await LobbyReadMarkerStorage.loadServer(
+              serverId: s, userId: unauthenticatedStorageUser),
+          {'r1': t});
+    });
+
+    test('clearServer removes every user, spares a same-host different port',
+        () async {
+      const s2 = 'https://foo.com:8443';
+      await LobbyReadMarkerStorage.saveServer(
+          serverId: s, userId: u1, markers: {'r1': t});
+      await LobbyReadMarkerStorage.saveServer(
+          serverId: s, userId: u2, markers: {'r1': t});
+      await LobbyReadMarkerStorage.saveServer(
+          serverId: s2, userId: u1, markers: {'r1': t});
+
+      await LobbyReadMarkerStorage.clearServer(s);
+
+      expect(await LobbyReadMarkerStorage.loadServer(serverId: s, userId: u1),
+          isEmpty);
+      expect(await LobbyReadMarkerStorage.loadServer(serverId: s, userId: u2),
+          isEmpty);
+      expect(await LobbyReadMarkerStorage.loadServer(serverId: s2, userId: u1),
+          {'r1': t});
+    });
+
+    test('discards a corrupt blob and returns empty', () async {
+      SharedPreferences.setMockInitialValues({
+        'soliplex_room_read_marker:${Uri.encodeComponent(s)}:'
+            '${Uri.encodeComponent(u1)}': 'not json{',
+      });
+      expect(await LobbyReadMarkerStorage.loadServer(serverId: s, userId: u1),
+          isEmpty);
+    });
+
+    test('a non-object payload loads as empty', () async {
+      SharedPreferences.setMockInitialValues({
+        'soliplex_room_read_marker:${Uri.encodeComponent(s)}:'
+            '${Uri.encodeComponent(u1)}': '["r1"]',
+      });
+      expect(await LobbyReadMarkerStorage.loadServer(serverId: s, userId: u1),
+          isEmpty);
     });
 
     test('skips malformed entries but keeps valid ones', () async {
       SharedPreferences.setMockInitialValues({
-        'soliplex_lobby_read_markers': '['
-            '{"s":"a","r":"r1","t":"2026-06-01T00:00:00Z"},'
-            '{"s":"a","r":"r2","t":"not-a-date"},'
-            '{"s":"a","t":"2026-06-01T00:00:00Z"},'
-            '"garbage"'
-            ']',
+        'soliplex_room_read_marker:${Uri.encodeComponent(s)}:'
+                '${Uri.encodeComponent(u1)}':
+            '{"r1":"2026-06-01T00:00:00Z","r2":"not-a-date","r3":5}',
       });
-      final loaded = await LobbyReadMarkerStorage.load();
+      final loaded =
+          await LobbyReadMarkerStorage.loadServer(serverId: s, userId: u1);
       expect(loaded, hasLength(1));
-      expect(loaded[(serverId: 'a', roomId: 'r1')], DateTime.utc(2026, 6));
-    });
-
-    test('a non-list payload loads as empty', () async {
-      SharedPreferences.setMockInitialValues(
-        {'soliplex_lobby_read_markers': '{"s":"a"}'},
-      );
-      expect(await LobbyReadMarkerStorage.load(), isEmpty);
+      expect(loaded['r1'], DateTime.utc(2026, 6));
     });
   });
 }

--- a/test/modules/lobby/lobby_state_test.dart
+++ b/test/modules/lobby/lobby_state_test.dart
@@ -1239,6 +1239,33 @@ void main() {
         expect(state.serverReadMarkers.value, {'srvA': t, 'srvB': t});
         state.dispose();
       });
+
+      test('a live sign-in loads and projects that user\'s persisted markers',
+          () async {
+        final t = DateTime.utc(2026, 6, 1);
+        // Bob has read state persisted from a previous session.
+        await LobbyReadMarkerStorage.saveServer(
+            serverId: 'srvA',
+            userId: testIdentityFor('bob'),
+            markers: {'r1': t});
+
+        final manager = _createManager();
+        final entry = manager.addServer(
+            serverId: 'srvA', serverUrl: Uri.parse('http://a.test'));
+        final state = LobbyState(serverManager: manager);
+        await pumpEventQueue();
+        // Signed out: no user resolves, so nothing projects.
+        expect(state.roomReadMarkers.value, isEmpty);
+
+        loginAs(entry, 'bob');
+        await pumpEventQueue();
+
+        // The auth change loads Bob's blob and re-runs the projection (his
+        // currentUserId is a tracked dependency), surfacing his marker.
+        expect(
+            state.roomReadMarkers.value[(serverId: 'srvA', roomId: 'r1')], t);
+        state.dispose();
+      });
     });
   });
 

--- a/test/modules/lobby/lobby_state_test.dart
+++ b/test/modules/lobby/lobby_state_test.dart
@@ -9,11 +9,14 @@ import 'package:soliplex_agent/soliplex_agent.dart';
 import 'package:soliplex_frontend/src/modules/auth/auth_session.dart';
 import 'package:soliplex_frontend/src/modules/auth/auth_tokens.dart';
 import 'package:soliplex_frontend/src/modules/auth/selected_server_storage.dart';
+import 'package:soliplex_frontend/src/modules/auth/server_entry.dart';
 import 'package:soliplex_frontend/src/modules/auth/server_manager.dart';
 import 'package:soliplex_frontend/src/core/activity_read.dart';
+import 'package:soliplex_frontend/src/modules/lobby/lobby_read_markers.dart';
 import 'package:soliplex_frontend/src/modules/lobby/lobby_state.dart';
 
 import '../../helpers/fakes.dart';
+import '../../helpers/test_server_entry.dart';
 
 ServerManager _createManager() => ServerManager(
       authFactory: () => AuthSession(refreshService: FakeTokenRefreshService()),
@@ -1127,25 +1130,114 @@ void main() {
     });
 
     group('mark as read', () {
-      test('markRoomRead stamps the room marker so it reads as read', () {
+      const provider = OidcProvider(
+        discoveryUrl: 'https://sso/.well-known/openid-configuration',
+        clientId: 'c',
+      );
+
+      void loginAs(ServerEntry entry, String sub) => entry.auth.login(
+            provider: provider,
+            tokens: AuthTokens(
+              accessToken: testAccessToken(sub: sub),
+              refreshToken: 'r',
+              expiresAt: DateTime.now().add(const Duration(hours: 1)),
+            ),
+          );
+
+      test('markRoomRead stamps under the signed-in user and projects it back',
+          () {
         withClock(Clock.fixed(DateTime.utc(2026, 6, 1)), () {
-          final state = LobbyState(serverManager: _createManager());
-          state.markRoomRead('srv', 'roomA');
+          final manager = _createManager();
+          loginAs(
+            manager.addServer(
+                serverId: 'srvA', serverUrl: Uri.parse('http://a.test')),
+            'alice',
+          );
+          final state = LobbyState(serverManager: manager);
+
+          state.markRoomRead('srvA', 'roomA');
+
           expect(
-            state.roomReadMarkers.value[(serverId: 'srv', roomId: 'roomA')],
+            state.roomReadMarkers.value[(serverId: 'srvA', roomId: 'roomA')],
             DateTime.utc(2026, 6, 1),
           );
           state.dispose();
         });
       });
 
-      test('markServerRead stamps the server marker', () {
+      test('markServerRead stamps under the signed-in user', () {
         withClock(Clock.fixed(DateTime.utc(2026, 6, 1)), () {
-          final state = LobbyState(serverManager: _createManager());
-          state.markServerRead('s');
-          expect(state.serverReadMarkers.value['s'], DateTime.utc(2026, 6, 1));
+          final manager = _createManager();
+          loginAs(
+            manager.addServer(
+                serverId: 'srvA', serverUrl: Uri.parse('http://a.test')),
+            'alice',
+          );
+          final state = LobbyState(serverManager: manager);
+
+          state.markServerRead('srvA');
+
+          expect(
+            state.serverReadMarkers.value['srvA'],
+            DateTime.utc(2026, 6, 1),
+          );
           state.dispose();
         });
+      });
+
+      test(
+          'projects each server to its own user, hiding another user\'s marker',
+          () async {
+        final t = DateTime.utc(2026, 6, 1);
+        final manager = _createManager();
+        loginAs(
+          manager.addServer(
+              serverId: 'srvA', serverUrl: Uri.parse('http://a.test')),
+          'alice',
+        );
+        loginAs(
+          manager.addServer(
+              serverId: 'srvB', serverUrl: Uri.parse('http://b.test')),
+          'bob',
+        );
+
+        final room = RoomReadMarkers();
+        room.markRead(
+            serverId: 'srvA',
+            userId: testIdentityFor('alice'),
+            roomId: 'r1',
+            at: t);
+        // A stale marker from a user who is NOT srvA's current user: must be
+        // hidden by the per-server projection.
+        room.markRead(
+            serverId: 'srvA',
+            userId: testIdentityFor('bob'),
+            roomId: 'rStale',
+            at: t);
+        room.markRead(
+            serverId: 'srvB',
+            userId: testIdentityFor('bob'),
+            roomId: 'r2',
+            at: t);
+        final server = ServerReadMarkers();
+        server.markRead(
+            serverId: 'srvA', userId: testIdentityFor('alice'), at: t);
+        server.markRead(
+            serverId: 'srvB', userId: testIdentityFor('bob'), at: t);
+
+        final state = LobbyState(
+          serverManager: manager,
+          roomReadMarkers: room,
+          serverReadMarkers: server,
+        );
+        await pumpEventQueue();
+
+        expect(state.roomReadMarkers.value, {
+          (serverId: 'srvA', roomId: 'r1'): t,
+          (serverId: 'srvB', roomId: 'r2'): t,
+        });
+        expect(state.serverReadMarkers.value, {'srvA': t, 'srvB': t});
+        state.dispose();
       });
     });
   });

--- a/test/modules/lobby/room_read_markers_test.dart
+++ b/test/modules/lobby/room_read_markers_test.dart
@@ -162,5 +162,41 @@ void main() {
       store.dispose();
       reloaded.dispose();
     });
+
+    test('a clearServer during an in-flight load is not undone on resume',
+        () async {
+      // A blob on disk for (s, u1). The singleton is warm, so the concurrent
+      // load below reads the blob (it wins the shared cache), giving a real
+      // in-flight window in which the clear lands — the production timing.
+      await SharedPreferences.getInstance();
+      await LobbyReadMarkerStorage.saveServer(
+          serverId: s, userId: u1, markers: {r: at});
+
+      final store = RoomReadMarkers();
+      // Start the load but DON'T await it — it is now parked on the disk read.
+      final loading = store.ensureLoaded(serverId: s, userId: u1);
+      // The server is removed while that load is in flight.
+      store.clearServer(s);
+      await loading; // the load resumes AFTER the clear, holding the read blob
+      await Future<void>.delayed(Duration.zero);
+
+      // The resumed load must not re-insert the swept blob: doing so would hide
+      // unread content if the server were re-added under the same id.
+      expect(store.value[key(s, u1, r)], isNull,
+          reason: 'a load resuming after clearServer must not resurrect it');
+      store.dispose();
+    });
+
+    test('a load resolving after dispose does not throw', () async {
+      await SharedPreferences.getInstance();
+      await LobbyReadMarkerStorage.saveServer(
+          serverId: s, userId: u1, markers: {r: at});
+
+      final store = RoomReadMarkers();
+      final loading = store.ensureLoaded(serverId: s, userId: u1);
+      store.dispose(); // disposed while the load is in flight
+      // The load must not write to the disposed signal; no throw is the assert.
+      await loading;
+    });
   });
 }

--- a/test/modules/lobby/room_read_markers_test.dart
+++ b/test/modules/lobby/room_read_markers_test.dart
@@ -74,6 +74,34 @@ void main() {
       reloaded.dispose();
     });
 
+    test('a stamp during an in-flight load does not truncate the on-disk blob',
+        () async {
+      // A room already persisted for (s, u1). resetStatic() drops the warmed
+      // SharedPreferences singleton so the load below actually re-reads disk
+      // (a real in-flight window), not a cached hit.
+      await LobbyReadMarkerStorage.saveServer(
+          serverId: s, userId: u1, markers: {'other': at});
+      SharedPreferences.resetStatic();
+
+      final store = RoomReadMarkers();
+      final now = DateTime.utc(2026, 7, 1);
+      // Start the load but DON'T await it — it is now in flight. A stamp landing
+      // now must still wait for the load before rewriting the blob, or it drops
+      // 'other' off disk (it isn't in memory yet).
+      final loading = store.ensureLoaded(serverId: s, userId: u1);
+      store.markRead(serverId: s, userId: u1, roomId: r, at: now);
+      await loading;
+      await Future<void>.delayed(Duration.zero);
+
+      final reloaded = RoomReadMarkers();
+      await reloaded.ensureLoaded(serverId: s, userId: u1);
+      expect(reloaded.value[key(s, u1, 'other')], at,
+          reason: 'the pre-existing room must survive a stamp made mid-load');
+      expect(reloaded.value[key(s, u1, r)], now);
+      store.dispose();
+      reloaded.dispose();
+    });
+
     test('clearServer sweeps disk for a user the in-memory view never loaded',
         () async {
       // Another user's blob left on disk that this store never ensureLoaded —

--- a/test/modules/lobby/room_read_markers_test.dart
+++ b/test/modules/lobby/room_read_markers_test.dart
@@ -6,16 +6,19 @@ void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
   setUp(() => SharedPreferences.setMockInitialValues({}));
 
-  group('RoomReadMarkers', () {
-    const key = (serverId: 's', roomId: 'r');
-    final at = DateTime.utc(2026, 6, 19);
+  const s = 'server', u1 = 'iss#alice', u2 = 'iss#bob', r = 'r';
+  final at = DateTime.utc(2026, 6, 19);
 
+  RoomMarkerKey key(String serverId, String userId, String roomId) =>
+      (serverId: serverId, userId: userId, roomId: roomId);
+
+  group('RoomReadMarkers', () {
     test('markRead notifies a subscriber synchronously', () {
       final store = RoomReadMarkers();
       final seen = <DateTime?>[];
-      final unsub = store.markers.subscribe((m) => seen.add(m[key]));
+      final unsub = store.markers.subscribe((m) => seen.add(m[key(s, u1, r)]));
 
-      store.markRead(key, at);
+      store.markRead(serverId: s, userId: u1, roomId: r, at: at);
 
       // A watcher (the lobby) sees the stamp immediately, with no storage
       // round-trip — this is what removes the lobby/room handoff race.
@@ -24,57 +27,110 @@ void main() {
       store.dispose();
     });
 
-    test('ensureLoaded reads markers persisted by an earlier store', () async {
-      final seed = RoomReadMarkers()..markRead(key, at);
-      // Let the write-through persist before the next store loads.
-      await Future<void>.delayed(Duration.zero);
-      seed.dispose();
-
+    test('a stamp by one user is invisible to another (isolation)', () {
       final store = RoomReadMarkers();
-      await store.ensureLoaded();
-
-      expect(store.markers.value[key], at);
+      store.markRead(serverId: s, userId: u1, roomId: r, at: at);
+      expect(store.value[key(s, u1, r)], at);
+      expect(store.value[key(s, u2, r)], isNull);
       store.dispose();
     });
 
-    test('ensureLoaded is a no-op after the first load', () async {
+    test('ensureLoaded reads markers persisted by an earlier store', () async {
+      RoomReadMarkers().markRead(serverId: s, userId: u1, roomId: r, at: at);
+      // Let the write-through persist before the next store loads.
+      await Future<void>.delayed(Duration.zero);
+
       final store = RoomReadMarkers();
-      await store.ensureLoaded();
-      store.markRead(key, at);
-      // A second ensureLoaded must not reload and clobber the in-memory stamp.
-      await store.ensureLoaded();
-      expect(store.markers.value[key], at);
+      await store.ensureLoaded(serverId: s, userId: u1);
+
+      expect(store.value[key(s, u1, r)], at);
+      store.dispose();
+    });
+
+    test('ensureLoaded merges under an optimistic stamp made before it returns',
+        () async {
+      SharedPreferences.setMockInitialValues({});
+      // Seed disk with a sibling room for the same (server,user).
+      await LobbyReadMarkerStorage.saveServer(
+          serverId: s, userId: u1, markers: {'other': at});
+
+      final store = RoomReadMarkers();
+      final now = DateTime.utc(2026, 7, 1);
+      store.markRead(serverId: s, userId: u1, roomId: r, at: now);
+      await store.ensureLoaded(serverId: s, userId: u1);
+
+      // The optimistic stamp survives; the disk sibling is merged in under it.
+      expect(store.value[key(s, u1, r)], now);
+      expect(store.value[key(s, u1, 'other')], at);
+
+      // The stamp's persist loaded the blob first, so it rewrote the full
+      // (server,user) set — the disk sibling isn't clobbered to just the stamp.
+      await Future<void>.delayed(Duration.zero);
+      final reloaded = RoomReadMarkers();
+      await reloaded.ensureLoaded(serverId: s, userId: u1);
+      expect(reloaded.value[key(s, u1, r)], now);
+      expect(reloaded.value[key(s, u1, 'other')], at);
+      store.dispose();
+      reloaded.dispose();
+    });
+
+    test('clearServer sweeps disk for a user the in-memory view never loaded',
+        () async {
+      // Another user's blob left on disk that this store never ensureLoaded —
+      // clearServer must still remove it (the cross-user leak on server re-add).
+      await LobbyReadMarkerStorage.saveServer(
+          serverId: 's1', userId: 'iss#alice', markers: {'a': at});
+      final store = RoomReadMarkers();
+
+      store.clearServer('s1');
+      await Future<void>.delayed(Duration.zero);
+
+      expect(
+        await LobbyReadMarkerStorage.loadServer(
+            serverId: 's1', userId: 'iss#alice'),
+        isEmpty,
+      );
+      store.dispose();
+    });
+
+    test('two servers with different users coexist in one signal', () async {
+      final store = RoomReadMarkers();
+      store.markRead(serverId: 's1', userId: u1, roomId: 'a', at: at);
+      store.markRead(serverId: 's2', userId: u2, roomId: 'b', at: at);
+      expect(store.value[key('s1', u1, 'a')], at);
+      expect(store.value[key('s2', u2, 'b')], at);
       store.dispose();
     });
 
     test('markRead normalizes a non-UTC timestamp to UTC', () {
       final store = RoomReadMarkers();
       final local = DateTime(2026, 6, 1, 12); // device-local
-      store.markRead(key, local);
-      final stored = store.value[key]!;
+      store.markRead(serverId: s, userId: u1, roomId: r, at: local);
+      final stored = store.value[key(s, u1, r)]!;
       expect(stored.isUtc, isTrue);
       expect(stored, local.toUtc());
       store.dispose();
     });
 
-    test('clearServer drops only that server\'s markers and persists',
-        () async {
+    test('clearServer drops every user for the server and persists', () async {
       final store = RoomReadMarkers();
-      store.markRead((serverId: 's1', roomId: 'a'), at);
-      store.markRead((serverId: 's1', roomId: 'b'), at);
-      store.markRead((serverId: 's2', roomId: 'c'), at);
+      store.markRead(serverId: 's1', userId: u1, roomId: 'a', at: at);
+      store.markRead(serverId: 's1', userId: u2, roomId: 'b', at: at);
+      store.markRead(serverId: 's2', userId: u1, roomId: 'c', at: at);
       // Let the mark write-throughs settle before clearing, so the reload
       // below observes clearServer's write rather than a racing stamp save.
       await Future<void>.delayed(Duration.zero);
 
       store.clearServer('s1');
 
-      expect(store.value.keys, {(serverId: 's2', roomId: 'c')});
+      expect(store.value.keys, {key('s2', u1, 'c')});
       // Persisted: a fresh store loads only the surviving server's marker.
       await Future<void>.delayed(Duration.zero);
       final reloaded = RoomReadMarkers();
-      await reloaded.ensureLoaded();
-      expect(reloaded.value.keys, {(serverId: 's2', roomId: 'c')});
+      await reloaded.ensureLoaded(serverId: 's1', userId: u1);
+      await reloaded.ensureLoaded(serverId: 's1', userId: u2);
+      await reloaded.ensureLoaded(serverId: 's2', userId: u1);
+      expect(reloaded.value.keys, {key('s2', u1, 'c')});
       store.dispose();
       reloaded.dispose();
     });

--- a/test/modules/lobby/room_read_markers_test.dart
+++ b/test/modules/lobby/room_read_markers_test.dart
@@ -187,6 +187,26 @@ void main() {
       store.dispose();
     });
 
+    test('a clearServer for another server does not discard an in-flight load',
+        () async {
+      // Epochs are keyed per server, so clearing one server must not invalidate
+      // another's in-flight load. A single global epoch would wrongly discard
+      // the s1 load's result, rendering it unloaded (and its rooms unread).
+      await SharedPreferences.getInstance();
+      await LobbyReadMarkerStorage.saveServer(
+          serverId: 's1', userId: u1, markers: {r: at});
+
+      final store = RoomReadMarkers();
+      final loading = store.ensureLoaded(serverId: 's1', userId: u1);
+      store.clearServer('s2'); // a DIFFERENT server than the one loading
+      await loading; // the s1 load resumes after the unrelated clear
+      await Future<void>.delayed(Duration.zero);
+
+      expect(store.value[key('s1', u1, r)], at,
+          reason: 'clearing another server must not discard this load');
+      store.dispose();
+    });
+
     test('a load resolving after dispose does not throw', () async {
       await SharedPreferences.getInstance();
       await LobbyReadMarkerStorage.saveServer(

--- a/test/modules/lobby/server_read_markers_test.dart
+++ b/test/modules/lobby/server_read_markers_test.dart
@@ -1,103 +1,161 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:shared_preferences/shared_preferences.dart';
+import 'package:soliplex_frontend/src/core/keyed_storage.dart';
 import 'package:soliplex_frontend/src/modules/lobby/lobby_read_markers.dart';
 
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
   setUp(() => SharedPreferences.setMockInitialValues({}));
 
+  const s = 'https://foo.com', u1 = 'iss#alice', u2 = 'iss#bob';
+  final at = DateTime.utc(2026, 6, 1, 12);
+
+  ServerMarkerKey key(String serverId, String userId) =>
+      (serverId: serverId, userId: userId);
+
   group('ServerReadMarkerStorage', () {
-    test('defaults to empty when nothing is persisted', () async {
-      expect(await ServerReadMarkerStorage.load(), isEmpty);
+    test('defaults to null when nothing is persisted', () async {
+      expect(await ServerReadMarkerStorage.loadServer(serverId: s, userId: u1),
+          isNull);
     });
 
-    test('round-trips markers, normalizing to UTC', () async {
-      final markers = {
-        's1': DateTime.utc(2026, 6, 1, 12),
-        's2': DateTime.utc(2026, 1, 2, 3, 4),
-      };
-      await ServerReadMarkerStorage.save(markers);
-
-      final loaded = await ServerReadMarkerStorage.load();
-      expect(loaded, hasLength(2));
-      expect(loaded['s1'], DateTime.utc(2026, 6, 1, 12));
-      expect(loaded['s2']!.isUtc, isTrue);
+    test('round-trips a marker per user, normalizing to UTC', () async {
+      await ServerReadMarkerStorage.saveServer(serverId: s, userId: u1, at: at);
+      final loaded =
+          await ServerReadMarkerStorage.loadServer(serverId: s, userId: u1);
+      expect(loaded, at);
+      expect(loaded!.isUtc, isTrue);
     });
 
-    test('a corrupt payload loads as empty rather than throwing', () async {
-      SharedPreferences.setMockInitialValues(
-        {'soliplex_server_read_markers': 'not json{'},
-      );
-      expect(await ServerReadMarkerStorage.load(), isEmpty);
+    test('a marker saved as one user is invisible to another (isolation)',
+        () async {
+      await ServerReadMarkerStorage.saveServer(serverId: s, userId: u1, at: at);
+      expect(await ServerReadMarkerStorage.loadServer(serverId: s, userId: u2),
+          isNull);
     });
 
-    test('skips malformed entries but keeps valid ones', () async {
-      // A partially-corrupt payload must drop only the bad rows, not reset the
-      // whole read model: a missing field, an unparseable time, and a non-object
-      // entry are each skipped while the one valid row survives.
+    test('a null userId resolves to the shared unauthenticated bucket',
+        () async {
+      await ServerReadMarkerStorage.saveServer(
+          serverId: s, userId: null, at: at);
+      expect(
+          await ServerReadMarkerStorage.loadServer(
+              serverId: s, userId: unauthenticatedStorageUser),
+          at);
+    });
+
+    test('clearServer removes every user, spares a same-host different port',
+        () async {
+      const s2 = 'https://foo.com:8443';
+      await ServerReadMarkerStorage.saveServer(serverId: s, userId: u1, at: at);
+      await ServerReadMarkerStorage.saveServer(serverId: s, userId: u2, at: at);
+      await ServerReadMarkerStorage.saveServer(
+          serverId: s2, userId: u1, at: at);
+
+      await ServerReadMarkerStorage.clearServer(s);
+
+      expect(await ServerReadMarkerStorage.loadServer(serverId: s, userId: u1),
+          isNull);
+      expect(await ServerReadMarkerStorage.loadServer(serverId: s, userId: u2),
+          isNull);
+      expect(await ServerReadMarkerStorage.loadServer(serverId: s2, userId: u1),
+          at);
+    });
+
+    test('a corrupt value loads as null rather than throwing', () async {
       SharedPreferences.setMockInitialValues({
-        'soliplex_server_read_markers': '['
-            '{"s":"s1","t":"2026-06-01T00:00:00Z"},'
-            '{"s":"s2","t":"not-a-date"},'
-            '{"t":"2026-06-01T00:00:00Z"},'
-            '"garbage"'
-            ']',
+        'soliplex_server_read_marker:${Uri.encodeComponent(s)}:'
+            '${Uri.encodeComponent(u1)}': 'not-a-date',
       });
-      final loaded = await ServerReadMarkerStorage.load();
-      expect(loaded, hasLength(1));
-      expect(loaded['s1'], DateTime.utc(2026, 6));
+      expect(await ServerReadMarkerStorage.loadServer(serverId: s, userId: u1),
+          isNull);
     });
   });
 
   group('ServerReadMarkers', () {
-    const serverId = 's';
-    final at = DateTime.utc(2026, 6, 1);
-
     test('markRead stamps and exposes the marker synchronously', () {
-      final markers = ServerReadMarkers();
-      markers.markRead(serverId, at);
-      expect(markers.value[serverId], at);
-      markers.dispose();
+      final store = ServerReadMarkers();
+      store.markRead(serverId: s, userId: u1, at: at);
+      expect(store.value[key(s, u1)], at);
+      store.dispose();
     });
 
-    test('ensureLoaded reads markers persisted by an earlier store', () async {
-      final seed = ServerReadMarkers()..markRead(serverId, at);
-      // Let the write-through persist before the next store loads.
+    test('a stamp by one user is invisible to another (isolation)', () {
+      final store = ServerReadMarkers();
+      store.markRead(serverId: s, userId: u1, at: at);
+      expect(store.value[key(s, u1)], at);
+      expect(store.value[key(s, u2)], isNull);
+      store.dispose();
+    });
+
+    test('ensureLoaded reads a marker persisted by an earlier store', () async {
+      ServerReadMarkers().markRead(serverId: s, userId: u1, at: at);
       await Future<void>.delayed(Duration.zero);
-      seed.dispose();
 
       final store = ServerReadMarkers();
-      await store.ensureLoaded();
-
-      expect(store.markers.value[serverId], at);
+      await store.ensureLoaded(serverId: s, userId: u1);
+      expect(store.value[key(s, u1)], at);
       store.dispose();
     });
 
     test('markRead normalizes a non-UTC timestamp to UTC', () {
       final store = ServerReadMarkers();
       final local = DateTime(2026, 6, 1, 12); // device-local
-      store.markRead(serverId, local);
-      final stored = store.value[serverId]!;
+      store.markRead(serverId: s, userId: u1, at: local);
+      final stored = store.value[key(s, u1)]!;
       expect(stored.isUtc, isTrue);
       expect(stored, local.toUtc());
       store.dispose();
     });
 
-    test('clearServer drops only that server\'s marker and persists', () async {
+    test('ensureLoaded does not clobber a fresher in-memory stamp', () async {
+      // A slow disk load must not overwrite a floor stamped after the load
+      // began, which would re-floor the server's rooms to a stale time.
+      final older = DateTime.utc(2026, 1, 1);
+      await ServerReadMarkerStorage.saveServer(
+          serverId: s, userId: u1, at: older);
+
       final store = ServerReadMarkers();
-      store.markRead('s1', at);
-      store.markRead('s2', at);
-      // Let the mark write-throughs settle before clearing, so the reload
-      // below observes clearServer's write rather than a racing stamp save.
+      store.markRead(serverId: s, userId: u1, at: at); // fresher, in-memory
+      await store.ensureLoaded(serverId: s, userId: u1);
+
+      expect(store.value[key(s, u1)], at);
+      store.dispose();
+    });
+
+    test('clearServer sweeps disk for a user the in-memory view never loaded',
+        () async {
+      await ServerReadMarkerStorage.saveServer(
+          serverId: 's1', userId: 'iss#alice', at: at);
+      final store = ServerReadMarkers();
+
+      store.clearServer('s1');
+      await Future<void>.delayed(Duration.zero);
+
+      expect(
+        await ServerReadMarkerStorage.loadServer(
+            serverId: 's1', userId: 'iss#alice'),
+        isNull,
+      );
+      store.dispose();
+    });
+
+    test('clearServer drops every user for the server and persists', () async {
+      final store = ServerReadMarkers();
+      store.markRead(serverId: 's1', userId: u1, at: at);
+      store.markRead(serverId: 's1', userId: u2, at: at);
+      store.markRead(serverId: 's2', userId: u1, at: at);
       await Future<void>.delayed(Duration.zero);
 
       store.clearServer('s1');
 
-      expect(store.value.keys, {'s2'});
+      expect(store.value.keys, {key('s2', u1)});
       await Future<void>.delayed(Duration.zero);
       final reloaded = ServerReadMarkers();
-      await reloaded.ensureLoaded();
-      expect(reloaded.value.keys, {'s2'});
+      await reloaded.ensureLoaded(serverId: 's1', userId: u1);
+      await reloaded.ensureLoaded(serverId: 's1', userId: u2);
+      await reloaded.ensureLoaded(serverId: 's2', userId: u1);
+      expect(reloaded.value.keys, {key('s2', u1)});
       store.dispose();
       reloaded.dispose();
     });

--- a/test/modules/lobby/server_read_markers_test.dart
+++ b/test/modules/lobby/server_read_markers_test.dart
@@ -176,5 +176,39 @@ void main() {
       store.dispose();
       reloaded.dispose();
     });
+
+    test('a clearServer during an in-flight load is not undone on resume',
+        () async {
+      // A marker on disk for (s, u1). The singleton is warm, so the concurrent
+      // load below reads the marker (it wins the shared cache), giving a real
+      // in-flight window in which the clear lands — the production timing.
+      await SharedPreferences.getInstance();
+      await ServerReadMarkerStorage.saveServer(serverId: s, userId: u1, at: at);
+
+      final store = ServerReadMarkers();
+      // Start the load but DON'T await it — it is now parked on the disk read.
+      final loading = store.ensureLoaded(serverId: s, userId: u1);
+      // The server is removed while that load is in flight.
+      store.clearServer(s);
+      await loading; // the load resumes AFTER the clear, holding the read marker
+      await Future<void>.delayed(Duration.zero);
+
+      // The resumed load must not re-insert the swept floor: doing so would hide
+      // unread content if the server were re-added under the same id.
+      expect(store.value[key(s, u1)], isNull,
+          reason: 'a load resuming after clearServer must not resurrect it');
+      store.dispose();
+    });
+
+    test('a load resolving after dispose does not throw', () async {
+      await SharedPreferences.getInstance();
+      await ServerReadMarkerStorage.saveServer(serverId: s, userId: u1, at: at);
+
+      final store = ServerReadMarkers();
+      final loading = store.ensureLoaded(serverId: s, userId: u1);
+      store.dispose(); // disposed while the load is in flight
+      // The load must not write to the disposed signal; no throw is the assert.
+      await loading;
+    });
   });
 }

--- a/test/modules/lobby/server_read_markers_test.dart
+++ b/test/modules/lobby/server_read_markers_test.dart
@@ -123,6 +123,23 @@ void main() {
       store.dispose();
     });
 
+    test('a concurrent ensureLoaded awaits the same in-flight load', () async {
+      await ServerReadMarkerStorage.saveServer(serverId: s, userId: u1, at: at);
+      // Drop the warmed singleton so the load below actually re-reads disk.
+      SharedPreferences.resetStatic();
+
+      final store = ServerReadMarkers();
+      // Two overlapping loads: awaiting the second must still see the marker,
+      // i.e. it awaits the first's disk read rather than returning early.
+      final first = store.ensureLoaded(serverId: s, userId: u1);
+      final second = store.ensureLoaded(serverId: s, userId: u1);
+      await second;
+      expect(store.value[key(s, u1)], at,
+          reason: 'a concurrent load must not resolve before the disk read');
+      await first;
+      store.dispose();
+    });
+
     test('clearServer sweeps disk for a user the in-memory view never loaded',
         () async {
       await ServerReadMarkerStorage.saveServer(

--- a/test/modules/lobby/server_read_markers_test.dart
+++ b/test/modules/lobby/server_read_markers_test.dart
@@ -200,6 +200,26 @@ void main() {
       store.dispose();
     });
 
+    test('a clearServer for another server does not discard an in-flight load',
+        () async {
+      // Epochs are keyed per server, so clearing one server must not invalidate
+      // another's in-flight load. A single global epoch would wrongly discard
+      // the s1 load's result, rendering it unloaded (and its rooms unread).
+      await SharedPreferences.getInstance();
+      await ServerReadMarkerStorage.saveServer(
+          serverId: 's1', userId: u1, at: at);
+
+      final store = ServerReadMarkers();
+      final loading = store.ensureLoaded(serverId: 's1', userId: u1);
+      store.clearServer('s2'); // a DIFFERENT server than the one loading
+      await loading; // the s1 load resumes after the unrelated clear
+      await Future<void>.delayed(Duration.zero);
+
+      expect(store.value[key('s1', u1)], at,
+          reason: 'clearing another server must not discard this load');
+      store.dispose();
+    });
+
     test('a load resolving after dispose does not throw', () async {
       await SharedPreferences.getInstance();
       await ServerReadMarkerStorage.saveServer(serverId: s, userId: u1, at: at);

--- a/test/modules/lobby/ui/lobby_screen_test.dart
+++ b/test/modules/lobby/ui/lobby_screen_test.dart
@@ -7,6 +7,7 @@ import 'package:soliplex_agent/soliplex_agent.dart' show Room, RoomStats;
 import 'package:soliplex_frontend/src/modules/auth/auth_session.dart';
 import 'package:soliplex_frontend/src/modules/auth/auth_tokens.dart';
 import 'package:soliplex_frontend/src/modules/auth/server_manager.dart';
+import 'package:soliplex_frontend/src/modules/lobby/lobby_read_markers.dart';
 import 'package:soliplex_frontend/src/modules/lobby/lobby_sort_mode.dart';
 import 'package:soliplex_frontend/src/modules/lobby/lobby_state.dart';
 import 'package:soliplex_frontend/src/modules/lobby/ui/lobby_screen.dart';
@@ -334,8 +335,11 @@ void main() {
       // room must not stamp it read — the room screen's per-thread rollup owns
       // that, so a genuinely-unread thread isn't hidden.
       expect(find.text('Room'), findsOneWidget);
-      final prefs = await SharedPreferences.getInstance();
-      expect(prefs.getString('soliplex_lobby_read_markers'), isNull);
+      expect(
+        await LobbyReadMarkerStorage.loadServer(
+            serverId: 'local', userId: null),
+        isEmpty,
+      );
     });
 
     testWidgets('honors the persisted grid mode on load', (tester) async {
@@ -803,8 +807,12 @@ void main() {
       // The dot clears reactively, and the room's marker is persisted keyed by
       // its id (so the gating wired the correct room, not just any room).
       expect(find.byType(UnreadDot), findsNothing);
-      final prefs = await SharedPreferences.getInstance();
-      expect(prefs.getString('soliplex_lobby_read_markers'), contains('r1'));
+      expect(
+        (await LobbyReadMarkerStorage.loadServer(
+                serverId: 'local', userId: null))
+            .keys,
+        contains('r1'),
+      );
     });
 
     testWidgets('a read room card offers no Mark as read menu', (tester) async {
@@ -863,8 +871,12 @@ void main() {
       await tester.pumpAndSettle();
 
       expect(find.byType(UnreadDot), findsNothing);
-      final prefs = await SharedPreferences.getInstance();
-      expect(prefs.getString('soliplex_lobby_read_markers'), contains('r1'));
+      expect(
+        (await LobbyReadMarkerStorage.loadServer(
+                serverId: 'local', userId: null))
+            .keys,
+        contains('r1'),
+      );
     });
   });
 }

--- a/test/modules/room/ui/room_screen_test.dart
+++ b/test/modules/room/ui/room_screen_test.dart
@@ -1764,6 +1764,66 @@ void main() {
         expect(markers['room-1'], leave);
       });
     });
+
+    testWidgets(
+        'a logout while in a room stamps the left room under the logged-in '
+        'user, not the unauthenticated bucket', (tester) async {
+      tester.view.physicalSize = const Size(1200, 800);
+      tester.view.devicePixelRatio = 1.0;
+      addTearDown(tester.view.resetPhysicalSize);
+      SharedPreferences.setMockInitialValues(const {});
+
+      final open = DateTime.utc(2026, 6, 1, 10);
+      final leave = DateTime.utc(2026, 6, 1, 10, 1);
+      var now = open;
+
+      api.nextThreads = [
+        ThreadInfo(
+          id: 'thread-1',
+          roomId: 'room-1',
+          name: 'First thread',
+          createdAt: DateTime(2026, 3, 2),
+          lastActivity: DateTime.utc(2026, 6, 1, 10, 0, 30),
+        ),
+      ];
+
+      final aliceEntry =
+          createTestServerEntry(api: api, auth: authWithIdentity(sub: 'alice'));
+
+      await withClock(Clock(() => now), () async {
+        await tester.pumpWidget(MaterialApp(
+          home: RoomScreen(
+            serverEntry: aliceEntry,
+            roomId: 'room-1',
+            threadId: 'thread-1',
+            runtimeManager: runtimeManager,
+            registry: registry,
+            uploadRegistry: uploadRegistry,
+            documentSelections: DocumentSelections(),
+          ),
+        ));
+        await tester.pumpAndSettle();
+
+        // Log out while mounted, then let the screen dispose. The room-level
+        // leave stamp (which the lobby reads) must file under alice, captured
+        // at open, not the now-null live session.
+        now = leave;
+        aliceEntry.auth.logout();
+        await tester.pumpWidget(const SizedBox());
+        await tester.pumpAndSettle();
+
+        expect(
+          await LobbyReadMarkerStorage.loadServer(
+              serverId: aliceEntry.serverId, userId: testIdentityFor('alice')),
+          containsPair('room-1', leave),
+        );
+        expect(
+          await LobbyReadMarkerStorage.loadServer(
+              serverId: aliceEntry.serverId, userId: null),
+          isEmpty,
+        );
+      });
+    });
   });
 
   testWidgets('the room-info button navigates to the room info route',

--- a/test/modules/room/ui/room_screen_test.dart
+++ b/test/modules/room/ui/room_screen_test.dart
@@ -1654,8 +1654,9 @@ void main() {
         await tester.pumpWidget(const SizedBox());
         await tester.pumpAndSettle();
 
-        final markers = await LobbyReadMarkerStorage.load();
-        expect(markers[(serverId: entry.serverId, roomId: 'room-1')], leave);
+        final markers = await LobbyReadMarkerStorage.loadServer(
+            serverId: entry.serverId, userId: null);
+        expect(markers['room-1'], leave);
       });
     });
 
@@ -1705,8 +1706,9 @@ void main() {
         await tester.pumpWidget(const SizedBox());
         await tester.pumpAndSettle();
 
-        final markers = await LobbyReadMarkerStorage.load();
-        expect(markers[(serverId: entry.serverId, roomId: 'room-1')], isNull);
+        final markers = await LobbyReadMarkerStorage.loadServer(
+            serverId: entry.serverId, userId: null);
+        expect(markers['room-1'], isNull);
       });
     });
 
@@ -1721,6 +1723,12 @@ void main() {
       final leave = DateTime.utc(2026, 6, 1, 10, 1);
       var now = open;
 
+      // Signed in: the left room's marker must persist under the user's bucket,
+      // not the unauthenticated one — the room-screen captures the identity at
+      // open and files the leave stamp against it.
+      final authedEntry =
+          createTestServerEntry(api: api, auth: authWithIdentity());
+
       api.nextThreads = [
         ThreadInfo(
           id: 'thread-1',
@@ -1733,7 +1741,7 @@ void main() {
 
       Widget roomScreen(String roomId) => MaterialApp(
             home: RoomScreen(
-              serverEntry: entry,
+              serverEntry: authedEntry,
               roomId: roomId,
               threadId: roomId == 'room-1' ? 'thread-1' : null,
               runtimeManager: runtimeManager,
@@ -1751,8 +1759,9 @@ void main() {
         await tester.pumpWidget(roomScreen('room-2'));
         await tester.pumpAndSettle();
 
-        final markers = await LobbyReadMarkerStorage.load();
-        expect(markers[(serverId: entry.serverId, roomId: 'room-1')], leave);
+        final markers = await LobbyReadMarkerStorage.loadServer(
+            serverId: authedEntry.serverId, userId: testUserIdentity);
+        expect(markers['room-1'], leave);
       });
     });
   });


### PR DESCRIPTION
## What

Scopes lobby **room** and **server** read markers to the signed-in user, per server — closing the last device-local read-state leak between users on a shared device. The multi-server lobby now resolves each server's own signed-in user.

Storage moves from two monolithic JSON-array blobs to one blob per `(serverId, userId)`, keyed through the shared codec. A shared, auth-agnostic in-memory store holds every `(serverId, userId, …)` marker; consumers project down to the current user per server (`currentUserRoomMarkers` / `currentUserServerMarkers`). A null identity (signed-out / no-auth server) buckets under the `unauthenticated` sentinel via the single `storageUser` choke point.

As a one-time effect of the storage-format change, existing lobby read state resets on upgrade — every room reads as unread once.

## Concurrency

The stores coordinate load / persist / clear without a storage round-trip racing the screens' mount/dispose ordering:

- **Per-server clear epochs** — a suspended load/persist captures the epoch before its `await` and discards its work if a `clearServer` landed mid-flight, so a clear can't be undone by a resuming op re-inserting a swept blob.
- **In-flight load coalescing** — concurrent `ensureLoaded` calls await one disk read; a failed load leaves the key unloaded so a later mount retries.
- **Persist waits for load** — a stamp made before/during a load rewrites the full on-disk set rather than shrinking it; when the load never completed, the write is skipped (the stamp holds in memory).
- **Room screen** captures the user identity at mount and re-captures on room change, so a deferred write after a switch/logout can't misfile a marker into the wrong user's bucket.

## Review fixes (last commit)

Following a multi-aspect review:
- Routed the thread read-marker and thread-anchor stores through the shared `storageUser` helper so every marker-key site buckets a null identity identically (the helper is now genuinely the single choke point).
- Corrected the `ServerReadMarkers` epoch-comment to the real ordering invariant; raised the skipped-persist log to `warning` so a dropped durable write is observable.
- Added per-server epoch-isolation tests: clearing one server must not discard another's in-flight load.

## Testing

- `flutter analyze` — clean.
- Affected suites pass, including user-isolation coverage at disk / signal / projection / integrated layers, the load-vs-clear and dispose-mid-flight races (using SharedPreferences singleton warmth to open real in-flight windows), and corrupt-payload handling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)