### PR TITLE
feat: consolidate zoomable image and SVG viewers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,18 @@ Versions follow the `version+build` scheme from `pubspec.yaml`, bumped via
   shows alongside the room name in the room view header, and as a title band at
   the top of the lobby's room pane, so a user connected to several servers can
   tell which one they are viewing.
+- Tapping an inline image in chat or other markdown now opens a full-size
+  pan/zoom/rotate view; SVG code blocks open the same view on tap.
+- A citation's figures open in a pageable browser over all of that citation's
+  figures, with previous/next chevrons, page dots, and left/right arrow-key
+  navigation, instead of a single figure at a time.
+
+### Changed
+
+- The image and SVG preview surfaces — chunk visualization, workdir file
+  preview, citation figures, and SVG previews — share a single
+  pan/zoom/rotate/reset viewer, so those interactions behave consistently and
+  zooming out returns to a centered fit.
 
 ## [0.94.0+68] - 2026-07-17
 

--- a/lib/src/modules/room/ui/chunk_visualization_page.dart
+++ b/lib/src/modules/room/ui/chunk_visualization_page.dart
@@ -8,7 +8,7 @@ import 'package:soliplex_logging/soliplex_logging.dart';
 import 'package:soliplex_design/soliplex_design.dart';
 import '../../../shared/failed_image.dart';
 import '../../../shared/zoomable_image.dart';
-import 'pager_dots.dart';
+import 'paged_zoomable_images.dart';
 
 final _logger =
     LogManager.instance.getLogger('soliplex_frontend.chunk_visualization');
