### PR TITLE
fix(soliplex_design): paint component surfaces with surface roles, not onPrimary

### DIFF
--- a/packages/soliplex_design/lib/src/theme/theme.dart
+++ b/packages/soliplex_design/lib/src/theme/theme.dart
@@ -76,8 +76,11 @@ ThemeData buildSoliplexThemeData({
     surfaceBright: colors.background,
     outline: colors.outline,
     outlineVariant: colors.outlineVariant,
-    inverseSurface: colors.primary,
-    onInverseSurface: colors.onPrimary,
+    // Inverting the neutral pair gives an opposite-brightness surface whose
+    // foreground is legible by construction, for any brand. Deriving it from
+    // `primary` only works while `primary` is itself an inverse neutral.
+    inverseSurface: colors.foreground,
+    onInverseSurface: colors.background,
     inversePrimary: colors.inversePrimary,
     shadow: const Color(0xFF000000),
     scrim: const Color(0xFF000000),
@@ -93,8 +96,8 @@ ThemeData buildSoliplexThemeData({
     brightness: brightness,
     colorScheme: colorScheme,
     appBarTheme: AppBarTheme(
-      backgroundColor: colors.onPrimary,
-      foregroundColor: colors.primary,
+      backgroundColor: colors.background,
+      foregroundColor: colors.foreground,
       elevation: 0,
       actionsPadding: const EdgeInsets.symmetric(
         horizontal: SoliplexSpacing.s2,
@@ -197,7 +200,9 @@ ThemeData buildSoliplexThemeData({
         borderRadius: BorderRadius.circular(radii.md),
       ),
       collapsedBackgroundColor: colors.inputBackground,
-      backgroundColor: colors.onPrimary,
+      // Expanded, the body opens onto the page surface; the collapsed header
+      // keeps the raised container fill.
+      backgroundColor: colors.background,
     ),
     chipTheme: ChipThemeData(
       backgroundColor: colors.inputBackground,
@@ -254,7 +259,10 @@ ThemeData buildSoliplexThemeData({
       ),
     ),
     popupMenuTheme: PopupMenuThemeData(
-      color: colors.onPrimary,
+      // `surfaceContainer` — the M3 role for a floating menu. It sits above the
+      // page on the tonal ladder in both brightnesses, so the menu reads as
+      // elevated without an elevation shadow.
+      color: colors.inputBackground,
       shape: RoundedRectangleBorder(
         borderRadius: BorderRadius.circular(radii.md),
       ),

--- a/packages/soliplex_design/test/theme/theme_test.dart
+++ b/packages/soliplex_design/test/theme/theme_test.dart
@@ -155,8 +155,8 @@ void main() {
       expect(cs.outline, lightSoliplexColors.outline);
       expect(cs.outlineVariant, lightSoliplexColors.outlineVariant);
       // Inverse
-      expect(cs.inverseSurface, lightSoliplexColors.primary);
-      expect(cs.onInverseSurface, lightSoliplexColors.onPrimary);
+      expect(cs.inverseSurface, lightSoliplexColors.foreground);
+      expect(cs.onInverseSurface, lightSoliplexColors.background);
       expect(cs.inversePrimary, lightSoliplexColors.inversePrimary);
     });
 
@@ -180,6 +180,50 @@ void main() {
         (shape! as RoundedRectangleBorder).borderRadius,
         BorderRadius.circular(radii.md),
       );
+    });
+  });
+
+  // Regression: component backgrounds were painted with `onPrimary`, whose
+  // contrast guarantee holds only against `primary`. The shipped palettes hide
+  // it — their `primary` is an inverse neutral, so `onPrimary` lands on a
+  // plausible surface tone by coincidence. A brand that keeps a saturated
+  // primary in dark mode must set `onPrimary` white for its button labels, and
+  // every surface borrowing that slot then rendered white. See issue #418.
+  group('surfaces never borrow onPrimary', () {
+    // A saturated brand primary in dark mode, with the white onPrimary its own
+    // button labels require.
+    final colors = darkSoliplexColors.copyWith(
+      primary: const Color(0xFF0A7AFF),
+      onPrimary: const Color(0xFFFFFFFF),
+    );
+    final theme = soliplexDarkTheme(colors: colors);
+
+    test('app bar, popup menu and expanded tile take surface roles', () {
+      expect(theme.appBarTheme.backgroundColor, colors.background);
+      expect(theme.appBarTheme.foregroundColor, colors.foreground);
+      expect(theme.popupMenuTheme.color, colors.inputBackground);
+      expect(theme.expansionTileTheme.backgroundColor, colors.background);
+    });
+
+    test('inverse surface pair stays neutral', () {
+      expect(theme.colorScheme.inverseSurface, colors.foreground);
+      expect(theme.colorScheme.onInverseSurface, colors.background);
+    });
+
+    test('every painted surface still reads as dark', () {
+      final surfaces = <String, Color?>{
+        'appBar': theme.appBarTheme.backgroundColor,
+        'popupMenu': theme.popupMenuTheme.color,
+        'expansionTile': theme.expansionTileTheme.backgroundColor,
+      };
+
+      for (final MapEntry(key: role, value: color) in surfaces.entries) {
+        expect(
+          ThemeData.estimateBrightnessForColor(color!),
+          Brightness.dark,
+          reason: '$role must not render light in dark mode',
+        );
+      }
     });
   });
 


### PR DESCRIPTION
Addresses #418 (left open deliberately — @johnboyle5 may want to confirm the fix against a real fork, or elaborate). Reported by @johnboyle5, whose diagnosis was correct in full — this lands essentially as suggested there.

## The bug

`buildSoliplexThemeData` used `colors.onPrimary` as the **background** for four slots. `onPrimary` is a foreground role: its contrast guarantee holds only against `primary`, and it is never a background.

The shipped palettes hide it. Their `primary` is an *inverse neutral* — near-black `#030213` in light, near-white `#FAFAFA` in dark — so `onPrimary` lands on a plausible surface tone by coincidence. The coincidence collapses for any brand keeping a saturated `primary` in dark mode: such a brand must set `onPrimary` white for its own button labels, and every surface borrowing that slot then rendered **white in dark mode**.

No fork could work around it. The slot genuinely has to stay white for the button labels, so one token cannot serve both "text on primary" and "menu surface" once `primary` is an actual color.

Note this is on `main`, not only the reporter's branch.

## The fix

Each background is repointed at the surface role it should have had:

| Slot | Was | Now |
| --- | --- | --- |
| App bar | `onPrimary` / `primary` | `background` / `foreground` |
| Expansion tile (expanded) | `onPrimary` | `background` |
| Popup menu | `onPrimary` | `surfaceContainer` |
| `inverseSurface` / `onInverseSurface` | `primary` / `onPrimary` | `foreground` / `background` |

Two notes beyond the report:

- **The app bar had a second defect** the issue didn't list: `foregroundColor: colors.primary` painted a colored brand's app-bar title text and icons *in the brand color*. Fixed alongside the background.
- **The inverse pair is now correct by construction.** `foreground`/`background` are a guaranteed contrast pair, so inverting them yields an opposite-brightness surface that stays legible for any brand — rather than one that happened to work while `primary` was an inverse neutral.

Menu surface (`surfaceContainer`) is the M3 role for a floating menu: it sits above the page on the tonal ladder in both brightnesses, so menus read as elevated without an elevation shadow. Chosen with design sign-off over `surfaceContainerLowest`, which would have preserved today's pure-white light menus at the cost of dark menus landing *below* the page tone.

## Effect on the shipped brand

No mapping can preserve both brightnesses — light `onPrimary` is pure white, dark `onPrimary` is `#222222` — so the default theme does move:

- **Light:** unchanged, except menus picking up the card fill (`#FFFFFF` → `#F3F3F5`).
- **Dark:** app bar and expanded tile settle from `#222222` onto the page tone `#111111` (flatter — which is what the elevation-0 + hairline-border design was always reaching for); menus step up to `#333333` so they read as elevated.

## Tests

Three regression tests in the reporter's exact configuration (saturated blue primary, white `onPrimary`, dark mode): the surface roles resolve correctly, the inverse pair stays neutral, and every painted surface still estimates as `Brightness.dark`. Two existing assertions that encoded the old inverse mapping are updated.

**No golden churn** — the galleries render buttons, badges, chips, inputs, dropdowns and pickers, none of which touch these three component themes. Full suite green: 2,022 root tests, 228 in `soliplex_design`, analyzer clean.

## Follow-up

#421 tracks the reporter's separate extensibility asks (a seam for full color control, spacing tokens, border widths). Deliberately not bundled here — those are design calls, this is a defect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

