### PR TITLE
chore: version 0.94.0+68

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 Versions follow the `version+build` scheme from `pubspec.yaml`, bumped via
 `dart run tool/bump_version.dart`.
 
-## [Unreleased]
+## [0.94.0+68] - 2026-07-17
 
 ### Added
 

--- a/lib/version.dart
+++ b/lib/version.dart
@@ -2,4 +2,4 @@
 ///
 /// Generated from pubspec.yaml. Run `dart run tool/update_version.dart` after
 /// changing the version in pubspec.yaml.
-const String soliplexVersion = '0.93.1+67';
+const String soliplexVersion = '0.94.0+68';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,7 +3,7 @@ description: Modular Flutter frontend framework for Soliplex
 publish_to: none
 # To update version, run:
 # dart run tool/bump_version.dart <major|minor|patch|build>
-version: 0.93.1+67
+version: 0.94.0+68
 
 environment:
   sdk: ^3.6.0


### PR DESCRIPTION
Minor release bump `0.93.1+67` → `0.94.0+68`.

Cuts the flavor-reification work into a release. This is a **minor (breaking)** bump: the `package:soliplex_frontend/flavors.dart` entrypoint is removed (its exports moved to the main barrel), `ShellConfig.fromModules` is now sync and validates at construction, `ShellConfig.validate()` is gone, and `AppIdentity` asserts a non-empty `appName`. See the `[0.94.0+68]` CHANGELOG entry for the full list and migration guidance.

Consumer fixes (amia, theme2026) follow in their own PRs.

- `pubspec.yaml` / `lib/version.dart`: version → `0.94.0+68`
- `CHANGELOG.md`: `[Unreleased]` → `[0.94.0+68] - 2026-07-17`

🤖 Generated with [Claude Code](https://claude.com/claude-code)