### PR TITLE
feat: documentBrowserUrl injection point for citation/chunk links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,8 @@ Versions follow the `version+build` scheme from `pubspec.yaml`, bumped via
   room document listing, document filter, citations, and the chunk-visualization
   page, replacing the internal file path — which remains only in the document
   listing's metadata dialog. Where the backend does not yet carry `source_url`
-  (citations, chunks), the link comes from a resolver a deployment injects.
+  (citations, chunks), the link comes from a resolver a deployment injects via
+  `standard(documentBrowserUrl: ...)`.
 - Room and lobby: the current server's name (or its address when unnamed) now
   shows alongside the room name in the room view header, and as a title band at
   the top of the lobby's room pane, so a user connected to several servers can

--- a/lib/soliplex_frontend.dart
+++ b/lib/soliplex_frontend.dart
@@ -35,6 +35,11 @@ export 'src/core/shell_config.dart' show ShellConfig;
 export 'src/core/status_message_config.dart' show StatusMessageConfig;
 export 'src/flavors/standard.dart' show standard, standardFlavor;
 export 'src/flavors/standard_kit.dart' show buildStandardKit, StandardKit;
+// TEMPORARY: the resolver type for `standard(documentBrowserUrl: ...)`; the
+// provider itself stays internal. Delete with the seam — see
+// `src/modules/room/document_browser_url.dart`.
+export 'src/modules/room/document_browser_url.dart'
+    show DocumentBrowserUrlResolver;
 export 'src/interfaces/auth_state.dart'
     show AuthState, Authenticated, Unauthenticated;
 export 'src/modules/auth/auth_providers.dart'

--- a/lib/src/flavors/standard.dart
+++ b/lib/src/flavors/standard.dart
@@ -9,6 +9,7 @@ import '../core/shell_config.dart';
 import '../core/status_message_config.dart';
 import '../modules/auth/consent_notice.dart';
 import '../modules/auth/platform/callback_params.dart';
+import '../modules/room/document_browser_url.dart';
 import 'standard_kit.dart';
 
 /// Builds the standard [Flavor]: the full module set on shared session
