### PR TITLE
feat(room): tear down in-memory session state on a different-user sign-in

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,7 +38,9 @@ Versions follow the `version+build` scheme from `pubspec.yaml`, bumped via
   an old draft.
 - Removing a server now evicts its in-memory agent runtime and tracked runs
   instead of leaking them until app exit — the runtime's timers and stream are
-  disposed and any live run for the server is cancelled.
+  disposed and any live run for the server is cancelled. Its in-memory
+  document-filter selections are dropped too, so re-adding the same server (ids
+  derive from the URL) starts with an empty filter.
 
 ### Security
 
@@ -61,6 +63,13 @@ Versions follow the `version+build` scheme from `pubspec.yaml`, bumped via
   own signed-in user. This closes the last device-local read-state leak between
   users. As a one-time effect of the storage-format change, existing lobby
   read state resets on upgrade — every room reads as unread once.
+- When a different user signs in on a server within the same app session, that
+  server's in-memory session state is now torn down — the agent runtime, any
+  tracked runs, in-flight and completed uploads, and document-filter selections
+  — so the new user can't reattach to or observe the previous user's session.
+  Servers whose identity provider issues opaque (non-JWT) access tokens are a
+  known exception: they carry no per-user identity to key on, so the switch
+  can't be detected for them.
 
 ## [0.92.0+65] - 2026-07-02
 

--- a/lib/src/core/removed_server_cleanup.dart
+++ b/lib/src/core/removed_server_cleanup.dart
@@ -6,6 +6,7 @@ import '../modules/auth/return_to_storage.dart';
 import '../modules/auth/server_manager.dart';
 import '../modules/lobby/lobby_read_markers.dart'
     show RoomReadMarkers, ServerReadMarkers;
+import '../modules/room/document_selections.dart';
 import '../modules/room/thread_anchor_storage.dart';
 import '../modules/room/thread_read_markers.dart';
 
@@ -13,8 +14,9 @@ final Logger _logger =
     LogManager.instance.getLogger('soliplex.removed_server_cleanup');
 
 /// Drops a removed server's device-local state so re-adding it under the same
-/// id doesn't resurrect stale read state, a misplaced thread divider, or an
-/// unsent draft. Server ids derive from the URL, so a re-add reuses the id.
+/// id doesn't resurrect stale read state, a misplaced thread divider, an unsent
+/// draft, or its in-memory document filter selections. Server ids derive from
+/// the URL, so a re-add reuses the id.
 ///
 /// Owned by [RoomAppModule] (like [UploadTrackerRegistry]) rather than a screen
 /// because removal fires from surfaces that don't mount the lobby — notably the
@@ -33,13 +35,16 @@ class RemovedServerCleanup {
     required ServerManager serverManager,
     required RoomReadMarkers roomReadMarkers,
     required ServerReadMarkers serverReadMarkers,
+    required DocumentSelections documentSelections,
   })  : _roomReadMarkers = roomReadMarkers,
