### PR TITLE
fix(room): restore the document filter on reload via run-history hydration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,11 @@ Versions follow the `version+build` scheme from `pubspec.yaml`, bumped via
   button.
 - Lobby: an "Unread first" sort option groups a server's rooms into an Unread
   section above a Read section, each ordered by recent activity.
+- Room: the document filter now survives a reload. On thread open the selection
+  is restored from the thread's run history (the last-sent filter), so reopening
+  a thread no longer drops the filter and silently searches the whole corpus. A
+  filtered document that has since been deleted shows as an "Unavailable
+  document" chip and is still applied, so results stay correctly scoped.
 
 ### Changed
 

--- a/lib/src/modules/room/document_filter_hydration.dart
+++ b/lib/src/modules/room/document_filter_hydration.dart
@@ -22,3 +22,49 @@ Set<RagDocument> resolveSelectionFromFilter(
       corpusById[id] ?? RagDocument(id: id, title: unavailableDocumentTitle),
   };
 }
+
+/// Coordinates the two async inputs hydration needs — the room's document
+/// corpus and the thread's stored filter — and resolves the selection exactly
+/// once per thread, whichever input arrives last. The corpus is room-scoped
+/// and survives thread switches; [beginThread] resets the per-thread filter
+/// state so the next thread re-resolves.
+class DocumentFilterHydrator {
+  DocumentFilterHydrator({required this.onResolved});
+
+  /// Fired once per thread with the resolved selection. The caller decides
+  /// whether to apply it (e.g. skip if the user already edited the selection).
+  final void Function(Set<RagDocument> selection) onResolved;
+
+  Map<String, RagDocument> _corpusById = const {};
+  bool _hasCorpus = false;
+  String? _filter;
+  bool _hasFilter = false;
+  bool _resolved = false;
+
+  /// Room-scoped corpus; survives [beginThread].
+  void setCorpus(List<RagDocument> corpus) {
+    _corpusById = {for (final doc in corpus) doc.id: doc};
+    _hasCorpus = true;
+    _tryResolve();
+  }
+
+  /// Resets per-thread filter state on thread (re)open; keeps the corpus.
+  void beginThread() {
+    _filter = null;
+    _hasFilter = false;
+    _resolved = false;
+  }
+
+  /// The thread's last-run filter (may be null = unfiltered).
+  void setFilter(String? filter) {
+    _filter = filter;
+    _hasFilter = true;
+    _tryResolve();
+  }
+
+  void _tryResolve() {
+    if (_resolved || !_hasCorpus || !_hasFilter) return;
+    _resolved = true;
+    onResolved(resolveSelectionFromFilter(_filter, _corpusById));
+  }
+}

--- a/lib/src/modules/room/document_filter_hydration.dart
+++ b/lib/src/modules/room/document_filter_hydration.dart
@@ -23,6 +23,23 @@ Set<RagDocument> resolveSelectionFromFilter(
   };
 }
 
+/// Whether a hydration result should be applied to the selection store.
+///
+/// Applies only when the resolution is for the still-active thread, the resolved
+/// selection is non-empty, and the user has not already made a selection for
+/// that thread during the async load (local edit wins).
+bool shouldApplyHydratedSelection({
+  required String resolvedThreadId,
+  required String? activeThreadId,
+  required bool resolvedSelectionIsEmpty,
+  required bool currentSelectionIsEmpty,
+}) {
+  if (resolvedThreadId != activeThreadId) return false;
+  if (resolvedSelectionIsEmpty) return false;
+  if (!currentSelectionIsEmpty) return false;
+  return true;
+}
+
 /// Coordinates the two async inputs hydration needs — the room's document
 /// corpus and the thread's stored filter — and resolves the selection once per
 /// thread, whichever arrives last. The corpus is room-scoped; the hydrator is

--- a/lib/src/modules/room/document_filter_hydration.dart
+++ b/lib/src/modules/room/document_filter_hydration.dart
@@ -24,47 +24,49 @@ Set<RagDocument> resolveSelectionFromFilter(
 }
 
 /// Coordinates the two async inputs hydration needs — the room's document
