### PR TITLE
fix(soliplex_client): harden HTTP transport + API decode against crashes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,12 @@ Versions follow the `version+build` scheme from `pubspec.yaml`, bumped via
 
 ### Fixed
 
+- A malformed backend response no longer crashes the client: a payload whose
+  shape doesn't match the contract (a wrong-typed or missing field, non-UTF-8
+  or undecodable JSON body) now surfaces as a non-retryable error carrying the
+  underlying cause instead of an uncaught type/format error. A non-UTF-8 *error*
+  body can no longer mask the HTTP status, so retry and re-auth still classify
+  correctly.
 - Deleting the open thread no longer writes a stale "read" marker for it on the
   way out (via dispose, or the auto-navigate to a sibling thread), so a thread
   later re-created under the same id no longer appears already-read.

--- a/packages/soliplex_client/lib/src/api/soliplex_api.dart
+++ b/packages/soliplex_client/lib/src/api/soliplex_api.dart
@@ -197,13 +197,7 @@ class SoliplexApi {
       cancelToken: cancelToken,
     );
 
-    final token = response['mcp_token'] as String?;
-    if (token == null) {
-      throw FormatException(
-        'Response missing "mcp_token" field for room $roomId',
-      );
-    }
-    return token;
+    return _requireString(response, 'mcp_token', 'getMcpToken(room $roomId)');
   }
 
   /// Gets documents available for narrowing RAG in a room.
@@ -286,10 +280,26 @@ class SoliplexApi {
       cancelToken: cancelToken,
     );
     // Backend returns {"threads": [...]} - extract the threads array
-    final threads = response['threads'] as List<dynamic>;
-    return threads
-        .map((e) => threadInfoFromJson(e as Map<String, dynamic>))
-        .toList();
+    final rawThreads = response['threads'];
+    if (rawThreads is! List) {
+      throw MalformedResponseException(
+        message: 'getThreads: expected a list "threads", '
+            'got ${rawThreads.runtimeType}.',
+      );
+    }
+    try {
+      return rawThreads
+          .map((e) => threadInfoFromJson(e as Map<String, dynamic>))
+          .toList();
+    } on SoliplexException {
+      rethrow;
+    } on Object catch (error, stackTrace) {
+      throw MalformedResponseException(
+        message: 'getThreads: malformed thread entry.',
+        originalError: error,
+        stackTrace: stackTrace,
+      );
+    }
   }
 
   /// Gets last-activity stats for the user's accessible rooms in one request.
