### PR TITLE
fix(soliplex_agent): stop tool re-execution on cancel/reset during resume

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,14 @@ Versions follow the `version+build` scheme from `pubspec.yaml`, bumped via
 
 ### Fixed
 
+- Cancelling or resetting an agent run while it was resuming after a tool call
+  could execute the tool a second time (or repeatedly, when resetting), causing
+  duplicate tool side effects. The run now stops cleanly without re-running the
+  tool.
+- A frontend decoding bug is no longer misreported as a backend
+  malformed-response error: a run failure now classifies by its underlying
+  cause, so an internal type error is surfaced and logged as internal rather
+  than blamed on the server.
 - A malformed chunk-visualization payload — a wrong-typed or missing
   `chunk_id`, `document_uri`, or `images_base_64` field — now surfaces as a
   non-retryable error instead of an uncaught type error, consistent with the

--- a/packages/soliplex_agent/lib/src/orchestration/error_classifier.dart
+++ b/packages/soliplex_agent/lib/src/orchestration/error_classifier.dart
@@ -16,6 +16,12 @@ FailureReason classifyError(Object error) {
   if (error is NetworkException && error.originalError != null) {
     return classifyError(error.originalError!);
   }
+  // Unwrap the decode cause so a frontend fromJson/mapper bug (a wrapped
+  // TypeError) is classified by its real origin rather than blamed on a
+  // backend malformation.
+  if (error is MalformedResponseException && error.originalError != null) {
+    return classifyError(error.originalError!);
+  }
   if (error is AuthException) return FailureReason.authExpired;
   if (error is PermissionDeniedException) {
     return FailureReason.permissionDenied;

--- a/packages/soliplex_agent/lib/src/orchestration/run_orchestrator.dart
+++ b/packages/soliplex_agent/lib/src/orchestration/run_orchestrator.dart
@@ -541,18 +541,25 @@ class RunOrchestrator {
       cancelToken: _cancelToken,
       onReconnectStatus: _activeOnReconnectStatus,
     );
-    // Cancel/dispose during the await leaves state as CancelledState (or
-    // disposed). Subscribing here would overwrite that with RunningState
-    // and silently resume the run after the user pressed Stop. Drain
-    // the unowned event stream so the underlying SSE socket releases.
+    // Cancel/reset/dispose during the await leaves state as CancelledState,
+    // IdleState, or disposed. Subscribing here would overwrite that with
+    // RunningState and silently resume the run after the user pressed Stop
+    // (or synced away). Drain the unowned event stream so the underlying
+    // SSE socket releases, then re-mint the terminal completer holding the
+    // current state: `_setState` already consumed the old completer with
+    // the now-stale ToolYieldingState, so without this `_driveToolLoop`'s
+    // next await would return that yield and re-run the tool.
     if (_disposed || _currentState is! ToolYieldingState) {
-      if (!_disposed && _currentState is! CancelledState) {
+      if (!_disposed &&
+          _currentState is! CancelledState &&
+          _currentState is! IdleState) {
         _logger.warning(
           'resumeStream aborted: unexpected post-await state '
           '(state=${_currentState.runtimeType})',
         );
       }
       _drainUnownedStream(handle.events, 'Resume drain failed');
+      _terminalCompleter = Completer<RunState>()..complete(_currentState);
       return;
     }
     _subscribeToStream(

--- a/packages/soliplex_agent/test/orchestration/error_classifier_test.dart
+++ b/packages/soliplex_agent/test/orchestration/error_classifier_test.dart
@@ -64,6 +64,37 @@ void main() {
       });
     });
 
+    group('MalformedResponseException unwrap', () {
+      test('unwraps to the original cause classification', () {
+        const original = AuthException(message: '401');
+        const wrapped = MalformedResponseException(
+          message: 'decode failed',
+          originalError: original,
+        );
+        expect(classifyError(wrapped), equals(FailureReason.authExpired));
+      });
+
+      test('a wrapped TypeError from a frontend mapper bug is internalError',
+          () {
+        Object? typeError;
+        try {
+          <Object?>['not a number'].cast<int>().first;
+        } on Object catch (e) {
+          typeError = e;
+        }
+        final wrapped = MalformedResponseException(
+          message: 'fromJson threw',
+          originalError: typeError,
+        );
+        expect(classifyError(wrapped), equals(FailureReason.internalError));
+      });
+
+      test('falls back to internalError when originalError is null', () {
+        const wrapped = MalformedResponseException(message: 'no cause');
+        expect(classifyError(wrapped), equals(FailureReason.internalError));
+      });
+    });
+
     group('unknown errors', () {
       test('FormatException maps to internalError', () {
         const error = FormatException('bad json');

--- a/packages/soliplex_agent/test/orchestration/run_orchestrator_test.dart
+++ b/packages/soliplex_agent/test/orchestration/run_orchestrator_test.dart
@@ -1596,10 +1596,12 @@ void main() {
       // Block the tool executor so the test can re-stub createRun before
       // _resumeStream fires.
       final toolExecutorTrigger = Completer<void>();
+      var toolExecutorCallCount = 0;
       final runFuture = orchestrator.runToCompletion(
         key: _key,
         userMessage: 'Weather?',
         toolExecutor: (_) async {
+          toolExecutorCallCount++;
           await toolExecutorTrigger.future;
           return _executedTools();
         },
@@ -1641,6 +1643,98 @@ void main() {
         reason: 'orchestrator must drain the abandoned LlmRunHandle.events '
             'stream so the underlying SSE socket releases — without the '
             'subscribe-then-cancel, the HTTP transport would hold it open',
+      );
+      expect(
+        toolExecutorCallCount,
+        equals(1),
+        reason: 'the tool must execute exactly once — after the resume drains '
+            'on cancel, the loop must not re-enter the tool executor on the '
+            'stale ToolYieldingState held by the consumed completer',
+      );
+    });
+
+    test('reset during _resumeStream createRun await runs the tool once',
+        () async {
+      // Sibling to the cancelRun-during-resume test: pressing reset (via
+      // syncToThread(null) in production) while a tool-yield resume is
+      // awaiting createRun must abandon the run without re-executing the
+      // tool. reset transitions to the non-terminal IdleState, so without
+      // re-minting the consumed completer the loop spins on the stale
+      // ToolYieldingState, re-running the tool up to maxToolDepth times
+      // before failing on the depth guard.
+      orchestrator = RunOrchestrator(
+        llmProvider: AgUiLlmProvider(
+          api: api,
+          agUiStreamClient: agUiStreamClient,
+        ),
+        toolRegistry: _registryWith(),
+        logger: logger,
+      );
+      stubCreateRun();
+      var runAgentCallCount = 0;
+      final resumeStreamController = StreamController<BaseEvent>();
+      addTearDown(resumeStreamController.close);
+      when(
+        () => agUiStreamClient.runAgent(
+          any(),
+          any(),
+          cancelToken: any(named: 'cancelToken'),
+          resumePolicy: any(named: 'resumePolicy'),
+          onReconnectStatus: any(named: 'onReconnectStatus'),
+        ),
+      ).thenAnswer((_) {
+        runAgentCallCount++;
+        if (runAgentCallCount == 1) {
+          return _wrap(Stream.fromIterable(_toolCallEvents()));
+        }
+        return _wrap(resumeStreamController.stream);
+      });
+
+      final toolExecutorTrigger = Completer<void>();
+      var toolExecutorCallCount = 0;
+      final runFuture = orchestrator.runToCompletion(
+        key: _key,
+        userMessage: 'Weather?',
+        toolExecutor: (_) async {
+          toolExecutorCallCount++;
+          await toolExecutorTrigger.future;
+          return _executedTools();
+        },
+      );
+      await Future<void>.delayed(Duration.zero);
+      expect(orchestrator.currentState, isA<ToolYieldingState>());
+
+      final resumeCreateRun = Completer<RunInfo>();
+      when(
+        () => api.createRun(any(), any()),
+      ).thenAnswer((_) => resumeCreateRun.future);
+
+      toolExecutorTrigger.complete();
+      await Future<void>.delayed(Duration.zero);
+      expect(orchestrator.currentState, isA<ToolYieldingState>());
+
+      orchestrator.reset();
+      expect(
+        orchestrator.currentState,
+        isA<IdleState>(),
+        reason: 'reset must transition to IdleState immediately',
+      );
+
+      resumeCreateRun.complete(_runInfo());
+      final result = await runFuture;
+
+      expect(
+        result,
+        isA<IdleState>(),
+        reason: 'reset abandons the run; the loop must settle on IdleState '
+            'rather than spinning to a depth-exceeded FailedState',
+      );
+      expect(
+        toolExecutorCallCount,
+        equals(1),
+        reason: 'the tool must execute exactly once — after reset the loop '
+            'must not re-run the tool on the stale ToolYieldingState held by '
+            'the consumed completer',
       );
     });
   });


### PR DESCRIPTION
## Group C — runtime robustness (`soliplex_agent`)

Two related hardening fixes in the run orchestrator, scoped to `soliplex_agent`.

### C3 — tool re-executes on cancel/reset during resume

When cancel, reset, or dispose lands during the resume `startRun` await,
`_resumeStream` drains the unowned stream and returns without re-subscribing.
The terminal completer is minted only in `_subscribeToStream` and stays
completed holding the stale `ToolYieldingState`, so `_driveToolLoop`'s next
`await` returns that yield immediately. The guards differ by path:

- **cancel** → `CancelledState`, but its guard is *after* `toolExecutor` → the
  tool runs a **second time**;
- **reset** → `IdleState` (non-terminal), caught nowhere before the executor →
  the loop **spins**, re-running the tool up to `maxToolDepth` times before
  failing on the depth guard;
- **dispose** → already safe (the `_disposed` guard fires before the executor).

Production `toolExecutor` performs real tool side effects (API mutations), so
this was duplicate side effects on a user Stop / thread switch.

**Fix:** on the drain path, re-mint `_terminalCompleter` completed with the
current state (`Completer<RunState>()..complete(_currentState)`), mirroring the
happy-path re-mint in `_subscribeToStream`. The loop's next `await` then observes
the real `CancelledState` / `IdleState` transition and returns via
`if (state is! ToolYieldingState) return state;` — the tool runs exactly once,
no spin. `IdleState` was added to the drain-path no-warn condition, since
reset-during-resume is now a legitimate path.

Returning `IdleState` from `runToCompletion` is safe: `AgentSession` calls it
fire-and-forget and maps `IdleState` to a no-op in `_onStateChange`.

### C5 — `MalformedResponseException` misclassification

`classifyError` unwrapped `NetworkException.originalError` but had no
`MalformedResponseException` arm, so a wrapped frontend `fromJson`/mapper bug
(a `TypeError`) was classified `internalError` and surfaced as a *backend*
malformation. Added a `MalformedResponseException.originalError` unwrap arm
mirroring the `NetworkException` one: a wrapped classifiable cause is now
attributed to its true origin, and a wrapped `TypeError` stays `internalError`.

## Tests

TDD — RED confirmed before each fix:

- Extended the existing cancel-during-resume test with an exactly-once
  tool-executor assertion (was 2×).
- Added a sibling reset-during-resume test asserting exactly-once + terminal
  `IdleState` (was spinning to a `FailedState`).
- Three `classifyError` tests: wrapped cause, wrapped `TypeError`, null cause.

## Verification

- `dart format` clean, `dart analyze --fatal-infos` → no issues.
- All 180 `test/orchestration/` unit tests pass.
- The only failing tests are pre-existing live-backend integration tests
  (`test/integration/`, `test/run/`) — Connection refused, unrelated to this
  change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
