### PR TITLE
refactor(soliplex_client): extract shared parse_utils for resilient JSON reads

### DIFF
--- a/packages/soliplex_client/lib/src/api/mappers.dart
+++ b/packages/soliplex_client/lib/src/api/mappers.dart
@@ -13,6 +13,7 @@ import 'package:soliplex_client/src/domain/room_tool.dart';
 import 'package:soliplex_client/src/domain/run_info.dart';
 import 'package:soliplex_client/src/domain/thread_info.dart';
 import 'package:soliplex_client/src/domain/workdir_file.dart';
+import 'package:soliplex_client/src/utils/parse_utils.dart';
 
 // ============================================================
 // Timestamp helpers
@@ -83,9 +84,8 @@ BackendVersionInfo backendVersionInfoFromJson(Map<String, dynamic> json) {
 RoomAgent roomAgentFromJson(Map<String, dynamic> json) {
   final kind = json['kind'] as String? ?? '';
   final id = _requireString(json, 'id', 'agent');
-  final aguiFeatureNames = _parseStringList(
-    json['agui_feature_names'] as List<dynamic>?,
-  );
+  final aguiFeatureNames =
+      stringList(json['agui_feature_names'], 'agui_feature_names');
 
   // Backend omits kind for default agents; infer from model_name presence
   final effectiveKind =
@@ -131,9 +131,8 @@ RoomTool roomToolFromJson(String name, Map<String, dynamic> json) {
     allowMcp: json['allow_mcp'] as bool? ?? false,
     extraParameters:
         (json['extra_parameters'] as Map<String, dynamic>?) ?? const {},
-    aguiFeatureNames: _parseStringList(
-      json['agui_feature_names'] as List<dynamic>?,
-    ),
+    aguiFeatureNames:
+        stringList(json['agui_feature_names'], 'agui_feature_names'),
   );
 }
 
@@ -204,13 +203,6 @@ DateTime? _tryParseTimestamp(
     );
     return null;
   }
-}
-
-/// Parses a dynamic list into a list of strings,
-/// filtering out non-string items.
-List<String> _parseStringList(List<dynamic>? raw) {
-  if (raw == null) return const [];
-  return raw.whereType<String>().toList();
 }
 
 /// Creates a [Room] from JSON.
@@ -340,9 +332,8 @@ Room roomFromJson(Map<String, dynamic> json) {
     tools: tools,
     mcpClientToolsets: mcpClientToolsets,
     toolDefinitions: toolDefinitions,
-    aguiFeatureNames: _parseStringList(
-      json['agui_feature_names'] as List<dynamic>?,
-    ),
+    aguiFeatureNames:
+        stringList(json['agui_feature_names'], 'agui_feature_names'),
   );
 }
 

