### PR TITLE
feat: show current server in room header and lobby

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 Versions follow the `version+build` scheme from `pubspec.yaml`, bumped via
 `dart run tool/bump_version.dart`.
 
+## [Unreleased]
+
+### Added
+
+- Room and lobby: the current server's name (or its address when unnamed) now
+  shows alongside the room name in the room view header, and as a title band at
+  the top of the lobby's room pane, so a user connected to several servers can
+  tell which one they are viewing.
+
 ## [0.94.0+68] - 2026-07-17
 
 ### Added

--- a/lib/src/modules/lobby/ui/lobby_screen.dart
+++ b/lib/src/modules/lobby/ui/lobby_screen.dart
@@ -503,13 +503,32 @@ class _RoomContent extends StatelessWidget {
             selectedServerId == null ? null : servers[selectedServerId];
         return Column(
           children: [
-            if (selectedEntry != null)
+            if (selectedEntry != null) ...[
+              Padding(
+                padding: const EdgeInsets.fromLTRB(SoliplexSpacing.s4,
+                    SoliplexSpacing.s3, SoliplexSpacing.s4, SoliplexSpacing.s2),
+                child: Align(
+                  alignment: Alignment.centerLeft,
+                  child: Text(
+                    selectedEntry.displayName,
+                    style: Theme.of(context).textTheme.titleMedium,
+                    maxLines: 1,
+                    overflow: TextOverflow.ellipsis,
+                  ),
+                ),
+              ),
+              Divider(
+                height: 1,
+                thickness: 1,
+                color: Theme.of(context).colorScheme.outlineVariant,
+              ),
               StatusMessageBanner(
                 key: ValueKey(selectedEntry.serverUrl),
                 baseUrl: selectedEntry.serverUrl,
                 client: selectedEntry.httpClient,
                 serverLabel: selectedEntry.displayName,
               ),
+            ],
             Padding(
               padding: const EdgeInsets.fromLTRB(SoliplexSpacing.s4,
                   SoliplexSpacing.s2, SoliplexSpacing.s4, 0),

--- a/lib/src/modules/room/ui/room_screen.dart
+++ b/lib/src/modules/room/ui/room_screen.dart
@@ -1441,7 +1441,7 @@ class _RoomScreenState extends State<RoomScreen> {
                   onPressed: () => Scaffold.of(context).openDrawer(),
                 ),
               ),
-              title: Text(roomName),
+              title: _roomTitle(roomName),
             ),
             drawer: Drawer(
               child: Builder(
@@ -1618,14 +1618,7 @@ class _RoomScreenState extends State<RoomScreen> {
           // space and pins the trailing buttons to the right edge. A Flexible
           // beside a Spacer would split the free space and leave the buttons
           // stranded mid-row.
-          Expanded(
-            child: Text(
-              roomName,
-              style: theme.textTheme.titleMedium,
-              maxLines: 1,
-              overflow: TextOverflow.ellipsis,
-            ),
-          ),
+          Expanded(child: _roomTitle(roomName)),
           if (documentsButton != null) documentsButton,
           IconButton(
             icon: const Icon(Icons.info_outline),
@@ -1635,6 +1628,31 @@ class _RoomScreenState extends State<RoomScreen> {
           ),
         ],
       ),
+    );
+  }
+
+  /// The header title: the room name over the server it lives on, so a user
+  /// with several servers connected can see which one this room belongs to.
+  Widget _roomTitle(String roomName) {
+    final theme = Theme.of(context);
+    return Column(
+      mainAxisSize: MainAxisSize.min,
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text(
+          roomName,
+          style: theme.textTheme.titleMedium,
+          maxLines: 1,
+          overflow: TextOverflow.ellipsis,
+        ),
+        Text(
+          widget.serverEntry.displayName,
+          style: theme.textTheme.labelSmall
+              ?.copyWith(color: theme.colorScheme.onSurfaceVariant),
+          maxLines: 1,
+          overflow: TextOverflow.ellipsis,
+        ),
+      ],
     );
   }
 

--- a/test/modules/lobby/ui/lobby_screen_test.dart
+++ b/test/modules/lobby/ui/lobby_screen_test.dart
@@ -280,6 +280,28 @@ void main() {
       },
     );
 
