### PR TITLE
feat: clickable document source_url links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,9 +10,11 @@ Versions follow the `version+build` scheme from `pubspec.yaml`, bumped via
 
 ### Added
 
-- Document origin URLs (`source_url`) render as clickable links in the room's
-  document listing and document filter; citations show the link when a
-  deployment provides a browser-url resolver.
+- Document origin URLs (`source_url`) now render as clickable links across the
+  room document listing, document filter, citations, and the chunk-visualization
+  page, replacing the internal file path — which remains only in the document
+  listing's metadata dialog. Where the backend does not yet carry `source_url`
+  (citations, chunks), the link comes from a resolver a deployment injects.
 - Room and lobby: the current server's name (or its address when unnamed) now
   shows alongside the room name in the room view header, and as a title band at
   the top of the lobby's room pane, so a user connected to several servers can

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ Versions follow the `version+build` scheme from `pubspec.yaml`, bumped via
 
 ### Added
 
+- Document origin URLs (`source_url`) render as clickable links in the room's
+  document listing and document filter; citations show the link when a
+  deployment provides a browser-url resolver.
 - Room and lobby: the current server's name (or its address when unnamed) now
   shows alongside the room name in the room view header, and as a title band at
   the top of the lobby's room pane, so a user connected to several servers can

--- a/lib/src/modules/room/document_browser_url.dart
+++ b/lib/src/modules/room/document_browser_url.dart
@@ -33,8 +33,9 @@ typedef DocumentBrowserUrlResolver = Uri? Function(String documentUri);
 /// // standardFlavor(extraModules: (kit) => [DocumentLinkModule()])
 /// ```
 ///
-/// DELETE this provider, its `citations_section.dart` call site, and any fork
-/// module overriding it once the backend surfaces `source_url` on citations;
-/// the citation line then reads the field like the document surfaces do.
+/// DELETE this provider, its call sites (`citations_section.dart` and
+/// `chunk_visualization_page.dart`), and any fork module overriding it once the
+/// backend surfaces `source_url` on citations / chunks; those surfaces then
+/// read the field like the document surfaces do.
 final documentBrowserUrlResolverProvider =
     Provider<DocumentBrowserUrlResolver>((_) => (_) => null);

--- a/lib/src/modules/room/document_browser_url.dart
+++ b/lib/src/modules/room/document_browser_url.dart
@@ -1,0 +1,40 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+/// Derives a document's clickable browser URL from its `documentUri`.
+typedef DocumentBrowserUrlResolver = Uri? Function(String documentUri);
+
+/// TEMPORARY citation stopgap. Citations do not yet carry the backend
+/// `source_url` metadata key (search hits omit document metadata), so a
+/// deployment derives the browser link from the citation's `documentUri` by
+/// injecting a resolver. The default resolves nothing, so the standard build
+/// shows no citation link. Document listing and the document filter do NOT use
+/// this — they read `RagDocument.sourceUrl` directly.
+///
+/// A fork injects its rule through a small [AppModule] and
+/// `standardFlavor(extraModules: ...)`; the concrete URL rule lives in the
+/// fork, never here:
+///
+/// ```dart
+/// class DocumentLinkModule extends AppModule {
+///   @override
+///   String get namespace => 'document_link';
+///
+///   @override
+///   ModuleRoutes build() => ModuleRoutes(
+///         overrides: [
+///           documentBrowserUrlResolverProvider.overrideWithValue(_resolve),
+///         ],
+///       );
+///
+///   // Deployment-specific: map an internal `file://…` path to a public
+///   // browser URL, or return null to render no link.
+///   static Uri? _resolve(String documentUri) => null;
+/// }
+/// // standardFlavor(extraModules: (kit) => [DocumentLinkModule()])
+/// ```
+///
+/// DELETE this provider, its `citations_section.dart` call site, and any fork
+/// module overriding it once the backend surfaces `source_url` on citations;
+/// the citation line then reads the field like the document surfaces do.
+final documentBrowserUrlResolverProvider =
+    Provider<DocumentBrowserUrlResolver>((_) => (_) => null);

--- a/lib/src/modules/room/ui/chunk_visualization_page.dart
+++ b/lib/src/modules/room/ui/chunk_visualization_page.dart
@@ -2,13 +2,16 @@ import 'dart:convert';
 import 'dart:typed_data';
 
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:soliplex_client/soliplex_client.dart' show SoliplexApi;
 import 'package:soliplex_logging/soliplex_logging.dart';
 
 import 'package:soliplex_design/soliplex_design.dart';
+import '../../../shared/browser_url_link.dart';
 import '../../../shared/copy_button.dart';
 import '../../../shared/failed_image.dart';
 import '../../../shared/zoomable_image.dart';
+import '../document_browser_url.dart';
 import 'paged_zoomable_images.dart';
 
 final _logger =
