### PR TITLE
chore: version 0.93.1+67

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,16 @@ Versions follow the `version+build` scheme from `pubspec.yaml`, bumped via
 
 ## [Unreleased]
 
+## [0.93.1+67] - 2026-07-14
+
+### Added
+
+- Room: the document filter now survives a reload. On thread open the selection
+  is restored from the thread's run history (the last-sent filter), so reopening
+  a thread no longer drops the filter and silently searches the whole corpus. A
+  filtered document that has since been deleted shows as an "Unavailable
+  document" chip and is still applied, so results stay correctly scoped.
+
 ## [0.93.0+66] - 2026-07-13
 
 ### Added
@@ -19,11 +29,6 @@ Versions follow the `version+build` scheme from `pubspec.yaml`, bumped via
   button.
 - Lobby: an "Unread first" sort option groups a server's rooms into an Unread
   section above a Read section, each ordered by recent activity.
-- Room: the document filter now survives a reload. On thread open the selection
-  is restored from the thread's run history (the last-sent filter), so reopening
-  a thread no longer drops the filter and silently searches the whole corpus. A
-  filtered document that has since been deleted shows as an "Unavailable
-  document" chip and is still applied, so results stay correctly scoped.
 
 ### Changed
 

--- a/lib/version.dart
+++ b/lib/version.dart
@@ -2,4 +2,4 @@
 ///
 /// Generated from pubspec.yaml. Run `dart run tool/update_version.dart` after
 /// changing the version in pubspec.yaml.
-const String soliplexVersion = '0.93.0+66';
+const String soliplexVersion = '0.93.1+67';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,7 +3,7 @@ description: Modular Flutter frontend framework for Soliplex
 publish_to: none
 # To update version, run:
 # dart run tool/bump_version.dart <major|minor|patch|build>
-version: 0.93.0+66
+version: 0.93.1+67
 
 environment:
   sdk: ^3.6.0


### PR DESCRIPTION
Patch release bumping `soliplex_frontend` to `0.93.1+67`.

- Bump `version` in `pubspec.yaml` and `lib/version.dart`.
- Move the "document filter survives a reload" changelog entry (PR #423, merged after the `v0.93.0+66` tag) from the already-released `[0.93.0+66]` section into a new `[0.93.1+67]` section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)