@@ -440,7 +450,7 @@ class SoliplexApi {
     // Prefer the backend's server `created`; fall back to the client clock if
     // the response omits it or the value is malformed.
     final threadInfo = ThreadInfo(
-      id: response['thread_id'] as String,
+      id: _requireString(response, 'thread_id', 'createThread'),
       roomId: roomId,
       initialRunId: initialRunId ?? '',
       name: threadName,
@@ -552,7 +562,7 @@ class SoliplexApi {
     // backend's server `created`; fall back to the client clock if the response
     // omits it or the value is malformed.
     return RunInfo(
-      id: response['run_id'] as String,
+      id: _requireString(response, 'run_id', 'createRun'),
       threadId: threadId,
       createdAt: _createdOrNow(response['created']),
     );
@@ -1383,9 +1393,24 @@ class SoliplexApi {
       cancelToken: cancelToken,
     );
 
-    final schemas = response['schemas'] as Map<String, dynamic>?;
-    if (schemas == null) return {};
-    return schemas.map((k, v) => MapEntry(k, v as String));
+    final rawSchemas = response['schemas'];
+    // An absent "schemas" is a legitimate "no schemas configured" — empty map.
+    if (rawSchemas == null) return {};
+    if (rawSchemas is! Map<String, dynamic>) {
+      throw MalformedResponseException(
+        message: 'getMontySchemas: expected a map "schemas", '
+            'got ${rawSchemas.runtimeType}.',
+      );
+    }
+    return rawSchemas.map((k, v) {
+      if (v is! String) {
+        throw MalformedResponseException(
+          message: 'getMontySchemas: expected a String value for "$k", '
+              'got ${v.runtimeType}.',
+        );
+      }
+      return MapEntry(k, v);
+    });
   }
 
   // ============================================================
@@ -1690,6 +1715,22 @@ class SoliplexApi {
     if (value.isEmpty) {
       throw ArgumentError.value(value, name, 'must not be empty');
     }
+  }
+
+  /// Reads a required String [key] from a decoded JSON [response], raising a
+  /// (non-retryable) [MalformedResponseException] instead of a raw `TypeError`
+  /// when the field is missing, null, or not a String. [context] names the
+  /// calling endpoint in the message.
+  String _requireString(
+    Map<String, dynamic> response,
+    String key,
+    String context,
+  ) {
+    final value = response[key];
+    if (value is String) return value;
+    throw MalformedResponseException(
+      message: '$context: expected a String "$key", got ${value.runtimeType}.',
+    );
   }
 
   /// Extracts typed entries from a list field in a JSON response.

--- a/packages/soliplex_client/lib/src/api/soliplex_api.dart
+++ b/packages/soliplex_client/lib/src/api/soliplex_api.dart
@@ -295,7 +295,7 @@ class SoliplexApi {
       rethrow;
     } on Object catch (error, stackTrace) {
       throw MalformedResponseException(
-        message: 'getThreads: malformed thread entry.',
+        message: 'getThreads: malformed thread entry: $error',
         originalError: error,
         stackTrace: stackTrace,
       );

--- a/packages/soliplex_client/lib/src/http/http_response.dart
+++ b/packages/soliplex_client/lib/src/http/http_response.dart
@@ -30,7 +30,19 @@ class HttpResponse {
   final String? reasonPhrase;
 
   /// The response body decoded as a UTF-8 string.
+  ///
+  /// Strict: throws [FormatException] on malformed bytes. Used for success
+  /// payloads, where a non-UTF-8 body is a genuine malformed response rather
+  /// than something to paper over.
   String get body => utf8.decode(bodyBytes);
+
+  /// The response body decoded as UTF-8, substituting the replacement
+  /// character for malformed byte sequences instead of throwing.
+  ///
+  /// Used for error bodies (human-readable diagnostics only): a non-UTF-8
+  /// error payload must never mask the HTTP status, or it would defeat
+  /// retry / re-auth classification.
+  String get bodyLenient => utf8.decode(bodyBytes, allowMalformed: true);
 
   /// Whether this response indicates success (2xx status code).
   bool get isSuccess => statusCode >= 200 && statusCode < 300;

--- a/packages/soliplex_client/lib/src/http/http_transport.dart
+++ b/packages/soliplex_client/lib/src/http/http_transport.dart
@@ -393,12 +393,11 @@ class HttpTransport {
     HttpResponse response,
     T Function(Map<String, dynamic>)? fromJson,
   ) {
-    // Every failure below — non-UTF-8 bytes, a `null`/`body`/`decoded` cast
-    // that doesn't match T, invalid JSON, or a throwing fromJson mapper —
-    // is a malformed *payload* on an otherwise well-formed HTTP response, so
-    // it surfaces as a (non-retryable) MalformedResponseException rather than a
-    // raw TypeError/FormatException. A SoliplexException from the mapper passes
-    // through unchanged.
+    // Any failure decoding the body of an otherwise well-formed HTTP response
+    // (bad bytes, a cast that doesn't match T, invalid JSON, or a throwing
+    // fromJson mapper) is a malformed *payload*, surfaced as a (non-retryable)
+    // MalformedResponseException rather than a raw TypeError/FormatException. A
+    // SoliplexException from the mapper passes through unchanged.
     try {
       final body = response.body;
 
@@ -433,7 +432,7 @@ class HttpTransport {
       rethrow;
     } on Object catch (error, stackTrace) {
       throw MalformedResponseException(
-        message: 'Could not decode the response body as $T.',
+        message: 'Could not decode the response body as $T: $error',
         originalError: error,
         stackTrace: stackTrace,
       );

--- a/packages/soliplex_client/lib/src/http/http_transport.dart
+++ b/packages/soliplex_client/lib/src/http/http_transport.dart
@@ -331,7 +331,9 @@ class HttpTransport {
       return; // Success
     }
 
-    final body = response.body;
+    // Lenient: an error body is diagnostic text only, and a non-UTF-8 payload
+    // must not throw here or it would mask the status (breaking retry/re-auth).
+    final body = response.bodyLenient;
     final serverMessage = _extractErrorMessage(body);
     final message = serverMessage ?? 'HTTP $statusCode';
 
@@ -391,33 +393,50 @@ class HttpTransport {
     HttpResponse response,
     T Function(Map<String, dynamic>)? fromJson,
   ) {
-    final body = response.body;
+    // Every failure below — non-UTF-8 bytes, a `null`/`body`/`decoded` cast
+    // that doesn't match T, invalid JSON, or a throwing fromJson mapper —
+    // is a malformed *payload* on an otherwise well-formed HTTP response, so
+    // it surfaces as a (non-retryable) MalformedResponseException rather than a
+    // raw TypeError/FormatException. A SoliplexException from the mapper passes
+    // through unchanged.
+    try {
+      final body = response.body;
 
-    // Handle empty body
-    if (body.isEmpty) {
-      return null as T;
+      // Empty body is legitimate for a nullable/void T (e.g. 204); a failed
+      // cast here means the caller expected a body that never arrived.
+      if (body.isEmpty) {
+        return null as T;
+      }
+
+      // Check if response is JSON
+      final contentType = response.contentType ?? '';
+      final isJson = contentType.contains('application/json') ||
+          body.trimLeft().startsWith('{') ||
+          body.trimLeft().startsWith('[');
+
+      if (!isJson) {
+        // Return raw string
+        return body as T;
+      }
+
+      // Decode JSON
+      final decoded = jsonDecode(body);
+
+      // If fromJson is provided and response is a Map, use it
+      if (fromJson != null && decoded is Map<String, dynamic>) {
+        return fromJson(decoded);
+      }
+
+      // Return decoded JSON as-is
+      return decoded as T;
+    } on SoliplexException {
+      rethrow;
+    } on Object catch (error, stackTrace) {
+      throw MalformedResponseException(
+        message: 'Could not decode the response body as $T.',
+        originalError: error,
+        stackTrace: stackTrace,
+      );
     }
-
-    // Check if response is JSON
-    final contentType = response.contentType ?? '';
-    final isJson = contentType.contains('application/json') ||
-        body.trimLeft().startsWith('{') ||
-        body.trimLeft().startsWith('[');
-
-    if (!isJson) {
-      // Return raw string
-      return body as T;
-    }
-
-    // Decode JSON
-    final decoded = jsonDecode(body);
-
-    // If fromJson is provided and response is a Map, use it
-    if (fromJson != null && decoded is Map<String, dynamic>) {
-      return fromJson(decoded);
-    }
-
-    // Return decoded JSON as-is
-    return decoded as T;
   }
 }

--- a/packages/soliplex_client/test/api/soliplex_api_test.dart
+++ b/packages/soliplex_client/test/api/soliplex_api_test.dart
@@ -437,6 +437,54 @@ void main() {
         expect(threads, isEmpty);
       });
 
+      test(
+        'throws MalformedResponseException when "threads" is not a list',
+        () async {
+          when(
+            () => mockTransport.request<Map<String, dynamic>>(
+              'GET',
+              any(),
+              cancelToken: any(named: 'cancelToken'),
+              fromJson: any(named: 'fromJson'),
+              body: any(named: 'body'),
+              headers: any(named: 'headers'),
+              timeout: any(named: 'timeout'),
+            ),
+          ).thenAnswer((_) async => {'threads': 'not-a-list'});
+
+          await expectLater(
+            api.getThreads('room-123'),
+            throwsA(isA<MalformedResponseException>()),
+          );
+        },
+      );
+
+      test(
+        'throws MalformedResponseException when a "threads" entry is not a map',
+        () async {
+          when(
+            () => mockTransport.request<Map<String, dynamic>>(
+              'GET',
+              any(),
+              cancelToken: any(named: 'cancelToken'),
+              fromJson: any(named: 'fromJson'),
+              body: any(named: 'body'),
+              headers: any(named: 'headers'),
+              timeout: any(named: 'timeout'),
+            ),
+          ).thenAnswer(
+            (_) async => {
+              'threads': [1, 2],
+            },
+          );
+
+          await expectLater(
+            api.getThreads('room-123'),
+            throwsA(isA<MalformedResponseException>()),
+          );
+        },
+      );
+
       test('validates non-empty roomId', () {
         expect(() => api.getThreads(''), throwsA(isA<ArgumentError>()));
       });
@@ -908,6 +956,78 @@ void main() {
 
         expect(capturedUri?.path, equals('/api/v1/rooms/room-123/agui'));
       });
+
+      test(
+        'throws MalformedResponseException when "thread_id" is missing',
+        () async {
+          when(
+            () => mockTransport.request<Map<String, dynamic>>(
+              'POST',
+              any(),
+              cancelToken: any(named: 'cancelToken'),
+              fromJson: any(named: 'fromJson'),
+              body: any(named: 'body'),
+              headers: any(named: 'headers'),
+              timeout: any(named: 'timeout'),
+            ),
+          ).thenAnswer((_) async => <String, dynamic>{});
+
+          await expectLater(
+            api.createThread('room-123'),
+            throwsA(isA<MalformedResponseException>()),
+          );
+        },
+      );
+    });
+
+    group('getMontySchemas', () {
+      test(
+        'throws MalformedResponseException when a schema value is not a String',
+        () async {
+          when(
+            () => mockTransport.request<Map<String, dynamic>>(
+              'GET',
+              any(),
+              cancelToken: any(named: 'cancelToken'),
+              fromJson: any(named: 'fromJson'),
+              body: any(named: 'body'),
+              headers: any(named: 'headers'),
+              timeout: any(named: 'timeout'),
+            ),
+          ).thenAnswer(
+            (_) async => {
+              'schemas': {'monty': 42},
+            },
+          );
+
+          await expectLater(
+            api.getMontySchemas(),
+            throwsA(isA<MalformedResponseException>()),
+          );
+        },
+      );
+
+      test(
+        'throws MalformedResponseException when "schemas" is not a map',
+        () async {
+          when(
+            () => mockTransport.request<Map<String, dynamic>>(
+              'GET',
+              any(),
+              cancelToken: any(named: 'cancelToken'),
+              fromJson: any(named: 'fromJson'),
+              body: any(named: 'body'),
+              headers: any(named: 'headers'),
+              timeout: any(named: 'timeout'),
+            ),
+          ).thenAnswer((_) async => {'schemas': 'not-a-map'});
+
+          await expectLater(
+            api.getMontySchemas(),
+            throwsA(isA<MalformedResponseException>()),
+          );
+        },
+      );
     });
 
     group('deleteThread', () {
@@ -4643,24 +4763,27 @@ void main() {
         expect(() => api.getMcpToken(''), throwsA(isA<ArgumentError>()));
       });
 
-      test('throws FormatException when response lacks mcp_token', () async {
-        when(
-          () => mockTransport.request<Map<String, dynamic>>(
-            'GET',
-            any(),
-            cancelToken: any(named: 'cancelToken'),
-            fromJson: any(named: 'fromJson'),
-            body: any(named: 'body'),
-            headers: any(named: 'headers'),
-            timeout: any(named: 'timeout'),
-          ),
-        ).thenAnswer((_) async => {'room_id': 'room-123'});
+      test(
+        'throws MalformedResponseException when response lacks mcp_token',
+        () async {
+          when(
+            () => mockTransport.request<Map<String, dynamic>>(
+              'GET',
+              any(),
+              cancelToken: any(named: 'cancelToken'),
+              fromJson: any(named: 'fromJson'),
+              body: any(named: 'body'),
+              headers: any(named: 'headers'),
+              timeout: any(named: 'timeout'),
+            ),
+          ).thenAnswer((_) async => {'room_id': 'room-123'});
 
-        expect(
-          () => api.getMcpToken('room-123'),
-          throwsA(isA<FormatException>()),
-        );
-      });
+          expect(
+            () => api.getMcpToken('room-123'),
+            throwsA(isA<MalformedResponseException>()),
+          );
+        },
+      );
     });
   });
 }

