### PR TITLE
Device-local storage cleanup: one-time pre-format sweep + room/thread disappearance pruning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,10 @@ Versions follow the `version+build` scheme from `pubspec.yaml`, bumped via
   in on the same server no longer sees the previous user's unsent draft. A
   by-server draft clear also no longer over-reaches a same-host server that
   differs only by an explicit vs default port.
+- On first launch after upgrade, a one-time cleanup removes device-local data
+  left over from the previous storage format — orphaned read/anchor markers and
+  raw-format composer drafts, plus a defunct hidden-servers key — so a former
+  user's leftover plaintext no longer lingers on disk.
 - Thread read markers and unread-divider anchors are now scoped to the signed-in
   user: a different user signing in on the same server no longer inherits the
   previous user's read state or "New messages" dividers. As a one-time effect of

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,9 +20,17 @@ Versions follow the `version+build` scheme from `pubspec.yaml`, bumped via
   Only a genuine removal clears a server's read state, unread-divider anchors,
   and composer drafts; a signal reset such as shell teardown no longer risks
   wiping stored state, independent of module dispose order.
+- When a room or thread disappears from a server (deleted, or access removed),
+  its device-local read markers and unread-divider anchors are dropped across
+  users, and a deleted thread's document-filter selection is cleared. Unsent
+  composer drafts are intentionally kept (they self-expire and clear on explicit
+  server removal), so a transient fetch shortfall can't destroy unsent text.
 
 ### Fixed
 
+- Deleting the open thread no longer writes a stale "read" marker for it on the
+  way out (via dispose, or the auto-navigate to a sibling thread), so a thread
+  later re-created under the same id no longer appears already-read.
 - Removing a server now clears the rest of its device-local state, not just its
   read markers: the thread unread-divider anchors and unsent composer drafts are
   dropped too, on every removal path. Because server ids derive from the URL,

--- a/lib/src/core/storage_migration.dart
+++ b/lib/src/core/storage_migration.dart
@@ -9,9 +9,10 @@ const _currentSchemaVersion = 1;
 
 /// Device-local keys from the pre-keyed storage format that no code reads any
 /// more, plus a defunct hidden-servers key. Removed by exact match, not a prefix