-        _serverReadMarkers = serverReadMarkers {
+        _serverReadMarkers = serverReadMarkers,
+        _documentSelections = documentSelections {
     _unsubscribe = serverManager.onServerRemoved(_clearServer);
   }
 
   final RoomReadMarkers _roomReadMarkers;
   final ServerReadMarkers _serverReadMarkers;
+  final DocumentSelections _documentSelections;
   late final void Function() _unsubscribe;
   bool _isDisposed = false;
 
@@ -56,6 +61,8 @@ class RemovedServerCleanup {
         () => _serverReadMarkers.clearServer(id), 'server read marker', id);
     _clearInMemory(
         () => _roomReadMarkers.clearServer(id), 'room read markers', id);
+    _clearInMemory(
+        () => _documentSelections.clearServer(id), 'document selections', id);
     unawaited(
       ThreadReadMarkerStorage.clearServer(id)
           .catchError((Object error, StackTrace st) {

--- a/lib/src/modules/auth/auth_session.dart
+++ b/lib/src/modules/auth/auth_session.dart
@@ -26,10 +26,17 @@ class AuthSession implements TokenRefresher {
   /// changes and yields the same value across a same-user refresh, so watchers
   /// don't churn. Raw (un-encoded); key builders percent-encode it downstream.
   ///
-  /// A `null` on an *authenticated* session (an opaque, non-JWT access token
-  /// carrying no `iss`/`sub`) is expected, not an error: user-scoped
-  /// device-local state then shares this server's unauthenticated bucket, since
-  /// there is no identity claim to isolate it by.
+  /// Keyed on the access token, not the id token. The id token is the
+  /// conventional identity assertion, but the backend does not forward it to
+  /// the web client, whereas the access token reaches every platform. The
+  /// backend authenticates that access token by verifying its JWT signature
+  /// locally (RS256, no remote introspection), so a token it accepts is a
+  /// non-opaque JWT carrying `iss`/`sub`.
+  ///
+  /// A `null` on an *authenticated* session (an opaque access token carrying no
+  /// `iss`/`sub`) is expected, not an error: user-scoped device-local state
+  /// then shares this server's unauthenticated bucket, since there is no
+  /// identity claim to isolate it by.
   late final ReadonlySignal<String?> currentUserId = computed(() {
     final token = switch (_session.value) {
       ActiveSession(:final tokens) => tokens.accessToken,

--- a/lib/src/modules/auth/auth_session.dart
+++ b/lib/src/modules/auth/auth_session.dart
@@ -26,12 +26,9 @@ class AuthSession implements TokenRefresher {
   /// changes and yields the same value across a same-user refresh, so watchers
   /// don't churn. Raw (un-encoded); key builders percent-encode it downstream.
   ///
-  /// Keyed on the access token, not the id token. The id token is the
-  /// conventional identity assertion, but the backend does not forward it to
-  /// the web client, whereas the access token reaches every platform. The
-  /// backend authenticates that access token by verifying its JWT signature
-  /// locally (RS256, no remote introspection), so a token it accepts is a
-  /// non-opaque JWT carrying `iss`/`sub`.
+  /// Keyed on the access token, not the id token: the access token is the one
+  /// credential available on every platform. We only decode it — never verify
+  /// its signature — because the backend already validated it cryptographically.
   ///
   /// A `null` on an *authenticated* session (an opaque access token carrying no
   /// `iss`/`sub`) is expected, not an error: user-scoped device-local state

--- a/lib/src/modules/room/agent_runtime_manager.dart
+++ b/lib/src/modules/room/agent_runtime_manager.dart
@@ -71,13 +71,25 @@ class AgentRuntimeManager {
 
   /// Disposes and drops the cached runtime for every server no longer present
   /// in [snapshot], so a removed server's runtime doesn't linger until the
-  /// whole manager is disposed. Disposal is fire-and-forget: it runs teardown
-  /// that can throw, and this eviction must not strand the other disposals or
-  /// propagate, so a throw is logged.
+  /// whole manager is disposed.
   void _evictRemoved(Map<String, ServerEntry> snapshot) {
-    if (_isDisposed) return;
     final liveIds = snapshot.keys.toSet();
-    final dead = _cache.entries.where((e) => !liveIds.contains(e.key)).toList();
+    _evictWhere((serverId) => !liveIds.contains(serverId));
+  }
+
+  /// Disposes and drops the cached runtime for [serverId], so the next
+  /// [getRuntime] builds one bound to the current session. Used when a
+  /// different user signs in on that server. No-op if nothing is cached.
+  void evictServer(String serverId) {
+    _evictWhere((id) => id == serverId);
+  }
+
+  /// Disposal is fire-and-forget: it runs teardown that can throw, and this
+  /// eviction must not strand the other disposals or propagate, so a throw is
+  /// logged.
+  void _evictWhere(bool Function(String serverId) shouldEvict) {
+    if (_isDisposed) return;
+    final dead = _cache.entries.where((e) => shouldEvict(e.key)).toList();
     for (final entry in dead) {
       _cache.remove(entry.key);
       unawaited(_disposeRuntime(entry.key, entry.value.runtime));

--- a/lib/src/modules/room/document_selections.dart
+++ b/lib/src/modules/room/document_selections.dart
@@ -8,18 +8,23 @@ import 'package:soliplex_client/soliplex_client.dart';
 /// Lives above RoomScreen in the dependency graph — created once at the module
 /// level and injected via constructor.
 class DocumentSelections {
-  final _selections = <(String, String, String?), Set<RagDocument>>{};
+  final _selections = <_Key, Set<RagDocument>>{};
 
-  Set<RagDocument> get(String serverId, String roomId, String? threadId) =>
-      _selections[(serverId, roomId, threadId)] ?? const {};
+  Set<RagDocument> get({
+    required String serverId,
+    required String roomId,
+    required String? threadId,
+  }) =>
+      _selections[(serverId: serverId, roomId: roomId, threadId: threadId)] ??
+      const {};
 
-  void set(
-    String serverId,
-    String roomId,
-    String? threadId,
-    Set<RagDocument> docs,
-  ) {
-    final key = (serverId, roomId, threadId);
+  void set({
+    required String serverId,
+    required String roomId,
+    required String? threadId,
+    required Set<RagDocument> docs,
+  }) {
+    final key = (serverId: serverId, roomId: roomId, threadId: threadId);
     if (docs.isEmpty) {
       _selections.remove(key);
     } else {
@@ -28,25 +33,38 @@ class DocumentSelections {
   }
 
   /// Drops the selection for a deleted thread.
-  void clearThread(String serverId, String roomId, String threadId) {
-    _selections.remove((serverId, roomId, threadId));
+  void clearThread({
+    required String serverId,
+    required String roomId,
+    required String threadId,
+  }) {
+    _selections
+        .remove((serverId: serverId, roomId: roomId, threadId: threadId));
   }
 
   /// Drops every selection for [serverId], so a different user signing in on
   /// that server doesn't inherit the prior user's document filters, while
   /// leaving other servers' selections intact.
   void clearServer(String serverId) {
-    _selections.removeWhere((key, _) => key.$1 == serverId);
+    _selections.removeWhere((key, _) => key.serverId == serverId);
   }
 
   /// Moves the selection from the null-thread key to [threadId].
   ///
   /// Used when a user selects documents before a thread exists, then
   /// a thread is created implicitly by sending a message.
-  void migrateToThread(String serverId, String roomId, String threadId) {
-    final pending = _selections.remove((serverId, roomId, null));
+  void migrateToThread({
+    required String serverId,
+    required String roomId,
+    required String threadId,
+  }) {
+    final pending = _selections
+        .remove((serverId: serverId, roomId: roomId, threadId: null));
     if (pending != null && pending.isNotEmpty) {
-      _selections[(serverId, roomId, threadId)] = pending;
+      _selections[(serverId: serverId, roomId: roomId, threadId: threadId)] =
+          pending;
     }
   }
 }
+
+typedef _Key = ({String serverId, String roomId, String? threadId});

--- a/lib/src/modules/room/document_selections.dart
+++ b/lib/src/modules/room/document_selections.dart
@@ -24,6 +24,12 @@ class DocumentSelections {
     _selections.remove((roomId, threadId));
   }
 
+  /// Drops every selection, so the prior user's in-memory document filters
+  /// don't surface to a different user signing in on the same device.
+  void clear() {
+    _selections.clear();
+  }
+
   /// Moves the selection from the null-thread key to [threadId].
   ///
   /// Used when a user selects documents before a thread exists, then

--- a/lib/src/modules/room/document_selections.dart
+++ b/lib/src/modules/room/document_selections.dart
@@ -2,42 +2,51 @@ import 'package:soliplex_client/soliplex_client.dart';
 
 /// Persists per-thread document filter selections across navigation.
 ///
-/// Keyed by (roomId, threadId) so selections survive room switches.
-/// Lives above RoomScreen in the dependency graph — created once at the
-/// module level and injected via constructor.
+/// Keyed by (serverId, roomId, threadId) so selections survive room switches
+/// and stay isolated per server — two servers can assign the same roomId, and a
+/// user switch on one server must not disturb another server's selections.
+/// Lives above RoomScreen in the dependency graph — created once at the module
+/// level and injected via constructor.
 class DocumentSelections {
-  final _selections = <(String, String?), Set<RagDocument>>{};
+  final _selections = <(String, String, String?), Set<RagDocument>>{};
 
-  Set<RagDocument> get(String roomId, String? threadId) =>
-      _selections[(roomId, threadId)] ?? const {};
+  Set<RagDocument> get(String serverId, String roomId, String? threadId) =>
+      _selections[(serverId, roomId, threadId)] ?? const {};
 
-  void set(String roomId, String? threadId, Set<RagDocument> docs) {
+  void set(
+    String serverId,
+    String roomId,
+    String? threadId,
+    Set<RagDocument> docs,
+  ) {
+    final key = (serverId, roomId, threadId);
     if (docs.isEmpty) {
-      _selections.remove((roomId, threadId));
+      _selections.remove(key);
     } else {
-      _selections[(roomId, threadId)] = docs;
+      _selections[key] = docs;
     }
   }
 
   /// Drops the selection for a deleted thread.
-  void clearThread(String roomId, String threadId) {
-    _selections.remove((roomId, threadId));
+  void clearThread(String serverId, String roomId, String threadId) {
+    _selections.remove((serverId, roomId, threadId));
   }
 
-  /// Drops every selection, so the prior user's in-memory document filters
-  /// don't surface to a different user signing in on the same device.
-  void clear() {
-    _selections.clear();
+  /// Drops every selection for [serverId], so a different user signing in on
+  /// that server doesn't inherit the prior user's document filters, while
+  /// leaving other servers' selections intact.
+  void clearServer(String serverId) {
+    _selections.removeWhere((key, _) => key.$1 == serverId);
   }
 
   /// Moves the selection from the null-thread key to [threadId].
   ///
   /// Used when a user selects documents before a thread exists, then
   /// a thread is created implicitly by sending a message.
-  void migrateToThread(String roomId, String threadId) {
-    final pending = _selections.remove((roomId, null));
+  void migrateToThread(String serverId, String roomId, String threadId) {
+    final pending = _selections.remove((serverId, roomId, null));
     if (pending != null && pending.isNotEmpty) {
-      _selections[(roomId, threadId)] = pending;
+      _selections[(serverId, roomId, threadId)] = pending;
     }
   }
 }

--- a/lib/src/modules/room/message_expansions.dart
+++ b/lib/src/modules/room/message_expansions.dart
@@ -5,8 +5,12 @@ import 'compute_display_messages.dart' show loadingMessageId;
 /// are open. Owned by `roomModule()`; outlives widget rebuilds, thread
 /// switches, and room navigations within the room module.
 ///
-/// Identity is `(roomId, messageId)`. [loadingMessageId] is rejected,
-/// because it is reused across runs and state written under it would
+/// Identity is `(roomId, messageId)`. Unlike the module's other per-server
+/// caches this carries no `serverId`; adding it — for full isolation between
+/// servers that share a `roomId` — is a possible future enhancement, deferred
+/// because a collision also needs a shared `messageId` and would only swap
+/// cosmetic expand/collapse state between two messages. [loadingMessageId] is
+/// rejected, because it is reused across runs and state written under it would
 /// leak into the next response.
 ///
 /// Retention is capped at [maxEntries]; once reached, the oldest-inserted

--- a/lib/src/modules/room/room_module.dart
+++ b/lib/src/modules/room/room_module.dart
@@ -15,6 +15,7 @@ import 'run_registry.dart';
 import 'ui/room_info_screen.dart';
 import 'ui/room_screen.dart';
 import 'upload_tracker_registry.dart';
+import 'user_switch_teardown.dart';
 
 class RoomAppModule extends AppModule {
   RoomAppModule({
@@ -33,7 +34,15 @@ class RoomAppModule extends AppModule {
           serverManager: serverManager,
           roomReadMarkers: roomReadMarkers,
           serverReadMarkers: serverReadMarkers,
-        );
+        ) {
+    _userSwitchTeardown = UserSwitchTeardown(
+      servers: serverManager.servers,
+      runtimeManager: runtimeManager,
+      registry: registry,
+      uploadRegistry: _uploadRegistry,
+      documentSelections: _documentSelections,
+    );
+  }
 
   final ServerManager serverManager;
   final AgentRuntimeManager runtimeManager;
@@ -56,6 +65,7 @@ class RoomAppModule extends AppModule {
   final MessageExpansions _messageExpansions;
   final UploadTrackerRegistry _uploadRegistry;
   final RemovedServerCleanup _removedServerCleanup;
+  late final UserSwitchTeardown _userSwitchTeardown;
 
   @override
   String get namespace => 'room';
@@ -122,6 +132,7 @@ class RoomAppModule extends AppModule {
 
   @override
   Future<void> onDispose() async {
+    _userSwitchTeardown.dispose();
     _removedServerCleanup.dispose();
     await runtimeManager.dispose();
     registry.dispose();

--- a/lib/src/modules/room/room_module.dart
+++ b/lib/src/modules/room/room_module.dart
@@ -29,12 +29,14 @@ class RoomAppModule extends AppModule {
     this.enableDocumentFilter = false,
   })  : _documentSelections = DocumentSelections(),
         _messageExpansions = MessageExpansions(),
-        _uploadRegistry = UploadTrackerRegistry(servers: serverManager.servers),
-        _removedServerCleanup = RemovedServerCleanup(
-          serverManager: serverManager,
-          roomReadMarkers: roomReadMarkers,
-          serverReadMarkers: serverReadMarkers,
-        ) {
+        _uploadRegistry =
+            UploadTrackerRegistry(servers: serverManager.servers) {
+    _removedServerCleanup = RemovedServerCleanup(
+      serverManager: serverManager,
+      roomReadMarkers: roomReadMarkers,
+      serverReadMarkers: serverReadMarkers,
+      documentSelections: _documentSelections,
+    );
     _userSwitchTeardown = UserSwitchTeardown(
       servers: serverManager.servers,
       runtimeManager: runtimeManager,
@@ -64,7 +66,7 @@ class RoomAppModule extends AppModule {
   final DocumentSelections _documentSelections;
   final MessageExpansions _messageExpansions;
   final UploadTrackerRegistry _uploadRegistry;
-  final RemovedServerCleanup _removedServerCleanup;
+  late final RemovedServerCleanup _removedServerCleanup;
   late final UserSwitchTeardown _userSwitchTeardown;
 
   @override

--- a/lib/src/modules/room/run_registry.dart
+++ b/lib/src/modules/room/run_registry.dart
@@ -126,18 +126,27 @@ class RunRegistry {
   /// [snapshot], so a removed server's live session is cancelled and its
   /// captured outcome released instead of lingering until [dispose].
   void _evictRemoved(Map<String, ServerEntry> snapshot) {
-    if (_isDisposed) return;
     final liveIds = snapshot.keys.toSet();
-    final dead =
-        _runs.keys.where((key) => !liveIds.contains(key.serverId)).toList();
+    _evictWhere((key) => !liveIds.contains(key.serverId));
+  }
+
+  /// Cancels and drops every tracked run for [serverId], so a different user
+  /// signing in on that server can't reattach to the prior user's runs or read
+  /// their captured outcomes. No-op if the server has no tracked runs.
+  void evictServer(String serverId) {
+    _evictWhere((key) => key.serverId == serverId);
+  }
+
+  void _evictWhere(bool Function(ThreadKey key) shouldEvict) {
+    if (_isDisposed) return;
+    final dead = _runs.keys.where(shouldEvict).toList();
     if (dead.isEmpty) return;
     for (final key in dead) {
       final session = _runs.remove(key)?.session;
       if (session != null) _cancelQuietly(key, session);
     }
-    final nextActive = _activeKeys.value
-        .where((key) => liveIds.contains(key.serverId))
-        .toSet();
+    final nextActive =
+        _activeKeys.value.where((key) => !shouldEvict(key)).toSet();
     if (nextActive.length != _activeKeys.value.length) {
       _activeKeys.value = nextActive;
     }

--- a/lib/src/modules/room/run_registry.dart
+++ b/lib/src/modules/room/run_registry.dart
@@ -154,9 +154,9 @@ class RunRegistry {
 
   /// Cancels [session], swallowing and logging any throw. [cancel] runs real
   /// teardown that can throw; both callers cancel in a loop where one throw must
-  /// not strand the rest. Eviction also runs synchronously inside the
-  /// servers-signal write, where an escape would unwind removeServer before it
-  /// deletes the stored session.
+  /// not strand the rest. Eviction also runs synchronously inside a signal
+  /// write (server removal, or a user switch mid-login), where an escape would
+  /// unwind the caller before it deletes the stored session.
   void _cancelQuietly(ThreadKey key, AgentSession session) {
     try {
       session.cancel();

--- a/lib/src/modules/room/run_registry.dart
+++ b/lib/src/modules/room/run_registry.dart
@@ -155,8 +155,9 @@ class RunRegistry {
   /// Cancels [session], swallowing and logging any throw. [cancel] runs real
   /// teardown that can throw; both callers cancel in a loop where one throw must
   /// not strand the rest. Eviction also runs synchronously inside a signal
-  /// write (server removal, or a user switch mid-login), where an escape would
-  /// unwind the caller before it deletes the stored session.
+  /// write, where an escape would unwind the caller: on server removal, aborting
+  /// `removeServer` before it deletes the persisted session; on a user switch
+  /// mid-login, unwinding the sign-in.
   void _cancelQuietly(ThreadKey key, AgentSession session) {
     try {
       session.cancel();

--- a/lib/src/modules/room/ui/room_screen.dart
+++ b/lib/src/modules/room/ui/room_screen.dart
@@ -301,13 +301,21 @@ class _RoomScreenState extends State<RoomScreen> {
   String get _serverId => widget.serverEntry.serverId;
 
   Set<RagDocument> get _selectedDocuments => _filterEnabled
-      ? _documentSelections.get(_serverId, widget.roomId, widget.threadId)
+      ? _documentSelections.get(
+          serverId: _serverId,
+          roomId: widget.roomId,
+          threadId: widget.threadId,
+        )
       : const {};
 
   void _updateSelection(Set<RagDocument> selection) {
     setState(() {
       _documentSelections.set(
-          _serverId, widget.roomId, widget.threadId, selection);
+        serverId: _serverId,
+        roomId: widget.roomId,
+        threadId: widget.threadId,
+        docs: selection,
+      );
     });
   }
 
@@ -554,7 +562,8 @@ class _RoomScreenState extends State<RoomScreen> {
       // then clear disk across all users.
       _threadReadTracker.clearThread(threadId);
       _anchorTracker.clearThread(threadId);
-      _documentSelections.clearThread(serverId, roomId, threadId);
+      _documentSelections.clearThread(
+          serverId: serverId, roomId: roomId, threadId: threadId);
       unawaited(
         ThreadReadMarkerStorage.clearThread(serverId, roomId, threadId)
             .catchError((Object error, StackTrace st) {
@@ -812,11 +821,17 @@ class _RoomScreenState extends State<RoomScreen> {
       context: context,
       fetchDocuments: () =>
           widget.serverEntry.connection.api.getDocuments(roomId),
-      selected: _documentSelections.get(_serverId, roomId, threadId),
+      selected: _documentSelections.get(
+          serverId: _serverId, roomId: roomId, threadId: threadId),
     );
     if (result != null && mounted) {
       setState(() {
-        _documentSelections.set(_serverId, roomId, threadId, result);
+        _documentSelections.set(
+          serverId: _serverId,
+          roomId: roomId,
+          threadId: threadId,
+          docs: result,
+        );
       });
     }
   }
@@ -980,7 +995,9 @@ class _RoomScreenState extends State<RoomScreen> {
         _markThreadRead(widget.threadId);
         if (_filterEnabled && oldWidget.threadId == null) {
           _documentSelections.migrateToThread(
-              _serverId, widget.roomId, widget.threadId!);
+              serverId: _serverId,
+              roomId: widget.roomId,
+              threadId: widget.threadId!);
         }
         _state.selectThread(widget.threadId!);
         _beginUnreadTracking(widget.threadId!);

--- a/lib/src/modules/room/ui/room_screen.dart
+++ b/lib/src/modules/room/ui/room_screen.dart
@@ -298,13 +298,16 @@ class _RoomScreenState extends State<RoomScreen> {
 
   DocumentSelections get _documentSelections => widget.documentSelections;
 
+  String get _serverId => widget.serverEntry.serverId;
+
   Set<RagDocument> get _selectedDocuments => _filterEnabled
-      ? _documentSelections.get(widget.roomId, widget.threadId)
+      ? _documentSelections.get(_serverId, widget.roomId, widget.threadId)
       : const {};
 
   void _updateSelection(Set<RagDocument> selection) {
     setState(() {
-      _documentSelections.set(widget.roomId, widget.threadId, selection);
+      _documentSelections.set(
+          _serverId, widget.roomId, widget.threadId, selection);
     });
   }
 
@@ -551,7 +554,7 @@ class _RoomScreenState extends State<RoomScreen> {
       // then clear disk across all users.
       _threadReadTracker.clearThread(threadId);
       _anchorTracker.clearThread(threadId);
-      _documentSelections.clearThread(roomId, threadId);
+      _documentSelections.clearThread(serverId, roomId, threadId);
       unawaited(
         ThreadReadMarkerStorage.clearThread(serverId, roomId, threadId)
             .catchError((Object error, StackTrace st) {
@@ -809,11 +812,11 @@ class _RoomScreenState extends State<RoomScreen> {
       context: context,
       fetchDocuments: () =>
           widget.serverEntry.connection.api.getDocuments(roomId),
-      selected: _documentSelections.get(roomId, threadId),
+      selected: _documentSelections.get(_serverId, roomId, threadId),
     );
     if (result != null && mounted) {
       setState(() {
-        _documentSelections.set(roomId, threadId, result);
+        _documentSelections.set(_serverId, roomId, threadId, result);
       });
     }
   }
@@ -976,7 +979,8 @@ class _RoomScreenState extends State<RoomScreen> {
         _workdirs.clearCache();
         _markThreadRead(widget.threadId);
         if (_filterEnabled && oldWidget.threadId == null) {
-          _documentSelections.migrateToThread(widget.roomId, widget.threadId!);
+          _documentSelections.migrateToThread(
+              _serverId, widget.roomId, widget.threadId!);
         }
         _state.selectThread(widget.threadId!);
         _beginUnreadTracking(widget.threadId!);

--- a/lib/src/modules/room/upload_tracker_registry.dart
+++ b/lib/src/modules/room/upload_tracker_registry.dart
@@ -72,8 +72,9 @@ class UploadTrackerRegistry {
   }
 
   /// Disposes and drops every tracker for [serverId], so a different user
-  /// signing in on that server gets a fresh tracker built with their own
-  /// api/auth rather than the prior user's. No-op if none are cached.
+  /// signing in on that server starts with an empty tracker instead of
+  /// inheriting the prior user's in-flight and completed uploads. No-op if
+  /// none are cached.
   void evictServer(String serverId) {
     _evictWhere((id) => id == serverId);
   }

--- a/lib/src/modules/room/upload_tracker_registry.dart
+++ b/lib/src/modules/room/upload_tracker_registry.dart
@@ -88,16 +88,7 @@ class UploadTrackerRegistry {
     final dead = _trackers.entries.where((e) => shouldEvict(e.key.$1)).toList();
     for (final entry in dead) {
       _trackers.remove(entry.key);
-      try {
-        entry.value.dispose();
-      } on Object catch (error, stackTrace) {
-        _logger.error(
-          'Failed to dispose upload tracker',
-          error: error,
-          stackTrace: stackTrace,
-          attributes: {'serverId': entry.key.$1, 'roomId': entry.key.$2},
-        );
-      }
+      _disposeQuietly(entry.key, entry.value);
     }
   }
 
@@ -105,9 +96,25 @@ class UploadTrackerRegistry {
     if (_isDisposed) return;
     _isDisposed = true;
     _unsubscribe();
-    for (final tracker in _trackers.values) {
-      tracker.dispose();
+    for (final entry in _trackers.entries) {
+      _disposeQuietly(entry.key, entry.value);
     }
     _trackers.clear();
+  }
+
+  /// Disposes [tracker], swallowing and logging any throw so one tracker's
+  /// failing teardown can't strand the rest — whether it runs inside the
+  /// synchronous eviction signal write or the disposal loop.
+  void _disposeQuietly((String, String) key, UploadTracker tracker) {
+    try {
+      tracker.dispose();
+    } on Object catch (error, stackTrace) {
+      _logger.error(
+        'Failed to dispose upload tracker',
+        error: error,
+        stackTrace: stackTrace,
+        attributes: {'serverId': key.$1, 'roomId': key.$2},
+      );
+    }
   }
 }

--- a/lib/src/modules/room/upload_tracker_registry.dart
+++ b/lib/src/modules/room/upload_tracker_registry.dart
@@ -1,7 +1,11 @@
 import 'package:signals_flutter/signals_flutter.dart';
+import 'package:soliplex_logging/soliplex_logging.dart';
 
 import '../auth/server_entry.dart';
 import 'upload_tracker.dart';
+
+final Logger _logger =
+    LogManager.instance.getLogger('soliplex.upload_tracker_registry');
 
 /// Module-scoped registry that hands out one `UploadTracker` per
 /// `(serverId, roomId)`.
@@ -74,12 +78,26 @@ class UploadTrackerRegistry {
     _evictWhere((id) => id == serverId);
   }
 
+  /// Drops each matching tracker before disposing it — disposal runs real
+  /// teardown that can throw, and eviction runs synchronously inside a signal
+  /// write (server removal, or a user switch mid-login), where an escape would
+  /// unwind the caller and strand the remaining evictions. Removing first keeps
+  /// a throw from leaving a disposed tracker referenced; the throw is logged.
   void _evictWhere(bool Function(String serverId) shouldEvict) {
     if (_isDisposed) return;
     final dead = _trackers.entries.where((e) => shouldEvict(e.key.$1)).toList();
     for (final entry in dead) {
-      entry.value.dispose();
       _trackers.remove(entry.key);
+      try {
+        entry.value.dispose();
+      } on Object catch (error, stackTrace) {
+        _logger.error(
+          'Failed to dispose upload tracker',
+          error: error,
+          stackTrace: stackTrace,
+          attributes: {'serverId': entry.key.$1, 'roomId': entry.key.$2},
+        );
+      }
     }
   }
 

--- a/lib/src/modules/room/upload_tracker_registry.dart
+++ b/lib/src/modules/room/upload_tracker_registry.dart
@@ -63,10 +63,20 @@ class UploadTrackerRegistry {
   }
 
   void _evictRemoved(Map<String, ServerEntry> snapshot) {
-    if (_isDisposed) return;
     final liveIds = snapshot.keys.toSet();
-    final dead =
-        _trackers.entries.where((e) => !liveIds.contains(e.key.$1)).toList();
+    _evictWhere((serverId) => !liveIds.contains(serverId));
+  }
+
+  /// Disposes and drops every tracker for [serverId], so a different user
+  /// signing in on that server gets a fresh tracker built with their own
+  /// api/auth rather than the prior user's. No-op if none are cached.
+  void evictServer(String serverId) {
+    _evictWhere((id) => id == serverId);
+  }
+
+  void _evictWhere(bool Function(String serverId) shouldEvict) {
+    if (_isDisposed) return;
+    final dead = _trackers.entries.where((e) => shouldEvict(e.key.$1)).toList();
     for (final entry in dead) {
       entry.value.dispose();
       _trackers.remove(entry.key);

--- a/lib/src/modules/room/user_switch_teardown.dart
+++ b/lib/src/modules/room/user_switch_teardown.dart
@@ -1,0 +1,79 @@
+import 'package:signals_flutter/signals_flutter.dart';
+import 'package:soliplex_logging/soliplex_logging.dart';
+
+import '../auth/server_entry.dart';
+import 'agent_runtime_manager.dart';
+import 'document_selections.dart';
+import 'run_registry.dart';
+import 'upload_tracker_registry.dart';
+
+final Logger _logger =
+    LogManager.instance.getLogger('soliplex.user_switch_teardown');
+
+/// Tears down a server's in-memory, session-bound state when a *different*
+/// user signs in on it within the same process.
+///
+/// Persistent device-local state is partitioned by user identity, so a switch
+/// needs no teardown there. But [AgentRuntimeManager], [RunRegistry],
+/// [UploadTrackerRegistry], and [DocumentSelections] cache state against the
+/// live session, and re-auth reuses the same `ServerConnection` instance — so
+/// without this the next user would reattach to the prior user's runtime,
+/// runs, uploads, and document filters.
+///
+/// Detection keys off each server's `AuthSession.currentUserId` rather than the
+/// sign-in call sites: that signal is stable across a token refresh (no
+/// teardown), stays set through an `ExpiredSession` (so an expiry followed by a
+/// different user still counts as a switch), and reading state instead of
+/// intercepting transitions covers every auth path — including the silent
+/// sign-in that `ServerManager.restoreServers` performs on launch, which the
+/// first effect run records as the baseline without evicting. A `null` identity
+/// (signed out, or an undecodable token) is ignored, so a logout alone tears
+/// down nothing; the switch is recognised only when a server's identity moves
+/// from one non-null user to a different non-null user.
+///
+/// Owned by [RoomAppModule] alongside `RemovedServerCleanup`.
+class UserSwitchTeardown {
+  UserSwitchTeardown({
+    required ReadonlySignal<Map<String, ServerEntry>> servers,
+    required AgentRuntimeManager runtimeManager,
+    required RunRegistry registry,
+    required UploadTrackerRegistry uploadRegistry,
+    required DocumentSelections documentSelections,
+  })  : _runtimeManager = runtimeManager,
+        _registry = registry,
+        _uploadRegistry = uploadRegistry,
+        _documentSelections = documentSelections {
+    _dispose = effect(() {
+      for (final MapEntry(key: serverId, value: entry)
+          in servers.value.entries) {
+        final identity = entry.auth.currentUserId.value;
+        if (identity == null) continue;
+        final previous = _lastSeen[serverId];
+        _lastSeen[serverId] = identity;
+        if (previous != null && previous != identity) {
+          _evict(serverId);
+        }
+      }
+    });
+  }
+
+  final AgentRuntimeManager _runtimeManager;
+  final RunRegistry _registry;
+  final UploadTrackerRegistry _uploadRegistry;
+  final DocumentSelections _documentSelections;
+  final Map<String, String> _lastSeen = {};
+  late final void Function() _dispose;
+
+  void _evict(String serverId) {
+    _logger.info(
+      'Different user signed in on $serverId; '
+      'tearing down the prior in-memory session',
+    );
+    _runtimeManager.evictServer(serverId);
+    _registry.evictServer(serverId);
+    _uploadRegistry.evictServer(serverId);
+    _documentSelections.clear();
+  }
+
+  void dispose() => _dispose();
+}

--- a/lib/src/modules/room/user_switch_teardown.dart
+++ b/lib/src/modules/room/user_switch_teardown.dart
@@ -10,15 +10,17 @@ import 'upload_tracker_registry.dart';
 final Logger _logger =
     LogManager.instance.getLogger('soliplex.user_switch_teardown');
 
-/// Tears down a server's in-memory, session-bound state when a *different*
-/// user signs in on it within the same process.
+/// Tears down a server's in-memory state when a *different* user signs in on it
+/// within the same process.
 ///
 /// Persistent device-local state is partitioned by user identity, so a switch
-/// needs no teardown there. But [AgentRuntimeManager], [RunRegistry],
-/// [UploadTrackerRegistry], and [DocumentSelections] cache state against the
-/// live session, and re-auth reuses the same `ServerConnection` instance — so
-/// without this the next user would reattach to the prior user's runtime,
-/// runs, uploads, and document filters.
+/// needs no teardown there. But four in-memory caches would carry the prior
+/// user's state into the new session: [AgentRuntimeManager], [RunRegistry], and
+/// [UploadTrackerRegistry] cache against the live `ServerConnection`, which
+/// re-auth reuses; and [DocumentSelections] holds document filters in a
+/// process-global map that is not partitioned by user. Without this the next
+/// user would reattach to the prior user's runtime, runs, uploads, and document
+/// filters.
 ///
 /// Detection keys off each server's `AuthSession.currentUserId` rather than the
 /// sign-in call sites: that signal is stable across a token refresh (no
@@ -72,7 +74,7 @@ class UserSwitchTeardown {
     _runtimeManager.evictServer(serverId);
     _registry.evictServer(serverId);
     _uploadRegistry.evictServer(serverId);
-    _documentSelections.clear();
+    _documentSelections.clearServer(serverId);
   }
 
   void dispose() => _dispose();

--- a/lib/src/modules/room/user_switch_teardown.dart
+++ b/lib/src/modules/room/user_switch_teardown.dart
@@ -15,12 +15,12 @@ final Logger _logger =
 ///
 /// Persistent device-local state is partitioned by user identity, so a switch
 /// needs no teardown there. But four in-memory caches would carry the prior
-/// user's state into the new session: [AgentRuntimeManager], [RunRegistry], and
+/// user's state into the new session: [AgentRuntimeManager] and
 /// [UploadTrackerRegistry] cache against the live `ServerConnection`, which
-/// re-auth reuses; and [DocumentSelections] holds document filters in a
-/// process-global map that is not partitioned by user. Without this the next
-/// user would reattach to the prior user's runtime, runs, uploads, and document
-/// filters.
+/// re-auth reuses; [RunRegistry] keys live runs by the stable `serverId`; and
+/// [DocumentSelections] holds document filters in a process-global map that is
+/// not partitioned by user. Without this the next user would reattach to the
+/// prior user's runtime, runs, uploads, and document filters.
 ///
 /// Detection keys off each server's `AuthSession.currentUserId` rather than the
 /// sign-in call sites: that signal is stable across a token refresh (no
@@ -63,6 +63,10 @@ class UserSwitchTeardown {
   final RunRegistry _registry;
   final UploadTrackerRegistry _uploadRegistry;
   final DocumentSelections _documentSelections;
+  // Baseline identity per server. An entry for a removed server is left in
+  // place: the map is bounded by servers seen this process, and a stale
+  // baseline only ever fires a harmless no-op eviction if that id is re-added,
+  // since its caches were already cleared on removal.
   final Map<String, String> _lastSeen = {};
   late final void Function() _dispose;
 

--- a/lib/src/modules/room/user_switch_teardown.dart
+++ b/lib/src/modules/room/user_switch_teardown.dart
@@ -71,10 +71,26 @@ class UserSwitchTeardown {
       'Different user signed in on $serverId; '
       'tearing down the prior in-memory session',
     );
-    _runtimeManager.evictServer(serverId);
-    _registry.evictServer(serverId);
-    _uploadRegistry.evictServer(serverId);
-    _documentSelections.clearServer(serverId);
+    // Each step is isolated: eviction runs synchronously inside the auth signal
+    // write that recorded the switch, so a throw escaping here would strand the
+    // remaining caches (leaking the prior user's state) and unwind the sign-in.
+    _step(() => _runtimeManager.evictServer(serverId), 'runtime', serverId);
+    _step(() => _registry.evictServer(serverId), 'runs', serverId);
+    _step(() => _uploadRegistry.evictServer(serverId), 'uploads', serverId);
+    _step(() => _documentSelections.clearServer(serverId), 'filters', serverId);
+  }
+
+  void _step(void Function() evict, String what, String serverId) {
+    try {
+      evict();
+    } on Object catch (error, stackTrace) {
+      _logger.error(
+        'Failed to tear down $what for $serverId',
+        error: error,
+        stackTrace: stackTrace,
+        attributes: {'serverId': serverId},
+      );
+    }
   }
 
   void dispose() => _dispose();

--- a/lib/src/modules/room/user_switch_teardown.dart
+++ b/lib/src/modules/room/user_switch_teardown.dart
@@ -15,12 +15,15 @@ final Logger _logger =
 ///
 /// Persistent device-local state is partitioned by user identity, so a switch
 /// needs no teardown there. But four in-memory caches would carry the prior
-/// user's state into the new session: [AgentRuntimeManager] and
-/// [UploadTrackerRegistry] cache against the live `ServerConnection`, which
-/// re-auth reuses; [RunRegistry] keys live runs by the stable `serverId`; and
-/// [DocumentSelections] holds document filters in a process-global map that is
-/// not partitioned by user. Without this the next user would reattach to the
-/// prior user's runtime, runs, uploads, and document filters.
+/// user's state into the new session: [AgentRuntimeManager] caches against the
+/// live `ServerConnection`, which re-auth reuses; [RunRegistry] and
+/// [UploadTrackerRegistry] key by the stable `serverId`; and [DocumentSelections]
+/// holds document filters in a single shared map that is not partitioned by
+/// user. Without this the next user would reattach to the prior user's runtime,
+/// runs, uploads, and document filters. `MessageExpansions` is a fifth
+/// module-owned cache left untouched on purpose: its per-message expand/collapse
+/// state is cosmetic, and a cross-user collision would need a shared
+/// server-assigned `messageId`.
 ///
 /// Detection keys off each server's `AuthSession.currentUserId` rather than the
 /// sign-in call sites: that signal is stable across a token refresh (no
@@ -29,9 +32,16 @@ final Logger _logger =
 /// intercepting transitions covers every auth path — including the silent
 /// sign-in that `ServerManager.restoreServers` performs on launch, which the
 /// first effect run records as the baseline without evicting. A `null` identity
-/// (signed out, or an undecodable token) is ignored, so a logout alone tears
+/// (signed out, or an opaque non-JWT token) is ignored, so a logout alone tears
 /// down nothing; the switch is recognised only when a server's identity moves
 /// from one non-null user to a different non-null user.
+///
+/// This leaves a known gap: a server whose IdP issues opaque access tokens has
+/// a `null` identity for *every* user, so a switch between two such users is
+/// undetectable here and the next user inherits the prior user's in-memory
+/// session. That mirrors how those servers already share one unauthenticated
+/// bucket for persistent state (see `AuthSession.currentUserId`); isolating them
+/// would need a credential fingerprint the token doesn't carry.
 ///
 /// Owned by [RoomAppModule] alongside `RemovedServerCleanup`.
 class UserSwitchTeardown {
@@ -49,6 +59,8 @@ class UserSwitchTeardown {
       for (final MapEntry(key: serverId, value: entry)
           in servers.value.entries) {
         final identity = entry.auth.currentUserId.value;
+        // Opaque-token servers report a null identity for every user, so their
+        // switches go undetected here — see the class doc's known-gap note.
         if (identity == null) continue;
         final previous = _lastSeen[serverId];
         _lastSeen[serverId] = identity;

--- a/test/core/removed_server_cleanup_test.dart
+++ b/test/core/removed_server_cleanup_test.dart
@@ -1,10 +1,12 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:shared_preferences/shared_preferences.dart';
+import 'package:soliplex_client/soliplex_client.dart' show RagDocument;
 import 'package:soliplex_frontend/src/core/removed_server_cleanup.dart';
 import 'package:soliplex_frontend/src/modules/auth/auth_session.dart';
 import 'package:soliplex_frontend/src/modules/auth/return_to_storage.dart';
 import 'package:soliplex_frontend/src/modules/auth/server_manager.dart';
 import 'package:soliplex_frontend/src/modules/lobby/lobby_read_markers.dart';
+import 'package:soliplex_frontend/src/modules/room/document_selections.dart';
 import 'package:soliplex_frontend/src/modules/room/thread_anchor_storage.dart';
 import 'package:soliplex_frontend/src/modules/room/thread_read_markers.dart';
 
@@ -24,6 +26,7 @@ void main() {
     ServerManager manager,
     RoomReadMarkers room,
     ServerReadMarkers server,
+    DocumentSelections docs,
     RemovedServerCleanup cleanup,
   }) wire() {
     final manager = _createManager();
@@ -39,13 +42,21 @@ void main() {
     );
     final room = RoomReadMarkers();
     final server = ServerReadMarkers();
+    final docs = DocumentSelections();
     final cleanup = RemovedServerCleanup(
       serverManager: manager,
       roomReadMarkers: room,
       serverReadMarkers: server,
+      documentSelections: docs,
     );
     addTearDown(cleanup.dispose);
-    return (manager: manager, room: room, server: server, cleanup: cleanup);
+    return (
+      manager: manager,
+      room: room,
+      server: server,
+      docs: docs,
+      cleanup: cleanup
+    );
   }
 
   group('RemovedServerCleanup', () {
@@ -125,6 +136,21 @@ void main() {
             serverId: 's2', userId: 'u', roomId: 'r'),
         's2 draft',
       );
+    });
+
+    test('clears the removed server\'s document selections, keeping others\'',
+        () async {
+      const doc = RagDocument(id: 'd1', title: 'Doc');
+      final wired = wire();
+      wired.docs.set(serverId: 's1', roomId: 'r', threadId: 't', docs: {doc});
+      wired.docs.set(serverId: 's2', roomId: 'r', threadId: 't', docs: {doc});
+
+      wired.manager.removeServer('s1');
+      await pumpEventQueue();
+
+      expect(
+          wired.docs.get(serverId: 's1', roomId: 'r', threadId: 't'), isEmpty);
+      expect(wired.docs.get(serverId: 's2', roomId: 'r', threadId: 't'), {doc});
     });
 
     // A signal empty-out is not a removal: ServerManager.dispose() empties the

--- a/test/modules/room/document_selections_test.dart
+++ b/test/modules/room/document_selections_test.dart
@@ -13,78 +13,100 @@ void main() {
 
   group('get and set', () {
     test('returns empty set for unknown key', () {
-      expect(selections.get('room-1', 'thread-1'), isEmpty);
+      expect(selections.get('s1', 'room-1', 'thread-1'), isEmpty);
     });
 
     test('stores and retrieves selection', () {
-      selections.set('room-1', 'thread-1', {_doc1, _doc2});
-      expect(selections.get('room-1', 'thread-1'), {_doc1, _doc2});
+      selections.set('s1', 'room-1', 'thread-1', {_doc1, _doc2});
+      expect(selections.get('s1', 'room-1', 'thread-1'), {_doc1, _doc2});
     });
 
     test('selections are independent per thread', () {
-      selections.set('room-1', 'thread-1', {_doc1});
-      selections.set('room-1', 'thread-2', {_doc2});
+      selections.set('s1', 'room-1', 'thread-1', {_doc1});
+      selections.set('s1', 'room-1', 'thread-2', {_doc2});
 
-      expect(selections.get('room-1', 'thread-1'), {_doc1});
-      expect(selections.get('room-1', 'thread-2'), {_doc2});
+      expect(selections.get('s1', 'room-1', 'thread-1'), {_doc1});
+      expect(selections.get('s1', 'room-1', 'thread-2'), {_doc2});
     });
 
     test('selections are independent per room', () {
-      selections.set('room-1', 'thread-1', {_doc1});
-      selections.set('room-2', 'thread-1', {_doc2});
+      selections.set('s1', 'room-1', 'thread-1', {_doc1});
+      selections.set('s1', 'room-2', 'thread-1', {_doc2});
 
-      expect(selections.get('room-1', 'thread-1'), {_doc1});
-      expect(selections.get('room-2', 'thread-1'), {_doc2});
+      expect(selections.get('s1', 'room-1', 'thread-1'), {_doc1});
+      expect(selections.get('s1', 'room-2', 'thread-1'), {_doc2});
+    });
+
+    test('selections are independent per server', () {
+      selections.set('s1', 'room-1', 'thread-1', {_doc1});
+      selections.set('s2', 'room-1', 'thread-1', {_doc2});
+
+      expect(selections.get('s1', 'room-1', 'thread-1'), {_doc1});
+      expect(selections.get('s2', 'room-1', 'thread-1'), {_doc2});
     });
 
     test('setting empty set removes the entry', () {
-      selections.set('room-1', 'thread-1', {_doc1});
-      selections.set('room-1', 'thread-1', {});
+      selections.set('s1', 'room-1', 'thread-1', {_doc1});
+      selections.set('s1', 'room-1', 'thread-1', {});
 
-      expect(selections.get('room-1', 'thread-1'), isEmpty);
+      expect(selections.get('s1', 'room-1', 'thread-1'), isEmpty);
     });
 
     test('supports null threadId', () {
-      selections.set('room-1', null, {_doc1});
-      expect(selections.get('room-1', null), {_doc1});
-      expect(selections.get('room-1', 'thread-1'), isEmpty);
+      selections.set('s1', 'room-1', null, {_doc1});
+      expect(selections.get('s1', 'room-1', null), {_doc1});
+      expect(selections.get('s1', 'room-1', 'thread-1'), isEmpty);
     });
   });
 
   group('clearThread', () {
-    test('clearThread removes just that (room, thread)', () {
-      selections.set('room-1', 'thread-1', {_doc1});
-      selections.set('room-1', 'thread-2', {_doc2});
+    test('clearThread removes just that (server, room, thread)', () {
+      selections.set('s1', 'room-1', 'thread-1', {_doc1});
+      selections.set('s1', 'room-1', 'thread-2', {_doc2});
 
-      selections.clearThread('room-1', 'thread-1');
+      selections.clearThread('s1', 'room-1', 'thread-1');
 
-      expect(selections.get('room-1', 'thread-1'), isEmpty);
-      expect(selections.get('room-1', 'thread-2'), {_doc2});
+      expect(selections.get('s1', 'room-1', 'thread-1'), isEmpty);
+      expect(selections.get('s1', 'room-1', 'thread-2'), {_doc2});
+    });
+  });
+
+  group('clearServer', () {
+    test('drops the server\'s selections, keeping other servers\'', () {
+      selections.set('s1', 'room-1', 'thread-1', {_doc1});
+      selections.set('s1', 'room-2', null, {_doc1});
+      selections.set('s2', 'room-1', 'thread-1', {_doc2});
+
+      selections.clearServer('s1');
+
+      expect(selections.get('s1', 'room-1', 'thread-1'), isEmpty);
+      expect(selections.get('s1', 'room-2', null), isEmpty);
+      expect(selections.get('s2', 'room-1', 'thread-1'), {_doc2});
     });
   });
 
   group('migrateToThread', () {
     test('moves null-key selection to thread', () {
-      selections.set('room-1', null, {_doc1, _doc2});
-      selections.migrateToThread('room-1', 'thread-1');
+      selections.set('s1', 'room-1', null, {_doc1, _doc2});
+      selections.migrateToThread('s1', 'room-1', 'thread-1');
 
-      expect(selections.get('room-1', null), isEmpty);
-      expect(selections.get('room-1', 'thread-1'), {_doc1, _doc2});
+      expect(selections.get('s1', 'room-1', null), isEmpty);
+      expect(selections.get('s1', 'room-1', 'thread-1'), {_doc1, _doc2});
     });
 
     test('no-op when null key is empty', () {
-      selections.migrateToThread('room-1', 'thread-1');
-      expect(selections.get('room-1', 'thread-1'), isEmpty);
+      selections.migrateToThread('s1', 'room-1', 'thread-1');
+      expect(selections.get('s1', 'room-1', 'thread-1'), isEmpty);
     });
 
     test('does not affect other rooms', () {
-      selections.set('room-1', null, {_doc1});
-      selections.set('room-2', null, {_doc2});
+      selections.set('s1', 'room-1', null, {_doc1});
+      selections.set('s1', 'room-2', null, {_doc2});
 
-      selections.migrateToThread('room-1', 'thread-1');
+      selections.migrateToThread('s1', 'room-1', 'thread-1');
 
-      expect(selections.get('room-1', 'thread-1'), {_doc1});
-      expect(selections.get('room-2', null), {_doc2});
+      expect(selections.get('s1', 'room-1', 'thread-1'), {_doc1});
+      expect(selections.get('s1', 'room-2', null), {_doc2});
     });
   });
 }

--- a/test/modules/room/document_selections_test.dart
+++ b/test/modules/room/document_selections_test.dart
@@ -13,100 +13,148 @@ void main() {
 
   group('get and set', () {
     test('returns empty set for unknown key', () {
-      expect(selections.get('s1', 'room-1', 'thread-1'), isEmpty);
+      expect(selections.get(serverId: 's1', roomId: 'room-1', threadId: 't1'),
+          isEmpty);
     });
 
     test('stores and retrieves selection', () {
-      selections.set('s1', 'room-1', 'thread-1', {_doc1, _doc2});
-      expect(selections.get('s1', 'room-1', 'thread-1'), {_doc1, _doc2});
+      selections.set(
+          serverId: 's1',
+          roomId: 'room-1',
+          threadId: 't1',
+          docs: {_doc1, _doc2});
+      expect(selections.get(serverId: 's1', roomId: 'room-1', threadId: 't1'),
+          {_doc1, _doc2});
     });
 
     test('selections are independent per thread', () {
-      selections.set('s1', 'room-1', 'thread-1', {_doc1});
-      selections.set('s1', 'room-1', 'thread-2', {_doc2});
+      selections
+          .set(serverId: 's1', roomId: 'room-1', threadId: 't1', docs: {_doc1});
+      selections
+          .set(serverId: 's1', roomId: 'room-1', threadId: 't2', docs: {_doc2});
 
-      expect(selections.get('s1', 'room-1', 'thread-1'), {_doc1});
-      expect(selections.get('s1', 'room-1', 'thread-2'), {_doc2});
+      expect(selections.get(serverId: 's1', roomId: 'room-1', threadId: 't1'),
+          {_doc1});
+      expect(selections.get(serverId: 's1', roomId: 'room-1', threadId: 't2'),
+          {_doc2});
     });
 
     test('selections are independent per room', () {
-      selections.set('s1', 'room-1', 'thread-1', {_doc1});
-      selections.set('s1', 'room-2', 'thread-1', {_doc2});
+      selections
+          .set(serverId: 's1', roomId: 'room-1', threadId: 't1', docs: {_doc1});
+      selections
+          .set(serverId: 's1', roomId: 'room-2', threadId: 't1', docs: {_doc2});
 
-      expect(selections.get('s1', 'room-1', 'thread-1'), {_doc1});
-      expect(selections.get('s1', 'room-2', 'thread-1'), {_doc2});
+      expect(selections.get(serverId: 's1', roomId: 'room-1', threadId: 't1'),
+          {_doc1});
+      expect(selections.get(serverId: 's1', roomId: 'room-2', threadId: 't1'),
+          {_doc2});
     });
 
     test('selections are independent per server', () {
-      selections.set('s1', 'room-1', 'thread-1', {_doc1});
-      selections.set('s2', 'room-1', 'thread-1', {_doc2});
+      selections
+          .set(serverId: 's1', roomId: 'room-1', threadId: 't1', docs: {_doc1});
+      selections
+          .set(serverId: 's2', roomId: 'room-1', threadId: 't1', docs: {_doc2});
 
-      expect(selections.get('s1', 'room-1', 'thread-1'), {_doc1});
-      expect(selections.get('s2', 'room-1', 'thread-1'), {_doc2});
+      expect(selections.get(serverId: 's1', roomId: 'room-1', threadId: 't1'),
+          {_doc1});
+      expect(selections.get(serverId: 's2', roomId: 'room-1', threadId: 't1'),
+          {_doc2});
     });
 
     test('setting empty set removes the entry', () {
-      selections.set('s1', 'room-1', 'thread-1', {_doc1});
-      selections.set('s1', 'room-1', 'thread-1', {});
+      selections
+          .set(serverId: 's1', roomId: 'room-1', threadId: 't1', docs: {_doc1});
+      selections
+          .set(serverId: 's1', roomId: 'room-1', threadId: 't1', docs: {});
 
-      expect(selections.get('s1', 'room-1', 'thread-1'), isEmpty);
+      expect(selections.get(serverId: 's1', roomId: 'room-1', threadId: 't1'),
+          isEmpty);
     });
 
     test('supports null threadId', () {
-      selections.set('s1', 'room-1', null, {_doc1});
-      expect(selections.get('s1', 'room-1', null), {_doc1});
-      expect(selections.get('s1', 'room-1', 'thread-1'), isEmpty);
+      selections
+          .set(serverId: 's1', roomId: 'room-1', threadId: null, docs: {_doc1});
+      expect(selections.get(serverId: 's1', roomId: 'room-1', threadId: null),
+          {_doc1});
+      expect(selections.get(serverId: 's1', roomId: 'room-1', threadId: 't1'),
+          isEmpty);
     });
   });
 
   group('clearThread', () {
     test('clearThread removes just that (server, room, thread)', () {
-      selections.set('s1', 'room-1', 'thread-1', {_doc1});
-      selections.set('s1', 'room-1', 'thread-2', {_doc2});
+      selections
+          .set(serverId: 's1', roomId: 'room-1', threadId: 't1', docs: {_doc1});
+      selections
+          .set(serverId: 's1', roomId: 'room-1', threadId: 't2', docs: {_doc2});
 
-      selections.clearThread('s1', 'room-1', 'thread-1');
+      selections.clearThread(serverId: 's1', roomId: 'room-1', threadId: 't1');
 
-      expect(selections.get('s1', 'room-1', 'thread-1'), isEmpty);
-      expect(selections.get('s1', 'room-1', 'thread-2'), {_doc2});
+      expect(selections.get(serverId: 's1', roomId: 'room-1', threadId: 't1'),
+          isEmpty);
+      expect(selections.get(serverId: 's1', roomId: 'room-1', threadId: 't2'),
+          {_doc2});
     });
   });
 
   group('clearServer', () {
     test('drops the server\'s selections, keeping other servers\'', () {
-      selections.set('s1', 'room-1', 'thread-1', {_doc1});
-      selections.set('s1', 'room-2', null, {_doc1});
-      selections.set('s2', 'room-1', 'thread-1', {_doc2});
+      selections
+          .set(serverId: 's1', roomId: 'room-1', threadId: 't1', docs: {_doc1});
+      selections
+          .set(serverId: 's1', roomId: 'room-2', threadId: null, docs: {_doc1});
+      selections
+          .set(serverId: 's2', roomId: 'room-1', threadId: 't1', docs: {_doc2});
 
       selections.clearServer('s1');
 
-      expect(selections.get('s1', 'room-1', 'thread-1'), isEmpty);
-      expect(selections.get('s1', 'room-2', null), isEmpty);
-      expect(selections.get('s2', 'room-1', 'thread-1'), {_doc2});
+      expect(selections.get(serverId: 's1', roomId: 'room-1', threadId: 't1'),
+          isEmpty);
+      expect(selections.get(serverId: 's1', roomId: 'room-2', threadId: null),
+          isEmpty);
+      expect(selections.get(serverId: 's2', roomId: 'room-1', threadId: 't1'),
+          {_doc2});
     });
   });
 
   group('migrateToThread', () {
     test('moves null-key selection to thread', () {
-      selections.set('s1', 'room-1', null, {_doc1, _doc2});
-      selections.migrateToThread('s1', 'room-1', 'thread-1');
+      selections.set(
+          serverId: 's1',
+          roomId: 'room-1',
+          threadId: null,
+          docs: {_doc1, _doc2});
+      selections.migrateToThread(
+          serverId: 's1', roomId: 'room-1', threadId: 't1');
 
-      expect(selections.get('s1', 'room-1', null), isEmpty);
-      expect(selections.get('s1', 'room-1', 'thread-1'), {_doc1, _doc2});
+      expect(selections.get(serverId: 's1', roomId: 'room-1', threadId: null),
+          isEmpty);
+      expect(selections.get(serverId: 's1', roomId: 'room-1', threadId: 't1'),
+          {_doc1, _doc2});
     });
 
     test('no-op when null key is empty', () {
-      selections.migrateToThread('s1', 'room-1', 'thread-1');
-      expect(selections.get('s1', 'room-1', 'thread-1'), isEmpty);
+      selections.migrateToThread(
+          serverId: 's1', roomId: 'room-1', threadId: 't1');
+      expect(selections.get(serverId: 's1', roomId: 'room-1', threadId: 't1'),
+          isEmpty);
     });
 
     test('does not affect other rooms', () {
-      selections.set('s1', 'room-1', null, {_doc1});
-      selections.set('s1', 'room-2', null, {_doc2});
+      selections
+          .set(serverId: 's1', roomId: 'room-1', threadId: null, docs: {_doc1});
+      selections
+          .set(serverId: 's1', roomId: 'room-2', threadId: null, docs: {_doc2});
 
-      selections.migrateToThread('s1', 'room-1', 'thread-1');
+      selections.migrateToThread(
+          serverId: 's1', roomId: 'room-1', threadId: 't1');
 
-      expect(selections.get('s1', 'room-1', 'thread-1'), {_doc1});
-      expect(selections.get('s1', 'room-2', null), {_doc2});
+      expect(selections.get(serverId: 's1', roomId: 'room-1', threadId: 't1'),
+          {_doc1});
+      expect(selections.get(serverId: 's1', roomId: 'room-2', threadId: null),
+          {_doc2});
     });
   });
 }

--- a/test/modules/room/user_switch_teardown_test.dart
+++ b/test/modules/room/user_switch_teardown_test.dart
@@ -1,0 +1,229 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:soliplex_agent/soliplex_agent.dart';
+
+import 'package:soliplex_frontend/src/modules/auth/auth_session.dart';
+import 'package:soliplex_frontend/src/modules/auth/auth_tokens.dart';
+import 'package:soliplex_frontend/src/modules/auth/server_entry.dart';
+import 'package:soliplex_frontend/src/modules/auth/server_manager.dart';
+import 'package:soliplex_frontend/src/modules/room/agent_runtime_manager.dart';
+import 'package:soliplex_frontend/src/modules/room/document_selections.dart';
+import 'package:soliplex_frontend/src/modules/room/run_registry.dart';
+import 'package:soliplex_frontend/src/modules/room/upload_tracker.dart';
+import 'package:soliplex_frontend/src/modules/room/upload_tracker_registry.dart';
+import 'package:soliplex_frontend/src/modules/room/user_switch_teardown.dart';
+
+import '../../helpers/fakes.dart';
+import '../../helpers/test_server_entry.dart';
+
+const _key = (serverId: 's1', roomId: 'room', threadId: 'thread');
+const _doc = RagDocument(id: 'd1', title: 'Doc');
+
+void _login(ServerEntry entry, String sub) {
+  entry.auth.login(
+    provider: const OidcProvider(
+      discoveryUrl: 'https://auth.example.com/.well-known/openid-configuration',
+      clientId: 'test-client',
+    ),
+    tokens: AuthTokens(
+      accessToken: testAccessToken(sub: sub),
+      refreshToken: 'refresh',
+      expiresAt: DateTime.now().add(const Duration(hours: 1)),
+    ),
+  );
+}
+
+typedef _Wired = ({
+  ServerManager manager,
+  ServerEntry entry,
+  AgentRuntimeManager runtimeManager,
+  RunRegistry registry,
+  UploadTrackerRegistry uploadRegistry,
+  DocumentSelections docs,
+});
+
+void main() {
+  // Builds a server signed in as [initialSub], with the four managers wired to
+  // the server signal but NOT yet populated, and NO coordinator yet — so a test
+  // controls exactly when the coordinator first sees the identity.
+  _Wired wire({String initialSub = 'alice'}) {
+    final manager = ServerManager(
+      authFactory: () => AuthSession(refreshService: FakeTokenRefreshService()),
+      clientFactory: ({getToken, tokenRefresher}) => FakeHttpClient(),
+      storage: InMemoryServerStorage(),
+    );
+    manager.addServer(
+      serverId: 's1',
+      serverUrl: Uri.parse('http://s1.test'),
+    );
+    final entry = manager.servers.value['s1']!;
+    _login(entry, initialSub);
+
+    final runtimeManager = AgentRuntimeManager(
+      platform: TestPlatformConstraints(),
+      toolRegistryResolver: (_) async => const ToolRegistry(),
+      logger: testLogger(),
+      servers: manager.servers,
+    );
+    final registry = RunRegistry(servers: manager.servers);
+    final uploadRegistry = UploadTrackerRegistry(servers: manager.servers);
+    final docs = DocumentSelections();
+
+    addTearDown(() async {
+      registry.dispose();
+      uploadRegistry.dispose();
+      await runtimeManager.dispose();
+      manager.dispose();
+    });
+
+    return (
+      manager: manager,
+      entry: entry,
+      runtimeManager: runtimeManager,
+      registry: registry,
+      uploadRegistry: uploadRegistry,
+      docs: docs,
+    );
+  }
+
+  UserSwitchTeardown coordinator(_Wired w) {
+    final teardown = UserSwitchTeardown(
+      servers: w.manager.servers,
+      runtimeManager: w.runtimeManager,
+      registry: w.registry,
+      uploadRegistry: w.uploadRegistry,
+      documentSelections: w.docs,
+    );
+    addTearDown(teardown.dispose);
+    return teardown;
+  }
+
+  // Fills all four managers with state attributable to the current user.
+  ({AgentRuntime runtime, UploadTracker tracker}) populate(_Wired w) {
+    final runtime = w.runtimeManager.getRuntime(w.entry.connection);
+    w.registry.register(_key, ManualAgentSession(_key));
+    final tracker = w.uploadRegistry.trackerFor(entry: w.entry, roomId: 'room');
+    w.docs.set('room', 'thread', {_doc});
+    return (runtime: runtime, tracker: tracker);
+  }
+
+  void expectEvicted(_Wired w, AgentRuntime runtime, UploadTracker tracker) {
+    expect(identical(w.runtimeManager.getRuntime(w.entry.connection), runtime),
+        isFalse,
+        reason: 'runtime should be evicted and rebuilt');
+    expect(w.registry.activeSession(_key), isNull,
+        reason: 'run should be evicted');
+    expect(
+      identical(
+          w.uploadRegistry.trackerFor(entry: w.entry, roomId: 'room'), tracker),
+      isFalse,
+      reason: 'upload tracker should be evicted and rebuilt',
+    );
+    expect(w.docs.get('room', 'thread'), isEmpty,
+        reason: 'document selections should be cleared');
+  }
+
+  void expectRetained(_Wired w, AgentRuntime runtime, UploadTracker tracker) {
+    expect(identical(w.runtimeManager.getRuntime(w.entry.connection), runtime),
+        isTrue,
+        reason: 'runtime should be retained');
+    expect(w.registry.activeSession(_key), isNotNull,
+        reason: 'run should be retained');
+    expect(
+      identical(
+          w.uploadRegistry.trackerFor(entry: w.entry, roomId: 'room'), tracker),
+      isTrue,
+      reason: 'upload tracker should be retained',
+    );
+    expect(w.docs.get('room', 'thread'), isNotEmpty,
+        reason: 'document selections should be retained');
+  }
+
+  group('UserSwitchTeardown', () {
+    test('a different user signing in evicts the prior user\'s state', () {
+      final w = wire(initialSub: 'alice');
+      coordinator(w);
+      final captured = populate(w);
+
+      w.entry.auth.logout();
+      _login(w.entry, 'bob');
+
+      expectEvicted(w, captured.runtime, captured.tracker);
+    });
+
+    test('a same-user token refresh evicts nothing', () {
+      final w = wire(initialSub: 'alice');
+      coordinator(w);
+      final captured = populate(w);
+
+      // A refresh swaps the session for the same identity.
+      _login(w.entry, 'alice');
+
+      expectRetained(w, captured.runtime, captured.tracker);
+    });
+
+    test('first sight of an already-signed-in user does not evict', () {
+      final w = wire(initialSub: 'alice');
+      final captured = populate(w);
+
+      // Coordinator constructed AFTER the user already has live state, as on a
+      // cold boot where restoreServers signed the user in before wiring.
+      coordinator(w);
+
+      expectRetained(w, captured.runtime, captured.tracker);
+    });
+
+    test('a switch on one server leaves another server\'s state intact', () {
+      final w = wire(initialSub: 'alice');
+      w.manager.addServer(
+        serverId: 's2',
+        serverUrl: Uri.parse('http://s2.test'),
+      );
+      final other = w.manager.servers.value['s2']!;
+      _login(other, 'carol');
+
+      coordinator(w);
+
+      // Live state on the untouched server.
+      final otherRuntime = w.runtimeManager.getRuntime(other.connection);
+      const otherKey = (serverId: 's2', roomId: 'room', threadId: 'thread');
+      w.registry.register(otherKey, ManualAgentSession(otherKey));
+      final otherTracker =
+          w.uploadRegistry.trackerFor(entry: other, roomId: 'room');
+
+      final captured = populate(w);
+      w.entry.auth.logout();
+      _login(w.entry, 'bob');
+
+      expectEvicted(w, captured.runtime, captured.tracker);
+      // The three server-keyed registries isolate per server; only s1 is torn
+      // down. (DocumentSelections has no server dimension and is cleared
+      // wholesale by design.)
+      expect(
+        identical(w.runtimeManager.getRuntime(other.connection), otherRuntime),
+        isTrue,
+        reason: "other server's runtime should survive",
+      );
+      expect(w.registry.activeSession(otherKey), isNotNull,
+          reason: "other server's run should survive");
+      expect(
+        identical(w.uploadRegistry.trackerFor(entry: other, roomId: 'room'),
+            otherTracker),
+        isTrue,
+        reason: "other server's upload tracker should survive",
+      );
+    });
+
+    test('expiry then a different user signing in evicts the prior state', () {
+      final w = wire(initialSub: 'alice');
+      coordinator(w);
+      final captured = populate(w);
+
+      // Session expires without an explicit logout.
+      w.entry.auth.markSessionExpired();
+      expectRetained(w, captured.runtime, captured.tracker);
+
+      _login(w.entry, 'bob');
+      expectEvicted(w, captured.runtime, captured.tracker);
+    });
+  });
+}

--- a/test/modules/room/user_switch_teardown_test.dart
+++ b/test/modules/room/user_switch_teardown_test.dart
@@ -313,5 +313,67 @@ void main() {
           isNotEmpty,
           reason: 'document selections should be retained on a first sign-in');
     });
+
+    test('a failing eviction is logged and the remaining caches still evict',
+        () {
+      final w = wire(initialSub: 'alice');
+      // Wire a runtime manager whose evictServer throws. It is the first of the
+      // four steps, so a guard that wrapped the whole sequence — rather than
+      // each step — would strand runs, uploads, and filters and unwind the
+      // sign-in that recorded the switch.
+      final throwingRuntime = _ThrowingRuntimeManager(
+        platform: TestPlatformConstraints(),
+        toolRegistryResolver: (_) async => const ToolRegistry(),
+        logger: testLogger(),
+        servers: w.manager.servers,
+      );
+      addTearDown(throwingRuntime.dispose);
+      final teardown = UserSwitchTeardown(
+        servers: w.manager.servers,
+        runtimeManager: throwingRuntime,
+        registry: w.registry,
+        uploadRegistry: w.uploadRegistry,
+        documentSelections: w.docs,
+      );
+      addTearDown(teardown.dispose);
+
+      w.registry.register(_key, ManualAgentSession(_key));
+      final tracker =
+          w.uploadRegistry.trackerFor(entry: w.entry, roomId: 'room');
+      w.docs.set(
+          serverId: 's1', roomId: 'room', threadId: 'thread', docs: {_doc});
+
+      expect(() {
+        w.entry.auth.logout();
+        _login(w.entry, 'bob');
+      }, returnsNormally,
+          reason: 'a throwing step must not unwind the sign-in');
+
+      expect(w.registry.activeSession(_key), isNull,
+          reason: 'run should be evicted despite the earlier step throwing');
+      expect(
+        identical(w.uploadRegistry.trackerFor(entry: w.entry, roomId: 'room'),
+            tracker),
+        isFalse,
+        reason: 'upload tracker should be evicted despite the earlier throw',
+      );
+      expect(w.docs.get(serverId: 's1', roomId: 'room', threadId: 'thread'),
+          isEmpty,
+          reason: 'document selections should be cleared despite the throw');
+    });
   });
+}
+
+/// Runtime manager whose [evictServer] throws, to exercise the per-step
+/// teardown guard in [UserSwitchTeardown].
+class _ThrowingRuntimeManager extends AgentRuntimeManager {
+  _ThrowingRuntimeManager({
+    required super.platform,
+    required super.toolRegistryResolver,
+    required super.logger,
+    required super.servers,
+  });
+
+  @override
+  void evictServer(String serverId) => throw StateError('evict boom');
 }

--- a/test/modules/room/user_switch_teardown_test.dart
+++ b/test/modules/room/user_switch_teardown_test.dart
@@ -102,7 +102,8 @@ void main() {
     final runtime = w.runtimeManager.getRuntime(w.entry.connection);
     w.registry.register(_key, ManualAgentSession(_key));
     final tracker = w.uploadRegistry.trackerFor(entry: w.entry, roomId: 'room');
-    w.docs.set('s1', 'room', 'thread', {_doc});
+    w.docs
+        .set(serverId: 's1', roomId: 'room', threadId: 'thread', docs: {_doc});
     return (runtime: runtime, tracker: tracker);
   }
 
@@ -118,7 +119,8 @@ void main() {
       isFalse,
       reason: 'upload tracker should be evicted and rebuilt',
     );
-    expect(w.docs.get('s1', 'room', 'thread'), isEmpty,
+    expect(
+        w.docs.get(serverId: 's1', roomId: 'room', threadId: 'thread'), isEmpty,
         reason: 'document selections should be cleared');
   }
 
@@ -134,7 +136,8 @@ void main() {
       isTrue,
       reason: 'upload tracker should be retained',
     );
-    expect(w.docs.get('s1', 'room', 'thread'), isNotEmpty,
+    expect(w.docs.get(serverId: 's1', roomId: 'room', threadId: 'thread'),
+        isNotEmpty,
         reason: 'document selections should be retained');
   }
 
@@ -211,7 +214,8 @@ void main() {
       w.registry.register(otherKey, ManualAgentSession(otherKey));
       final otherTracker =
           w.uploadRegistry.trackerFor(entry: other, roomId: 'room');
-      w.docs.set('s2', 'room', 'thread', {_doc});
+      w.docs.set(
+          serverId: 's2', roomId: 'room', threadId: 'thread', docs: {_doc});
 
       final captured = populate(w);
       w.entry.auth.logout();
@@ -232,7 +236,8 @@ void main() {
         isTrue,
         reason: "other server's upload tracker should survive",
       );
-      expect(w.docs.get('s2', 'room', 'thread'), isNotEmpty,
+      expect(w.docs.get(serverId: 's2', roomId: 'room', threadId: 'thread'),
+          isNotEmpty,
           reason: "other server's document selections should survive");
     });
 
@@ -247,6 +252,66 @@ void main() {
 
       _login(w.entry, 'bob');
       expectEvicted(w, captured.runtime, captured.tracker);
+    });
+
+    test('switching back to a prior user evicts again (baseline advances)', () {
+      final w = wire(initialSub: 'alice');
+      coordinator(w);
+
+      // alice -> bob evicts alice's state.
+      var captured = populate(w);
+      w.entry.auth.logout();
+      _login(w.entry, 'bob');
+      expectEvicted(w, captured.runtime, captured.tracker);
+
+      // bob -> alice must evict again: the baseline has to have advanced to bob,
+      // not stayed at the original alice.
+      captured = populate(w);
+      w.entry.auth.logout();
+      _login(w.entry, 'alice');
+      expectEvicted(w, captured.runtime, captured.tracker);
+    });
+
+    test('a server signing in after wiring records a baseline, not a switch',
+        () {
+      final w = wire(initialSub: 'alice');
+      coordinator(w);
+
+      // A second server appears while the coordinator is already subscribed.
+      w.manager.addServer(
+        serverId: 's2',
+        serverUrl: Uri.parse('http://s2.test'),
+      );
+      final other = w.manager.servers.value['s2']!;
+
+      // Live state on s2 before its first sign-in.
+      final otherRuntime = w.runtimeManager.getRuntime(other.connection);
+      const otherKey = (serverId: 's2', roomId: 'room', threadId: 'thread');
+      w.registry.register(otherKey, ManualAgentSession(otherKey));
+      final otherTracker =
+          w.uploadRegistry.trackerFor(entry: other, roomId: 'room');
+      w.docs.set(
+          serverId: 's2', roomId: 'room', threadId: 'thread', docs: {_doc});
+
+      // First sign-in on a newly-seen server is a baseline, not a switch.
+      _login(other, 'carol');
+
+      expect(
+        identical(w.runtimeManager.getRuntime(other.connection), otherRuntime),
+        isTrue,
+        reason: 'runtime should be retained on a first sign-in',
+      );
+      expect(w.registry.activeSession(otherKey), isNotNull,
+          reason: 'run should be retained on a first sign-in');
+      expect(
+        identical(w.uploadRegistry.trackerFor(entry: other, roomId: 'room'),
+            otherTracker),
+        isTrue,
+        reason: 'upload tracker should be retained on a first sign-in',
+      );
+      expect(w.docs.get(serverId: 's2', roomId: 'room', threadId: 'thread'),
+          isNotEmpty,
+          reason: 'document selections should be retained on a first sign-in');
     });
   });
 }

--- a/test/modules/room/user_switch_teardown_test.dart
+++ b/test/modules/room/user_switch_teardown_test.dart
@@ -102,7 +102,7 @@ void main() {
     final runtime = w.runtimeManager.getRuntime(w.entry.connection);
     w.registry.register(_key, ManualAgentSession(_key));
     final tracker = w.uploadRegistry.trackerFor(entry: w.entry, roomId: 'room');
-    w.docs.set('room', 'thread', {_doc});
+    w.docs.set('s1', 'room', 'thread', {_doc});
     return (runtime: runtime, tracker: tracker);
   }
 
@@ -118,7 +118,7 @@ void main() {
       isFalse,
       reason: 'upload tracker should be evicted and rebuilt',
     );
-    expect(w.docs.get('room', 'thread'), isEmpty,
+    expect(w.docs.get('s1', 'room', 'thread'), isEmpty,
         reason: 'document selections should be cleared');
   }
 
@@ -134,7 +134,7 @@ void main() {
       isTrue,
       reason: 'upload tracker should be retained',
     );
-    expect(w.docs.get('room', 'thread'), isNotEmpty,
+    expect(w.docs.get('s1', 'room', 'thread'), isNotEmpty,
         reason: 'document selections should be retained');
   }
 
@@ -189,15 +189,14 @@ void main() {
       w.registry.register(otherKey, ManualAgentSession(otherKey));
       final otherTracker =
           w.uploadRegistry.trackerFor(entry: other, roomId: 'room');
+      w.docs.set('s2', 'room', 'thread', {_doc});
 
       final captured = populate(w);
       w.entry.auth.logout();
       _login(w.entry, 'bob');
 
       expectEvicted(w, captured.runtime, captured.tracker);
-      // The three server-keyed registries isolate per server; only s1 is torn
-      // down. (DocumentSelections has no server dimension and is cleared
-      // wholesale by design.)
+      // All four caches isolate per server; only s1 is torn down.
       expect(
         identical(w.runtimeManager.getRuntime(other.connection), otherRuntime),
         isTrue,
@@ -211,6 +210,8 @@ void main() {
         isTrue,
         reason: "other server's upload tracker should survive",
       );
+      expect(w.docs.get('s2', 'room', 'thread'), isNotEmpty,
+          reason: "other server's document selections should survive");
     });
 
     test('expiry then a different user signing in evicts the prior state', () {

--- a/test/modules/room/user_switch_teardown_test.dart
+++ b/test/modules/room/user_switch_teardown_test.dart
@@ -172,6 +172,28 @@ void main() {
       expectRetained(w, captured.runtime, captured.tracker);
     });
 
+    test('a logout alone evicts nothing', () {
+      final w = wire(initialSub: 'alice');
+      coordinator(w);
+      final captured = populate(w);
+
+      w.entry.auth.logout();
+
+      expectRetained(w, captured.runtime, captured.tracker);
+    });
+
+    test('a disposed coordinator ignores later user switches', () {
+      final w = wire(initialSub: 'alice');
+      final teardown = coordinator(w);
+      final captured = populate(w);
+
+      teardown.dispose();
+      w.entry.auth.logout();
+      _login(w.entry, 'bob');
+
+      expectRetained(w, captured.runtime, captured.tracker);
+    });
+
     test('a switch on one server leaves another server\'s state intact', () {
       final w = wire(initialSub: 'alice');
       w.manager.addServer(


### PR DESCRIPTION
## Summary

Tears down a server's **in-memory** session state when a *different* user signs in on it within the same app session, and scopes document-filter selections per server so they can be cleared cleanly.

Persistent device-local state is already partitioned by user identity. But four in-memory caches would otherwise carry the prior user's state into the next session:

- `AgentRuntimeManager` (keyed on the live `ServerConnection`, which re-auth reuses)
- `RunRegistry` (keyed on the stable `serverId`)
- `UploadTrackerRegistry` (keyed on `serverId`)
- `DocumentSelections` (a single shared map, previously not partitioned by user)

The new `UserSwitchTeardown` watches each server's `AuthSession.currentUserId` and evicts all four when a server's identity moves from one non-null user to a different non-null user. Reading identity state (rather than intercepting sign-in call sites) covers every auth path — silent restore-on-launch, token refresh (no teardown), and expiry-then-different-user (a switch).

## Changes

- **`DocumentSelections`** now keys on `(serverId, roomId, threadId)` via a named record, isolating selections per server, and gains `clearServer`.
- **`AgentRuntimeManager` / `RunRegistry` / `UploadTrackerRegistry`** expose `evictServer(serverId)` via a shared predicate-driven `_evictWhere`; `UploadTrackerRegistry` hardens disposal with remove-before-dispose + swallow-and-log.
- **`RemovedServerCleanup`** now also clears a removed server's document-filter selections.
- **`UserSwitchTeardown`** (new) coordinates the four evictions, each isolated so one throw can't strand the rest or unwind the sign-in.

## Known limitation

Servers whose IdP issues **opaque (non-JWT) access tokens** report a `null` identity for every user, so a switch between two such users is undetectable — the next user inherits the prior in-memory session. This mirrors the shared unauthenticated bucket those servers already use for persistent state, and is documented in the `UserSwitchTeardown` class doc.

## Test plan

- `flutter analyze` — clean across the project.
- `flutter test` on the affected suites — all green:
  - `test/modules/room/user_switch_teardown_test.dart` (10 tests: switch/refresh/first-sight/logout/disposed/per-server-isolation/expiry-then-switch/switch-back/late-signin baseline, and step-isolation under a throwing eviction — mutation-verified).
  - `test/modules/room/document_selections_test.dart`, `test/core/removed_server_cleanup_test.dart`.
- CHANGELOG updated (Fixed + Security).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
