### PR TITLE
fix: extract citations from every citation-bearing state namespace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,14 @@ Versions follow the `version+build` scheme from `pubspec.yaml`, bumped via
 - In an expanded citation, the cited figures now appear above the source text
   rather than below it.
 
+### Fixed
+
+- Citations now appear for agents whose sources arrive under a non-`rag` state
+  namespace (such as the analysis agent). Citation extraction reads every
+  citation-bearing namespace in the agent state rather than only `rag`, so a
+  reply that cites sources renders its citations regardless of which retrieval
+  skill produced them.
+
 ## [0.94.0+68] - 2026-07-17
 
 ### Added

--- a/packages/soliplex_client/lib/src/application/citation_extractor.dart
+++ b/packages/soliplex_client/lib/src/application/citation_extractor.dart
@@ -2,72 +2,66 @@ import 'package:soliplex_client/src/application/rag_snapshot.dart';
 import 'package:soliplex_client/src/domain/source_reference.dart';
 import 'package:soliplex_client/src/schema/agui_features/rag.dart';
 import 'package:soliplex_client/src/utils/source_url.dart';
-import 'package:soliplex_logging/soliplex_logging.dart';
-
-final _logger =
-    LogManager.instance.getLogger('soliplex_client.citation_extractor');
 
 /// Extracts new [SourceReference]s by comparing AG-UI state snapshots.
 ///
 /// **Schema firewall**: this file and [RagSnapshot] in
 /// `rag_snapshot.dart` are the only places that import the schema-mirror
-/// types in `rag.dart`. When the backend `rag` shape changes, updates are
-/// confined to `rag_snapshot.dart`.
+/// types in `rag.dart`. When the backend citation shape changes, updates
+/// are confined to `rag_snapshot.dart`.
 ///
