### PR TITLE
chore: version 0.93.0+66

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ Versions follow the `version+build` scheme from `pubspec.yaml`, bumped via
 
 ## [Unreleased]
 
+## [0.93.0+66] - 2026-07-13
+
 ### Added
 
 - Room: a citation's cited figures now render inline as thumbnails, tapped to
@@ -20,6 +22,9 @@ Versions follow the `version+build` scheme from `pubspec.yaml`, bumped via
 
 ### Changed
 
+- The chat "generating" placeholder and running agent step labels now animate
+  with a light-sweep shimmer instead of static spinners, giving clearer
+  in-progress feedback without a layout shift.
 - Update route for thread-specific file uploads to stay current with
   backend release
   [v0.72.1](https://github.com/soliplex/soliplex/releases/tag/v0.72.1).

--- a/lib/version.dart
+++ b/lib/version.dart
@@ -2,4 +2,4 @@
 ///
 /// Generated from pubspec.yaml. Run `dart run tool/update_version.dart` after
 /// changing the version in pubspec.yaml.
-const String soliplexVersion = '0.92.0+65';
+const String soliplexVersion = '0.93.0+66';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,7 +3,7 @@ description: Modular Flutter frontend framework for Soliplex
 publish_to: none
 # To update version, run:
 # dart run tool/bump_version.dart <major|minor|patch|build>
-version: 0.92.0+65
+version: 0.93.0+66
 
 environment:
   sdk: ^3.6.0


### PR DESCRIPTION
Bumps the app version from `0.92.0+65` to `0.93.0+66` (minor).

- `pubspec.yaml` and `lib/version.dart` bumped via `dart run tool/bump_version.dart minor`.
- `CHANGELOG.md`: rolled `[Unreleased]` into `## [0.93.0+66] - 2026-07-13` and opened a fresh `[Unreleased]`. Added a Changed entry for the chat "generating" placeholder and running step labels now animating with a shimmer instead of static spinners (previously undocumented).

🤖 Generated with [Claude Code](https://claude.com/claude-code)