--- a/packages/soliplex_client/lib/src/api/mappers.dart
+++ b/packages/soliplex_client/lib/src/api/mappers.dart
@@ -113,6 +113,14 @@ RoomAgent roomAgentFromJson(Map<String, dynamic> json) {
 
 /// Extracts a required string field, throwing [FormatException] if missing
 /// or not a string.
+///
+/// [FormatException] (not MalformedResponseException) is deliberate: these
+/// reads sit inside per-entry parsing that an enclosing fail-soft loop —
+/// `roomFromJson`'s agent parse, `_parseFileList`'s per-row parse — catches on
+/// [FormatException] to skip just the malformed entry. A hard
+/// MalformedResponseException would fail the whole response instead. Contrast
+/// the top-level required-field reads in `SoliplexApi`, which throw
+/// MalformedResponseException by design.
 String _requireString(Map<String, dynamic> json, String field, String context) {
   final value = json[field];
   if (value is! String) {

--- a/packages/soliplex_client/lib/src/api/soliplex_api.dart
+++ b/packages/soliplex_client/lib/src/api/soliplex_api.dart
@@ -1721,6 +1721,12 @@ class SoliplexApi {
   /// (non-retryable) [MalformedResponseException] instead of a raw `TypeError`
   /// when the field is missing, null, or not a String. [context] names the
   /// calling endpoint in the message.
+  ///
+  /// [MalformedResponseException] (not [FormatException]) is deliberate: these
+  /// are top-level response fields whose absence makes the whole response
+  /// unusable, so the failure is hard rather than skippable. Contrast the
+  /// per-entry `_requireString` in `mappers.dart`, which throws
+  /// [FormatException] so an enclosing loop can skip one malformed entry.
   String _requireString(
     Map<String, dynamic> response,
     String key,

--- a/packages/soliplex_client/lib/src/schema/agui_features/rag.dart
+++ b/packages/soliplex_client/lib/src/schema/agui_features/rag.dart
@@ -11,102 +11,7 @@
 // ignore_for_file: inference_failure_on_untyped_parameter
 // ignore_for_file: inference_failure_on_collection_literal
 
-import 'package:soliplex_client/src/errors/exceptions.dart';
-import 'package:soliplex_logging/soliplex_logging.dart';
-
-final _logger = LogManager.instance.getLogger('soliplex_client.rag');
-
-/// A required string field: throws [MalformedResponseException] when absent
-/// or not a string, so the caller can drop just this entry (its siblings are
-/// parsed independently) instead of the whole batch.
-String _requiredString(dynamic value, String field) {
-  if (value is String) return value;
-  throw MalformedResponseException(
-    message: 'Citation field "$field" must be a string, '
-        'got ${value.runtimeType}',
-  );
-}
-
-void _logDropped(String message) => _logger.warning(message);
-
-/// An optional string field: a present-but-wrong-typed value degrades to null
-/// (logged) rather than throwing, so one malformed field never takes down the
-/// rest of the object. An absent field is normal and silent.
-String? _stringOrNull(dynamic value, String field) {
-  if (value == null || value is String) return value as String?;
-  _logDropped('Citation field "$field": expected string, '
-      'got ${value.runtimeType}; dropped.');
-  return null;
-}
-
-/// An optional int field: a present-but-wrong-typed value degrades to null
-/// (logged). An absent field is normal and silent.
-int? _intOrNull(dynamic value, String field) {
-  if (value == null || value is int) return value as int?;
-  _logDropped('Citation field "$field": expected int, '
-      'got ${value.runtimeType}; dropped.');
-  return null;
-}
-
-/// An optional list-of-strings field: a present-but-non-list degrades to empty
-/// and any non-string element is dropped, isolating malformed input to this
-/// field. Both cases are logged; an absent field is normal and silent.
-List<String> _stringList(dynamic value, String field) {
-  if (value == null) return const [];
-  if (value is! List) {
-    _logDropped('Citation field "$field": expected list, '
-        'got ${value.runtimeType}; using empty.');
-    return const [];
-  }
-  final result = value.whereType<String>().toList();
-  if (result.length != value.length) {
-    _logDropped('Citation field "$field": dropped '
-        '${value.length - result.length} non-string element(s).');
-  }
-  return result;
-}
-
-/// An optional list-of-ints field: a present-but-non-list degrades to empty and
-/// any non-int element is dropped. Both cases are logged; an absent field is
-/// normal and silent.
-List<int> _intList(dynamic value, String field) {
-  if (value == null) return const [];
-  if (value is! List) {
-    _logDropped('Citation field "$field": expected list, '
-        'got ${value.runtimeType}; using empty.');
-    return const [];
-  }
-  final result = value.whereType<int>().toList();
-  if (result.length != value.length) {
-    _logDropped('Citation field "$field": dropped '
-        '${value.length - result.length} non-int element(s).');
-  }
-  return result;
-}
-
-/// Reads a raw JSON value into a string→string map, dropping (and logging) any
-/// non-string key or value. The single interpreter for `image_data` and
-/// `picture_captions`, which share this wire shape, so both read identically.
-/// An absent field is normal and silent.
-Map<String, String> _parseStringMap(Object? raw, String field) {
-  if (raw is! Map) {
-    if (raw != null) {
-      _logDropped('SearchResult field "$field": expected map, '
-          'got ${raw.runtimeType}; using empty.');
-    }
-    return const {};
-  }
-  final out = <String, String>{};
-  raw.forEach((key, value) {
-    if (key is String && value is String) out[key] = value;
-  });
-  final dropped = raw.length - out.length;
-  if (dropped != 0) {
-    _logDropped('SearchResult field "$field": dropped $dropped '
-        'non-string entr${dropped == 1 ? 'y' : 'ies'}.');
-  }
-  return out;
-}
+import 'package:soliplex_client/src/utils/parse_utils.dart';
 
 ///Resolved citation with full metadata for display/visual grounding.
 ///
@@ -140,17 +45,17 @@ class Citation {
   });
 
   factory Citation.fromJson(Map<String, dynamic> json) => Citation(
-        chunkId: _requiredString(json["chunk_id"], "chunk_id"),
-        chunkIds: _stringList(json["chunk_ids"], "chunk_ids"),
-        content: _requiredString(json["content"], "content"),
-        docItemRefs: _stringList(json["doc_item_refs"], "doc_item_refs"),
-        documentId: _requiredString(json["document_id"], "document_id"),
-        documentTitle: _stringOrNull(json["document_title"], "document_title"),
-        documentUri: _requiredString(json["document_uri"], "document_uri"),
-        headings: _stringList(json["headings"], "headings"),
-        index: _intOrNull(json["index"], "index"),
-        pageNumbers: _intList(json["page_numbers"], "page_numbers"),
-        pictureRefs: _stringList(json["picture_refs"], "picture_refs"),
+        chunkId: requireString(json["chunk_id"], "chunk_id"),
+        chunkIds: stringList(json["chunk_ids"], "chunk_ids"),
+        content: requireString(json["content"], "content"),
+        docItemRefs: stringList(json["doc_item_refs"], "doc_item_refs"),
+        documentId: requireString(json["document_id"], "document_id"),
+        documentTitle: stringOrNull(json["document_title"], "document_title"),
+        documentUri: requireString(json["document_uri"], "document_uri"),
+        headings: stringList(json["headings"], "headings"),
+        index: intOrNull(json["index"], "index"),
+        pageNumbers: intList(json["page_numbers"], "page_numbers"),
+        pictureRefs: stringList(json["picture_refs"], "picture_refs"),
       );
 
   Map<String, dynamic> toJson() => {
@@ -224,12 +129,12 @@ class SearchResult {
   });
 
   /// Reads a raw `image_data` JSON value into a picture-ref → base64 map.
-  /// Delegates to [_parseStringMap]; see it for the shared parsing contract.
+  /// Delegates to [stringMap]; see it for the shared parsing contract.
   static Map<String, String> parseImageData(Object? raw) =>
-      _parseStringMap(raw, 'image_data');
+      stringMap(raw, 'image_data');
 
   /// Reads a raw `picture_captions` JSON value into a picture-ref → caption
-  /// map. Delegates to [_parseStringMap].
+  /// map. Delegates to [stringMap].
   static Map<String, String> parsePictureCaptions(Object? raw) =>
-      _parseStringMap(raw, 'picture_captions');
+      stringMap(raw, 'picture_captions');
 }

--- a/packages/soliplex_client/lib/src/utils/parse_utils.dart
+++ b/packages/soliplex_client/lib/src/utils/parse_utils.dart
@@ -1,0 +1,107 @@
+/// Resilient readers for a single field of a JSON map, shared by the
+/// backend-schema parsers.
+///
+/// Each reader isolates a malformed field to itself: an optional field
+/// degrades to `null` / empty (logged) rather than throwing, so one bad
+/// field never takes down an otherwise-valid object. A required field
+/// throws [MalformedResponseException] so the caller can drop just the
+/// enclosing entry (its siblings parse independently). An absent field is
+/// always normal and silent.
+library;
+
+import 'package:soliplex_client/src/errors/exceptions.dart';
+import 'package:soliplex_logging/soliplex_logging.dart';
+
+final _logger = LogManager.instance.getLogger('soliplex_client.parse_utils');
+
+void _logDropped(String message) => _logger.warning(message);
+
+/// A required string field: throws [MalformedResponseException] when absent
+/// or not a string.
+String requireString(Object? value, String field) {
+  if (value is String) return value;
+  throw MalformedResponseException(
+    message: 'field "$field" must be a string, got ${value.runtimeType}',
+  );
+}
+
+/// An optional string field: a present-but-wrong-typed value degrades to null
+/// (logged). An absent field is normal and silent.
+String? stringOrNull(Object? value, String field) {
+  if (value == null || value is String) return value as String?;
+  _logDropped(
+    'field "$field": expected string, got ${value.runtimeType}; dropped.',
+  );
+  return null;
+}
+
+/// An optional int field: a present-but-wrong-typed value degrades to null
+/// (logged). An absent field is normal and silent.
+int? intOrNull(Object? value, String field) {
+  if (value == null || value is int) return value as int?;
+  _logDropped(
+    'field "$field": expected int, got ${value.runtimeType}; dropped.',
+  );
+  return null;
+}
+
+/// An optional list-of-strings field: a present-but-non-list degrades to empty
+/// and any non-string element is dropped. Both cases are logged; an absent
+/// field is normal and silent.
+List<String> stringList(Object? value, String field) {
+  if (value == null) return const [];
+  if (value is! List) {
+    _logDropped(
+      'field "$field": expected list, got ${value.runtimeType}; using empty.',
+    );
+    return const [];
+  }
+  final result = value.whereType<String>().toList();
+  if (result.length != value.length) {
+    _logDropped('field "$field": dropped '
+        '${value.length - result.length} non-string element(s).');
+  }
+  return result;
+}
+
+/// An optional list-of-ints field: a present-but-non-list degrades to empty and
+/// any non-int element is dropped. Both cases are logged; an absent field is
+/// normal and silent.
+List<int> intList(Object? value, String field) {
+  if (value == null) return const [];
+  if (value is! List) {
+    _logDropped(
+      'field "$field": expected list, got ${value.runtimeType}; using empty.',
+    );
+    return const [];
+  }
+  final result = value.whereType<int>().toList();
+  if (result.length != value.length) {
+    _logDropped('field "$field": dropped '
+        '${value.length - result.length} non-int element(s).');
+  }
+  return result;
+}
+
+/// Reads a raw JSON value into a string→string map, dropping (and logging) any
+/// non-string key or value. An absent field is normal and silent.
+Map<String, String> stringMap(Object? value, String field) {
+  if (value is! Map) {
+    if (value != null) {
+      _logDropped(
+        'field "$field": expected map, got ${value.runtimeType}; using empty.',
+      );
+    }
+    return const {};
+  }
+  final out = <String, String>{};
+  value.forEach((key, mapValue) {
+    if (key is String && mapValue is String) out[key] = mapValue;
+  });
+  final dropped = value.length - out.length;
+  if (dropped != 0) {
+    _logDropped('field "$field": dropped $dropped '
+        'non-string entr${dropped == 1 ? 'y' : 'ies'}.');
+  }
+  return out;
+}

--- a/packages/soliplex_client/test/utils/parse_utils_test.dart
+++ b/packages/soliplex_client/test/utils/parse_utils_test.dart
@@ -1,0 +1,104 @@
+import 'package:soliplex_client/src/errors/exceptions.dart';
+import 'package:soliplex_client/src/utils/parse_utils.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('requireString', () {
+    test('returns the value when it is a string', () {
+      expect(requireString('hello', 'field'), equals('hello'));
+    });
+
+    test('throws MalformedResponseException when absent', () {
+      expect(
+        () => requireString(null, 'field'),
+        throwsA(isA<MalformedResponseException>()),
+      );
+    });
+
+    test('throws MalformedResponseException when wrong-typed', () {
+      expect(
+        () => requireString(42, 'field'),
+        throwsA(isA<MalformedResponseException>()),
+      );
+    });
+  });
+
+  group('stringOrNull', () {
+    test('returns the value when it is a string', () {
+      expect(stringOrNull('hi', 'field'), equals('hi'));
+    });
+
+    test('returns null when absent', () {
+      expect(stringOrNull(null, 'field'), isNull);
+    });
+
+    test('degrades a wrong-typed value to null', () {
+      expect(stringOrNull(42, 'field'), isNull);
+    });
+  });
+
+  group('intOrNull', () {
+    test('returns the value when it is an int', () {
+      expect(intOrNull(7, 'field'), equals(7));
+    });
+
+    test('returns null when absent', () {
+      expect(intOrNull(null, 'field'), isNull);
+    });
+
+    test('degrades a wrong-typed value to null', () {
+      expect(intOrNull('7', 'field'), isNull);
+    });
+  });
+
+  group('stringList', () {
+    test('returns an empty list when absent', () {
+      expect(stringList(null, 'field'), isEmpty);
+    });
+
+    test('returns an empty list for a non-list value', () {
+      expect(stringList('nope', 'field'), isEmpty);
+    });
+
+    test('keeps strings and drops non-string elements', () {
+      expect(
+        stringList(<Object?>['a', 1, 'b', null], 'field'),
+        equals(['a', 'b']),
+      );
+    });
+  });
+
+  group('intList', () {
+    test('returns an empty list when absent', () {
+      expect(intList(null, 'field'), isEmpty);
+    });
+
+    test('returns an empty list for a non-list value', () {
+      expect(intList(3, 'field'), isEmpty);
+    });
+
+    test('keeps ints and drops non-int elements', () {
+      expect(
+        intList(<Object?>[1, 'x', 2, null], 'field'),
+        equals([1, 2]),
+      );
+    });
+  });
+
+  group('stringMap', () {
+    test('returns an empty map when absent', () {
+      expect(stringMap(null, 'field'), isEmpty);
+    });
+
+    test('returns an empty map for a non-map value', () {
+      expect(stringMap(<Object?>['a'], 'field'), isEmpty);
+    });
+
+    test('keeps string→string entries and drops the rest', () {
+      expect(
+        stringMap(<Object?, Object?>{'a': '1', 'b': 2, 3: 'c'}, 'field'),
+        equals({'a': '1'}),
+      );
+    });
+  });
+}


