### PR TITLE
feat: look up a chunk by id from Room Info

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,11 @@ Versions follow the `version+build` scheme from `pubspec.yaml`, bumped via
   shows alongside the room name in the room view header, and as a title band at
   the top of the lobby's room pane, so a user connected to several servers can
   tell which one they are viewing.
+- Room info: a "View chunk" card lets you enter a chunk id and open its
+  rendered page images, so a chunk can be viewed directly from an id (e.g. one
+  taken from logs) rather than only by tapping a PDF citation. Expanded
+  citations and the chunk viewer now also surface the chunk id and document
+  provenance, each copyable.
 - Tapping an inline image in chat or other markdown now opens a full-size
   pan/zoom/rotate view; SVG code blocks open the same view on tap.
 - A citation's figures open in a pageable browser over all of that citation's

--- a/lib/src/modules/room/ui/chunk_visualization_page.dart
+++ b/lib/src/modules/room/ui/chunk_visualization_page.dart
@@ -383,7 +383,7 @@ class _ChunkVisualizationPageState extends State<ChunkVisualizationPage> {
         mainAxisSize: MainAxisSize.min,
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
-          const Divider(),
+          Divider(color: Theme.of(context).colorScheme.outline),
           _detailField(context, 'chunk id', widget.chunkId),
           if (document != null && document.isNotEmpty) ...[
             const SizedBox(height: SoliplexSpacing.s2),

--- a/lib/src/modules/room/ui/chunk_visualization_page.dart
+++ b/lib/src/modules/room/ui/chunk_visualization_page.dart
@@ -6,6 +6,7 @@ import 'package:soliplex_client/soliplex_client.dart' show SoliplexApi;
 import 'package:soliplex_logging/soliplex_logging.dart';
 
 import 'package:soliplex_design/soliplex_design.dart';
+import '../../../shared/copy_button.dart';
 import '../../../shared/failed_image.dart';
 import '../../../shared/zoomable_image.dart';
 import 'paged_zoomable_images.dart';
@@ -45,16 +46,26 @@ class ChunkVisualizationPage extends StatefulWidget {
     required this.api,
     required this.roomId,
     required this.chunkId,
-    required this.documentTitle,
     required this.pageNumbers,
     required this.useDialogLayout,
+    this.documentTitle,
+    this.documentUri,
     this.docItemRefs = const [],
   });
 
   final SoliplexApi api;
   final String roomId;
   final String chunkId;
-  final String documentTitle;
+
+  /// The document's display name for the title bar, when the caller knows it
+  /// (citations). Null for a bare chunk-id lookup, where the title falls back
+  /// to a neutral label.
+  final String? documentTitle;
+
+  /// The document uri shown in the detail block, when the caller knows it
+  /// (citations). Null for a bare chunk-id lookup, where the detail block
+  /// falls back to the uri returned by the fetch (which may itself be absent).
+  final String? documentUri;
   final List<int> pageNumbers;
   final bool useDialogLayout;
 
@@ -67,8 +78,9 @@ class ChunkVisualizationPage extends StatefulWidget {
     required SoliplexApi api,
     required String roomId,
     required String chunkId,
-    required String documentTitle,
     required List<int> pageNumbers,
+    String? documentTitle,
+    String? documentUri,
     List<String> docItemRefs = const [],
   }) {
     final useDialog =
@@ -78,6 +90,7 @@ class ChunkVisualizationPage extends StatefulWidget {
       roomId: roomId,
       chunkId: chunkId,
       documentTitle: documentTitle,
+      documentUri: documentUri,
       pageNumbers: pageNumbers,
       useDialogLayout: useDialog,
       docItemRefs: docItemRefs,
@@ -110,8 +123,15 @@ class ChunkVisualizationPage extends StatefulWidget {
   State<ChunkVisualizationPage> createState() => _ChunkVisualizationPageState();
 }
 
+/// The decoded pages plus the document uri the backend reported for the
+/// chunk, surfaced together so the detail block can show provenance.
+typedef _VizResult = ({List<PageImage> pages, String? documentUri});
+
 class _ChunkVisualizationPageState extends State<ChunkVisualizationPage> {
-  late Future<List<PageImage>> _future;
+  /// Title shown when the caller has no document name (bare chunk-id lookup).
+  static const _fallbackTitle = 'Chunk preview';
+
+  late Future<_VizResult> _future;
   // Bumped on retry so the pager remounts with fresh rotation/page state.
   int _reloadNonce = 0;
 
@@ -125,7 +145,7 @@ class _ChunkVisualizationPageState extends State<ChunkVisualizationPage> {
     _future = _fetchAndDecode();
   }
 
-  Future<List<PageImage>> _fetchAndDecode() async {
+  Future<_VizResult> _fetchAndDecode() async {
     final refCount = widget.docItemRefs.length;
     final grounded = refCount > 0;
     _logger.debug(
@@ -152,7 +172,10 @@ class _ChunkVisualizationPageState extends State<ChunkVisualizationPage> {
           'pageCount': viz.imagesBase64.length,
         },
       );
-      return viz.imagesBase64.map(_decodePageImage).toList();
+      return (
+        pages: viz.imagesBase64.map(_decodePageImage).toList(),
+        documentUri: viz.documentUri,
+      );
     } catch (error, stack) {
       _logger.error(
         'chunk visualization fetch failed',
@@ -204,7 +227,7 @@ class _ChunkVisualizationPageState extends State<ChunkVisualizationPage> {
   }
 
   Widget _buildContent(BuildContext context) {
-    return FutureBuilder<List<PageImage>>(
+    return FutureBuilder<_VizResult>(
       future: _future,
       builder: (context, snapshot) {
         if (snapshot.connectionState != ConnectionState.done) {
@@ -213,7 +236,8 @@ class _ChunkVisualizationPageState extends State<ChunkVisualizationPage> {
         if (snapshot.hasError) {
           return _buildError(context, snapshot.error!);
         }
-        return _buildImages(context, snapshot.data ?? const []);
+        final result = snapshot.data!;
+        return _buildLoaded(context, result.pages, result.documentUri);
       },
     );
   }
@@ -241,7 +265,7 @@ class _ChunkVisualizationPageState extends State<ChunkVisualizationPage> {
 
     return Scaffold(
       appBar: AppBar(
-        title: Text(widget.documentTitle),
+        title: Text(widget.documentTitle ?? _fallbackTitle),
         titleTextStyle: Theme.of(context).textTheme.titleMedium,
       ),
       // Without SafeArea, the system gesture inset (iOS home indicator,
@@ -264,7 +288,7 @@ class _ChunkVisualizationPageState extends State<ChunkVisualizationPage> {
         children: [
           Expanded(
             child: Text(
-              widget.documentTitle,
+              widget.documentTitle ?? _fallbackTitle,
               style: theme.textTheme.titleMedium,
               maxLines: 1,
               overflow: TextOverflow.ellipsis,
@@ -291,12 +315,80 @@ class _ChunkVisualizationPageState extends State<ChunkVisualizationPage> {
             'Failed to load visualization',
             style: theme.textTheme.bodyMedium,
           ),
+          const SizedBox(height: SoliplexSpacing.s3),
+          _detailField(context, 'chunk id', widget.chunkId),
           const SizedBox(height: SoliplexSpacing.s4),
           SoliplexButton.filled(
             onPressed: _retry,
             icon: const Icon(Icons.refresh),
             child: const Text('Retry'),
           ),
+        ],
+      ),
+    );
+  }
+
+  /// A labelled metadata field with a copy button and a selectable monospace
+  /// value, copyable in one tap or selectable directly. Used for the chunk id
+  /// (detail block and error state) and the document uri (detail block only).
+  Widget _detailField(BuildContext context, String label, String value) {
+    final theme = Theme.of(context);
+    final labelStyle = theme.textTheme.labelSmall?.copyWith(
+      fontWeight: FontWeight.w600,
+      color: theme.colorScheme.onSurfaceVariant,
+    );
+    return Column(
+      mainAxisSize: MainAxisSize.min,
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Row(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Text(label, style: labelStyle),
+            const SizedBox(width: SoliplexSpacing.s1),
+            // Match the copy icon to the label's type-scale size so the two
+            // read as one line rather than the icon overpowering the label.
+            CopyButton(
+              text: value,
+              tooltip: 'Copy $label',
+              iconSize: labelStyle?.fontSize ?? 12,
+            ),
+          ],
+        ),
+        SelectableText(
+          value,
+          style: context.monospaceOn(theme.textTheme.bodySmall),
+        ),
+      ],
+    );
+  }
+
+  Widget _buildDetails(BuildContext context, String? fetchedDocumentUri) {
+    // Prefer the caller's uri (citations), treating empty as absent so a blank
+    // citation uri doesn't shadow a real fetched one; fall back to the fetched
+    // uri for a bare chunk-id lookup. Absent in both (null/empty) → the row is
+    // hidden and only the chunk id shows.
+    final callerUri = widget.documentUri;
+    final document = (callerUri != null && callerUri.isNotEmpty)
+        ? callerUri
+        : fetchedDocumentUri;
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(
+        SoliplexSpacing.s4,
+        0,
+        SoliplexSpacing.s4,
+        SoliplexSpacing.s2,
+      ),
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          const Divider(),
+          _detailField(context, 'chunk id', widget.chunkId),
+          if (document != null && document.isNotEmpty) ...[
+            const SizedBox(height: SoliplexSpacing.s2),
+            _detailField(context, 'document', document),
+          ],
         ],
       ),
     );
@@ -327,21 +419,34 @@ class _ChunkVisualizationPageState extends State<ChunkVisualizationPage> {
     };
   }
 
-  Widget _buildImages(BuildContext context, List<PageImage> pages) {
-    if (pages.isEmpty) {
-      return const Center(child: Text('No page images available'));
-    }
-
-    return PagedZoomableImages(
-      key: ValueKey(_reloadNonce),
-      itemCount: pages.length,
-      pageBuilder: (context, index, rotation) => _buildPageImage(
-          pages[index], rotation.quarterTurns, rotation.onRotate),
-      footerBuilder: (context, index) => Text(
-        _pageLabel(index, pages.length),
-        style: Theme.of(context).textTheme.bodySmall,
-      ),
-      dotLabelForIndex: (i) => 'Page ${i + 1}',
+  Widget _buildLoaded(
+    BuildContext context,
+    List<PageImage> pages,
+    String? documentUri,
+  ) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        Expanded(
+          child: pages.isEmpty
+              ? const Center(child: Text('No page images available'))
+              : PagedZoomableImages(
+                  key: ValueKey(_reloadNonce),
+                  itemCount: pages.length,
+                  pageBuilder: (context, index, rotation) => _buildPageImage(
+                    pages[index],
+                    rotation.quarterTurns,
+                    rotation.onRotate,
+                  ),
+                  footerBuilder: (context, index) => Text(
+                    _pageLabel(index, pages.length),
+                    style: Theme.of(context).textTheme.bodySmall,
+                  ),
+                  dotLabelForIndex: (i) => 'Page ${i + 1}',
+                ),
+        ),
+        _buildDetails(context, documentUri),
+      ],
     );
   }
 }

--- a/lib/src/modules/room/ui/citations_section.dart
+++ b/lib/src/modules/room/ui/citations_section.dart
@@ -256,18 +256,10 @@ class _SourceReferenceRow extends StatelessWidget {
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
           if (sourceReference.documentUri.isNotEmpty)
-            Padding(
-              padding: const EdgeInsets.only(bottom: SoliplexSpacing.s1),
-              child: Text(
-                sourceReference.documentUri,
-                style: theme.textTheme.labelSmall?.copyWith(
-                  color: theme.colorScheme.onSurfaceVariant,
-                ),
-                maxLines: 1,
-                overflow: TextOverflow.ellipsis,
-              ),
-            ),
-          if (sourceReference.headings.isNotEmpty)
+            _metaLine(context, theme, 'document', sourceReference.documentUri),
+          _metaLine(context, theme, 'chunk id', sourceReference.chunkId),
+          if (sourceReference.headings.isNotEmpty) ...[
+            const SizedBox(height: SoliplexSpacing.s2),
             Padding(
               padding: const EdgeInsets.only(bottom: SoliplexSpacing.s1),
               child: Text(
@@ -279,6 +271,7 @@ class _SourceReferenceRow extends StatelessWidget {
                 overflow: TextOverflow.ellipsis,
               ),
             ),
+          ],
           if (sourceReference.content.isNotEmpty)
             Container(
               constraints: const BoxConstraints(maxHeight: 250),
@@ -297,6 +290,39 @@ class _SourceReferenceRow extends StatelessWidget {
           if (sourceReference.figures.isNotEmpty)
             _CitationFigures(sourceReference: sourceReference),
         ],
+      ),
+    );
+  }
+
+  /// A single provenance line: a muted-bold [label] lead-in followed by a
+  /// monospace [value] that wraps to the margin, so the full uri / chunk id
+  /// stays visible without a hanging indent.
+  Widget _metaLine(
+    BuildContext context,
+    ThemeData theme,
+    String label,
+    String value,
+  ) {
+    return Padding(
+      padding: const EdgeInsets.only(bottom: SoliplexSpacing.s1),
+      child: Text.rich(
+        TextSpan(
+          style: theme.textTheme.labelSmall?.copyWith(
+            fontWeight: FontWeight.w700,
+            color: theme.colorScheme.onSurfaceVariant,
+          ),
+          children: [
+            TextSpan(text: '$label  '),
+            TextSpan(
+              text: value,
+              style: context.monospaceOn(
+                theme.textTheme.labelSmall?.copyWith(
+                  color: theme.colorScheme.onSurfaceVariant,
+                ),
+              ),
+            ),
+          ],
+        ),
       ),
     );
   }
@@ -505,6 +531,7 @@ String formatCitationForClipboard(SourceReference ref) {
   if (ref.documentUri.isNotEmpty) {
     lines.add(ref.documentUri);
   }
+  lines.add('chunk id: ${ref.chunkId}');
   if (ref.content.isNotEmpty) {
     lines
       ..add('')

--- a/lib/src/modules/room/ui/room_info/chunk_lookup_card.dart
+++ b/lib/src/modules/room/ui/room_info/chunk_lookup_card.dart
@@ -1,0 +1,85 @@
+import 'package:flutter/material.dart';
+import 'package:soliplex_client/soliplex_client.dart' show SoliplexApi;
+import 'package:soliplex_design/soliplex_design.dart';
+
+import '../chunk_visualization_page.dart';
+import 'room_info_widgets.dart';
+
+/// A free-form chunk-id lookup: enter a chunk id and open its
+/// [ChunkVisualizationPage]. Complements the citation-tap entry point for
+/// cases where the id is known up front (logs, support triage).
+class ChunkLookupCard extends StatefulWidget {
+  const ChunkLookupCard({
+    super.key,
+    required this.api,
+    required this.roomId,
+  });
+
+  final SoliplexApi api;
+  final String roomId;
+
+  @override
+  State<ChunkLookupCard> createState() => _ChunkLookupCardState();
+}
+
+class _ChunkLookupCardState extends State<ChunkLookupCard> {
+  final _controller = TextEditingController();
+  String _chunkId = '';
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  void _view() {
+    final id = _chunkId.trim();
+    if (id.isEmpty) return;
+    ChunkVisualizationPage.show(
+      context: context,
+      api: widget.api,
+      roomId: widget.roomId,
+      chunkId: id,
+      // No document title or page numbers are known for a bare id lookup; the
+      // title bar falls back to a neutral label and the detail block shows the
+      // id and (once fetched) the document uri.
+      pageNumbers: const [],
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final hasText = _chunkId.trim().isNotEmpty;
+    return SectionCard(
+      title: 'VIEW CHUNK',
+      children: [
+        SoliplexInput(
+          controller: _controller,
+          hintText: 'Enter chunk ID',
+          leadingIcon: const Icon(Icons.search),
+          textInputAction: TextInputAction.go,
+          trailingIcon: hasText
+              ? IconButton(
+                  icon: const Icon(Icons.clear),
+                  tooltip: 'Clear',
+                  onPressed: () => setState(() {
+                    _controller.clear();
+                    _chunkId = '';
+                  }),
+                )
+              : null,
+          onChanged: (value) => setState(() => _chunkId = value),
+          onSubmitted: (_) => _view(),
+        ),
+        const SizedBox(height: SoliplexSpacing.s2),
+        Align(
+          alignment: Alignment.centerRight,
+          child: SoliplexButton.filled(
+            onPressed: hasText ? _view : null,
+            child: const Text('View chunk'),
+          ),
+        ),
+      ],
+    );
+  }
+}

--- a/lib/src/modules/room/ui/room_info_screen.dart
+++ b/lib/src/modules/room/ui/room_info_screen.dart
@@ -14,6 +14,7 @@ import '../../auth/server_entry.dart';
 import '../../auth/ui/home_shell.dart';
 import '../upload_tracker.dart';
 import '../upload_tracker_registry.dart';
+import 'room_info/chunk_lookup_card.dart';
 import 'room_info/client_tools_card.dart';
 import 'room_info/documents_card.dart';
 import 'room_info/expandable_list_card.dart';
@@ -248,6 +249,7 @@ class _RoomInfoBody extends StatelessWidget {
             documentsFuture: documentsFuture,
             onRetry: onRetryDocuments,
           ),
+          ChunkLookupCard(api: api, roomId: roomId),
         ],
       ),
     );

--- a/lib/src/modules/room/ui/room_screen.dart
+++ b/lib/src/modules/room/ui/room_screen.dart
@@ -2046,6 +2046,7 @@ class _RoomScreenState extends State<RoomScreen> {
                             roomId: widget.roomId,
                             chunkId: ref.chunkId,
                             documentTitle: ref.displayTitle,
+                            documentUri: ref.documentUri,
                             pageNumbers: ref.pageNumbers,
                             docItemRefs: ref.docItemRefs,
                           ),

--- a/test/modules/room/ui/chunk_visualization_page_test.dart
+++ b/test/modules/room/ui/chunk_visualization_page_test.dart
@@ -303,4 +303,158 @@ void main() {
     final rotated = tester.widget<RotatedBox>(find.byType(RotatedBox));
     expect(rotated.quarterTurns, 1);
   });
+
+  testWidgets('detail block prefers the callers uri over the fetched one',
+      (tester) async {
+    final api = _ChunkVizApi()
+      ..nextVisualization = ChunkVisualization(
+        chunkId: 'c1',
+        documentUri: 'file://fetched.pdf',
+        imagesBase64: [_pngBase64],
+      );
+
+    await tester.pumpWidget(_wrap(
+      ChunkVisualizationPage(
+        api: api,
+        roomId: 'room-1',
+        chunkId: 'c1',
+        useDialogLayout: false,
+        documentTitle: 'My Doc',
+        documentUri: 'file://caller.pdf',
+        pageNumbers: const [1],
+      ),
+    ));
+    await tester.pumpAndSettle();
+
+    expect(find.text('c1'), findsOneWidget);
+    // Name is the title (once); the detail block shows the caller's uri, not
+    // the fetched one.
+    expect(find.text('My Doc'), findsOneWidget);
+    expect(find.text('file://caller.pdf'), findsOneWidget);
+    expect(find.text('file://fetched.pdf'), findsNothing);
+  });
+
+  testWidgets('detail block treats an empty caller uri as absent',
+      (tester) async {
+    // A citation whose documentUri is '' must not shadow a real fetched uri.
+    final api = _ChunkVizApi()
+      ..nextVisualization = ChunkVisualization(
+        chunkId: 'c1',
+        documentUri: 'file://fetched.pdf',
+        imagesBase64: [_pngBase64],
+      );
+
+    await tester.pumpWidget(_wrap(
+      ChunkVisualizationPage(
+        api: api,
+        roomId: 'room-1',
+        chunkId: 'c1',
+        useDialogLayout: false,
+        documentUri: '',
+        pageNumbers: const [1],
+      ),
+    ));
+    await tester.pumpAndSettle();
+
+    expect(find.text('file://fetched.pdf'), findsOneWidget);
+  });
+
+  testWidgets('empty result still shows the chunk id in the detail block',
+      (tester) async {
+    // The lookup flow can produce zero images; the detail block (chunk id)
+    // must still render alongside the empty-state message.
+    final api = _ChunkVizApi()
+      ..nextVisualization = ChunkVisualization(
+        chunkId: 'c1',
+        documentUri: null,
+        imagesBase64: const [],
+      );
+
+    await tester.pumpWidget(_wrap(
+      ChunkVisualizationPage(
+        api: api,
+        roomId: 'room-1',
+        chunkId: 'c1',
+        useDialogLayout: false,
+        pageNumbers: const [],
+      ),
+    ));
+    await tester.pumpAndSettle();
+
+    expect(find.text('No page images available'), findsOneWidget);
+    expect(find.text('chunk id'), findsOneWidget);
+    expect(find.text('c1'), findsOneWidget);
+  });
+
+  testWidgets('detail block falls back to the fetched uri when caller has none',
+      (tester) async {
+    final api = _ChunkVizApi()
+      ..nextVisualization = ChunkVisualization(
+        chunkId: 'c1',
+        documentUri: 'file://doc.pdf',
+        imagesBase64: [_pngBase64],
+      );
+
+    await tester.pumpWidget(_wrap(
+      ChunkVisualizationPage(
+        api: api,
+        roomId: 'room-1',
+        chunkId: 'c1',
+        useDialogLayout: false,
+        pageNumbers: const [1],
+      ),
+    ));
+    await tester.pumpAndSettle();
+
+    expect(find.text('c1'), findsOneWidget);
+    expect(find.text('file://doc.pdf'), findsOneWidget);
+    expect(find.text('Chunk preview'), findsOneWidget);
+  });
+
+  testWidgets('detail block hides the document row when no uri is available',
+      (tester) async {
+    // Bare lookup + backend returns a null document_uri: only the chunk id
+    // shows, no empty "document" label.
+    final api = _ChunkVizApi()
+      ..nextVisualization = ChunkVisualization(
+        chunkId: 'c1',
+        documentUri: null,
+        imagesBase64: [_pngBase64],
+      );
+
+    await tester.pumpWidget(_wrap(
+      ChunkVisualizationPage(
+        api: api,
+        roomId: 'room-1',
+        chunkId: 'c1',
+        useDialogLayout: false,
+        pageNumbers: const [1],
+      ),
+    ));
+    await tester.pumpAndSettle();
+
+    expect(find.text('chunk id'), findsOneWidget);
+    expect(find.text('c1'), findsOneWidget);
+    expect(find.text('document'), findsNothing);
+  });
+
+  testWidgets('detail block shows the chunk id in the error state',
+      (tester) async {
+    final api = _ChunkVizApi()..nextVizError = Exception('boom');
+
+    await tester.pumpWidget(_wrap(
+      ChunkVisualizationPage(
+        api: api,
+        roomId: 'room-1',
+        chunkId: 'c-err',
+        useDialogLayout: false,
+        documentTitle: 'Doc',
+        pageNumbers: const [],
+      ),
+    ));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Failed to load visualization'), findsOneWidget);
+    expect(find.text('c-err'), findsOneWidget);
+  });
 }

--- a/test/modules/room/ui/citations_section_test.dart
+++ b/test/modules/room/ui/citations_section_test.dart
@@ -148,6 +148,21 @@ void main() {
     expect(find.text('Preview text here'), findsOneWidget);
   });
 
+  testWidgets('expanded row shows the chunk id', (tester) async {
+    await tester.pumpWidget(_wrap(
+      CitationsSection(
+        sourceReferences: [_ref(index: 1, title: 'Doc')],
+      ),
+    ));
+
+    await tester.tap(find.text('1 source'));
+    await tester.pump();
+    await tester.tap(find.text('Doc'));
+    await tester.pump();
+
+    expect(find.textContaining('chunk-1'), findsOneWidget);
+  });
+
   testWidgets('shows page numbers when present', (tester) async {
     await tester.pumpWidget(_wrap(
       CitationsSection(
@@ -207,6 +222,7 @@ void main() {
         'Chapter 1 > Section 2\n'
         'p.5-6\n'
         'file://doc-1.txt\n'
+        'chunk id: chunk-1\n'
         '\n'
         'Preview text here',
       );
@@ -224,7 +240,7 @@ void main() {
         index: 1,
       );
 
-      expect(formatCitationForClipboard(ref), 'Doc');
+      expect(formatCitationForClipboard(ref), 'Doc\nchunk id: chunk-1');
     });
   });
 

--- a/test/modules/room/ui/room_info/chunk_lookup_card_test.dart
+++ b/test/modules/room/ui/room_info/chunk_lookup_card_test.dart
@@ -1,0 +1,67 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:soliplex_client/soliplex_client.dart';
+
+import 'package:soliplex_frontend/src/modules/room/ui/chunk_visualization_page.dart';
+import 'package:soliplex_frontend/src/modules/room/ui/room_info/chunk_lookup_card.dart';
+
+import '../../../../helpers/fakes.dart';
+
+class _ChunkVizApi extends FakeSoliplexApi {
+  @override
+  Future<ChunkVisualization> getChunkVisualization(
+    String roomId,
+    String chunkId, {
+    List<String>? refs,
+    bool expand = true,
+    CancelToken? cancelToken,
+  }) async =>
+      ChunkVisualization(
+        chunkId: chunkId,
+        documentUri: null,
+        imagesBase64: const [],
+      );
+}
+
+void main() {
+  Widget wrap(Widget child) => MaterialApp(
+        home: Scaffold(body: SingleChildScrollView(child: child)),
+      );
+
+  Finder viewButton() => find.widgetWithText(FilledButton, 'View chunk');
+
+  testWidgets('View chunk is disabled until a non-blank id is entered',
+      (tester) async {
+    await tester.pumpWidget(wrap(
+      ChunkLookupCard(api: _ChunkVizApi(), roomId: 'room-1'),
+    ));
+
+    expect(tester.widget<FilledButton>(viewButton()).onPressed, isNull);
+
+    await tester.enterText(find.byType(TextField), '   ');
+    await tester.pump();
+    expect(tester.widget<FilledButton>(viewButton()).onPressed, isNull);
+
+    await tester.enterText(find.byType(TextField), 'chunk-42');
+    await tester.pump();
+    expect(tester.widget<FilledButton>(viewButton()).onPressed, isNotNull);
+  });
+
+  testWidgets('tapping View chunk opens the visualization with the trimmed id',
+      (tester) async {
+    await tester.pumpWidget(wrap(
+      ChunkLookupCard(api: _ChunkVizApi(), roomId: 'room-1'),
+    ));
+
+    await tester.enterText(find.byType(TextField), '  chunk-42  ');
+    await tester.pump();
+    await tester.tap(viewButton());
+    await tester.pump();
+
+    final page = tester.widget<ChunkVisualizationPage>(
+      find.byType(ChunkVisualizationPage),
+    );
+    expect(page.chunkId, 'chunk-42');
+    expect(page.roomId, 'room-1');
+  });
+}


### PR DESCRIPTION
## What

Adds an entry point to look up a chunk by its `chunk_id` and view what the backend returns for it — the highlighted, rendered page images (afsoc-rag #1590). Previously the chunk visualization was reachable only by tapping a PDF citation in the chat timeline.

- **Room Info → "VIEW CHUNK" card**: enter a chunk id and open its visualization directly (e.g. an id taken from logs). The action is disabled until the input is non-blank and the id is trimmed.
- **Discoverability**: expanded citations now show the chunk id + document provenance, and the chunk viewer's detail block (below the pager, and in the error state) shows the chunk id + document uri — all copyable / selectable.

## How

- New `ChunkLookupCard` wired into `RoomInfoScreen`; it calls `ChunkVisualizationPage.show(...)`.
- `ChunkVisualizationPage`: optional `documentTitle` (title bar, falls back to "Chunk preview") and `documentUri` (detail block). The detail shows the caller's uri (citations) → the fetched uri (lookup) → hidden when both absent; an empty caller uri is treated as absent so it can't shadow a real fetched one. A private `_VizResult` record threads the fetched uri out of the `FutureBuilder`.
- The citation eye-flow now passes `ref.documentUri`; the chunk id is included in the citation clipboard export.

## Notes

- The backend `GET /rooms/{roomId}/chunk/{chunkId}` currently returns `document_uri: null` on this path (`get_by_id` doesn't populate it), so the lookup flow shows just the chunk id; the citation flow shows the document via the citation's own uri. No backend change here.

## Testing

- New/updated widget + unit tests: lookup card (disabled-when-empty, trimmed id passed), chunk viewer detail block (name/uri, caller-vs-fetched preference, empty-uri and empty-pages and error cases), citation provenance + clipboard format.
- Full suite: 2110 tests passing; `flutter analyze` clean; markdown lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)