@@ -32,6 +33,10 @@ Future<Flavor> standardFlavor({
   bool enableDocumentFilter = true,
   String statusMessageFilePath = StatusMessageConfig.defaultFilePath,
   Duration statusMessagePollInterval = StatusMessageConfig.defaultPollInterval,
+  // TEMPORARY: derives the citation / chunk-visualization browser link from a
+  // document uri until the backend carries `source_url` on those responses.
+  // Delete with the seam — see [documentBrowserUrlResolverProvider].
+  DocumentBrowserUrlResolver? documentBrowserUrl,
   List<AppModule> Function(StandardKit kit)? extraModules,
 }) async {
   final effectiveIdentity = identity ?? AppIdentity.soliplex;
@@ -50,7 +55,12 @@ Future<Flavor> standardFlavor({
   return Flavor(
     identity: effectiveIdentity,
     theme: theme,
-    modules: [...kit.modules, ...?extraModules?.call(kit)],
+    modules: [
+      ...kit.modules,
+      if (documentBrowserUrl != null)
+        DocumentBrowserUrlModule(documentBrowserUrl),
+      ...?extraModules?.call(kit),
+    ],
     initialRoute: kit.initialRoute,
     refreshListenable: kit.refreshListenable,
     inactivity: kit.inactivity,
@@ -77,6 +87,10 @@ Future<ShellConfig> standard({
   Duration inactivityGraceDuration = InactivityConfig.defaultGraceDuration,
   String statusMessageFilePath = StatusMessageConfig.defaultFilePath,
   Duration statusMessagePollInterval = StatusMessageConfig.defaultPollInterval,
+  // TEMPORARY: derives the citation / chunk-visualization browser link from a
+  // document uri until the backend carries `source_url` on those responses.
+  // Delete with the seam — see [documentBrowserUrlResolverProvider].
+  DocumentBrowserUrlResolver? documentBrowserUrl,
 }) async {
   final flavor = await standardFlavor(
     identity: identity,
@@ -94,6 +108,7 @@ Future<ShellConfig> standard({
     inactivityGraceDuration: inactivityGraceDuration,
     statusMessageFilePath: statusMessageFilePath,
     statusMessagePollInterval: statusMessagePollInterval,
+    documentBrowserUrl: documentBrowserUrl,
   );
   return flavor.build();
 }

--- a/lib/src/modules/room/document_browser_url.dart
+++ b/lib/src/modules/room/document_browser_url.dart
@@ -1,41 +1,47 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
+import '../../core/app_module.dart';
+
 /// Derives a document's clickable browser URL from its `documentUri`.
 typedef DocumentBrowserUrlResolver = Uri? Function(String documentUri);
 
-/// TEMPORARY citation stopgap. Citations do not yet carry the backend
-/// `source_url` metadata key (search hits omit document metadata), so a
-/// deployment derives the browser link from the citation's `documentUri` by
-/// injecting a resolver. The default resolves nothing, so the standard build
-/// shows no citation link. Document listing and the document filter do NOT use
-/// this — they read `RagDocument.sourceUrl` directly.
+/// TEMPORARY stopgap. Citations and the chunk-visualization page cannot read
+/// the backend `source_url` yet — search hits, `Citation`, and the
+/// chunk-visualization response all omit document metadata — so a deployment
+/// supplies a resolver that derives the browser link from the document's
+/// `documentUri`. The default resolves nothing, so the standard build shows no
+/// link on those surfaces. (Document listing and the document filter do NOT use
+/// this — they read `RagDocument.sourceUrl` directly.)
 ///
-/// A fork injects its rule through a small [AppModule] and
-/// `standardFlavor(extraModules: ...)`; the concrete URL rule lives in the
-/// fork, never here:
+/// A deployment injects its rule through `standard(documentBrowserUrl: ...)` or
+/// `standardFlavor(documentBrowserUrl: ...)`; the concrete URL rule lives in the
+/// deployment, never here.
 ///
-/// ```dart
-/// class DocumentLinkModule extends AppModule {
-///   @override
-///   String get namespace => 'document_link';
-///
-///   @override
-///   ModuleRoutes build() => ModuleRoutes(
-///         overrides: [
-///           documentBrowserUrlResolverProvider.overrideWithValue(_resolve),
-///         ],
-///       );
-///
-///   // Deployment-specific: map an internal `file://…` path to a public
-///   // browser URL, or return null to render no link.
-///   static Uri? _resolve(String documentUri) => null;
-/// }
-/// // standardFlavor(extraModules: (kit) => [DocumentLinkModule()])
-/// ```
-///
-/// DELETE this provider, its call sites (`citations_section.dart` and
-/// `chunk_visualization_page.dart`), and any fork module overriding it once the
-/// backend surfaces `source_url` on citations / chunks; those surfaces then
-/// read the field like the document surfaces do.
+/// DELETE THIS SEAM once the backend carries `source_url` on citation payloads
+/// AND the chunk-visualization response. Remove: this provider, the
+/// [DocumentBrowserUrlModule], the `documentBrowserUrl` params on `standard` /
+/// `standardFlavor`, and the call sites in `citations_section.dart` and
+/// `chunk_visualization_page.dart` — those surfaces then read the field like
+/// the document listing / filter already do.
 final documentBrowserUrlResolverProvider =
     Provider<DocumentBrowserUrlResolver>((_) => (_) => null);
+
+/// TEMPORARY. Installs [resolver] as the app-wide
+/// [documentBrowserUrlResolverProvider] override. Added by `standardFlavor`
+/// when a `documentBrowserUrl` is supplied; delete alongside the provider
+/// (see above).
+class DocumentBrowserUrlModule extends AppModule {
+  DocumentBrowserUrlModule(this.resolver);
+
+  final DocumentBrowserUrlResolver resolver;
+
+  @override
+  String get namespace => 'document_browser_url';
+
+  @override
+  ModuleRoutes build() => ModuleRoutes(
+        overrides: [
+          documentBrowserUrlResolverProvider.overrideWithValue(resolver),
+        ],
+      );
+}

--- a/test/flavors/standard_flavor_test.dart
+++ b/test/flavors/standard_flavor_test.dart
@@ -1,7 +1,9 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:soliplex_frontend/soliplex_frontend.dart';
 import 'package:soliplex_frontend/src/core/routes.dart';
 import 'package:soliplex_frontend/src/modules/auth/platform/callback_params.dart';
+import 'package:soliplex_frontend/src/modules/room/document_browser_url.dart';
 
 import 'platform_mocks.dart';
 
@@ -39,5 +41,31 @@ void main() {
     expect(flavor.inactivity, same(kit.inactivity));
     expect(flavor.modules.sublist(0, kit.modules.length), kit.modules);
     expect(flavor.modules.last, same(extra));
+  });
+
+  test('documentBrowserUrl installs the resolver override', () async {
+    Uri? resolver(String uri) => Uri.parse('https://example.test/x');
+
+    final flavor = await standardFlavor(
+      callbackParams: WebCallbackSuccess(accessToken: 'x'),
+      documentBrowserUrl: resolver,
+    );
+    final container = ProviderContainer(overrides: flavor.build().overrides);
+    addTearDown(container.dispose);
+
+    expect(container.read(documentBrowserUrlResolverProvider), same(resolver));
+  });
+
+  test('no documentBrowserUrl leaves the resolver returning null', () async {
+    final flavor = await standardFlavor(
+      callbackParams: WebCallbackSuccess(accessToken: 'x'),
+    );
+    final container = ProviderContainer(overrides: flavor.build().overrides);
+    addTearDown(container.dispose);
+
+    expect(
+      container.read(documentBrowserUrlResolverProvider)('file:///x/a.pdf'),
+      isNull,
+    );
   });
 }


### PR DESCRIPTION
## What & why

Gives deployments a clean way to supply the citation / chunk-visualization
browser-link rule. Follow-up to the `source_url` links feature: the document
listing and filter read `source_url` directly, but citations and the
chunk-visualization page have no backend `source_url` yet, so the link is
derived from a deployment-provided resolver.

Before this, a fork could only inject that resolver by reaching into
`package:soliplex_frontend/src/...` (an `implementation_imports` violation) and
abandoning `standard()` for `standardFlavor(extraModules:)`.

## Change

- Add a `documentBrowserUrl` resolver parameter to `standard()` and
  `standardFlavor()`. When provided, it's installed as the
  `documentBrowserUrlResolverProvider` override via a small internal module.
- Export the `DocumentBrowserUrlResolver` typedef for the parameter type; the
  provider itself stays internal.

A deployment then wires it at the blessed entry point:

```dart
final config = await standard(
  …,
  documentBrowserUrl: myDocumentBrowserUrl, // Uri? Function(String documentUri)
);
```

## Temporary

This whole seam is a stopgap. It is to be **deleted** once the backend carries
`source_url` on both citation payloads and the chunk-visualization response —
at which point those surfaces read the field directly like the document listing
and filter already do. The `documentBrowserUrl` params, the internal module, the
provider, and the two UI call sites all go together. The deletion trigger is
documented on `documentBrowserUrlResolverProvider`.

## Tests

`standard_flavor_test.dart`: a supplied `documentBrowserUrl` reaches the
provider; without one, the provider resolves to null. Full suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