-/// corpus and the thread's stored filter — and resolves the selection exactly
-/// once per thread, whichever input arrives last. The corpus is room-scoped
-/// and survives thread switches; [beginThread] resets the per-thread filter
-/// state so the next thread re-resolves.
+/// corpus and the thread's stored filter — and resolves the selection once per
+/// thread, whichever arrives last. The corpus is room-scoped; the hydrator is
+/// recreated on room change (so there is no cross-room state to invalidate).
+/// [setFilter] carries the thread id so a resolution can be attributed to the
+/// thread it is for, and switching threads re-arms resolution.
 class DocumentFilterHydrator {
   DocumentFilterHydrator({required this.onResolved});
 
-  /// Fired once per thread with the resolved selection. The caller decides
-  /// whether to apply it (e.g. skip if the user already edited the selection).
-  final void Function(Set<RagDocument> selection) onResolved;
+  /// Fired once per thread with the thread id and its resolved selection. The
+  /// caller applies it only if that thread is still active and the user has not
+  /// edited the selection (local edit wins).
+  final void Function(String threadId, Set<RagDocument> selection) onResolved;
 
   Map<String, RagDocument> _corpusById = const {};
   bool _hasCorpus = false;
+  String? _threadId;
   String? _filter;
   bool _hasFilter = false;
   bool _resolved = false;
 
-  /// Room-scoped corpus; survives [beginThread].
+  /// Room-scoped corpus.
   void setCorpus(List<RagDocument> corpus) {
     _corpusById = {for (final doc in corpus) doc.id: doc};
     _hasCorpus = true;
     _tryResolve();
   }
 
-  /// Resets per-thread filter state on thread (re)open; keeps the corpus.
-  void beginThread() {
-    _filter = null;
-    _hasFilter = false;
-    _resolved = false;
-  }
-
-  /// The thread's last-run filter (may be null = unfiltered).
-  void setFilter(String? filter) {
+  /// The thread's last-run filter (may be null = unfiltered). Switching to a new
+  /// thread re-arms resolution for it.
+  void setFilter(String threadId, String? filter) {
+    if (threadId != _threadId) {
+      _threadId = threadId;
+      _resolved = false;
+    }
     _filter = filter;
     _hasFilter = true;
     _tryResolve();
   }
 
   void _tryResolve() {
-    if (_resolved || !_hasCorpus || !_hasFilter) return;
+    final threadId = _threadId;
+    if (_resolved || !_hasCorpus || !_hasFilter || threadId == null) return;
     _resolved = true;
-    onResolved(resolveSelectionFromFilter(_filter, _corpusById));
+    onResolved(threadId, resolveSelectionFromFilter(_filter, _corpusById));
   }
 }

--- a/lib/src/modules/room/document_filter_hydration.dart
+++ b/lib/src/modules/room/document_filter_hydration.dart
@@ -1,0 +1,24 @@
+import 'package:soliplex_client/soliplex_client.dart';
+
+/// Title shown for a filtered document id that is no longer in the room's
+/// corpus (deleted server-side). The id is still sent in the filter so the
+/// search stays correctly scoped; the placeholder makes the deletion visible.
+const String unavailableDocumentTitle = 'Unavailable document';
+
+/// Resolves a thread's document-filter WHERE clause into the selected
+/// documents, using [corpusById] (the room's current corpus keyed by id) to
+/// recover titles. An id absent from the corpus becomes a placeholder
+/// [RagDocument] titled [unavailableDocumentTitle] and is kept in the set, so
+/// [buildDocumentFilter] still targets it (no silent scope-broadening).
+///
+/// A null [filter] yields an empty set (the thread is unfiltered).
+Set<RagDocument> resolveSelectionFromFilter(
+  String? filter,
+  Map<String, RagDocument> corpusById,
+) {
+  if (filter == null) return {};
+  return {
+    for (final id in parseDocumentFilter(filter))
+      corpusById[id] ?? RagDocument(id: id, title: unavailableDocumentTitle),
+  };
+}

--- a/lib/src/modules/room/room_state.dart
+++ b/lib/src/modules/room/room_state.dart
@@ -40,6 +40,7 @@ class RoomState {
     required RunRegistry registry,
     required UploadTrackerRegistry uploadRegistry,
     this.onNavigateToThread,
+    this.onHistoryLoaded,
   })  : _connection = serverEntry.connection,
         _auth = serverEntry.auth,
         _roomId = roomId,
@@ -87,6 +88,11 @@ class RoomState {
   final AgentRuntimeManager _runtimeManager;
   final RunRegistry _registry;
   final void Function(String? threadId)? onNavigateToThread;
+
+  /// Invoked after a thread's history loads, so the host can react to the
+  /// fetched state (e.g. hydrate the document filter). Fires in addition to
+  /// the internal runtime seeding below.
+  final void Function(String threadId, ThreadHistory history)? onHistoryLoaded;
 
   /// Snapshot of the registry's active keys, to detect active→terminal
   /// transitions. Seeded before subscribing so the immediate first emission is
@@ -197,6 +203,7 @@ class RoomState {
           ),
           history,
         );
+        onHistoryLoaded?.call(id, history);
       },
     );
     // Thread switch → force a refresh for the same reasons as room

--- a/lib/src/modules/room/ui/room_screen.dart
+++ b/lib/src/modules/room/ui/room_screen.dart
@@ -20,6 +20,7 @@ import 'package:soliplex_client/soliplex_client.dart'
         Reconnecting,
         Room,
         SourceReferenceFormatting,
+        ThreadHistory,
         buildDocumentFilter;
 import 'package:soliplex_logging/soliplex_logging.dart';
 
@@ -37,6 +38,7 @@ import '../thread_anchor_storage.dart';
 import '../thread_read_markers.dart';
 import '../thread_read_tracker.dart';
 import '../unread_boundary.dart';
+import '../document_filter_hydration.dart';
 import '../document_selections.dart';
 import '../pick_file.dart';
 import '../agent_runtime_manager.dart';
