### PR TITLE
chore: version 0.97.1+74

### DIFF
--- a/lib/version.dart
+++ b/lib/version.dart
@@ -2,4 +2,4 @@
 ///
 /// Generated from pubspec.yaml. Run `dart run tool/update_version.dart` after
 /// changing the version in pubspec.yaml.
-const String soliplexVersion = '0.97.0+73';
+const String soliplexVersion = '0.97.1+74';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,7 +3,7 @@ description: Modular Flutter frontend framework for Soliplex
 publish_to: none
 # To update version, run:
 # dart run tool/bump_version.dart <major|minor|patch|build>
-version: 0.97.0+73
+version: 0.97.1+74
 
 environment:
   sdk: ^3.6.0


### PR DESCRIPTION
Version bump to `0.97.1+74` (patch).

- Updated `pubspec.yaml` and `lib/version.dart` via `dart run tool/bump_version.dart patch`.