-/// sweep: each shares a stem with a live keyed key (e.g.
-/// `soliplex_server_read_markers` vs `soliplex_server_read_marker:…`), so a
-/// prefix sweep would take the live data with it.
+/// sweep: some share a stem with a live keyed key (e.g.
+/// `soliplex_server_read_markers` vs `soliplex_server_read_marker:…`), where a
+/// prefix sweep would take the live data with it. Exact match is used uniformly
+/// so the list stays trivially safe to extend.
 const _legacyExactKeys = <String>[
   'soliplex_thread_read_markers',
   'soliplex_thread_unread_anchors',

--- a/lib/src/core/storage_migration.dart
+++ b/lib/src/core/storage_migration.dart
@@ -23,7 +23,7 @@ const _orphanedExactKeys = <String>[
 
 /// Runs device-local storage migrations in order, once per version bump.
 ///
-/// Each step is gated on the stored schema version, and the new version is
+/// Each step is gated on the stored schema version, and the target version is
 /// written only after the steps complete, so a failure retries on the next
 /// launch. Best-effort: the whole run is guarded and never rethrows — a corrupt
 /// `SharedPreferences` file must not white-screen the app at bootstrap. Safe to
@@ -52,13 +52,13 @@ Future<void> migrateStorage() async {
 }
 
 /// v1: removes the orphaned pre-keyed-format keys. The keyed stores no longer
-/// read these, so this clears the leftover plaintext from disk.
+/// read these, so this clears the leftover data from disk.
 Future<void> _sweepOrphanedKeys(SharedPreferences prefs) async {
   for (final key in _orphanedExactKeys) {
     await prefs.remove(key);
   }
-  // Pre-keyed composer drafts share the new prefix head but carry a raw '://'
-  // (the un-encoded server origin); a percent-encoded new key never does,
+  // Pre-keyed composer drafts share the current prefix head but carry a raw
+  // '://' (the un-encoded server origin); a percent-encoded key never does,
   // because Uri.encodeComponent escapes it to %3A%2F%2F.
   final orphanedDrafts = prefs
       .getKeys()

--- a/lib/src/core/storage_migration.dart
+++ b/lib/src/core/storage_migration.dart
@@ -13,7 +13,7 @@ const _currentSchemaVersion = 1;
 /// `soliplex_server_read_markers` vs `soliplex_server_read_marker:…`), where a
 /// prefix sweep would take the live data with it. Exact match is used uniformly
 /// so the list stays trivially safe to extend.
-const _legacyExactKeys = <String>[
+const _orphanedExactKeys = <String>[
   'soliplex_thread_read_markers',
   'soliplex_thread_unread_anchors',
   'soliplex_lobby_read_markers',
@@ -38,7 +38,7 @@ Future<void> migrateStorage() async {
     // Each step's literal is the version it brings storage up to (not
     // [_currentSchemaVersion], which is the latest — they diverge once a v2 step
     // exists, and a step must never re-run for an install already past it).
-    if (from < 1) await _sweepLegacyKeys(prefs);
+    if (from < 1) await _sweepOrphanedKeys(prefs);
 
     await prefs.setInt(_schemaVersionKey, _currentSchemaVersion);
   } catch (error, stackTrace) {
@@ -53,19 +53,19 @@ Future<void> migrateStorage() async {
 
 /// v1: removes the orphaned pre-keyed-format keys. The keyed stores no longer
 /// read these, so this clears the leftover plaintext from disk.
-Future<void> _sweepLegacyKeys(SharedPreferences prefs) async {
-  for (final key in _legacyExactKeys) {
+Future<void> _sweepOrphanedKeys(SharedPreferences prefs) async {
+  for (final key in _orphanedExactKeys) {
     await prefs.remove(key);
   }
-  // Legacy composer drafts share the new prefix head but carry a raw '://' (the
-  // un-encoded server origin); a percent-encoded new key never does, because
-  // Uri.encodeComponent escapes it to %3A%2F%2F.
-  final legacyDrafts = prefs
+  // Pre-keyed composer drafts share the new prefix head but carry a raw '://'
+  // (the un-encoded server origin); a percent-encoded new key never does,
+  // because Uri.encodeComponent escapes it to %3A%2F%2F.
+  final orphanedDrafts = prefs
       .getKeys()
       .where((k) =>
           k.startsWith('soliplex_return_to:composer:') && k.contains('://'))
       .toList();
-  for (final key in legacyDrafts) {
+  for (final key in orphanedDrafts) {
     await prefs.remove(key);
   }
 }

--- a/lib/src/core/storage_migration.dart
+++ b/lib/src/core/storage_migration.dart
@@ -1,0 +1,71 @@
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:soliplex_logging/soliplex_logging.dart';
+
+final Logger _logger =
+    LogManager.instance.getLogger('soliplex.storage_migration');
+
+const _schemaVersionKey = 'soliplex_storage_schema_version';
+const _currentSchemaVersion = 1;
+
+/// Device-local keys left over from the pre-keyed storage format (and the
+/// hidden-servers key orphaned by the single-server lobby rework). Verified
+/// against git history as real removed `_key` constants. Removed by exact match,
+/// not a prefix sweep: each shares a stem with a new keyed key
+/// (e.g. `soliplex_server_read_markers` vs `soliplex_server_read_marker:…`), so a
+/// prefix sweep would take the live data with it.
+const _legacyExactKeys = <String>[
+  'soliplex_thread_read_markers',
+  'soliplex_thread_unread_anchors',
+  'soliplex_lobby_read_markers',
+  'soliplex_server_read_markers',
+  'soliplex_lobby_hidden_servers',
+];
+
+/// Runs device-local storage migrations in order, once per version bump.
+///
+/// Each step is gated on the stored schema version, and the new version is
+/// written only after the steps complete, so a failure retries on the next
+/// launch. Best-effort: the whole run is guarded and never rethrows — a corrupt
+/// `SharedPreferences` file must not white-screen the app at bootstrap. Safe to
+/// re-run. A future format change adds an `if (from < 2)` step and bumps
+/// [_currentSchemaVersion]; it reuses this same gate rather than a fresh flag.
+Future<void> migrateStorage() async {
+  try {
+    final prefs = await SharedPreferences.getInstance();
+    final from = prefs.getInt(_schemaVersionKey) ?? 0;
+    if (from >= _currentSchemaVersion) return;
+
+    // Each step's literal is the version it brings storage up to (not
+    // [_currentSchemaVersion], which is the latest — they diverge once a v2 step
+    // exists, and a step must never re-run for an install already past it).
+    if (from < 1) await _sweepLegacyKeys(prefs); // reach v1
+
+    await prefs.setInt(_schemaVersionKey, _currentSchemaVersion);
+  } catch (error, stackTrace) {
+    // Do not rethrow: the version isn't advanced, so the next launch retries.
+    _logger.warning(
+      'Storage migration failed',
+      error: error,
+      stackTrace: stackTrace,
+    );
+  }
+}
+
+/// v1: removes the orphaned pre-keyed-format keys. The keyed stores (PRs 3–5) no
+/// longer read these, so this clears the leftover plaintext from disk.
+Future<void> _sweepLegacyKeys(SharedPreferences prefs) async {
+  for (final key in _legacyExactKeys) {
+    await prefs.remove(key);
+  }
+  // Legacy composer drafts share the new prefix head but carry a raw '://' (the
+  // un-encoded server origin); a percent-encoded new key never does, because
+  // Uri.encodeComponent escapes it to %3A%2F%2F.
+  final legacyDrafts = prefs
+      .getKeys()
+      .where((k) =>
+          k.startsWith('soliplex_return_to:composer:') && k.contains('://'))
+      .toList();
+  for (final key in legacyDrafts) {
+    await prefs.remove(key);
+  }
+}

--- a/lib/src/core/storage_migration.dart
+++ b/lib/src/core/storage_migration.dart
@@ -7,11 +7,10 @@ final Logger _logger =
 const _schemaVersionKey = 'soliplex_storage_schema_version';
 const _currentSchemaVersion = 1;
 
-/// Device-local keys left over from the pre-keyed storage format (and the
-/// hidden-servers key orphaned by the single-server lobby rework). Verified
-/// against git history as real removed `_key` constants. Removed by exact match,
-/// not a prefix sweep: each shares a stem with a new keyed key
-/// (e.g. `soliplex_server_read_markers` vs `soliplex_server_read_marker:…`), so a
+/// Device-local keys from the pre-keyed storage format that no code reads any
+/// more, plus a defunct hidden-servers key. Removed by exact match, not a prefix
+/// sweep: each shares a stem with a live keyed key (e.g.
+/// `soliplex_server_read_markers` vs `soliplex_server_read_marker:…`), so a
 /// prefix sweep would take the live data with it.
 const _legacyExactKeys = <String>[
   'soliplex_thread_read_markers',
@@ -27,8 +26,8 @@ const _legacyExactKeys = <String>[
 /// written only after the steps complete, so a failure retries on the next
 /// launch. Best-effort: the whole run is guarded and never rethrows — a corrupt
 /// `SharedPreferences` file must not white-screen the app at bootstrap. Safe to
-/// re-run. A future format change adds an `if (from < 2)` step and bumps
-/// [_currentSchemaVersion]; it reuses this same gate rather than a fresh flag.
+/// re-run. The stored version is a monotonic integer, not a per-migration flag,
+/// so each step gates on `from < N` and shares this one gate.
 Future<void> migrateStorage() async {
   try {
     final prefs = await SharedPreferences.getInstance();
@@ -38,7 +37,7 @@ Future<void> migrateStorage() async {
     // Each step's literal is the version it brings storage up to (not
     // [_currentSchemaVersion], which is the latest — they diverge once a v2 step
     // exists, and a step must never re-run for an install already past it).
-    if (from < 1) await _sweepLegacyKeys(prefs); // reach v1
+    if (from < 1) await _sweepLegacyKeys(prefs);
 
     await prefs.setInt(_schemaVersionKey, _currentSchemaVersion);
   } catch (error, stackTrace) {
@@ -51,8 +50,8 @@ Future<void> migrateStorage() async {
   }
 }
 
-/// v1: removes the orphaned pre-keyed-format keys. The keyed stores (PRs 3–5) no
-/// longer read these, so this clears the leftover plaintext from disk.
+/// v1: removes the orphaned pre-keyed-format keys. The keyed stores no longer
+/// read these, so this clears the leftover plaintext from disk.
 Future<void> _sweepLegacyKeys(SharedPreferences prefs) async {
   for (final key in _legacyExactKeys) {
     await prefs.remove(key);

--- a/lib/src/flavors/standard.dart
+++ b/lib/src/flavors/standard.dart
@@ -8,6 +8,7 @@ import '../core/app_identity.dart';
 import '../core/inactivity/inactivity_config.dart';
 import '../core/routes.dart';
 import '../core/shell_config.dart';
+import '../core/storage_migration.dart';
 import 'package:soliplex_design/soliplex_design.dart';
 import '../interfaces/auth_state.dart' show Authenticated;
 import '../modules/auth/auth_module.dart';
@@ -95,6 +96,7 @@ Future<ShellConfig> standard({
 
   final serverStorage = SecureServerStorage();
   await clearServersIfFreshInstall(serverStorage);
+  await migrateStorage();
 
   final serverManager = ServerManager(
     authFactory: buildAuth,

--- a/lib/src/modules/lobby/lobby_read_markers.dart
+++ b/lib/src/modules/lobby/lobby_read_markers.dart
@@ -128,6 +128,27 @@ abstract final class LobbyReadMarkerStorage {
       await prefs.remove(k);
     }
   }
+
+  /// Removes [roomId] from every user's blob for [serverId], leaving sibling
+  /// rooms intact. Sweeps this class's `(serverId, userId)` keys; unrelated keys
+  /// are untouched.
+  static Future<void> clearRoom(String serverId, String roomId) async {
+    final prefs = await SharedPreferences.getInstance();
+    final sweep = serverKeyPrefix(_prefix, serverId);
+    for (final k
+        in prefs.getKeys().where((k) => k.startsWith(sweep)).toList()) {
+      final raw = prefs.getString(k);
+      if (raw == null || raw.isEmpty) continue;
+      try {
+        final decoded = jsonDecode(raw);
+        if (decoded is! Map || !decoded.containsKey(roomId)) continue;
+        decoded.remove(roomId);
+        await prefs.setString(k, jsonEncode(decoded));
+      } on FormatException {
+        continue;
+      }
+    }
+  }
 }
 
 /// In-memory, reactive source of truth for per-room read markers, shared by the
@@ -296,6 +317,28 @@ class RoomReadMarkers {
           error: error,
           stackTrace: st,
           attributes: {'serverId': serverId},
+        );
+      }),
+    );
+  }
+
+  /// Drops [roomId] for every user on [serverId] from memory and disk, so a
+  /// disappeared room doesn't read as read if re-created under the same id.
+  /// Unlike [clearServer] this does not bump [_generation]: the epoch is
+  /// server-wide, so bumping it on a single-room clear would abort in-flight
+  /// loads/persists for other rooms on the server and drop their stamps.
+  void clearRoom(String serverId, String roomId) {
+    final next = {..._markers.value}..removeWhere(
+        (key, _) => key.serverId == serverId && key.roomId == roomId);
+    if (next.length != _markers.value.length) _markers.value = next;
+    unawaited(
+      LobbyReadMarkerStorage.clearRoom(serverId, roomId)
+          .catchError((Object error, StackTrace st) {
+        _logger.error(
+          'Failed to clear room read markers for removed room',
+          error: error,
+          stackTrace: st,
+          attributes: {'serverId': serverId, 'roomId': roomId},
         );
       }),
     );

--- a/lib/src/modules/lobby/lobby_read_markers.dart
+++ b/lib/src/modules/lobby/lobby_read_markers.dart
@@ -344,8 +344,9 @@ class RoomReadMarkers {
   /// need the epoch: the disk-level [LobbyReadMarkerStorage.clearRoom] is the
   /// source of truth, a prune only runs on a non-first fetch (the first seeds
   /// the baseline, so no cold-start path opens the window), the local
-  /// SharedPreferences reads a prune races against resolve quickly, and a
-  /// re-added marker self-corrects on the next genuine clear.
+  /// SharedPreferences reads a prune races against resolve quickly from the
+  /// in-memory cache, and a re-added marker self-corrects on the next genuine
+  /// clear.
   void clearRoom(String serverId, String roomId) {
     final next = {..._markers.value}..removeWhere(
         (key, _) => key.serverId == serverId && key.roomId == roomId);

--- a/lib/src/modules/lobby/lobby_read_markers.dart
+++ b/lib/src/modules/lobby/lobby_read_markers.dart
@@ -337,15 +337,15 @@ class RoomReadMarkers {
   /// server-wide, so bumping it on a single-room clear would abort in-flight
   /// loads/persists for other rooms on the server and drop their stamps.
   ///
-  /// The tradeoff is a resurrection window that no real user path opens on the
-  /// current wiring: an in-flight [_load] for this server that read disk before
-  /// the async disk clear finished carries the old value and — with the epoch
-  /// unchanged — commits it, re-adding [roomId] to memory (a later persist then
-  /// rewrites it to disk). Reaching it needs that load still parked when a fetch
-  /// diffs the deletion, but only a non-first fetch prunes, and the only one that
-  /// fires is a silent re-auth into ActiveSession — minutes after connect, where
-  /// the marker load was kicked off alongside the first fetch. By then the local
-  /// SharedPreferences read has long since resolved.
+  /// The tradeoff is a narrow, self-healing resurrection window rather than a
+  /// hard guarantee. An in-flight [_load] or [_persist] for this server that
+  /// captured state before the async disk clear finished can re-add [roomId] to
+  /// memory (and a later persist then rewrites it to disk). Closing it does not
+  /// need the epoch: the disk-level [LobbyReadMarkerStorage.clearRoom] is the
+  /// source of truth, a prune only runs on a non-first fetch (the first seeds
+  /// the baseline, so no cold-start path opens the window), the local
+  /// SharedPreferences reads a prune races against resolve quickly, and a
+  /// re-added marker self-corrects on the next genuine clear.
   void clearRoom(String serverId, String roomId) {
     final next = {..._markers.value}..removeWhere(
         (key, _) => key.serverId == serverId && key.roomId == roomId);

--- a/lib/src/modules/lobby/lobby_read_markers.dart
+++ b/lib/src/modules/lobby/lobby_read_markers.dart
@@ -144,7 +144,16 @@ abstract final class LobbyReadMarkerStorage {
         if (decoded is! Map || !decoded.containsKey(roomId)) continue;
         decoded.remove(roomId);
         await prefs.setString(k, jsonEncode(decoded));
-      } on FormatException {
+      } on FormatException catch (error, st) {
+        // A corrupt blob can't be stripped, so the room's marker survives here;
+        // the next loadServer discards the whole blob and re-logs. Log so this
+        // skip isn't silent, matching the other corruption sites in this class.
+        _logger.warning(
+          'Skipped corrupt room read marker blob while clearing a room',
+          error: error,
+          stackTrace: st,
+          attributes: {'serverId': serverId, 'roomId': roomId, 'key': k},
+        );
         continue;
       }
     }
@@ -327,6 +336,16 @@ class RoomReadMarkers {
   /// Unlike [clearServer] this does not bump [_generation]: the epoch is
   /// server-wide, so bumping it on a single-room clear would abort in-flight
   /// loads/persists for other rooms on the server and drop their stamps.
+  ///
+  /// The tradeoff is a resurrection window that no real user path opens on the
+  /// current wiring: an in-flight [_load] for this server that read disk before
+  /// the async disk clear finished carries the old value and — with the epoch
+  /// unchanged — commits it, re-adding [roomId] to memory (a later persist then
+  /// rewrites it to disk). Reaching it needs that load still parked when a fetch
+  /// diffs the deletion, but only a non-first fetch prunes, and the only one that
+  /// fires is a silent re-auth into ActiveSession — minutes after connect, where
+  /// the marker load was kicked off alongside the first fetch. By then the local
+  /// SharedPreferences read has long since resolved.
   void clearRoom(String serverId, String roomId) {
     final next = {..._markers.value}..removeWhere(
         (key, _) => key.serverId == serverId && key.roomId == roomId);

--- a/lib/src/modules/lobby/lobby_state.dart
+++ b/lib/src/modules/lobby/lobby_state.dart
@@ -20,6 +20,8 @@ import '../auth/server_entry.dart';
 import '../auth/server_manager.dart';
 import '../room/room_run_activity.dart';
 import '../room/run_registry.dart';
+import '../room/thread_anchor_storage.dart' show ThreadAnchorStorage;
+import '../room/thread_read_markers.dart' show ThreadReadMarkerStorage;
 import 'lobby_read_markers.dart';
 import 'lobby_sort_mode.dart';
 import 'lobby_view_mode.dart';
@@ -657,7 +659,8 @@ class LobbyState {
     final token = CancelToken();
     _cancelTokens[serverId] = token;
 
-    // Mark as loading
+    // Mark as loading, keeping the prior list to diff for disappeared rooms.
+    final previous = _roomsByServer.value[serverId];
     _roomsByServer.value = {
       ..._roomsByServer.value,
       serverId: const RoomsLoading(),
@@ -670,6 +673,7 @@ class LobbyState {
         ..._roomsByServer.value,
         serverId: RoomsLoaded(rooms),
       };
+      _pruneDisappearedRooms(serverId, previous, rooms);
       // A fresh room list invalidates cached activity for this server (rooms
       // may have been added); drop those entries so recency refetches.
       _invalidateActivity(serverId);
@@ -700,6 +704,41 @@ class LobbyState {
         serverId: RoomsFailed(error),
       };
     });
+  }
+
+  /// Prunes device-local state for rooms that vanished from [serverId]'s list
+  /// between [previous] and the fresh [rooms] (a backend delete / access loss).
+  /// Only diffs a prior loaded list against the new one — a failed or first
+  /// fetch removes nothing. Drafts are deliberately left alone (they self-expire
+  /// and clear on server removal); a passive list diff must never destroy unsent
+  /// text on a transient shortfall.
+  void _pruneDisappearedRooms(
+      String serverId, ServerRooms? previous, List<Room> rooms) {
+    if (previous is! RoomsLoaded) return;
+    final live = rooms.map((r) => r.id).toSet();
+    final removed =
+        previous.rooms.map((r) => r.id).where((id) => !live.contains(id));
+    for (final roomId in removed) {
+      _roomReadMarkers.clearRoom(serverId, roomId);
+      unawaited(ThreadReadMarkerStorage.clearRoom(serverId, roomId)
+          .catchError((Object error, StackTrace st) {
+        _logger.error(
+          'Failed to clear thread read markers for removed room',
+          error: error,
+          stackTrace: st,
+          attributes: {'serverId': serverId, 'roomId': roomId},
+        );
+      }));
+      unawaited(ThreadAnchorStorage.clearRoom(serverId, roomId)
+          .catchError((Object error, StackTrace st) {
+        _logger.warning(
+          'Failed to clear thread anchors for removed room',
+          error: error,
+          stackTrace: st,
+          attributes: {'serverId': serverId, 'roomId': roomId},
+        );
+      }));
+    }
   }
 
   void _fetchUserProfile(String serverId, ServerEntry entry) {

--- a/lib/src/modules/room/anchor_tracker.dart
+++ b/lib/src/modules/room/anchor_tracker.dart
@@ -137,10 +137,12 @@ class AnchorTracker {
   }
 
   /// Drops [threadId]'s anchor (a deleted thread) from the in-memory map so a
-  /// later flush doesn't re-persist it. Only flushes once loaded — the exit-time
-  /// prune that calls this runs against an already-loaded tracker, so the
-  /// in-flight-load merge that could otherwise re-add the entry isn't reached in
-  /// practice. The disk store's all-users `clearThread` is the source of truth.
+  /// later flush doesn't re-persist it. Only flushes once loaded: the sole caller
+  /// (the room screen's thread-list-diff prune) fires on live list updates, and
+  /// its first emission only seeds the disappearance baseline — a clear reaches
+  /// this tracker on a later emission, by which point the disk load has resolved,
+  /// so the in-flight-load merge that could otherwise re-add the entry isn't hit
+  /// in practice. The disk store's all-users `clearThread` is the source of truth.
   void clearThread(String threadId) {
     final next = {..._anchors}..removeWhere((k, _) => k.threadId == threadId);
     if (next.length == _anchors.length) return;

--- a/lib/src/modules/room/anchor_tracker.dart
+++ b/lib/src/modules/room/anchor_tracker.dart
@@ -136,6 +136,20 @@ class AnchorTracker {
     if (_dirty) unawaited(_flush());
   }
 
+  /// Drops [threadId]'s anchor (a deleted thread) from the in-memory map so a
+  /// later flush doesn't re-persist it. Only flushes once loaded — the exit-time
+  /// prune that calls this runs against an already-loaded tracker, so the
+  /// in-flight-load merge that could otherwise re-add the entry isn't reached in
+  /// practice. The disk store's all-users `clearThread` is the source of truth.
+  void clearThread(String threadId) {
+    final next = {..._anchors}..removeWhere((k, _) => k.threadId == threadId);
+    if (next.length == _anchors.length) return;
+    _anchors = next;
+    _dirty = true;
+    if (_loadState != _LoadState.loaded) return;
+    unawaited(_flush());
+  }
+
   /// Writes [_anchors] while any change is pending, one write at a time. Keeps
   /// [_dirty] set on failure so the change is retried by the next flush rather
   /// than lost, and escalates the log once failures persist.

--- a/lib/src/modules/room/document_selections.dart
+++ b/lib/src/modules/room/document_selections.dart
@@ -19,6 +19,11 @@ class DocumentSelections {
     }
   }
 
+  /// Drops the selection for a deleted thread.
+  void clearThread(String roomId, String threadId) {
+    _selections.remove((roomId, threadId));
+  }
+
   /// Moves the selection from the null-thread key to [threadId].
   ///
   /// Used when a user selects documents before a thread exists, then

--- a/lib/src/modules/room/thread_anchor_storage.dart
+++ b/lib/src/modules/room/thread_anchor_storage.dart
@@ -116,7 +116,21 @@ abstract final class ThreadAnchorStorage {
         if (decoded is! Map || !decoded.containsKey(threadId)) continue;
         decoded.remove(threadId);
         await prefs.setString(k, jsonEncode(decoded));
-      } on FormatException {
+      } on FormatException catch (error, st) {
+        // A corrupt blob can't be stripped, so the thread's anchor survives
+        // here; the next loadRoom discards the whole blob and re-logs. Log so
+        // this skip isn't silent, matching the corruption sites elsewhere.
+        _logger.warning(
+          'Skipped corrupt thread anchor blob while clearing a thread',
+          error: error,
+          stackTrace: st,
+          attributes: {
+            'serverId': serverId,
+            'roomId': roomId,
+            'threadId': threadId,
+            'key': k,
+          },
+        );
         continue;
       }
     }

--- a/lib/src/modules/room/thread_read_markers.dart
+++ b/lib/src/modules/room/thread_read_markers.dart
@@ -132,7 +132,21 @@ abstract final class ThreadReadMarkerStorage {
         if (decoded is! Map || !decoded.containsKey(threadId)) continue;
         decoded.remove(threadId);
         await prefs.setString(k, jsonEncode(decoded));
-      } on FormatException {
+      } on FormatException catch (error, st) {
+        // A corrupt blob can't be stripped, so the thread's marker survives
+        // here; the next loadRoom discards the whole blob and re-logs. Log so
+        // this skip isn't silent, matching the corruption sites elsewhere.
+        _logger.warning(
+          'Skipped corrupt thread read marker blob while clearing a thread',
+          error: error,
+          stackTrace: st,
+          attributes: {
+            'serverId': serverId,
+            'roomId': roomId,
+            'threadId': threadId,
+            'key': k,
+          },
+        );
         continue;
       }
     }

--- a/lib/src/modules/room/thread_read_tracker.dart
+++ b/lib/src/modules/room/thread_read_tracker.dart
@@ -91,6 +91,21 @@ class ThreadReadTracker {
     unawaited(_flush());
   }
 
+  /// Drops [threadId]'s marker (a deleted thread) from the in-memory map so a
+  /// later flush doesn't re-persist it. Only flushes once loaded — the exit-time
+  /// prune that calls this runs against an already-loaded tracker, so the
+  /// in-flight-load merge that could otherwise re-add the entry isn't reached in
+  /// practice. The disk store's all-users `clearThread` is the source of truth
+  /// for the removal.
+  void clearThread(String threadId) {
+    final next = {..._markers}..removeWhere((k, _) => k.threadId == threadId);
+    if (next.length == _markers.length) return;
+    _markers = next;
+    _dirty = true;
+    if (_loadState != _LoadState.loaded) return;
+    unawaited(_flush());
+  }
+
   /// Writes [_markers] while any change is pending, one write at a time. Keeps
   /// [_dirty] set on failure so the change is retried by the next flush rather
   /// than lost, and escalates the log once failures persist.

--- a/lib/src/modules/room/thread_read_tracker.dart
+++ b/lib/src/modules/room/thread_read_tracker.dart
@@ -92,10 +92,12 @@ class ThreadReadTracker {
   }
 
   /// Drops [threadId]'s marker (a deleted thread) from the in-memory map so a
-  /// later flush doesn't re-persist it. Only flushes once loaded — the exit-time
-  /// prune that calls this runs against an already-loaded tracker, so the
-  /// in-flight-load merge that could otherwise re-add the entry isn't reached in
-  /// practice. The disk store's all-users `clearThread` is the source of truth
+  /// later flush doesn't re-persist it. Only flushes once loaded: the sole caller
+  /// (the room screen's thread-list-diff prune) fires on live list updates, and
+  /// its first emission only seeds the disappearance baseline — a clear reaches
+  /// this tracker on a later emission, by which point the disk load has resolved,
+  /// so the in-flight-load merge that could otherwise re-add the entry isn't hit
+  /// in practice. The disk store's all-users `clearThread` is the source of truth
   /// for the removal.
   void clearThread(String threadId) {
     final next = {..._markers}..removeWhere((k, _) => k.threadId == threadId);

--- a/lib/src/modules/room/ui/room_screen.dart
+++ b/lib/src/modules/room/ui/room_screen.dart
@@ -585,9 +585,12 @@ class _RoomScreenState extends State<RoomScreen> {
     }
   }
 
-  /// Whether [threadId] is still in the room's current thread list. A
-  /// just-deleted thread is absent, so an exit re-stamp of it would write an
-  /// orphan marker for a thread that no longer exists.
+  /// Whether [threadId] is present in the room's currently-loaded thread list.
+  /// A just-deleted thread is absent, so an exit re-stamp of it would write an
+  /// orphan marker for a thread that no longer exists — that is the case this
+  /// guards. It also returns false while the list is not `ThreadsLoaded` (a
+  /// mid-refresh load/failure); skipping the stamp then is harmless, as the
+  /// marker re-derives the next time the thread is opened.
   bool _threadStillListed(String threadId) {
     final status = _state.threadList.threads.value;
     return status is ThreadsLoaded &&

--- a/lib/src/modules/room/ui/room_screen.dart
+++ b/lib/src/modules/room/ui/room_screen.dart
@@ -513,14 +513,85 @@ class _RoomScreenState extends State<RoomScreen> {
     }
   }
 
+  /// The thread ids last seen in this room's list, for the disappearance diff.
+  /// Null until the first `ThreadsLoaded` establishes a baseline, and reset on
+  /// room change so a new room never diffs against the previous room's ids.
+  Set<String>? _knownThreadIds;
+
   /// Subscribes the room read marker to thread-list changes. The subscription
   /// fires immediately with the current value, so this also performs the
-  /// initial recompute.
+  /// initial recompute and seeds the disappearance baseline.
   void _watchRoomRead() {
     _roomReadUnsub?.call();
-    _roomReadUnsub = _state.threadList.threads.subscribe((_) {
-      if (mounted) _recomputeRoomRead();
+    _knownThreadIds = null; // new room (or first mount) rebuilds the baseline
+    _roomReadUnsub = _state.threadList.threads.subscribe((status) {
+      if (!mounted) return;
+      _pruneVanishedThreads(status);
+      _recomputeRoomRead();
     });
+  }
+
+  /// Prunes device-local state for threads that vanished from this room's list
+  /// (an explicit delete or a refresh that dropped one). Diffs the new loaded set
+  /// against the last seen. A non-loaded status is ignored, so the baseline
+  /// survives a refresh's loading phase; a null baseline (first load) seeds it and
+  /// prunes nothing — a cold load never mass-prunes. A thread deleted while this
+  /// room isn't open isn't caught (no baseline on the next open); its stale
+  /// markers are harmless and re-derive.
+  void _pruneVanishedThreads(ThreadListStatus status) {
+    if (status is! ThreadsLoaded) return;
+    final live = status.threads.map((t) => t.id).toSet();
+    final known = _knownThreadIds;
+    _knownThreadIds = live;
+    if (known == null) return;
+    final serverId = widget.serverEntry.serverId;
+    final roomId = widget.roomId;
+    for (final threadId in known.where((id) => !live.contains(id))) {
+      // Drop from the live trackers first so a later flush can't re-persist it,
+      // then clear disk across all users.
+      _threadReadTracker.clearThread(threadId);
+      _anchorTracker.clearThread(threadId);
+      _documentSelections.clearThread(roomId, threadId);
+      unawaited(
+        ThreadReadMarkerStorage.clearThread(serverId, roomId, threadId)
+            .catchError((Object error, StackTrace st) {
+          _logger.error(
+            'Failed to clear thread read markers for removed thread',
+            error: error,
+            stackTrace: st,
+            attributes: {
+              'serverId': serverId,
+              'roomId': roomId,
+              'threadId': threadId,
+            },
+          );
+        }),
+      );
+      unawaited(
+        ThreadAnchorStorage.clearThread(serverId, roomId, threadId)
+            .catchError((Object error, StackTrace st) {
+          _logger.warning(
+            'Failed to clear thread anchors for removed thread',
+            error: error,
+            stackTrace: st,
+            attributes: {
+              'serverId': serverId,
+              'roomId': roomId,
+              'threadId': threadId,
+            },
+          );
+        }),
+      );
+    }
+  }
+
+  /// Whether [threadId] is still in the room's current thread list. A
+  /// just-deleted thread is absent, so an exit re-stamp of it would write an
+  /// orphan marker for a thread that no longer exists.
+  bool _threadStillListed(String threadId) {
+    final status = _state.threadList.threads.value;
+    return status is ThreadsLoaded &&
+        status.threads.any((t) => t.id == threadId);
   }
 
   /// Refetches the server's room-activity batch whenever a run on this server
@@ -605,6 +676,9 @@ class _RoomScreenState extends State<RoomScreen> {
   void _markPreviousThreadRead(RoomScreen oldWidget) {
     final threadId = oldWidget.threadId;
     if (threadId == null) return;
+    // A just-deleted thread has already left the list; re-stamping it would
+    // write an orphan read marker for a thread that no longer exists.
+    if (!_threadStillListed(threadId)) return;
     _stampThreadRead(
       (
         serverId: oldWidget.serverEntry.serverId,
@@ -1038,8 +1112,9 @@ class _RoomScreenState extends State<RoomScreen> {
     // Stamp the open thread read on the way out, as the deselect path does:
     // the user has seen this thread's activity, so it must not surface a false
     // unread dot when they return. Save-only — no setState while disposing.
+    // Skip a just-deleted thread: stamping it would write an orphan marker.
     final threadId = widget.threadId;
-    if (threadId != null) {
+    if (threadId != null && _threadStillListed(threadId)) {
       _threadReadTracker.stamp(
         (
           serverId: widget.serverEntry.serverId,

--- a/test/core/storage_migration_test.dart
+++ b/test/core/storage_migration_test.dart
@@ -1,0 +1,118 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:soliplex_frontend/src/core/keyed_storage.dart';
+import 'package:soliplex_frontend/src/core/storage_migration.dart';
+
+const _schemaVersionKey = 'soliplex_storage_schema_version';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+  setUp(() => SharedPreferences.setMockInitialValues({}));
+
+  const legacyExactKeys = [
+    'soliplex_thread_read_markers',
+    'soliplex_thread_unread_anchors',
+    'soliplex_lobby_read_markers',
+    'soliplex_server_read_markers',
+    'soliplex_lobby_hidden_servers',
+  ];
+
+  group('migrateStorage', () {
+    test('removes the legacy exact-match keys', () async {
+      SharedPreferences.setMockInitialValues({
+        for (final k in legacyExactKeys) k: 'legacy-value',
+      });
+
+      await migrateStorage();
+
+      final prefs = await SharedPreferences.getInstance();
+      for (final k in legacyExactKeys) {
+        expect(prefs.containsKey(k), isFalse, reason: '$k should be removed');
+      }
+    });
+
+    test('removes legacy raw-format drafts but keeps new keyed drafts',
+        () async {
+      const legacyDraft =
+          'soliplex_return_to:composer:https://host.example:general';
+      final newDraft = encodeKey('soliplex_return_to:composer',
+          ['https://host.example', 'iss#user', 'room-1']);
+
+      SharedPreferences.setMockInitialValues({
+        legacyDraft: 'draft-a',
+        newDraft: 'draft-b',
+      });
+
+      await migrateStorage();
+
+      final prefs = await SharedPreferences.getInstance();
+      expect(prefs.containsKey(legacyDraft), isFalse,
+          reason: 'raw :// legacy draft should be removed');
+      expect(prefs.containsKey(newDraft), isTrue,
+          reason: 'percent-encoded new draft should survive');
+    });
+
+    test('preserves live keyed data and current keys', () async {
+      const server = 'https://host.example', user = 'iss#user';
+      final serverMarker =
+          encodeKey('soliplex_server_read_marker', [server, user]);
+      final threadMarker =
+          encodeKey('soliplex_thread_read_marker', [server, user, 'room-1']);
+      final roomMarker = encodeKey('soliplex_room_read_marker', [server, user]);
+      final threadAnchor =
+          encodeKey('soliplex_thread_anchor', [server, user, 'room-1']);
+      final preserved = <String, Object>{
+        serverMarker: 'v',
+        threadMarker: 'v',
+        roomMarker: 'v',
+        threadAnchor: 'v',
+        'soliplex_has_launched': true,
+        'soliplex_lobby_view_mode': 'grid',
+      };
+
+      SharedPreferences.setMockInitialValues({
+        // Same-stem legacy plural — must go without taking the new key with it.
+        'soliplex_server_read_markers': 'legacy',
+        ...preserved,
+      });
+
+      await migrateStorage();
+
+      final prefs = await SharedPreferences.getInstance();
+      expect(prefs.containsKey('soliplex_server_read_markers'), isFalse);
+      for (final k in preserved.keys) {
+        expect(prefs.containsKey(k), isTrue, reason: '$k should survive');
+      }
+    });
+
+    test('no sweep when already at the current schema version', () async {
+      SharedPreferences.setMockInitialValues({
+        _schemaVersionKey: 1,
+        'soliplex_thread_read_markers': 'legacy',
+      });
+
+      await migrateStorage();
+
+      final prefs = await SharedPreferences.getInstance();
+      expect(prefs.containsKey('soliplex_thread_read_markers'), isTrue,
+          reason: 'an already-migrated install must not re-sweep');
+    });
+
+    test('sweeps once, then latches at the current version', () async {
+      SharedPreferences.setMockInitialValues({
+        'soliplex_thread_read_markers': 'legacy',
+      });
+
+      await migrateStorage();
+
+      final prefs = await SharedPreferences.getInstance();
+      expect(prefs.containsKey('soliplex_thread_read_markers'), isFalse);
+      expect(prefs.getInt(_schemaVersionKey), 1);
+
+      // A legacy key that reappears after the migration is not swept again.
+      await prefs.setString('soliplex_thread_read_markers', 'reappeared');
+      await migrateStorage();
+      expect(prefs.containsKey('soliplex_thread_read_markers'), isTrue);
+    });
+  });
+}

--- a/test/modules/lobby/lobby_read_markers_test.dart
+++ b/test/modules/lobby/lobby_read_markers_test.dart
@@ -90,6 +90,25 @@ void main() {
           {'r1': t});
     });
 
+    test('clearRoom skips a corrupt user blob but strips valid siblings',
+        () async {
+      final corruptKey = 'soliplex_room_read_marker:${Uri.encodeComponent(s)}:'
+          '${Uri.encodeComponent(u2)}';
+      SharedPreferences.setMockInitialValues({corruptKey: 'not json{'});
+      // A valid sibling user carrying the target room plus another.
+      await LobbyReadMarkerStorage.saveServer(
+          serverId: s, userId: u1, markers: {'r1': t, 'r2': t});
+
+      await LobbyReadMarkerStorage.clearRoom(s, 'r1');
+
+      // The valid user's r1 is stripped and r2 kept; the corrupt blob can't be
+      // stripped, so it is left intact on disk rather than dropped.
+      expect(await LobbyReadMarkerStorage.loadServer(serverId: s, userId: u1),
+          {'r2': t});
+      final prefs = await SharedPreferences.getInstance();
+      expect(prefs.getString(corruptKey), 'not json{');
+    });
+
     test('discards a corrupt blob and returns empty', () async {
       SharedPreferences.setMockInitialValues({
         'soliplex_room_read_marker:${Uri.encodeComponent(s)}:'

--- a/test/modules/lobby/lobby_read_markers_test.dart
+++ b/test/modules/lobby/lobby_read_markers_test.dart
@@ -68,6 +68,28 @@ void main() {
           {'r1': t});
     });
 
+    test('clearRoom drops one room across users, keeps siblings and peers',
+        () async {
+      const s2 = 'https://foo.com:8443';
+      await LobbyReadMarkerStorage.saveServer(
+          serverId: s, userId: u1, markers: {'r1': t, 'r2': t});
+      await LobbyReadMarkerStorage.saveServer(
+          serverId: s, userId: u2, markers: {'r1': t});
+      await LobbyReadMarkerStorage.saveServer(
+          serverId: s2, userId: u1, markers: {'r1': t});
+
+      await LobbyReadMarkerStorage.clearRoom(s, 'r1');
+
+      // r1 gone for every user of s; r2 sibling kept; the different-port peer
+      // and its r1 untouched.
+      expect(await LobbyReadMarkerStorage.loadServer(serverId: s, userId: u1),
+          {'r2': t});
+      expect(await LobbyReadMarkerStorage.loadServer(serverId: s, userId: u2),
+          isEmpty);
+      expect(await LobbyReadMarkerStorage.loadServer(serverId: s2, userId: u1),
+          {'r1': t});
+    });
+
     test('discards a corrupt blob and returns empty', () async {
       SharedPreferences.setMockInitialValues({
         'soliplex_room_read_marker:${Uri.encodeComponent(s)}:'

--- a/test/modules/lobby/lobby_state_test.dart
+++ b/test/modules/lobby/lobby_state_test.dart
@@ -14,6 +14,9 @@ import 'package:soliplex_frontend/src/modules/auth/server_manager.dart';
 import 'package:soliplex_frontend/src/core/activity_read.dart';
 import 'package:soliplex_frontend/src/modules/lobby/lobby_read_markers.dart';
 import 'package:soliplex_frontend/src/modules/lobby/lobby_state.dart';
+import 'package:soliplex_frontend/src/modules/auth/return_to_storage.dart';
+import 'package:soliplex_frontend/src/modules/room/thread_anchor_storage.dart';
+import 'package:soliplex_frontend/src/modules/room/thread_read_markers.dart';
 
 import '../../helpers/fakes.dart';
 import '../../helpers/test_server_entry.dart';
@@ -29,6 +32,154 @@ void main() {
   setUp(() => SharedPreferences.setMockInitialValues({}));
 
   group('LobbyState', () {
+    group('room disappearance pruning', () {
+      const alice = 'iss#alice';
+      final t = DateTime.utc(2026, 6, 1);
+
+      Future<void> seedRoom(String roomId) async {
+        await ThreadReadMarkerStorage.saveRoom(
+            serverId: 'local',
+            userId: alice,
+            roomId: roomId,
+            markers: {'th-$roomId': t});
+        await ThreadAnchorStorage.saveRoom(
+            serverId: 'local',
+            userId: alice,
+            roomId: roomId,
+            anchors: {'th-$roomId': 'm-$roomId'});
+      }
+
+      test('prunes a vanished room across users, keeps siblings and drafts',
+          () async {
+        final manager = _createManager();
+        manager.addServer(
+          serverId: 'local',
+          serverUrl: Uri.parse('http://localhost:8000'),
+          requiresAuth: false,
+        );
+        await seedRoom('room-1');
+        await seedRoom('room-2');
+        await ReturnToStorage.saveComposer(
+            serverId: 'local',
+            userId: alice,
+            roomId: 'room-1',
+            unsentText: 'unsent');
+        // Lobby read markers for both rooms, so the prune's clearRoom on the
+        // shared model is observable (not a no-op false pass).
+        final roomMarkers = RoomReadMarkers()
+          ..markRead(serverId: 'local', userId: null, roomId: 'room-1', at: t)
+          ..markRead(serverId: 'local', userId: null, roomId: 'room-2', at: t);
+
+        final fakeApi = FakeSoliplexApi();
+        fakeApi.nextRooms = const [
+          Room(id: 'room-1', name: 'One'),
+          Room(id: 'room-2', name: 'Two'),
+        ];
+        final state = LobbyState(
+          serverManager: manager,
+          apiResolver: (_) => fakeApi,
+          roomReadMarkers: roomMarkers,
+        );
+        await Future<void>.delayed(Duration.zero); // first load = baseline
+
+        // room-1 disappears from the server's list.
+        fakeApi.nextRooms = const [Room(id: 'room-2', name: 'Two')];
+        state.refresh('local');
+        await Future<void>.delayed(Duration.zero);
+
+        // room-1's read markers + anchors are gone (any user); room-2 kept.
+        expect(
+            await ThreadReadMarkerStorage.loadRoom(
+                serverId: 'local', userId: alice, roomId: 'room-1'),
+            isEmpty);
+        expect(
+            await ThreadAnchorStorage.loadRoom(
+                serverId: 'local', userId: alice, roomId: 'room-1'),
+            isEmpty);
+        expect(
+            await ThreadReadMarkerStorage.loadRoom(
+                serverId: 'local', userId: alice, roomId: 'room-2'),
+            {'th-room-2': t});
+        // The draft is deliberately preserved (self-expires; cleared on server
+        // removal) — a passive list diff must not destroy unsent text.
+        expect(
+            await ReturnToStorage.loadComposer(
+                serverId: 'local', userId: alice, roomId: 'room-1'),
+            'unsent');
+        // The lobby's in-memory room marker for the vanished room is dropped too;
+        // the surviving room's marker is kept.
+        expect(
+            roomMarkers.value.keys.where((k) => k.roomId == 'room-1'), isEmpty);
+        expect(roomMarkers.value.keys.where((k) => k.roomId == 'room-2'),
+            isNotEmpty);
+        state.dispose();
+      });
+
+      test('a failed refetch after a loaded baseline prunes nothing', () async {
+        final manager = _createManager();
+        manager.addServer(
+          serverId: 'local',
+          serverUrl: Uri.parse('http://localhost:8000'),
+          requiresAuth: false,
+        );
+        await seedRoom('room-1');
+        await seedRoom('room-2');
+
+        final fakeApi = FakeSoliplexApi();
+        fakeApi.nextRooms = const [
+          Room(id: 'room-1', name: 'One'),
+          Room(id: 'room-2', name: 'Two'),
+        ];
+        final state =
+            LobbyState(serverManager: manager, apiResolver: (_) => fakeApi);
+        await Future<void>.delayed(Duration.zero); // baseline loaded
+
+        // The refetch fails (a transient network/permission blip). A failure
+        // must never read as "these rooms disappeared" and prune read state.
+        fakeApi.nextError =
+            const PermissionDeniedException(message: 'forbidden');
+        state.refresh('local');
+        await Future<void>.delayed(Duration.zero);
+
+        expect(state.roomsByServer.value['local'], isA<RoomsFailed>());
+        expect(
+            await ThreadReadMarkerStorage.loadRoom(
+                serverId: 'local', userId: alice, roomId: 'room-1'),
+            {'th-room-1': t});
+        expect(
+            await ThreadAnchorStorage.loadRoom(
+                serverId: 'local', userId: alice, roomId: 'room-1'),
+            {'th-room-1': 'm-room-1'});
+        state.dispose();
+      });
+
+      test('a room absent from the first fetch is not pruned (no baseline)',
+          () async {
+        final manager = _createManager();
+        manager.addServer(
+          serverId: 'local',
+          serverUrl: Uri.parse('http://localhost:8000'),
+          requiresAuth: false,
+        );
+        await seedRoom('room-1');
+
+        final fakeApi = FakeSoliplexApi();
+        // room-1 is not in the very first list — but with no prior RoomsLoaded
+        // to diff against, its state must survive (never mass-prune on a cold
+        // load).
+        fakeApi.nextRooms = const [Room(id: 'room-2', name: 'Two')];
+        final state =
+            LobbyState(serverManager: manager, apiResolver: (_) => fakeApi);
+        await Future<void>.delayed(Duration.zero);
+
+        expect(
+            await ThreadReadMarkerStorage.loadRoom(
+                serverId: 'local', userId: alice, roomId: 'room-1'),
+            {'th-room-1': t});
+        state.dispose();
+      });
+    });
+
     group('room fetching on init', () {
       test('fetches rooms from all connected servers', () async {
         final manager = _createManager();

--- a/test/modules/lobby/room_read_markers_test.dart
+++ b/test/modules/lobby/room_read_markers_test.dart
@@ -207,6 +207,55 @@ void main() {
       store.dispose();
     });
 
+    test('clearRoom drops one room across users, keeps siblings, and persists',
+        () async {
+      final store = RoomReadMarkers();
+      store.markRead(serverId: s, userId: u1, roomId: 'r1', at: at);
+      store.markRead(serverId: s, userId: u1, roomId: 'r2', at: at);
+      store.markRead(serverId: s, userId: u2, roomId: 'r1', at: at);
+      await Future<void>.delayed(Duration.zero);
+
+      store.clearRoom(s, 'r1');
+
+      // In-memory: r1 gone for both users, r2 sibling intact.
+      expect(store.value[key(s, u1, 'r1')], isNull);
+      expect(store.value[key(s, u2, 'r1')], isNull);
+      expect(store.value[key(s, u1, 'r2')], at);
+
+      // Persisted across users.
+      await Future<void>.delayed(Duration.zero);
+      final reloaded = RoomReadMarkers();
+      await reloaded.ensureLoaded(serverId: s, userId: u1);
+      await reloaded.ensureLoaded(serverId: s, userId: u2);
+      expect(reloaded.value[key(s, u1, 'r1')], isNull);
+      expect(reloaded.value[key(s, u1, 'r2')], at);
+      expect(reloaded.value[key(s, u2, 'r1')], isNull);
+      store.dispose();
+      reloaded.dispose();
+    });
+
+    test('clearRoom does not discard an in-flight load for the same server',
+        () async {
+      // clearRoom must NOT bump the server-wide epoch: doing so would abort an
+      // in-flight load/persist for OTHER rooms on this server and silently drop
+      // their read stamps (RoomReadMarkers has no dirty-retry).
+      await SharedPreferences.getInstance();
+      await LobbyReadMarkerStorage.saveServer(
+          serverId: s, userId: u1, markers: {'other': at});
+
+      final store = RoomReadMarkers();
+      final loading = store.ensureLoaded(serverId: s, userId: u1);
+      // A different room on the same server is cleared while the load is parked.
+      store.clearRoom(s, 'gone');
+      await loading;
+      await Future<void>.delayed(Duration.zero);
+
+      expect(store.value[key(s, u1, 'other')], at,
+          reason:
+              'clearRoom must not discard the same server\'s in-flight load');
+      store.dispose();
+    });
+
     test('a load resolving after dispose does not throw', () async {
       await SharedPreferences.getInstance();
       await LobbyReadMarkerStorage.saveServer(

--- a/test/modules/room/anchor_tracker_test.dart
+++ b/test/modules/room/anchor_tracker_test.dart
@@ -41,6 +41,21 @@ void main() {
       expect(saves.last[_key('a')], 'm3');
     });
 
+    test('clearThread drops the anchor from memory and persists without it',
+        () async {
+      disk = {_key('a'): 'm1', _key('b'): 'm2'};
+      final t = make();
+      await t.loadFromDisk();
+
+      t.clearThread('a');
+      await pumpEventQueue();
+
+      // The persisted snapshot no longer contains the deleted thread (so a later
+      // flush can't resurrect it); the sibling anchor survives.
+      expect(saves.last.containsKey(_key('a')), isFalse);
+      expect(saves.last[_key('b')], 'm2');
+    });
+
     test('cold load of a caught-up thread does not re-save on first advance',
         () async {
       disk = {_key('a'): 'm3'};

--- a/test/modules/room/document_selections_test.dart
+++ b/test/modules/room/document_selections_test.dart
@@ -51,6 +51,18 @@ void main() {
     });
   });
 
+  group('clearThread', () {
+    test('clearThread removes just that (room, thread)', () {
+      selections.set('room-1', 'thread-1', {_doc1});
+      selections.set('room-1', 'thread-2', {_doc2});
+
+      selections.clearThread('room-1', 'thread-1');
+
+      expect(selections.get('room-1', 'thread-1'), isEmpty);
+      expect(selections.get('room-1', 'thread-2'), {_doc2});
+    });
+  });
+
   group('migrateToThread', () {
     test('moves null-key selection to thread', () {
       selections.set('room-1', null, {_doc1, _doc2});

--- a/test/modules/room/thread_anchor_storage_test.dart
+++ b/test/modules/room/thread_anchor_storage_test.dart
@@ -123,6 +123,30 @@ void main() {
           isEmpty);
     });
 
+    test('clearThread skips a corrupt user blob but strips valid siblings',
+        () async {
+      final corruptKey = 'soliplex_thread_anchor:${Uri.encodeComponent(s)}:'
+          '${Uri.encodeComponent(u2)}:${Uri.encodeComponent(r)}';
+      SharedPreferences.setMockInitialValues({corruptKey: 'not json{'});
+      // A valid sibling user carrying the target thread plus another.
+      await ThreadAnchorStorage.saveRoom(
+          serverId: s,
+          userId: u1,
+          roomId: r,
+          anchors: {'th1': 'm1', 'th2': 'm2'});
+
+      await ThreadAnchorStorage.clearThread(s, r, 'th1');
+
+      // The valid user's th1 is stripped and th2 kept; the corrupt blob can't be
+      // stripped, so it is left intact on disk rather than dropped.
+      expect(
+          await ThreadAnchorStorage.loadRoom(
+              serverId: s, userId: u1, roomId: r),
+          {'th2': 'm2'});
+      final prefs = await SharedPreferences.getInstance();
+      expect(prefs.getString(corruptKey), 'not json{');
+    });
+
     test('discards a corrupt blob and returns empty', () async {
       SharedPreferences.setMockInitialValues({
         'soliplex_thread_anchor:${Uri.encodeComponent(s)}:'

--- a/test/modules/room/thread_read_markers_test.dart
+++ b/test/modules/room/thread_read_markers_test.dart
@@ -133,6 +133,27 @@ void main() {
           isEmpty);
     });
 
+    test('clearThread skips a corrupt user blob but strips valid siblings',
+        () async {
+      final corruptKey = 'soliplex_thread_read_marker:${Uri.encodeComponent(s)}'
+          ':${Uri.encodeComponent(u2)}:${Uri.encodeComponent(r)}';
+      SharedPreferences.setMockInitialValues({corruptKey: 'not json{'});
+      // A valid sibling user carrying the target thread plus another.
+      await ThreadReadMarkerStorage.saveRoom(
+          serverId: s, userId: u1, roomId: r, markers: {'th1': t, 'th2': t});
+
+      await ThreadReadMarkerStorage.clearThread(s, r, 'th1');
+
+      // The valid user's th1 is stripped and th2 kept; the corrupt blob can't be
+      // stripped, so it is left intact on disk rather than dropped.
+      expect(
+          await ThreadReadMarkerStorage.loadRoom(
+              serverId: s, userId: u1, roomId: r),
+          {'th2': t});
+      final prefs = await SharedPreferences.getInstance();
+      expect(prefs.getString(corruptKey), 'not json{');
+    });
+
     test('discards a corrupt blob and returns empty', () async {
       SharedPreferences.setMockInitialValues({
         'soliplex_thread_read_marker:${Uri.encodeComponent(s)}:'

--- a/test/modules/room/thread_read_tracker_test.dart
+++ b/test/modules/room/thread_read_tracker_test.dart
@@ -35,6 +35,23 @@ void main() {
       expect(t.markers[_key('a')], _at(3));
     });
 
+    test('clearThread drops the thread from memory and persists without it',
+        () async {
+      disk = {_key('a'): _at(1), _key('b'): _at(2)};
+      final t = make();
+      await t.loadFromDisk();
+
+      t.clearThread('a');
+      await pumpEventQueue();
+
+      // Gone from memory AND from the persisted snapshot, so a later flush can't
+      // resurrect the deleted thread; the sibling survives.
+      expect(t.markers.containsKey(_key('a')), isFalse);
+      expect(t.markers[_key('b')], _at(2));
+      expect(saves.last.containsKey(_key('a')), isFalse);
+      expect(saves.last[_key('b')], _at(2));
+    });
+
     test('stamp before load does not persist and does not wipe other threads',
         () async {
       disk = {_key('a'): _at(1), _key('b'): _at(2)};

--- a/test/modules/room/ui/room_screen_test.dart
+++ b/test/modules/room/ui/room_screen_test.dart
@@ -14,10 +14,12 @@ import 'package:soliplex_frontend/src/modules/lobby/ui/unread_dot.dart';
 import 'package:soliplex_frontend/src/modules/room/agent_runtime_manager.dart';
 import 'package:soliplex_frontend/src/modules/room/document_selections.dart';
 import 'package:soliplex_frontend/src/modules/room/run_registry.dart';
+import 'package:soliplex_frontend/src/modules/room/thread_anchor_storage.dart';
 import 'package:soliplex_frontend/src/modules/room/thread_read_markers.dart';
 import 'package:soliplex_frontend/src/modules/room/ui/room_rail.dart';
 import 'package:soliplex_frontend/src/modules/room/ui/room_screen.dart';
 import 'package:soliplex_frontend/src/modules/room/ui/thread_sidebar.dart';
+import 'package:soliplex_frontend/src/modules/room/ui/thread_tile.dart';
 import 'package:soliplex_frontend/src/modules/room/upload_tracker_registry.dart';
 import 'package:soliplex_frontend/src/modules/auth/auth_tokens.dart';
 import 'package:soliplex_frontend/src/modules/auth/server_entry.dart';
@@ -1510,6 +1512,157 @@ void main() {
           isEmpty,
         );
       });
+    });
+  });
+
+  group('thread disappearance pruning', () {
+    // Opens a thread tile's overflow menu, taps Delete, and confirms the dialog.
+    Future<void> deleteViaMenu(WidgetTester tester, Finder menu) async {
+      await tester.tap(menu);
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('Delete')); // overflow-menu item
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('Delete').last); // confirm-dialog action
+      await tester.pumpAndSettle();
+    }
+
+    testWidgets(
+        'deleting the open thread does not re-stamp it read on the way out',
+        (tester) async {
+      tester.view.physicalSize = const Size(1200, 800);
+      tester.view.devicePixelRatio = 1.0;
+      addTearDown(tester.view.resetPhysicalSize);
+      SharedPreferences.setMockInitialValues(const {});
+
+      api.nextThreads = [
+        ThreadInfo(
+          id: 'thread-1',
+          roomId: 'room-1',
+          name: 'First thread',
+          createdAt: DateTime(2026, 3, 1),
+        ),
+      ];
+
+      // Routed, because deleting the open thread navigates off it.
+      await tester.pumpWidget(_buildRouted(
+        entry: entry,
+        runtimeManager: runtimeManager,
+        registry: registry,
+        uploadRegistry: uploadRegistry,
+        threadId: 'thread-1',
+      ));
+      await tester.pumpAndSettle();
+
+      // Deleting the open thread leaves it. The exit re-stamp must skip the
+      // just-deleted thread, or it writes an orphan "read" marker for a thread
+      // that no longer exists.
+      await deleteViaMenu(
+        tester,
+        find.descendant(
+          of: find.byType(ThreadSidebar),
+          matching: find.byIcon(Icons.more_vert),
+        ),
+      );
+
+      expect(
+        await ThreadReadMarkerStorage.loadRoom(
+          serverId: entry.serverId,
+          userId: null,
+          roomId: 'room-1',
+        ),
+        isEmpty,
+      );
+    });
+
+    testWidgets(
+        'deleting a thread sweeps its stored markers and anchors, sparing '
+        'the sibling', (tester) async {
+      tester.view.physicalSize = const Size(1200, 800);
+      tester.view.devicePixelRatio = 1.0;
+      addTearDown(tester.view.resetPhysicalSize);
+      SharedPreferences.setMockInitialValues(const {});
+
+      final signedInEntry =
+          createTestServerEntry(api: api, auth: authWithIdentity());
+      final seen = DateTime.utc(2026, 6, 1);
+      // thread-1 (the delete target) and thread-3 (an untouched sibling) carry
+      // stored read state; thread-2 is only there to stay open, so deleting
+      // thread-1 does not navigate.
+      await ThreadReadMarkerStorage.saveRoom(
+        serverId: signedInEntry.serverId,
+        userId: testUserIdentity,
+        roomId: 'room-1',
+        markers: {'thread-1': seen, 'thread-3': seen},
+      );
+      await ThreadAnchorStorage.saveRoom(
+        serverId: signedInEntry.serverId,
+        userId: testUserIdentity,
+        roomId: 'room-1',
+        anchors: {'thread-1': 'm1', 'thread-3': 'm3'},
+      );
+
+      api.nextThreads = [
+        ThreadInfo(
+          id: 'thread-1',
+          roomId: 'room-1',
+          name: 'First thread',
+          createdAt: DateTime(2026, 3, 3),
+        ),
+        ThreadInfo(
+          id: 'thread-2',
+          roomId: 'room-1',
+          name: 'Second thread',
+          createdAt: DateTime(2026, 3, 2),
+        ),
+        ThreadInfo(
+          id: 'thread-3',
+          roomId: 'room-1',
+          name: 'Third thread',
+          createdAt: DateTime(2026, 3, 1),
+        ),
+      ];
+
+      await tester.pumpWidget(MaterialApp(
+        home: RoomScreen(
+          serverEntry: signedInEntry,
+          roomId: 'room-1',
+          threadId: 'thread-2',
+          runtimeManager: runtimeManager,
+          registry: registry,
+          uploadRegistry: uploadRegistry,
+          documentSelections: DocumentSelections(),
+        ),
+      ));
+      await tester.pumpAndSettle();
+
+      // Delete the non-open thread-1 from the sidebar (no navigation follows,
+      // since thread-2 stays the active thread).
+      await deleteViaMenu(
+        tester,
+        find.descendant(
+          of: find.ancestor(
+            of: find.text('First thread'),
+            matching: find.byType(ThreadTile),
+          ),
+          matching: find.byIcon(Icons.more_vert),
+        ),
+      );
+
+      final markers = await ThreadReadMarkerStorage.loadRoom(
+        serverId: signedInEntry.serverId,
+        userId: testUserIdentity,
+        roomId: 'room-1',
+      );
+      expect(markers.containsKey('thread-1'), isFalse);
+      expect(markers['thread-3'], seen);
+
+      final anchors = await ThreadAnchorStorage.loadRoom(
+        serverId: signedInEntry.serverId,
+        userId: testUserIdentity,
+        roomId: 'room-1',
+      );
+      expect(anchors.containsKey('thread-1'), isFalse);
+      expect(anchors['thread-3'], 'm3');
     });
   });
 

--- a/test/modules/room/ui/room_screen_test.dart
+++ b/test/modules/room/ui/room_screen_test.dart
@@ -1664,6 +1664,63 @@ void main() {
       expect(anchors.containsKey('thread-1'), isFalse);
       expect(anchors['thread-3'], 'm3');
     });
+
+    testWidgets(
+        'a thread absent from the first load is not pruned (no baseline)',
+        (tester) async {
+      tester.view.physicalSize = const Size(1200, 800);
+      tester.view.devicePixelRatio = 1.0;
+      addTearDown(tester.view.resetPhysicalSize);
+      SharedPreferences.setMockInitialValues(const {});
+
+      final seen = DateTime.utc(2026, 6, 1);
+      // thread-9 has stored read state but is not in the room's first thread
+      // list. With no prior baseline to diff against, a cold load must never
+      // read its absence as a deletion and prune it.
+      await ThreadReadMarkerStorage.saveRoom(
+        serverId: entry.serverId,
+        userId: null,
+        roomId: 'room-1',
+        markers: {'thread-9': seen},
+      );
+      await ThreadAnchorStorage.saveRoom(
+        serverId: entry.serverId,
+        userId: null,
+        roomId: 'room-1',
+        anchors: {'thread-9': 'm9'},
+      );
+
+      api.nextThreads = [
+        ThreadInfo(
+          id: 'thread-1',
+          roomId: 'room-1',
+          name: 'First thread',
+          createdAt: DateTime(2026, 3, 1),
+        ),
+      ];
+
+      await tester.pumpWidget(MaterialApp(
+        home: RoomScreen(
+          serverEntry: entry,
+          roomId: 'room-1',
+          threadId: 'thread-1',
+          runtimeManager: runtimeManager,
+          registry: registry,
+          uploadRegistry: uploadRegistry,
+          documentSelections: DocumentSelections(),
+        ),
+      ));
+      await tester.pumpAndSettle();
+
+      // thread-9 survives the cold load untouched (opening thread-1 may stamp
+      // its own marker, which is fine — the point is thread-9 is not pruned).
+      final markers = await ThreadReadMarkerStorage.loadRoom(
+          serverId: entry.serverId, userId: null, roomId: 'room-1');
+      expect(markers['thread-9'], seen);
+      final anchors = await ThreadAnchorStorage.loadRoom(
+          serverId: entry.serverId, userId: null, roomId: 'room-1');
+      expect(anchors['thread-9'], 'm9');
+    });
   });
 
   group('room unread rollup', () {


### PR DESCRIPTION
## Summary

Device-local (`SharedPreferences`) cleanup for the keyed-user-storage stack (PR-06 + PR-07 of the `keyed-user-local-storage` plan; PRs 1–5 already merged in #401/#402/#403).

**One-time upgrade sweep** — on first launch after upgrade, a version-gated `migrateStorage()` removes device-local data left over from the pre-keyed storage format: orphaned read/anchor markers and raw-format composer drafts, plus a defunct hidden-servers key. Gated by a monotonic `soliplex_storage_schema_version` so future format changes reuse the same gate. Best-effort and idempotent: a failure doesn't advance the version, so it retries next launch, and a corrupt prefs file can't white-screen bootstrap.

**Room/thread disappearance pruning** — when a room or thread disappears from a server (deleted, or access removed), its device-local read markers and unread-divider anchors are dropped across users, and a deleted thread's document-filter selection is cleared. Unsent composer drafts are intentionally kept (they self-expire and clear on explicit server removal), so a transient fetch shortfall can't destroy unsent text. The prune only fires on a non-first loaded diff — a first/failed fetch prunes nothing.

**Dispose-restamp fix** — deleting the open thread no longer writes a stale "read" marker for it on the way out (via dispose or auto-navigate to a sibling), so a thread later re-created under the same id no longer appears already-read.

## Key correctness properties
- The sweep removes orphaned keys by **exact match**, not prefix, so a live keyed key sharing a stem (`soliplex_server_read_marker:…` vs `soliplex_server_read_markers`) is never taken with it. Raw-format drafts are distinguished by a literal `://` that percent-encoded keys can never contain.
- Single-room `clearRoom` deliberately does **not** bump the server-wide generation epoch (that would abort in-flight loads/persists for sibling rooms); the accepted tradeoff is a narrow, self-healing resurrection window, documented inline.

## Test plan
- `flutter test --exclude-tags golden` — all 1999 pass; analyzer clean; formatter clean.
- New/updated coverage: migration run-once/gating/latch, exact-key vs live-key preservation, `://` draft discriminator, `clearRoom`/`clearThread` across users + corrupt-blob skip (lobby and both thread stores), room- and thread-level disappearance pruning (prune on real disappearance, nothing on failed/first fetch, drafts preserved), and the dispose-restamp regression.

## Review
Ran a multi-aspect review (code quality, error handling, comment accuracy, test coverage) before opening: no correctness bugs or guideline violations. Follow-ups applied here — repaired an unparseable doc sentence, removed temporal comment wording, and added tests for the two thread-store corrupt-blob skips and the thread-level cold-load prune guard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)