@@ -291,6 +293,8 @@ class _RoomScreenState extends State<RoomScreen> {
 
   CancelToken? _filterDocsCancelToken;
 
+  late DocumentFilterHydrator _filterHydrator;
+
   /// Show the filter button only when filtering is enabled and there is
   /// something to filter (or we failed to find out).
   bool get _showDocumentFilter =>
@@ -331,6 +335,7 @@ class _RoomScreenState extends State<RoomScreen> {
         .getDocuments(widget.roomId, cancelToken: token)
         .then((docs) {
       if (!mounted || token != _filterDocsCancelToken) return;
+      _filterHydrator.setCorpus(docs);
       setState(() {
         _hasFilterableDocuments = docs.isNotEmpty;
         _filterDocsLoadFailed = false;
@@ -836,9 +841,36 @@ class _RoomScreenState extends State<RoomScreen> {
     }
   }
 
-  // TODO: If a selected document is deleted server-side before send,
-  // the backend silently returns empty results. Consider reconciling
-  // selections against the fetched document list.
+  /// Feeds the thread's last-run filter to the hydrator on history load.
+  void _onThreadHistoryLoaded(String threadId, ThreadHistory history) {
+    if (!_filterEnabled) return;
+    if (threadId != widget.threadId) return; // stale fetch for another thread
+    _filterHydrator.setFilter(threadId, history.documentFilter);
+  }
+
+  /// Seeds the resolved selection — but only if the thread is still active and
+  /// the user hasn't already made a selection for it during the async load
+  /// (local edit wins).
+  void _applyHydratedSelection(String threadId, Set<RagDocument> selection) {
+    if (!mounted) return;
+    if (threadId != widget.threadId) return;
+    if (selection.isEmpty) return;
+    final current = _documentSelections.get(
+      serverId: _serverId,
+      roomId: widget.roomId,
+      threadId: threadId,
+    );
+    if (current.isNotEmpty) return; // user edited, or already hydrated
+    setState(() {
+      _documentSelections.set(
+        serverId: _serverId,
+        roomId: widget.roomId,
+        threadId: threadId,
+        docs: selection,
+      );
+    });
+  }
+
   Map<String, dynamic>? _buildStateOverlay() {
     if (!_filterEnabled) return null;
     final selected = _selectedDocuments;
@@ -858,6 +890,8 @@ class _RoomScreenState extends State<RoomScreen> {
     _serverReadMarkers = widget.serverReadMarkers ?? ServerReadMarkers();
     _userId = widget.serverEntry.auth.currentUserId.value;
     _state = _createRoomState();
+    _filterHydrator =
+        DocumentFilterHydrator(onResolved: _applyHydratedSelection);
     _workdirs = _createWorkdirController();
     _refreshFilterableDocuments();
     _fetchServerRooms();
@@ -963,6 +997,8 @@ class _RoomScreenState extends State<RoomScreen> {
       _threadReadTracker = _createThreadReadTracker();
       _hasFilterableDocuments = false;
       _filterDocsLoadFailed = false;
+      _filterHydrator =
+          DocumentFilterHydrator(onResolved: _applyHydratedSelection);
       _refreshFilterableDocuments();
       _watchRoomRead();
       _markThreadRead(widget.threadId);
@@ -1032,6 +1068,7 @@ class _RoomScreenState extends State<RoomScreen> {
         registry: widget.registry,
         uploadRegistry: widget.uploadRegistry,
         onNavigateToThread: (id) => _navigateToThread(id),
+        onHistoryLoaded: _onThreadHistoryLoaded,
       );
 
   WorkdirController _createWorkdirController() => WorkdirController(

--- a/lib/src/modules/room/ui/room_screen.dart
+++ b/lib/src/modules/room/ui/room_screen.dart
@@ -853,14 +853,19 @@ class _RoomScreenState extends State<RoomScreen> {
   /// (local edit wins).
   void _applyHydratedSelection(String threadId, Set<RagDocument> selection) {
     if (!mounted) return;
-    if (threadId != widget.threadId) return;
-    if (selection.isEmpty) return;
     final current = _documentSelections.get(
       serverId: _serverId,
       roomId: widget.roomId,
       threadId: threadId,
     );
-    if (current.isNotEmpty) return; // user edited, or already hydrated
+    if (!shouldApplyHydratedSelection(
+      resolvedThreadId: threadId,
+      activeThreadId: widget.threadId,
+      resolvedSelectionIsEmpty: selection.isEmpty,
+      currentSelectionIsEmpty: current.isEmpty,
+    )) {
+      return;
+    }
     setState(() {
       _documentSelections.set(
         serverId: _serverId,

--- a/packages/soliplex_client/lib/src/api/soliplex_api.dart
+++ b/packages/soliplex_client/lib/src/api/soliplex_api.dart
@@ -703,6 +703,7 @@ class SoliplexApi {
     final runs =
         rawRuns is Map<String, dynamic> ? rawRuns : const <String, dynamic>{};
     if (runs.isEmpty) return ThreadHistory(messages: const []);
+    final documentFilter = _extractLatestDocumentFilter(runs);
 
     // 2. Walk runs in creation order, collecting:
     //    - completed run ids → fetched in parallel below
@@ -745,7 +746,7 @@ class SoliplexApi {
     }
 
     if (completedRunIds.isEmpty && preFetchDrops.isEmpty) {
-      return ThreadHistory(messages: const []);
+      return ThreadHistory(messages: const [], documentFilter: documentFilter);
     }
 
     // 3. Fetch all run events in parallel (cache handles duplicates)
@@ -821,7 +822,7 @@ class SoliplexApi {
     }
 
     // 5. Replay events to reconstruct history (messages + AG-UI state)
-    return _replayEventsToHistory(eventsPerRun, threadId);
+    return _replayEventsToHistory(eventsPerRun, threadId, documentFilter);
   }
 
   /// Fetches events for a single run, using cache for completed runs.
@@ -916,6 +917,33 @@ class SoliplexApi {
     ];
   }
 
+  /// The `document_filter` from the newest run that carries one in its
+  /// persisted input state. The backend returns runs in ascending creation
+  /// order (`Thread.runs` is `order_by="Run.created"`), and that order is
+  /// preserved through the JSON dict into [runs], so the last entry carrying
+  /// the key is the newest — no dependence on any per-run `created` value.
+  /// Each run stores the complete filter it was sent (the client re-asserts it
+  /// every run; the backend keeps no merged state), so the newest run's value
+  /// IS the current filter — there is nothing to accumulate. An explicit null
+  /// on the newest carrying run means "cleared" and wins over older runs.
+  /// Resilient: malformed entries are skipped. See U3.
+  String? _extractLatestDocumentFilter(Map<String, dynamic> runs) {
+    for (final entry in runs.entries.toList().reversed) {
+      final value = entry.value;
+      if (value is! Map<String, dynamic>) continue;
+      final runInput = value['run_input'];
+      if (runInput is! Map<String, dynamic>) continue;
+      final state = runInput['state'];
+      if (state is! Map<String, dynamic>) continue;
+      final rag = state['rag'];
+      if (rag is! Map<String, dynamic>) continue;
+      if (!rag.containsKey('document_filter')) continue;
+      final filter = rag['document_filter'];
+      return filter is String ? filter : null;
+    }
+    return null;
+  }
+
   /// Replays events to reconstruct thread history (messages + AG-UI state).
   ///
   /// Processes events per-run to properly correlate citations with user
@@ -931,8 +959,11 @@ class SoliplexApi {
             })>
         eventsPerRun,
     String threadId,
+    String? documentFilter,
   ) {
-    if (eventsPerRun.isEmpty) return ThreadHistory(messages: const []);
+    if (eventsPerRun.isEmpty) {
+      return ThreadHistory(messages: const [], documentFilter: documentFilter);
+    }
 
     var conversation = Conversation.empty(threadId: threadId);
     var streaming = const AwaitingText() as StreamingState;
@@ -1114,6 +1145,7 @@ class SoliplexApi {
       aguiState: conversation.aguiState,
       messageStates: messageStates,
       runs: runs,
+      documentFilter: documentFilter,
     );
   }
 

--- a/packages/soliplex_client/lib/src/domain/rag_document.dart
+++ b/packages/soliplex_client/lib/src/domain/rag_document.dart
@@ -22,6 +22,45 @@ String buildDocumentFilter(List<RagDocument> documents) {
   return "id IN (${escaped.map((id) => "'$id'").join(', ')})";
 }
 
+/// Parses the id list out of a WHERE clause produced by [buildDocumentFilter].
+///
+/// Extracts every SQL single-quoted literal in order, unescaping doubled
+/// quotes (`''` -> `'`), which recovers the ids from both shapes the builder
+/// emits (`id = '<id>'` and `id IN ('<id>', ...)`). Any other or empty input
+/// yields `const []`; this never throws, so a malformed stored filter degrades
+/// to "no selection" rather than crashing hydration.
+List<String> parseDocumentFilter(String filter) {
+  final ids = <String>[];
+  var i = 0;
+  while (i < filter.length) {
+    if (filter[i] != "'") {
+      i++;
+      continue;
+    }
+    i++; // consume the opening quote
+    final buffer = StringBuffer();
+    var foundClosingQuote = false;
+    while (i < filter.length) {
+      if (filter[i] == "'") {
+        if (i + 1 < filter.length && filter[i + 1] == "'") {
+          buffer.write("'"); // escaped quote
+          i += 2;
+          continue;
+        }
+        i++; // consume the closing quote
+        foundClosingQuote = true;
+        break;
+      }
+      buffer.write(filter[i]);
+      i++;
+    }
+    if (foundClosingQuote) {
+      ids.add(buffer.toString());
+    }
+  }
+  return ids;
+}
+
 /// Represents a document available for narrowing RAG searches.
 ///
 /// Documents are fetched from a room and can be selected to limit

--- a/packages/soliplex_client/lib/src/domain/thread_history.dart
+++ b/packages/soliplex_client/lib/src/domain/thread_history.dart
@@ -15,6 +15,7 @@ class ThreadHistory {
     Map<String, dynamic> aguiState = const {},
     Map<String, MessageState> messageStates = const {},
     List<RunEventBundle> runs = const [],
+    this.documentFilter,
   })  : messages = List.unmodifiable(messages),
         aguiState = Map.unmodifiable(aguiState),
         messageStates = Map.unmodifiable(messageStates),
@@ -43,6 +44,12 @@ class ThreadHistory {
   /// and citations are still derived from [messages] / [messageStates];
   /// [runs] is an additive surface for execution-tracker replay.
   final List<RunEventBundle> runs;
+
+  /// The document-filter WHERE clause the client last asserted for this thread,
+  /// read from the newest run's `run_input.state.rag.document_filter`. `null`
+  /// when no run carries one. The backend keeps no merged filter state, so this
+  /// (not any state event) is the only record of the thread's active filter.
+  final String? documentFilter;
 }
 
 /// Decoded AG-UI events for a single run, in arrival order.

--- a/packages/soliplex_client/test/api/soliplex_api_test.dart
+++ b/packages/soliplex_client/test/api/soliplex_api_test.dart
@@ -4207,6 +4207,198 @@ void main() {
       });
     });
 
+    group('getThreadHistory document filter', () {
+      void stubRun(String runId) {
+        when(
+          () => mockTransport.request<Map<String, dynamic>>(
+            'GET',
+            Uri.parse(
+              'https://api.example.com/api/v1/rooms/room-123/agui/thread-456/$runId',
+            ),
+            cancelToken: any(named: 'cancelToken'),
+            fromJson: any(named: 'fromJson'),
+            body: any(named: 'body'),
+            headers: any(named: 'headers'),
+            timeout: any(named: 'timeout'),
+          ),
+        ).thenAnswer((_) async => {'run_id': runId, 'events': <dynamic>[]});
+      }
+
+      void stubThread(Map<String, dynamic> runs) {
+        when(
+          () => mockTransport.request<Map<String, dynamic>>(
+            'GET',
+            Uri.parse(
+              'https://api.example.com/api/v1/rooms/room-123/agui/thread-456',
+            ),
+            cancelToken: any(named: 'cancelToken'),
+            fromJson: any(named: 'fromJson'),
+            body: any(named: 'body'),
+            headers: any(named: 'headers'),
+            timeout: any(named: 'timeout'),
+          ),
+        ).thenAnswer((_) async => {'runs': runs});
+      }
+
+      test('surfaces the filter from a run input state', () async {
+        stubThread({
+          'run-1': {
+            'run_id': 'run-1',
+            'created': '2026-01-07T01:00:00.000Z',
+            'finished': '2026-01-07T01:01:00.000Z',
+            'run_input': {
+              'state': {
+                'rag': {'document_filter': "id IN ('a', 'b')"},
+              },
+            },
+          },
+        });
+        stubRun('run-1');
+
+        final history = await api.getThreadHistory('room-123', 'thread-456');
+
+        expect(history.documentFilter, equals("id IN ('a', 'b')"));
+      });
+
+      test('picks the last run in the map (newest)', () async {
+        stubThread({
+          'run-1': {
+            'run_id': 'run-1',
+            'created': '2026-01-07T01:00:00.000Z',
+            'finished': '2026-01-07T01:01:00.000Z',
+            'run_input': {
+              'state': {
+                'rag': {'document_filter': "id = 'old'"},
+              },
+            },
+          },
+          'run-2': {
+            'run_id': 'run-2',
+            'created': '2026-01-07T02:00:00.000Z',
+            'finished': '2026-01-07T02:01:00.000Z',
+            'run_input': {
+              'state': {
+                'rag': {'document_filter': "id = 'new'"},
+              },
+            },
+          },
+        });
+        stubRun('run-1');
+        stubRun('run-2');
+
+        final history = await api.getThreadHistory('room-123', 'thread-456');
+
+        expect(history.documentFilter, equals("id = 'new'"));
+      });
+
+      test('newest run (map-last) with no created still wins', () async {
+        stubThread({
+          'run-1': {
+            'run_id': 'run-1',
+            'created': '2026-01-07T01:00:00.000Z',
+            'finished': '2026-01-07T01:01:00.000Z',
+            'run_input': {
+              'state': {
+                'rag': {'document_filter': "id = 'old'"},
+              },
+            },
+          },
+          'run-2': {
+            'run_id': 'run-2',
+            'finished': '2026-01-07T02:01:00.000Z',
+            'run_input': {
+              'state': {
+                'rag': {'document_filter': "id = 'new'"},
+              },
+            },
+          },
+        });
+        stubRun('run-1');
+        stubRun('run-2');
+
+        final history = await api.getThreadHistory('room-123', 'thread-456');
+
+        expect(history.documentFilter, equals("id = 'new'"));
+      });
+
+      test('an earlier run with no created does not win', () async {
+        stubThread({
+          'run-1': {
+            'run_id': 'run-1',
+            'finished': '2026-01-07T01:01:00.000Z',
+            'run_input': {
+              'state': {
+                'rag': {'document_filter': "id = 'stray'"},
+              },
+            },
+          },
+          'run-2': {
+            'run_id': 'run-2',
+            'created': '2026-01-07T02:00:00.000Z',
+            'finished': '2026-01-07T02:01:00.000Z',
+            'run_input': {
+              'state': {
+                'rag': {'document_filter': "id = 'new'"},
+              },
+            },
+          },
+        });
+        stubRun('run-1');
+        stubRun('run-2');
+
+        final history = await api.getThreadHistory('room-123', 'thread-456');
+
+        expect(history.documentFilter, equals("id = 'new'"));
+      });
+
+      test('explicit null on the newest run wins over an older run', () async {
+        stubThread({
+          'run-1': {
+            'run_id': 'run-1',
+            'created': '2026-01-07T01:00:00.000Z',
+            'finished': '2026-01-07T01:01:00.000Z',
+            'run_input': {
+              'state': {
+                'rag': {'document_filter': "id = 'old'"},
+              },
+            },
+          },
+          'run-2': {
+            'run_id': 'run-2',
+            'created': '2026-01-07T02:00:00.000Z',
+            'finished': '2026-01-07T02:01:00.000Z',
+            'run_input': {
+              'state': {
+                'rag': {'document_filter': null},
+              },
+            },
+          },
+        });
+        stubRun('run-1');
+        stubRun('run-2');
+
+        final history = await api.getThreadHistory('room-123', 'thread-456');
+
+        expect(history.documentFilter, isNull);
+      });
+
+      test('is null when the newest run has no rag filter', () async {
+        stubThread({
+          'run-1': {
+            'run_id': 'run-1',
+            'created': '2026-01-07T01:00:00.000Z',
+            'finished': '2026-01-07T01:01:00.000Z',
+            'run_input': {'state': <String, dynamic>{}},
+          },
+        });
+        stubRun('run-1');
+
+        final history = await api.getThreadHistory('room-123', 'thread-456');
+
+        expect(history.documentFilter, isNull);
+      });
+    });
+
     group('getRun', () {
       test('returns run by ID', () async {
         when(

--- a/packages/soliplex_client/test/domain/rag_document_test.dart
+++ b/packages/soliplex_client/test/domain/rag_document_test.dart
@@ -92,5 +92,57 @@ void main() {
         );
       });
     });
+
+    group('parseDocumentFilter', () {
+      test('parses a single-id equality filter', () {
+        expect(parseDocumentFilter("id = 'abc-123'"), equals(['abc-123']));
+      });
+
+      test('parses a multi-id IN filter', () {
+        expect(
+          parseDocumentFilter("id IN ('abc-123', 'def-456')"),
+          equals(['abc-123', 'def-456']),
+        );
+      });
+
+      test('unescapes doubled single quotes', () {
+        expect(parseDocumentFilter("id = 'id''inject'"), equals(["id'inject"]));
+      });
+
+      test('round-trips buildDocumentFilter output', () {
+        const docs = [
+          RagDocument(id: 'abc-123', title: 'A'),
+          RagDocument(id: 'def-456', title: 'B'),
+        ];
+        expect(
+          parseDocumentFilter(buildDocumentFilter(docs)),
+          equals(['abc-123', 'def-456']),
+        );
+      });
+
+      test('returns empty list for empty or unrecognized input', () {
+        expect(parseDocumentFilter(''), isEmpty);
+        expect(parseDocumentFilter('   '), isEmpty);
+        expect(parseDocumentFilter('not a filter'), isEmpty);
+      });
+
+      test('returns empty list for unterminated quote', () {
+        expect(parseDocumentFilter("id = 'abc"), isEmpty);
+      });
+
+      test('returns empty list for lone quote', () {
+        expect(parseDocumentFilter("'"), isEmpty);
+      });
+
+      test('round-trips id containing escaped quote', () {
+        const docs = [
+          RagDocument(id: "a'b", title: 'X'),
+        ];
+        expect(
+          parseDocumentFilter(buildDocumentFilter(docs)),
+          equals(["a'b"]),
+        );
+      });
+    });
   });
 }

--- a/packages/soliplex_client/test/domain/thread_history_test.dart
+++ b/packages/soliplex_client/test/domain/thread_history_test.dart
@@ -133,6 +133,15 @@ void main() {
 
       expect(history.runs, hasLength(1));
     });
+
+    test('documentFilter defaults to null and carries a provided value', () {
+      expect(ThreadHistory(messages: const []).documentFilter, isNull);
+      expect(
+        ThreadHistory(messages: const [], documentFilter: "id = 'x'")
+            .documentFilter,
+        equals("id = 'x'"),
+      );
+    });
   });
 
   group('RunEventBundle', () {

--- a/test/modules/room/document_filter_hydration_test.dart
+++ b/test/modules/room/document_filter_hydration_test.dart
@@ -41,61 +41,77 @@ void main() {
     ];
 
     test('resolves once when corpus arrives before filter', () {
-      final resolved = <Set<RagDocument>>[];
-      DocumentFilterHydrator(onResolved: resolved.add)
+      final resolved = <({String threadId, Set<RagDocument> selection})>[];
+      DocumentFilterHydrator(
+        onResolved: (t, s) => resolved.add((threadId: t, selection: s)),
+      )
         ..setCorpus(corpus)
-        ..beginThread()
-        ..setFilter("id = 'a'");
+        ..setFilter('t1', "id = 'a'");
       expect(resolved, hasLength(1));
-      expect(resolved.single.single.id, equals('a'));
+      expect(resolved.single.threadId, equals('t1'));
+      expect(resolved.single.selection.single.id, equals('a'));
     });
 
     test('resolves when filter arrives before corpus', () {
-      final resolved = <Set<RagDocument>>[];
-      DocumentFilterHydrator(onResolved: resolved.add)
-        ..beginThread()
-        ..setFilter("id = 'b'")
+      final resolved = <({String threadId, Set<RagDocument> selection})>[];
+      DocumentFilterHydrator(
+        onResolved: (t, s) => resolved.add((threadId: t, selection: s)),
+      )
+        ..setFilter('t1', "id = 'b'")
         ..setCorpus(corpus);
-      expect(resolved.single.single.id, equals('b'));
+      expect(resolved.single.threadId, equals('t1'));
+      expect(resolved.single.selection.single.id, equals('b'));
     });
 
-    test('does not resolve with only one input', () {
-      final resolved = <Set<RagDocument>>[];
-      DocumentFilterHydrator(onResolved: resolved.add).setCorpus(corpus);
+    test('does not resolve with only corpus (no filter)', () {
+      final resolved = <({String threadId, Set<RagDocument> selection})>[];
+      DocumentFilterHydrator(
+        onResolved: (t, s) => resolved.add((threadId: t, selection: s)),
+      ).setCorpus(corpus);
+      expect(resolved, isEmpty);
+    });
+
+    test('does not resolve with only filter (no corpus)', () {
+      final resolved = <({String threadId, Set<RagDocument> selection})>[];
+      DocumentFilterHydrator(
+        onResolved: (t, s) => resolved.add((threadId: t, selection: s)),
+      ).setFilter('t1', "id = 'a'");
       expect(resolved, isEmpty);
     });
 
     test('resolves a null filter to an empty selection', () {
-      final resolved = <Set<RagDocument>>[];
-      DocumentFilterHydrator(onResolved: resolved.add)
+      final resolved = <({String threadId, Set<RagDocument> selection})>[];
+      DocumentFilterHydrator(
+        onResolved: (t, s) => resolved.add((threadId: t, selection: s)),
+      )
         ..setCorpus(corpus)
-        ..beginThread()
-        ..setFilter(null);
+        ..setFilter('t1', null);
       expect(resolved, hasLength(1));
-      expect(resolved.single, isEmpty);
+      expect(resolved.single.selection, isEmpty);
     });
 
-    test('resolves only once even if the filter is set twice', () {
-      final resolved = <Set<RagDocument>>[];
-      DocumentFilterHydrator(onResolved: resolved.add)
+    test('resolves only once for the same thread', () {
+      final resolved = <({String threadId, Set<RagDocument> selection})>[];
+      DocumentFilterHydrator(
+        onResolved: (t, s) => resolved.add((threadId: t, selection: s)),
+      )
         ..setCorpus(corpus)
-        ..beginThread()
-        ..setFilter("id = 'a'")
-        ..setFilter("id = 'b'");
+        ..setFilter('t1', "id = 'a'")
+        ..setFilter('t1', "id = 'b'");
       expect(resolved, hasLength(1));
     });
 
-    test('beginThread lets a new thread resolve with the retained corpus', () {
-      final resolved = <Set<RagDocument>>[];
-      final hydrator = DocumentFilterHydrator(onResolved: resolved.add)
+    test('switching thread re-resolves with the retained corpus', () {
+      final resolved = <({String threadId, Set<RagDocument> selection})>[];
+      DocumentFilterHydrator(
+        onResolved: (t, s) => resolved.add((threadId: t, selection: s)),
+      )
         ..setCorpus(corpus)
-        ..beginThread()
-        ..setFilter("id = 'a'");
-      hydrator
-        ..beginThread()
-        ..setFilter("id = 'b'");
+        ..setFilter('t1', "id = 'a'")
+        ..setFilter('t2', "id = 'b'");
       expect(resolved, hasLength(2));
-      expect(resolved.last.single.id, equals('b'));
+      expect(resolved.last.threadId, equals('t2'));
+      expect(resolved.last.selection.single.id, equals('b'));
     });
   });
 }

--- a/test/modules/room/document_filter_hydration_test.dart
+++ b/test/modules/room/document_filter_hydration_test.dart
@@ -114,4 +114,68 @@ void main() {
       expect(resolved.last.selection.single.id, equals('b'));
     });
   });
+
+  group('shouldApplyHydratedSelection', () {
+    test(
+        'applies for the active thread with a non-empty result and empty store',
+        () {
+      expect(
+        shouldApplyHydratedSelection(
+          resolvedThreadId: 't1',
+          activeThreadId: 't1',
+          resolvedSelectionIsEmpty: false,
+          currentSelectionIsEmpty: true,
+        ),
+        isTrue,
+      );
+    });
+
+    test('rejects when the resolution is for a different thread', () {
+      expect(
+        shouldApplyHydratedSelection(
+          resolvedThreadId: 't1',
+          activeThreadId: 't2',
+          resolvedSelectionIsEmpty: false,
+          currentSelectionIsEmpty: true,
+        ),
+        isFalse,
+      );
+    });
+
+    test('rejects when no thread is active', () {
+      expect(
+        shouldApplyHydratedSelection(
+          resolvedThreadId: 't1',
+          activeThreadId: null,
+          resolvedSelectionIsEmpty: false,
+          currentSelectionIsEmpty: true,
+        ),
+        isFalse,
+      );
+    });
+
+    test('rejects an empty resolved selection', () {
+      expect(
+        shouldApplyHydratedSelection(
+          resolvedThreadId: 't1',
+          activeThreadId: 't1',
+          resolvedSelectionIsEmpty: true,
+          currentSelectionIsEmpty: true,
+        ),
+        isFalse,
+      );
+    });
+
+    test('rejects when the user already has a selection (local edit wins)', () {
+      expect(
+        shouldApplyHydratedSelection(
+          resolvedThreadId: 't1',
+          activeThreadId: 't1',
+          resolvedSelectionIsEmpty: false,
+          currentSelectionIsEmpty: false,
+        ),
+        isFalse,
+      );
+    });
+  });
 }

--- a/test/modules/room/document_filter_hydration_test.dart
+++ b/test/modules/room/document_filter_hydration_test.dart
@@ -1,0 +1,36 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:soliplex_client/soliplex_client.dart';
+import 'package:soliplex_frontend/src/modules/room/document_filter_hydration.dart';
+
+void main() {
+  group('resolveSelectionFromFilter', () {
+    const corpus = {
+      'a': RagDocument(id: 'a', title: 'Alpha'),
+      'b': RagDocument(id: 'b', title: 'Beta'),
+    };
+
+    test('resolves ids to their corpus documents', () {
+      final selection = resolveSelectionFromFilter("id IN ('a', 'b')", corpus);
+      expect(selection, contains(const RagDocument(id: 'a', title: 'Alpha')));
+      expect(
+        selection.firstWhere((d) => d.id == 'b').title,
+        equals('Beta'),
+      );
+    });
+
+    test('keeps an unresolved id as an unavailable placeholder', () {
+      final selection = resolveSelectionFromFilter("id = 'gone'", corpus);
+      final doc = selection.single;
+      expect(doc.id, equals('gone'));
+      expect(doc.title, equals(unavailableDocumentTitle));
+    });
+
+    test('null filter yields an empty selection', () {
+      expect(resolveSelectionFromFilter(null, corpus), isEmpty);
+    });
+
+    test('empty filter string yields an empty selection', () {
+      expect(resolveSelectionFromFilter('', corpus), isEmpty);
+    });
+  });
+}

--- a/test/modules/room/document_filter_hydration_test.dart
+++ b/test/modules/room/document_filter_hydration_test.dart
@@ -33,4 +33,69 @@ void main() {
       expect(resolveSelectionFromFilter('', corpus), isEmpty);
     });
   });