-/// The algorithm: resolve each state into a [RagSnapshot], take the
-/// difference of `citationIds`, and resolve each new id back to a full
-/// [Citation].
+/// The algorithm: collect every citation-bearing namespace in the state
+/// (each RAG-producing skill — `rag`, `analysis`, … — publishes its own),
+/// take the difference of their combined `citationIds`, and resolve each
+/// new id back to a full [Citation].
 class CitationExtractor {
-  /// Extracts source references added since [previousState].
+  /// Extracts source references added since [previousState] across every
+  /// citation-bearing namespace in the state.
   ///
   /// Returns an empty list if:
-  /// - The current state has no `rag` namespace or an unparseable one.
+  /// - The current state carries no citation-bearing namespace.
   /// - Current citations are a subset of previous.
-  /// - New ids cannot be resolved against the snapshot.
+  /// - New ids cannot be resolved against any current snapshot.
+  ///
+  /// Ids are deduped across namespaces so a chunk cited in more than one
+  /// namespace in a single turn yields a single reference.
+  ///
+  /// Never throws: a namespace whose block fails to parse is skipped by
+  /// [RagSnapshot.extractAll], and everything after operates on already-
+  /// parsed snapshots. The replay path relies on this — it calls this
+  /// method without a surrounding guard.
   List<SourceReference> extractNew(
     Map<String, dynamic> previousState,
     Map<String, dynamic> currentState,
   ) {
-    final currentRag = _snapshot(currentState);
-    if (currentRag == null) return [];
+    final currentSnapshots = RagSnapshot.extractAll(currentState);
+    if (currentSnapshots.isEmpty) return [];
 
-    final previousRag = _snapshot(previousState);
-    final previousIds = (previousRag?.citationIds ?? const <String>[]).toSet();
+    final previousIds = <String>{
+      for (final s in RagSnapshot.extractAll(previousState)) ...s.citationIds,
+    };
 
-    final newIds = currentRag.citationIds
-        .where((id) => !previousIds.contains(id))
-        .toList();
+    final newIds = <String>[];
+    final seen = <String>{};
+    for (final snapshot in currentSnapshots) {
+      for (final id in snapshot.citationIds) {
+        if (previousIds.contains(id)) continue;
+        if (seen.add(id)) newIds.add(id);
+      }
+    }
     if (newIds.isEmpty) return [];
 
-    return newIds
-        .map(currentRag.resolveCitation)
-        .whereType<Citation>()
-        .map((c) => _citationToSourceReference(c, currentRag))
-        .toList();
-  }
-
-  /// Resolves [state]'s `rag` namespace into a [RagSnapshot], or null
-  /// when the key is absent, not a Map, or fails to parse.
-  RagSnapshot? _snapshot(Map<String, dynamic> state) {
-    final raw = state[ragStateKey];
-    if (raw == null) return null;
-    if (raw is! Map<String, dynamic>) {
-      _logger.warning(
-        'Expected rag state to be Map<String, dynamic>, '
-        'got ${raw.runtimeType}.',
-      );
-      return null;
+    final refs = <SourceReference>[];
+    for (final id in newIds) {
+      for (final snapshot in currentSnapshots) {
+        final citation = snapshot.resolveCitation(id);
+        if (citation != null) {
+          refs.add(_citationToSourceReference(citation, snapshot));
+          break;
+        }
+      }
     }
-    try {
-      return RagSnapshot.fromJson(raw);
-    } on Object catch (error, stackTrace) {
-      _logger.warning(
-        'Failed to parse rag state.',
-        error: error,
-        stackTrace: stackTrace,
-      );
-      return null;
-    }
+    return refs;
   }
 
   SourceReference _citationToSourceReference(Citation c, RagSnapshot rag) {

--- a/packages/soliplex_client/lib/src/application/rag_snapshot.dart
+++ b/packages/soliplex_client/lib/src/application/rag_snapshot.dart
@@ -129,14 +129,16 @@ Uint8List? _decodePicture(
   }
 }
 
-/// A read-model view of the backend's `rag`-namespaced AG-UI state.
+/// A read-model view of a RAG skill's AG-UI state slice.
 ///
-/// The `rag` state carries `citations` as a list of chunk ids and a
-/// `citation_index` map resolving each id to a full [Citation]. This
-/// snapshot exposes only what citation extraction and figure rendering
-/// need: the citation ids, id → [Citation] resolution, and inline picture
-/// bytes / captions. Other fields (e.g. `searches`, `document_filter`) are
-/// read through a resilient per-entry reader when a consumer needs them.
+/// Every RAG-producing skill publishes the same citation shape under its
+/// own namespace — `rag` and `analysis` both carry `citations` as a list
+/// of chunk ids and a `citation_index` map resolving each id to a full
+/// [Citation]. This snapshot exposes only what citation extraction and
+/// figure rendering need: the citation ids, id → [Citation] resolution,
+/// and inline picture bytes / captions. Other fields (e.g. `searches`,
+/// `document_filter`, and `analysis`'s `executions`) are read through a
+/// resilient per-entry reader when a consumer needs them, or ignored.
 ///
 /// [RagSnapshot.fromJson] parses `citations` and `citation_index`
 /// entry-by-entry so one malformed entry is logged and skipped rather than
@@ -166,7 +168,7 @@ class RagSnapshot {
     }
 
     final index = <String, Citation>{};
-    final rawIndex = json['citation_index'];
+    final rawIndex = json[_citationIndexKey];
     if (rawIndex is Map) {
       for (final entry in rawIndex.entries) {
         final key = entry.key;
@@ -199,6 +201,38 @@ class RagSnapshot {
     }
 
     return RagSnapshot._(ids, index, _indexPictures(json));
+  }
+
+  /// Wire key marking a citation-bearing skill-state block: the
+  /// `id → Citation` map the extractor needs to render a source.
+  static const _citationIndexKey = 'citation_index';
+
+  /// Every citation-bearing namespace block in a full agent-state map,
+  /// identified by a [`_citationIndexKey`] map. Non-citation namespaces
+  /// (e.g. `bubble-sandbox`) and non-Map or mistyped blocks are skipped,
+  /// so this is the single place that knows how a citation block is shaped.
+  ///
+  /// [RagSnapshot.fromJson] is resilient by construction and should not
+  /// throw, but a block that fails to parse is caught and skipped rather
+  /// than propagated: one malformed namespace must not take down the
+  /// others, nor abort the unguarded replay path that consumes this.
+  static List<RagSnapshot> extractAll(Map<String, dynamic> state) {
+    final snapshots = <RagSnapshot>[];
+    for (final raw in state.values) {
+      if (raw is! Map<String, dynamic> || raw[_citationIndexKey] is! Map) {
+        continue;
+      }
+      try {
+        snapshots.add(RagSnapshot.fromJson(raw));
+      } on Object catch (error, stackTrace) {
+        _logger.warning(
+          'RagSnapshot: skipping a citation namespace that failed to parse.',
+          error: error,
+          stackTrace: stackTrace,
+        );
+      }
+    }
+    return snapshots;
   }
 
   final List<String> _citationIds;

--- a/packages/soliplex_client/test/application/citation_extractor_test.dart
+++ b/packages/soliplex_client/test/application/citation_extractor_test.dart
@@ -350,5 +350,46 @@ void main() {
         },
       );
     });
