### PR TITLE
refactor(room): sync route for thread upload POST with backend v0.72.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@ Versions follow the `version+build` scheme from `pubspec.yaml`, bumped via
 
 ### Changed
 
+- Update route for thread-specific file uploads to stay current with
+  backend release
+  [v0.72.1](https://github.com/soliplex/soliplex/releases/tag/v0.72.1).
 - Device-local cleanup on server removal is driven by an explicit
   `ServerManager.onServerRemoved` event instead of diffing the servers signal.
   Only a genuine removal clears a server's read state, unread-divider anchors,

--- a/packages/soliplex_client/lib/src/api/soliplex_api.dart
+++ b/packages/soliplex_client/lib/src/api/soliplex_api.dart
@@ -1537,7 +1537,9 @@ class SoliplexApi {
     void Function(int sent, int total)? onProgress,
     CancelToken? cancelToken,
   }) async {
-    final uri = _urlBuilder.build(pathSegments: ['uploads', roomId, threadId]);
+    final uri = _urlBuilder.build(
+        pathSegments: ['uploads', roomId, 'thread', threadId],
+    );
     if (webFileBlob != null) {
       await _transport.request<void>(
         'POST',

--- a/packages/soliplex_client/lib/src/api/soliplex_api.dart
+++ b/packages/soliplex_client/lib/src/api/soliplex_api.dart
@@ -1538,7 +1538,7 @@ class SoliplexApi {
     CancelToken? cancelToken,
   }) async {
     final uri = _urlBuilder.build(
-        pathSegments: ['uploads', roomId, 'thread', threadId],
+      pathSegments: ['uploads', roomId, 'thread', threadId],
     );
     if (webFileBlob != null) {
       await _transport.request<void>(

--- a/packages/soliplex_client/test/api/upload_test.dart
+++ b/packages/soliplex_client/test/api/upload_test.dart
@@ -86,7 +86,7 @@ void main() {
 
   group('uploadFileToThread', () {
     test(
-      'sends streamed multipart POST to /uploads/{roomId}/{threadId}',
+      'sends streamed multipart POST to /uploads/{roomId}/thread/{threadId}',
       () async {
         when(
           () => mockTransport.request<void>(
@@ -119,7 +119,7 @@ void main() {
         ).captured;
 
         final uri = captured[0] as Uri;
-        expect(uri.path, contains('/uploads/room-123/thread-456'));
+        expect(uri.path, contains('/uploads/room-123/thread/thread-456'));
 
         final body = captured[1] as Stream<List<int>>;
         final bytes = await body.fold<List<int>>(


### PR DESCRIPTION
# Summary

Backend has deprecated the `POST /api/v1/uploads/{room_id}/{thread_id}` route in favor of 
`POST /api/v1/uploads/{room_id}/thread/{thread_id}`, for consistency with the `GET` route.