@@ -59,12 +62,12 @@ class ChunkVisualizationPage extends StatefulWidget {
 
   /// The document's display name for the title bar, when the caller knows it
   /// (citations). Null for a bare chunk-id lookup, where the title falls back
-  /// to a neutral label.
+  /// to the chunk id so the user sees the id they looked up.
   final String? documentTitle;
 
-  /// The document uri shown in the detail block, when the caller knows it
-  /// (citations). Null for a bare chunk-id lookup, where the detail block
-  /// falls back to the uri returned by the fetch (which may itself be absent).
+  /// The document uri the caller knows (citations); null for a bare chunk-id
+  /// lookup, where the detail block falls back to the uri returned by the
+  /// fetch. Used only to derive the browser link — the raw path is never shown.
   final String? documentUri;
   final List<int> pageNumbers;
   final bool useDialogLayout;
@@ -128,9 +131,6 @@ class ChunkVisualizationPage extends StatefulWidget {
 typedef _VizResult = ({List<PageImage> pages, String? documentUri});
 
 class _ChunkVisualizationPageState extends State<ChunkVisualizationPage> {
-  /// Title shown when the caller has no document name (bare chunk-id lookup).
-  static const _fallbackTitle = 'Chunk preview';
-
   late Future<_VizResult> _future;
   // Bumped on retry so the pager remounts with fresh rotation/page state.
   int _reloadNonce = 0;
@@ -265,7 +265,7 @@ class _ChunkVisualizationPageState extends State<ChunkVisualizationPage> {
 
     return Scaffold(
       appBar: AppBar(
-        title: Text(widget.documentTitle ?? _fallbackTitle),
+        title: Text(widget.documentTitle ?? widget.chunkId),
         titleTextStyle: Theme.of(context).textTheme.titleMedium,
       ),
       // Without SafeArea, the system gesture inset (iOS home indicator,
@@ -288,7 +288,7 @@ class _ChunkVisualizationPageState extends State<ChunkVisualizationPage> {
         children: [
           Expanded(
             child: Text(
-              widget.documentTitle ?? _fallbackTitle,
+              widget.documentTitle ?? widget.chunkId,
               style: theme.textTheme.titleMedium,
               maxLines: 1,
               overflow: TextOverflow.ellipsis,
@@ -315,8 +315,6 @@ class _ChunkVisualizationPageState extends State<ChunkVisualizationPage> {
             'Failed to load visualization',
             style: theme.textTheme.bodyMedium,
           ),
-          const SizedBox(height: SoliplexSpacing.s3),
-          _detailField(context, 'chunk id', widget.chunkId),
           const SizedBox(height: SoliplexSpacing.s4),
           SoliplexButton.filled(
             onPressed: _retry,
@@ -328,10 +326,9 @@ class _ChunkVisualizationPageState extends State<ChunkVisualizationPage> {
     );
   }
 
-  /// A labelled metadata field with a copy button and a selectable monospace
-  /// value, copyable in one tap or selectable directly. Used for the chunk id
-  /// (detail block and error state) and the document uri (detail block only).
-  Widget _detailField(BuildContext context, String label, String value) {
+  /// The `document` row: a label + copy button and the clickable browser link.
+  /// The copy button copies the full browser url; the raw path is never shown.
+  Widget _documentLink(BuildContext context, Uri url) {
     final theme = Theme.of(context);
     final labelStyle = theme.textTheme.labelSmall?.copyWith(
       fontWeight: FontWeight.w600,
@@ -344,21 +341,18 @@ class _ChunkVisualizationPageState extends State<ChunkVisualizationPage> {
         Row(
           mainAxisSize: MainAxisSize.min,
           children: [
-            Text(label, style: labelStyle),
+            Text('document', style: labelStyle),
             const SizedBox(width: SoliplexSpacing.s1),
             // Match the copy icon to the label's type-scale size so the two
             // read as one line rather than the icon overpowering the label.
             CopyButton(
-              text: value,
-              tooltip: 'Copy $label',
+              text: url.toString(),
+              tooltip: 'Copy document',
               iconSize: labelStyle?.fontSize ?? 12,
             ),
           ],
         ),
-        SelectableText(
-          value,
-          style: context.monospaceOn(theme.textTheme.bodySmall),
-        ),
+        BrowserUrlLink(url: url),
       ],
     );
   }
@@ -366,31 +360,40 @@ class _ChunkVisualizationPageState extends State<ChunkVisualizationPage> {
   Widget _buildDetails(BuildContext context, String? fetchedDocumentUri) {
     // Prefer the caller's uri (citations), treating empty as absent so a blank
     // citation uri doesn't shadow a real fetched one; fall back to the fetched
-    // uri for a bare chunk-id lookup. Absent in both (null/empty) → the row is
-    // hidden and only the chunk id shows.
+    // uri for a bare chunk-id lookup.
     final callerUri = widget.documentUri;
-    final document = (callerUri != null && callerUri.isNotEmpty)
+    final documentUri = (callerUri != null && callerUri.isNotEmpty)
         ? callerUri
         : fetchedDocumentUri;
-    return Padding(
-      padding: const EdgeInsets.fromLTRB(
-        SoliplexSpacing.s4,
-        0,
-        SoliplexSpacing.s4,
-        SoliplexSpacing.s2,
-      ),
-      child: Column(
-        mainAxisSize: MainAxisSize.min,
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          Divider(color: Theme.of(context).colorScheme.outline),
-          _detailField(context, 'chunk id', widget.chunkId),
-          if (document != null && document.isNotEmpty) ...[
-            const SizedBox(height: SoliplexSpacing.s2),
-            _detailField(context, 'document', document),
-          ],
-        ],
-      ),
+    if (documentUri == null || documentUri.isEmpty) {
+      return const SizedBox.shrink();
+    }
+    // TEMPORARY: the chunk endpoint doesn't carry the backend `source_url`, so
+    // the browser link is derived from the document uri via the injected
+    // resolver. The row disappears when nothing resolves — the raw path is
+    // never shown. Remove this once the backend surfaces `source_url`. See
+    // documentBrowserUrlResolverProvider.
+    return Consumer(
+      builder: (context, ref, _) {
+        final url = ref.watch(documentBrowserUrlResolverProvider)(documentUri);
+        if (url == null) return const SizedBox.shrink();
+        return Padding(
+          padding: const EdgeInsets.fromLTRB(
+            SoliplexSpacing.s4,
+            0,
+            SoliplexSpacing.s4,
+            SoliplexSpacing.s2,
+          ),
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Divider(color: Theme.of(context).colorScheme.outline),
+              _documentLink(context, url),
+            ],
+          ),
+        );
+      },
     );
   }
 

--- a/lib/src/modules/room/ui/citations_section.dart
+++ b/lib/src/modules/room/ui/citations_section.dart
@@ -276,7 +276,6 @@ class _SourceReferenceRow extends StatelessWidget {
               );
             },
           ),
-          _metaLine(context, theme, 'chunk id', sourceReference.chunkId),
           if (sourceReference.headings.isNotEmpty) ...[
             const SizedBox(height: SoliplexSpacing.s2),
             Padding(
@@ -308,6 +307,8 @@ class _SourceReferenceRow extends StatelessWidget {
             ),
           if (sourceReference.figures.isNotEmpty)
             _CitationFigures(sourceReference: sourceReference),
+          const SizedBox(height: SoliplexSpacing.s2),
+          _metaLine(context, theme, 'chunk id', sourceReference.chunkId),
         ],
       ),
     );

--- a/lib/src/modules/room/ui/citations_section.dart
+++ b/lib/src/modules/room/ui/citations_section.dart
@@ -1,13 +1,16 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:soliplex_agent/soliplex_agent.dart' hide State;
 import 'package:soliplex_design/soliplex_design.dart';
 import 'package:soliplex_logging/soliplex_logging.dart';
 
+import '../../../shared/browser_url_link.dart';
 import '../../../shared/copy_button.dart';
 import '../../../shared/failed_image.dart';
 import '../../../shared/preview_icon_button.dart';
 import '../../../shared/zoomable_image.dart';
 import '../../../shared/zoomable_view.dart';
+import '../document_browser_url.dart';
 import 'markdown/flutter_markdown_plus_renderer.dart';
 import 'markdown/log_source.dart';
 import 'paged_zoomable_images.dart';
@@ -255,8 +258,28 @@ class _SourceReferenceRow extends StatelessWidget {
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
-          if (sourceReference.documentUri.isNotEmpty)
-            _metaLine(context, theme, 'document', sourceReference.documentUri),
+          // TEMPORARY: citations don't yet carry the backend `source_url`, so the
+          // browser link is derived from `documentUri` via the injected resolver.
+          // Remove this Consumer (and revert to reading a citation `source_url` field)
+          // once the backend surfaces `source_url` on citations. See
+          // documentBrowserUrlResolverProvider.
+          Consumer(
+            builder: (context, ref, _) {
+              final url = ref.watch(documentBrowserUrlResolverProvider)(
+                  sourceReference.documentUri);
+              if (url != null) {
+                return Padding(
+                  padding: const EdgeInsets.only(bottom: SoliplexSpacing.s1),
+                  child: BrowserUrlLink(url: url),
+                );
+              }
+              if (sourceReference.documentUri.isNotEmpty) {
+                return _metaLine(
+                    context, theme, 'document', sourceReference.documentUri);
+              }
+              return const SizedBox.shrink();
+            },
+          ),
           _metaLine(context, theme, 'chunk id', sourceReference.chunkId),
           if (sourceReference.headings.isNotEmpty) ...[
             const SizedBox(height: SoliplexSpacing.s2),

--- a/lib/src/modules/room/ui/citations_section.dart
+++ b/lib/src/modules/room/ui/citations_section.dart
@@ -260,24 +260,20 @@ class _SourceReferenceRow extends StatelessWidget {
         children: [
           // TEMPORARY: citations don't yet carry the backend `source_url`, so the
           // browser link is derived from `documentUri` via the injected resolver.
-          // Remove this Consumer (and revert to reading a citation `source_url` field)
-          // once the backend surfaces `source_url` on citations. See
+          // The internal path is never shown here (the row header already carries
+          // the document name); only the resolved browser link appears. Remove
+          // this Consumer (and read a citation `source_url` field) once the
+          // backend surfaces `source_url` on citations. See
           // documentBrowserUrlResolverProvider.
           Consumer(
             builder: (context, ref, _) {
               final url = ref.watch(documentBrowserUrlResolverProvider)(
                   sourceReference.documentUri);
-              if (url != null) {
-                return Padding(
-                  padding: const EdgeInsets.only(bottom: SoliplexSpacing.s1),
-                  child: BrowserUrlLink(url: url),
-                );
-              }
-              if (sourceReference.documentUri.isNotEmpty) {
-                return _metaLine(
-                    context, theme, 'document', sourceReference.documentUri);
-              }
-              return const SizedBox.shrink();
+              if (url == null) return const SizedBox.shrink();
+              return Padding(
+                padding: const EdgeInsets.only(bottom: SoliplexSpacing.s1),
+                child: BrowserUrlLink(url: url),
+              );
             },
           ),
           _metaLine(context, theme, 'chunk id', sourceReference.chunkId),

--- a/lib/src/modules/room/ui/document_picker.dart
+++ b/lib/src/modules/room/ui/document_picker.dart
@@ -3,6 +3,7 @@ import 'dart:developer' as developer;
 import 'package:flutter/material.dart';
 import 'package:soliplex_client/soliplex_client.dart' hide State;
 
+import '../../../shared/browser_url_link.dart';
 import '../../../shared/file_type_icons.dart';
 import 'package:soliplex_design/soliplex_design.dart';
 
@@ -40,6 +41,18 @@ class _DocumentPickerState extends State<DocumentPicker> {
     final next = Set<RagDocument>.of(widget.selected);
     if (!next.remove(doc)) next.add(doc);
     widget.onChanged(next);
+  }
+
+  Widget? _subtitle(RagDocument doc, ThemeData theme) {
+    final url = doc.sourceUrl;
+    if (url != null) return BrowserUrlLink(url: url);
+    if (doc.uri.isEmpty) return null;
+    return Text(
+      doc.uri,
+      style: theme.textTheme.bodySmall?.copyWith(
+        color: theme.colorScheme.onSurfaceVariant,
+      ),
+    );
   }
 
   @override
@@ -118,14 +131,7 @@ class _DocumentPickerState extends State<DocumentPicker> {
                         documentDisplayName(doc),
                         overflow: TextOverflow.ellipsis,
                       ),
-                      subtitle: doc.uri.isNotEmpty
-                          ? Text(
-                              doc.uri,
-                              style: theme.textTheme.bodySmall?.copyWith(
-                                color: theme.colorScheme.onSurfaceVariant,
-                              ),
-                            )
-                          : null,
+                      subtitle: _subtitle(doc, theme),
                       value: selected,
                       onChanged: (_) => _toggle(doc),
                     );

--- a/lib/src/modules/room/ui/document_picker.dart
+++ b/lib/src/modules/room/ui/document_picker.dart
@@ -43,16 +43,10 @@ class _DocumentPickerState extends State<DocumentPicker> {
     widget.onChanged(next);
   }
 
-  Widget? _subtitle(RagDocument doc, ThemeData theme) {
+  Widget? _subtitle(RagDocument doc) {
     final url = doc.sourceUrl;
-    if (url != null) return BrowserUrlLink(url: url);
-    if (doc.uri.isEmpty) return null;
-    return Text(
-      doc.uri,
-      style: theme.textTheme.bodySmall?.copyWith(
-        color: theme.colorScheme.onSurfaceVariant,
-      ),
-    );
+    if (url == null) return null;
+    return BrowserUrlLink(url: url);
   }
 
   @override
@@ -131,7 +125,7 @@ class _DocumentPickerState extends State<DocumentPicker> {
                         documentDisplayName(doc),
                         overflow: TextOverflow.ellipsis,
                       ),
-                      subtitle: _subtitle(doc, theme),
+                      subtitle: _subtitle(doc),
                       value: selected,
                       onChanged: (_) => _toggle(doc),
                     );

--- a/lib/src/modules/room/ui/room_info/documents_card.dart
+++ b/lib/src/modules/room/ui/room_info/documents_card.dart
@@ -205,7 +205,7 @@ class _DocumentsCardState extends State<DocumentsCard> {
     if (doc.updatedAt != null) {
       dateFields.add(('updated_at', _formatDateTime(doc.updatedAt!)));
     }
-    final sourceUrl = sourceUrlFromMetadata(doc.metadata);
+    final sourceUrl = doc.sourceUrl;
 
     return Padding(
       padding: const EdgeInsets.only(top: SoliplexSpacing.s1),

--- a/lib/src/modules/room/ui/room_info/documents_card.dart
+++ b/lib/src/modules/room/ui/room_info/documents_card.dart
@@ -225,25 +225,14 @@ class _DocumentsCardState extends State<DocumentsCard> {
               doc.id,
               style: context.monospaceOn(valueStyle),
             ),
-            if (doc.uri.isNotEmpty || dateFields.isNotEmpty)
-              const SizedBox(height: SoliplexSpacing.s2),
-            if (doc.uri.isNotEmpty) ...[
-              Text('uri', style: labelStyle),
-              const SizedBox(height: SoliplexSpacing.s1),
-              SelectableText(
-                doc.uri,
-                style: context.monospaceOn(valueStyle),
-              ),
-              if (dateFields.isNotEmpty)
-                const SizedBox(height: SoliplexSpacing.s2),
-            ],
             if (sourceUrl != null) ...[
               const SizedBox(height: SoliplexSpacing.s2),
               Text('link', style: labelStyle),
               const SizedBox(height: SoliplexSpacing.s1),
               BrowserUrlLink(url: sourceUrl),
             ],
-            if (dateFields.isNotEmpty)
+            if (dateFields.isNotEmpty) ...[
+              const SizedBox(height: SoliplexSpacing.s2),
               Wrap(
                 spacing: SoliplexSpacing.s4,
                 runSpacing: SoliplexSpacing.s2,
@@ -265,20 +254,24 @@ class _DocumentsCardState extends State<DocumentsCard> {
                     ),
                 ],
               ),
-            if (doc.metadata.isNotEmpty)
+            ],
+            if (doc.metadata.isNotEmpty) ...[
+              const SizedBox(height: SoliplexSpacing.s2),
               Align(
                 alignment: Alignment.centerRight,
                 child: SoliplexButton.text(
                   onPressed: () => showDialog<void>(
                     context: context,
                     builder: (_) => MetadataDialog(
-                      title: doc.title,
+                      title: documentDisplayName(doc),
+                      uri: doc.uri,
                       metadata: doc.metadata,
                     ),
                   ),
                   child: const Text('Show metadata'),
                 ),
               ),
+            ],
           ],
         ),
       ),
@@ -299,17 +292,39 @@ class MetadataDialog extends StatelessWidget {
   const MetadataDialog({
     super.key,
     required this.title,
+    required this.uri,
     required this.metadata,
   });
 
   final String title;
+
+  /// The document's internal source path. Shown here — the metadata view — is
+  /// the one place this path is surfaced; the friendly link lives in the
+  /// document detail.
+  final String uri;
+
   final Map<String, dynamic> metadata;
 
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
-    final colorScheme = theme.colorScheme;
-    final entries = metadata.entries.toList();
+
+    final rows = <Widget>[
+      if (uri.isNotEmpty)
+        _card(
+          context,
+          'uri',
+          SelectableText(uri,
+              style: context.monospaceOn(theme.textTheme.bodySmall)),
+        ),
+      for (final entry in metadata.entries)
+        _card(
+          context,
+          entry.key,
+          formatDynamicValue(context, entry.value,
+              style: theme.textTheme.bodySmall),
+        ),
+    ];
 
     return AlertDialog(
       title: Text(
@@ -323,35 +338,9 @@ class MetadataDialog extends StatelessWidget {
           child: Column(
             mainAxisSize: MainAxisSize.min,
             children: [
-              for (final entry in entries) ...[
-                SizedBox(
-                  width: double.infinity,
-                  child: Card(
-                    margin: EdgeInsets.zero,
-                    child: Padding(
-                      padding: const EdgeInsets.all(SoliplexSpacing.s3),
-                      child: Column(
-                        crossAxisAlignment: CrossAxisAlignment.start,
-                        children: [
-                          Text(
-                            entry.key,
-                            style: theme.textTheme.labelSmall?.copyWith(
-                              fontWeight: FontWeight.w600,
-                              color: colorScheme.onSurfaceVariant,
-                            ),
-                          ),
-                          const SizedBox(height: SoliplexSpacing.s1),
-                          formatDynamicValue(
-                            context,
-                            entry.value,
-                            style: theme.textTheme.bodySmall,
-                          ),
-                        ],
-                      ),
-                    ),
-                  ),
-                ),
-                if (entry.key != entries.last.key)
+              for (var i = 0; i < rows.length; i++) ...[
+                rows[i],
+                if (i != rows.length - 1)
                   const SizedBox(height: SoliplexSpacing.s2),
               ],
             ],
@@ -364,6 +353,33 @@ class MetadataDialog extends StatelessWidget {
           child: const Text('Close'),
         ),
       ],
+    );
+  }
+
+  Widget _card(BuildContext context, String label, Widget value) {
+    final theme = Theme.of(context);
+    return SizedBox(
+      width: double.infinity,
+      child: Card(
+        margin: EdgeInsets.zero,
+        child: Padding(
+          padding: const EdgeInsets.all(SoliplexSpacing.s3),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Text(
+                label,
+                style: theme.textTheme.labelSmall?.copyWith(
+                  fontWeight: FontWeight.w600,
+                  color: theme.colorScheme.onSurfaceVariant,
+                ),
+              ),
+              const SizedBox(height: SoliplexSpacing.s1),
+              value,
+            ],
+          ),
+        ),
+      ),
     );
   }
 }

--- a/lib/src/modules/room/ui/room_info/documents_card.dart
+++ b/lib/src/modules/room/ui/room_info/documents_card.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:soliplex_client/soliplex_client.dart' hide State;
 
+import '../../../../shared/browser_url_link.dart';
 import '../../../../shared/file_type_icons.dart';
 import 'room_info_widgets.dart';
 import 'package:soliplex_design/soliplex_design.dart';
@@ -204,6 +205,7 @@ class _DocumentsCardState extends State<DocumentsCard> {
     if (doc.updatedAt != null) {
       dateFields.add(('updated_at', _formatDateTime(doc.updatedAt!)));
     }
+    final sourceUrl = sourceUrlFromMetadata(doc.metadata);
 
     return Padding(
       padding: const EdgeInsets.only(top: SoliplexSpacing.s1),
@@ -234,6 +236,12 @@ class _DocumentsCardState extends State<DocumentsCard> {
               ),
               if (dateFields.isNotEmpty)
                 const SizedBox(height: SoliplexSpacing.s2),
+            ],
+            if (sourceUrl != null) ...[
+              const SizedBox(height: SoliplexSpacing.s2),
+              Text('link', style: labelStyle),
+              const SizedBox(height: SoliplexSpacing.s1),
+              BrowserUrlLink(url: sourceUrl),
             ],
             if (dateFields.isNotEmpty)
               Wrap(

--- a/lib/src/shared/browser_url_link.dart
+++ b/lib/src/shared/browser_url_link.dart
@@ -1,0 +1,19 @@
+/// Display text for a browser URL: scheme (and any query/fragment) removed so
+/// the origin reads as `host/path` without `https://` noise.
+String browserUrlDisplay(Uri url) => '${url.host}${url.path}';
+
+/// The clickable origin URL a document carries under the backend `source_url`
+/// metadata key, or null when absent/unusable.
+///
+/// `source_url` is the transformed, viewer-ready URL (e.g. `…/view`); the raw
+/// `source_uri` upstream path is intentionally ignored. Only `http`/`https`
+/// values are accepted — a bare `file://` path is not a browser URL.
+Uri? sourceUrlFromMetadata(Map<String, dynamic> metadata) {
+  final value = metadata['source_url'];
+  if (value is! String || value.isEmpty) return null;
+  final uri = Uri.tryParse(value);
+  if (uri == null || (uri.scheme != 'http' && uri.scheme != 'https')) {
+    return null;
+  }
+  return uri;
+}

--- a/lib/src/shared/browser_url_link.dart
+++ b/lib/src/shared/browser_url_link.dart
@@ -7,22 +7,6 @@ import 'markdown/launch_markdown_link.dart';
 /// the origin reads as `host/path` without `https://` noise.
 String browserUrlDisplay(Uri url) => '${url.host}${url.path}';
 
-/// The clickable origin URL a document carries under the backend `source_url`
-/// metadata key, or null when absent/unusable.
-///
-/// `source_url` is the transformed, viewer-ready URL (e.g. `…/view`); the raw
-/// `source_uri` upstream path is intentionally ignored. Only `http`/`https`
-/// values are accepted — a bare `file://` path is not a browser URL.
-Uri? sourceUrlFromMetadata(Map<String, dynamic> metadata) {
-  final value = metadata['source_url'];
-  if (value is! String || value.isEmpty) return null;
-  final uri = Uri.tryParse(value);
-  if (uri == null || (uri.scheme != 'http' && uri.scheme != 'https')) {
-    return null;
-  }
-  return uri;
-}
-
 /// A clickable document origin link: a link icon plus the scheme-stripped
 /// origin, opening [url] in the platform's default handler (a new browser tab
 /// on web). The raw `https://` is hidden to reduce noise.

--- a/lib/src/shared/browser_url_link.dart
+++ b/lib/src/shared/browser_url_link.dart
@@ -1,3 +1,8 @@
+import 'package:flutter/material.dart';
+import 'package:soliplex_design/soliplex_design.dart';
+
+import 'markdown/launch_markdown_link.dart';
+
 /// Display text for a browser URL: scheme (and any query/fragment) removed so
 /// the origin reads as `host/path` without `https://` noise.
 String browserUrlDisplay(Uri url) => '${url.host}${url.path}';
@@ -16,4 +21,42 @@ Uri? sourceUrlFromMetadata(Map<String, dynamic> metadata) {
     return null;
   }
   return uri;
+}
+
+/// A clickable document origin link: a link icon plus the scheme-stripped
+/// origin, opening [url] in the platform's default handler (a new browser tab
+/// on web). The raw `https://` is hidden to reduce noise.
+class BrowserUrlLink extends StatelessWidget {
+  const BrowserUrlLink({required this.url, super.key});
+
+  final Uri url;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return InkWell(
+      onTap: () => launchMarkdownLink(url.toString()),
+      borderRadius: BorderRadius.circular(context.radii.sm),
+      child: Padding(
+        padding: const EdgeInsets.symmetric(vertical: SoliplexSpacing.s1),
+        child: Row(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Icon(Icons.link, size: 14, color: theme.colorScheme.primary),
+            const SizedBox(width: SoliplexSpacing.s1),
+            Flexible(
+              child: Text(
+                browserUrlDisplay(url),
+                maxLines: 1,
+                overflow: TextOverflow.ellipsis,
+                style: theme.textTheme.labelSmall?.copyWith(
+                  color: theme.colorScheme.primary,
+                ),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
 }

--- a/packages/soliplex_client/lib/src/domain/rag_document.dart
+++ b/packages/soliplex_client/lib/src/domain/rag_document.dart
@@ -139,7 +139,9 @@ extension RagDocumentMetadataParsing on RagDocument {
     final value = metadata['source_url'];
     if (value is! String || value.isEmpty) return null;
     final uri = Uri.tryParse(value);
-    if (uri == null || (uri.scheme != 'http' && uri.scheme != 'https')) {
+    if (uri == null ||
+        (uri.scheme != 'http' && uri.scheme != 'https') ||
+        uri.host.isEmpty) {
       return null;
     }
     return uri;

--- a/packages/soliplex_client/lib/src/domain/rag_document.dart
+++ b/packages/soliplex_client/lib/src/domain/rag_document.dart
@@ -126,3 +126,22 @@ class RagDocument {
   @override
   String toString() => 'RagDocument(id: $id, title: $title, uri: $uri)';
 }
+
+/// Derived interpretations of a [RagDocument]'s free-form metadata.
+extension RagDocumentMetadataParsing on RagDocument {
+  /// The document's clickable origin URL, from the `source_url` metadata key.
+  ///
+  /// Null when absent, empty, non-string, or not a web URL — only `http`/
+  /// `https` are accepted, so a raw `file://` path (or the separate
+  /// `source_uri` upstream key) yields null. `source_url` is the backend's
+  /// viewer-ready URL; rejecting a non-web scheme guards its contract.
+  Uri? get sourceUrl {
+    final value = metadata['source_url'];
+    if (value is! String || value.isEmpty) return null;
+    final uri = Uri.tryParse(value);
+    if (uri == null || (uri.scheme != 'http' && uri.scheme != 'https')) {
+      return null;
+    }
+    return uri;
+  }
+}

--- a/packages/soliplex_client/test/domain/rag_document_test.dart
+++ b/packages/soliplex_client/test/domain/rag_document_test.dart
@@ -144,5 +144,34 @@ void main() {
         );
       });
     });
+
+    group('RagDocument.sourceUrl', () {
+      RagDocument doc(Map<String, dynamic> metadata) =>
+          RagDocument(id: 'd1', title: 'Doc', metadata: metadata);
+
+      test('parses an http(s) source_url', () {
+        expect(
+          doc({'source_url': 'https://example.test/a/view'}).sourceUrl,
+          Uri.parse('https://example.test/a/view'),
+        );
+      });
+
+      test('is null when key absent', () {
+        expect(doc({'other': 'x'}).sourceUrl, isNull);
+      });
+
+      test('is null for empty, non-string, or non-http values', () {
+        expect(doc({'source_url': ''}).sourceUrl, isNull);
+        expect(doc({'source_url': 42}).sourceUrl, isNull);
+        expect(doc({'source_url': 'file:///x/a.pdf'}).sourceUrl, isNull);
+      });
+
+      test('ignores the raw source_uri key', () {
+        expect(
+          doc({'source_uri': 'https://example.test/x'}).sourceUrl,
+          isNull,
+        );
+      });
+    });
   });
 }

--- a/packages/soliplex_client/test/domain/rag_document_test.dart
+++ b/packages/soliplex_client/test/domain/rag_document_test.dart
@@ -160,10 +160,11 @@ void main() {
         expect(doc({'other': 'x'}).sourceUrl, isNull);
       });
 
-      test('is null for empty, non-string, or non-http values', () {
+      test('is null for empty, non-string, non-http, or hostless values', () {
         expect(doc({'source_url': ''}).sourceUrl, isNull);
         expect(doc({'source_url': 42}).sourceUrl, isNull);
         expect(doc({'source_url': 'file:///x/a.pdf'}).sourceUrl, isNull);
+        expect(doc({'source_url': 'https://'}).sourceUrl, isNull);
       });
 
       test('ignores the raw source_uri key', () {

--- a/test/modules/room/document_browser_url_test.dart
+++ b/test/modules/room/document_browser_url_test.dart
@@ -1,0 +1,25 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:soliplex_frontend/src/modules/room/document_browser_url.dart';
+
+void main() {
+  test('default resolver resolves nothing', () {
+    final c = ProviderContainer();
+    addTearDown(c.dispose);
+    expect(
+        c.read(documentBrowserUrlResolverProvider)('file:///x/a.pdf'), isNull);
+  });
+
+  test('an override supplies a resolver', () {
+    final c = ProviderContainer(overrides: [
+      documentBrowserUrlResolverProvider.overrideWithValue(
+        (uri) => Uri.parse('https://example.test/a/view'),
+      ),
+    ]);
+    addTearDown(c.dispose);
+    expect(
+      c.read(documentBrowserUrlResolverProvider)('file:///x/a.pdf'),
+      Uri.parse('https://example.test/a/view'),
+    );
+  });
+}

--- a/test/modules/room/document_browser_url_test.dart
+++ b/test/modules/room/document_browser_url_test.dart
@@ -9,17 +9,4 @@ void main() {
     expect(
         c.read(documentBrowserUrlResolverProvider)('file:///x/a.pdf'), isNull);
   });
-
-  test('an override supplies a resolver', () {
-    final c = ProviderContainer(overrides: [
-      documentBrowserUrlResolverProvider.overrideWithValue(
-        (uri) => Uri.parse('https://example.test/a/view'),
-      ),
-    ]);
-    addTearDown(c.dispose);
-    expect(
-      c.read(documentBrowserUrlResolverProvider)('file:///x/a.pdf'),
-      Uri.parse('https://example.test/a/view'),
-    );
-  });
 }

--- a/test/modules/room/ui/chunk_visualization_page_test.dart
+++ b/test/modules/room/ui/chunk_visualization_page_test.dart
@@ -1,10 +1,14 @@
 import 'dart:convert';
 
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_riverpod/misc.dart' show Override;
 import 'package:flutter_test/flutter_test.dart';
 import 'package:soliplex_agent/soliplex_agent.dart' hide State;
 
+import 'package:soliplex_frontend/src/modules/room/document_browser_url.dart';
 import 'package:soliplex_frontend/src/modules/room/ui/chunk_visualization_page.dart';
+import 'package:soliplex_frontend/src/shared/browser_url_link.dart';
 import 'package:soliplex_frontend/src/shared/failed_image.dart';
 
 import '../../../helpers/fakes.dart';
@@ -34,7 +38,18 @@ class _ChunkVizApi extends FakeSoliplexApi {
   }
 }
 
-Widget _wrap(Widget child) => MaterialApp(home: Scaffold(body: child));
+Widget _wrap(Widget child, {List<Override> overrides = const []}) =>
+    ProviderScope(
+      overrides: overrides,
+      child: MaterialApp(home: Scaffold(body: child)),
+    );
+
+// Maps any document uri to a distinguishable browser URL so tests can assert
+// the link renders and which uri fed the resolver.
+Uri _resolveEcho(String uri) => Uri.parse('https://docs.test/$uri');
+final _resolverOverride = <Override>[
+  documentBrowserUrlResolverProvider.overrideWithValue(_resolveEcho),
+];
 
 void main() {
   // Decoded page bytes are a shared imageCache key; clear it between tests so a
@@ -224,16 +239,14 @@ void main() {
         imagesBase64: [_pngBase64],
       );
 
-    await tester.pumpWidget(MaterialApp(
-      home: Scaffold(
-        body: ChunkVisualizationPage(
-          api: api,
-          roomId: 'room-1',
-          chunkId: 'c1',
-          useDialogLayout: true,
-          documentTitle: 'My Report',
-          pageNumbers: const [1],
-        ),
+    await tester.pumpWidget(_wrap(
+      ChunkVisualizationPage(
+        api: api,
+        roomId: 'room-1',
+        chunkId: 'c1',
+        useDialogLayout: true,
+        documentTitle: 'My Report',
+        pageNumbers: const [1],
       ),
     ));
     await tester.pumpAndSettle();
@@ -304,7 +317,37 @@ void main() {
     expect(rotated.quarterTurns, 1);
   });
 
-  testWidgets('detail block prefers the callers uri over the fetched one',
+  testWidgets('document row shows the resolved link, not the raw uri',
+      (tester) async {
+    final api = _ChunkVizApi()
+      ..nextVisualization = ChunkVisualization(
+        chunkId: 'c1',
+        documentUri: 'file://doc.pdf',
+        imagesBase64: [_pngBase64],
+      );
+
+    await tester.pumpWidget(_wrap(
+      ChunkVisualizationPage(
+        api: api,
+        roomId: 'room-1',
+        chunkId: 'c1',
+        useDialogLayout: false,
+        documentTitle: 'My Doc',
+        documentUri: 'file://doc.pdf',
+        pageNumbers: const [1],
+      ),
+      overrides: _resolverOverride,
+    ));
+    await tester.pumpAndSettle();
+
+    expect(find.byType(BrowserUrlLink), findsOneWidget);
+    expect(find.text('document'), findsOneWidget);
+    // Neither the raw path nor the chunk id appears in the detail block.
+    expect(find.text('file://doc.pdf'), findsNothing);
+    expect(find.text('chunk id'), findsNothing);
+  });
+
+  testWidgets('document link prefers the callers uri over the fetched one',
       (tester) async {
     final api = _ChunkVizApi()
       ..nextVisualization = ChunkVisualization(
@@ -323,18 +366,16 @@ void main() {
         documentUri: 'file://caller.pdf',
         pageNumbers: const [1],
       ),
+      overrides: _resolverOverride,
     ));
     await tester.pumpAndSettle();
 
-    expect(find.text('c1'), findsOneWidget);
-    // Name is the title (once); the detail block shows the caller's uri, not
-    // the fetched one.
-    expect(find.text('My Doc'), findsOneWidget);
-    expect(find.text('file://caller.pdf'), findsOneWidget);
-    expect(find.text('file://fetched.pdf'), findsNothing);
+    final link = tester.widget<BrowserUrlLink>(find.byType(BrowserUrlLink));
+    expect(link.url.toString(), contains('caller'));
+    expect(link.url.toString(), isNot(contains('fetched')));
   });
 
-  testWidgets('detail block treats an empty caller uri as absent',
+  testWidgets('document link falls back to the fetched uri when caller empty',
       (tester) async {
     // A citation whose documentUri is '' must not shadow a real fetched uri.
     final api = _ChunkVizApi()
@@ -353,41 +394,41 @@ void main() {
         documentUri: '',
         pageNumbers: const [1],
       ),
+      overrides: _resolverOverride,
     ));
     await tester.pumpAndSettle();
 
-    expect(find.text('file://fetched.pdf'), findsOneWidget);
+    final link = tester.widget<BrowserUrlLink>(find.byType(BrowserUrlLink));
+    expect(link.url.toString(), contains('fetched'));
   });
 
-  testWidgets('empty result still shows the chunk id in the detail block',
+  testWidgets('title falls back to the chunk id for a bare lookup',
       (tester) async {
-    // The lookup flow can produce zero images; the detail block (chunk id)
-    // must still render alongside the empty-state message.
     final api = _ChunkVizApi()
       ..nextVisualization = ChunkVisualization(
-        chunkId: 'c1',
+        chunkId: 'chunk-42',
         documentUri: null,
-        imagesBase64: const [],
+        imagesBase64: [_pngBase64],
       );
 
     await tester.pumpWidget(_wrap(
       ChunkVisualizationPage(
         api: api,
         roomId: 'room-1',
-        chunkId: 'c1',
+        chunkId: 'chunk-42',
         useDialogLayout: false,
-        pageNumbers: const [],
+        pageNumbers: const [1],
       ),
     ));
     await tester.pumpAndSettle();
 
-    expect(find.text('No page images available'), findsOneWidget);
-    expect(find.text('chunk id'), findsOneWidget);
-    expect(find.text('c1'), findsOneWidget);
+    // No documentTitle → the title shows the looked-up chunk id.
+    expect(find.text('chunk-42'), findsOneWidget);
   });
 
-  testWidgets('detail block falls back to the fetched uri when caller has none',
-      (tester) async {
+  testWidgets('no document row when the uri does not resolve', (tester) async {
+    // Default resolver returns null (standard build): no link, no raw path,
+    // no chunk id in the detail block.
     final api = _ChunkVizApi()
       ..nextVisualization = ChunkVisualization(
         chunkId: 'c1',
@@ -401,25 +442,25 @@ void main() {
         roomId: 'room-1',
         chunkId: 'c1',
         useDialogLayout: false,
+        documentTitle: 'My Doc',
+        documentUri: 'file://doc.pdf',
         pageNumbers: const [1],
       ),
     ));
     await tester.pumpAndSettle();
 
-    expect(find.text('c1'), findsOneWidget);
-    expect(find.text('file://doc.pdf'), findsOneWidget);
-    expect(find.text('Chunk preview'), findsOneWidget);
+    expect(find.byType(BrowserUrlLink), findsNothing);
+    expect(find.text('document'), findsNothing);
+    expect(find.text('chunk id'), findsNothing);
   });
 
-  testWidgets('detail block hides the document row when no uri is available',
+  testWidgets('empty result shows the empty-state message and no detail block',
       (tester) async {
-    // Bare lookup + backend returns a null document_uri: only the chunk id
-    // shows, no empty "document" label.
     final api = _ChunkVizApi()
       ..nextVisualization = ChunkVisualization(
         chunkId: 'c1',
         documentUri: null,
-        imagesBase64: [_pngBase64],
+        imagesBase64: const [],
       );
 
     await tester.pumpWidget(_wrap(
@@ -428,17 +469,18 @@ void main() {
         roomId: 'room-1',
         chunkId: 'c1',
         useDialogLayout: false,
-        pageNumbers: const [1],
+        documentTitle: 'My Doc',
+        pageNumbers: const [],
       ),
     ));
     await tester.pumpAndSettle();
 
-    expect(find.text('chunk id'), findsOneWidget);
-    expect(find.text('c1'), findsOneWidget);
+    expect(find.text('No page images available'), findsOneWidget);
+    expect(find.text('chunk id'), findsNothing);
     expect(find.text('document'), findsNothing);
   });
 
-  testWidgets('detail block shows the chunk id in the error state',
+  testWidgets('error state shows failure and retry, without the chunk id',
       (tester) async {
     final api = _ChunkVizApi()..nextVizError = Exception('boom');
 
@@ -455,6 +497,7 @@ void main() {
     await tester.pumpAndSettle();
 
     expect(find.text('Failed to load visualization'), findsOneWidget);
-    expect(find.text('c-err'), findsOneWidget);
+    expect(find.text('Retry'), findsOneWidget);
+    expect(find.text('c-err'), findsNothing);
   });
 }

--- a/test/modules/room/ui/citations_figures_test.dart
+++ b/test/modules/room/ui/citations_figures_test.dart
@@ -1,6 +1,7 @@
 import 'dart:typed_data';
 
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:soliplex_agent/soliplex_agent.dart' hide State;
 
@@ -89,9 +90,11 @@ SourceReference _ref({required List<Figure> figures}) => SourceReference(
     );
 
 void main() {
-  Widget host(SourceReference ref) => MaterialApp(
-        home: Scaffold(
-          body: CitationsSection(sourceReferences: [ref]),
+  Widget host(SourceReference ref) => ProviderScope(
+        child: MaterialApp(
+          home: Scaffold(
+            body: CitationsSection(sourceReferences: [ref]),
+          ),
         ),
       );
 

--- a/test/modules/room/ui/citations_section_source_url_test.dart
+++ b/test/modules/room/ui/citations_section_source_url_test.dart
@@ -31,9 +31,15 @@ Future<void> _pump(WidgetTester tester,
 }
 
 void main() {
-  testWidgets('no link with the default resolver', (tester) async {
+  testWidgets('no link and no raw path with the default resolver',
+      (tester) async {
     await _pump(tester);
     expect(find.byType(BrowserUrlLink), findsNothing);
+    // The internal file path is not shown when no link resolves.
+    expect(
+      find.textContaining('file:///x/foo.pdf', findRichText: true),
+      findsNothing,
+    );
   });
 
   testWidgets('renders a link when a resolver is injected', (tester) async {

--- a/test/modules/room/ui/citations_section_source_url_test.dart
+++ b/test/modules/room/ui/citations_section_source_url_test.dart
@@ -1,0 +1,47 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_riverpod/misc.dart' show Override;
+import 'package:flutter_test/flutter_test.dart';
+import 'package:soliplex_agent/soliplex_agent.dart' hide State;
+import 'package:soliplex_frontend/src/modules/room/document_browser_url.dart';
+import 'package:soliplex_frontend/src/modules/room/ui/citations_section.dart';
+import 'package:soliplex_frontend/src/shared/browser_url_link.dart';
+
+SourceReference _ref() => const SourceReference(
+      documentId: 'd1',
+      documentUri: 'file:///x/foo.pdf',
+      content: 'body',
+      chunkId: 'c1',
+      documentTitle: 'Alpha',
+      index: 1,
+    );
+
+Future<void> _pump(WidgetTester tester,
+    {List<Override> overrides = const []}) async {
+  await tester.pumpWidget(ProviderScope(
+    overrides: overrides,
+    child: MaterialApp(
+      home: Scaffold(body: CitationsSection(sourceReferences: [_ref()])),
+    ),
+  ));
+  await tester.tap(find.text('1 source')); // expand the section
+  await tester.pump();
+  await tester.tap(find.text('Alpha')); // expand the row
+  await tester.pump();
+}
+
+void main() {
+  testWidgets('no link with the default resolver', (tester) async {
+    await _pump(tester);
+    expect(find.byType(BrowserUrlLink), findsNothing);
+  });
+
+  testWidgets('renders a link when a resolver is injected', (tester) async {
+    await _pump(tester, overrides: [
+      documentBrowserUrlResolverProvider.overrideWithValue(
+        (uri) => Uri.parse('https://example.test/foo.pdf/view'),
+      ),
+    ]);
+    expect(find.byType(BrowserUrlLink), findsOneWidget);
+  });
+}

--- a/test/modules/room/ui/citations_section_test.dart
+++ b/test/modules/room/ui/citations_section_test.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:soliplex_agent/soliplex_agent.dart' hide State;
 
@@ -24,7 +25,9 @@ SourceReference _ref({
       index: index,
     );
 
-Widget _wrap(Widget child) => MaterialApp(home: Scaffold(body: child));
+Widget _wrap(Widget child) => ProviderScope(
+      child: MaterialApp(home: Scaffold(body: child)),
+    );
 
 void main() {
   testWidgets(
@@ -34,14 +37,16 @@ void main() {
     // captures the drag gesture itself and drops out of the transcript-wide
     // selection; this proves the citation content renders selectable:false and
     // so joins the surrounding area's selection.
-    await tester.pumpWidget(MaterialApp(
-      home: Scaffold(
-        body: SelectionArea(
-          child: SingleChildScrollView(
-            child: CitationsSection(
-              sourceReferences: [
-                _ref(index: 1, title: 'Alpha', content: 'cited body'),
-              ],
+    await tester.pumpWidget(ProviderScope(
+      child: MaterialApp(
+        home: Scaffold(
+          body: SelectionArea(
+            child: SingleChildScrollView(
+              child: CitationsSection(
+                sourceReferences: [
+                  _ref(index: 1, title: 'Alpha', content: 'cited body'),
+                ],
+              ),
             ),
           ),
         ),

--- a/test/modules/room/ui/document_picker_source_url_test.dart
+++ b/test/modules/room/ui/document_picker_source_url_test.dart
@@ -26,13 +26,14 @@ void main() {
     expect(find.text('file:///files/Report.pdf'), findsNothing);
   });
 
-  testWidgets('subtitle falls back to raw uri when source_url absent',
+  testWidgets('no subtitle link or raw uri when source_url absent',
       (tester) async {
     await tester.pumpWidget(_picker([
       const RagDocument(id: '1', title: 'Report.pdf', uri: '/files/Report.pdf'),
     ]));
 
     expect(find.byType(BrowserUrlLink), findsNothing);
-    expect(find.text('/files/Report.pdf'), findsOneWidget);
+    // The internal path is not shown in the picker.
+    expect(find.text('/files/Report.pdf'), findsNothing);
   });
 }

--- a/test/modules/room/ui/document_picker_source_url_test.dart
+++ b/test/modules/room/ui/document_picker_source_url_test.dart
@@ -1,0 +1,38 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:soliplex_client/soliplex_client.dart' hide State;
+import 'package:soliplex_frontend/src/modules/room/ui/document_picker.dart';
+import 'package:soliplex_frontend/src/shared/browser_url_link.dart';
+
+Widget _picker(List<RagDocument> docs) => MaterialApp(
+      home: Scaffold(
+        body: DocumentPicker(
+            documents: docs, selected: const {}, onChanged: (_) {}),
+      ),
+    );
+
+void main() {
+  testWidgets('subtitle is a browser link when source_url set', (tester) async {
+    await tester.pumpWidget(_picker([
+      const RagDocument(
+        id: '1',
+        title: 'Report.pdf',
+        uri: 'file:///files/Report.pdf',
+        metadata: {'source_url': 'https://example.test/Report.pdf/view'},
+      ),
+    ]));
+
+    expect(find.byType(BrowserUrlLink), findsOneWidget);
+    expect(find.text('file:///files/Report.pdf'), findsNothing);
+  });
+
+  testWidgets('subtitle falls back to raw uri when source_url absent',
+      (tester) async {
+    await tester.pumpWidget(_picker([
+      const RagDocument(id: '1', title: 'Report.pdf', uri: '/files/Report.pdf'),
+    ]));
+
+    expect(find.byType(BrowserUrlLink), findsNothing);
+    expect(find.text('/files/Report.pdf'), findsOneWidget);
+  });
+}

--- a/test/modules/room/ui/room_info/documents_card_source_url_test.dart
+++ b/test/modules/room/ui/room_info/documents_card_source_url_test.dart
@@ -13,27 +13,29 @@ Widget _card(List<RagDocument> docs) => MaterialApp(
       ),
     );
 
+const _doc = RagDocument(
+  id: 'd1',
+  title: 'RAW-TITLE',
+  uri: 'file:///x/foo.pdf',
+  metadata: {'source_url': 'https://example.test/foo.pdf/view'},
+);
+
 void main() {
-  testWidgets('shows a browser link and keeps the raw uri when source_url set',
+  testWidgets('expanded detail shows the browser link, not the raw uri',
       (tester) async {
-    await tester.pumpWidget(_card([
-      const RagDocument(
-        id: 'd1',
-        title: 'Doc',
-        uri: 'file:///x/foo.pdf',
-        metadata: {'source_url': 'https://example.test/foo.pdf/view'},
-      ),
-    ]));
+    await tester.pumpWidget(_card([_doc]));
     await tester.pumpAndSettle();
 
     await tester.tap(find.text('foo.pdf')); // display name expands the tile
     await tester.pumpAndSettle();
 
     expect(find.byType(BrowserUrlLink), findsOneWidget);
-    expect(find.text('file:///x/foo.pdf'), findsOneWidget); // raw uri retained
+    // Internal file path is not shown in the expanded detail.
+    expect(find.text('file:///x/foo.pdf'), findsNothing);
   });
 
-  testWidgets('shows no link when source_url absent', (tester) async {
+  testWidgets('no link and no raw uri in detail when source_url absent',
+      (tester) async {
     await tester.pumpWidget(_card([
       const RagDocument(id: 'd1', title: 'Doc', uri: 'file:///x/foo.pdf'),
     ]));
@@ -43,6 +45,24 @@ void main() {
     await tester.pumpAndSettle();
 
     expect(find.byType(BrowserUrlLink), findsNothing);
+    expect(find.text('file:///x/foo.pdf'), findsNothing);
+  });
+
+  testWidgets('metadata dialog carries the file uri and a friendly title',
+      (tester) async {
+    await tester.pumpWidget(_card([_doc]));
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.text('foo.pdf'));
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.text('Show metadata'));
+    await tester.pumpAndSettle();
+
+    // The internal path lives in the metadata dialog.
     expect(find.text('file:///x/foo.pdf'), findsOneWidget);
+    expect(find.text('uri'), findsOneWidget);
+    // Dialog is titled with the display name, not the raw doc.title.
+    expect(find.text('RAW-TITLE'), findsNothing);
   });
 }

--- a/test/modules/room/ui/room_info/documents_card_source_url_test.dart
+++ b/test/modules/room/ui/room_info/documents_card_source_url_test.dart
@@ -1,0 +1,48 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:soliplex_client/soliplex_client.dart' hide State;
+import 'package:soliplex_frontend/src/modules/room/ui/room_info/documents_card.dart';
+import 'package:soliplex_frontend/src/shared/browser_url_link.dart';
+
+Widget _card(List<RagDocument> docs) => MaterialApp(
+      home: Scaffold(
+        body: DocumentsCard(
+          documentsFuture: Future.value(docs),
+          onRetry: () {},
+        ),
+      ),
+    );
+
+void main() {
+  testWidgets('shows a browser link and keeps the raw uri when source_url set',
+      (tester) async {
+    await tester.pumpWidget(_card([
+      const RagDocument(
+        id: 'd1',
+        title: 'Doc',
+        uri: 'file:///x/foo.pdf',
+        metadata: {'source_url': 'https://example.test/foo.pdf/view'},
+      ),
+    ]));
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.text('foo.pdf')); // display name expands the tile
+    await tester.pumpAndSettle();
+
+    expect(find.byType(BrowserUrlLink), findsOneWidget);
+    expect(find.text('file:///x/foo.pdf'), findsOneWidget); // raw uri retained
+  });
+
+  testWidgets('shows no link when source_url absent', (tester) async {
+    await tester.pumpWidget(_card([
+      const RagDocument(id: 'd1', title: 'Doc', uri: 'file:///x/foo.pdf'),
+    ]));
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.text('foo.pdf'));
+    await tester.pumpAndSettle();
+
+    expect(find.byType(BrowserUrlLink), findsNothing);
+    expect(find.text('file:///x/foo.pdf'), findsOneWidget);
+  });
+}

--- a/test/modules/room/ui/room_info/documents_card_test.dart
+++ b/test/modules/room/ui/room_info/documents_card_test.dart
@@ -227,7 +227,8 @@ void main() {
       expect(find.text('id'), findsNothing);
     });
 
-    testWidgets('metadata shows document ID and URI', (tester) async {
+    testWidgets('metadata shows document ID but not the internal uri',
+        (tester) async {
       await tester.pumpWidget(wrap(
         DocumentsCard(
           documentsFuture: Future.value(const [docA]),
@@ -240,7 +241,9 @@ void main() {
       await tester.pump();
 
       expect(find.text('id-a'), findsOneWidget);
-      expect(find.text('/files/alpha.pdf'), findsOneWidget);
+      // The internal path is not surfaced in the expanded detail (it lives in
+      // the metadata dialog).
+      expect(find.text('/files/alpha.pdf'), findsNothing);
     });
 
     testWidgets('metadata shows timestamps when present', (tester) async {

--- a/test/shared/browser_url_link_test.dart
+++ b/test/shared/browser_url_link_test.dart
@@ -1,4 +1,4 @@
-// test/shared/browser_url_link_test.dart
+import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:soliplex_frontend/src/shared/browser_url_link.dart';
 
@@ -35,6 +35,24 @@ void main() {
       expect(sourceUrlFromMetadata({'source_url': ''}), isNull);
       expect(sourceUrlFromMetadata({'source_url': 42}), isNull);
       expect(sourceUrlFromMetadata({'source_url': 'file:///x/a.pdf'}), isNull);
+    });
+  });
+
+  group('BrowserUrlLink', () {
+    testWidgets('renders scheme-stripped text with a link icon and is tappable',
+        (tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: BrowserUrlLink(
+                url: Uri.parse('https://example.test/a/b.pdf/view')),
+          ),
+        ),
+      );
+
+      expect(find.text('example.test/a/b.pdf/view'), findsOneWidget);
+      expect(find.byIcon(Icons.link), findsOneWidget);
+      expect(find.byType(InkWell), findsOneWidget);
     });
   });
 }

--- a/test/shared/browser_url_link_test.dart
+++ b/test/shared/browser_url_link_test.dart
@@ -1,0 +1,40 @@
+// test/shared/browser_url_link_test.dart
+import 'package:flutter_test/flutter_test.dart';
+import 'package:soliplex_frontend/src/shared/browser_url_link.dart';
+
+void main() {
+  group('browserUrlDisplay', () {
+    test('strips scheme, keeps host and path', () {
+      expect(
+        browserUrlDisplay(Uri.parse('https://example.test/a/b.pdf/view')),
+        'example.test/a/b.pdf/view',
+      );
+    });
+
+    test('drops query and fragment', () {
+      expect(
+        browserUrlDisplay(Uri.parse('https://example.test/a?x=1#f')),
+        'example.test/a',
+      );
+    });
+  });
+
+  group('sourceUrlFromMetadata', () {
+    test('parses an http(s) source_url', () {
+      expect(
+        sourceUrlFromMetadata({'source_url': 'https://example.test/a/view'}),
+        Uri.parse('https://example.test/a/view'),
+      );
+    });
+
+    test('returns null when key is absent', () {
+      expect(sourceUrlFromMetadata({'other': 'x'}), isNull);
+    });
+
+    test('returns null for empty, non-string, or non-http values', () {
+      expect(sourceUrlFromMetadata({'source_url': ''}), isNull);
+      expect(sourceUrlFromMetadata({'source_url': 42}), isNull);
+      expect(sourceUrlFromMetadata({'source_url': 'file:///x/a.pdf'}), isNull);
+    });
+  });
+}

--- a/test/shared/browser_url_link_test.dart
+++ b/test/shared/browser_url_link_test.dart
@@ -19,25 +19,6 @@ void main() {
     });
   });
 
-  group('sourceUrlFromMetadata', () {
-    test('parses an http(s) source_url', () {
-      expect(
-        sourceUrlFromMetadata({'source_url': 'https://example.test/a/view'}),
-        Uri.parse('https://example.test/a/view'),
-      );
-    });
-
-    test('returns null when key is absent', () {
-      expect(sourceUrlFromMetadata({'other': 'x'}), isNull);
-    });
-
-    test('returns null for empty, non-string, or non-http values', () {
-      expect(sourceUrlFromMetadata({'source_url': ''}), isNull);
-      expect(sourceUrlFromMetadata({'source_url': 42}), isNull);
-      expect(sourceUrlFromMetadata({'source_url': 'file:///x/a.pdf'}), isNull);
-    });
-  });
-
   group('BrowserUrlLink', () {
     testWidgets('renders scheme-stripped text with a link icon and is tappable',
         (tester) async {


### PR DESCRIPTION
## What & why

Renders a document's origin browser URL as a clickable link across the room UI,
per enfold/afsoc-rag#1595. Ingestion writes a viewer-ready `source_url` into
each document's metadata; this surfaces it and replaces the noisy internal
`file://` path.

## Surfaces

- **Document listing** and **document filter** — read `source_url` directly
  (`RagDocument.sourceUrl`), which the backend already forwards via document
  metadata. No backend change needed.
- **Citations** and the **chunk-visualization page** — the backend does not yet
  carry document metadata here, so the link is derived from the document uri via
  a **temporary injected resolver** (`documentBrowserUrlResolverProvider`,
  default resolves to nothing). Clearly marked for deletion once the backend
  surfaces `source_url` on citations/chunks.

## Behavior

- The internal file path is hidden on every friendly surface; it remains only in
  the document listing's **Show metadata** dialog (titled with the document
  name, with the `uri` row inside it).
- Links render scheme-stripped with a link icon (`BrowserUrlLink`), opening in a
  new tab/window. Copy buttons copy the full browser URL.
- The chunk-visualization detail block drops the chunk id; a bare chunk-id
  lookup now titles the page with the chunk id so the user sees what they typed.

## Design notes

- `source_url` interpretation lives in `soliplex_client` as a derived
  `RagDocument.sourceUrl` extension getter (single source of truth; http/https
  host required), not the widget layer.
- No customer-specific URL rules in the shared repo — the concrete rule lives
  only in a deployment's injected resolver.

## Follow-ups (not in this PR)

- Backend: surface `source_url` on citations/chunks (in haiku.rag's `Citation`
  or via soliplex stream enrichment), after which the temporary resolver seam is
  deleted.
- A couple of optional test-coverage nits and an extension-vs-class placement
  question are tracked in `docs/source-url-links-followups.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