+
+    group('multiple namespaces', () {
+      Map<String, dynamic> citation(String chunkId) => {
+            'chunk_id': chunkId,
+            'content': 'content for $chunkId',
+            'document_id': 'doc-1',
+            'document_uri': 'https://example.com/doc.pdf',
+          };
+
+      Map<String, dynamic> block(List<String> citations) => {
+            'citation_index': {for (final id in citations) id: citation(id)},
+            'citations': citations,
+          };
+
+      test('extracts citations from the analysis namespace', () {
+        final previous = <String, dynamic>{'analysis': block(const [])};
+        final current = <String, dynamic>{
+          'analysis': block(const ['a1']),
+        };
+
+        final refs = extractor.extractNew(previous, current);
+
+        expect(refs, hasLength(1));
+        expect(refs.single.chunkId, 'a1');
+      });
+
+      test('deduplicates a chunk cited in both rag and analysis', () {
+        final previous = <String, dynamic>{
+          'rag': block(const []),
+          'analysis': block(const []),
+        };
+        final current = <String, dynamic>{
+          'rag': block(const ['shared']),
+          'analysis': block(const ['shared', 'analysis-only']),
+        };
+
+        final refs = extractor.extractNew(previous, current);
+
+        expect(refs.map((r) => r.chunkId), ['shared', 'analysis-only']);
+      });
+    });
   });
 }


### PR DESCRIPTION
## Problem

The analysis agent cites sources in its reply, but no citations render in the
client. Citation extraction read **only** the `rag` state namespace
(`state['rag']`), while RAG-producing skills each publish their citations under
their own AG-UI state namespace. The analysis skill writes to `state['analysis']`
(an `AnalysisState`, structurally a superset of `RAGState`), so its citations
were never seen — the reply's inline prose citations were invisible to the
pipeline, which is driven entirely by the structured citation state.

## Fix

Extraction now reads **every citation-bearing namespace** in the agent state
rather than a hardcoded `rag`:

- `RagSnapshot.extractAll(state)` (behind the schema firewall) collects each
  namespace block that carries a `citation_index` map — the exact data the
  extractor needs to resolve a chunk id into a renderable citation. This is
  self-describing, so `rag`, `analysis`, and any future retrieval skill are
  picked up with no per-namespace hardcoding and no plumbing of room/agent
  metadata into the extractor.
- `CitationExtractor.extractNew` diffs the combined citation ids across those
  namespaces and dedupes by chunk id, so a chunk cited in more than one
  namespace in a single turn yields one reference.
- A per-namespace parse guard in `extractAll` keeps one malformed block from
  dropping citations in the others, and makes `extractNew` total so the
  history-replay path (which calls it unguarded) can't be aborted by a bad
  block.

Backend verification: the `analysis` skill's `citations` list is cleared at each
invocation start identically to `rag` (`_reset_invocation_state`), so the
per-run diff behaves the same for both namespaces.

## Testing

- Added tests: citations extracted from the `analysis` namespace; a chunk cited
  in both `rag` and `analysis` yields a single deduped reference. Both failed
  first (RED) against the `rag`-only code, then passed.
- Existing citation/rag-snapshot edge-case tests unchanged and green.
- `flutter analyze` clean; `dart format` clean; full `soliplex_client`
  `application/` suite passes (196 tests).

## Follow-up (not in this PR)

The analysis skill also emits `executions` (sandbox code-run results:
code/stdout/stderr/success) under `state['analysis']`, which the client renders
nowhere. That is a separate feature tracked in #453 — out of scope here, which
is strictly the citations fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