### PR DESCRIPTION
## Extract shared `parse_utils` for resilient JSON reads

`Citation` / `RagSnapshot` parsing hand-rolled a set of fail-soft field
readers, and the same intent was duplicated across the schema/mapper layers.
This consolidates the reusable field-level readers into one module and adopts
them where it's a clean, behavior-preserving swap.

### What changed

- **New `lib/src/utils/parse_utils.dart`** — six shared fail-soft field
  readers: `requireString` (throws `MalformedResponseException`),
  `stringOrNull`, `intOrNull`, `stringList`, `intList`, `stringMap`. Optional
  fields degrade to null/empty + log; a required string throws so an enclosing
  parser can drop just that entry. Messages are owner-agnostic so any schema
  parser can reuse them.
- **`rag.dart`** — deletes its private copies (−95 LOC) and delegates to the
  shared readers; behavior identical.
- **`mappers.dart`** — `agui_feature_names` parsing adopts `stringList`. Minor
  robustness gain: a wrong-typed value now degrades to empty (logged) instead
  of throwing and failing the whole room/agent parse, matching the fail-soft
  handling already used for tools/skills in `roomFromJson`.
- **Doc comments** on the two `_requireString` helpers recording their
  *intentional* exception-contract split: `mappers.dart` throws
  `FormatException` (an enclosing loop skips the malformed entry);
  `SoliplexApi` throws `MalformedResponseException` (top-level field, hard
  fail). This is deliberate, not duplication — documented so it isn't
  collapsed and the per-entry-skip behavior regressed.

### Scope notes

- `RagSnapshot`'s inline collection loops and the `mappers` per-entry loops are
  left as-is: their per-entry diagnostics are richer than a generic helper
  would give. A shared collection-level `parseList`/`parseMap` is deferred to
  when the `analysis`/`searches` snapshot parsers are built.
- `mcpClientToolsets.allowedTools` (`List<String>?`) is left on its raw
  `whereType` — its `null` is meaningful ("no allowlist" vs "empty") and
  `stringList` would flatten it to `[]`.

### Verification

- `dart format` clean, `dart analyze --fatal-infos` → no issues.
- 936 tests pass across api/domain/schema/application/utils; the new
  `parse_utils` readers have direct unit coverage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
