### PR TITLE
Per-server status message banner

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,10 +13,14 @@ Versions follow the `version+build` scheme from `pubspec.yaml`, bumped via
 - Room and lobby: a per-server status banner, chiefly an upcoming-maintenance
   warning with a live countdown, that operators post or cancel by dropping or
   deleting a static JSON file on the backend — no app rebuild. It is scoped to
-  the in-context server, minimizes to a thin strip (never fully dismissible),
-  and auto-hides once a maintenance window ends. A missing file or fetch error
-  resolves silently to "no message". The file location and poll interval are
-  flavor-configurable.
+  the in-context server and auto-hides once a maintenance window ends. A missing
+  file or fetch error resolves silently to "no message". The file location and
+  poll interval are flavor-configurable.
+- The banner starts collapsed (title + countdown + one body line) and expands on
+  demand to show the server name, the maintenance window as a range in the
+  viewer's local time (stacked onto two lines on narrow screens), and the full
+  body. A dismiss button hides a message for the session; it returns on the next
+  app start or after logging out and back in to the server.
 
 ## [0.93.1+67] - 2026-07-14
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,16 @@ Versions follow the `version+build` scheme from `pubspec.yaml`, bumped via
 
 ## [Unreleased]
 
+### Added
+
+- Room and lobby: a per-server status banner, chiefly an upcoming-maintenance
+  warning with a live countdown, that operators post or cancel by dropping or
+  deleting a static JSON file on the backend — no app rebuild. It is scoped to
+  the in-context server, minimizes to a thin strip (never fully dismissible),
+  and auto-hides once a maintenance window ends. A missing file or fetch error
+  resolves silently to "no message". The file location and poll interval are
+  flavor-configurable.
+
 ## [0.93.1+67] - 2026-07-14
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,8 +14,9 @@ Versions follow the `version+build` scheme from `pubspec.yaml`, bumped via
   warning with a live countdown, that operators post or cancel by dropping or
   deleting a static JSON file on the backend — no app rebuild. It is scoped to
   the in-context server and auto-hides once a maintenance window ends. A missing
-  file or fetch error resolves silently to "no message". The file location and
-  poll interval are flavor-configurable.
+  file or fetch error resolves silently to "no message"; a message whose
+  maintenance window is malformed still shows, just without the window. The file
+  location and poll interval are flavor-configurable.
 - The banner starts collapsed (title + countdown + one body line) and expands on
   demand to show the server name, the maintenance window as a range in the
   viewer's local time (stacked onto two lines on narrow screens), and the full

--- a/lib/src/core/shell.dart
+++ b/lib/src/core/shell.dart
@@ -71,7 +71,7 @@ class _SoliplexShellState extends State<SoliplexShell> {
         ...widget.config.overrides,
         inactivityConfigProvider.overrideWithValue(widget.config.inactivity),
         statusMessageConfigProvider
-            .overrideWithValue(widget.config.maintenance),
+            .overrideWithValue(widget.config.statusMessage),
       ],
       child: _ShellRoot(config: widget.config, router: _router),
     );

--- a/lib/src/core/shell.dart
+++ b/lib/src/core/shell.dart
@@ -13,6 +13,7 @@ import 'inactivity/inactivity_monitor.dart';
 import 'inactivity/inactivity_provider.dart';
 import 'router.dart';
 import 'shell_config.dart';
+import 'status_message_config.dart';
 
 /// Boots the Soliplex shell from a [ShellConfig].
 ///
@@ -69,6 +70,8 @@ class _SoliplexShellState extends State<SoliplexShell> {
       overrides: [
         ...widget.config.overrides,
         inactivityConfigProvider.overrideWithValue(widget.config.inactivity),
+        statusMessageConfigProvider
+            .overrideWithValue(widget.config.maintenance),
       ],
       child: _ShellRoot(config: widget.config, router: _router),
     );

--- a/lib/src/core/shell_config.dart
+++ b/lib/src/core/shell_config.dart
@@ -15,7 +15,7 @@ class ShellConfig {
   final String initialRoute;
   final Listenable? refreshListenable;
   final InactivityConfig inactivity;
-  final StatusMessageConfig maintenance;
+  final StatusMessageConfig statusMessage;
 
   /// Tears down every module's `onDispose` in reverse registration order.
   ///
@@ -42,7 +42,7 @@ class ShellConfig {
     required List<GoRouterRedirect> redirects,
     this.refreshListenable,
     this.inactivity = const InactivityConfig(),
-    this.maintenance = const StatusMessageConfig(),
+    this.statusMessage = const StatusMessageConfig(),
     this.dispose,
   })  : _routes = routes,
         _overrides = overrides,
@@ -71,7 +71,7 @@ class ShellConfig {
     String initialRoute = '/',
     Listenable? refreshListenable,
     InactivityConfig inactivity = const InactivityConfig(),
-    StatusMessageConfig maintenance = const StatusMessageConfig(),
+    StatusMessageConfig statusMessage = const StatusMessageConfig(),
   }) async {
     final coordinator = _AppModuleCoordinator(modules);
     return ShellConfig._internal(
@@ -85,7 +85,7 @@ class ShellConfig {
       redirects: coordinator.redirects,
       refreshListenable: refreshListenable,
       inactivity: inactivity,
-      maintenance: maintenance,
+      statusMessage: statusMessage,
       dispose: coordinator.disposeAll,
     );
   }

--- a/lib/src/core/shell_config.dart
+++ b/lib/src/core/shell_config.dart
@@ -5,6 +5,7 @@ import 'package:go_router/go_router.dart';
 import 'app_module.dart';
 import 'inactivity/inactivity_config.dart';
 import 'router.dart';
+import 'status_message_config.dart';
 
 class ShellConfig {
   final String appName;
@@ -14,6 +15,7 @@ class ShellConfig {
   final String initialRoute;
   final Listenable? refreshListenable;
   final InactivityConfig inactivity;
+  final StatusMessageConfig maintenance;
 
   /// Tears down every module's `onDispose` in reverse registration order.
   ///
@@ -40,6 +42,7 @@ class ShellConfig {
     required List<GoRouterRedirect> redirects,
     this.refreshListenable,
     this.inactivity = const InactivityConfig(),
+    this.maintenance = const StatusMessageConfig(),
     this.dispose,
   })  : _routes = routes,
         _overrides = overrides,
@@ -68,6 +71,7 @@ class ShellConfig {
     String initialRoute = '/',
     Listenable? refreshListenable,
     InactivityConfig inactivity = const InactivityConfig(),
+    StatusMessageConfig maintenance = const StatusMessageConfig(),
   }) async {
     final coordinator = _AppModuleCoordinator(modules);
     return ShellConfig._internal(
@@ -81,6 +85,7 @@ class ShellConfig {
       redirects: coordinator.redirects,
       refreshListenable: refreshListenable,
       inactivity: inactivity,
+      maintenance: maintenance,
       dispose: coordinator.disposeAll,
     );
   }

--- a/lib/src/core/status_message_config.dart
+++ b/lib/src/core/status_message_config.dart
@@ -1,0 +1,34 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+/// Compile-time configuration for the per-server status-message banner.
+///
+/// `filePath` is the path (relative to the server base) of the static JSON
+/// file operators drop to post a message. `pollInterval` bounds cancel
+/// latency to one cycle. Pass [StatusMessageConfig.disabled] (or any zero
+/// interval) to opt out; the controller checks [isEnabled] and never
+/// schedules a fetch when off.
+class StatusMessageConfig {
+  const StatusMessageConfig({
+    this.filePath = defaultFilePath,
+    this.pollInterval = defaultPollInterval,
+  });
+
+  static const String defaultFilePath = '/maintenance.json';
+  static const Duration defaultPollInterval = Duration(minutes: 5);
+  static const StatusMessageConfig disabled =
+      StatusMessageConfig(pollInterval: Duration.zero);
+
+  final String filePath;
+  final Duration pollInterval;
+
+  bool get isEnabled => pollInterval > Duration.zero;
+}
+
+/// Holds the active [StatusMessageConfig].
+///
+/// Overridden by [SoliplexShell] with the value from [ShellConfig.maintenance];
+/// defaults to the built-in config so a bare [ProviderScope] (e.g. a widget
+/// test) can read it without an override.
+final statusMessageConfigProvider = Provider<StatusMessageConfig>(
+  (_) => const StatusMessageConfig(),
+);

--- a/lib/src/core/status_message_config.dart
+++ b/lib/src/core/status_message_config.dart
@@ -13,7 +13,7 @@ class StatusMessageConfig {
     this.pollInterval = defaultPollInterval,
   });
 
-  static const String defaultFilePath = '/maintenance.json';
+  static const String defaultFilePath = '/messages/status.json';
   static const Duration defaultPollInterval = Duration(minutes: 5);
   static const StatusMessageConfig disabled =
       StatusMessageConfig(pollInterval: Duration.zero);

--- a/lib/src/core/status_message_config.dart
+++ b/lib/src/core/status_message_config.dart
@@ -2,16 +2,18 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 /// Compile-time configuration for the per-server status-message banner.
 ///
-/// `filePath` is the path (relative to the server base) of the static JSON
-/// file operators drop to post a message. `pollInterval` bounds cancel
-/// latency to one cycle. Pass [StatusMessageConfig.disabled] (or any zero
-/// interval) to opt out; the controller checks [isEnabled] and never
+/// `filePath` locates the static JSON file operators drop to post a message,
+/// resolved against the server URL via `baseUrl.resolve(filePath)` — a
+/// leading-slash path (the `/messages/status.json` default) resolves against
+/// the server origin, discarding any base-URL path. `pollInterval` bounds
+/// cancel latency to one cycle. Pass [StatusMessageConfig.disabled] (or any
+/// zero interval) to opt out; the controller checks [isEnabled] and never
 /// schedules a fetch when off.
 class StatusMessageConfig {
   const StatusMessageConfig({
     this.filePath = defaultFilePath,
     this.pollInterval = defaultPollInterval,
-  });
+  }) : assert(filePath.length > 0, 'filePath must be non-empty');
 
   static const String defaultFilePath = '/messages/status.json';
   static const Duration defaultPollInterval = Duration(minutes: 5);