@@ -30,7 +30,8 @@ final class PageImageDecoded extends PageImage {
 
 /// A page whose base64 payload could not be decoded. Codec-time failures
 /// (bytes were valid base64 but not a valid image) are not represented here —
-/// they happen during paint and are caught by [Image.memory]'s `errorBuilder`.
+/// they happen during paint and are surfaced by [ZoomableImage]'s decode
+/// fallback.
 @visibleForTesting
 final class PageImageBroken extends PageImage {
   const PageImageBroken({required this.reason});
@@ -111,20 +112,13 @@ class ChunkVisualizationPage extends StatefulWidget {
 
 class _ChunkVisualizationPageState extends State<ChunkVisualizationPage> {
   late Future<List<PageImage>> _future;
-  final PageController _pageController = PageController();
-  int _currentPage = 0;
-  final Map<int, int> _rotations = {};
+  // Bumped on retry so the pager remounts with fresh rotation/page state.
+  int _reloadNonce = 0;
 
   @override
   void initState() {
     super.initState();
     _loadVisualization();
-  }
-
-  @override
-  void dispose() {
-    _pageController.dispose();
-    super.dispose();
   }
 
   void _loadVisualization() {
@@ -193,14 +187,8 @@ class _ChunkVisualizationPageState extends State<ChunkVisualizationPage> {
 
   void _retry() {
     setState(() {
-      _rotations.clear();
+      _reloadNonce++;
       _loadVisualization();
-    });
-  }
-
-  void _rotate(int pageIndex) {
-    setState(() {
-      _rotations[pageIndex] = ((_rotations[pageIndex] ?? 0) + 1) % 4;
     });
   }
 
@@ -314,7 +302,11 @@ class _ChunkVisualizationPageState extends State<ChunkVisualizationPage> {
     );
   }
 
-  Widget _buildPageImage(PageImage page, int index) {
+  Widget _buildPageImage(
+    PageImage page,
+    int rotationQuarterTurns,
+    VoidCallback onRotate,
+  ) {
     return switch (page) {
       PageImageBroken(:final reason) => Center(
           // FormatException messages are usually short but uncapped; bound
@@ -325,13 +317,12 @@ class _ChunkVisualizationPageState extends State<ChunkVisualizationPage> {
                 '${reason.length <= 80 ? reason : '${reason.substring(0, 80)}…'}',
           ),
         ),
-      PageImageDecoded(:final bytes) => ZoomableImage(
+      PageImageDecoded(:final bytes) => ZoomableImage.controlledRotation(
           bytes: bytes,
-          rotationQuarterTurns: _rotations[index] ?? 0,
-          onRotate: () => _rotate(index),
-          decodeFailureChild: const Center(
-            child: FailedImage(label: 'Page image failed to render'),
-          ),
+          rotationQuarterTurns: rotationQuarterTurns,
+          onRotate: onRotate,
+          decodeFailureChild:
+              const FailedImage(label: 'Page image failed to render'),
         ),
     };
   }
@@ -341,42 +332,16 @@ class _ChunkVisualizationPageState extends State<ChunkVisualizationPage> {
       return const Center(child: Text('No page images available'));
     }
 
-    return Column(
-      children: [
-        Expanded(
-          child: PageView.builder(
-            controller: _pageController,
-            itemCount: pages.length,
-            onPageChanged: (index) => setState(() => _currentPage = index),
-            itemBuilder: (context, index) =>
-                _buildPageImage(pages[index], index),
-          ),
-        ),
-        Padding(
-          padding: const EdgeInsets.symmetric(vertical: SoliplexSpacing.s2),
-          child: Column(
-            children: [
-              Text(
-                _pageLabel(_currentPage, pages.length),
-                style: Theme.of(context).textTheme.bodySmall,
-              ),
-              if (pages.length > 1) ...[
-                const SizedBox(height: SoliplexSpacing.s1),
-                PagerDots(
-                  itemCount: pages.length,
-                  currentIndex: _currentPage,
-                  onGoTo: (index) => _pageController.animateToPage(
-                    index,
-                    duration: const Duration(milliseconds: 200),
-                    curve: Curves.easeOut,
-                  ),
-                  labelForIndex: (i) => 'Page ${i + 1}',
-                ),
-              ],
-            ],
-          ),
-        ),
-      ],
+    return PagedZoomableImages(
+      key: ValueKey(_reloadNonce),
+      itemCount: pages.length,
+      pageBuilder: (context, index, rotation) => _buildPageImage(
+          pages[index], rotation.quarterTurns, rotation.onRotate),
+      footerBuilder: (context, index) => Text(
+        _pageLabel(index, pages.length),
+        style: Theme.of(context).textTheme.bodySmall,
+      ),
+      dotLabelForIndex: (i) => 'Page ${i + 1}',
     );
   }
 }

--- a/lib/src/modules/room/ui/citations_section.dart
+++ b/lib/src/modules/room/ui/citations_section.dart
@@ -6,7 +6,11 @@ import 'package:soliplex_logging/soliplex_logging.dart';
 import '../../../shared/copy_button.dart';
 import '../../../shared/failed_image.dart';
 import '../../../shared/preview_icon_button.dart';
+import '../../../shared/zoomable_image.dart';
+import '../../../shared/zoomable_view.dart';
 import 'markdown/flutter_markdown_plus_renderer.dart';
+import 'markdown/log_source.dart';
+import 'paged_zoomable_images.dart';
 
 final _logger = LogManager.instance.getLogger('soliplex_frontend.citations');
 
@@ -306,6 +310,34 @@ class _CitationFigures extends StatelessWidget {
 
   final SourceReference sourceReference;
 
+  void _openBrowser(BuildContext context, int index) {
+    final figures = sourceReference.figures;
+    showZoomableMediaDialog(
+      context,
+      viewer: PagedZoomableImages(
+        itemCount: figures.length,
+        initialIndex: index,
+        autofocus: true,
+        pageBuilder: (context, i, rotation) {
+          final figure = figures[i];
+          return ZoomableImage.controlledRotation(
+            bytes: figure.bytes,
+            semanticLabel: figure.caption ?? _figureSemanticLabel,
+            logSource: figure.ref,
+            rotationQuarterTurns: rotation.quarterTurns,
+            onRotate: rotation.onRotate,
+            decodeFailureChild:
+                const FailedImage(label: _figureUnavailableLabel),
+          );
+        },
+        footerBuilder: (context, i) {
+          final caption = figures[i].caption;
+          return caption != null ? _FigureCaption(caption: caption) : null;
+        },
+      ),
+    );
+  }
+
   @override
   Widget build(BuildContext context) {
     final figures = sourceReference.figures;
@@ -318,8 +350,10 @@ class _CitationFigures extends StatelessWidget {
           itemCount: figures.length,
           separatorBuilder: (_, __) =>
               const SizedBox(width: SoliplexSpacing.s2),
-          itemBuilder: (context, index) =>
-              _FigureThumbnail(figure: figures[index]),
+          itemBuilder: (context, index) => _FigureThumbnail(
+            figure: figures[index],
+            onTap: () => _openBrowser(context, index),
+          ),
         ),
       ),
     );
@@ -327,56 +361,18 @@ class _CitationFigures extends StatelessWidget {
 }
 
 /// One cited-figure thumbnail rendered from in-state bytes. Tapping opens a
-/// zoomable full-size view. A decode failure shows a broken-image fallback.
+/// zoomable browser over the citation's figures. A decode failure shows a
+/// broken-image fallback.
 class _FigureThumbnail extends StatelessWidget {
-  const _FigureThumbnail({required this.figure});
+  const _FigureThumbnail({required this.figure, required this.onTap});
 
   final Figure figure;
-
-  void _openFullSize(BuildContext context) {
-    final caption = figure.caption;
-    showDialog<void>(
-      context: context,
-      builder: (context) => Dialog(
-        insetPadding: const EdgeInsets.all(SoliplexSpacing.s4),
-        child: ConstrainedBox(
-          constraints: BoxConstraints(
-            maxWidth: 800,
-            maxHeight: MediaQuery.sizeOf(context).height * 0.85,
-          ),
-          child: Column(
-            mainAxisSize: MainAxisSize.min,
-            children: [
-              Expanded(
-                child: InteractiveViewer(
-                  maxScale: 5,
-                  child: Image.memory(
-                    figure.bytes,
-                    fit: BoxFit.contain,
-                    semanticLabel: caption ?? _figureSemanticLabel,
-                    errorBuilder: (context, error, stack) {
-                      _logger.warning(
-                        'cited figure decode failed (full-size)',
-                        error: error,
-                        attributes: {'pictureRef': figure.ref},
-                      );
-                      return const FailedImage(label: _figureUnavailableLabel);
-                    },
-                  ),
-                ),
-              ),
-              if (caption != null) _FigureCaption(caption: caption),
-            ],
-          ),
-        ),
-      ),
-    );
-  }
+  final VoidCallback onTap;
 
   @override
   Widget build(BuildContext context) {
     return InkWell(
-      onTap: () => _openFullSize(context),
+      onTap: onTap,
       borderRadius: BorderRadius.circular(context.radii.md),
       child: ClipRRect(
         borderRadius: BorderRadius.circular(context.radii.md),
@@ -387,10 +383,12 @@ class _FigureThumbnail extends StatelessWidget {
           fit: BoxFit.cover,
           semanticLabel: figure.caption ?? _figureSemanticLabel,
           errorBuilder: (context, error, stack) {
-            _logger.warning(
-              'cited figure decode failed',
+            logFailedSourceOnce(
+              _logger,
+              'cited figure decode failed: ${figure.ref}',
+              figure.ref,
               error: error,
-              attributes: {'pictureRef': figure.ref},
+              stackTrace: stack,
             );
             return const SizedBox(
               width: _figureThumbnailSize,

--- a/lib/src/modules/room/ui/markdown/code_block_builder.dart
+++ b/lib/src/modules/room/ui/markdown/code_block_builder.dart
@@ -5,9 +5,16 @@ import 'package:flutter_highlight/themes/vs2015.dart';
 import 'package:flutter_markdown_plus/flutter_markdown_plus.dart';
 import 'package:flutter_svg/flutter_svg.dart';
 import 'package:markdown/markdown.dart' as md;
+import 'package:soliplex_logging/soliplex_logging.dart';
 
+import '../../../../shared/zoomable_view.dart';
 import '../copy_button.dart';
+import '../workdir_preview/svg_preview.dart';
+import 'log_source.dart';
 import 'package:soliplex_design/soliplex_design.dart';
+
+final _logger =
+    LogManager.instance.getLogger('soliplex_frontend.code_block_svg');
 
 class CodeBlockBuilder extends MarkdownElementBuilder {
   CodeBlockBuilder({required this.preferredStyle});
@@ -87,19 +94,50 @@ class _SvgCodeBlockState extends State<_SvgCodeBlock> {
   }
 
   Widget _previewView() {
-    return ConstrainedBox(
-      constraints: const BoxConstraints(maxHeight: 400),
-      child: SvgPicture.string(
-        widget.code,
-        placeholderBuilder: (_) => const SizedBox.shrink(),
-        errorBuilder: (_, __, ___) => Icon(
-          Icons.broken_image,
-          size: 48,
-          color: Theme.of(context).colorScheme.outline,
+    // Inline preview; tapping opens the full-size zoomable view, matching
+    // inline images.
+    return MouseRegion(
+      cursor: SystemMouseCursors.click,
+      child: GestureDetector(
+        onTap: _openFullSize,
+        child: ConstrainedBox(
+          constraints: const BoxConstraints(maxHeight: 400),
+          child: SvgPicture.string(
+            widget.code,
+            placeholderBuilder: (_) => const SizedBox.shrink(),
+            errorBuilder: (_, error, stack) => _brokenIcon(error, stack),
+          ),
         ),
       ),
     );
   }
+
+  void _openFullSize() {
+    showZoomableMediaDialog(
+      context,
+      viewer: SvgPreview(
+        content: widget.code,
+        fallback: Center(child: _brokenIconVisual()),
+      ),
+    );
+  }
+
+  Widget _brokenIcon(Object? error, StackTrace? stack) {
+    logFailedSourceOnce(
+      _logger,
+      'svg code block failed to render',
+      'svg-code-block:${widget.code}',
+      error: error,
+      stackTrace: stack,
+    );
+    return _brokenIconVisual();
+  }
+
+  Widget _brokenIconVisual() => Icon(
+        Icons.broken_image,
+        size: 48,
+        color: Theme.of(context).colorScheme.outline,
+      );
 
   Widget _sourceView() {
     final isDark = Theme.of(context).brightness == Brightness.dark;

--- a/lib/src/modules/room/ui/markdown/file_image_loader.dart
+++ b/lib/src/modules/room/ui/markdown/file_image_loader.dart
@@ -8,3 +8,9 @@ import '../../../../shared/failed_image.dart';
 /// `file_image_loader_io.dart` replaces this on platforms with a filesystem.
 Widget loadFileImage(Uri uri, String rawUri, String? alt) =>
     FailedImage(source: rawUri, label: alt);
+
+/// Full-size zoomable viewer for a `file:` image, shown in the tap-to-zoom
+/// dialog. Web stub: `file:` images can't be read, so it shows a bare centered
+/// fallback (no zoom/rotate chrome).
+Widget fileImageZoomViewer(Uri uri, String rawUri) =>
+    const Center(child: FailedImage());

--- a/lib/src/modules/room/ui/markdown/file_image_loader_io.dart
+++ b/lib/src/modules/room/ui/markdown/file_image_loader_io.dart
@@ -4,6 +4,7 @@ import 'package:flutter/material.dart';
 import 'package:soliplex_logging/soliplex_logging.dart';
 
 import '../../../../shared/failed_image.dart';
+import '../../../../shared/zoomable_image.dart';
 import 'log_source.dart';
 
 final _logger =
@@ -40,5 +41,29 @@ Widget loadFileImage(Uri uri, String rawUri, String? alt) {
       stackTrace: stack,
     );
     return FailedImage(source: rawUri, label: alt);
+  }
+}
+
+/// Full-size zoomable viewer for a `file:` image, shown in the tap-to-zoom
+/// dialog. Routes through [ZoomableImage.provider] so a load failure shows a
+/// bare centered fallback rather than a broken image under zoom/rotate chrome.
+/// A `File.fromUri` construction failure is caught and shown the same way.
+Widget fileImageZoomViewer(Uri uri, String rawUri) {
+  try {
+    return ZoomableImage.provider(
+      FileImage(File.fromUri(uri)),
+      logSource: safeSourceForLog(rawUri),
+      decodeFailureChild: const FailedImage(),
+    );
+  } on UnsupportedError catch (error, stack) {
+    logFailedSourceOnce(
+      _logger,
+      'file: URI could not be converted to a file path: '
+      '${safeSourceForLog(rawUri)}',
+      rawUri,
+      error: error,
+      stackTrace: stack,
+    );
+    return const Center(child: FailedImage());
   }
 }

--- a/lib/src/modules/room/ui/markdown/flutter_markdown_plus_renderer.dart
+++ b/lib/src/modules/room/ui/markdown/flutter_markdown_plus_renderer.dart
@@ -10,6 +10,8 @@ import '../../../../shared/markdown/launch_markdown_link.dart';
 import '../../../../shared/markdown/markdown_renderer.dart';
 import '../../../../shared/markdown/markdown_style_sheet.dart';
 import '../../../../shared/markdown/sanitize_markdown.dart';
+import '../../../../shared/zoomable_image.dart';
+import '../../../../shared/zoomable_view.dart';
 import 'code_block_builder.dart';
 import 'data_uri_image.dart';
 import 'file_image_loader.dart'
@@ -62,7 +64,12 @@ class FlutterMarkdownPlusRenderer extends MarkdownRenderer {
           launchMarkdownLink(href);
         }
       },
-      imageBuilder: _buildImage,
+      imageBuilder: (uri, title, alt) => _MaybeZoomableImage(
+        uri: uri,
+        alt: alt,
+        onImageTap: onImageTap,
+        inline: _buildImage(uri, title, alt),
+      ),
       builders: {
         'code': InlineCodeBuilder(),
         'pre': CodeBlockBuilder(
@@ -88,34 +95,35 @@ Widget _buildImage(Uri uri, String? title, String? alt) {
     'data' => _buildDataImage(uri, alt, rawUri),
     'http' || 'https' => Image.network(
         rawUri,
-        errorBuilder: (_, error, stack) {
-          logFailedSourceOnce(
-            _logger,
-            'http image failed to load: ${safeSourceForLog(rawUri)}',
-            rawUri,
-            error: error,
-            stackTrace: stack,
-          );
-          return FailedImage(source: rawUri, label: alt);
-        },
+        errorBuilder: _loadErrorBuilder(rawUri, alt, 'http'),
       ),
     'resource' => Image.asset(
         uri.path,
-        errorBuilder: (_, error, stack) {
-          logFailedSourceOnce(
-            _logger,
-            'resource image failed to load: ${safeSourceForLog(rawUri)}',
-            rawUri,
-            error: error,
-            stackTrace: stack,
-          );
-          return FailedImage(source: rawUri, label: alt);
-        },
+        errorBuilder: _loadErrorBuilder(rawUri, alt, 'resource'),
       ),
     'file' => loadFileImage(uri, rawUri, alt),
     _ => _unsupportedSchemeFallback(uri, rawUri, alt),
   };
 }
+
+/// Error builder for network/asset image loads: logs the failure once per
+/// source, then renders an inspectable [FailedImage]. [scheme] is the label
+/// used in the log message (e.g. `'http'`, `'resource'`).
+ImageErrorWidgetBuilder _loadErrorBuilder(
+  String rawUri,
+  String? alt,
+  String scheme,
+) =>
+    (_, error, stack) {
+      logFailedSourceOnce(
+        _logger,
+        '$scheme image failed to load: ${safeSourceForLog(rawUri)}',
+        rawUri,
+        error: error,
+        stackTrace: stack,
+      );
+      return FailedImage(source: rawUri, label: alt);
+    };
 
 Widget _unsupportedSchemeFallback(Uri uri, String rawUri, String? alt) {
   logFailedSourceOnce(
@@ -180,4 +188,111 @@ Widget _buildDataImage(Uri uri, String? alt, String rawUri) {
     rawUri,
   );
   return FailedImage(source: rawUri, label: alt);
+}
+
+/// Wraps an inline markdown image so tapping it opens a full-size zoomable
+/// view. Inlines we don't open in a zoom view are returned as-is and left
+/// inert: content not treated as a zoomable image (`text/` data URIs, which
+/// render as [Text], and unsupported schemes — see [_isZoomableImageUri]), and
+/// inlines that already resolved synchronously to a [FailedImage]. Image URIs
+/// that fail asynchronously (http/https/resource/file) render after this
+/// wrapper is built, so they stay tappable and open a dialog around their own
+/// failure fallback. When [onImageTap] is provided the host handles the tap
+/// instead of the default zoom dialog.
+class _MaybeZoomableImage extends StatelessWidget {
+  const _MaybeZoomableImage({
+    required this.uri,
+    required this.alt,
+    required this.onImageTap,
+    required this.inline,
+  });
+
+  final Uri uri;
+  final String? alt;
+  final MarkdownImageHandler? onImageTap;
+  final Widget inline;
+
+  @override
+  Widget build(BuildContext context) {
+    if (!_isZoomableImageUri(uri) || inline is FailedImage) return inline;
+    return MouseRegion(
+      cursor: SystemMouseCursors.click,
+      child: GestureDetector(
+        onTap: () {
+          final handler = onImageTap;
+          if (handler != null) {
+            handler(uri.toString(), alt);
+            return;
+          }
+          final label = alt;
+          showZoomableMediaDialog(
+            context,
+            viewer: _zoomableImageViewerFor(uri),
+            caption: label == null || label.isEmpty
+                ? null
+                : Padding(
+                    padding: const EdgeInsets.all(SoliplexSpacing.s2),
+                    child: Text(
+                      label,
+                      style: Theme.of(context).textTheme.bodySmall,
+                      textAlign: TextAlign.center,
+                    ),
+                  ),
+          );
+        },
+        child: inline,
+      ),
+    );
+  }
+}
+
+/// Whether [uri] resolves to an image we can open in a zoomable view.
+bool _isZoomableImageUri(Uri uri) => switch (uri.scheme) {
+      'http' || 'https' || 'resource' || 'file' => true,
+      'data' => uri.data?.mimeType.startsWith('image/') ?? false,
+      _ => false,
+    };
+
+/// Builds the full-size, `BoxFit.contain` viewer for [uri] shown in the zoom
+/// dialog. Each scheme routes through a viewer that owns its own load failure
+/// ([ZoomableImage] / [fileImageZoomViewer]), so a broken image shows a bare
+/// centered fallback rather than a broken image under zoom/rotate chrome. The
+/// image's caption is supplied separately by the dialog, so the fallbacks are
+/// intentionally label-less.
+Widget _zoomableImageViewerFor(Uri uri) {
+  final rawUri = uri.toString();
+  return switch (uri.scheme) {
+    'data' => switch (tryDecodeImageDataUri(rawUri)) {
+        final decoded? => ZoomableImage(
+            bytes: decoded.bytes,
+            logSource: safeSourceForLog(rawUri),
+            decodeFailureChild: const FailedImage(),
+          ),
+        _ => _dataDecodeFailure(rawUri),
+      },
+    'http' || 'https' => ZoomableImage.provider(
+        NetworkImage(rawUri),
+        logSource: safeSourceForLog(rawUri),
+        decodeFailureChild: const FailedImage(),
+      ),
+    'resource' => ZoomableImage.provider(
+        AssetImage(uri.path),
+        logSource: safeSourceForLog(rawUri),
+        decodeFailureChild: const FailedImage(),
+      ),
+    'file' => fileImageZoomViewer(uri, rawUri),
+    _ => const Center(child: FailedImage()),
+  };
+}
+
+/// Fallback for a `data:image/*` URI whose payload can't be decoded, mirroring
+/// the inline [_buildDataImage] path so the failure is logged even when it is
+/// only reached via the zoom dialog.
+Widget _dataDecodeFailure(String rawUri) {
+  logFailedSourceOnce(
+    _logger,
+    'data:image/* URI failed to decode: ${safeSourceForLog(rawUri)}',
+    rawUri,
+  );
+  return const Center(child: FailedImage());
 }

--- a/lib/src/modules/room/ui/markdown/log_source.dart
+++ b/lib/src/modules/room/ui/markdown/log_source.dart
@@ -18,17 +18,22 @@ String safeSourceForLog(String src, {int max = 120}) {
       : '${src.substring(0, max)}…(${src.length} chars)';
 }
 
-/// Set of source keys already logged once at warning level. Flutter's
+/// Hashes of source keys already logged once at warning level. Flutter's
 /// `errorBuilder` is invoked on every rebuild while the failed image is
-/// mounted; without dedupe a single broken image in chat history can flood
-/// the log sink. Shared across markdown-image callers so a URI that fails
-/// in multiple code paths still logs once total.
-final _loggedSources = <String>{};
+/// mounted; without dedupe a single broken image in chat history can flood the
+/// log sink. Shared across all callers of [logFailedSourceOnce] so a key that
+/// fails in several of those paths logs once total. Only each key's hash is
+/// retained, so a `data:` URI's (potentially multi-megabyte) base64 payload is
+/// not held for the process lifetime.
+final _loggedSources = <int>{};
 
 /// Logs [message] at warning level the first time [key] is seen, otherwise
-/// silently drops it. Keys are URIs for per-source dedupe, or short tags
-/// like `'scheme:ftp'` for per-category dedupe. Pass [logger] so the call
-/// site's logger namespace appears in the output.
+/// silently drops it. Keys are URIs for per-source dedupe, or short tags like
+/// `'scheme:ftp'` for per-category dedupe. Dedupe is best-effort: keyed on
+/// [key]'s hash so large payloads are never retained, at the cost that two keys
+/// whose hashes collide are treated as one — an acceptable, rare miss for log
+/// dedupe. Pass [logger] so the call site's logger namespace appears in the
+/// output.
 void logFailedSourceOnce(
   Logger logger,
   String message,
@@ -36,7 +41,7 @@ void logFailedSourceOnce(
   Object? error,
   StackTrace? stackTrace,
 }) {
-  if (_loggedSources.add(key)) {
+  if (_loggedSources.add(key.hashCode)) {
     logger.warning(message, error: error, stackTrace: stackTrace);
   }
 }

--- a/lib/src/modules/room/ui/paged_zoomable_images.dart
+++ b/lib/src/modules/room/ui/paged_zoomable_images.dart
@@ -1,0 +1,153 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:soliplex_design/soliplex_design.dart';
+
+import 'pager_dots.dart';
+
+/// A pageable set of zoomable images sharing one page indicator and per-page
+/// rotation that persists across paging. Used by the chunk-visualization page
+/// browser and the citation-figure browser.
+///
+/// Each page is built by [pageBuilder], which receives the page's current
+/// rotation and a rotate callback to wire into a `ZoomableImage`. [footerBuilder]
+/// renders optional content (a page label, a caption) above the page dots for
+/// the current page. Paging is driven by the page dots, the prev/next chevrons,
+/// and the left/right arrow keys (set [autofocus] so the arrows work without a
+/// prior tap, e.g. in a dialog).
+///
+/// Rotation and current-page state live for the widget's lifetime; to reset
+/// them (e.g. on a reload) give the widget a new [key] so it remounts.
+class PagedZoomableImages extends StatefulWidget {
+  const PagedZoomableImages({
+    required this.itemCount,
+    required this.pageBuilder,
+    this.initialIndex = 0,
+    this.footerBuilder,
+    this.dotLabelForIndex,
+    this.autofocus = false,
+    super.key,
+  })  : assert(itemCount > 0, 'PagedZoomableImages requires at least one item'),
+        assert(
+          initialIndex >= 0 && initialIndex < itemCount,
+          'initialIndex must be within [0, itemCount)',
+        );
+
+  final int itemCount;
+  final Widget Function(
+    BuildContext context,
+    int index,
+    ({int quarterTurns, VoidCallback onRotate}) rotation,
+  ) pageBuilder;
+  final int initialIndex;
+  final Widget? Function(BuildContext context, int index)? footerBuilder;
+  final String Function(int index)? dotLabelForIndex;
+  final bool autofocus;
+
+  @override
+  State<PagedZoomableImages> createState() => _PagedZoomableImagesState();
+}
+
+class _PagedZoomableImagesState extends State<PagedZoomableImages> {
+  late final PageController _controller =
+      PageController(initialPage: widget.initialIndex);
+  final FocusNode _focusNode = FocusNode();
+  late int _current = widget.initialIndex;
+  final Map<int, int> _rotations = {};
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    _focusNode.dispose();
+    super.dispose();
+  }
+
+  void _rotate(int index) =>
+      setState(() => _rotations[index] = ((_rotations[index] ?? 0) + 1) % 4);
+
+  void _goTo(int index) => _controller.animateToPage(
+        index.clamp(0, widget.itemCount - 1),
+        duration: const Duration(milliseconds: 200),
+        curve: Curves.easeOut,
+      );
+
+  KeyEventResult _onKey(FocusNode node, KeyEvent event) {
+    if (event is KeyUpEvent) return KeyEventResult.ignored;
+    switch (event.logicalKey) {
+      case LogicalKeyboardKey.arrowRight:
+        _goTo(_current + 1);
+        return KeyEventResult.handled;
+      case LogicalKeyboardKey.arrowLeft:
+        _goTo(_current - 1);
+        return KeyEventResult.handled;
+    }
+    return KeyEventResult.ignored;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final footer = widget.footerBuilder?.call(context, _current);
+    final showNav = widget.itemCount > 1;
+    return Focus(
+      focusNode: _focusNode,
+      autofocus: widget.autofocus,
+      onKeyEvent: _onKey,
+      child: Column(
+        children: [
+          Expanded(
+            child: PageView.builder(
+              controller: _controller,
+              itemCount: widget.itemCount,
+              onPageChanged: (index) => setState(() => _current = index),
+              itemBuilder: (context, index) => widget.pageBuilder(
+                context,
+                index,
+                (
+                  quarterTurns: _rotations[index] ?? 0,
+                  onRotate: () => _rotate(index),
+                ),
+              ),
+            ),
+          ),
+          if (footer != null || showNav)
+            Padding(
+              padding: const EdgeInsets.symmetric(vertical: SoliplexSpacing.s2),
+              child: Column(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  if (footer != null) footer,
+                  if (footer != null && showNav)
+                    const SizedBox(height: SoliplexSpacing.s1),
+                  if (showNav)
+                    Row(
+                      mainAxisSize: MainAxisSize.min,
+                      mainAxisAlignment: MainAxisAlignment.center,
+                      children: [
+                        IconButton(
+                          icon: const Icon(Icons.chevron_left),
+                          tooltip: 'Previous',
+                          onPressed:
+                              _current > 0 ? () => _goTo(_current - 1) : null,
+                        ),
+                        PagerDots(
+                          itemCount: widget.itemCount,
+                          currentIndex: _current,
+                          onGoTo: _goTo,
+                          labelForIndex: widget.dotLabelForIndex,
+                        ),
+                        IconButton(
+                          icon: const Icon(Icons.chevron_right),
+                          tooltip: 'Next',
+                          onPressed: _current < widget.itemCount - 1
+                              ? () => _goTo(_current + 1)
+                              : null,
+                        ),
+                      ],
+                    ),
+                ],
+              ),
+            ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/src/modules/room/ui/workdir_files_section.dart
+++ b/lib/src/modules/room/ui/workdir_files_section.dart
@@ -722,7 +722,7 @@ class _PreviewBody extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     if (kind == PreviewKind.image) {
-      return ZoomableImage(
+      return ZoomableImage.controlledRotation(
         bytes: bytes,
         rotationQuarterTurns: rotationQuarterTurns,
         onRotate: onRotate,

--- a/lib/src/modules/room/ui/workdir_preview/svg_preview.dart
+++ b/lib/src/modules/room/ui/workdir_preview/svg_preview.dart
@@ -2,11 +2,12 @@ import 'package:flutter/material.dart';
 import 'package:flutter_svg/flutter_svg.dart';
 import 'package:soliplex_logging/soliplex_logging.dart';
 
+import '../../../../shared/zoomable_view.dart';
+
 final _logger = LogManager.instance.getLogger('soliplex_frontend.svg_preview');
 
-/// Renders an SVG payload inside an [InteractiveViewer]. Falls back to
-/// [fallback] if the bytes don't parse — sized as a peer of the viewer
-/// so its controls aren't pannable/zoomable.
+/// Renders an SVG payload inside a [ZoomableView] (pan/zoom/rotate/reset).
+/// Falls back to [fallback] if the content doesn't parse.
 class SvgPreview extends StatefulWidget {
   const SvgPreview({
     super.key,
@@ -48,19 +49,15 @@ class _SvgPreviewState extends State<SvgPreview> {
   @override
   Widget build(BuildContext context) {
     if (_failed) return widget.fallback;
-    return Center(
-      child: InteractiveViewer(
-        minScale: 1.0,
-        maxScale: 4.0,
-        child: SvgPicture.string(
-          widget.content,
-          fit: BoxFit.contain,
-          placeholderBuilder: (_) => const SizedBox.shrink(),
-          errorBuilder: (_, error, stack) {
-            _markFailed(error, stack);
-            return const SizedBox.shrink();
-          },
-        ),
+    return ZoomableView(
+      child: SvgPicture.string(
+        widget.content,
+        fit: BoxFit.contain,
+        placeholderBuilder: (_) => const SizedBox.shrink(),
+        errorBuilder: (_, error, stack) {
+          _markFailed(error, stack);
+          return const SizedBox.shrink();
+        },
       ),
     );
   }

--- a/lib/src/shared/zoomable_image.dart
+++ b/lib/src/shared/zoomable_image.dart
@@ -1,219 +1,124 @@
-import 'dart:math' show min;
 import 'dart:typed_data';
 
 import 'package:flutter/material.dart';
-import 'package:soliplex_design/soliplex_design.dart';
 import 'package:soliplex_logging/soliplex_logging.dart';
+
+import 'zoomable_view.dart';
 
 final _logger =
     LogManager.instance.getLogger('soliplex_frontend.zoomable_image');
 
-/// Pan/zoom/rotate viewer for a single decoded image, shared by the chunk
-/// visualization and workdir file previews.
+/// Pan/zoom/rotate viewer for a single image, shared by the app's image-preview
+/// surfaces. Delegates the interaction to [ZoomableView]; owns the load/decode
+/// failure so the fallback is shown *in place of* the viewer — no zoom or rotate
+/// chrome over a broken image.
 ///
-/// Zoom works for mouse wheel, trackpad pinch, and — via
-/// [InteractiveViewer.trackpadScrollCausesScale] — trackpad two-finger scroll,
-/// which Flutter would otherwise route to a (clamped, invisible) pan.
-///
-/// Intrinsic dimensions are read from the decoded image so the image is sized
-/// to its exact aspect ratio under `constrained: false`; zoom then scales only
-/// image content, never surrounding whitespace. Works for every format the
-/// engine decodes, not just PNG.
-///
-/// Rotation state is owned by the caller ([rotationQuarterTurns] / [onRotate])
-/// so it can persist across paging. When the bytes can't be decoded,
-/// [decodeFailureChild] is shown in place of the viewer and the rotate control
-/// is hidden.
+/// The rotate control is always shown. Rotation is self-managed by default; use
+/// [ZoomableImage.controlledRotation] to own rotation from the caller so it
+/// persists across paging. When the image fails to load or decode,
+/// [decodeFailureChild] is shown, centered, in place of the viewer.
 class ZoomableImage extends StatefulWidget {
-  const ZoomableImage({
-    required this.bytes,
-    required this.rotationQuarterTurns,
-    required this.onRotate,
+  /// Decoded bytes, self-managed rotation, starting unrotated.
+  ZoomableImage({
+    required Uint8List bytes,
     required this.decodeFailureChild,
+    this.semanticLabel,
+    this.logSource,
     super.key,
-  });
+  })  : provider = MemoryImage(bytes),
+        byteLength = bytes.length,
+        rotationQuarterTurns = 0,
+        onRotate = null;
 
-  final Uint8List bytes;
-  final int rotationQuarterTurns;
-  final VoidCallback onRotate;
+  /// Decoded bytes with caller-owned rotation so it survives paging (e.g. per
+  /// document page).
+  ZoomableImage.controlledRotation({
+    required Uint8List bytes,
+    required this.decodeFailureChild,
+    required this.rotationQuarterTurns,
+    required VoidCallback this.onRotate,
+    this.semanticLabel,
+    this.logSource,
+    super.key,
+  })  : provider = MemoryImage(bytes),
+        byteLength = bytes.length;
+
+  /// Any [ImageProvider] (network, asset, file), self-managed rotation. The
+  /// provider's load failure is owned here, so the fallback shows without the
+  /// zoom/rotate chrome.
+  const ZoomableImage.provider(
+    this.provider, {
+    required this.decodeFailureChild,
+    this.semanticLabel,
+    this.logSource,
+    super.key,
+  })  : byteLength = null,
+        rotationQuarterTurns = 0,
+        onRotate = null;
+
+  final ImageProvider provider;
   final Widget decodeFailureChild;
+  final int rotationQuarterTurns;
+  final VoidCallback? onRotate;
+  final String? semanticLabel;
+
+  /// Byte length recorded in the failure log when the image was built from
+  /// bytes; null for provider-backed images.
+  final int? byteLength;
+
+  /// Optional identifier for the image source (e.g. a figure ref or redacted
+  /// URI) recorded in the failure log so a failure can be traced to its source.
+  final String? logSource;
 
   @override
   State<ZoomableImage> createState() => _ZoomableImageState();
 }
 
 class _ZoomableImageState extends State<ZoomableImage> {
-  final TransformationController _controller = TransformationController();
-  late MemoryImage _provider;
-  ImageStream? _stream;
-  ImageStreamListener? _listener;
-  Size? _intrinsicSize;
   bool _failed = false;
-  bool _zoomed = false;
-
-  @override
-  void initState() {
-    super.initState();
-    _provider = MemoryImage(widget.bytes);
-    _controller.addListener(_onTransformChanged);
-  }
-
-  @override
-  void didChangeDependencies() {
-    super.didChangeDependencies();
-    _resolveDimensions();
-  }
 
   @override
   void didUpdateWidget(ZoomableImage old) {
     super.didUpdateWidget(old);
-    if (!identical(old.bytes, widget.bytes)) {
-      _detachStream();
-      _provider = MemoryImage(widget.bytes);
-      _intrinsicSize = null;
-      _failed = false;
-      _controller.value = Matrix4.identity();
-      _resolveDimensions();
-    }
+    if (old.provider != widget.provider) _failed = false;
   }
-
-  @override
-  void dispose() {
-    _detachStream();
-    _controller
-      ..removeListener(_onTransformChanged)
-      ..dispose();
-    super.dispose();
-  }
-
-  void _onTransformChanged() {
-    final zoomed = _controller.value.getMaxScaleOnAxis() > 1.001;
-    if (zoomed != _zoomed && mounted) setState(() => _zoomed = zoomed);
-  }
-
-  void _resolveDimensions() {
-    _detachStream();
-    final stream = _provider.resolve(createLocalImageConfiguration(context));
-    final listener = ImageStreamListener(
-      (info, _) {
-        final size = Size(
-          info.image.width.toDouble(),
-          info.image.height.toDouble(),
-        );
-        info.dispose();
-        if (mounted) setState(() => _intrinsicSize = size);
-      },
-      onError: _markFailed,
-    );
-    _stream = stream..addListener(listener);
-    _listener = listener;
-  }
-
-  void _detachStream() {
-    if (_stream != null && _listener != null) {
-      _stream!.removeListener(_listener!);
-    }
-    _stream = null;
-    _listener = null;
-  }
-
-  void _reset() => _controller.value = Matrix4.identity();
 
   void _markFailed(Object error, StackTrace? stackTrace) {
     if (_failed) return;
     _logger.warning(
-      'image bytes failed to decode',
+      'image failed to load',
       error: error,
       stackTrace: stackTrace,
-      attributes: {'byteLength': widget.bytes.length},
+      attributes: {
+        if (widget.byteLength != null) 'byteLength': widget.byteLength,
+        if (widget.logSource != null) 'source': widget.logSource,
+      },
     );
     WidgetsBinding.instance.addPostFrameCallback((_) {
       if (mounted) setState(() => _failed = true);
     });
   }
 
-  Widget _interactive({required bool constrained, required Widget child}) {
-    return InteractiveViewer(
-      transformationController: _controller,
-      constrained: constrained,
-      trackpadScrollCausesScale: true,
-      minScale: 1.0,
-      maxScale: 4.0,
-      child: child,
-    );
-  }
-
-  Widget _viewer() {
-    final rotation = widget.rotationQuarterTurns;
-    final image = RotatedBox(
-      quarterTurns: rotation,
-      child: Image(
-        image: _provider,
-        fit: BoxFit.contain,
-        errorBuilder: (_, error, stack) {
-          _markFailed(error, stack);
-          return const SizedBox.shrink();
-        },
-      ),
-    );
-
-    final size = _intrinsicSize;
-    if (size == null) {
-      return Center(child: _interactive(constrained: true, child: image));
-    }
-
-    return LayoutBuilder(
-      builder: (context, constraints) {
-        final effW = rotation.isOdd ? size.height : size.width;
-        final effH = rotation.isOdd ? size.width : size.height;
-        final scale = min(
-          constraints.maxWidth / effW,
-          constraints.maxHeight / effH,
-        );
-        return Center(
-          child: _interactive(
-            constrained: false,
-            child: SizedBox(
-              width: effW * scale,
-              height: effH * scale,
-              child: image,
-            ),
-          ),
-        );
-      },
-    );
-  }
-
   @override
   Widget build(BuildContext context) {
-    if (_failed) return widget.decodeFailureChild;
+    if (_failed) return Center(child: widget.decodeFailureChild);
 
-    return Stack(
-      children: [
-        Positioned.fill(child: _viewer()),
-        // With constrained:false zoom, scrolling back out clamps scale but
-        // leaves a residual offset, so there's otherwise no reliable way back
-        // to the starting view. The reset control appears only while zoomed.
-        if (_zoomed)
-          Positioned(
-            left: SoliplexSpacing.s2,
-            top: SoliplexSpacing.s2,
-            child: IconButton.filledTonal(
-              onPressed: _reset,
-              icon: const Icon(Icons.zoom_out_map),
-              tooltip: 'Reset zoom',
-            ),
-          ),
-        Positioned(
-          right: SoliplexSpacing.s2,
-          top: SoliplexSpacing.s2,
-          child: IconButton.filledTonal(
-            onPressed: widget.onRotate,
-            icon: const Icon(Icons.rotate_right),
-            tooltip: 'Rotate',
-          ),
-        ),
-      ],
+    final image = Image(
+      image: widget.provider,
+      fit: BoxFit.contain,
+      semanticLabel: widget.semanticLabel,
+      errorBuilder: (_, error, stack) {
+        _markFailed(error, stack);
+        return const SizedBox.shrink();
+      },
     );
+    final onRotate = widget.onRotate;
+    return onRotate != null
+        ? ZoomableView.controlledRotation(
+            rotationQuarterTurns: widget.rotationQuarterTurns,
+            onRotate: onRotate,
+            child: image,
+          )
+        : ZoomableView(child: image);
   }
 }

--- a/lib/src/shared/zoomable_view.dart
+++ b/lib/src/shared/zoomable_view.dart
@@ -1,0 +1,160 @@
+import 'package:flutter/material.dart';
+import 'package:soliplex_design/soliplex_design.dart';
+
+/// Pan/zoom/rotate viewport for a single piece of visual content (a raster
+/// image, a vector picture, anything). The content is laid out inside a
+/// viewport-sized child (`constrained: true`), so fit is exactly `scale == 1.0`,
+/// centered: zooming out always returns to the original position, with no
+/// off-center drift.
+///
+/// Zoom works for mouse wheel, trackpad pinch, and — via
+/// [InteractiveViewer.trackpadScrollCausesScale] — trackpad two-finger scroll,
+/// which Flutter would otherwise route to a (clamped, invisible) pan.
+///
+/// A reset control appears while zoomed. A rotate control is always shown.
+/// Rotation is self-managed by default; use [ZoomableView.controlledRotation]
+/// to own rotation from the caller so it can persist across paging (e.g. per
+/// document page).
+class ZoomableView extends StatefulWidget {
+  /// Self-managed rotation, starting unrotated.
+  const ZoomableView({
+    required this.child,
+    super.key,
+  })  : rotationQuarterTurns = 0,
+        onRotate = null;
+
+  /// Caller-owned rotation: [rotationQuarterTurns] is the live source of truth
+  /// and [onRotate] is invoked on each rotate tap, so rotation survives paging.
+  const ZoomableView.controlledRotation({
+    required this.child,
+    required this.rotationQuarterTurns,
+    required VoidCallback this.onRotate,
+    super.key,
+  });
+
+  final Widget child;
+  final int rotationQuarterTurns;
+  final VoidCallback? onRotate;
+
+  @override
+  State<ZoomableView> createState() => _ZoomableViewState();
+}
+
+class _ZoomableViewState extends State<ZoomableView> {
+  final TransformationController _controller = TransformationController();
+  bool _zoomed = false;
+  // Used only in self-managed mode (default constructor); starts unrotated.
+  int _selfRotation = 0;
+
+  @override
+  void initState() {
+    super.initState();
+    _controller.addListener(_onTransformChanged);
+  }
+
+  @override
+  void dispose() {
+    _controller
+      ..removeListener(_onTransformChanged)
+      ..dispose();
+    super.dispose();
+  }
+
+  void _onTransformChanged() {
+    final zoomed = _controller.value.getMaxScaleOnAxis() > 1.001;
+    if (zoomed != _zoomed && mounted) setState(() => _zoomed = zoomed);
+  }
+
+  void _reset() => _controller.value = Matrix4.identity();
+
+  // Caller-owned when [onRotate] is provided (persists across paging);
+  // self-managed otherwise.
+  int get _rotationQuarterTurns =>
+      widget.onRotate != null ? widget.rotationQuarterTurns : _selfRotation;
+
+  void _rotate() {
+    final onRotate = widget.onRotate;
+    if (onRotate != null) {
+      onRotate();
+    } else {
+      setState(() => _selfRotation = (_selfRotation + 1) % 4);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Stack(
+      children: [
+        Positioned.fill(
+          child: InteractiveViewer(
+            transformationController: _controller,
+            constrained: true,
+            trackpadScrollCausesScale: true,
+            // Slower than the default (200) so wheel/trackpad zoom advances in
+            // fine steps instead of jumping.
+            scaleFactor: 800.0,
+            minScale: 1.0,
+            maxScale: 4.0,
+            // At fit the whole content is already visible, so there is nothing
+            // to pan; panning is only for moving around zoomed-in content.
+            panEnabled: _zoomed,
+            child: RotatedBox(
+              quarterTurns: _rotationQuarterTurns,
+              child: widget.child,
+            ),
+          ),
+        ),
+        // A quick way back to fit without scrolling all the way out. Shown only
+        // while zoomed.
+        if (_zoomed)
+          Positioned(
+            left: SoliplexSpacing.s2,
+            top: SoliplexSpacing.s2,
+            child: IconButton.filledTonal(
+              onPressed: _reset,
+              icon: const Icon(Icons.zoom_out_map),
+              tooltip: 'Reset zoom',
+            ),
+          ),
+        Positioned(
+          right: SoliplexSpacing.s2,
+          top: SoliplexSpacing.s2,
+          child: IconButton.filledTonal(
+            onPressed: _rotate,
+            icon: const Icon(Icons.rotate_right),
+            tooltip: 'Rotate',
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+/// Opens [viewer] full-size in a centered dialog, with an optional [caption]
+/// row beneath it, so the image and SVG zoom paths frame the viewer
+/// identically.
+Future<void> showZoomableMediaDialog(
+  BuildContext context, {
+  required Widget viewer,
+  Widget? caption,
+}) {
+  return showDialog<void>(
+    context: context,
+    builder: (context) => Dialog(
+      insetPadding: const EdgeInsets.all(SoliplexSpacing.s4),
+      child: ConstrainedBox(
+        constraints: BoxConstraints(
+          maxWidth: 800,
+          maxHeight: MediaQuery.sizeOf(context).height * 0.85,
+        ),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Expanded(child: viewer),
+            if (caption != null) caption,
+          ],
+        ),
+      ),
+    ),
+  );
+}

--- a/test/modules/room/ui/citations_figures_test.dart
+++ b/test/modules/room/ui/citations_figures_test.dart
@@ -5,7 +5,9 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:soliplex_agent/soliplex_agent.dart' hide State;
 
 import 'package:soliplex_frontend/src/modules/room/ui/citations_section.dart';
+import 'package:soliplex_frontend/src/modules/room/ui/pager_dots.dart';
 import 'package:soliplex_frontend/src/shared/failed_image.dart';
+import 'package:soliplex_frontend/src/shared/zoomable_image.dart';
 
 // 1x1 transparent PNG.
 final _png = Uint8List.fromList(const [
@@ -123,6 +125,54 @@ void main() {
 
     expect(find.byType(Dialog), findsOneWidget);
     expect(find.byType(InteractiveViewer), findsOneWidget);
+    // The dialog reuses the shared ZoomableImage viewer.
+    expect(find.byType(ZoomableImage), findsOneWidget);
+  });
+
+  testWidgets('a multi-figure citation opens a pageable browser',
+      (tester) async {
+    await tester.pumpWidget(host(_ref(
+      figures: [
+        Figure(ref: '#/pictures/0', bytes: _png),
+        Figure(ref: '#/pictures/1', bytes: _png),
+      ],
+    )));
+    await tester.tap(find.text('1 source'));
+    await tester.pump();
+    await tester.tap(find.text('doc-1.pdf'));
+    await tester.pump();
+
+    // Two thumbnails; tapping the first opens the browser at that figure.
+    await tester.tap(find.byType(Image).first);
+    await tester.pumpAndSettle();
+
+    expect(find.byType(Dialog), findsOneWidget);
+    expect(find.byType(PageView), findsOneWidget);
+    // More than one figure => page-dots navigation is shown.
+    expect(find.byType(PagerDots), findsOneWidget);
+  });
+
+  testWidgets('tapping a figure opens the browser at that figure',
+      (tester) async {
+    await tester.pumpWidget(host(_ref(
+      figures: [
+        Figure(ref: '#/pictures/0', bytes: _png, caption: 'cap-zero'),
+        Figure(ref: '#/pictures/1', bytes: _png, caption: 'cap-one'),
+      ],
+    )));
+    await tester.tap(find.text('1 source'));
+    await tester.pump();
+    await tester.tap(find.text('doc-1.pdf'));
+    await tester.pump();
+
+    // Tap the second thumbnail: the browser must open on that figure, not the
+    // first — guarding that the tapped index is threaded into initialIndex.
+    await tester.tap(find.byType(Image).at(1));
+    await tester.pumpAndSettle();
+
+    // The footer shows only the current page's caption.
+    expect(find.text('cap-one'), findsOneWidget);
+    expect(find.text('cap-zero'), findsNothing);
   });
 
   testWidgets('a thumbnail whose bytes fail to decode shows a fallback',

--- a/test/modules/room/ui/markdown/code_block_builder_test.dart
+++ b/test/modules/room/ui/markdown/code_block_builder_test.dart
@@ -1,6 +1,8 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_svg/flutter_svg.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:soliplex_frontend/src/modules/room/ui/markdown/flutter_markdown_plus_renderer.dart';
+import 'package:soliplex_frontend/src/modules/room/ui/workdir_preview/svg_preview.dart';
 
 void main() {
   group('CodeBlockBuilder', () {
@@ -100,6 +102,46 @@ void main() {
       // After tap, shows preview toggle (source is now visible)
       expect(find.byTooltip('Show preview'), findsOneWidget);
       expect(find.byTooltip('Show source'), findsNothing);
+    });
+
+    testWidgets('tapping the SVG preview opens a zoomable dialog',
+        (tester) async {
+      const svgCode = '<svg xmlns="http://www.w3.org/2000/svg">'
+          '<circle cx="50" cy="50" r="40"/>'
+          '</svg>';
+
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Scaffold(
+            body: SingleChildScrollView(
+              child: FlutterMarkdownPlusRenderer(
+                data: '```svg\n$svgCode\n```',
+              ),
+            ),
+          ),
+        ),
+      );
+      await tester.pump();
+
+      // The inline preview is not itself the full-size viewer.
+      expect(find.byType(SvgPreview), findsNothing);
+
+      // The preview is laid out at zero size until the SVG rasterizes, so a
+      // hit-test tap misses; invoke the wrapper's onTap directly.
+      final gesture = tester.widget<GestureDetector>(
+        find
+            .ancestor(
+              of: find.byType(SvgPicture),
+              matching: find.byType(GestureDetector),
+            )
+            .first,
+      );
+      gesture.onTap!();
+      await tester.pumpAndSettle();
+
+      // The dialog frames the SVG in the shared zoomable SVG viewer, which owns
+      // its own parse-failure fallback (no zoom/rotate chrome over a failure).
+      expect(find.byType(SvgPreview), findsOneWidget);
     });
   });
 }

--- a/test/modules/room/ui/markdown/flutter_markdown_plus_renderer_test.dart
+++ b/test/modules/room/ui/markdown/flutter_markdown_plus_renderer_test.dart
@@ -7,6 +7,7 @@ import 'package:flutter_test/flutter_test.dart';
 
 import 'package:soliplex_frontend/src/modules/room/ui/markdown/flutter_markdown_plus_renderer.dart';
 import 'package:soliplex_frontend/src/shared/failed_image.dart';
+import 'package:soliplex_frontend/src/shared/zoomable_image.dart';
 
 void main() {
   group('FlutterMarkdownPlusRenderer widget', () {
@@ -134,6 +135,39 @@ void main() {
 
       expect(tester.takeException(), isNull);
       expect(find.byType(FailedImage), findsOneWidget);
+    });
+
+    testWidgets(
+        'a data:image that fails to decode synchronously is left inert (no '
+        'tap-to-zoom wrapper)', (tester) async {
+      // An empty base64 payload is rejected by tryDecodeImageDataUri, so the
+      // inline resolves synchronously to a FailedImage. _MaybeZoomableImage must
+      // leave it inert — otherwise tapping a broken image would open a dialog
+      // around another broken image. This guards the `inline is FailedImage`
+      // branch, distinct from the unsupported-scheme branch. The tap wrapper is
+      // uniquely identified by its click-cursor MouseRegion (markdown's own
+      // selection/scroll gesture detectors use different cursors).
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Scaffold(
+            body: FlutterMarkdownPlusRenderer(
+              data: '![alt](data:image/png;base64,)',
+            ),
+          ),
+        ),
+      );
+      await tester.pump();
+
+      expect(find.byType(FailedImage), findsOneWidget);
+      expect(
+        find.ancestor(
+          of: find.byType(FailedImage),
+          matching: find.byWidgetPredicate(
+            (w) => w is MouseRegion && w.cursor == SystemMouseCursors.click,
+          ),
+        ),
+        findsNothing,
+      );
     });
 
     testWidgets(
@@ -320,6 +354,119 @@ void main() {
 
       expect(tester.takeException(), isNull);
       expect(find.byType(FailedImage), findsOneWidget);
+    });
+
+    // The inline image is laid out at zero size until its bytes decode (which
+    // does not happen under the test scheduler), so hit-test taps miss. We
+    // invoke the wrapper's onTap directly to exercise the tap wiring.
+    VoidCallback imageTapHandler(WidgetTester tester) {
+      final gesture = tester.widget<GestureDetector>(
+        find
+            .ancestor(
+              of: find.byType(Image),
+              matching: find.byType(GestureDetector),
+            )
+            .first,
+      );
+      return gesture.onTap!;
+    }
+
+    testWidgets('tapping a valid image opens a zoomable full-size dialog',
+        (tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: FlutterMarkdownPlusRenderer(
+              data: '![alt](data:image/png;base64,$pngBase64)',
+            ),
+          ),
+        ),
+      );
+      await tester.pump();
+
+      // Inline render is a plain image, not the zoomable viewer.
+      expect(find.byType(ZoomableImage), findsNothing);
+
+      imageTapHandler(tester)();
+      await tester.pumpAndSettle();
+
+      // The dialog frames the image in a ZoomableImage.
+      expect(find.byType(ZoomableImage), findsOneWidget);
+    });
+
+    testWidgets('a provided onImageTap overrides the default zoom dialog',
+        (tester) async {
+      String? tappedSrc;
+      String? tappedAlt;
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: FlutterMarkdownPlusRenderer(
+              data: '![the alt](data:image/png;base64,$pngBase64)',
+              onImageTap: (src, alt) {
+                tappedSrc = src;
+                tappedAlt = alt;
+              },
+            ),
+          ),
+        ),
+      );
+      await tester.pump();
+
+      imageTapHandler(tester)();
+      await tester.pumpAndSettle();
+
+      expect(tappedSrc, startsWith('data:image/png;base64,'));
+      expect(tappedAlt, 'the alt');
+      // Host handled it; no default dialog opened.
+      expect(find.byType(ZoomableImage), findsNothing);
+    });
+
+    testWidgets(
+        'an http image is tap-wired for zoom (routing is not data-only)',
+        (tester) async {
+      // Guards the http branch of _isZoomableImageUri, which is a separate
+      // switch from the provider routing in _buildImage. We assert on the
+      // first frame (before the network attempt resolves) to avoid racing DNS.
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Scaffold(
+            body: FlutterMarkdownPlusRenderer(
+              data: '![alt](https://example.invalid/missing.png)',
+            ),
+          ),
+        ),
+      );
+      await tester.pump();
+      expect(tester.takeException(), isNull);
+
+      // http is a zoomable scheme, so the inline is wrapped for tap-to-zoom;
+      // an inert inline would have no GestureDetector ancestor and the helper
+      // would throw.
+      expect(imageTapHandler(tester), isNotNull);
+    });
+
+    testWidgets('a non-image inline (text data URI) is not tap-to-zoom',
+        (tester) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Scaffold(
+            body: FlutterMarkdownPlusRenderer(
+              data: '![ignored](data:text/plain,Hello%20there)',
+            ),
+          ),
+        ),
+      );
+      await tester.pump();
+
+      expect(find.text('Hello there'), findsOneWidget);
+
+      // Tapping a non-image must not open the zoom dialog.
+      await tester.tap(find.text('Hello there'), warnIfMissed: false);
+      await tester.pumpAndSettle();
+      expect(find.byType(Dialog), findsNothing);
+      expect(find.byType(ZoomableImage), findsNothing);
     });
   });
 }

--- a/test/modules/room/ui/markdown/log_source_test.dart
+++ b/test/modules/room/ui/markdown/log_source_test.dart
@@ -1,0 +1,75 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:soliplex_frontend/src/modules/room/ui/markdown/log_source.dart';
+import 'package:soliplex_logging/soliplex_logging.dart';
+
+void main() {
+  late MemorySink sink;
+  late Logger logger;
+
+  setUp(() {
+    sink = MemorySink();
+    LogManager.instance.addSink(sink);
+    logger = LogManager.instance.getLogger('test.log_source');
+  });
+
+  tearDown(() => LogManager.instance.removeSink(sink));
+
+  group('safeSourceForLog', () {
+    test('redacts a data: URI payload to a length marker', () {
+      final safe = safeSourceForLog('data:image/png;base64,AAAA');
+
+      expect(safe, 'data:image/png;base64,<4 chars redacted>');
+      expect(safe, isNot(contains('AAAA')));
+    });
+
+    test('marks a data: URI with no payload separator', () {
+      expect(safeSourceForLog('data:image/png'), 'data:<no payload separator>');
+    });
+
+    test('truncates a long non-data URI and appends its length', () {
+      final long = 'http://example.com/${'a' * 200}';
+
+      final safe = safeSourceForLog(long);
+
+      expect(safe, startsWith(long.substring(0, 120)));
+      expect(safe, endsWith('…(${long.length} chars)'));
+    });
+  });
+
+  group('logFailedSourceOnce', () {
+    test('logs a source once and drops repeats', () {
+      logFailedSourceOnce(logger, 'boom', 'source-once');
+      logFailedSourceOnce(logger, 'boom again', 'source-once');
+
+      expect(
+        sink.records.where((r) => r.message.startsWith('boom')),
+        hasLength(1),
+      );
+    });
+
+    test('logs distinct sources separately', () {
+      logFailedSourceOnce(logger, 'first', 'source-distinct-a');
+      logFailedSourceOnce(logger, 'second', 'source-distinct-b');
+
+      expect(sink.records.where((r) => r.message == 'first'), hasLength(1));
+      expect(sink.records.where((r) => r.message == 'second'), hasLength(1));
+    });
+
+    test(
+        'two data: URIs sharing a header and payload length but differing bytes '
+        'each log', () {
+      // Same mime header and identical base64 length; only the payload bytes
+      // differ. Deduping on the redacted form (which replaces the payload with
+      // just its length) would collapse these two distinct failures into one.
+      logFailedSourceOnce(
+          logger, 'decode failed', 'data:image/png;base64,AAAA');
+      logFailedSourceOnce(
+          logger, 'decode failed', 'data:image/png;base64,BBBB');
+
+      expect(
+        sink.records.where((r) => r.message == 'decode failed'),
+        hasLength(2),
+      );
+    });
+  });
+}

--- a/test/modules/room/ui/paged_zoomable_images_test.dart
+++ b/test/modules/room/ui/paged_zoomable_images_test.dart
@@ -1,0 +1,153 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:soliplex_frontend/src/modules/room/ui/paged_zoomable_images.dart';
+import 'package:soliplex_frontend/src/modules/room/ui/pager_dots.dart';
+
+Widget _host(Widget child) => MaterialApp(
+      home: Scaffold(
+        body: Center(child: SizedBox(width: 400, height: 400, child: child)),
+      ),
+    );
+
+void main() {
+  testWidgets('persists per-page rotation across paging', (tester) async {
+    await tester.pumpWidget(_host(
+      PagedZoomableImages(
+        itemCount: 3,
+        pageBuilder: (context, index, rotation) => Center(
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              Text('page$index rot${rotation.quarterTurns}'),
+              TextButton(
+                  onPressed: rotation.onRotate, child: Text('rot$index')),
+            ],
+          ),
+        ),
+      ),
+    ));
+    await tester.pumpAndSettle();
+
+    // Rotate page 0 twice.
+    expect(find.text('page0 rot0'), findsOneWidget);
+    await tester.tap(find.text('rot0'));
+    await tester.pump();
+    await tester.tap(find.text('rot0'));
+    await tester.pump();
+    expect(find.text('page0 rot2'), findsOneWidget);
+
+    // Swipe to page 1 — its rotation is independent.
+    await tester.drag(find.byType(PageView), const Offset(-500, 0));
+    await tester.pumpAndSettle();
+    expect(find.text('page1 rot0'), findsOneWidget);
+
+    // Swipe back to page 0 — its rotation persisted.
+    await tester.drag(find.byType(PageView), const Offset(500, 0));
+    await tester.pumpAndSettle();
+    expect(find.text('page0 rot2'), findsOneWidget);
+  });
+
+  testWidgets('hides page dots and chevrons for a single item', (tester) async {
+    await tester.pumpWidget(_host(
+      PagedZoomableImages(
+        itemCount: 1,
+        pageBuilder: (context, index, _) => Center(child: Text('page$index')),
+      ),
+    ));
+    await tester.pumpAndSettle();
+
+    expect(find.text('page0'), findsOneWidget);
+    expect(find.byType(PagerDots), findsNothing);
+    expect(find.byIcon(Icons.chevron_left), findsNothing);
+    expect(find.byIcon(Icons.chevron_right), findsNothing);
+  });
+
+  testWidgets('opens at the given initialIndex', (tester) async {
+    await tester.pumpWidget(_host(
+      PagedZoomableImages(
+        itemCount: 3,
+        initialIndex: 1,
+        pageBuilder: (context, index, _) => Center(child: Text('page$index')),
+      ),
+    ));
+    await tester.pumpAndSettle();
+
+    expect(find.text('page1'), findsOneWidget);
+  });
+
+  testWidgets('footer follows the current page', (tester) async {
+    await tester.pumpWidget(_host(
+      PagedZoomableImages(
+        itemCount: 3,
+        // Arrow-key paging needs focus, which a dialog host grants via autofocus.
+        autofocus: true,
+        pageBuilder: (context, index, _) => Center(child: Text('page$index')),
+        footerBuilder: (context, index) => Text('footer$index'),
+      ),
+    ));
+    await tester.pumpAndSettle();
+
+    expect(find.text('footer0'), findsOneWidget);
+
+    await tester.sendKeyEvent(LogicalKeyboardKey.arrowRight);
+    await tester.pumpAndSettle();
+    expect(find.text('footer1'), findsOneWidget);
+  });
+
+  testWidgets('left/right arrow keys page between items, clamped at the ends',
+      (tester) async {
+    await tester.pumpWidget(_host(
+      PagedZoomableImages(
+        itemCount: 3,
+        autofocus: true,
+        pageBuilder: (context, index, _) => Center(child: Text('page$index')),
+      ),
+    ));
+    await tester.pumpAndSettle();
+
+    expect(find.text('page0'), findsOneWidget);
+
+    await tester.sendKeyEvent(LogicalKeyboardKey.arrowRight);
+    await tester.pumpAndSettle();
+    expect(find.text('page1'), findsOneWidget);
+
+    await tester.sendKeyEvent(LogicalKeyboardKey.arrowLeft);
+    await tester.pumpAndSettle();
+    expect(find.text('page0'), findsOneWidget);
+
+    // Arrow-left at the first page is clamped — stays on page 0.
+    await tester.sendKeyEvent(LogicalKeyboardKey.arrowLeft);
+    await tester.pumpAndSettle();
+    expect(find.text('page0'), findsOneWidget);
+  });
+
+  testWidgets('prev/next chevrons page and disable at the ends',
+      (tester) async {
+    await tester.pumpWidget(_host(
+      PagedZoomableImages(
+        itemCount: 3,
+        pageBuilder: (context, index, _) => Center(child: Text('page$index')),
+      ),
+    ));
+    await tester.pumpAndSettle();
+
+    IconButton chevron(IconData icon) =>
+        tester.widget<IconButton>(find.widgetWithIcon(IconButton, icon));
+
+    // First page: Previous disabled, Next enabled.
+    expect(chevron(Icons.chevron_left).onPressed, isNull);
+    expect(chevron(Icons.chevron_right).onPressed, isNotNull);
+
+    await tester.tap(find.byIcon(Icons.chevron_right));
+    await tester.pumpAndSettle();
+    await tester.tap(find.byIcon(Icons.chevron_right));
+    await tester.pumpAndSettle();
+
+    // Last page: Next disabled, Previous enabled.
+    expect(find.text('page2'), findsOneWidget);
+    expect(chevron(Icons.chevron_right).onPressed, isNull);
+    expect(chevron(Icons.chevron_left).onPressed, isNotNull);
+  });
+}

--- a/test/shared/zoomable_image_test.dart
+++ b/test/shared/zoomable_image_test.dart
@@ -1,21 +1,15 @@
-import 'dart:convert';
 import 'dart:typed_data';
 
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 import 'package:soliplex_frontend/src/shared/zoomable_image.dart';
-
-// 1x1 red PNG pixel (minimal valid PNG).
-final _pngBytes = base64Decode(
-  'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR4'
-  '2mP8/58BAwAI/AL+hc2rNAAAAABJRU5ErkJggg==',
-);
+import 'package:soliplex_frontend/src/shared/zoomable_view.dart';
 
 Widget _wrap(Widget child) => MaterialApp(
       home: Scaffold(
-        // A bounded box mirroring the dialog/preview host so InteractiveViewer
-        // has finite constraints and the image fills the viewport.
+        // A bounded box mirroring the dialog/preview host so the viewer has
+        // finite constraints and the image fills the viewport.
         body: Center(child: SizedBox(width: 400, height: 300, child: child)),
       ),
     );
@@ -29,104 +23,39 @@ void main() {
       ..clearLiveImages();
   });
 
-  testWidgets('enables trackpad-scroll zoom within scale bounds',
-      (tester) async {
-    await tester.pumpWidget(_wrap(
-      ZoomableImage(
-        bytes: _pngBytes,
-        rotationQuarterTurns: 0,
-        onRotate: () {},
-        decodeFailureChild: const Text('failed'),
-      ),
-    ));
-    await tester.pump();
-
-    // On the web, Flutter routes Mac trackpad two-finger scroll to a pan; with
-    // the image filling the viewport that pan is clamped and nothing happens.
-    // trackpadScrollCausesScale makes the gesture zoom instead.
-    final viewer = tester.widget<InteractiveViewer>(
-      find.byType(InteractiveViewer),
-    );
-    expect(viewer.trackpadScrollCausesScale, isTrue);
-    expect(viewer.minScale, 1.0);
-    expect(viewer.maxScale, 4.0);
-  });
-
-  testWidgets('reset control appears only while zoomed and restores fit',
-      (tester) async {
-    await tester.pumpWidget(_wrap(
-      ZoomableImage(
-        bytes: _pngBytes,
-        rotationQuarterTurns: 0,
-        onRotate: () {},
-        decodeFailureChild: const Text('failed'),
-      ),
-    ));
-    await tester.pump();
-
-    // Not zoomed: no reset control.
-    expect(find.byTooltip('Reset zoom'), findsNothing);
-
-    final controller = tester
-        .widget<InteractiveViewer>(find.byType(InteractiveViewer))
-        .transformationController!;
-    controller.value = Matrix4.diagonal3Values(2.5, 2.5, 1.0);
-    await tester.pump();
-
-    // Zoomed: reset control shows; tapping it returns to the original fit.
-    expect(find.byTooltip('Reset zoom'), findsOneWidget);
-    await tester.tap(find.byTooltip('Reset zoom'));
-    await tester.pump();
-
-    expect(controller.value, Matrix4.identity());
-    expect(find.byTooltip('Reset zoom'), findsNothing);
-  });
-
-  testWidgets('rotate button invokes onRotate', (tester) async {
-    var rotations = 0;
-    await tester.pumpWidget(_wrap(
-      ZoomableImage(
-        bytes: _pngBytes,
-        rotationQuarterTurns: 0,
-        onRotate: () => rotations++,
-        decodeFailureChild: const Text('failed'),
-      ),
-    ));
-    await tester.pump();
-
-    await tester.tap(find.byTooltip('Rotate'));
-    expect(rotations, 1);
-  });
-
-  testWidgets('applies the given quarter-turn rotation', (tester) async {
-    await tester.pumpWidget(_wrap(
-      ZoomableImage(
-        bytes: _pngBytes,
-        rotationQuarterTurns: 3,
-        onRotate: () {},
-        decodeFailureChild: const Text('failed'),
-      ),
-    ));
-    await tester.pump();
-
-    final rotated = tester.widget<RotatedBox>(find.byType(RotatedBox));
-    expect(rotated.quarterTurns, 3);
-  });
-
-  testWidgets('shows fallback and hides rotate button on decode failure',
+  testWidgets('shows fallback and hides the viewer on decode failure',
       (tester) async {
     await tester.pumpWidget(_wrap(
       ZoomableImage(
         bytes: Uint8List.fromList(const [1, 2, 3, 4, 5]),
-        rotationQuarterTurns: 0,
-        onRotate: () {},
         decodeFailureChild: const Text('failed'),
       ),
     ));
     await tester.pumpAndSettle();
 
     expect(find.text('failed'), findsOneWidget);
+    expect(find.byType(ZoomableView), findsNothing);
     expect(find.byTooltip('Rotate'), findsNothing);
-    expect(find.byType(InteractiveViewer), findsNothing);
+  });
+
+  testWidgets(
+      'a provider that fails to load shows the fallback without zoom/rotate '
+      'chrome', (tester) async {
+    // A provider-backed image (network/asset/file in the zoom dialog) whose
+    // load fails must own the failure the same way the bytes path does: the
+    // fallback replaces the viewer, so there is no rotate button hovering over
+    // a broken image. Undecodable bytes via MemoryImage stand in for a failing
+    // provider without needing the network.
+    await tester.pumpWidget(_wrap(
+      ZoomableImage.provider(
+        MemoryImage(Uint8List.fromList(const [1, 2, 3, 4, 5])),
+        decodeFailureChild: const Text('failed'),
+      ),
+    ));
+    await tester.pumpAndSettle();
+
+    expect(find.text('failed'), findsOneWidget);
+    expect(find.byType(ZoomableView), findsNothing);
+    expect(find.byTooltip('Rotate'), findsNothing);
   });
 }

--- a/test/shared/zoomable_view_test.dart
+++ b/test/shared/zoomable_view_test.dart
@@ -1,0 +1,96 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:soliplex_frontend/src/shared/zoomable_view.dart';
+
+Widget _wrap(Widget child) => MaterialApp(
+      home: Scaffold(
+        // A bounded box mirroring the dialog/preview host so the viewer has
+        // finite constraints.
+        body: Center(child: SizedBox(width: 400, height: 300, child: child)),
+      ),
+    );
+
+InteractiveViewer _viewer(WidgetTester tester) =>
+    tester.widget<InteractiveViewer>(find.byType(InteractiveViewer));
+
+void main() {
+  testWidgets('enables trackpad-scroll zoom (Mac web support)', (tester) async {
+    // On Mac web, Flutter routes trackpad two-finger scroll to a pan; with the
+    // content filling the viewport that pan is clamped and nothing happens.
+    // This flag makes the gesture zoom instead. The gesture can't be simulated
+    // in a widget test, so this assertion is the only guard against a silent
+    // revert to the default (false).
+    await tester.pumpWidget(_wrap(const ZoomableView(child: SizedBox())));
+
+    expect(_viewer(tester).trackpadScrollCausesScale, isTrue);
+  });
+
+  testWidgets('panning is disabled at fit and enabled once zoomed',
+      (tester) async {
+    await tester.pumpWidget(_wrap(const ZoomableView(child: SizedBox())));
+
+    // At fit the whole content is visible, so dragging it is meaningless.
+    expect(_viewer(tester).panEnabled, isFalse);
+
+    _viewer(tester).transformationController!.value =
+        Matrix4.diagonal3Values(2.5, 2.5, 1.0);
+    await tester.pump();
+
+    expect(_viewer(tester).panEnabled, isTrue);
+  });
+
+  testWidgets('reset control appears only while zoomed and restores fit',
+      (tester) async {
+    await tester.pumpWidget(_wrap(const ZoomableView(child: SizedBox())));
+
+    expect(find.byTooltip('Reset zoom'), findsNothing);
+
+    final controller = _viewer(tester).transformationController!;
+    controller.value = Matrix4.diagonal3Values(2.5, 2.5, 1.0);
+    await tester.pump();
+
+    expect(find.byTooltip('Reset zoom'), findsOneWidget);
+    await tester.tap(find.byTooltip('Reset zoom'));
+    await tester.pump();
+
+    expect(controller.value, Matrix4.identity());
+    expect(find.byTooltip('Reset zoom'), findsNothing);
+  });
+
+  testWidgets('rotate control is always shown and self-manages rotation',
+      (tester) async {
+    await tester.pumpWidget(_wrap(const ZoomableView(child: SizedBox())));
+
+    expect(find.byTooltip('Rotate'), findsOneWidget);
+    expect(tester.widget<RotatedBox>(find.byType(RotatedBox)).quarterTurns, 0);
+
+    await tester.tap(find.byTooltip('Rotate'));
+    await tester.pump();
+
+    expect(tester.widget<RotatedBox>(find.byType(RotatedBox)).quarterTurns, 1);
+  });
+
+  testWidgets('rotate delegates to onRotate when provided (no self-rotation)',
+      (tester) async {
+    var rotations = 0;
+    await tester.pumpWidget(_wrap(
+      ZoomableView.controlledRotation(
+        rotationQuarterTurns: 3,
+        onRotate: () => rotations++,
+        child: const SizedBox(),
+      ),
+    ));
+
+    // The caller-supplied rotation is applied to the content.
+    expect(tester.widget<RotatedBox>(find.byType(RotatedBox)).quarterTurns, 3);
+
+    await tester.tap(find.byTooltip('Rotate'));
+    await tester.pump();
+
+    expect(rotations, 1);
+    // Caller owns rotation; the view does not rotate itself — it stays at the
+    // caller's value until the caller updates it.
+    expect(tester.widget<RotatedBox>(find.byType(RotatedBox)).quarterTurns, 3);
+  });
+}


### PR DESCRIPTION
## Summary

Consolidates the app's image and SVG zoom surfaces onto two shared widgets and
extends tap-to-zoom to inline markdown images.

- **`ZoomableView`** (new, `lib/src/shared/`) — the pan/zoom/rotate/reset
  viewport for any single piece of visual content (raster or vector). Uses
  `constrained: true` + `BoxFit.contain`, so fit is exactly `scale == 1.0`
  centered and zooming out always returns to a centered fit with no drift.
  Rotation is self-managed by default, or caller-owned so it survives paging.
- **`ZoomableImage`** (rewritten) — now delegates interaction to `ZoomableView`
  and owns the load/decode failure so the fallback shows *in place of* the
  viewer (no rotate/zoom chrome over a broken image). Adds a `.provider`
  constructor for network/asset/file images.
- **`PagedZoomableImages`** (new) — a pageable set of zoomable images sharing
  one page indicator and per-page rotation, with prev/next chevrons, page dots,
  and left/right arrow-key navigation. Backs both the chunk-visualization page
  browser and the citation-figure browser.

## User-facing changes

- Inline images in chat and other markdown are now tap-to-zoom; SVG code blocks
  open the same full-size viewer.
- Citation figures open in a pageable browser over all of a citation's figures
  (chevrons, dots, arrow keys) rather than one figure at a time.
- Image and SVG previews (chunk visualization, workdir file preview, citation
  figures, SVG previews) behave consistently for zoom, rotate, and reset.

## Review

Reviewed with emphasis on failure points and regressions (code-reviewer +
silent-failure-hunter). No regressions or silent failures found; analyzer clean.
One known MEDIUM log-noise item (zoom-dialog viewers log a broken source through
a separate path from the inline widget, so it can log twice / re-log on reopen)
was assessed and deliberately left as-is — it is partly pre-existing and never
swallows an error or affects the user-visible fallback.

## Test plan

- `flutter analyze` — clean.
- `flutter test` — existing + new widget tests for the shared viewers, the
  paged browser, and the markdown image paths.
- Manual: pinch-zoom + rotate on a landscape image in the dialog; page through a
  multi-figure citation with chevrons and arrow keys.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
