### PR TITLE
docs: fix stale module-system claims in agent docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,9 +5,9 @@ Instructions for AI coding agents working with the Soliplex Flutter frontend.
 ## Project Overview
 
 Soliplex Flutter frontend -- a runnable app and importable library built on a
-modular shell architecture. Each feature module is a function returning a
-`ModuleContribution` (routes, Riverpod overrides, optional redirect). Flavors
-compose modules into a `ShellConfig` that boots the app via
+modular shell architecture. Each feature module is an `AppModule` subclass whose
+`build()` returns `ModuleRoutes` (routes, Riverpod overrides, optional redirect).
+A `Flavor` composes modules into a `ShellConfig` that boots the app via
 `runSoliplexShell()`.
 
 ## Setup
@@ -50,11 +50,11 @@ presenting work for review.
 
 ## Modules
 
-Five feature modules composed in the standard flavor (`lib/src/flavors/standard.dart`):
+Six feature modules composed in the standard flavor (`lib/src/flavors/standard.dart`):
 
 - **auth** (`lib/src/modules/auth/`) -- Multi-server OIDC authentication with
   token refresh, secure storage, consent notices, and platform-specific OAuth
-  flows (native and web). Routes: `/`, `/servers`, `/auth/callback`.
+  flows (native and web). Routes: `/`, `/auth/callback`.
 - **lobby** (`lib/src/modules/lobby/`) -- Server and room discovery with
   responsive wide/narrow layouts, user profile display, and server sidebar.
   Route: `/lobby`.
@@ -72,13 +72,15 @@ Five feature modules composed in the standard flavor (`lib/src/flavors/standard.
 - **diagnostics** (`lib/src/modules/diagnostics/`) -- Network inspector for
   HTTP request/response observation, event filtering by run, and SSE stream
   parsing. Route: `/diagnostics/network`.
+- **versions** (`lib/src/modules/versions/`) -- App and backend version
+  display. Routes: `/versions`, `/versions/server/:serverAlias`.
 
 ## Architecture
 
-- **Modules**: Functions taking dependencies via constructor injection,
-  returning `ModuleContribution`. No base class, no registry.
-- **Flavors**: Functions that compose module functions into `ShellConfig`.
-  Add/remove a module by adding/removing a function call.
+- **Modules**: `AppModule` subclasses taking dependencies via constructor
+  injection; `build()` returns `ModuleRoutes`. No registry.
+- **Flavors**: A `Flavor` object composes module instances into a
+  `ShellConfig`. Add/remove a module by adding/removing it from the list.
 - **State management**: Riverpod for DI/service locator only. Reactive state
   via `signals` (from `soliplex_agent` package). No AsyncNotifier or
   FutureProvider chains.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -215,13 +215,14 @@ Don't, without explicit user approval. If a value is genuinely missing:
 
 ## Modules
 
-Five feature modules composed in the standard flavor:
+Six feature modules composed in the standard flavor:
 
 - **auth** — Multi-server OIDC authentication, token refresh, secure storage
 - **lobby** — Server/room discovery with responsive layout
 - **room** — Chat interface, threads, agent execution, file upload, citations, document filtering, feedback
 - **quiz** — Interactive quizzes with multiple-choice and free-text input
 - **diagnostics** — Network inspector for HTTP request/response debugging
+- **versions** — App and backend version display (`/versions`, `/versions/server/:serverAlias`)
 
 ## Workspace Packages
 

--- a/design_system/README.md
+++ b/design_system/README.md
@@ -237,11 +237,11 @@ List of doc rows with checkbox + filename + page count + last-modified. Selected
 - **Quiz**: lock icon on rooms with quizzes; submit reveals correctness + explanation + 3 sources.
 
 ## State Management
-Riverpod throughout. Each feature module exposes a `ModuleContribution { routes, providers, redirect? }`. Providers are overridden at the shell level — never inside the module — so flavors can swap implementations.
+Riverpod throughout. Each feature module is an `AppModule` subclass whose `build()` returns a `ModuleRoutes { routes, overrides, redirect? }`. Provider overrides are applied at the shell level — never inside the module — so flavors can swap implementations.
 
 ## Architecture
 - `runSoliplexShell(ShellConfig)` boots the app from a single config object.
-- Modules: `auth`, `lobby`, `room`, `quiz`, `diagnostics`.
+- Modules: `auth`, `lobby`, `room`, `quiz`, `diagnostics`, `versions`.
 - Targets: Android, iOS, macOS, Linux, Windows, Web.
 - Theming: `tokens/colors.dart` → `soliplexLightTheme` / `soliplexDarkTheme` → `ThemeExtension<SoliplexTheme>`.
 


### PR DESCRIPTION
## Why

Onboarding on a fresh machine surfaced several **outright-wrong claims** in the agent-facing docs about how the module system works. These send AI agents (and new humans) down the wrong path and cost tokens re-discovering the truth from code. This PR fixes only the factual errors — verified against the code — nothing more.

## What's wrong today

| Doc | Claim | Reality |
| --- | --- | --- |
| AGENTS.md, design_system/README.md | Modules are "functions returning `ModuleContribution`", "no base class" | Modules are `AppModule` subclasses whose `build()` returns `ModuleRoutes` (`lib/src/core/app_module.dart`) |
| AGENTS.md | "Flavors: functions that compose module functions" | A `Flavor` **object** composes module instances into a `ShellConfig` (`lib/src/core/flavor.dart`, ADR-003) |
| CLAUDE.md, AGENTS.md, design_system/README.md | "Five feature modules" | **Six** — the `versions` module (`/versions`, `/versions/server/:serverAlias`) was undocumented |
| AGENTS.md | auth `Routes: /, /servers, /auth/callback` | No `/servers` route exists — auth is `/` and `/auth/callback` |

## Scope

- **Factual corrections only.** No restructuring, no new sections.
- A **follow-up PR is expected** to expand and improve these docs more broadly (better architecture narrative, module deep-dives) — deferred until we have hands-on context later this session.
- Historical records (`CHANGELOG.md`, `docs/plans/`) left untouched so history stays honest; they mention `ModuleContribution` as it was at the time.

## Verification

Every corrected claim was checked against the current code (`app_module.dart`, `flavor.dart`, `standard_kit.dart`, each `*_module.dart`, `routes.dart`). Markdown lint passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)