--- a/packages/soliplex_client/test/api/soliplex_api_test.dart
+++ b/packages/soliplex_client/test/api/soliplex_api_test.dart
@@ -1028,6 +1028,45 @@ void main() {
           );
         },
       );
+
+      test('returns an empty map when "schemas" is absent', () async {
+        when(
+          () => mockTransport.request<Map<String, dynamic>>(
+            'GET',
+            any(),
+            cancelToken: any(named: 'cancelToken'),
+            fromJson: any(named: 'fromJson'),
+            body: any(named: 'body'),
+            headers: any(named: 'headers'),
+            timeout: any(named: 'timeout'),
+          ),
+        ).thenAnswer((_) async => <String, dynamic>{});
+
+        expect(await api.getMontySchemas(), isEmpty);
+      });
+
+      test('returns the schema map for a well-formed response', () async {
+        when(
+          () => mockTransport.request<Map<String, dynamic>>(
+            'GET',
+            any(),
+            cancelToken: any(named: 'cancelToken'),
+            fromJson: any(named: 'fromJson'),
+            body: any(named: 'body'),
+            headers: any(named: 'headers'),
+            timeout: any(named: 'timeout'),
+          ),
+        ).thenAnswer(
+          (_) async => {
+            'schemas': {'monty': 'schema-yaml'},
+          },
+        );
+
+        expect(
+          await api.getMontySchemas(),
+          equals({'monty': 'schema-yaml'}),
+        );
+      });
     });
 
     group('deleteThread', () {

--- a/packages/soliplex_client/test/http/http_transport_test.dart
+++ b/packages/soliplex_client/test/http/http_transport_test.dart
@@ -1566,16 +1566,26 @@ void main() {
         );
       });
 