+    testWidgets('names the selected server in a pane header', (tester) async {
+      tester.view.physicalSize = const Size(400, 800);
+      tester.view.devicePixelRatio = 1.0;
+      addTearDown(tester.view.resetPhysicalSize);
+
+      final manager = _createManager();
+      manager.addServer(
+        serverId: 'local',
+        serverUrl: Uri.parse('http://localhost:8000'),
+        requiresAuth: false,
+      );
+      final fakeApi = FakeSoliplexApi()
+        ..nextRooms = const [Room(id: 'r1', name: 'General')];
+
+      await tester.pumpWidget(_buildApp(manager, apiResolver: (_) => fakeApi));
+      await tester.pumpAndSettle();
+
+      // On a narrow viewport the sidebar lives in a closed drawer, so the
+      // selected server's address shows only in the pane header.
+      expect(find.text('http://localhost:8000'), findsOneWidget);
+    });
+
     testWidgets('toggle switches loaded rooms from list to grid cards',
         (tester) async {
       tester.view.physicalSize = const Size(900, 600);

--- a/test/modules/room/ui/room_screen_test.dart
+++ b/test/modules/room/ui/room_screen_test.dart
@@ -284,6 +284,96 @@ void main() {
     expect(find.byIcon(Icons.menu), findsOneWidget);
   });
 
+  group('server label in header', () {
+    testWidgets('shows the server name beside the room name', (tester) async {
+      tester.view.physicalSize = const Size(1200, 800);
+      tester.view.devicePixelRatio = 1.0;
+      addTearDown(tester.view.resetPhysicalSize);
+
+      api.nextRoom = const Room(id: 'room-1', name: 'General');
+      final namedEntry = createTestServerEntry(api: api, name: 'Prod API');
+
+      await tester.pumpWidget(MaterialApp(
+        home: RoomScreen(
+          serverEntry: namedEntry,
+          roomId: 'room-1',
+          threadId: null,
+          runtimeManager: runtimeManager,
+          registry: registry,
+          uploadRegistry: uploadRegistry,
+          documentSelections: DocumentSelections(),
+        ),
+      ));
+      await tester.pumpAndSettle();
+
+      expect(find.text('General'), findsOneWidget);
+      expect(find.text('Prod API'), findsOneWidget);
+    });
+
+    testWidgets('falls back to the server address when the server is unnamed',
+        (tester) async {
+      tester.view.physicalSize = const Size(1200, 800);
+      tester.view.devicePixelRatio = 1.0;
+      addTearDown(tester.view.resetPhysicalSize);
+
+      api.nextRoom = const Room(id: 'room-1', name: 'General');
+      // The default `entry` carries no name, so the header shows its address.
+
+      await tester.pumpWidget(MaterialApp(
+        home: RoomScreen(
+          serverEntry: entry,
+          roomId: 'room-1',
+          threadId: null,
+          runtimeManager: runtimeManager,
+          registry: registry,
+          uploadRegistry: uploadRegistry,
+          documentSelections: DocumentSelections(),
+        ),
+      ));
+      await tester.pumpAndSettle();
+
+      expect(find.text('http://test-server:8000'), findsOneWidget);
+    });
+
+    testWidgets(
+        'narrow AppBar fits the stacked room and server title without overflow',
+        (tester) async {
+      tester.view.physicalSize = const Size(500, 800);
+      tester.view.devicePixelRatio = 1.0;
+      addTearDown(tester.view.resetPhysicalSize);
+
+      api.nextRoom = const Room(id: 'room-1', name: 'General');
+      final namedEntry = createTestServerEntry(api: api, name: 'Prod API');
+
+      await tester.pumpWidget(MaterialApp(
+        home: RoomScreen(
+          serverEntry: namedEntry,
+          roomId: 'room-1',
+          threadId: null,
+          runtimeManager: runtimeManager,
+          registry: registry,
+          uploadRegistry: uploadRegistry,
+          documentSelections: DocumentSelections(),
+        ),
+      ));
+      await tester.pumpAndSettle();
+
+      // The two-line title sits in the fixed-height AppBar toolbar; both lines
+      // must fit without a RenderFlex overflow.
+      expect(
+        find.descendant(
+            of: find.byType(AppBar), matching: find.text('General')),
+        findsOneWidget,
+      );
+      expect(
+        find.descendant(
+            of: find.byType(AppBar), matching: find.text('Prod API')),
+        findsOneWidget,
+      );
+      expect(tester.takeException(), isNull);
+    });
+  });
+
   testWidgets(
       'narrow layout: tapping drawer icon opens drawer with thread list',
       (tester) async {


### PR DESCRIPTION
## What

When connected to multiple servers, nothing told you which server a room (or the lobby) belonged to. This adds a plain server-name indicator:

- **Room view**: the server name — or its address when unnamed — shows beneath the room name in both the wide header and the narrow AppBar title, via a shared `_roomTitle` builder.
- **Lobby**: a persistent server-name title band with a hairline divider at the top of the room pane, above the status banner, on every breakpoint.

Label only (no per-server color), always shown. `ServerEntry.displayName` (`name ?? formatServerUrl(url)`) is the source; long names ellipsize to a single line.

## Testing

- 4 new widget tests: named-server label, URL fallback, narrow-AppBar overflow guard, lobby pane header.
- Room + lobby suites green (82 tests), `flutter analyze` clean, markdownlint clean.

## Notes

- CHANGELOG updated under a new `## [Unreleased]` section. Pre-existing gap left untouched: `0.94.1+69` has no changelog entry of its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)