+
+  group('DocumentFilterHydrator', () {
+    const corpus = [
+      RagDocument(id: 'a', title: 'Alpha'),
+      RagDocument(id: 'b', title: 'Beta'),
+    ];
+
+    test('resolves once when corpus arrives before filter', () {
+      final resolved = <Set<RagDocument>>[];
+      DocumentFilterHydrator(onResolved: resolved.add)
+        ..setCorpus(corpus)
+        ..beginThread()
+        ..setFilter("id = 'a'");
+      expect(resolved, hasLength(1));
+      expect(resolved.single.single.id, equals('a'));
+    });
+
+    test('resolves when filter arrives before corpus', () {
+      final resolved = <Set<RagDocument>>[];
+      DocumentFilterHydrator(onResolved: resolved.add)
+        ..beginThread()
+        ..setFilter("id = 'b'")
+        ..setCorpus(corpus);
+      expect(resolved.single.single.id, equals('b'));
+    });
+
+    test('does not resolve with only one input', () {
+      final resolved = <Set<RagDocument>>[];
+      DocumentFilterHydrator(onResolved: resolved.add).setCorpus(corpus);
+      expect(resolved, isEmpty);
+    });
+
+    test('resolves a null filter to an empty selection', () {
+      final resolved = <Set<RagDocument>>[];
+      DocumentFilterHydrator(onResolved: resolved.add)
+        ..setCorpus(corpus)
+        ..beginThread()
+        ..setFilter(null);
+      expect(resolved, hasLength(1));
+      expect(resolved.single, isEmpty);
+    });
+
+    test('resolves only once even if the filter is set twice', () {
+      final resolved = <Set<RagDocument>>[];
+      DocumentFilterHydrator(onResolved: resolved.add)
+        ..setCorpus(corpus)
+        ..beginThread()
+        ..setFilter("id = 'a'")
+        ..setFilter("id = 'b'");
+      expect(resolved, hasLength(1));
+    });
+
+    test('beginThread lets a new thread resolve with the retained corpus', () {
+      final resolved = <Set<RagDocument>>[];
+      final hydrator = DocumentFilterHydrator(onResolved: resolved.add)
+        ..setCorpus(corpus)
+        ..beginThread()
+        ..setFilter("id = 'a'");
+      hydrator
+        ..beginThread()
+        ..setFilter("id = 'b'");
+      expect(resolved, hasLength(2));
+      expect(resolved.last.single.id, equals('b'));
+    });
+  });
 }