-      test('undecodable JSON body throws MalformedResponseException', () async {
-        stubResponse(textResponse(200, '{"broken": '));
-        await expectLater(
-          transport.request<Map<String, dynamic>>(
-            'GET',
-            Uri.parse('https://api.example.com'),
-          ),
-          throwsA(isA<MalformedResponseException>()),
-        );
-      });
+      test(
+        'undecodable JSON body throws MalformedResponseException whose message '
+        'carries the underlying decode error',
+        () async {
+          stubResponse(textResponse(200, '{"broken": '));
+          await expectLater(
+            transport.request<Map<String, dynamic>>(
+              'GET',
+              Uri.parse('https://api.example.com'),
+            ),
+            throwsA(
+              isA<MalformedResponseException>().having(
+                (e) => e.message,
+                'message',
+                contains('FormatException'),
+              ),
+            ),
+          );
+        },
+      );
 
       test(
         'empty body with a non-nullable expected type throws '

--- a/packages/soliplex_client/test/http/http_transport_test.dart
+++ b/packages/soliplex_client/test/http/http_transport_test.dart
@@ -1513,5 +1513,107 @@ void main() {
         expect(captured, containsPair('X-Trace-Id', 'abc123'));
       });
     });
+
+    group('request - malformed response hardening', () {
+      void stubResponse(HttpResponse response) {
+        when(
+          () => mockClient.request(
+            any(),
+            any(),
+            headers: any(named: 'headers'),
+            body: any(named: 'body'),
+            timeout: any(named: 'timeout'),
+          ),
+        ).thenAnswer((_) async => response);
+      }
+
+      // 0xFF is never a valid leading UTF-8 byte.
+      final invalidUtf8 = Uint8List.fromList([0xff, 0xfe, 0xff]);
+
+      test(
+        'non-UTF-8 error body preserves the status (ApiException), not a '
+        'decode error that would defeat retry/re-auth classification',
+        () async {
+          stubResponse(HttpResponse(statusCode: 500, bodyBytes: invalidUtf8));
+          await expectLater(
+            transport.request<Map<String, dynamic>>(
+              'GET',
+              Uri.parse('https://api.example.com'),
+            ),
+            throwsA(
+              isA<ApiException>()
+                  .having((e) => e.statusCode, 'statusCode', 500),
+            ),
+          );
+        },
+      );
+
+      test('non-UTF-8 success body throws MalformedResponseException',
+          () async {
+        stubResponse(
+          HttpResponse(
+            statusCode: 200,
+            bodyBytes: invalidUtf8,
+            headers: const {'content-type': 'application/json'},
+          ),
+        );
+        await expectLater(
+          transport.request<Map<String, dynamic>>(
+            'GET',
+            Uri.parse('https://api.example.com'),
+          ),
+          throwsA(isA<MalformedResponseException>()),
+        );
+      });
+
+      test('undecodable JSON body throws MalformedResponseException', () async {
+        stubResponse(textResponse(200, '{"broken": '));
+        await expectLater(
+          transport.request<Map<String, dynamic>>(
+            'GET',
+            Uri.parse('https://api.example.com'),
+          ),
+          throwsA(isA<MalformedResponseException>()),
+        );
+      });
+
+      test(
+        'empty body with a non-nullable expected type throws '
+        'MalformedResponseException',
+        () async {
+          stubResponse(emptyResponse(200));
+          await expectLater(
+            transport.request<Map<String, dynamic>>(
+              'GET',
+              Uri.parse('https://api.example.com'),
+            ),
+            throwsA(isA<MalformedResponseException>()),
+          );
+        },
+      );
+
+      test(
+        'a SoliplexException from the fromJson mapper is not downgraded to '
+        'MalformedResponseException',
+        () async {
+          stubResponse(
+            HttpResponse(
+              statusCode: 200,
+              bodyBytes: Uint8List.fromList(utf8.encode('{"x": 1}')),
+              headers: const {'content-type': 'application/json'},
+            ),
+          );
+          await expectLater(
+            transport.request<Room>(
+              'GET',
+              Uri.parse('https://api.example.com'),
+              fromJson: (_) =>
+                  throw const AuthException(message: 'boom', statusCode: 401),
+            ),
+            throwsA(isA<AuthException>()),
+          );
+        },
+      );
+    });
   });
 }


