### PR TITLE
fix: detect sandbox skill for attachments (replaces enable_attachments)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,11 @@ Versions follow the `version+build` scheme from `pubspec.yaml`, bumped via
 
 ### Changed
 
+- File attachments now appear based on the `bubble-sandbox` skill — the room's
+  configured skills for room-level (admin) uploads, and a thread's AG-UI state
+  for thread-level uploads — instead of an `enable_attachments` room flag the
+  backend no longer sends. Attachments were effectively unreachable while gated
+  on that flag.
 - The lobby's rooms page is more compact on phones: a room's confidentiality
   marking and quiz indicator move to their own row so the room name keeps the
   full tile width, the sort control collapses to an icon button that shares the

--- a/lib/src/modules/room/ui/room_info/features_card.dart
+++ b/lib/src/modules/room/ui/room_info/features_card.dart
@@ -30,7 +30,7 @@ class FeaturesCard extends StatelessWidget {
       children: [
         InfoRow(
           label: 'Attachments',
-          value: room.enableAttachments ? 'Enabled' : 'Disabled',
+          value: room.supportsAttachments ? 'Enabled' : 'Disabled',
         ),
         InfoRow(
           label: 'Allow MCP',

--- a/lib/src/modules/room/ui/room_info_screen.dart
+++ b/lib/src/modules/room/ui/room_info_screen.dart
@@ -239,7 +239,7 @@ class _RoomInfoBody extends StatelessWidget {
             contentOf: (e) => _buildToolsetContent(e.value),
           ),
           ClientToolsCard(clientToolsFuture: clientToolsFuture),
-          if (room.enableAttachments)
+          if (room.supportsAttachments)
             _UploadedFilesCard(
               uploadRegistry: uploadRegistry,
               serverEntry: serverEntry,

--- a/lib/src/modules/room/ui/room_screen.dart
+++ b/lib/src/modules/room/ui/room_screen.dart
@@ -295,6 +295,12 @@ class _RoomScreenState extends State<RoomScreen> {
 
   late DocumentFilterHydrator _filterHydrator;
 
+  /// Per-thread attachment support hydrated from thread history (the sandbox
+  /// namespace in the thread's AG-UI state). A missing entry means history has
+  /// not loaded, or was bypassed for a registry-restored / just-spawned thread;
+  /// callers fall back to the room's current capability in that case.
+  final Map<String, bool> _threadAttachmentSupport = <String, bool>{};
+
   /// Show the filter button only when filtering is enabled and there is
   /// something to filter (or we failed to find out).
   bool get _showDocumentFilter =>
@@ -841,10 +847,16 @@ class _RoomScreenState extends State<RoomScreen> {
     }
   }
 
-  /// Feeds the thread's last-run filter to the hydrator on history load.
+  /// Records thread-level attachment support and feeds the thread's last-run
+  /// filter to the hydrator on history load.
   void _onThreadHistoryLoaded(String threadId, ThreadHistory history) {
-    if (!_filterEnabled) return;
     if (threadId != widget.threadId) return; // stale fetch for another thread
+    if (_threadAttachmentSupport[threadId] != history.supportsAttachments) {
+      setState(() {
+        _threadAttachmentSupport[threadId] = history.supportsAttachments;
+      });
+    }
+    if (!_filterEnabled) return;
     _filterHydrator.setFilter(threadId, history.documentFilter);
   }
 
@@ -1556,14 +1568,17 @@ class _RoomScreenState extends State<RoomScreen> {
 
   Widget _buildContent(Room? room) {
     final threadView = _state.activeThreadView;
-    final attachEnabled = room?.enableAttachments ?? false;
+    final roomAttachEnabled = room?.supportsAttachments ?? false;
     final messagesStatus = threadView?.messages.watch(context);
 
-    final UploadsStatus roomStatus = attachEnabled
+    final UploadsStatus roomStatus = roomAttachEnabled
         ? _state.uploadTracker.roomUploads(widget.roomId).watch(context)
         : const UploadsLoaded(<DisplayUpload>[]);
     final threadId = threadView?.threadId;
-    final UploadsStatus threadStatus = attachEnabled && threadId != null
+    final threadAttachEnabled = threadId != null
+        ? (_threadAttachmentSupport[threadId] ?? roomAttachEnabled)
+        : false;
+    final UploadsStatus threadStatus = threadAttachEnabled
         ? _state.uploadTracker
             .threadUploads(widget.roomId, threadId)
             .watch(context)
@@ -1962,7 +1977,7 @@ class _RoomScreenState extends State<RoomScreen> {
             error: roomError,
             onDismiss: _state.clearError,
           ),
-        if (room?.enableAttachments ?? false)
+        if (room?.supportsAttachments ?? false)
           UploadEventBanner(
             tracker: _state.uploadTracker,
             roomId: widget.roomId,
@@ -1980,7 +1995,8 @@ class _RoomScreenState extends State<RoomScreen> {
     final streaming = threadView.streamingState.watch(context);
     final sendError = threadView.lastSendError.watch(context);
     final reconnectStatus = threadView.reconnectStatus.watch(context);
-    final attachEnabled = room?.enableAttachments ?? false;
+    final attachEnabled = _threadAttachmentSupport[threadView.threadId] ??
+        (room?.supportsAttachments ?? false);
 
     _restoreUnsentText(sendError?.unsentText);
 
@@ -2093,7 +2109,12 @@ class _RoomScreenState extends State<RoomScreen> {
     Room? room,
     ThreadViewStatus? status,
   ) {
-    final attachEnabled = room?.enableAttachments ?? false;
+    final threadId = threadView?.threadId;
+    final attachEnabled = threadId != null
+        ? (_threadAttachmentSupport[threadId] ??
+            room?.supportsAttachments ??
+            false)
+        : (room?.supportsAttachments ?? false);
     VoidCallback? attachCallback(Future<PickFilesResult?> Function() pick) {
       if (!attachEnabled) return null;
       return threadView != null

--- a/lib/src/modules/room/ui/room_screen.dart
+++ b/lib/src/modules/room/ui/room_screen.dart
@@ -850,6 +850,7 @@ class _RoomScreenState extends State<RoomScreen> {
   /// Records thread-level attachment support and feeds the thread's last-run
   /// filter to the hydrator on history load.
   void _onThreadHistoryLoaded(String threadId, ThreadHistory history) {
+    if (!mounted) return;
     if (threadId != widget.threadId) return; // stale fetch for another thread
     if (_threadAttachmentSupport[threadId] != history.supportsAttachments) {
       setState(() {

--- a/packages/soliplex_client/lib/src/api/mappers.dart
+++ b/packages/soliplex_client/lib/src/api/mappers.dart
@@ -333,7 +333,6 @@ Room roomFromJson(Map<String, dynamic> json) {
     quizzes: quizzes,
     suggestions: suggestions,
     welcomeMessage: (json['welcome_message'] as String?) ?? '',
-    enableAttachments: json['enable_attachments'] as bool? ?? false,
     allowMcp: json['allow_mcp'] as bool? ?? false,
     agent: agent,
     skills: skills,
@@ -357,7 +356,6 @@ Map<String, dynamic> roomToJson(Room room) {
     if (room.description.isNotEmpty) 'description': room.description,
     if (room.metadata.isNotEmpty) 'metadata': room.metadata,
     if (room.welcomeMessage.isNotEmpty) 'welcome_message': room.welcomeMessage,
-    if (room.enableAttachments) 'enable_attachments': room.enableAttachments,
     if (room.skills.isNotEmpty)
       'skills': {
         for (final entry in room.skills.entries)

--- a/packages/soliplex_client/lib/src/domain/attachments.dart
+++ b/packages/soliplex_client/lib/src/domain/attachments.dart
@@ -1,0 +1,6 @@
+/// Name of the skill whose presence enables file attachments.
+///
+/// The backend uses this same string as the AG-UI state namespace it seeds
+/// into every thread created in a room that has the skill, so it identifies
+/// attachment capability at both the room and thread level.
+const sandboxSkillName = 'bubble-sandbox';

--- a/packages/soliplex_client/lib/src/domain/domain.dart
+++ b/packages/soliplex_client/lib/src/domain/domain.dart
@@ -1,4 +1,5 @@
 export 'activity_record.dart';
+export 'attachments.dart';
 export 'auth_provider_config.dart';
 export 'backend_version_info.dart';
 export 'chat_message.dart';

--- a/packages/soliplex_client/lib/src/domain/room.dart
+++ b/packages/soliplex_client/lib/src/domain/room.dart
@@ -1,5 +1,6 @@
 import 'package:meta/meta.dart';
 
+import 'package:soliplex_client/src/domain/attachments.dart';
 import 'package:soliplex_client/src/domain/mcp_client_toolset.dart';
 import 'package:soliplex_client/src/domain/room_agent.dart';
 import 'package:soliplex_client/src/domain/room_skill.dart';
@@ -96,6 +97,10 @@ class Room {
 
   /// Whether the room has any AG-UI feature names.
   bool get hasAguiFeatures => aguiFeatureNames.isNotEmpty;
+
+  /// Whether this room is configured for file attachments (it carries the
+  /// [sandboxSkillName] skill).
+  bool get supportsAttachments => skills.containsKey(sandboxSkillName);
 
   /// Creates a copy of this room with the given fields replaced.
   Room copyWith({

--- a/packages/soliplex_client/lib/src/domain/room.dart
+++ b/packages/soliplex_client/lib/src/domain/room.dart
@@ -18,7 +18,6 @@ class Room {
     this.quizzes = const {},
     this.suggestions = const [],
     this.welcomeMessage = '',
-    this.enableAttachments = false,
     this.allowMcp = false,
     this.agent,
     this.skills = const {},
@@ -49,9 +48,6 @@ class Room {
 
   /// Welcome message shown when entering the room.
   final String welcomeMessage;
-
-  /// Whether file attachments are enabled for this room.
-  final bool enableAttachments;
 
   /// Whether MCP server access is allowed for this room.
   final bool allowMcp;
@@ -111,7 +107,6 @@ class Room {
     Map<String, String>? quizzes,
     List<String>? suggestions,
     String? welcomeMessage,
-    bool? enableAttachments,
     bool? allowMcp,
     RoomAgent? agent,
     Map<String, RoomSkill>? skills,
@@ -128,7 +123,6 @@ class Room {
       quizzes: quizzes ?? this.quizzes,
       suggestions: suggestions ?? this.suggestions,
       welcomeMessage: welcomeMessage ?? this.welcomeMessage,
-      enableAttachments: enableAttachments ?? this.enableAttachments,
       allowMcp: allowMcp ?? this.allowMcp,
       agent: agent ?? this.agent,
       skills: skills ?? this.skills,

--- a/packages/soliplex_client/lib/src/domain/thread_history.dart
+++ b/packages/soliplex_client/lib/src/domain/thread_history.dart
@@ -1,6 +1,7 @@
 import 'package:ag_ui/ag_ui.dart';
 import 'package:meta/meta.dart';
 
+import 'package:soliplex_client/src/domain/attachments.dart';
 import 'package:soliplex_client/src/domain/chat_message.dart';
 import 'package:soliplex_client/src/domain/message_state.dart';
 
@@ -50,6 +51,10 @@ class ThreadHistory {
   /// when no run carries one. The backend keeps no merged filter state, so this
   /// (not any state event) is the only record of the thread's active filter.
   final String? documentFilter;
+
+  /// Whether this thread's AG-UI state carries the [sandboxSkillName]
+  /// namespace, i.e. attachments are available for this thread.
+  bool get supportsAttachments => aguiState.containsKey(sandboxSkillName);
 }
 
 /// Decoded AG-UI events for a single run, in arrival order.

--- a/packages/soliplex_client/test/api/mappers_test.dart
+++ b/packages/soliplex_client/test/api/mappers_test.dart
@@ -225,30 +225,6 @@ void main() {
         expect(room.hasWelcomeMessage, isFalse);
       });
 
-      test('parses enable_attachments', () {
-        final json = <String, dynamic>{
-          'id': 'room-1',
-          'name': 'Test Room',
-          'enable_attachments': true,
-        };
-
-        final room = roomFromJson(json);
-
-        expect(room.enableAttachments, isTrue);
-      });
-
-      test('handles null enable_attachments', () {
-        final json = <String, dynamic>{
-          'id': 'room-1',
-          'name': 'Test Room',
-          'enable_attachments': null,
-        };
-
-        final room = roomFromJson(json);
-
-        expect(room.enableAttachments, isFalse);
-      });
-
       test('parses tools map (backend format)', () {
         final json = <String, dynamic>{
           'id': 'room-1',
@@ -410,7 +386,6 @@ void main() {
         expect(json.containsKey('description'), isFalse);
         expect(json.containsKey('metadata'), isFalse);
         expect(json.containsKey('welcome_message'), isFalse);
-        expect(json.containsKey('enable_attachments'), isFalse);
         expect(json.containsKey('tools'), isFalse);
         expect(json.containsKey('agui_feature_names'), isFalse);
       });
@@ -420,7 +395,6 @@ void main() {
           id: 'room-1',
           name: 'Test Room',
           welcomeMessage: 'Welcome!',
-          enableAttachments: true,
           toolDefinitions: [
             {'tool_name': 'search', 'tool_description': 'Search'},
           ],
@@ -430,7 +404,6 @@ void main() {
         final json = roomToJson(room);
 
         expect(json['welcome_message'], equals('Welcome!'));
-        expect(json['enable_attachments'], isTrue);
         expect(json['tools'], isA<Map<String, dynamic>>());
         final toolsMap = json['tools'] as Map<String, dynamic>;
         final firstTool = toolsMap.values.first as Map<String, dynamic>;
@@ -1857,18 +1830,6 @@ void main() {
         expect(room.welcomeMessage, equals('Welcome!'));
       });
 
-      test('parses enable_attachments', () {
-        final json = <String, dynamic>{
-          'id': 'room-1',
-          'name': 'Test Room',
-          'enable_attachments': true,
-        };
-
-        final room = roomFromJson(json);
-
-        expect(room.enableAttachments, isTrue);
-      });
-
       test('parses allow_mcp', () {
         final json = <String, dynamic>{
           'id': 'room-1',
@@ -1899,7 +1860,6 @@ void main() {
         final room = roomFromJson(json);
 
         expect(room.welcomeMessage, equals(''));
-        expect(room.enableAttachments, isFalse);
         expect(room.allowMcp, isFalse);
         expect(room.aguiFeatureNames, isEmpty);
       });

--- a/packages/soliplex_client/test/domain/attachments_test.dart
+++ b/packages/soliplex_client/test/domain/attachments_test.dart
@@ -1,0 +1,8 @@
+import 'package:soliplex_client/soliplex_client.dart';
+import 'package:test/test.dart';
+
+void main() {
+  test('sandboxSkillName matches the backend wire key', () {
+    expect(sandboxSkillName, 'bubble-sandbox');
+  });
+}

--- a/packages/soliplex_client/test/domain/room_test.dart
+++ b/packages/soliplex_client/test/domain/room_test.dart
@@ -13,7 +13,6 @@ void main() {
       expect(room.quizzes, equals(const <String, String>{}));
       expect(room.suggestions, equals(const <String>[]));
       expect(room.welcomeMessage, equals(''));
-      expect(room.enableAttachments, isFalse);
       expect(room.toolDefinitions, equals(const <Map<String, dynamic>>[]));
       expect(room.aguiFeatureNames, equals(const <String>[]));
       expect(room.quizIds, isEmpty);
@@ -51,7 +50,6 @@ void main() {
         quizzes: {'quiz-1': 'Quiz One', 'quiz-2': 'Quiz Two'},
         suggestions: ['How can I help?', 'Tell me more'],
         welcomeMessage: 'Welcome!',
-        enableAttachments: true,
         allowMcp: true,
         agent: agent,
         tools: {'search': tool},
@@ -72,7 +70,6 @@ void main() {
       );
       expect(room.suggestions, equals(['How can I help?', 'Tell me more']));
       expect(room.welcomeMessage, equals('Welcome!'));
-      expect(room.enableAttachments, isTrue);
       expect(room.allowMcp, isTrue);
       expect(room.agent, equals(agent));
       expect(room.tools, equals({'search': tool}));
@@ -108,7 +105,6 @@ void main() {
           quizzes: {'quiz-1': 'Quiz One'},
           suggestions: ['Suggestion 1', 'Suggestion 2'],
           welcomeMessage: 'Hello!',
-          enableAttachments: true,
           toolDefinitions: [
             {'tool_name': 'lookup'},
           ],
@@ -123,7 +119,6 @@ void main() {
         expect(modified.quizIds, equals(['quiz-1']));
         expect(modified.suggestions, equals(['Suggestion 1', 'Suggestion 2']));
         expect(modified.welcomeMessage, equals('Hello!'));
-        expect(modified.enableAttachments, isTrue);
         expect(modified.toolDefinitions, hasLength(1));
         expect(modified.aguiFeatureNames, equals(['streaming']));
       });
@@ -137,7 +132,6 @@ void main() {
           quizzes: {'quiz-1': 'Quiz One'},
           suggestions: ['Suggestion'],
           welcomeMessage: 'Hi',
-          enableAttachments: true,
           toolDefinitions: [
             {'tool_name': 'test'},
           ],
@@ -153,7 +147,6 @@ void main() {
         expect(copy.quizIds, equals(room.quizIds));
         expect(copy.suggestions, equals(room.suggestions));
         expect(copy.welcomeMessage, equals(room.welcomeMessage));
-        expect(copy.enableAttachments, equals(room.enableAttachments));
         expect(copy.toolDefinitions, equals(room.toolDefinitions));
         expect(copy.aguiFeatureNames, equals(room.aguiFeatureNames));
       });

--- a/packages/soliplex_client/test/domain/room_test.dart
+++ b/packages/soliplex_client/test/domain/room_test.dart
@@ -190,5 +190,37 @@ void main() {
       expect(str, contains('room-1'));
       expect(str, contains('Test Room'));
     });
+
+    group('supportsAttachments', () {
+      test('is true when the sandbox skill is present', () {
+        const room = Room(
+          id: 'r1',
+          name: 'Test',
+          skills: {
+            sandboxSkillName: RoomSkill(
+              name: sandboxSkillName,
+              description: 'Sandbox',
+            ),
+          },
+        );
+        expect(room.supportsAttachments, isTrue);
+      });
+
+      test('is false when the sandbox skill is absent', () {
+        const room = Room(id: 'r1', name: 'Test');
+        expect(room.supportsAttachments, isFalse);
+      });
+
+      test('is false when only a different skill is present', () {
+        const room = Room(
+          id: 'r1',
+          name: 'Test',
+          skills: {
+            'other-skill': RoomSkill(name: 'other-skill', description: 'Other'),
+          },
+        );
+        expect(room.supportsAttachments, isFalse);
+      });
+    });
   });
 }

--- a/packages/soliplex_client/test/domain/thread_history_test.dart
+++ b/packages/soliplex_client/test/domain/thread_history_test.dart
@@ -1,8 +1,4 @@
-import 'package:ag_ui/ag_ui.dart';
-import 'package:soliplex_client/src/domain/chat_message.dart';
-import 'package:soliplex_client/src/domain/message_state.dart';
-import 'package:soliplex_client/src/domain/source_reference.dart';
-import 'package:soliplex_client/src/domain/thread_history.dart';
+import 'package:soliplex_client/soliplex_client.dart';
 import 'package:test/test.dart';
 
 void main() {
@@ -141,6 +137,29 @@ void main() {
             .documentFilter,
         equals("id = 'x'"),
       );
+    });
+
+    group('supportsAttachments', () {
+      test('is true when aguiState carries the sandbox namespace', () {
+        final history = ThreadHistory(
+          messages: const [],
+          aguiState: const {sandboxSkillName: <String, dynamic>{}},
+        );
+        expect(history.supportsAttachments, isTrue);
+      });
+
+      test('is false when aguiState lacks the sandbox namespace', () {
+        final history = ThreadHistory(messages: const []);
+        expect(history.supportsAttachments, isFalse);
+      });
+
+      test('is false when only other namespaces are present', () {
+        final history = ThreadHistory(
+          messages: const [],
+          aguiState: const {'rag': <String, dynamic>{}},
+        );
+        expect(history.supportsAttachments, isFalse);
+      });
     });
   });
 

--- a/test/helpers/fakes.dart
+++ b/test/helpers/fakes.dart
@@ -459,13 +459,24 @@ class ManualAgentSession implements AgentSession {
   final ThreadKey threadKey;
   final Completer<AgentResult> _resultCompleter = Completer<AgentResult>();
   final Signal<RunState> _runState = Signal<RunState>(const IdleState());
+  final Signal<ReconnectStatus?> _reconnectStatus =
+      Signal<ReconnectStatus?>(null);
   bool cancelCalled = false;
+
+  @override
+  AgentSessionState get state => AgentSessionState.spawning;
 
   @override
   Future<AgentResult> get result => _resultCompleter.future;
 
   @override
   ReadonlySignal<RunState> get runState => _runState;
+
+  @override
+  ReadonlySignal<ReconnectStatus?> get reconnectStatus => _reconnectStatus;
+
+  @override
+  T? getExtension<T extends SessionExtension>() => null;
 
   @override
   void cancel() {

--- a/test/modules/room/ui/room_info/features_card_test.dart
+++ b/test/modules/room/ui/room_info/features_card_test.dart
@@ -31,7 +31,14 @@ void main() {
       final api = FakeSoliplexApi();
       await tester.pumpWidget(wrap(
         FeaturesCard(
-          room: baseRoom.copyWith(enableAttachments: true),
+          room: baseRoom.copyWith(
+            skills: const {
+              sandboxSkillName: RoomSkill(
+                name: sandboxSkillName,
+                description: 'Sandbox',
+              ),
+            },
+          ),
           api: api,
           roomId: 'r1',
         ),
@@ -46,7 +53,7 @@ void main() {
       final api = FakeSoliplexApi();
       await tester.pumpWidget(wrap(
         FeaturesCard(
-          room: baseRoom.copyWith(enableAttachments: false),
+          room: baseRoom,
           api: api,
           roomId: 'r1',
         ),

--- a/test/modules/room/ui/room_info_screen_test.dart
+++ b/test/modules/room/ui/room_info_screen_test.dart
@@ -11,11 +11,13 @@ import 'package:soliplex_frontend/src/modules/room/upload_tracker_registry.dart'
 import '../../../helpers/fakes.dart';
 import '../../../helpers/test_server_entry.dart';
 
+const _sandboxSkill = RoomSkill(name: sandboxSkillName, description: 'Sandbox');
+
 const _testRoom = Room(
   id: 'room-1',
   name: 'Test Room',
   description: 'A test room',
-  enableAttachments: true,
+  skills: {sandboxSkillName: _sandboxSkill},
   allowMcp: true,
   agent: DefaultRoomAgent(
     id: 'agent-1',
@@ -209,7 +211,8 @@ void main() {
     });
 
     testWidgets('shows empty skills section when no skills', (tester) async {
-      await tester.pumpWidget(_buildScreen());
+      final room = _testRoom.copyWith(skills: const {});
+      await tester.pumpWidget(_buildScreen(room: room));
       await tester.pumpAndSettle();
 
       await tester.scrollUntilVisible(

--- a/test/modules/room/ui/room_screen_test.dart
+++ b/test/modules/room/ui/room_screen_test.dart
@@ -27,6 +27,8 @@ import 'package:soliplex_frontend/src/modules/auth/server_entry.dart';
 import '../../../helpers/fakes.dart';
 import '../../../helpers/test_server_entry.dart';
 
+const _sandboxSkill = RoomSkill(name: sandboxSkillName, description: 'Sandbox');
+
 class _BlockingThreadsApi extends FakeSoliplexApi {
   final _completer = Completer<List<ThreadInfo>>();
 
@@ -634,7 +636,7 @@ void main() {
     api.nextRoom = const Room(
       id: 'room-1',
       name: 'Attachable',
-      enableAttachments: true,
+      skills: {sandboxSkillName: _sandboxSkill},
     );
     api.nextThreads = const [];
     // nextRoomUploads / nextThreadUploads default to empty → the chip
@@ -668,7 +670,7 @@ void main() {
     api.nextRoom = const Room(
       id: 'room-1',
       name: 'Attachable',
-      enableAttachments: true,
+      skills: {sandboxSkillName: _sandboxSkill},
     );
     api.nextThreads = const [];
     api.nextRoomUploads = [
@@ -709,7 +711,7 @@ void main() {
     api.nextRoom = const Room(
       id: 'room-1',
       name: 'Attachable',
-      enableAttachments: true,
+      skills: {sandboxSkillName: _sandboxSkill},
     );
     api.nextThreads = const [];
     api.nextRoomUploads = [
@@ -746,7 +748,7 @@ void main() {
     api.nextRoom = const Room(
       id: 'room-1',
       name: 'Attachable',
-      enableAttachments: true,
+      skills: {sandboxSkillName: _sandboxSkill},
     );
     api.nextThreads = const [];
     api.nextRoomUploadsError =
@@ -800,6 +802,162 @@ void main() {
     expect(textField.readOnly, isTrue);
 
     blockingApi.completeThreads(blockingApi.nextThreads!);
+  });
+
+  group('attachment detection', () {
+    testWidgets('welcome composer shows attach when room has sandbox skill',
+        (tester) async {
+      tester.view.physicalSize = const Size(1200, 800);
+      tester.view.devicePixelRatio = 1.0;
+      addTearDown(tester.view.resetPhysicalSize);
+
+      api.nextRoom = const Room(
+        id: 'room-1',
+        name: 'Attachable',
+        skills: {sandboxSkillName: _sandboxSkill},
+      );
+      api.nextThreads = const [];
+
+      await tester.pumpWidget(MaterialApp(
+        home: RoomScreen(
+          serverEntry: entry,
+          roomId: 'room-1',
+          threadId: null,
+          runtimeManager: runtimeManager,
+          registry: registry,
+          uploadRegistry: uploadRegistry,
+          documentSelections: DocumentSelections(),
+        ),
+      ));
+      await tester.pumpAndSettle();
+
+      expect(find.byIcon(Icons.attach_file), findsOneWidget);
+    });
+
+    testWidgets('welcome composer hides attach without the sandbox skill',
+        (tester) async {
+      tester.view.physicalSize = const Size(1200, 800);
+      tester.view.devicePixelRatio = 1.0;
+      addTearDown(tester.view.resetPhysicalSize);
+
+      api.nextRoom = const Room(id: 'room-1', name: 'Plain');
+      api.nextThreads = const [];
+
+      await tester.pumpWidget(MaterialApp(
+        home: RoomScreen(
+          serverEntry: entry,
+          roomId: 'room-1',
+          threadId: null,
+          runtimeManager: runtimeManager,
+          registry: registry,
+          uploadRegistry: uploadRegistry,
+          documentSelections: DocumentSelections(),
+        ),
+      ));
+      await tester.pumpAndSettle();
+
+      expect(find.byIcon(Icons.attach_file), findsNothing);
+    });
+
+    testWidgets(
+        'active thread shows attach from thread AG-UI state, not room '
+        'skill', (tester) async {
+      tester.view.physicalSize = const Size(1200, 800);
+      tester.view.devicePixelRatio = 1.0;
+      addTearDown(tester.view.resetPhysicalSize);
+
+      // Room WITHOUT the skill; thread state WITH the namespace. Attach must
+      // still appear, proving the active thread reads thread state.
+      api.nextRoom = const Room(id: 'room-1', name: 'Plain');
+      api.nextThreads = const [];
+      api.nextThreadHistory = ThreadHistory(
+        messages: const [],
+        aguiState: const {sandboxSkillName: <String, dynamic>{}},
+      );
+
+      await tester.pumpWidget(MaterialApp(
+        home: RoomScreen(
+          serverEntry: entry,
+          roomId: 'room-1',
+          threadId: 'thread-1',
+          runtimeManager: runtimeManager,
+          registry: registry,
+          uploadRegistry: uploadRegistry,
+          documentSelections: DocumentSelections(),
+        ),
+      ));
+      await tester.pumpAndSettle();
+
+      expect(find.byIcon(Icons.attach_file), findsOneWidget);
+    });
+
+    testWidgets(
+        'active thread hides attach when thread state lacks the '
+        'namespace even if the room has the skill', (tester) async {
+      tester.view.physicalSize = const Size(1200, 800);
+      tester.view.devicePixelRatio = 1.0;
+      addTearDown(tester.view.resetPhysicalSize);
+
+      api.nextRoom = const Room(
+        id: 'room-1',
+        name: 'Attachable',
+        skills: {sandboxSkillName: _sandboxSkill},
+      );
+      api.nextThreads = const [];
+      api.nextThreadHistory = ThreadHistory(messages: const []);
+
+      await tester.pumpWidget(MaterialApp(
+        home: RoomScreen(
+          serverEntry: entry,
+          roomId: 'room-1',
+          threadId: 'thread-1',
+          runtimeManager: runtimeManager,
+          registry: registry,
+          uploadRegistry: uploadRegistry,
+          documentSelections: DocumentSelections(),
+        ),
+      ));
+      await tester.pumpAndSettle();
+
+      expect(find.byIcon(Icons.attach_file), findsNothing);
+    });
+
+    testWidgets('registry-restored thread falls back to room skill for attach',
+        (tester) async {
+      tester.view.physicalSize = const Size(1200, 800);
+      tester.view.devicePixelRatio = 1.0;
+      addTearDown(tester.view.resetPhysicalSize);
+
+      // Room has the skill; a live session is pre-registered so ThreadViewState
+      // restores from the registry and never fetches history (the sendToNewThread
+      // / return-to-running-thread path). The Map has no entry → the composer
+      // must fall back to room capability and still show attach.
+      api.nextRoom = const Room(
+        id: 'room-1',
+        name: 'Attachable',
+        skills: {sandboxSkillName: _sandboxSkill},
+      );
+      api.nextThreads = const [];
+      final key =
+          (serverId: entry.serverId, roomId: 'room-1', threadId: 'thread-1');
+      registry.register(key, ManualAgentSession(key));
+
+      await tester.pumpWidget(MaterialApp(
+        home: RoomScreen(
+          serverEntry: entry,
+          roomId: 'room-1',
+          threadId: 'thread-1',
+          runtimeManager: runtimeManager,
+          registry: registry,
+          uploadRegistry: uploadRegistry,
+          documentSelections: DocumentSelections(),
+        ),
+      ));
+      await tester.pump();
+      await tester.pump();
+
+      expect(find.byIcon(Icons.attach_file), findsOneWidget);
+    });
   });
 
   group('document filter button visibility', () {


### PR DESCRIPTION
## What

Replaces the dead `RoomConfig.enable_attachments` flag with detection of the
`bubble-sandbox` skill, per #452.

- **Room-level (admin) uploads** → detected via `Room.supportsAttachments`
  (`skills` map contains `"bubble-sandbox"`).
- **Thread-level uploads** → detected via `ThreadHistory.supportsAttachments`
  (thread AG-UI state contains `"bubble-sandbox"`), cached per-thread and
  hydrated from thread history.
- **Welcome / new-thread composer** (no thread yet) → falls back to room-level
  detection, since a thread created from the current room config is seeded with
  the skill's namespace.

The backend no longer emits `enable_attachments`, so the frontend flag always
resolved to `false` and the upload UI was unreachable.

## Why the two sources are equivalent (and when they diverge)

A room configured with the sandbox skill unions `"bubble-sandbox"` into its
`agui_feature_names`, and the backend seeds each newly-created thread's initial
AG-UI state from that list — so room `skills` and thread state carry the same
key for threads created under the current config. They diverge only across a
room config change, where the thread state remains authoritative for that
specific thread.

## The per-thread cache + room fallback

Thread-level support is cached in `_threadAttachmentSupport` (hydrated in
`_onThreadHistoryLoaded`) and read as
`_threadAttachmentSupport[threadId] ?? room.supportsAttachments`. The fallback
is required because `ThreadViewState` bypasses the history fetch (so
`onHistoryLoaded` never fires) for registry-restored and just-spawned threads —
notably a thread started from the welcome screen via `sendToNewThread`, which
registers its session before `selectThread`. Those threads were created under
the current room config, so the room capability predicts them correctly; once
history loads, the cached value (including an explicit `false`) takes over.

## Commits

- `feat: add sandbox-skill attachment capability getters` — `sandboxSkillName`,
  `Room.supportsAttachments`, `ThreadHistory.supportsAttachments` + tests
- `docs: changelog for sandbox attachment detection`
- `feat: gate upload UI on sandbox-skill detection` — the four gating sites,
  per-thread cache with fallback, `room_info` + `features_card`, widget tests
- `refactor: drop the dead enable_attachments room field` — field + wire
  parse/serialize + test cleanup
- `fix: guard thread-history callback setState with mounted check`

## Tests

- `soliplex_client`: getter tests including a wire-key pin
  (`sandboxSkillName == 'bubble-sandbox'`) and namespace-specific false cases.
- `room`: five widget tests covering welcome-screen (room skill), active-thread
  (thread state, including thread-state-overrides-room), and the
  registry-restored fallback.
- Full app suite green (2164/2164); analyzer + format clean; no
  `enable_attachments` references remain.

## Follow-ups (optional, not blocking)

- Extract a `_attachEnabledFor(threadId, room)` helper to DRY the null-coalescing
  across the three gating sites.
- Explicit `String` type annotation on `sandboxSkillName`.

Closes #452

🤖 Generated with [Claude Code](https://claude.com/claude-code)