### PR DESCRIPTION
## What

After a reload, a thread's RAG document filter was silently lost: `DocumentSelections` is in-memory only, so on reopen the store was empty and the filter simply stopped being re-sent — every subsequent run searched the whole corpus. This restores the selection on thread open by **hydrating from the thread's run history** (no device-local persistence).

## Why this approach

Verified against `soliplex_backend_main` (haiku-rag-slim 0.65.1):
- The backend keeps **no cross-run merged filter state** — each run reconstructs `RAGState` from *that run's* input (absent == null == unfiltered). Carrying the filter forward is the client's job.
- `document_filter` is **never emitted in AG-UI state events** (only *read* by search), so it can't be rebuilt from event replay.
- It **is** present verbatim in `run_input.state`, which thread-open already downloads per run and previously discarded. So hydration needs no new network calls.

## How

- `parseDocumentFilter` — inverse of `buildDocumentFilter` (ids from the WHERE clause; never throws).
- `ThreadHistory.documentFilter` — surfaces the newest run's `document_filter` (runs arrive in the backend's creation order; explicit null on the newest run = "cleared").
- `resolveSelectionFromFilter` — resolves ids against the room corpus; an id no longer in the corpus (deleted) becomes an "Unavailable document" placeholder that is **kept** in the filter (no silent scope-broadening).
- `DocumentFilterHydrator` + `RoomScreen` wiring — coordinates the async corpus + filter, carries a thread-id token, and is recreated on room change, closing two races (in-room thread switch mis-seeding; cross-room stale corpus). Local edits during the async load win over hydration (`shouldApplyHydratedSelection`, unit-tested).

## Test plan

- `soliplex_client` suite green; `test/modules/room/` 1049 tests pass; `flutter analyze` clean.
- Unit coverage for the parser, the last-run extraction (incl. explicit-null-wins and missing-`created`), the resolver (unavailable placeholder kept), the hydrator (both input orders, thread-switch re-resolve), and the apply-guard.
- Manual: set a filter → reload → chips restored and the filter re-applies; edit-during-load isn't clobbered; a deleted doc shows "Unavailable document" and stays scoped.

## Follow-ups (not in this PR)

- "Revert unsent changes" button (restore the last-sent selection).
- Multi-device sync affordance (currently last-run-wins).

🤖 Generated with [Claude Code](https://claude.com/claude-code)