### PR DESCRIPTION
## What

Turns malformed-backend-response crashes in `soliplex_client` into typed, non-retryable errors, and stops a bad error body from masking the HTTP status.

- **Transport decode** (`http_transport.dart`): every payload failure on an otherwise well-formed HTTP response — non-UTF-8 bytes, a cast that doesn't match `T`, invalid JSON, or a throwing `fromJson` mapper — surfaces as `MalformedResponseException` instead of a raw `TypeError`/`FormatException`. A `SoliplexException` from the mapper passes through unchanged (so a 401 from a mapper is never downgraded).
- **Error bodies** (`http_response.dart`): a new lenient UTF-8 decode (`bodyLenient`) is used only for diagnostic error bodies, so a non-UTF-8 error payload can no longer throw and mask the status — keeping retry/re-auth classification intact. Success payloads stay strict.
- **API decode** (`soliplex_api.dart`): `getThreads` / `getMontySchemas` validate response shape and throw `MalformedResponseException`; `getMcpToken` / `createThread` / `createRun` use a shared `_requireString` helper.
- **Diagnostics**: `MalformedResponseException` messages on the decode and thread-mapping paths now carry the underlying cause, so logs that render only the message still show which field/format failed.

## Tests

- Transport: non-UTF-8 error body → `ApiException` (status preserved); non-UTF-8 success body, undecodable JSON, and empty body for a non-nullable `T` → `MalformedResponseException`; a `SoliplexException` from the mapper is not downgraded; decode-failure message carries the cause.
- API: shape-violation cases for `getThreads` / `getMontySchemas` / `getMcpToken` / `createThread`, plus `getMontySchemas` success + absent-`schemas` coverage.

All 187 `soliplex_client` API/transport tests pass; `dart analyze` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)