### PR TITLE
Send citation doc_item_refs to visual grounding

### DIFF
--- a/lib/src/modules/room/ui/chunk_visualization_page.dart
+++ b/lib/src/modules/room/ui/chunk_visualization_page.dart
@@ -47,6 +47,7 @@ class ChunkVisualizationPage extends StatefulWidget {
     required this.documentTitle,
     required this.pageNumbers,
     required this.useDialogLayout,
+    this.docItemRefs = const [],
   });
 
   final SoliplexApi api;
@@ -56,6 +57,10 @@ class ChunkVisualizationPage extends StatefulWidget {
   final List<int> pageNumbers;
   final bool useDialogLayout;
 
+  /// The citation's doc-item refs, sent to the backend so the highlight
+  /// matches the cited content instead of re-expanding.
+  final List<String> docItemRefs;
+
   static Future<void> show({
     required BuildContext context,
     required SoliplexApi api,
@@ -63,6 +68,7 @@ class ChunkVisualizationPage extends StatefulWidget {
     required String chunkId,
     required String documentTitle,
     required List<int> pageNumbers,
+    List<String> docItemRefs = const [],
   }) {
     final useDialog =
         MediaQuery.sizeOf(context).width >= SoliplexBreakpoints.tablet;
@@ -73,6 +79,7 @@ class ChunkVisualizationPage extends StatefulWidget {
       documentTitle: documentTitle,
       pageNumbers: pageNumbers,
       useDialogLayout: useDialog,
+      docItemRefs: docItemRefs,
     );
 
     if (useDialog) {
@@ -126,8 +133,11 @@ class _ChunkVisualizationPageState extends State<ChunkVisualizationPage> {
 
   Future<List<PageImage>> _fetchAndDecode() async {
     try {
-      final viz =
-          await widget.api.getChunkVisualization(widget.roomId, widget.chunkId);
+      final viz = await widget.api.getChunkVisualization(
+        widget.roomId,
+        widget.chunkId,
+        refs: widget.docItemRefs,
+      );
       return viz.imagesBase64.map(_decodePageImage).toList();
     } catch (error, stack) {
       _logger.error(

--- a/lib/src/modules/room/ui/room_screen.dart
+++ b/lib/src/modules/room/ui/room_screen.dart
@@ -1959,6 +1959,7 @@ class _RoomScreenState extends State<RoomScreen> {
                             chunkId: ref.chunkId,
                             documentTitle: ref.displayTitle,
                             pageNumbers: ref.pageNumbers,
+                            docItemRefs: ref.docItemRefs,
                           ),
                           onFetchWorkdirFiles: (runId) =>
                               _workdirs.fetchFiles(threadView.threadId, runId),

--- a/packages/soliplex_client/lib/src/api/soliplex_api.dart
+++ b/packages/soliplex_client/lib/src/api/soliplex_api.dart
@@ -1,3 +1,4 @@
+import 'dart:convert';
 import 'dart:developer' as developer;
 import 'dart:typed_data';
 
@@ -1312,14 +1313,27 @@ class SoliplexApi {
   Future<ChunkVisualization> getChunkVisualization(
     String roomId,
     String chunkId, {
+    List<String>? refs,
+    bool expand = true,
     CancelToken? cancelToken,
   }) async {
     _requireNonEmpty(roomId, 'roomId');
     _requireNonEmpty(chunkId, 'chunkId');
 
+    final queryParameters = <String, String>{};
+    if (refs != null && refs.isNotEmpty) {
+      queryParameters['refs'] = jsonEncode(refs);
+    }
+    if (!expand) {
+      queryParameters['expand'] = 'false';
+    }
+
     return _transport.request<ChunkVisualization>(
       'GET',
-      _urlBuilder.build(pathSegments: ['rooms', roomId, 'chunk', chunkId]),
+      _urlBuilder.build(
+        pathSegments: ['rooms', roomId, 'chunk', chunkId],
+        queryParameters: queryParameters,
+      ),
       cancelToken: cancelToken,
       fromJson: ChunkVisualization.fromJson,
     );

--- a/packages/soliplex_client/lib/src/application/citation_extractor.dart
+++ b/packages/soliplex_client/lib/src/application/citation_extractor.dart
@@ -84,6 +84,7 @@ class CitationExtractor {
       documentTitle: c.documentTitle,
       headings: c.headings ?? [],
       pageNumbers: c.pageNumbers ?? [],
+      docItemRefs: c.docItemRefs ?? [],
       index: c.index,
     );
   }

--- a/packages/soliplex_client/lib/src/domain/source_reference.dart
+++ b/packages/soliplex_client/lib/src/domain/source_reference.dart
@@ -17,6 +17,7 @@ class SourceReference {
     this.documentTitle,
     this.headings = const [],
     this.pageNumbers = const [],
+    this.docItemRefs = const [],
     this.index,
   });
 
@@ -41,6 +42,10 @@ class SourceReference {
   /// Page numbers where this content appears.
   final List<int> pageNumbers;
 
+  /// The doc-item refs the model saw for this citation, passed to the
+  /// visualization endpoint so the highlight matches the cited content.
+  final List<String> docItemRefs;
+
   /// Display index for numbered citations.
   final int? index;
 
@@ -56,6 +61,7 @@ class SourceReference {
         documentTitle == other.documentTitle &&
         listEquals.equals(headings, other.headings) &&
         listEquals.equals(pageNumbers, other.pageNumbers) &&
+        listEquals.equals(docItemRefs, other.docItemRefs) &&
         index == other.index;
   }
 
@@ -68,6 +74,7 @@ class SourceReference {
         documentTitle,
         const ListEquality<String>().hash(headings),
         const ListEquality<int>().hash(pageNumbers),
+        const ListEquality<String>().hash(docItemRefs),
         index,
       );
 

--- a/packages/soliplex_client/lib/src/schema/agui_features/rag.dart
+++ b/packages/soliplex_client/lib/src/schema/agui_features/rag.dart
@@ -83,6 +83,7 @@ class Rag {
 class Citation {
   final String chunkId;
   final String content;
+  final List<String>? docItemRefs;
   final String documentId;
   final String? documentTitle;
   final String documentUri;
@@ -93,6 +94,7 @@ class Citation {
   Citation({
     required this.chunkId,
     required this.content,
+    this.docItemRefs,
     required this.documentId,
     this.documentTitle,
     required this.documentUri,
@@ -104,6 +106,9 @@ class Citation {
   factory Citation.fromJson(Map<String, dynamic> json) => Citation(
         chunkId: json["chunk_id"],
         content: json["content"],
+        docItemRefs: json["doc_item_refs"] == null
+            ? []
+            : List<String>.from(json["doc_item_refs"]!.map((x) => x)),
         documentId: json["document_id"],
         documentTitle: json["document_title"],
         documentUri: json["document_uri"],
@@ -119,6 +124,9 @@ class Citation {
   Map<String, dynamic> toJson() => {
         "chunk_id": chunkId,
         "content": content,
+        "doc_item_refs": docItemRefs == null
+            ? []
+            : List<dynamic>.from(docItemRefs!.map((x) => x)),
         "document_id": documentId,
         "document_title": documentTitle,
         "document_uri": documentUri,

--- a/test/modules/room/ui/chunk_visualization_page_test.dart
+++ b/test/modules/room/ui/chunk_visualization_page_test.dart
@@ -24,6 +24,8 @@ class _ChunkVizApi extends FakeSoliplexApi {
   Future<ChunkVisualization> getChunkVisualization(
     String roomId,
     String chunkId, {
+    List<String>? refs,
+    bool expand = true,
     CancelToken? cancelToken,
   }) async {
     if (nextVizError != null) throw nextVizError!;


### PR DESCRIPTION
## What

Carry the model-seen `doc_item_refs` from the AG-UI `Citation` through the schema, `SourceReference`, and the `CitationExtractor` firewall, and pass them to the chunk visualization endpoint. The backend then highlights exactly the cited items instead of re-expanding the chunk's section. Also adds an `expand` flag to the API for chunk-only grounding.

## Changes

**Package (`soliplex_client`)**
- `Citation` schema gains `docItemRefs` (parses `doc_item_refs`).
- `SourceReference` gains `docItemRefs` (+ `==`/`hashCode`).
- `CitationExtractor` maps it through the firewall.
- `getChunkVisualization` accepts `refs` (JSON-encoded) and `expand`, sent as query params (both optional; omitted params leave existing behaviour unchanged).

**App (`lib/src/modules/room/`)**
- `ChunkVisualizationPage` carries `docItemRefs` and passes it to the API call.
- `room_screen.dart` passes the tapped citation's `docItemRefs`.

## Compatibility

Requires the backend to serve `haiku.rag 0.65` (`Citation.doc_item_refs`) — pairs with the soliplex backend PR. Both are additive and independent: an un-updated backend ignores the `?refs=` query param, and the backend's `refs`/`expand` are optional, so either side can land first without breaking.

## Verification

Package-layer changes mirror an equivalent branch whose `soliplex_client` tests passed (schema contract, `SourceReference`, `CitationExtractor`, `getChunkVisualization`). CI should run the full suite here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)