@@ -26,7 +28,7 @@ class StatusMessageConfig {
 
 /// Holds the active [StatusMessageConfig].
 ///
-/// Overridden by [SoliplexShell] with the value from [ShellConfig.maintenance];
+/// Overridden by [SoliplexShell] with the value from [ShellConfig.statusMessage];
 /// defaults to the built-in config so a bare [ProviderScope] (e.g. a widget
 /// test) can read it without an override.
 final statusMessageConfigProvider = Provider<StatusMessageConfig>(

--- a/lib/src/flavors/standard.dart
+++ b/lib/src/flavors/standard.dart
@@ -51,8 +51,8 @@ Future<ShellConfig> standard({
   ConsentNotice? consentNotice,
   Duration inactivityWarningDuration = InactivityConfig.defaultWarningDuration,
   Duration inactivityGraceDuration = InactivityConfig.defaultGraceDuration,
-  String maintenanceFilePath = StatusMessageConfig.defaultFilePath,
-  Duration maintenancePollInterval = StatusMessageConfig.defaultPollInterval,
+  String statusMessageFilePath = StatusMessageConfig.defaultFilePath,
+  Duration statusMessagePollInterval = StatusMessageConfig.defaultPollInterval,
 }) async {
   final effectiveIdentity = identity ?? AppIdentity.soliplex;
   final lightTheme = lowerBrandTheme(
@@ -174,9 +174,9 @@ Future<ShellConfig> standard({
       warningDuration: inactivityWarningDuration,
       graceDuration: inactivityGraceDuration,
     ),
-    maintenance: StatusMessageConfig(
-      filePath: maintenanceFilePath,
-      pollInterval: maintenancePollInterval,
+    statusMessage: StatusMessageConfig(
+      filePath: statusMessageFilePath,
+      pollInterval: statusMessagePollInterval,
     ),
     modules: [
       DiagnosticsAppModule(

--- a/lib/src/flavors/standard.dart
+++ b/lib/src/flavors/standard.dart
@@ -8,6 +8,7 @@ import '../core/app_identity.dart';
 import '../core/inactivity/inactivity_config.dart';
 import '../core/routes.dart';
 import '../core/shell_config.dart';
+import '../core/status_message_config.dart';
 import '../core/storage_migration.dart';
 import 'package:soliplex_design/soliplex_design.dart';
 import '../interfaces/auth_state.dart' show Authenticated;
@@ -50,6 +51,8 @@ Future<ShellConfig> standard({
   ConsentNotice? consentNotice,
   Duration inactivityWarningDuration = InactivityConfig.defaultWarningDuration,
   Duration inactivityGraceDuration = InactivityConfig.defaultGraceDuration,
+  String maintenanceFilePath = StatusMessageConfig.defaultFilePath,
+  Duration maintenancePollInterval = StatusMessageConfig.defaultPollInterval,
 }) async {
   final effectiveIdentity = identity ?? AppIdentity.soliplex;
   final lightTheme = lowerBrandTheme(
@@ -170,6 +173,10 @@ Future<ShellConfig> standard({
     inactivity: InactivityConfig(
       warningDuration: inactivityWarningDuration,
       graceDuration: inactivityGraceDuration,
+    ),
+    maintenance: StatusMessageConfig(
+      filePath: maintenanceFilePath,
+      pollInterval: maintenancePollInterval,
     ),
     modules: [
       DiagnosticsAppModule(

--- a/lib/src/modules/auth/connect_flow.dart
+++ b/lib/src/modules/auth/connect_flow.dart
@@ -240,8 +240,20 @@ class ConnectFlow {
     DefaultBackendUrlStorage.save(probeResult.serverUrl.toString());
     await SelectedServerStorage.save(serverId);
     if (!_isCancelled(gen)) {
-      onServerConnected?.call(probeResult.serverUrl);
+      _notifyConnected(probeResult.serverUrl);
       state.value = const Connected();
+    }
+  }
+
+  /// Fires [onServerConnected], isolating any throw so a misbehaving callback
+  /// can neither escape as an unhandled async error nor bounce an
+  /// already-connected user to the error state.
+  void _notifyConnected(Uri serverUrl) {
+    try {
+      onServerConnected?.call(serverUrl);
+    } on Object catch (e, st) {
+      _logger.warning('ConnectFlow: onServerConnected callback failed',
+          error: e, stackTrace: st);
     }
   }
 
@@ -301,7 +313,7 @@ class ConnectFlow {
         ),
       );
 
-      onServerConnected?.call(probeResult.serverUrl);
+      if (!_isCancelled(gen)) _notifyConnected(probeResult.serverUrl);
 
       // Post-login housekeeping is best-effort: the user is already
       // signed in, so a storage failure here must not bounce them to the

--- a/lib/src/modules/auth/connect_flow.dart
+++ b/lib/src/modules/auth/connect_flow.dart
@@ -90,6 +90,7 @@ class ConnectFlow {
     required this.authFlow,
     required this.inactivityLogoutFlags,
     this.consentNotice,
+    this.onServerConnected,
   });
 
   final ServerManager serverManager;
@@ -98,6 +99,11 @@ class ConnectFlow {
   final AuthFlow authFlow;
   final InactivityLogoutFlagStorage inactivityLogoutFlags;
   final ConsentNotice? consentNotice;
+
+  /// Fired when a server establishes a fresh connection — after an OIDC login
+  /// or when a no-auth server is added. Lets the app layer react (e.g. reset a
+  /// server's dismissed status messages) without this flow depending on it.
+  final void Function(Uri serverUrl)? onServerConnected;
 
   final Signal<ConnectState> state = Signal<ConnectState>(const UrlInput());
 
@@ -233,7 +239,10 @@ class ConnectFlow {
     );
     DefaultBackendUrlStorage.save(probeResult.serverUrl.toString());
     await SelectedServerStorage.save(serverId);
-    if (!_isCancelled(gen)) state.value = const Connected();
+    if (!_isCancelled(gen)) {
+      onServerConnected?.call(probeResult.serverUrl);
+      state.value = const Connected();
+    }
   }
 
   Future<void> _authenticate(
@@ -291,6 +300,8 @@ class ConnectFlow {
           idToken: authResult.idToken,
         ),
       );
+
+      onServerConnected?.call(probeResult.serverUrl);
 
       // Post-login housekeeping is best-effort: the user is already
       // signed in, so a storage failure here must not bounce them to the

--- a/lib/src/modules/auth/ui/home_screen.dart
+++ b/lib/src/modules/auth/ui/home_screen.dart
@@ -6,6 +6,7 @@ import 'package:soliplex_agent/soliplex_agent.dart' hide AuthException;
 
 import '../../../core/routes.dart';
 import '../../../shared/markdown/prose_markdown.dart';
+import '../../../status_message/status_message_dismissals.dart';
 import '../auth_providers.dart';
 import '../connect_flow.dart';
 import '../consent_notice.dart';
@@ -71,6 +72,11 @@ class _HomeScreenState extends ConsumerState<HomeScreen> {
       authFlow: ref.read(authFlowProvider),
       inactivityLogoutFlags: ref.read(inactivityLogoutFlagsProvider),
       consentNotice: ref.read(consentNoticeProvider),
+      // A fresh connection re-surfaces a maintenance banner the user dismissed
+      // earlier in the session for this server.
+      onServerConnected: (url) => ref
+          .read(statusMessageDismissalsProvider)
+          .clear(serverKey: url.toString()),
     );
 
     _urlController.addListener(_onUrlChanged);

--- a/lib/src/modules/lobby/ui/lobby_screen.dart
+++ b/lib/src/modules/lobby/ui/lobby_screen.dart
@@ -9,6 +9,7 @@ import '../../../core/activity_read.dart';
 import '../../../core/app_identity.dart';
 import '../../../core/routes.dart';
 import '../../../shared/mark_read_context_menu.dart';
+import '../../../status_message/ui/status_message_banner.dart';
 import '../../auth/server_entry.dart';
 import '../../auth/server_manager.dart';
 import '../../room/run_registry.dart';
@@ -498,8 +499,16 @@ class _RoomContent extends StatelessWidget {
         // the persisted choice is honoured again once the pane is wide enough.
         final allowGrid = constraints.maxWidth >= SoliplexBreakpoints.tablet;
         final effectiveViewMode = allowGrid ? viewMode : LobbyViewMode.list;
+        final selectedEntry =
+            selectedServerId == null ? null : servers[selectedServerId];
         return Column(
           children: [
+            if (selectedEntry != null)
+              StatusMessageBanner(
+                key: ValueKey(selectedEntry.serverUrl),
+                baseUrl: selectedEntry.serverUrl,
+                client: selectedEntry.httpClient,
+              ),
             Padding(
               padding: const EdgeInsets.fromLTRB(SoliplexSpacing.s4,
                   SoliplexSpacing.s2, SoliplexSpacing.s4, 0),

--- a/lib/src/modules/lobby/ui/lobby_screen.dart
+++ b/lib/src/modules/lobby/ui/lobby_screen.dart
@@ -508,6 +508,7 @@ class _RoomContent extends StatelessWidget {
                 key: ValueKey(selectedEntry.serverUrl),
                 baseUrl: selectedEntry.serverUrl,
                 client: selectedEntry.httpClient,
+                serverLabel: selectedEntry.displayName,
               ),
             Padding(
               padding: const EdgeInsets.fromLTRB(SoliplexSpacing.s4,

--- a/lib/src/modules/lobby/ui/server_sidebar.dart
+++ b/lib/src/modules/lobby/ui/server_sidebar.dart
@@ -7,6 +7,7 @@ import 'package:signals_flutter/signals_flutter.dart';
 
 import '../../../../version.dart';
 import '../../../core/app_identity.dart';
+import '../../../status_message/status_message_dismissals.dart';
 import '../../auth/auth_providers.dart';
 import '../../auth/auth_tokens.dart';
 import '../../auth/server_entry.dart';
@@ -427,6 +428,9 @@ class _ServerTileMenuState extends ConsumerState<_ServerTileMenu> {
         authFlow: ref.read(authFlowProvider),
         probeClient: ref.read(probeClientProvider),
       );
+      ref
+          .read(statusMessageDismissalsProvider)
+          .clear(serverKey: widget.entry.serverUrl.toString());
       switch (then) {
         case _AfterLogout.keep:
           break;

--- a/lib/src/modules/lobby/ui/server_sidebar.dart
+++ b/lib/src/modules/lobby/ui/server_sidebar.dart
@@ -7,7 +7,6 @@ import 'package:signals_flutter/signals_flutter.dart';
 
 import '../../../../version.dart';
 import '../../../core/app_identity.dart';
-import '../../../status_message/status_message_dismissals.dart';
 import '../../auth/auth_providers.dart';
 import '../../auth/auth_tokens.dart';
 import '../../auth/server_entry.dart';
@@ -428,9 +427,6 @@ class _ServerTileMenuState extends ConsumerState<_ServerTileMenu> {
         authFlow: ref.read(authFlowProvider),
         probeClient: ref.read(probeClientProvider),
       );
-      ref
-          .read(statusMessageDismissalsProvider)
-          .clear(serverKey: widget.entry.serverUrl.toString());
       switch (then) {
         case _AfterLogout.keep:
           break;

--- a/lib/src/modules/room/message_timestamp_format.dart
+++ b/lib/src/modules/room/message_timestamp_format.dart
@@ -1,35 +1,13 @@
 // Pure formatting for chat message time captions and day dividers.
 //
 // All inputs are converted to the viewer's local zone before any calendar
-// field is read. `now` is injectable for testing. No `intl` — the 12-hour
-// clock and weekday/month names are built by hand.
+// field is read. `now` is injectable for testing. The 12-hour clock,
+// weekday/month names, and same-day check come from the shared, dependency-free
+// local-time helpers.
+
+import '../../shared/local_time_format.dart';
 
 enum _DayBucket { today, yesterday, weekday, thisYear, older }
-
-const _weekdayNames = [
-  'Monday',
-  'Tuesday',
-  'Wednesday',
-  'Thursday',
-  'Friday',
-  'Saturday',
-  'Sunday',
-];
-
-const _monthNames = [
-  'January',
-  'February',
-  'March',
-  'April',
-  'May',
-  'June',
-  'July',
-  'August',
-  'September',
-  'October',
-  'November',
-  'December',
-];
 
 /// Whole calendar days between two local dates, computed DST-immune by flooring
 /// each to a UTC midnight (UTC has no DST, so the diff is always whole days).
@@ -51,22 +29,6 @@ _DayBucket _bucketFor(DateTime localT, DateTime localNow) {
   return localT.year == localNow.year ? _DayBucket.thisYear : _DayBucket.older;
 }
 
-/// 12-hour clock: midnight → `12:xx AM`, noon → `12:xx PM`, minute zero-padded,
-/// hour unpadded.
-String _clock(DateTime local) {
-  final h = local.hour;
-  final hour12 = h % 12 == 0 ? 12 : h % 12;
-  final period = h < 12 ? 'AM' : 'PM';
-  final mm = local.minute.toString().padLeft(2, '0');
-  return '$hour12:$mm $period';
-}
-
-String _weekdayAbbrev(DateTime local) =>
-    _weekdayNames[local.weekday - 1].substring(0, 3);
-
-String _monthAbbrev(DateTime local) =>
-    _monthNames[local.month - 1].substring(0, 3);
-
 /// Muted caption under a message bubble. Today shows just the time (the day
 /// divider carries the day); older buckets stay self-describing.
 ///
@@ -78,14 +40,14 @@ String _monthAbbrev(DateTime local) =>
 String formatMessageCaption(DateTime time, {DateTime? now}) {
   final local = time.toLocal();
   final localNow = (now ?? DateTime.now()).toLocal();
-  final clock = _clock(local);
+  final clock = formatClock12(local);
   return switch (_bucketFor(local, localNow)) {
     _DayBucket.today => clock,
     _DayBucket.yesterday => 'Yesterday · $clock',
-    _DayBucket.weekday => '${_weekdayAbbrev(local)} · $clock',
-    _DayBucket.thisYear => '${_monthAbbrev(local)} ${local.day} · $clock',
+    _DayBucket.weekday => '${weekdayAbbrev(local)} · $clock',
+    _DayBucket.thisYear => '${monthAbbrev(local)} ${local.day} · $clock',
     _DayBucket.older =>
-      '${_monthAbbrev(local)} ${local.day}, ${local.year} · $clock',
+      '${monthAbbrev(local)} ${local.day}, ${local.year} · $clock',
   };
 }
 
@@ -101,8 +63,8 @@ String formatMessageCaption(DateTime time, {DateTime? now}) {
 String formatDayDivider(DateTime time, {DateTime? now}) {
   final local = time.toLocal();
   final localNow = (now ?? DateTime.now()).toLocal();
-  final weekday = _weekdayNames[local.weekday - 1];
-  final month = _monthNames[local.month - 1];
+  final weekday = weekdayNames[local.weekday - 1];
+  final month = monthNames[local.month - 1];
   return switch (_bucketFor(local, localNow)) {
     _DayBucket.today => 'Today',
     _DayBucket.yesterday => 'Yesterday',
@@ -110,12 +72,4 @@ String formatDayDivider(DateTime time, {DateTime? now}) {
     _DayBucket.thisYear => '$month ${local.day}',
     _DayBucket.older => '$month ${local.day}, ${local.year}',
   };
-}
-
-/// Whether [a] and [b] fall on the same local calendar day. Component equality
-/// (no arithmetic), so it is DST-safe. Used for the day-divider boundary.
-bool isSameCalendarDay(DateTime a, DateTime b) {
-  final la = a.toLocal();
-  final lb = b.toLocal();
-  return la.year == lb.year && la.month == lb.month && la.day == lb.day;
 }

--- a/lib/src/modules/room/message_timestamp_format.dart
+++ b/lib/src/modules/room/message_timestamp_format.dart
@@ -1,9 +1,8 @@
 // Pure formatting for chat message time captions and day dividers.
 //
 // All inputs are converted to the viewer's local zone before any calendar
-// field is read. `now` is injectable for testing. The 12-hour clock,
-// weekday/month names, and same-day check come from the shared, dependency-free
-// local-time helpers.
+// field is read. `now` is injectable for testing. The 12-hour clock and
+// weekday/month names come from the shared, dependency-free local-time helpers.
 
 import '../../shared/local_time_format.dart';
 

--- a/lib/src/modules/room/ui/message_timeline.dart
+++ b/lib/src/modules/room/ui/message_timeline.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
 import 'package:soliplex_agent/soliplex_agent.dart' hide State;
 
+import '../../../shared/local_time_format.dart' show isSameCalendarDay;
 import '../compute_display_messages.dart';
 import '../execution_tracker.dart';
 import '../message_timestamp_format.dart';

--- a/lib/src/modules/room/ui/room_screen.dart
+++ b/lib/src/modules/room/ui/room_screen.dart
@@ -1578,6 +1578,7 @@ class _RoomScreenState extends State<RoomScreen> {
           key: ValueKey(widget.serverEntry.serverUrl),
           baseUrl: widget.serverEntry.serverUrl,
           client: widget.serverEntry.httpClient,
+          serverLabel: widget.serverEntry.displayName,
         ),
         _buildRoomHeader(room, roomStatus, threadStatus),
         if (_filesExpanded) _buildFilePanel(roomStatus, threadStatus),

--- a/lib/src/modules/room/ui/room_screen.dart
+++ b/lib/src/modules/room/ui/room_screen.dart
@@ -28,6 +28,7 @@ import '../../../core/activity_read.dart' show currentUserRoomMarkers;
 import '../../../core/keyed_storage.dart' show storageUser;
 import '../../../core/util/debouncer.dart';
 import '../../../core/routes.dart';
+import '../../../status_message/ui/status_message_banner.dart';
 import '../../auth/return_to_storage.dart';
 import '../../auth/server_entry.dart';
 import '../../lobby/lobby_read_markers.dart';
@@ -1573,6 +1574,11 @@ class _RoomScreenState extends State<RoomScreen> {
 
     return Column(
       children: [
+        StatusMessageBanner(
+          key: ValueKey(widget.serverEntry.serverUrl),
+          baseUrl: widget.serverEntry.serverUrl,
+          client: widget.serverEntry.httpClient,
+        ),
         _buildRoomHeader(room, roomStatus, threadStatus),
         if (_filesExpanded) _buildFilePanel(roomStatus, threadStatus),
         Expanded(child: _capWidth(body)),

--- a/lib/src/shared/local_time_format.dart
+++ b/lib/src/shared/local_time_format.dart
@@ -1,0 +1,54 @@
+// Pure, dependency-free local-time formatting primitives (no `intl`). Callers
+// pass an already-local `DateTime` (via `.toLocal()`) before reading any
+// calendar field, except [isSameCalendarDay], which localizes its own inputs.
+
+const weekdayNames = [
+  'Monday',
+  'Tuesday',
+  'Wednesday',
+  'Thursday',
+  'Friday',
+  'Saturday',
+  'Sunday',
+];
+
+const monthNames = [
+  'January',
+  'February',
+  'March',
+  'April',
+  'May',
+  'June',
+  'July',
+  'August',
+  'September',
+  'October',
+  'November',
+  'December',
+];
+
+/// Three-letter weekday for a local date, e.g. `"Mon"`.
+String weekdayAbbrev(DateTime local) =>
+    weekdayNames[local.weekday - 1].substring(0, 3);
+
+/// Three-letter month for a local date, e.g. `"Jun"`.
+String monthAbbrev(DateTime local) =>
+    monthNames[local.month - 1].substring(0, 3);
+
+/// 12-hour clock for a local time: midnight → `12:xx AM`, noon → `12:xx PM`,
+/// minute zero-padded, hour unpadded.
+String formatClock12(DateTime local) {
+  final h = local.hour;
+  final hour12 = h % 12 == 0 ? 12 : h % 12;
+  final period = h < 12 ? 'AM' : 'PM';
+  final mm = local.minute.toString().padLeft(2, '0');
+  return '$hour12:$mm $period';
+}
+
+/// Whether [a] and [b] fall on the same local calendar day. Component equality
+/// (no arithmetic), so it is DST-safe.
+bool isSameCalendarDay(DateTime a, DateTime b) {
+  final la = a.toLocal();
+  final lb = b.toLocal();
+  return la.year == lb.year && la.month == lb.month && la.day == lb.day;
+}

--- a/lib/src/status_message/status_message.dart
+++ b/lib/src/status_message/status_message.dart
@@ -9,6 +9,18 @@ class MessageWindow {
   const MessageWindow({required this.start, required this.end});
   final DateTime start;
   final DateTime end;
+
+  /// False when [end] precedes [start] — a malformed operator window. The
+  /// message is still shown (the invalid range is flagged in error color and
+  /// logged) rather than silently dropped.
+  bool get isValid => !end.isBefore(start);
+
+  @override
+  bool operator ==(Object other) =>
+      other is MessageWindow && other.start == start && other.end == end;
+
+  @override
+  int get hashCode => Object.hash(start, end);
 }
 
 @immutable
@@ -20,7 +32,10 @@ class StatusMessage {
     required this.intent,
     required this.category,
     this.window,
-  });
+  }) : assert(
+          id.length > 0 && title.length > 0 && body.length > 0,
+          'id, title, and body must be non-empty',
+        );
 
   final String id;
   final String title;
@@ -65,4 +80,17 @@ class StatusMessage {
       window: parseWindow(),
     );
   }
+
+  @override
+  bool operator ==(Object other) =>
+      other is StatusMessage &&
+      other.id == id &&
+      other.title == title &&
+      other.body == body &&
+      other.intent == intent &&
+      other.category == category &&
+      other.window == window;
+
+  @override
+  int get hashCode => Object.hash(id, title, body, intent, category, window);
 }

--- a/lib/src/status_message/status_message.dart
+++ b/lib/src/status_message/status_message.dart
@@ -6,7 +6,8 @@ enum MessageCategory { general, maintenance }
 
 @immutable
 class MessageWindow {
-  const MessageWindow({required this.start, required this.end});
+  MessageWindow({required this.start, required this.end})
+      : assert(start.isUtc && end.isUtc, 'window bounds must be UTC');
   final DateTime start;
   final DateTime end;
 
@@ -53,20 +54,24 @@ class StatusMessage {
       return value;
     }
 
+    // A present-but-malformed window (not an object, unparseable bounds, or a
+    // non-UTC bound that would silently shift per viewer) degrades to null —
+    // the message still shows, windowless — rather than discarding the whole
+    // announcement. The fetcher warns so the operator can spot the mistake.
+    // Only id/title/body are load-bearing enough to reject the message.
     MessageWindow? parseWindow() {
       final raw = json['window'];
-      if (raw == null) return null;
-      if (raw is! Map) {
-        throw const FormatException('status message: invalid "window"');
-      }
+      if (raw is! Map) return null;
+      final DateTime start;
+      final DateTime end;
       try {
-        return MessageWindow(
-          start: DateTime.parse(raw['start'] as String).toUtc(),
-          end: DateTime.parse(raw['end'] as String).toUtc(),
-        );
-      } on Object catch (e) {
-        throw FormatException('status message: invalid window bounds: $e');
+        start = DateTime.parse(raw['start'] as String);
+        end = DateTime.parse(raw['end'] as String);
+      } on Object {
+        return null;
       }
+      if (!start.isUtc || !end.isUtc) return null;
+      return MessageWindow(start: start, end: end);
     }
 
     return StatusMessage(

--- a/lib/src/status_message/status_message.dart
+++ b/lib/src/status_message/status_message.dart
@@ -1,0 +1,68 @@
+import 'package:flutter/foundation.dart' show immutable;
+
+enum MessageIntent { info, warning }
+
+enum MessageCategory { general, maintenance }
+
+@immutable
+class MessageWindow {
+  const MessageWindow({required this.start, required this.end});
+  final DateTime start;
+  final DateTime end;
+}
+
+@immutable
+class StatusMessage {
+  const StatusMessage({
+    required this.id,
+    required this.title,
+    required this.body,
+    required this.intent,
+    required this.category,
+    this.window,
+  });
+
+  final String id;
+  final String title;
+  final String body;
+  final MessageIntent intent;
+  final MessageCategory category;
+  final MessageWindow? window;
+
+  factory StatusMessage.fromJson(Map<String, dynamic> json) {
+    String requireString(String key) {
+      final value = json[key];
+      if (value is! String || value.isEmpty) {
+        throw FormatException('status message: missing or invalid "$key"');
+      }
+      return value;
+    }
+
+    MessageWindow? parseWindow() {
+      final raw = json['window'];
+      if (raw == null) return null;
+      if (raw is! Map) {
+        throw const FormatException('status message: invalid "window"');
+      }
+      try {
+        return MessageWindow(
+          start: DateTime.parse(raw['start'] as String).toUtc(),
+          end: DateTime.parse(raw['end'] as String).toUtc(),
+        );
+      } on Object catch (e) {
+        throw FormatException('status message: invalid window bounds: $e');
+      }
+    }
+
+    return StatusMessage(
+      id: requireString('id'),
+      title: requireString('title'),
+      body: requireString('body'),
+      intent: MessageIntent.values.asNameMap()[json['intent']] ??
+          MessageIntent.info,
+      category: MessageCategory.values.asNameMap()[json['category']] ??
+          MessageCategory.general,
+      window: parseWindow(),
+    );
+  }
+}

--- a/lib/src/status_message/status_message_controller.dart
+++ b/lib/src/status_message/status_message_controller.dart
@@ -21,6 +21,7 @@ class StatusMessageController with WidgetsBindingObserver {
 
   Timer? _timer;
   bool _started = false;
+  bool _disposed = false;
 
   void start() {
     if (_started || !config.isEnabled) return;
@@ -31,7 +32,12 @@ class StatusMessageController with WidgetsBindingObserver {
   }
 
   Future<void> _fetch() async {
-    _message.value = await _fetcher();
+    final message = await _fetcher();
+    // The banner (keyed by server URL) can dispose this controller while a
+    // fetch is in flight — e.g. switching servers or navigating away. Writing a
+    // disposed signal throws, so bail before the assignment.
+    if (_disposed) return;
+    _message.value = message;
   }
 
   @override
@@ -40,6 +46,7 @@ class StatusMessageController with WidgetsBindingObserver {
   }
 
   void dispose() {
+    _disposed = true;
     _timer?.cancel();
     if (_started) WidgetsBinding.instance.removeObserver(this);
     _message.dispose();

--- a/lib/src/status_message/status_message_controller.dart
+++ b/lib/src/status_message/status_message_controller.dart
@@ -1,0 +1,47 @@
+import 'dart:async';
+
+import 'package:flutter/widgets.dart';
+import 'package:signals_flutter/signals_flutter.dart';
+
+import '../core/status_message_config.dart';
+import 'status_message.dart';
+import 'status_message_fetcher.dart';
+
+class StatusMessageController with WidgetsBindingObserver {
+  StatusMessageController({
+    required StatusMessageFetcher fetcher,
+    required this.config,
+  }) : _fetcher = fetcher;
+
+  final StatusMessageFetcher _fetcher;
+  final StatusMessageConfig config;
+
+  final Signal<StatusMessage?> _message = Signal<StatusMessage?>(null);
+  ReadonlySignal<StatusMessage?> get message => _message;
+
+  Timer? _timer;
+  bool _started = false;
+
+  void start() {
+    if (_started || !config.isEnabled) return;
+    _started = true;
+    WidgetsBinding.instance.addObserver(this);
+    unawaited(_fetch());
+    _timer = Timer.periodic(config.pollInterval, (_) => unawaited(_fetch()));
+  }
+
+  Future<void> _fetch() async {
+    _message.value = await _fetcher();
+  }
+
+  @override
+  void didChangeAppLifecycleState(AppLifecycleState state) {
+    if (state == AppLifecycleState.resumed) unawaited(_fetch());
+  }
+
+  void dispose() {
+    _timer?.cancel();
+    if (_started) WidgetsBinding.instance.removeObserver(this);
+    _message.dispose();
+  }
+}

--- a/lib/src/status_message/status_message_dismissals.dart
+++ b/lib/src/status_message/status_message_dismissals.dart
@@ -1,0 +1,31 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+/// In-memory, session-scoped record of dismissed status messages.
+///
+/// Keyed by `(serverKey, messageId)` so dismissing one message does not
+/// suppress a different, newly-posted message on the same server. Not
+/// persisted: it resets on app restart and is cleared on logout via [clear].
+class StatusMessageDismissals {
+  // Records key structurally, so a (serverKey, messageId) pair can never
+  // collide with a different pair — no delimiter to be ambiguous about.
+  final Set<(String, String)> _keys = <(String, String)>{};
+
+  bool isDismissed(String serverKey, String messageId) =>
+      _keys.contains((serverKey, messageId));
+
+  void markDismissed(String serverKey, String messageId) =>
+      _keys.add((serverKey, messageId));
+
+  void clear({String? serverKey}) {
+    if (serverKey == null) {
+      _keys.clear();
+      return;
+    }
+    _keys.removeWhere((k) => k.$1 == serverKey);
+  }
+}
+
+/// Session-lived store shared across every mounted banner.
+final statusMessageDismissalsProvider = Provider<StatusMessageDismissals>(
+  (_) => StatusMessageDismissals(),
+);

--- a/lib/src/status_message/status_message_dismissals.dart
+++ b/lib/src/status_message/status_message_dismissals.dart
@@ -4,7 +4,9 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 ///
 /// Keyed by `(serverKey, messageId)` so dismissing one message does not
 /// suppress a different, newly-posted message on the same server. Not
-/// persisted: it resets on app restart and is cleared on logout via [clear].
+/// persisted: it resets on app restart and is cleared via [clear] when a server
+/// (re)connects — after a login or a no-auth add — so a re-login re-surfaces a
+/// message dismissed earlier in the session.
 class StatusMessageDismissals {
   // Records key structurally, so a (serverKey, messageId) pair can never
   // collide with a different pair — no delimiter to be ambiguous about.

--- a/lib/src/status_message/status_message_display.dart
+++ b/lib/src/status_message/status_message_display.dart
@@ -4,20 +4,20 @@ sealed class MessageDisplay {
   const MessageDisplay();
 }
 
-class MessageHidden extends MessageDisplay {
+final class MessageHidden extends MessageDisplay {
   const MessageHidden();
 }
 
-class MessagePersistent extends MessageDisplay {
+final class MessagePersistent extends MessageDisplay {
   const MessagePersistent();
 }
 
-class MessageUpcoming extends MessageDisplay {
+final class MessageUpcoming extends MessageDisplay {
   const MessageUpcoming(this.remaining);
   final Duration remaining;
 }
 
-class MessageActive extends MessageDisplay {
+final class MessageActive extends MessageDisplay {
   const MessageActive(this.remaining);
   final Duration remaining;
 }
@@ -25,7 +25,9 @@ class MessageActive extends MessageDisplay {
 MessageDisplay resolveVisibility(StatusMessage message,
     {required DateTime now}) {
   final window = message.window;
-  if (window == null) return const MessagePersistent();
+  // A windowless message — or a malformed window (end before start) — shows as
+  // a plain persistent notice; a reversed window has no sensible countdown.
+  if (window == null || !window.isValid) return const MessagePersistent();
   if (!now.isBefore(window.end)) return const MessageHidden();
   if (now.isBefore(window.start)) {
     return MessageUpcoming(window.start.difference(now));

--- a/lib/src/status_message/status_message_display.dart
+++ b/lib/src/status_message/status_message_display.dart
@@ -1,0 +1,44 @@
+import 'status_message.dart';
+
+sealed class MessageDisplay {
+  const MessageDisplay();
+}
+
+class MessageHidden extends MessageDisplay {
+  const MessageHidden();
+}
+
+class MessagePersistent extends MessageDisplay {
+  const MessagePersistent();
+}
+
+class MessageUpcoming extends MessageDisplay {
+  const MessageUpcoming(this.remaining);
+  final Duration remaining;
+}
+
+class MessageActive extends MessageDisplay {
+  const MessageActive(this.remaining);
+  final Duration remaining;
+}
+
+MessageDisplay resolveVisibility(StatusMessage message,
+    {required DateTime now}) {
+  final window = message.window;
+  if (window == null) return const MessagePersistent();
+  if (!now.isBefore(window.end)) return const MessageHidden();
+  if (now.isBefore(window.start)) {
+    return MessageUpcoming(window.start.difference(now));
+  }
+  return MessageActive(window.end.difference(now));
+}
+
+String formatCountdown(Duration d) {
+  final total = d.isNegative ? Duration.zero : d;
+  final days = total.inDays;
+  final hours = total.inHours % 24;
+  final minutes = total.inMinutes % 60;
+  if (days > 0) return '${days}D ${hours}H';
+  if (hours > 0) return '${hours}H ${minutes}M';
+  return '${minutes}M';
+}

--- a/lib/src/status_message/status_message_fetcher.dart
+++ b/lib/src/status_message/status_message_fetcher.dart
@@ -18,7 +18,12 @@ Future<StatusMessage?> fetchStatusMessage({
     final json = await transport.request<Map<String, dynamic>>('GET', uri);
     final message = StatusMessage.fromJson(json);
     final window = message.window;
-    if (window != null && !window.isValid) {
+    if (json['window'] != null && window == null) {
+      // Operator authored a window we couldn't use (not an object, unparseable,
+      // or a non-UTC bound). Surface it; the message still shows windowless.
+      _logger.warning('Status message has a malformed window at $uri; '
+          'showing the message without it.');
+    } else if (window != null && !window.isValid) {
       // Operator-authored `end` precedes `start`. Surface the mistake (the
       // banner flags the range in error colour) rather than dropping the
       // message.
@@ -27,14 +32,21 @@ Future<StatusMessage?> fetchStatusMessage({
     return message;
   } on NotFoundException {
     return null; // No file configured — the steady state.
+  } on NetworkException catch (e) {
+    // Offline, timeout, a connection refused mid-flight — the expected
+    // transient noise for an auxiliary banner. Log quietly and degrade to
+    // "no message"; the next poll recovers.
+    _logger.debug('Status message fetch failed for $uri', error: e);
+    return null;
   } on FormatException catch (e) {
     _logger.warning('Malformed status message at $uri', error: e);
     return null;
   } on Object catch (e) {
-    // Transient failures (offline, 5xx, an HTML error page) are the expected
-    // noise here, so log at debug and degrade to "no message" — never surface
-    // a fetch error to the user for an auxiliary banner.
-    _logger.debug('Status message fetch failed for $uri', error: e);
+    // A persistent misconfiguration — an auth wall, a permission error, a 5xx,
+    // a wrong content type, or HTML served in place of the JSON. Surface it so
+    // an operator can tell "no message posted" from "message posted but
+    // broken"; still degrade to "no message" for the user.
+    _logger.warning('Status message fetch failed for $uri', error: e);
     return null;
   }
 }

--- a/lib/src/status_message/status_message_fetcher.dart
+++ b/lib/src/status_message/status_message_fetcher.dart
@@ -1,0 +1,36 @@
+import 'package:soliplex_client/soliplex_client.dart';
+import 'package:soliplex_logging/soliplex_logging.dart';
+
+import 'status_message.dart';
+
+final Logger _logger = LogManager.instance.getLogger('soliplex.status_message');
+
+typedef StatusMessageFetcher = Future<StatusMessage?> Function();
+
+Future<StatusMessage?> fetchStatusMessage({
+  required Uri baseUrl,
+  required SoliplexHttpClient client,
+  required String path,
+}) async {
+  final transport = HttpTransport(client: client);
+  final uri = baseUrl.resolve(path);
+  try {
+    final json = await transport.request<Map<String, dynamic>>('GET', uri);
+    return StatusMessage.fromJson(json);
+  } on NotFoundException {
+    return null; // No file configured — the steady state.
+  } on FormatException catch (e) {
+    _logger.warning('Malformed status message at $uri', error: e);
+    return null;
+  } on Object catch (e) {
+    _logger.debug('Status message fetch failed for $uri', error: e);
+    return null;
+  }
+}
+
+StatusMessageFetcher serverStatusMessageFetcher({
+  required Uri baseUrl,
+  required SoliplexHttpClient client,
+  required String path,
+}) =>
+    () => fetchStatusMessage(baseUrl: baseUrl, client: client, path: path);

--- a/lib/src/status_message/status_message_fetcher.dart
+++ b/lib/src/status_message/status_message_fetcher.dart
@@ -16,13 +16,24 @@ Future<StatusMessage?> fetchStatusMessage({
   final uri = baseUrl.resolve(path);
   try {
     final json = await transport.request<Map<String, dynamic>>('GET', uri);
-    return StatusMessage.fromJson(json);
+    final message = StatusMessage.fromJson(json);
+    final window = message.window;
+    if (window != null && !window.isValid) {
+      // Operator-authored `end` precedes `start`. Surface the mistake (the
+      // banner flags the range in error colour) rather than dropping the
+      // message.
+      _logger.warning('Status message window end precedes start at $uri');
+    }
+    return message;
   } on NotFoundException {
     return null; // No file configured — the steady state.
   } on FormatException catch (e) {
     _logger.warning('Malformed status message at $uri', error: e);
     return null;
   } on Object catch (e) {
+    // Transient failures (offline, 5xx, an HTML error page) are the expected
+    // noise here, so log at debug and degrade to "no message" — never surface
+    // a fetch error to the user for an auxiliary banner.
     _logger.debug('Status message fetch failed for $uri', error: e);
     return null;
   }

--- a/lib/src/status_message/status_message_window_format.dart
+++ b/lib/src/status_message/status_message_window_format.dart
@@ -1,0 +1,17 @@
+import '../shared/local_time_format.dart';
+
+String _dateLabel(DateTime local) =>
+    '${weekdayAbbrev(local)}, ${monthAbbrev(local)} ${local.day}';
+
+/// Local-time label for a window bound, e.g. `"Sun, Jun 28 · 1:16 PM"`.
+///
+/// When [sameDayAs] falls on the same local calendar day, the date is omitted
+/// and only the time is returned (e.g. `"3:16 PM"`).
+String formatWindowBound(DateTime bound, {DateTime? sameDayAs}) {
+  final local = bound.toLocal();
+  final time = formatClock12(local);
+  if (sameDayAs != null && isSameCalendarDay(bound, sameDayAs)) {
+    return time;
+  }
+  return '${_dateLabel(local)} · $time';
+}

--- a/lib/src/status_message/status_message_window_format.dart
+++ b/lib/src/status_message/status_message_window_format.dart
@@ -1,17 +1,28 @@
 import '../shared/local_time_format.dart';
 
-String _dateLabel(DateTime local) =>
-    '${weekdayAbbrev(local)}, ${monthAbbrev(local)} ${local.day}';
+String _stamp(DateTime local) =>
+    '${weekdayAbbrev(local)}, ${monthAbbrev(local)} ${local.day} · '
+    '${formatClock12(local)}';
 
-/// Local-time label for a window bound, e.g. `"Sun, Jun 28 · 1:16 PM"`.
+/// Combined local-time label for a maintenance window.
 ///
-/// When [sameDayAs] falls on the same local calendar day, the date is omitted
-/// and only the time is returned (e.g. `"3:16 PM"`).
-String formatWindowBound(DateTime bound, {DateTime? sameDayAs}) {
-  final local = bound.toLocal();
-  final time = formatClock12(local);
-  if (sameDayAs != null && isSameCalendarDay(bound, sameDayAs)) {
-    return time;
+/// Same day collapses to one date with an en-dash time range (the CLDR interval
+/// convention — the date governs the whole range once); a window that spans
+/// days spells out both ends joined by "to" (the style-guide separator for
+/// spelled-out ranges):
+///
+/// - same day → `"Fri, Jul 17 · 4:44 PM – 6:44 PM"`
+/// - spanning → `"Fri, Jul 17 · 4:44 PM to Sat, Jul 18 · 3:16 AM"`
+///
+/// When [stacked] is true, a spanning range breaks after "to" so the end date
+/// starts its own line (readable on narrow viewports without a mid-date wrap).
+/// [stacked] has no effect on a same-day range.
+String formatWindowRange(DateTime start, DateTime end, {bool stacked = false}) {
+  final ls = start.toLocal();
+  final le = end.toLocal();
+  if (isSameCalendarDay(start, end)) {
+    return '${_stamp(ls)} – ${formatClock12(le)}';
   }
-  return '${_dateLabel(local)} · $time';
+  final joiner = stacked ? 'to\n' : 'to ';
+  return '${_stamp(ls)} $joiner${_stamp(le)}';
 }

--- a/lib/src/status_message/ui/status_message_banner.dart
+++ b/lib/src/status_message/ui/status_message_banner.dart
@@ -11,6 +11,7 @@ import '../status_message.dart';
 import '../status_message_controller.dart';
 import '../status_message_display.dart';
 import '../status_message_fetcher.dart';
+import '../status_message_window_format.dart';
 
 /// Callers that can change target server while staying mounted (the lobby's
 /// selected server) MUST pass `key: ValueKey(baseUrl)` so Flutter recreates
@@ -47,7 +48,7 @@ class StatusMessageBanner extends ConsumerStatefulWidget {
 class _StatusMessageBannerState extends ConsumerState<StatusMessageBanner> {
   late final StatusMessageController _controller;
   Timer? _ticker;
-  bool _minimized = false;
+  bool _expanded = false;
 
   /// Reads the shell-provided config. The banner is self-contained and may be
   /// dropped into any tree; outside a shell (e.g. a widget test that doesn't
@@ -117,7 +118,7 @@ class _StatusMessageBannerState extends ConsumerState<StatusMessageBanner> {
       BuildContext context, StatusMessage message, MessageDisplay display) {
     final text = switch (display) {
       MessageUpcoming(:final remaining) =>
-        'BEGINS IN ${formatCountdown(remaining)}',
+        'STARTS IN ${formatCountdown(remaining)}',
       MessageActive(:final remaining) =>
         'ENDS IN ${formatCountdown(remaining)}',
       _ => null,
@@ -139,63 +140,112 @@ class _StatusMessageBannerState extends ConsumerState<StatusMessageBanner> {
   Widget _buildBanner(
       BuildContext context, StatusMessage message, MessageDisplay display) {
     final (bg, fg) = _colors(context, message.intent);
-    final theme = Theme.of(context);
     final pill = _pill(context, message, display);
-    // The header row (icon, title, pill, toggle) is identical whether expanded
-    // or minimized; the body only appears below it when expanded. This keeps
-    // the toggle button pinned in place across the transition.
+    final window = message.window;
     return Container(
       color: bg,
       padding: const EdgeInsets.all(SoliplexSpacing.s3),
-      child: Row(
-        crossAxisAlignment: CrossAxisAlignment.start,
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        mainAxisSize: MainAxisSize.min,
         children: [
-          Container(
-            padding: const EdgeInsets.all(SoliplexSpacing.s2),
-            decoration: BoxDecoration(
-              color: fg.withValues(alpha: 0.12),
-              borderRadius: BorderRadius.circular(context.radii.md),
-            ),
-            child: Icon(_icon(message.category), color: fg),
-          ),
-          const SizedBox(width: SoliplexSpacing.s3),
-          Expanded(
-            child: Column(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: [
-                Row(
-                  children: [
-                    Flexible(
-                      child: Text(
-                        message.title,
-                        overflow: TextOverflow.ellipsis,
-                        style: theme.textTheme.titleSmall?.copyWith(color: fg),
-                      ),
-                    ),
-                    if (pill != null) ...[
-                      const SizedBox(width: SoliplexSpacing.s2),
-                      pill,
-                    ],
-                  ],
+          Row(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Container(
+                padding: const EdgeInsets.all(SoliplexSpacing.s2),
+                decoration: BoxDecoration(
+                  color: fg.withValues(alpha: 0.12),
+                  borderRadius: BorderRadius.circular(context.radii.md),
                 ),
-                if (!_minimized) ...[
-                  const SizedBox(height: SoliplexSpacing.s1),
-                  Text(
-                    message.body,
-                    style: theme.textTheme.bodyMedium?.copyWith(color: fg),
-                  ),
-                ],
-              ],
-            ),
+                child: Icon(_icon(message.category), color: fg),
+              ),
+              const SizedBox(width: SoliplexSpacing.s3),
+              Expanded(
+                child: _expanded
+                    ? _expandedContent(context, message, pill, window, fg)
+                    : _collapsedContent(context, message, pill, fg),
+              ),
+            ],
           ),
-          IconButton(
-            icon: Icon(_minimized ? Icons.expand_more : Icons.expand_less),
-            color: fg,
-            tooltip: _minimized ? 'Expand' : 'Minimize',
-            onPressed: () => setState(() => _minimized = !_minimized),
+          Align(
+            alignment: Alignment.centerRight,
+            child: SoliplexButton.text(
+              isCompact: true,
+              onPressed: () => setState(() => _expanded = !_expanded),
+              child: Text(_expanded ? 'Show less' : 'Details'),
+            ),
           ),
         ],
       ),
+    );
+  }
+
+  Widget _collapsedContent(
+      BuildContext context, StatusMessage message, Widget? pill, Color fg) {
+    final theme = Theme.of(context);
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Row(
+          children: [
+            Flexible(
+              child: Text(
+                message.title,
+                overflow: TextOverflow.ellipsis,
+                style: theme.textTheme.titleSmall?.copyWith(color: fg),
+              ),
+            ),
+            if (pill != null) ...[
+              const SizedBox(width: SoliplexSpacing.s2),
+              pill,
+            ],
+          ],
+        ),
+        const SizedBox(height: SoliplexSpacing.s1),
+        Text(
+          message.body,
+          maxLines: 1,
+          overflow: TextOverflow.ellipsis,
+          style: theme.textTheme.bodyMedium?.copyWith(color: fg),
+        ),
+      ],
+    );
+  }
+
+  Widget _expandedContent(BuildContext context, StatusMessage message,
+      Widget? pill, MessageWindow? window, Color fg) {
+    final theme = Theme.of(context);
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text(
+          message.title,
+          style: theme.textTheme.titleSmall?.copyWith(color: fg),
+        ),
+        if (pill != null) ...[
+          const SizedBox(height: SoliplexSpacing.s2),
+          Align(alignment: Alignment.centerLeft, child: pill),
+        ],
+        if (window != null) ...[
+          const SizedBox(height: SoliplexSpacing.s2),
+          LayoutBuilder(
+            builder: (context, constraints) => Text(
+              formatWindowRange(
+                window.start,
+                window.end,
+                stacked: constraints.maxWidth < SoliplexBreakpoints.tablet,
+              ),
+              style: theme.textTheme.bodyMedium?.copyWith(color: fg),
+            ),
+          ),
+        ],
+        const SizedBox(height: SoliplexSpacing.s2),
+        Text(
+          message.body,
+          style: theme.textTheme.bodyMedium?.copyWith(color: fg),
+        ),
+      ],
     );
   }
 }

--- a/lib/src/status_message/ui/status_message_banner.dart
+++ b/lib/src/status_message/ui/status_message_banner.dart
@@ -1,0 +1,222 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:signals_flutter/signals_flutter.dart';
+import 'package:soliplex_agent/soliplex_agent.dart' show SoliplexHttpClient;
+import 'package:soliplex_design/soliplex_design.dart';
+
+import '../../core/status_message_config.dart';
+import '../status_message.dart';
+import '../status_message_controller.dart';
+import '../status_message_display.dart';
+import '../status_message_fetcher.dart';
+
+/// Callers that can change target server while staying mounted (the lobby's
+/// selected server) MUST pass `key: ValueKey(baseUrl)` so Flutter recreates
+/// the state — and thus the controller — when the URL changes. The mounts
+/// below do this.
+class StatusMessageBanner extends ConsumerStatefulWidget {
+  const StatusMessageBanner({
+    required Uri baseUrl,
+    required SoliplexHttpClient client,
+    Key? key,
+  }) : this._(baseUrl: baseUrl, client: client, key: key);
+
+  const StatusMessageBanner.withFetcher({
+    required StatusMessageFetcher fetcher,
+    Key? key,
+  }) : this._(fetcher: fetcher, key: key);
+
+  const StatusMessageBanner._({
+    this.baseUrl,
+    this.client,
+    this.fetcher,
+    super.key,
+  });
+
+  final Uri? baseUrl;
+  final SoliplexHttpClient? client;
+  final StatusMessageFetcher? fetcher;
+
+  @override
+  ConsumerState<StatusMessageBanner> createState() =>
+      _StatusMessageBannerState();
+}
+
+class _StatusMessageBannerState extends ConsumerState<StatusMessageBanner> {
+  late final StatusMessageController _controller;
+  Timer? _ticker;
+  bool _minimized = false;
+
+  @override
+  void initState() {
+    super.initState();
+    final config = ref.read(statusMessageConfigProvider);
+    final fetcher = widget.fetcher ??
+        serverStatusMessageFetcher(
+          baseUrl: widget.baseUrl!,
+          client: widget.client!,
+          path: config.filePath,
+        );
+    _controller = StatusMessageController(fetcher: fetcher, config: config)
+      ..start();
+    _ticker = Timer.periodic(const Duration(minutes: 1), (_) {
+      if (mounted) setState(() {});
+    });
+  }
+
+  @override
+  void dispose() {
+    _ticker?.cancel();
+    _controller.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Watch((context) {
+      final message = _controller.message.value;
+      if (message == null) return const SizedBox.shrink();
+      final display = resolveVisibility(message, now: DateTime.now());
+      if (display is MessageHidden) return const SizedBox.shrink();
+      return _minimized
+          ? _buildMinimized(context, message, display)
+          : _buildExpanded(context, message, display);
+    });
+  }
+
+  (Color, Color) _colors(BuildContext context, MessageIntent intent) {
+    final colors = SoliplexTheme.of(context).colors;
+    return switch (intent) {
+      MessageIntent.warning => (
+          colors.warningContainer,
+          colors.onWarningContainer
+        ),
+      MessageIntent.info => (colors.infoContainer, colors.onInfoContainer),
+    };
+  }
+
+  IconData _icon(MessageCategory category) => switch (category) {
+        MessageCategory.maintenance => Icons.build,
+        MessageCategory.general => Icons.campaign,
+      };
+
+  Widget? _pill(
+      BuildContext context, StatusMessage message, MessageDisplay display) {
+    final text = switch (display) {
+      MessageUpcoming(:final remaining) =>
+        'BEGINS IN ${formatCountdown(remaining)}',
+      MessageActive(:final remaining) =>
+        'ENDS IN ${formatCountdown(remaining)}',
+      _ => null,
+    };
+    if (text == null) return null;
+    final intent = message.intent == MessageIntent.warning
+        ? BadgeIntent.warning
+        : BadgeIntent.info;
+    return SoliplexBadge(
+      intent: intent,
+      icon: const Icon(Icons.schedule),
+      label: Text(
+        text,
+        style: context.monospaceOn(Theme.of(context).textTheme.labelSmall),
+      ),
+    );
+  }
+
+  Widget _buildExpanded(
+      BuildContext context, StatusMessage message, MessageDisplay display) {
+    final (bg, fg) = _colors(context, message.intent);
+    final theme = Theme.of(context);
+    final pill = _pill(context, message, display);
+    return Container(
+      color: bg,
+      padding: const EdgeInsets.all(SoliplexSpacing.s3),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Container(
+            padding: const EdgeInsets.all(SoliplexSpacing.s2),
+            decoration: BoxDecoration(
+              color: fg.withValues(alpha: 0.12),
+              borderRadius: BorderRadius.circular(context.radii.md),
+            ),
+            child: Icon(_icon(message.category), color: fg),
+          ),
+          const SizedBox(width: SoliplexSpacing.s3),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Row(
+                  children: [
+                    Flexible(
+                      child: Text(
+                        message.title,
+                        style: theme.textTheme.titleSmall?.copyWith(color: fg),
+                      ),
+                    ),
+                    if (pill != null) ...[
+                      const SizedBox(width: SoliplexSpacing.s2),
+                      pill,
+                    ],
+                  ],
+                ),
+                const SizedBox(height: SoliplexSpacing.s1),
+                Text(
+                  message.body,
+                  style: theme.textTheme.bodyMedium?.copyWith(color: fg),
+                ),
+              ],
+            ),
+          ),
+          IconButton(
+            icon: const Icon(Icons.expand_less),
+            color: fg,
+            tooltip: 'Minimize',
+            onPressed: () => setState(() => _minimized = true),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildMinimized(
+      BuildContext context, StatusMessage message, MessageDisplay display) {
+    final (bg, fg) = _colors(context, message.intent);
+    final theme = Theme.of(context);
+    final pill = _pill(context, message, display);
+    return Container(
+      color: bg,
+      padding: const EdgeInsets.symmetric(
+        horizontal: SoliplexSpacing.s3,
+        vertical: SoliplexSpacing.s1,
+      ),
+      child: Row(
+        children: [
+          Icon(_icon(message.category), color: fg, size: 18),
+          const SizedBox(width: SoliplexSpacing.s2),
+          Flexible(
+            child: Text(
+              message.title,
+              overflow: TextOverflow.ellipsis,
+              style: theme.textTheme.labelMedium?.copyWith(color: fg),
+            ),
+          ),
+          if (pill != null) ...[
+            const SizedBox(width: SoliplexSpacing.s2),
+            pill,
+          ],
+          const Spacer(),
+          IconButton(
+            icon: const Icon(Icons.expand_more),
+            color: fg,
+            tooltip: 'Expand',
+            onPressed: () => setState(() => _minimized = false),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/src/status_message/ui/status_message_banner.dart
+++ b/lib/src/status_message/ui/status_message_banner.dart
@@ -16,8 +16,8 @@ import '../status_message_window_format.dart';
 
 /// Callers that can change target server while staying mounted (the lobby's
 /// selected server) MUST pass `key: ValueKey(baseUrl)` so Flutter recreates
-/// the state — and thus the controller — when the URL changes. The mounts
-/// below do this.
+/// the state — and thus the controller — when the URL changes. The lobby and
+/// room mounts do this.
 class StatusMessageBanner extends ConsumerStatefulWidget {
   const StatusMessageBanner({
     required Uri baseUrl,
@@ -51,7 +51,8 @@ class StatusMessageBanner extends ConsumerStatefulWidget {
 
   /// Which server this message is about, shown in the expanded view for
   /// disambiguation. The mounts pass `ServerEntry.displayName` (the server's
-  /// name, or a cleaned host label when unnamed). Null → no label.
+  /// name, or the formatted address `scheme://host[:port]` when unnamed).
+  /// Null → no label.
   final String? serverLabel;
 
   @override
@@ -65,9 +66,11 @@ class _StatusMessageBannerState extends ConsumerState<StatusMessageBanner> {
   bool _expanded = false;
   StatusMessageDismissals? _dismissals;
 
-  /// Reads the shell-provided config. The banner is self-contained and may be
-  /// dropped into any tree; outside a shell (e.g. a widget test that doesn't
-  /// install the shell scope) there is no provider, so the banner stays inert.
+  /// Reads the config. `statusMessageConfigProvider` has an enabled default, so
+  /// under any `ProviderScope` (with or without the shell's override) the banner
+  /// runs live. The `StateError` guard only covers being mounted with no
+  /// `ProviderScope` at all (e.g. the room/lobby host widget tests), where it
+  /// falls back to disabled and the banner stays inert.
   StatusMessageConfig _readConfig() {
     try {
       return ref.read(statusMessageConfigProvider);
@@ -76,8 +79,9 @@ class _StatusMessageBannerState extends ConsumerState<StatusMessageBanner> {
     }
   }
 
-  /// Reads the session dismiss store. Guarded like the config: outside a shell
-  /// there is no provider, so treat it as "nothing dismissed".
+  /// Reads the session dismiss store. Guarded like the config: only when
+  /// mounted with no `ProviderScope` at all is there no store to read, in which
+  /// case treat it as "nothing dismissed".
   StatusMessageDismissals? _readDismissals() {
     try {
       return ref.read(statusMessageDismissalsProvider);
@@ -283,7 +287,10 @@ class _StatusMessageBannerState extends ConsumerState<StatusMessageBanner> {
                 window.end,
                 stacked: constraints.maxWidth < SoliplexBreakpoints.tablet,
               ),
-              style: theme.textTheme.labelMedium?.copyWith(color: fg),
+              // A malformed window (end before start) is flagged in error
+              // colour so the operator mistake is visible.
+              style: theme.textTheme.labelMedium
+                  ?.copyWith(color: window.isValid ? fg : context.danger),
             ),
           ),
         ],

--- a/lib/src/status_message/ui/status_message_banner.dart
+++ b/lib/src/status_message/ui/status_message_banner.dart
@@ -9,6 +9,7 @@ import 'package:soliplex_design/soliplex_design.dart';
 import '../../core/status_message_config.dart';
 import '../status_message.dart';
 import '../status_message_controller.dart';
+import '../status_message_dismissals.dart';
 import '../status_message_display.dart';
 import '../status_message_fetcher.dart';
 import '../status_message_window_format.dart';
@@ -21,24 +22,37 @@ class StatusMessageBanner extends ConsumerStatefulWidget {
   const StatusMessageBanner({
     required Uri baseUrl,
     required SoliplexHttpClient client,
+    String? serverLabel,
     Key? key,
-  }) : this._(baseUrl: baseUrl, client: client, key: key);
+  }) : this._(
+          baseUrl: baseUrl,
+          client: client,
+          serverLabel: serverLabel,
+          key: key,
+        );
 
   const StatusMessageBanner.withFetcher({
     required StatusMessageFetcher fetcher,
+    String? serverLabel,
     Key? key,
-  }) : this._(fetcher: fetcher, key: key);
+  }) : this._(fetcher: fetcher, serverLabel: serverLabel, key: key);
 
   const StatusMessageBanner._({
     this.baseUrl,
     this.client,
     this.fetcher,
+    this.serverLabel,
     super.key,
   });
 
   final Uri? baseUrl;
   final SoliplexHttpClient? client;
   final StatusMessageFetcher? fetcher;
+
+  /// Which server this message is about, shown in the expanded view for
+  /// disambiguation. The mounts pass `ServerEntry.displayName` (the server's
+  /// name, or a cleaned host label when unnamed). Null → no label.
+  final String? serverLabel;
 
   @override
   ConsumerState<StatusMessageBanner> createState() =>
@@ -49,6 +63,7 @@ class _StatusMessageBannerState extends ConsumerState<StatusMessageBanner> {
   late final StatusMessageController _controller;
   Timer? _ticker;
   bool _expanded = false;
+  StatusMessageDismissals? _dismissals;
 
   /// Reads the shell-provided config. The banner is self-contained and may be
   /// dropped into any tree; outside a shell (e.g. a widget test that doesn't
@@ -60,6 +75,18 @@ class _StatusMessageBannerState extends ConsumerState<StatusMessageBanner> {
       return StatusMessageConfig.disabled;
     }
   }
+
+  /// Reads the session dismiss store. Guarded like the config: outside a shell
+  /// there is no provider, so treat it as "nothing dismissed".
+  StatusMessageDismissals? _readDismissals() {
+    try {
+      return ref.read(statusMessageDismissalsProvider);
+    } on StateError {
+      return null;
+    }
+  }
+
+  String get _serverKey => widget.baseUrl?.toString() ?? '';
 
   @override
   void initState() {
@@ -73,6 +100,7 @@ class _StatusMessageBannerState extends ConsumerState<StatusMessageBanner> {
         );
     _controller = StatusMessageController(fetcher: fetcher, config: config)
       ..start();
+    _dismissals = _readDismissals();
     if (config.isEnabled) {
       _ticker = Timer.periodic(const Duration(minutes: 1), (_) {
         if (mounted) setState(() {});
@@ -92,6 +120,9 @@ class _StatusMessageBannerState extends ConsumerState<StatusMessageBanner> {
     return Watch((context) {
       final message = _controller.message.value;
       if (message == null) return const SizedBox.shrink();
+      if (_dismissals?.isDismissed(_serverKey, message.id) ?? false) {
+        return const SizedBox.shrink();
+      }
       final display = resolveVisibility(message, now: DateTime.now());
       if (display is MessageHidden) return const SizedBox.shrink();
       return _buildBanner(context, message, display);
@@ -166,6 +197,15 @@ class _StatusMessageBannerState extends ConsumerState<StatusMessageBanner> {
                     ? _expandedContent(context, message, pill, window, fg)
                     : _collapsedContent(context, message, pill, fg),
               ),
+              IconButton(
+                icon: const Icon(Icons.close),
+                color: fg,
+                tooltip: 'Dismiss',
+                onPressed: () {
+                  _dismissals?.markDismissed(_serverKey, message.id);
+                  setState(() {});
+                },
+              ),
             ],
           ),
           Align(
@@ -223,6 +263,13 @@ class _StatusMessageBannerState extends ConsumerState<StatusMessageBanner> {
           message.title,
           style: theme.textTheme.titleSmall?.copyWith(color: fg),
         ),
+        if (widget.serverLabel case final label? when label.isNotEmpty) ...[
+          const SizedBox(height: SoliplexSpacing.s1),
+          Text(
+            label,
+            style: theme.textTheme.labelSmall?.copyWith(color: fg),
+          ),
+        ],
         if (pill != null) ...[
           const SizedBox(height: SoliplexSpacing.s2),
           Align(alignment: Alignment.centerLeft, child: pill),
@@ -236,7 +283,8 @@ class _StatusMessageBannerState extends ConsumerState<StatusMessageBanner> {
                 window.end,
                 stacked: constraints.maxWidth < SoliplexBreakpoints.tablet,
               ),
-              style: theme.textTheme.bodyMedium?.copyWith(color: fg),
+              style: theme.textTheme.bodyMedium
+                  ?.copyWith(color: fg, fontWeight: FontWeight.w500),
             ),
           ),
         ],

--- a/lib/src/status_message/ui/status_message_banner.dart
+++ b/lib/src/status_message/ui/status_message_banner.dart
@@ -49,10 +49,21 @@ class _StatusMessageBannerState extends ConsumerState<StatusMessageBanner> {
   Timer? _ticker;
   bool _minimized = false;
 
+  /// Reads the shell-provided config. The banner is self-contained and may be
+  /// dropped into any tree; outside a shell (e.g. a widget test that doesn't
+  /// install the shell scope) there is no provider, so the banner stays inert.
+  StatusMessageConfig _readConfig() {
+    try {
+      return ref.read(statusMessageConfigProvider);
+    } on StateError {
+      return StatusMessageConfig.disabled;
+    }
+  }
+
   @override
   void initState() {
     super.initState();
-    final config = ref.read(statusMessageConfigProvider);
+    final config = _readConfig();
     final fetcher = widget.fetcher ??
         serverStatusMessageFetcher(
           baseUrl: widget.baseUrl!,
@@ -61,9 +72,11 @@ class _StatusMessageBannerState extends ConsumerState<StatusMessageBanner> {
         );
     _controller = StatusMessageController(fetcher: fetcher, config: config)
       ..start();
-    _ticker = Timer.periodic(const Duration(minutes: 1), (_) {
-      if (mounted) setState(() {});
-    });
+    if (config.isEnabled) {
+      _ticker = Timer.periodic(const Duration(minutes: 1), (_) {
+        if (mounted) setState(() {});
+      });
+    }
   }
 
   @override

--- a/lib/src/status_message/ui/status_message_banner.dart
+++ b/lib/src/status_message/ui/status_message_banner.dart
@@ -283,8 +283,7 @@ class _StatusMessageBannerState extends ConsumerState<StatusMessageBanner> {
                 window.end,
                 stacked: constraints.maxWidth < SoliplexBreakpoints.tablet,
               ),
-              style: theme.textTheme.bodyMedium
-                  ?.copyWith(color: fg, fontWeight: FontWeight.w500),
+              style: theme.textTheme.labelMedium?.copyWith(color: fg),
             ),
           ),
         ],

--- a/lib/src/status_message/ui/status_message_banner.dart
+++ b/lib/src/status_message/ui/status_message_banner.dart
@@ -93,9 +93,7 @@ class _StatusMessageBannerState extends ConsumerState<StatusMessageBanner> {
       if (message == null) return const SizedBox.shrink();
       final display = resolveVisibility(message, now: DateTime.now());
       if (display is MessageHidden) return const SizedBox.shrink();
-      return _minimized
-          ? _buildMinimized(context, message, display)
-          : _buildExpanded(context, message, display);
+      return _buildBanner(context, message, display);
     });
   }
 
@@ -138,11 +136,14 @@ class _StatusMessageBannerState extends ConsumerState<StatusMessageBanner> {
     );
   }
 
-  Widget _buildExpanded(
+  Widget _buildBanner(
       BuildContext context, StatusMessage message, MessageDisplay display) {
     final (bg, fg) = _colors(context, message.intent);
     final theme = Theme.of(context);
     final pill = _pill(context, message, display);
+    // The header row (icon, title, pill, toggle) is identical whether expanded
+    // or minimized; the body only appears below it when expanded. This keeps
+    // the toggle button pinned in place across the transition.
     return Container(
       color: bg,
       padding: const EdgeInsets.all(SoliplexSpacing.s3),
@@ -167,6 +168,7 @@ class _StatusMessageBannerState extends ConsumerState<StatusMessageBanner> {
                     Flexible(
                       child: Text(
                         message.title,
+                        overflow: TextOverflow.ellipsis,
                         style: theme.textTheme.titleSmall?.copyWith(color: fg),
                       ),
                     ),
@@ -176,57 +178,21 @@ class _StatusMessageBannerState extends ConsumerState<StatusMessageBanner> {
                     ],
                   ],
                 ),
-                const SizedBox(height: SoliplexSpacing.s1),
-                Text(
-                  message.body,
-                  style: theme.textTheme.bodyMedium?.copyWith(color: fg),
-                ),
+                if (!_minimized) ...[
+                  const SizedBox(height: SoliplexSpacing.s1),
+                  Text(
+                    message.body,
+                    style: theme.textTheme.bodyMedium?.copyWith(color: fg),
+                  ),
+                ],
               ],
             ),
           ),
           IconButton(
-            icon: const Icon(Icons.expand_less),
+            icon: Icon(_minimized ? Icons.expand_more : Icons.expand_less),
             color: fg,
-            tooltip: 'Minimize',
-            onPressed: () => setState(() => _minimized = true),
-          ),
-        ],
-      ),
-    );
-  }
-
-  Widget _buildMinimized(
-      BuildContext context, StatusMessage message, MessageDisplay display) {
-    final (bg, fg) = _colors(context, message.intent);
-    final theme = Theme.of(context);
-    final pill = _pill(context, message, display);
-    return Container(
-      color: bg,
-      padding: const EdgeInsets.symmetric(
-        horizontal: SoliplexSpacing.s3,
-        vertical: SoliplexSpacing.s1,
-      ),
-      child: Row(
-        children: [
-          Icon(_icon(message.category), color: fg, size: 18),
-          const SizedBox(width: SoliplexSpacing.s2),
-          Flexible(
-            child: Text(
-              message.title,
-              overflow: TextOverflow.ellipsis,
-              style: theme.textTheme.labelMedium?.copyWith(color: fg),
-            ),
-          ),
-          if (pill != null) ...[
-            const SizedBox(width: SoliplexSpacing.s2),
-            pill,
-          ],
-          const Spacer(),
-          IconButton(
-            icon: const Icon(Icons.expand_more),
-            color: fg,
-            tooltip: 'Expand',
-            onPressed: () => setState(() => _minimized = false),
+            tooltip: _minimized ? 'Expand' : 'Minimize',
+            onPressed: () => setState(() => _minimized = !_minimized),
           ),
         ],
       ),

--- a/test/modules/auth/connect_flow_test.dart
+++ b/test/modules/auth/connect_flow_test.dart
@@ -32,6 +32,7 @@ ConnectFlow _createFlow({
   InactivityLogoutFlagStorage? inactivityLogoutFlags,
   ServerManager? serverManager,
   DiscoverProviders? discover,
+  void Function(Uri serverUrl)? onServerConnected,
 }) =>
     ConnectFlow(
       serverManager: serverManager ?? _createManager(),
@@ -40,6 +41,7 @@ ConnectFlow _createFlow({
       authFlow: authFlow,
       inactivityLogoutFlags:
           inactivityLogoutFlags ?? InMemoryInactivityLogoutFlagStorage(),
+      onServerConnected: onServerConnected,
     );
 
 AuthResult _successResult() => AuthResult(
@@ -216,6 +218,49 @@ void main() {
         await SelectedServerStorage.load(),
         manager.servers.value.keys.single,
       );
+    });
+  });
+
+  group('ConnectFlow — onServerConnected', () {
+    setUp(() {
+      SharedPreferences.setMockInitialValues({});
+    });
+
+    test('fires once with the server URL after an OIDC login', () async {
+      final manager = _createManager();
+      Uri? connected;
+      var calls = 0;
+      final flow = _createFlow(
+        authFlow: FakeAuthFlow()..nextResult = _successResult(),
+        serverManager: manager,
+        onServerConnected: (url) {
+          connected = url;
+          calls++;
+        },
+      );
+
+      await flow.connect('https://server.example.com');
+      await pumpEventQueue();
+
+      expect(calls, 1);
+      expect(
+        connected.toString(),
+        manager.servers.value.values.single.serverUrl.toString(),
+      );
+    });
+
+    test('fires when a no-auth server is added', () async {
+      var calls = 0;
+      final flow = _createFlow(
+        authFlow: FakeAuthFlow(),
+        discover: (_, __) async => [],
+        onServerConnected: (_) => calls++,
+      );
+
+      await flow.connect('https://server.example.com');
+      await pumpEventQueue();
+
+      expect(calls, 1);
     });
   });
 }

--- a/test/modules/room/message_timestamp_format_test.dart
+++ b/test/modules/room/message_timestamp_format_test.dart
@@ -107,17 +107,4 @@ void main() {
       );
     });
   });
-
-  group('isSameCalendarDay', () {
-    test('true within a local calendar day, false across midnight', () {
-      expect(
-        isSameCalendarDay(DateTime(2026, 3, 15, 1), DateTime(2026, 3, 15, 23)),
-        isTrue,
-      );
-      expect(
-        isSameCalendarDay(DateTime(2026, 3, 15, 23), DateTime(2026, 3, 16, 1)),
-        isFalse,
-      );
-    });
-  });
 }

--- a/test/shared/local_time_format_test.dart
+++ b/test/shared/local_time_format_test.dart
@@ -1,0 +1,42 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:soliplex_frontend/src/shared/local_time_format.dart';
+
+void main() {
+  // Local DateTimes so the calendar fields are read as-is (timezone-independent).
+  group('formatClock12', () {
+    test('afternoon', () {
+      expect(formatClock12(DateTime(2026, 6, 28, 13, 16)), '1:16 PM');
+    });
+    test('midnight and noon read as 12', () {
+      expect(formatClock12(DateTime(2026, 6, 28, 0, 5)), '12:05 AM');
+      expect(formatClock12(DateTime(2026, 6, 28, 12, 0)), '12:00 PM');
+    });
+    test('minute is zero-padded, hour is not', () {
+      expect(formatClock12(DateTime(2026, 6, 28, 9, 3)), '9:03 AM');
+    });
+  });
+
+  group('weekdayAbbrev / monthAbbrev', () {
+    test('three-letter labels', () {
+      expect(weekdayAbbrev(DateTime(2026, 6, 28)), 'Sun'); // Sunday
+      expect(weekdayAbbrev(DateTime(2026, 6, 29)), 'Mon'); // Monday
+      expect(monthAbbrev(DateTime(2026, 6, 28)), 'Jun');
+      expect(monthAbbrev(DateTime(2026, 1, 1)), 'Jan');
+    });
+  });
+
+  group('isSameCalendarDay', () {
+    test('same local day, different hours', () {
+      expect(
+        isSameCalendarDay(DateTime(2026, 3, 15, 1), DateTime(2026, 3, 15, 23)),
+        isTrue,
+      );
+    });
+    test('adjacent days are different', () {
+      expect(
+        isSameCalendarDay(DateTime(2026, 3, 15, 23), DateTime(2026, 3, 16, 1)),
+        isFalse,
+      );
+    });
+  });
+}

--- a/test/status_message/status_message_controller_test.dart
+++ b/test/status_message/status_message_controller_test.dart
@@ -1,3 +1,7 @@
+import 'dart:async';
+
+import 'package:fake_async/fake_async.dart';
+import 'package:flutter/widgets.dart' show AppLifecycleState;
 import 'package:flutter_test/flutter_test.dart';
 import 'package:soliplex_frontend/src/core/status_message_config.dart';
 import 'package:soliplex_frontend/src/status_message/status_message.dart';
@@ -42,5 +46,64 @@ void main() {
     expect(calls, 0);
     expect(c.message.value, isNull);
     c.dispose();
+  });
+
+  test('re-fetches every poll interval', () {
+    fakeAsync((async) {
+      var calls = 0;
+      final c = StatusMessageController(
+        fetcher: () async {
+          calls++;
+          return _msg;
+        },
+        config: const StatusMessageConfig(pollInterval: Duration(minutes: 5)),
+      )..start();
+      async.flushMicrotasks();
+      expect(calls, 1); // immediate fetch
+
+      async.elapse(const Duration(minutes: 5));
+      expect(calls, 2); // one poll cycle
+
+      async.elapse(const Duration(minutes: 5));
+      expect(calls, 3); // recurs
+      c.dispose();
+    });
+  });
+
+  test('re-fetches on app resume, ignores other lifecycle states', () async {
+    var calls = 0;
+    final c = StatusMessageController(
+      fetcher: () async {
+        calls++;
+        return _msg;
+      },
+      config: const StatusMessageConfig(pollInterval: Duration(minutes: 5)),
+    )..start();
+    await Future<void>.delayed(Duration.zero);
+    expect(calls, 1);
+
+    c.didChangeAppLifecycleState(AppLifecycleState.paused);
+    await Future<void>.delayed(Duration.zero);
+    expect(calls, 1); // paused does not re-fetch
+
+    c.didChangeAppLifecycleState(AppLifecycleState.resumed);
+    await Future<void>.delayed(Duration.zero);
+    expect(calls, 2); // resume re-fetches
+    c.dispose();
+  });
+
+  test('a fetch completing after dispose does not write the disposed signal',
+      () async {
+    final completer = Completer<StatusMessage?>();
+    final c = StatusMessageController(
+      fetcher: () => completer.future,
+      config: const StatusMessageConfig(pollInterval: Duration(minutes: 5)),
+    )..start();
+
+    c.dispose(); // dispose while the initial fetch is in flight
+    completer.complete(_msg); // resolves after dispose
+
+    // Must not throw SignalsWriteAfterDisposeError.
+    await Future<void>.delayed(Duration.zero);
   });
 }

--- a/test/status_message/status_message_controller_test.dart
+++ b/test/status_message/status_message_controller_test.dart
@@ -1,0 +1,46 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:soliplex_frontend/src/core/status_message_config.dart';
+import 'package:soliplex_frontend/src/status_message/status_message.dart';
+import 'package:soliplex_frontend/src/status_message/status_message_controller.dart';
+
+const _msg = StatusMessage(
+  id: 'm',
+  title: 't',
+  body: 'b',
+  intent: MessageIntent.info,
+  category: MessageCategory.general,
+);
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  test('start() fetches immediately and publishes the result', () async {
+    var calls = 0;
+    final c = StatusMessageController(
+      fetcher: () async {
+        calls++;
+        return _msg;
+      },
+      config: const StatusMessageConfig(pollInterval: Duration(minutes: 5)),
+    )..start();
+    await Future<void>.delayed(Duration.zero);
+    expect(calls, 1);
+    expect(c.message.value, _msg);
+    c.dispose();
+  });
+
+  test('start() is a no-op when config is disabled', () async {
+    var calls = 0;
+    final c = StatusMessageController(
+      fetcher: () async {
+        calls++;
+        return _msg;
+      },
+      config: StatusMessageConfig.disabled,
+    )..start();
+    await Future<void>.delayed(Duration.zero);
+    expect(calls, 0);
+    expect(c.message.value, isNull);
+    c.dispose();
+  });
+}

--- a/test/status_message/status_message_dismissals_test.dart
+++ b/test/status_message/status_message_dismissals_test.dart
@@ -1,0 +1,37 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:soliplex_frontend/src/status_message/status_message_dismissals.dart';
+
+void main() {
+  group('StatusMessageDismissals', () {
+    test('marks and reports a dismissed message', () {
+      final d = StatusMessageDismissals();
+      expect(d.isDismissed('https://a', 'm1'), isFalse);
+      d.markDismissed('https://a', 'm1');
+      expect(d.isDismissed('https://a', 'm1'), isTrue);
+    });
+
+    test('scopes by server and by message id', () {
+      final d = StatusMessageDismissals()..markDismissed('https://a', 'm1');
+      expect(d.isDismissed('https://b', 'm1'), isFalse); // other server
+      expect(d.isDismissed('https://a', 'm2'), isFalse); // other message
+    });
+
+    test('clear(serverKey) removes only that server', () {
+      final d = StatusMessageDismissals()
+        ..markDismissed('https://a', 'm1')
+        ..markDismissed('https://b', 'm1');
+      d.clear(serverKey: 'https://a');
+      expect(d.isDismissed('https://a', 'm1'), isFalse);
+      expect(d.isDismissed('https://b', 'm1'), isTrue);
+    });
+
+    test('clear() removes everything', () {
+      final d = StatusMessageDismissals()
+        ..markDismissed('https://a', 'm1')
+        ..markDismissed('https://b', 'm1');
+      d.clear();
+      expect(d.isDismissed('https://a', 'm1'), isFalse);
+      expect(d.isDismissed('https://b', 'm1'), isFalse);
+    });
+  });
+}

--- a/test/status_message/status_message_display_test.dart
+++ b/test/status_message/status_message_display_test.dart
@@ -1,0 +1,71 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:soliplex_frontend/src/status_message/status_message.dart';
+import 'package:soliplex_frontend/src/status_message/status_message_display.dart';
+
+StatusMessage _windowed(DateTime start, DateTime end) => StatusMessage(
+      id: 'm',
+      title: 't',
+      body: 'b',
+      intent: MessageIntent.warning,
+      category: MessageCategory.maintenance,
+      window: MessageWindow(start: start, end: end),
+    );
+
+void main() {
+  final start = DateTime.utc(2026, 6, 28, 20);
+  final end = DateTime.utc(2026, 6, 28, 22);
+
+  group('resolveVisibility', () {
+    test('windowless is persistent', () {
+      final msg = StatusMessage(
+          id: 'n',
+          title: 't',
+          body: 'b',
+          intent: MessageIntent.info,
+          category: MessageCategory.general);
+      expect(resolveVisibility(msg, now: start), isA<MessagePersistent>());
+    });
+    test('before start is upcoming with remaining', () {
+      final d = resolveVisibility(_windowed(start, end),
+          now: start.subtract(const Duration(hours: 3)));
+      expect(d, isA<MessageUpcoming>());
+      expect((d as MessageUpcoming).remaining, const Duration(hours: 3));
+    });
+    test('exactly at start is active', () {
+      expect(resolveVisibility(_windowed(start, end), now: start),
+          isA<MessageActive>());
+    });
+    test('mid-window is active', () {
+      expect(
+          resolveVisibility(_windowed(start, end),
+              now: start.add(const Duration(minutes: 30))),
+          isA<MessageActive>());
+    });
+    test('at end is hidden', () {
+      expect(resolveVisibility(_windowed(start, end), now: end),
+          isA<MessageHidden>());
+    });
+    test('after end is hidden', () {
+      expect(
+          resolveVisibility(_windowed(start, end),
+              now: end.add(const Duration(hours: 1))),
+          isA<MessageHidden>());
+    });
+  });
+
+  group('formatCountdown', () {
+    test('days and hours', () {
+      expect(formatCountdown(const Duration(days: 2, hours: 4, minutes: 30)),
+          '2D 4H');
+    });
+    test('hours and minutes', () {
+      expect(formatCountdown(const Duration(hours: 1, minutes: 20)), '1H 20M');
+    });
+    test('minutes only', () {
+      expect(formatCountdown(const Duration(minutes: 5)), '5M');
+    });
+    test('negative clamps to zero', () {
+      expect(formatCountdown(const Duration(seconds: -30)), '0M');
+    });
+  });
+}

--- a/test/status_message/status_message_display_test.dart
+++ b/test/status_message/status_message_display_test.dart
@@ -51,6 +51,18 @@ void main() {
               now: end.add(const Duration(hours: 1))),
           isA<MessageHidden>());
     });
+    test('a reversed window (end before start) is persistent, not a countdown',
+        () {
+      // Malformed operator window: end precedes start. No sensible countdown,
+      // so it shows as a plain persistent notice (and is flagged/logged
+      // elsewhere) rather than a garbage MessageUpcoming/MessageActive.
+      final reversed = _windowed(end, start); // start=22:00, end=20:00
+      expect(reversed.window!.isValid, isFalse);
+      expect(
+          resolveVisibility(reversed,
+              now: start.subtract(const Duration(hours: 1))),
+          isA<MessagePersistent>());
+    });
   });
 
   group('formatCountdown', () {

--- a/test/status_message/status_message_test.dart
+++ b/test/status_message/status_message_test.dart
@@ -47,16 +47,31 @@ void main() {
           throwsFormatException);
     });
 
-    test('malformed window throws FormatException', () {
+    // A malformed window degrades to windowless — the message text still shows
+    // rather than the whole announcement being dropped.
+    StatusMessage windowed(Object? window) => StatusMessage.fromJson(
+        {'id': 'x', 'title': 't', 'body': 'b', 'window': window});
+
+    test('a non-object window drops to windowless, keeping the message', () {
+      final msg = windowed('soon');
+      expect(msg.window, isNull);
+      expect(msg.title, 't');
+    });
+
+    test('an unparseable window bound drops to windowless', () {
       expect(
-        () => StatusMessage.fromJson({
-          'id': 'x',
-          'title': 't',
-          'body': 'b',
-          'window': {'start': 'not-a-date'}
-        }),
-        throwsFormatException,
-      );
+          windowed({'start': 'not-a-date', 'end': '2026-06-28T22:16:00Z'})
+              .window,
+          isNull);
+    });
+
+    test('a naive (non-UTC) window bound drops to windowless', () {
+      expect(
+          windowed({
+            'start': '2026-06-28T20:16:00',
+            'end': '2026-06-28T22:16:00Z'
+          }).window,
+          isNull);
     });
   });
 

--- a/test/status_message/status_message_test.dart
+++ b/test/status_message/status_message_test.dart
@@ -59,4 +59,34 @@ void main() {
       );
     });
   });
+
+  group('value equality', () {
+    // Load-bearing: the controller republishes a Signal<StatusMessage?> on
+    // each poll, and value equality is what suppresses rebuilds when the file
+    // is unchanged.
+    StatusMessage build({String id = 'm', MessageWindow? window}) =>
+        StatusMessage(
+          id: id,
+          title: 't',
+          body: 'b',
+          intent: MessageIntent.warning,
+          category: MessageCategory.maintenance,
+          window: window,
+        );
+
+    test('equal when all fields (incl. window) match', () {
+      final w1 = MessageWindow(
+          start: DateTime.utc(2026, 6, 28, 20),
+          end: DateTime.utc(2026, 6, 28, 22));
+      final w2 = MessageWindow(
+          start: DateTime.utc(2026, 6, 28, 20),
+          end: DateTime.utc(2026, 6, 28, 22));
+      expect(build(window: w1), build(window: w2));
+      expect(build(window: w1).hashCode, build(window: w2).hashCode);
+    });
+
+    test('differ in one field are not equal', () {
+      expect(build(id: 'a'), isNot(build(id: 'b')));
+    });
+  });
 }

--- a/test/status_message/status_message_test.dart
+++ b/test/status_message/status_message_test.dart
@@ -1,0 +1,62 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:soliplex_frontend/src/status_message/status_message.dart';
+
+void main() {
+  group('StatusMessage.fromJson', () {
+    test('parses a windowed maintenance message', () {
+      final msg = StatusMessage.fromJson({
+        'id': 'm1',
+        'title': 'Scheduled maintenance',
+        'body': 'Down Sun 1-3 PM PT.',
+        'intent': 'warning',
+        'category': 'maintenance',
+        'window': {
+          'start': '2026-06-28T20:16:00Z',
+          'end': '2026-06-28T22:16:00Z'
+        },
+      });
+      expect(msg.id, 'm1');
+      expect(msg.intent, MessageIntent.warning);
+      expect(msg.category, MessageCategory.maintenance);
+      expect(msg.window!.start, DateTime.utc(2026, 6, 28, 20, 16));
+      expect(msg.window!.end, DateTime.utc(2026, 6, 28, 22, 16));
+    });
+
+    test('parses a windowless notice with defaults', () {
+      final msg = StatusMessage.fromJson(
+          {'id': 'n1', 'title': 'Heads up', 'body': 'Hi'});
+      expect(msg.window, isNull);
+      expect(msg.intent, MessageIntent.info);
+      expect(msg.category, MessageCategory.general);
+    });
+
+    test('unknown intent/category fall back to info/general', () {
+      final msg = StatusMessage.fromJson({
+        'id': 'x',
+        'title': 't',
+        'body': 'b',
+        'intent': 'nope',
+        'category': 'nope'
+      });
+      expect(msg.intent, MessageIntent.info);
+      expect(msg.category, MessageCategory.general);
+    });
+
+    test('missing title throws FormatException', () {
+      expect(() => StatusMessage.fromJson({'id': 'x', 'body': 'b'}),
+          throwsFormatException);
+    });
+
+    test('malformed window throws FormatException', () {
+      expect(
+        () => StatusMessage.fromJson({
+          'id': 'x',
+          'title': 't',
+          'body': 'b',
+          'window': {'start': 'not-a-date'}
+        }),
+        throwsFormatException,
+      );
+    });
+  });
+}

--- a/test/status_message/status_message_window_format_test.dart
+++ b/test/status_message/status_message_window_format_test.dart
@@ -2,32 +2,46 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:soliplex_frontend/src/status_message/status_message_window_format.dart';
 
 void main() {
-  group('formatWindowBound', () {
+  group('formatWindowRange', () {
     // Local DateTimes (not UTC) so toLocal() is identity and the test is
-    // timezone-independent. 2026-06-28 is a Sunday, 2026-06-29 a Monday.
-    test('full date and 12-hour time', () {
-      expect(formatWindowBound(DateTime(2026, 6, 28, 13, 16)),
-          'Sun, Jun 28 · 1:16 PM');
-    });
-    test('same local day omits the date', () {
+    // timezone-independent. 2026-07-17 is a Friday, 2026-07-18 a Saturday.
+    test('same day collapses to one date with an en-dash time range', () {
       expect(
-        formatWindowBound(DateTime(2026, 6, 28, 15, 16),
-            sameDayAs: DateTime(2026, 6, 28, 13, 16)),
-        '3:16 PM',
+        formatWindowRange(
+            DateTime(2026, 7, 17, 16, 44), DateTime(2026, 7, 17, 18, 44)),
+        'Fri, Jul 17 · 4:44 PM – 6:44 PM',
       );
     });
-    test('different local day keeps the date', () {
+    test('spanning days spells out both ends joined by "to"', () {
       expect(
-        formatWindowBound(DateTime(2026, 6, 29, 3, 16),
-            sameDayAs: DateTime(2026, 6, 28, 13, 16)),
-        'Mon, Jun 29 · 3:16 AM',
+        formatWindowRange(
+            DateTime(2026, 7, 17, 16, 44), DateTime(2026, 7, 18, 3, 16)),
+        'Fri, Jul 17 · 4:44 PM to Sat, Jul 18 · 3:16 AM',
+      );
+    });
+    test('stacked spanning breaks after "to" so the end date starts a new line',
+        () {
+      expect(
+        formatWindowRange(
+            DateTime(2026, 7, 17, 16, 44), DateTime(2026, 7, 18, 3, 16),
+            stacked: true),
+        'Fri, Jul 17 · 4:44 PM to\nSat, Jul 18 · 3:16 AM',
+      );
+    });
+    test('stacked has no effect on a same-day range', () {
+      expect(
+        formatWindowRange(
+            DateTime(2026, 7, 17, 16, 44), DateTime(2026, 7, 17, 18, 44),
+            stacked: true),
+        'Fri, Jul 17 · 4:44 PM – 6:44 PM',
       );
     });
     test('midnight and noon read as 12', () {
-      expect(formatWindowBound(DateTime(2026, 6, 28, 0, 5)),
-          'Sun, Jun 28 · 12:05 AM');
-      expect(formatWindowBound(DateTime(2026, 6, 28, 12, 0)),
-          'Sun, Jun 28 · 12:00 PM');
+      expect(
+        formatWindowRange(
+            DateTime(2026, 7, 17, 0, 5), DateTime(2026, 7, 17, 12, 0)),
+        'Fri, Jul 17 · 12:05 AM – 12:00 PM',
+      );
     });
   });
 }

--- a/test/status_message/status_message_window_format_test.dart
+++ b/test/status_message/status_message_window_format_test.dart
@@ -1,0 +1,33 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:soliplex_frontend/src/status_message/status_message_window_format.dart';
+
+void main() {
+  group('formatWindowBound', () {
+    // Local DateTimes (not UTC) so toLocal() is identity and the test is
+    // timezone-independent. 2026-06-28 is a Sunday, 2026-06-29 a Monday.
+    test('full date and 12-hour time', () {
+      expect(formatWindowBound(DateTime(2026, 6, 28, 13, 16)),
+          'Sun, Jun 28 · 1:16 PM');
+    });
+    test('same local day omits the date', () {
+      expect(
+        formatWindowBound(DateTime(2026, 6, 28, 15, 16),
+            sameDayAs: DateTime(2026, 6, 28, 13, 16)),
+        '3:16 PM',
+      );
+    });
+    test('different local day keeps the date', () {
+      expect(
+        formatWindowBound(DateTime(2026, 6, 29, 3, 16),
+            sameDayAs: DateTime(2026, 6, 28, 13, 16)),
+        'Mon, Jun 29 · 3:16 AM',
+      );
+    });
+    test('midnight and noon read as 12', () {
+      expect(formatWindowBound(DateTime(2026, 6, 28, 0, 5)),
+          'Sun, Jun 28 · 12:05 AM');
+      expect(formatWindowBound(DateTime(2026, 6, 28, 12, 0)),
+          'Sun, Jun 28 · 12:00 PM');
+    });
+  });
+}

--- a/test/status_message/ui/status_message_banner_test.dart
+++ b/test/status_message/ui/status_message_banner_test.dart
@@ -12,42 +12,60 @@ Widget _wrap(Widget child) => ProviderScope(
       ),
     );
 
+StatusMessage _upcoming() => StatusMessage(
+      id: 'm',
+      title: 'Scheduled maintenance',
+      body: 'Save your work.',
+      intent: MessageIntent.warning,
+      category: MessageCategory.maintenance,
+      window: MessageWindow(
+        start: DateTime.now().toUtc().add(const Duration(hours: 3)),
+        end: DateTime.now().toUtc().add(const Duration(hours: 5)),
+      ),
+    );
+
 void main() {
-  final upcoming = StatusMessage(
-    id: 'm',
-    title: 'Scheduled maintenance',
-    body: 'Save your work.',
-    intent: MessageIntent.warning,
-    category: MessageCategory.maintenance,
-    window: MessageWindow(
-      start: DateTime.now().toUtc().add(const Duration(hours: 3)),
-      end: DateTime.now().toUtc().add(const Duration(hours: 5)),
-    ),
-  );
-
-  testWidgets('renders an upcoming maintenance banner, then minimizes',
-      (tester) async {
+  testWidgets('collapsed by default, expands via Details', (tester) async {
     await tester.pumpWidget(_wrap(
-      StatusMessageBanner.withFetcher(fetcher: () async => upcoming),
+      StatusMessageBanner.withFetcher(fetcher: () async => _upcoming()),
     ));
-    await tester.pump(); // resolve the fetch future
-
-    expect(find.text('Scheduled maintenance'), findsOneWidget);
-    expect(find.text('Save your work.'), findsOneWidget);
-    expect(find.textContaining('BEGINS IN'), findsOneWidget);
-
-    await tester.tap(find.byIcon(Icons.expand_less));
     await tester.pump();
 
-    expect(find.text('Save your work.'), findsNothing); // body hidden minimized
-    expect(find.text('Scheduled maintenance'), findsOneWidget); // title stays
+    // Collapsed: title, countdown, one-line body, Details; no window range.
+    expect(find.text('Scheduled maintenance'), findsOneWidget);
+    expect(find.textContaining('STARTS IN'), findsOneWidget);
+    expect(find.text('Save your work.'), findsOneWidget);
+    expect(find.text('Details'), findsOneWidget);
+    expect(find.textContaining('·'), findsNothing);
+
+    await tester.tap(find.text('Details'));
+    await tester.pump();
+
+    // Expanded: the window range line appears, Show less replaces Details.
+    expect(find.textContaining('·'), findsOneWidget);
+    expect(find.text('Show less'), findsOneWidget);
+    expect(find.text('Details'), findsNothing);
   });
 
-  testWidgets('renders nothing when there is no message', (tester) async {
+  testWidgets('windowless message shows no pill and no window range',
+      (tester) async {
+    final windowless = StatusMessage(
+      id: 'n',
+      title: 'Heads up',
+      body: 'A general notice.',
+      intent: MessageIntent.info,
+      category: MessageCategory.general,
+    );
     await tester.pumpWidget(_wrap(
-      StatusMessageBanner.withFetcher(fetcher: () async => null),
+      StatusMessageBanner.withFetcher(fetcher: () async => windowless),
     ));
     await tester.pump();
+
+    expect(find.text('Heads up'), findsOneWidget);
     expect(find.byType(SoliplexBadge), findsNothing);
+    await tester.tap(find.text('Details'));
+    await tester.pump();
+    expect(find.textContaining('·'), findsNothing);
+    expect(find.text('A general notice.'), findsOneWidget);
   });
 }

--- a/test/status_message/ui/status_message_banner_test.dart
+++ b/test/status_message/ui/status_message_banner_test.dart
@@ -3,6 +3,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:soliplex_design/soliplex_design.dart';
 import 'package:soliplex_frontend/src/status_message/status_message.dart';
+import 'package:soliplex_frontend/src/status_message/status_message_dismissals.dart';
 import 'package:soliplex_frontend/src/status_message/ui/status_message_banner.dart';
 
 Widget _wrap(Widget child) => ProviderScope(
@@ -27,24 +28,65 @@ StatusMessage _upcoming() => StatusMessage(
 void main() {
   testWidgets('collapsed by default, expands via Details', (tester) async {
     await tester.pumpWidget(_wrap(
-      StatusMessageBanner.withFetcher(fetcher: () async => _upcoming()),
+      StatusMessageBanner.withFetcher(
+        fetcher: () async => _upcoming(),
+        serverLabel: 'production-east',
+      ),
     ));
     await tester.pump();
 
-    // Collapsed: title, countdown, one-line body, Details; no window range.
+    // Collapsed: title, countdown, one-line body, Details; no window range and
+    // no server label (that is expanded-only).
     expect(find.text('Scheduled maintenance'), findsOneWidget);
     expect(find.textContaining('STARTS IN'), findsOneWidget);
     expect(find.text('Save your work.'), findsOneWidget);
     expect(find.text('Details'), findsOneWidget);
     expect(find.textContaining('·'), findsNothing);
+    expect(find.text('production-east'), findsNothing);
 
     await tester.tap(find.text('Details'));
     await tester.pump();
 
-    // Expanded: the window range line appears, Show less replaces Details.
+    // Expanded: the window range line and server label appear, Show less
+    // replaces Details.
     expect(find.textContaining('·'), findsOneWidget);
+    expect(find.text('production-east'), findsOneWidget);
     expect(find.text('Show less'), findsOneWidget);
     expect(find.text('Details'), findsNothing);
+  });
+
+  testWidgets('dismiss hides the banner and survives a remount',
+      (tester) async {
+    final store = StatusMessageDismissals();
+    final msg = _upcoming();
+    Widget scoped(Key key) => ProviderScope(
+          overrides: [
+            statusMessageDismissalsProvider.overrideWithValue(store),
+          ],
+          child: MaterialApp(
+            theme:
+                lowerBrandTheme(const BrandTheme.soliplex(), Brightness.light),
+            home: Scaffold(
+              body: StatusMessageBanner.withFetcher(
+                key: key,
+                fetcher: () async => msg,
+              ),
+            ),
+          ),
+        );
+
+    await tester.pumpWidget(scoped(const ValueKey('a')));
+    await tester.pump();
+    expect(find.text('Scheduled maintenance'), findsOneWidget);
+
+    await tester.tap(find.byIcon(Icons.close));
+    await tester.pump();
+    expect(find.text('Scheduled maintenance'), findsNothing);
+
+    // Remount a fresh banner for the same message — still dismissed.
+    await tester.pumpWidget(scoped(const ValueKey('b')));
+    await tester.pump();
+    expect(find.text('Scheduled maintenance'), findsNothing);
   });
 
   testWidgets('windowless message shows no pill and no window range',

--- a/test/status_message/ui/status_message_banner_test.dart
+++ b/test/status_message/ui/status_message_banner_test.dart
@@ -1,0 +1,53 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:soliplex_design/soliplex_design.dart';
+import 'package:soliplex_frontend/src/status_message/status_message.dart';
+import 'package:soliplex_frontend/src/status_message/ui/status_message_banner.dart';
+
+Widget _wrap(Widget child) => ProviderScope(
+      child: MaterialApp(
+        theme: lowerBrandTheme(const BrandTheme.soliplex(), Brightness.light),
+        home: Scaffold(body: child),
+      ),
+    );
+
+void main() {
+  final upcoming = StatusMessage(
+    id: 'm',
+    title: 'Scheduled maintenance',
+    body: 'Save your work.',
+    intent: MessageIntent.warning,
+    category: MessageCategory.maintenance,
+    window: MessageWindow(
+      start: DateTime.now().toUtc().add(const Duration(hours: 3)),
+      end: DateTime.now().toUtc().add(const Duration(hours: 5)),
+    ),
+  );
+
+  testWidgets('renders an upcoming maintenance banner, then minimizes',
+      (tester) async {
+    await tester.pumpWidget(_wrap(
+      StatusMessageBanner.withFetcher(fetcher: () async => upcoming),
+    ));
+    await tester.pump(); // resolve the fetch future
+
+    expect(find.text('Scheduled maintenance'), findsOneWidget);
+    expect(find.text('Save your work.'), findsOneWidget);
+    expect(find.textContaining('BEGINS IN'), findsOneWidget);
+
+    await tester.tap(find.byIcon(Icons.expand_less));
+    await tester.pump();
+
+    expect(find.text('Save your work.'), findsNothing); // body hidden minimized
+    expect(find.text('Scheduled maintenance'), findsOneWidget); // title stays
+  });
+
+  testWidgets('renders nothing when there is no message', (tester) async {
+    await tester.pumpWidget(_wrap(
+      StatusMessageBanner.withFetcher(fetcher: () async => null),
+    ));
+    await tester.pump();
+    expect(find.byType(SoliplexBadge), findsNothing);
+  });
+}


### PR DESCRIPTION
## Summary

Adds a per-server status banner (chiefly an upcoming-maintenance warning with a
live countdown) that operators post or cancel by dropping or deleting a static
JSON file on the backend — no app rebuild. The banner is scoped to the
in-context server, shown in the lobby and room, and auto-hides once a
maintenance window ends.

- **Posting model** — a flavor-configurable file path (default
  `/messages/status.json`) resolved against the server URL, polled on a
  flavor-configurable interval so cancelling a message is bounded to one cycle.
- **Display** — starts collapsed (title + countdown + one body line) and expands
  to show the server name, the maintenance window as a range in the viewer's
  local time (stacked onto two lines on narrow screens), and the full body.
- **Dismissal** — a dismiss button hides a message for the session; it re-surfaces
  on the next app start or after logging out and back in to the server.
- **Resilience** — a missing file or fetch error resolves to "no message"; a
  message whose maintenance window is malformed still shows, just without the
  window. Fetch errors are triaged by kind: transient network noise logs at
  debug, while persistent misconfigurations (auth wall, 5xx, wrong content type,
  HTML in place of JSON) and malformed payloads log at warning so an operator can
  distinguish "nothing posted" from "posted but broken". Window timestamps must
  be UTC.

## Test plan

- [x] `flutter analyze` — no issues
- [x] `flutter test` — full suite passing (incl. new status_message unit/widget
      tests: visibility resolution, countdown formatting, window range
      formatting, dismissal store, controller lifecycle/dispose race, banner
      rendering, and malformed/naive-window degradation)
- [x] `dart format` — clean
- [x] markdownlint — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)