### PR TITLE
feat(room): move back-to-lobby into the rooms rail, free the thread column

### DIFF
--- a/lib/src/modules/room/ui/room_rail.dart
+++ b/lib/src/modules/room/ui/room_rail.dart
@@ -32,6 +32,7 @@ class RoomRail extends StatelessWidget {
     required this.rooms,
     required this.selectedRoomId,
     required this.onSelectRoom,
+    required this.onBackToLobby,
     required this.entry,
     required this.account,
     required this.onNetworkInspector,
@@ -63,6 +64,11 @@ class RoomRail extends StatelessWidget {
   final String selectedRoomId;
   final void Function(String roomId) onSelectRoom;
 
+  /// Returns to the lobby (server/room picker). Anchors the top of the rail as
+  /// a home button — it lives here, among the room nav, rather than in the
+  /// thread column, so the thread column's full width is free for its CTA.
+  final VoidCallback onBackToLobby;
+
   /// The current server entry; its session drives the Guest/signed-in label.
   final ServerEntry entry;
 
@@ -85,6 +91,17 @@ class RoomRail extends StatelessWidget {
   Widget build(BuildContext context) {
     return Column(
       children: [
+        // Home button anchoring the top of the nav rail. A tooltip names it;
+        // the house glyph reads as "back to the rooms lobby".
+        Padding(
+          padding: const EdgeInsets.symmetric(vertical: SoliplexSpacing.s2),
+          child: IconButton(
+            icon: const Icon(Icons.home_outlined),
+            tooltip: 'Back to lobby',
+            onPressed: onBackToLobby,
+          ),
+        ),
+        const Divider(height: 1),
         Expanded(child: _buildList(context)),
         const Divider(height: 1),
         Padding(

--- a/lib/src/modules/room/ui/room_screen.dart
+++ b/lib/src/modules/room/ui/room_screen.dart
@@ -1399,7 +1399,6 @@ class _RoomScreenState extends State<RoomScreen> {
               threadListStatus: threadListStatus,
               selectedThreadId: selectedThreadId,
               onThreadSelected: _onThreadSelected,
-              onBackToLobby: _onBackToLobby,
               onCreateThread: _state.createThread,
               onRetryThreads: () => _state.threadList.refresh(),
               onReauthenticate: _onReauthenticate,
@@ -1465,7 +1464,6 @@ class _RoomScreenState extends State<RoomScreen> {
                             Navigator.pop(drawerContext);
                             _onThreadSelected(threadId);
                           },
-                          onBackToLobby: _onBackToLobby,
                           onCreateThread: () {
                             Navigator.pop(drawerContext);
                             _state.createThread();
@@ -1529,6 +1527,10 @@ class _RoomScreenState extends State<RoomScreen> {
         onNavigate?.call();
         if (roomId == widget.roomId) return;
         context.go(AppRoutes.room(widget.serverEntry.alias, roomId));
+      },
+      onBackToLobby: () {
+        onNavigate?.call();
+        _onBackToLobby();
       },
       entry: widget.serverEntry,
       account: _account,

--- a/lib/src/modules/room/ui/thread_sidebar.dart
+++ b/lib/src/modules/room/ui/thread_sidebar.dart
@@ -12,7 +12,6 @@ class ThreadSidebar extends StatelessWidget {
     required this.threadListStatus,
     required this.selectedThreadId,
     required this.onThreadSelected,
-    required this.onBackToLobby,
     required this.onCreateThread,
     required this.runningThreadIds,
     this.unreadThreadIds = const {},
@@ -28,7 +27,6 @@ class ThreadSidebar extends StatelessWidget {
   final ThreadListStatus threadListStatus;
   final String? selectedThreadId;
   final void Function(String threadId) onThreadSelected;
-  final VoidCallback onBackToLobby;
   final VoidCallback onCreateThread;
   final Future<void> Function()? onRetryThreads;
   final VoidCallback? onReauthenticate;
@@ -51,25 +49,12 @@ class ThreadSidebar extends StatelessWidget {
       children: [
         Padding(
           padding: const EdgeInsets.all(SoliplexSpacing.s2),
-          child: Row(
-            children: [
-              SoliplexButton.text(
-                onPressed: onBackToLobby,
-                isCompact: true,
-                icon: const Icon(Icons.arrow_back, size: 16),
-                child: const Text('Lobby'),
-              ),
-              const SizedBox(width: SoliplexSpacing.s2),
-              // Filled primary CTA fills the remaining width so the
-              // thread-creation action carries the emphasis it deserves.
-              Expanded(
-                child: SoliplexButton.filled(
-                  onPressed: onCreateThread,
-                  icon: const Icon(Icons.add, size: 16),
-                  child: const Text('New'),
-                ),
-              ),
-            ],
+          // The primary CTA owns the full column width now that "back to lobby"
+          // has moved to the rooms rail — nothing competes with it here.
+          child: SoliplexButton.filled(
+            onPressed: onCreateThread,
+            icon: const Icon(Icons.add, size: 16),
+            child: const Text('New'),
           ),
         ),
         const Divider(height: 1),

--- a/test/modules/room/ui/room_rail_test.dart
+++ b/test/modules/room/ui/room_rail_test.dart
@@ -24,6 +24,7 @@ RoomRail _rail({
   void Function(String)? onSelectRoom,
   void Function(String)? onMarkRoomRead,
   VoidCallback? onRetryRooms,
+  VoidCallback? onBackToLobby,
   RoomAccount? account,
   VoidCallback? onNetworkInspector,
   VoidCallback? onVersions,
@@ -37,6 +38,7 @@ RoomRail _rail({
       selectedRoomId: selectedRoomId,
       onSelectRoom: onSelectRoom ?? (_) {},
       onMarkRoomRead: onMarkRoomRead,
+      onBackToLobby: onBackToLobby ?? () {},
       entry: createTestServerEntry(),
       account: account,
       onNetworkInspector: onNetworkInspector ?? () {},
@@ -56,6 +58,28 @@ void main() {
       await tester.pumpWidget(_wrap(_rail(onSelectRoom: (id) => picked = id)));
       await tester.tap(find.text('B'));
       expect(picked, 'r2');
+    });
+
+    testWidgets('home button fires onBackToLobby and carries a tooltip',
+        (tester) async {
+      var backCalled = false;
+      await tester.pumpWidget(
+        _wrap(_rail(onBackToLobby: () => backCalled = true)),
+      );
+
+      expect(find.byTooltip('Back to lobby'), findsOneWidget);
+      await tester.tap(find.byIcon(Icons.home_outlined));
+      expect(backCalled, isTrue);
+    });
+
+    testWidgets('surfaces the full room name in a tooltip on each avatar',
+        (tester) async {
+      await tester.pumpWidget(_wrap(_rail()));
+      // Each avatar shows only an initial and a hash-derived color, so the full
+      // room name must be recoverable via a tooltip (hover on desktop,
+      // long-press on touch).
+      expect(find.byTooltip('Alpha'), findsOneWidget);
+      expect(find.byTooltip('Beta'), findsOneWidget);
     });
 
     testWidgets('shows a spinner while rooms are loading', (tester) async {

--- a/test/modules/room/ui/thread_sidebar_quiz_row_test.dart
+++ b/test/modules/room/ui/thread_sidebar_quiz_row_test.dart
@@ -18,7 +18,6 @@ void main() {
           threadListStatus: ThreadsLoaded(const []),
           selectedThreadId: null,
           onThreadSelected: (_) {},
-          onBackToLobby: () {},
           onCreateThread: () {},
           runningThreadIds: emptyRunning,
           quizzes: quizzes,

--- a/test/modules/room/ui/thread_sidebar_test.dart
+++ b/test/modules/room/ui/thread_sidebar_test.dart
@@ -15,7 +15,6 @@ void main() {
           threadListStatus: ThreadsLoading(),
           selectedThreadId: null,
           onThreadSelected: (_) {},
-          onBackToLobby: () {},
           onCreateThread: () {},
           runningThreadIds: _emptyRunning,
           onRetryThreads: () async {},
@@ -32,7 +31,6 @@ void main() {
           threadListStatus: ThreadsLoading(),
           selectedThreadId: null,
           onThreadSelected: (_) {},
-          onBackToLobby: () {},
           onCreateThread: () {},
           runningThreadIds: _emptyRunning,
           onRetryThreads: () async {},
@@ -66,7 +64,6 @@ void main() {
           threadListStatus: ThreadsLoaded(threads),
           selectedThreadId: 't-1',
           onThreadSelected: (_) {},
-          onBackToLobby: () {},
           onCreateThread: () {},
           runningThreadIds: _emptyRunning,
           onRetryThreads: () async {},
@@ -101,7 +98,6 @@ void main() {
           threadListStatus: ThreadsLoaded(threads),
           selectedThreadId: null,
           onThreadSelected: (_) {},
-          onBackToLobby: () {},
           onCreateThread: () {},
           runningThreadIds: _emptyRunning,
           unreadThreadIds: const {'t-2'},
@@ -131,7 +127,6 @@ void main() {
           threadListStatus: ThreadsLoaded(threads),
           selectedThreadId: null,
           onThreadSelected: (id) => selectedId = id,
-          onBackToLobby: () {},
           onCreateThread: () {},
           runningThreadIds: _emptyRunning,
           onRetryThreads: () async {},
@@ -143,16 +138,14 @@ void main() {
     expect(selectedId, 't-1');
   });
 
-  testWidgets('shows back to lobby button', (tester) async {
-    bool backCalled = false;
-
+  testWidgets('no longer hosts a back-to-lobby control (moved to the rail)',
+      (tester) async {
     await tester.pumpWidget(MaterialApp(
       home: Scaffold(
         body: ThreadSidebar(
           threadListStatus: ThreadsLoaded(const []),
           selectedThreadId: null,
           onThreadSelected: (_) {},
-          onBackToLobby: () => backCalled = true,
           onCreateThread: () {},
           runningThreadIds: _emptyRunning,
           onRetryThreads: () async {},
@@ -160,8 +153,11 @@ void main() {
       ),
     ));
 
-    await tester.tap(find.text('Lobby'));
-    expect(backCalled, isTrue);
+    // "Back to lobby" moved to the rooms rail, so the thread column's top row
+    // is just the "New" CTA — nothing competes with it for width.
+    expect(find.text('Lobby'), findsNothing);
+    expect(find.byTooltip('Back to lobby'), findsNothing);
+    expect(find.text('New'), findsOneWidget);
   });
 
   testWidgets('wraps thread list with RefreshIndicator when callback provided',
@@ -181,7 +177,6 @@ void main() {
           threadListStatus: ThreadsLoaded(threads),
           selectedThreadId: null,
           onThreadSelected: (_) {},
-          onBackToLobby: () {},
           onCreateThread: () {},
           runningThreadIds: _emptyRunning,
           onRetryThreads: () async {},
@@ -200,7 +195,6 @@ void main() {
           threadListStatus: ThreadsLoaded(const []),
           selectedThreadId: null,
           onThreadSelected: (_) {},
-          onBackToLobby: () {},
           onCreateThread: () {},
           runningThreadIds: _emptyRunning,
         ),
@@ -227,7 +221,6 @@ void main() {
           threadListStatus: ThreadsLoaded(threads),
           selectedThreadId: null,
           onThreadSelected: (_) {},
-          onBackToLobby: () {},
           onCreateThread: () {},
           runningThreadIds: _emptyRunning,
           onRetryThreads: () async {},
@@ -263,7 +256,6 @@ void main() {
           threadListStatus: ThreadsLoaded(threads),
           selectedThreadId: null,
           onThreadSelected: (_) {},
-          onBackToLobby: () {},
           onCreateThread: () {},
           runningThreadIds: running.readonly(),
         ),
@@ -305,7 +297,6 @@ void main() {
           threadListStatus: ThreadsLoaded(threads),
           selectedThreadId: 't-1',
           onThreadSelected: (_) {},
-          onBackToLobby: () {},
           onCreateThread: () {},
           runningThreadIds: running.readonly(),
         ),
@@ -342,7 +333,6 @@ void main() {
           threadListStatus: ThreadsLoaded(threads),
           selectedThreadId: null,
           onThreadSelected: (_) {},
-          onBackToLobby: () {},
           onCreateThread: () {},
           runningThreadIds: _emptyRunning,
           onRetryThreads: () async {},


### PR DESCRIPTION
Scoped to the **room page** drawer (per our one-module-per-PR convention). Reorganizes the drawer's two nav columns.

## Before
The thread column's top row held **both** a "Lobby" text button and the "New" CTA, so they competed for width — this is #427's *"New thread button's text overflowing."* Back-to-lobby also sat oddly among thread actions.

## After
- **Back-to-lobby moved to the rooms rail** as a home icon button (`Icons.home_outlined`, tooltip "Back to lobby") anchoring the top of the column, where it reads as a nav action beside the rooms it returns you to.
- **The thread column's top row is now just "New"**, at full width — nothing competes with the primary CTA.
- `ThreadSidebar` no longer takes `onBackToLobby`; `RoomRail` does. In the narrow drawer the rail's home button pops the drawer before navigating, matching the existing room-select / inspector / versions actions.

## Room-name tooltips
These **already existed** on the rail avatars (`Tooltip(message: room.name)`) — they show on hover (desktop) / long-press (touch), which is why they're easy to miss on the iOS emulator. This PR doesn't add them, but **adds a test** guarding them, so the rail column is now consistently tooltipped: home button, every room avatar, and the account menu.

## Layout result
Rail column (top→bottom): **home** · room avatars · account ⋮. Thread column: full-width **New** · threads. Better clustering, more space, works identically on desktop panes and the mobile drawer.

## Testing
- Full suite green (2148 tests); `flutter analyze` clean.
- New/updated tests: rail home button fires `onBackToLobby` + tooltip; rail avatars carry per-room-name tooltips; `ThreadSidebar` no longer hosts a back control and keeps "New" full-width.

🤖 Generated with [Claude Code](https://claude.com/claude-code)