### PR TITLE
fix: surface every source a run cited, including re-cited chunks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,6 +75,10 @@ Versions follow the `version+build` scheme from `pubspec.yaml`, bumped via
   citation-bearing namespace in the agent state rather than only `rag`, so a
   reply that cites sources renders its citations regardless of which retrieval
   skill produced them.
+- A reply now shows every source it cited. Previously a source cited again from
+  an earlier turn could be dropped, and a reply whose agent searched several
+  times kept only its last batch of sources; both now render in full, and a
+  thread shows the same sources live and after a reload.
 
 ## [0.94.0+68] - 2026-07-17
 

--- a/packages/soliplex_agent/lib/src/orchestration/run_orchestrator.dart
+++ b/packages/soliplex_agent/lib/src/orchestration/run_orchestrator.dart
@@ -84,7 +84,12 @@ class RunOrchestrator {
 
   final CitationExtractor _citationExtractor = CitationExtractor();
 
-  Map<String, dynamic> _preRunAguiState = const {};
+  /// Union of citation ids seen in this turn's `StateDeltaEvent`s. Each delta's
+  /// touched namespace holds one skill invocation's absolute cited set (via
+  /// [CitationExtractor.citationIdsInDelta]); the union across the turn is its
+  /// complete set. Cleared at turn start (and on reset/sync). See
+  /// [_extractCitations].
+  final Set<String> _turnCitationIds = <String>{};
   String? _userMessageId;
 
   final StreamController<RunState> _controller =
@@ -328,7 +333,7 @@ class RunOrchestrator {
     _guardNotDisposed();
     _cancelToken?.cancel();
     _cleanup();
-    _preRunAguiState = const {};
+    _turnCitationIds.clear();
     _userMessageId = null;
     _setState(const IdleState());
   }
@@ -345,7 +350,7 @@ class RunOrchestrator {
     if (_currentState is RunningState || _currentState is ToolYieldingState) {
       throw StateError('Cannot sync while a run is active');
     }
-    _preRunAguiState = const {};
+    _turnCitationIds.clear();
     _userMessageId = null;
     _setState(const IdleState());
   }
@@ -808,7 +813,7 @@ class RunOrchestrator {
     final baseState = cachedHistory?.aguiState ?? const {};
     final aguiState =
         stateOverlay == null ? baseState : _mergeState(baseState, stateOverlay);
-    _preRunAguiState = aguiState;
+    _turnCitationIds.clear();
     _userMessageId = userMsg.id;
     return Conversation(
       threadId: key.threadId,
@@ -912,6 +917,27 @@ class RunOrchestrator {
         try {
           final result =
               processEvent(running.conversation, running.streaming, event);
+          // Accumulate the citation ids this StateDeltaEvent cited, scoped to
+          // the namespaces it touched — one skill invocation's absolute cited
+          // set. Snapshots are intentionally not accumulated: they only echo
+          // the round-tripped seed. Fail-soft because citations are a derived
+          // projection.
+          if (event is StateDeltaEvent) {
+            try {
+              _turnCitationIds.addAll(
+                _citationExtractor.citationIdsInDelta(
+                  result.conversation.aguiState,
+                  event,
+                ),
+              );
+            } on Object catch (e, st) {
+              _logger.error(
+                'Citation id accumulation failed on run ${running.runId}',
+                error: e,
+                stackTrace: st,
+              );
+            }
+          }
           _mapEventResult(running, result, event);
         } on Object catch (e, st) {
           _appendDropTile(
@@ -1059,68 +1085,53 @@ class RunOrchestrator {
     }
   }
 
-  /// Extracts citations by diffing AG-UI state before/after this run segment.
+  /// Resolves this turn's accumulated citation ids ([_turnCitationIds]) against
+  /// the current AG-UI state and writes them to the turn's [MessageState].
   ///
   /// Always creates a [MessageState] with the [runId] so downstream consumers
   /// (e.g. feedback buttons) can resolve it, even when there are no citations.
-  /// Updates [_preRunAguiState] for the next segment in a tool loop.
   ///
   /// In multi-segment tool loops, [runId] is overwritten each segment so the
   /// final [MessageState] carries the last segment's run ID — the one whose
-  /// output the user sees and may submit feedback on.
+  /// output the user sees and may submit feedback on. The accumulator is
+  /// monotonic across segments, so resolving at every call site (including
+  /// tool-yield boundaries) is safe — the final terminal replaces the
+  /// MessageState with the complete set.
   ///
-  /// `CitationExtractor.extractNew` calls into generated schema types
-  /// (`RagSnapshot.resolveCitation`, `SourceReference`'s ctor on
-  /// non-null fields the wire might omit) — schema drift can surface
-  /// here as `FormatException`, `TypeError` (null on non-null), or
-  /// other generated-type throws. Catching `Object` is deliberate:
-  /// citations are a derived projection, so fail-soft (skip
-  /// citations, complete the run) is the right UX for both
-  /// data-drift and programming bugs — propagating instead would
-  /// abort a working run with no user benefit. Logged at `error`
-  /// with stack trace so Sentry / `BackendLogSink` still surface
-  /// real bugs. The throw bypasses the [_preRunAguiState] update at
-  /// the next line so the next run's diff still resolves against the
-  /// prior baseline; only this segment's citations are skipped. No
-  /// drop tile — citations are a derived projection, not user-facing
-  /// content.
+  /// The `on Object catch` is defensive. `CitationExtractor.resolve` is
+  /// contractually non-throwing — schema drift is absorbed inside
+  /// `RagSnapshot.extractAll`, which skips namespaces that fail to parse — so
+  /// this should not fire on bad data. The guard exists only so a future
+  /// programming bug in resolution fails soft rather than aborting a working
+  /// run: citations are a derived projection, so skipping them and completing
+  /// the run is the right UX. Logged at `error` with stack trace so Sentry /
+  /// `BackendLogSink` still surface real bugs. No drop tile — citations are
+  /// not user-facing content.
   Conversation _extractCitations(Conversation conversation, String runId) {
+    final userMessageId = _userMessageId;
+    if (userMessageId == null) return conversation;
+
+    var citations = const <SourceReference>[];
     try {
-      final userMessageId = _userMessageId;
-      if (userMessageId == null) return conversation;
-
-      final citations = _citationExtractor.extractNew(
-        _preRunAguiState,
+      citations = _citationExtractor.resolve(
+        _turnCitationIds,
         conversation.aguiState,
+        logContext: 'run $runId',
       );
-      _preRunAguiState = conversation.aguiState;
-
-      final existing = conversation.messageStates[userMessageId];
-      final seenChunkIds = <String>{};
-      final mergedCitations = <SourceReference>[];
-      for (final ref in [
-        if (existing != null) ...existing.sourceReferences,
-        ...citations,
-      ]) {
-        if (seenChunkIds.add(ref.chunkId)) {
-          mergedCitations.add(ref);
-        }
-      }
-
-      final messageState = MessageState(
-        userMessageId: userMessageId,
-        sourceReferences: mergedCitations,
-        runId: runId,
-      );
-      return conversation.withMessageState(userMessageId, messageState);
     } on Object catch (e, st) {
       _logger.error(
-        'Citation extraction failed for run $runId',
+        'Citation resolution failed for run $runId',
         error: e,
         stackTrace: st,
       );
-      return conversation;
     }
+
+    final messageState = MessageState(
+      userMessageId: userMessageId,
+      sourceReferences: citations,
+      runId: runId,
+    );
+    return conversation.withMessageState(userMessageId, messageState);
   }
 
   void _onStreamDone() {

--- a/packages/soliplex_agent/test/orchestration/run_orchestrator_test.dart
+++ b/packages/soliplex_agent/test/orchestration/run_orchestrator_test.dart
@@ -2314,24 +2314,53 @@ void main() {
   });
 
   group('citation extraction', () {
+    // Each skill invocation emits one StateDeltaEvent whose post-delta
+    // rag.citations is that invocation's absolute set; citation_index is
+    // session-cumulative. Citations never arrive via StateSnapshotEvent (the
+    // only snapshot is the RUN_STARTED rebase echoing the round-tripped seed),
+    // so tests deliver citations exclusively via StateDeltaEvent.
+    StateDeltaEvent namespaceDelta(
+      String namespace, {
+      required Map<String, Map<String, dynamic>> citationIndex,
+      required List<String> citations,
+    }) =>
+        StateDeltaEvent(
+          delta: [
+            {
+              'op': 'add',
+              'path': '/$namespace',
+              'value': {
+                'citation_index': citationIndex,
+                'citations': citations,
+              },
+            },
+          ],
+        );
+
+    StateDeltaEvent ragDelta({
+      required Map<String, Map<String, dynamic>> citationIndex,
+      required List<String> citations,
+    }) =>
+        namespaceDelta(
+          'rag',
+          citationIndex: citationIndex,
+          citations: citations,
+        );
+
+    Map<String, dynamic> citation(String chunkId) => {
+          'chunk_id': chunkId,
+          'content': 'Citation text',
+          'document_id': 'doc-1',
+          'document_uri': 'https://example.com/doc.pdf',
+        };
+
     List<BaseEvent> citationEvents() => [
           const RunStartedEvent(threadId: 'thread-1', runId: _runId),
           const TextMessageStartEvent(messageId: 'msg-1'),
           const TextMessageContentEvent(messageId: 'msg-1', delta: 'Answer'),
-          const StateSnapshotEvent(
-            snapshot: {
-              'rag': {
-                'citation_index': {
-                  'chunk-1': {
-                    'chunk_id': 'chunk-1',
-                    'content': 'Citation text',
-                    'document_id': 'doc-1',
-                    'document_uri': 'https://example.com/doc.pdf',
-                  },
-                },
-                'citations': ['chunk-1'],
-              },
-            },
+          ragDelta(
+            citationIndex: {'chunk-1': citation('chunk-1')},
+            citations: ['chunk-1'],
           ),
           const TextMessageEndEvent(messageId: 'msg-1'),
           const RunFinishedEvent(threadId: 'thread-1', runId: _runId),
@@ -2372,6 +2401,173 @@ void main() {
       expect(entry.sourceReferences, isEmpty);
     });
 
+    test('unions citations across multiple deltas in one run', () async {
+      // Two skill invocations in a single run. The backend clears citations at
+      // each invocation start, so each delta carries only that invocation's
+      // set; the union is the run's complete cited set (Issue 2).
+      stubCreateRun();
+      stubRunAgent(
+        stream: Stream.fromIterable(<BaseEvent>[
+          const RunStartedEvent(threadId: 'thread-1', runId: _runId),
+          const TextMessageStartEvent(messageId: 'msg-1'),
+          const TextMessageContentEvent(messageId: 'msg-1', delta: 'Answer'),
+          ragDelta(
+            citationIndex: {'chunk-1': citation('chunk-1')},
+            citations: ['chunk-1'],
+          ),
+          ragDelta(
+            citationIndex: {
+              'chunk-1': citation('chunk-1'),
+              'chunk-2': citation('chunk-2'),
+            },
+            citations: ['chunk-2'],
+          ),
+          const TextMessageEndEvent(messageId: 'msg-1'),
+          const RunFinishedEvent(threadId: 'thread-1', runId: _runId),
+        ]),
+      );
+
+      await orchestrator.startRun(key: _key, userMessage: 'Search');
+      await Future<void>.delayed(Duration.zero);
+
+      final completed = orchestrator.currentState as CompletedState;
+      final refs =
+          completed.conversation.messageStates.values.first.sourceReferences;
+      expect(refs, hasLength(2));
+      expect(
+        refs.map((r) => r.chunkId),
+        containsAll(<String>['chunk-1', 'chunk-2']),
+      );
+    });
+
+    test('excludes a stale sibling namespace this run never invoked', () async {
+      // Prior turn left rag.citations=[seed-chunk]; the RUN_STARTED rebase
+      // echoes it (round-tripped seed). This run invokes only the analysis
+      // skill, so its delta touches /analysis alone. rag was never invoked
+      // this run — its stale citations must not be attributed here.
+      stubCreateRun();
+      stubRunAgent(
+        stream: Stream.fromIterable(<BaseEvent>[
+          const RunStartedEvent(threadId: 'thread-1', runId: _runId),
+          const StateSnapshotEvent(
+            snapshot: {
+              'rag': {
+                'citation_index': {
+                  'seed-chunk': {
+                    'chunk_id': 'seed-chunk',
+                    'content': 'Seed citation',
+                    'document_id': 'doc-seed',
+                    'document_uri': 'https://example.com/seed.pdf',
+                  },
+                },
+                'citations': ['seed-chunk'],
+              },
+            },
+          ),
+          const TextMessageStartEvent(messageId: 'msg-1'),
+          const TextMessageContentEvent(messageId: 'msg-1', delta: 'Answer'),
+          namespaceDelta(
+            'analysis',
+            citationIndex: {'chunk-2': citation('chunk-2')},
+            citations: ['chunk-2'],
+          ),
+          const TextMessageEndEvent(messageId: 'msg-1'),
+          const RunFinishedEvent(threadId: 'thread-1', runId: _runId),
+        ]),
+      );
+
+      await orchestrator.startRun(key: _key, userMessage: 'Analyze');
+      await Future<void>.delayed(Duration.zero);
+
+      final completed = orchestrator.currentState as CompletedState;
+      final refs =
+          completed.conversation.messageStates.values.first.sourceReferences;
+      expect(refs.map((r) => r.chunkId), ['chunk-2']);
+    });
+
+    test('keeps a chunk re-cited from the round-tripped seed', () async {
+      // The RUN_STARTED rebase snapshot echoes the round-tripped seed (a prior
+      // turn's leftover citations). When the run re-cites one of those chunks
+      // the delta carries it, so it must appear — no baseline subtraction
+      // (Issue 1).
+      stubCreateRun();
+      stubRunAgent(
+        stream: Stream.fromIterable(<BaseEvent>[
+          const RunStartedEvent(threadId: 'thread-1', runId: _runId),
+          const StateSnapshotEvent(
+            snapshot: {
+              'rag': {
+                'citation_index': {
+                  'seed-chunk': {
+                    'chunk_id': 'seed-chunk',
+                    'content': 'Seed citation',
+                    'document_id': 'doc-seed',
+                    'document_uri': 'https://example.com/seed.pdf',
+                  },
+                },
+                'citations': ['seed-chunk'],
+              },
+            },
+          ),
+          const TextMessageStartEvent(messageId: 'msg-1'),
+          const TextMessageContentEvent(messageId: 'msg-1', delta: 'Answer'),
+          ragDelta(
+            citationIndex: {'seed-chunk': citation('seed-chunk')},
+            citations: ['seed-chunk'],
+          ),
+          const TextMessageEndEvent(messageId: 'msg-1'),
+          const RunFinishedEvent(threadId: 'thread-1', runId: _runId),
+        ]),
+      );
+
+      await orchestrator.startRun(key: _key, userMessage: 'Search');
+      await Future<void>.delayed(Duration.zero);
+
+      final completed = orchestrator.currentState as CompletedState;
+      final refs =
+          completed.conversation.messageStates.values.first.sourceReferences;
+      expect(refs.map((r) => r.chunkId), ['seed-chunk']);
+    });
+
+    test('excludes a seed citation the run never re-cites', () async {
+      // A StateSnapshotEvent echoes the round-tripped seed, but the run cites
+      // nothing. Snapshots are not accumulated, so the seed leftover must not
+      // surface as this run's citation.
+      stubCreateRun();
+      stubRunAgent(
+        stream: Stream.fromIterable(<BaseEvent>[
+          const RunStartedEvent(threadId: 'thread-1', runId: _runId),
+          const StateSnapshotEvent(
+            snapshot: {
+              'rag': {
+                'citation_index': {
+                  'seed-chunk': {
+                    'chunk_id': 'seed-chunk',
+                    'content': 'Seed citation',
+                    'document_id': 'doc-seed',
+                    'document_uri': 'https://example.com/seed.pdf',
+                  },
+                },
+                'citations': ['seed-chunk'],
+              },
+            },
+          ),
+          const TextMessageStartEvent(messageId: 'msg-1'),
+          const TextMessageContentEvent(messageId: 'msg-1', delta: 'Answer'),
+          const TextMessageEndEvent(messageId: 'msg-1'),
+          const RunFinishedEvent(threadId: 'thread-1', runId: _runId),
+        ]),
+      );
+
+      await orchestrator.startRun(key: _key, userMessage: 'Search');
+      await Future<void>.delayed(Duration.zero);
+
+      final completed = orchestrator.currentState as CompletedState;
+      final entry = completed.conversation.messageStates.values.first;
+      expect(entry.runId, _runId);
+      expect(entry.sourceReferences, isEmpty);
+    });
+
     test('extracts citations at ToolYieldingState', () async {
       orchestrator = RunOrchestrator(
         llmProvider: AgUiLlmProvider(
@@ -2385,20 +2581,9 @@ void main() {
 
       final toolCallWithCitations = <BaseEvent>[
         const RunStartedEvent(threadId: 'thread-1', runId: _runId),
-        const StateSnapshotEvent(
-          snapshot: {
-            'rag': {
-              'citation_index': {
-                'chunk-1': {
-                  'chunk_id': 'chunk-1',
-                  'content': 'Citation text',
-                  'document_id': 'doc-1',
-                  'document_uri': 'https://example.com/doc.pdf',
-                },
-              },
-              'citations': ['chunk-1'],
-            },
-          },
+        ragDelta(
+          citationIndex: {'chunk-1': citation('chunk-1')},
+          citations: ['chunk-1'],
         ),
         const ToolCallStartEvent(
           toolCallId: 'tc-1',
@@ -2447,23 +2632,13 @@ void main() {
       ).thenAnswer((_) {
         callCount++;
         if (callCount == 1) {
+          // Invocation 1 cites chunk-1.
           return _wrap(
             Stream<BaseEvent>.fromIterable([
               const RunStartedEvent(threadId: 'thread-1', runId: _runId),
-              const StateSnapshotEvent(
-                snapshot: {
-                  'rag': {
-                    'citation_index': {
-                      'chunk-1': {
-                        'chunk_id': 'chunk-1',
-                        'content': 'First citation',
-                        'document_id': 'doc-1',
-                        'document_uri': 'https://example.com/doc1.pdf',
-                      },
-                    },
-                    'citations': ['chunk-1'],
-                  },
-                },
+              ragDelta(
+                citationIndex: {'chunk-1': citation('chunk-1')},
+                citations: ['chunk-1'],
               ),
               const ToolCallStartEvent(
                 toolCallId: 'tc-1',
@@ -2478,31 +2653,19 @@ void main() {
             ]),
           );
         }
+        // Invocation 2 clears citations and cites only chunk-2; the index
+        // stays session-cumulative.
         return _wrap(
           Stream<BaseEvent>.fromIterable([
             const RunStartedEvent(threadId: 'thread-1', runId: _runId),
             const TextMessageStartEvent(messageId: 'msg-2'),
             const TextMessageContentEvent(messageId: 'msg-2', delta: 'Done'),
-            const StateSnapshotEvent(
-              snapshot: {
-                'rag': {
-                  'citation_index': {
-                    'chunk-1': {
-                      'chunk_id': 'chunk-1',
-                      'content': 'First citation',
-                      'document_id': 'doc-1',
-                      'document_uri': 'https://example.com/doc1.pdf',
-                    },
-                    'chunk-2': {
-                      'chunk_id': 'chunk-2',
-                      'content': 'Second citation',
-                      'document_id': 'doc-2',
-                      'document_uri': 'https://example.com/doc2.pdf',
-                    },
-                  },
-                  'citations': ['chunk-1', 'chunk-2'],
-                },
+            ragDelta(
+              citationIndex: {
+                'chunk-1': citation('chunk-1'),
+                'chunk-2': citation('chunk-2'),
               },
+              citations: ['chunk-2'],
             ),
             const TextMessageEndEvent(messageId: 'msg-2'),
             const RunFinishedEvent(threadId: 'thread-1', runId: _runId),
@@ -2558,30 +2721,16 @@ void main() {
       ).thenAnswer((_) {
         callCount++;
         if (callCount == 1) {
-          // Segment 1: ask() returns chunk-1 and chunk-2.
+          // Invocation 1 cites chunk-1 and chunk-2.
           return _wrap(
             Stream<BaseEvent>.fromIterable([
               const RunStartedEvent(threadId: 'thread-1', runId: _runId),
-              const StateSnapshotEvent(
-                snapshot: {
-                  'rag': {
-                    'citation_index': {
-                      'chunk-1': {
-                        'chunk_id': 'chunk-1',
-                        'content': 'First',
-                        'document_id': 'doc-1',
-                        'document_uri': 'file:///doc1.pdf',
-                      },
-                      'chunk-2': {
-                        'chunk_id': 'chunk-2',
-                        'content': 'Second',
-                        'document_id': 'doc-1',
-                        'document_uri': 'file:///doc1.pdf',
-                      },
-                    },
-                    'citations': ['chunk-1', 'chunk-2'],
-                  },
+              ragDelta(
+                citationIndex: {
+                  'chunk-1': citation('chunk-1'),
+                  'chunk-2': citation('chunk-2'),
                 },
+                citations: ['chunk-1', 'chunk-2'],
               ),
               const ToolCallStartEvent(
                 toolCallId: 'tc-1',
@@ -2596,7 +2745,7 @@ void main() {
             ]),
           );
         }
-        // Segment 2: ask() returns chunk-2 (duplicate) and chunk-3 (new).
+        // Invocation 2 re-cites chunk-2 (duplicate) and adds chunk-3.
         return _wrap(
           Stream<BaseEvent>.fromIterable([
             const RunStartedEvent(threadId: 'thread-1', runId: _runId),
@@ -2605,32 +2754,13 @@ void main() {
               messageId: 'msg-2',
               delta: 'Done',
             ),
-            const StateSnapshotEvent(
-              snapshot: {
-                'rag': {
-                  'citation_index': {
-                    'chunk-1': {
-                      'chunk_id': 'chunk-1',
-                      'content': 'First',
-                      'document_id': 'doc-1',
-                      'document_uri': 'file:///doc1.pdf',
-                    },
-                    'chunk-2': {
-                      'chunk_id': 'chunk-2',
-                      'content': 'Second',
-                      'document_id': 'doc-1',
-                      'document_uri': 'file:///doc1.pdf',
-                    },
-                    'chunk-3': {
-                      'chunk_id': 'chunk-3',
-                      'content': 'Third',
-                      'document_id': 'doc-2',
-                      'document_uri': 'file:///doc2.pdf',
-                    },
-                  },
-                  'citations': ['chunk-1', 'chunk-2', 'chunk-3'],
-                },
+            ragDelta(
+              citationIndex: {
+                'chunk-1': citation('chunk-1'),
+                'chunk-2': citation('chunk-2'),
+                'chunk-3': citation('chunk-3'),
               },
+              citations: ['chunk-2', 'chunk-3'],
             ),
             const TextMessageEndEvent(messageId: 'msg-2'),
             const RunFinishedEvent(threadId: 'thread-1', runId: _runId),
@@ -2677,6 +2807,48 @@ void main() {
 
       stubRunAgent(stream: Stream.fromIterable(_happyPathEvents()));
       await orchestrator.startRun(key: _key, userMessage: 'Hi');
+      await Future<void>.delayed(Duration.zero);
+
+      expect(orchestrator.currentState, isA<CompletedState>());
+      final completed = orchestrator.currentState as CompletedState;
+      final entry = completed.conversation.messageStates.values.first;
+      expect(entry.sourceReferences, isEmpty);
+    });
+
+    test("does not leak a prior turn's citations into the next turn", () async {
+      // Two turns back-to-back with no reset between them. Turn 1 cites
+      // chunk-1; turn 2 cites nothing, but its RUN_STARTED rebase snapshot
+      // echoes the round-tripped seed (chunk-1 still in the cumulative
+      // citation_index). The turn accumulator is cleared at turn start, so
+      // turn 2 shows no sources — otherwise turn 1's id would resolve against
+      // turn 2's state and leak in. This isolates the turn-start clear: reset
+      // and syncToThread also null _userMessageId (short-circuiting resolve),
+      // so only a back-to-back run exercises it.
+      stubCreateRun();
+      stubRunAgent(stream: Stream.fromIterable(citationEvents()));
+
+      await orchestrator.startRun(key: _key, userMessage: 'Search');
+      await Future<void>.delayed(Duration.zero);
+      expect(orchestrator.currentState, isA<CompletedState>());
+
+      stubRunAgent(
+        stream: Stream.fromIterable(<BaseEvent>[
+          const RunStartedEvent(threadId: 'thread-1', runId: _runId),
+          StateSnapshotEvent(
+            snapshot: {
+              'rag': {
+                'citation_index': {'chunk-1': citation('chunk-1')},
+                'citations': ['chunk-1'],
+              },
+            },
+          ),
+          const TextMessageStartEvent(messageId: 'msg-2'),
+          const TextMessageContentEvent(messageId: 'msg-2', delta: 'Answer'),
+          const TextMessageEndEvent(messageId: 'msg-2'),
+          const RunFinishedEvent(threadId: 'thread-1', runId: _runId),
+        ]),
+      );
+      await orchestrator.startRun(key: _key, userMessage: 'Again');
       await Future<void>.delayed(Duration.zero);
 
       expect(orchestrator.currentState, isA<CompletedState>());

--- a/packages/soliplex_client/lib/src/api/soliplex_api.dart
+++ b/packages/soliplex_client/lib/src/api/soliplex_api.dart
@@ -20,6 +20,7 @@ import 'package:soliplex_client/src/domain/rag_document.dart';
 import 'package:soliplex_client/src/domain/room.dart';
 import 'package:soliplex_client/src/domain/room_stats.dart';
 import 'package:soliplex_client/src/domain/run_info.dart';
+import 'package:soliplex_client/src/domain/source_reference.dart';
 import 'package:soliplex_client/src/domain/thread_history.dart';
 import 'package:soliplex_client/src/domain/thread_info.dart';
 import 'package:soliplex_client/src/domain/workdir_file.dart';
@@ -969,6 +970,9 @@ class SoliplexApi {
     var streaming = const AwaitingText() as StreamingState;
     final extractor = CitationExtractor();
     final messageStates = <String, MessageState>{};
+    // Citation ids accumulated per turn (keyed by the run's last user message
+    // id), unioned across every run of the turn — mirroring the live path.
+    final citationIdsByUserMessage = <String, Set<String>>{};
     final runs = <RunEventBundle>[];
 
     for (final (:runId, :events, :fetchError, :created) in eventsPerRun) {
@@ -992,9 +996,6 @@ class SoliplexApi {
           ),
         );
       }
-
-      // Capture AG-UI state before processing this run
-      final previousAguiState = conversation.aguiState;
 
       // Find user message ID from LAST TEXT_MESSAGE_START with role=user.
       // The run_input.messages contains ALL conversation messages, but the
@@ -1112,6 +1113,27 @@ class SoliplexApi {
               );
               conversation = result.conversation;
               streaming = result.streaming;
+              // Accumulate the citation ids this StateDeltaEvent cited, scoped
+              // to the namespaces it touched, into the turn's set — one skill
+              // invocation's absolute cited set. Snapshots echo the
+              // round-tripped seed and are intentionally not accumulated. Own
+              // fail-soft guard (log-only, never a drop tile): the event
+              // already processed, and citations are a derived projection.
+              if (event is StateDeltaEvent && userMessageId != null) {
+                try {
+                  (citationIdsByUserMessage[userMessageId] ??= <String>{})
+                      .addAll(
+                    extractor.citationIdsInDelta(conversation.aguiState, event),
+                  );
+                } on Object catch (error, stackTrace) {
+                  _logger.error(
+                    'replay: citation id accumulation failed in run $runId of '
+                    'thread $threadId.',
+                    error: error,
+                    stackTrace: stackTrace,
+                  );
+                }
+              }
             } on Object catch (error, stackTrace) {
               appendDrop(
                 source: DropSource.eventProcessing,
@@ -1126,12 +1148,32 @@ class SoliplexApi {
       }
       runs.add(RunEventBundle(runId: runId, events: decodedEvents));
 
-      // Extract new citations by comparing state before/after this run
+      // Resolve the turn's accumulated ids against this run's end-of-turn state
+      // and (re)emit its MessageState — the turn's last run wins, mirroring the
+      // live path's resolve-at-every-terminal. Resolving against the run's own
+      // state is what preserves a turn's inline figure bytes: `searches` is
+      // per-invocation and a later turn overwrites it, while `citation_index`
+      // stays session-cumulative so the ids still resolve. A turn that cited
+      // nothing still gets a MessageState carrying its runId.
       if (userMessageId != null) {
-        final sourceReferences = extractor.extractNew(
-          previousAguiState,
-          conversation.aguiState,
-        );
+        var sourceReferences = const <SourceReference>[];
+        try {
+          sourceReferences = extractor.resolve(
+            citationIdsByUserMessage[userMessageId] ?? const <String>{},
+            conversation.aguiState,
+            logContext: 'run $runId, thread $threadId',
+          );
+        } on Object catch (error, stackTrace) {
+          // Fail-soft, mirroring the live orchestrator path: citations are a
+          // derived projection, so a resolution failure must not abort the
+          // history load. Emit the MessageState with its runId and no refs.
+          _logger.error(
+            'replay: citation resolution failed for run $runId in thread '
+            '$threadId.',
+            error: error,
+            stackTrace: stackTrace,
+          );
+        }
         messageStates[userMessageId] = MessageState(
           userMessageId: userMessageId,
           sourceReferences: sourceReferences,

--- a/packages/soliplex_client/lib/src/application/citation_extractor.dart
+++ b/packages/soliplex_client/lib/src/application/citation_extractor.dart
@@ -1,3 +1,4 @@
+import 'package:ag_ui/ag_ui.dart';
 import 'package:soliplex_client/src/application/rag_snapshot.dart';
 import 'package:soliplex_client/src/domain/source_reference.dart';
 import 'package:soliplex_client/src/schema/agui_features/rag.dart';
@@ -7,63 +8,133 @@ import 'package:soliplex_logging/soliplex_logging.dart';
 final _logger =
     LogManager.instance.getLogger('soliplex_client.citation_extractor');
 
-/// Extracts new [SourceReference]s by comparing AG-UI state snapshots.
+/// Reads and resolves citations from AG-UI state snapshots.
 ///
 /// **Schema firewall**: this file and [RagSnapshot] in
 /// `rag_snapshot.dart` are the only places that import the schema-mirror
 /// types in `rag.dart`. When the backend citation shape changes, updates
 /// are confined to `rag_snapshot.dart`.
 ///
-/// The algorithm: collect every citation-bearing namespace in the state
-/// (each RAG-producing skill — `rag`, `analysis`, … — publishes its own),
-/// take the difference of their combined `citationIds`, and resolve each
-/// new id back to a full [Citation].
+/// Each RAG-producing skill (`rag`, `analysis`, …) publishes its own
+/// citation-bearing namespace. [citationIdsInDelta] collects the ids a single
+/// `StateDeltaEvent` cited; [resolve] turns a set of ids into full
+/// [SourceReference]s using the state's session-cumulative `citation_index`.
+/// Neither subtracts a prior turn's ids — accumulation across a turn is the
+/// caller's responsibility.
 class CitationExtractor {
-  /// Extracts source references added since [previousState] across every
-  /// citation-bearing namespace in the state.
+  /// The union of chunk ids cited in [state], restricted to [namespaces] when
+  /// given, else across every citation-bearing namespace.
   ///
-  /// Returns an empty list if:
-  /// - The current state carries no citation-bearing namespace.
-  /// - Current citations are a subset of previous.
-  /// - New ids cannot be resolved against any current snapshot.
+  /// The backend clears a namespace's `citations` list only when that skill is
+  /// invoked, so an untouched namespace's list is a prior turn's. Prefer
+  /// [citationIdsInDelta] during accumulation, which scopes to the namespaces a
+  /// delta actually touched.
+  Set<String> citationIds(
+    Map<String, dynamic> state, {
+    Set<String>? namespaces,
+  }) {
+    return <String>{
+      for (final snapshot
+          in RagSnapshot.extractAll(state, namespaces: namespaces))
+        ...snapshot.citationIds,
+    };
+  }
+
+  /// The union of chunk ids cited in the namespaces that [delta] modified.
   ///
-  /// Ids are deduped across namespaces so a chunk cited in more than one
-  /// namespace in a single turn yields a single reference.
+  /// The backend re-emits every namespace's block in `state` — including a
+  /// prior turn's untouched one, whose stale `citations` ride the run's rebase
+  /// snapshot — but clears and repopulates `citations` only in the invoked
+  /// skill's namespace. So a namespace this delta did not touch carries a prior
+  /// turn's ids and must not be attributed to this one. Scoping to the
+  /// delta's touched namespaces is what keeps re-cited chunks and
+  /// multi-invocation runs while not inventing a stale namespace's citations.
+  Set<String> citationIdsInDelta(
+    Map<String, dynamic> state,
+    StateDeltaEvent delta,
+  ) {
+    final namespaces = _touchedNamespaces(delta);
+    if (namespaces.isEmpty) return const <String>{};
+    return citationIds(state, namespaces: namespaces);
+  }
+
+  /// The top-level state keys touched by [delta]'s JSON-Patch ops, e.g.
+  /// `/rag/citations/-` → `rag`. A malformed op is skipped with a warning:
+  /// silently dropping it could lose a namespace's citations off a drifting
+  /// wire with no trace.
+  Set<String> _touchedNamespaces(StateDeltaEvent delta) {
+    final namespaces = <String>{};
+    for (final op in delta.delta) {
+      if (op is! Map) {
+        _logger.warning('citationIdsInDelta: skipping non-Map delta op: $op');
+        continue;
+      }
+      final path = op['path'];
+      if (path is! String) {
+        _logger.warning(
+          'citationIdsInDelta: skipping delta op with non-String path: $op',
+        );
+        continue;
+      }
+      final segments = path.split('/').where((s) => s.isNotEmpty);
+      if (segments.isEmpty) {
+        _logger.warning(
+          'citationIdsInDelta: skipping delta op with no namespace segment '
+          'in path: $op',
+        );
+        continue;
+      }
+      namespaces.add(segments.first);
+    }
+    return namespaces;
+  }
+
+  /// Resolves [ids] to full [SourceReference]s against the citation index in
+  /// [state], deduping ids and logging then omitting any absent from every
+  /// namespace's index — an absent cited id signals a backend contract
+  /// violation (the index is cumulative), so it is surfaced, not dropped
+  /// silently.
+  ///
+  /// Ids are looked up in `citation_index`, which is session-cumulative, so an
+  /// id cited in an earlier invocation still resolves even when it is no longer
+  /// in the current `citations` list. No subtraction of any kind is applied.
   ///
   /// Never throws: a namespace whose block fails to parse is skipped by
-  /// [RagSnapshot.extractAll], and everything after operates on already-
-  /// parsed snapshots. The replay path relies on this — it calls this
-  /// method without a surrounding guard.
-  List<SourceReference> extractNew(
-    Map<String, dynamic> previousState,
-    Map<String, dynamic> currentState,
-  ) {
-    final currentSnapshots = RagSnapshot.extractAll(currentState);
-    if (currentSnapshots.isEmpty) return [];
-
-    final previousIds = <String>{
-      for (final s in RagSnapshot.extractAll(previousState)) ...s.citationIds,
-    };
-
-    final newIds = <String>[];
-    final seen = <String>{};
-    for (final snapshot in currentSnapshots) {
-      for (final id in snapshot.citationIds) {
-        if (previousIds.contains(id)) continue;
-        if (seen.add(id)) newIds.add(id);
-      }
-    }
-    if (newIds.isEmpty) return [];
+  /// [RagSnapshot.extractAll], everything after operates on already-parsed
+  /// snapshots, and the one render-time decode ([RagSnapshot.pictureBytes]'s
+  /// base64 decode) is itself guarded.
+  List<SourceReference> resolve(
+    Iterable<String> ids,
+    Map<String, dynamic> state, {
+    String? logContext,
+  }) {
+    final snapshots = RagSnapshot.extractAll(state);
 
     final refs = <SourceReference>[];
-    for (final id in newIds) {
-      for (final snapshot in currentSnapshots) {
+    final seen = <String>{};
+    final unresolved = <String>[];
+    for (final id in ids) {
+      if (!seen.add(id)) continue;
+      var resolved = false;
+      for (final snapshot in snapshots) {
         final citation = snapshot.resolveCitation(id);
         if (citation != null) {
           refs.add(_citationToSourceReference(citation, snapshot));
+          resolved = true;
           break;
         }
       }
+      if (!resolved) unresolved.add(id);
+    }
+    // A cited id absent from every `citation_index` means the rendered source
+    // list is silently short — a backend contract violation, since the index is
+    // cumulative. Surface it rather than dropping it without a trace.
+    if (unresolved.isNotEmpty) {
+      final where = logContext != null ? ' [$logContext]' : '';
+      _logger.warning(
+        'resolve$where: ${unresolved.length} cited id(s) absent from every '
+        'citation_index; source list rendered incomplete. ids: $unresolved',
+      );
     }
     return refs;
   }

--- a/packages/soliplex_client/lib/src/application/rag_snapshot.dart
+++ b/packages/soliplex_client/lib/src/application/rag_snapshot.dart
@@ -165,11 +165,23 @@ class RagSnapshot {
           );
         }
       }
+    } else if (rawCitations != null) {
+      _logger.warning(
+        'RagSnapshot: `citations` present but not a List '
+        '(runtimeType=${rawCitations.runtimeType}); no citation ids read.',
+      );
     }
 
     final index = <String, Citation>{};
     final rawIndex = json[_citationIndexKey];
-    if (rawIndex is Map) {
+    if (rawIndex is! Map) {
+      if (rawIndex != null) {
+        _logger.warning(
+          'RagSnapshot: `citation_index` present but not a Map '
+          '(runtimeType=${rawIndex.runtimeType}); no citations resolvable.',
+        );
+      }
+    } else {
       for (final entry in rawIndex.entries) {
         final key = entry.key;
         final value = entry.value;
@@ -212,13 +224,21 @@ class RagSnapshot {
   /// (e.g. `bubble-sandbox`) and non-Map or mistyped blocks are skipped,
   /// so this is the single place that knows how a citation block is shaped.
   ///
+  /// When [namespaces] is given, only blocks under those keys are considered;
+  /// otherwise every namespace in [state] is.
+  ///
   /// [RagSnapshot.fromJson] is resilient by construction and should not
   /// throw, but a block that fails to parse is caught and skipped rather
   /// than propagated: one malformed namespace must not take down the
   /// others, nor abort the unguarded replay path that consumes this.
-  static List<RagSnapshot> extractAll(Map<String, dynamic> state) {
+  static List<RagSnapshot> extractAll(
+    Map<String, dynamic> state, {
+    Set<String>? namespaces,
+  }) {
     final snapshots = <RagSnapshot>[];
-    for (final raw in state.values) {
+    for (final entry in state.entries) {
+      if (namespaces != null && !namespaces.contains(entry.key)) continue;
+      final raw = entry.value;
       if (raw is! Map<String, dynamic> || raw[_citationIndexKey] is! Map) {
         continue;
       }

--- a/packages/soliplex_client/test/api/soliplex_api_test.dart
+++ b/packages/soliplex_client/test/api/soliplex_api_test.dart
@@ -1,3 +1,5 @@
+import 'dart:convert';
+
 import 'package:mocktail/mocktail.dart';
 // SoliplexApi uses our local CancelToken, not ag_ui's.
 // Hide ag_ui's CancelToken to avoid ambiguity.
@@ -3723,7 +3725,7 @@ void main() {
       });
 
       test(
-        'populates messageStates from per-run STATE_SNAPSHOT events',
+        'populates messageStates from per-run STATE_DELTA events',
         () async {
           // Thread with two completed runs
           when(
@@ -3757,7 +3759,7 @@ void main() {
             },
           );
 
-          // Run 1: user message + STATE_SNAPSHOT with one citation turn
+          // Run 1: user message + STATE_DELTA citing chunk-1
           when(
             () => mockTransport.request<Map<String, dynamic>>(
               'GET',
@@ -3781,20 +3783,24 @@ void main() {
               },
               'events': [
                 {
-                  'type': 'STATE_SNAPSHOT',
-                  'snapshot': {
-                    'rag': {
-                      'citation_index': {
-                        'chunk-1': {
-                          'document_id': 'doc-1',
-                          'chunk_id': 'chunk-1',
-                          'document_uri': 'file:///doc1.pdf',
-                          'content': 'Citation 1 content',
+                  'type': 'STATE_DELTA',
+                  'delta': [
+                    {
+                      'op': 'add',
+                      'path': '/rag',
+                      'value': {
+                        'citation_index': {
+                          'chunk-1': {
+                            'document_id': 'doc-1',
+                            'chunk_id': 'chunk-1',
+                            'document_uri': 'file:///doc1.pdf',
+                            'content': 'Citation 1 content',
+                          },
                         },
+                        'citations': ['chunk-1'],
                       },
-                      'citations': ['chunk-1'],
                     },
-                  },
+                  ],
                 },
                 {
                   'type': 'TEXT_MESSAGE_START',
@@ -3816,7 +3822,7 @@ void main() {
             },
           );
 
-          // Run 2: user message + STATE_SNAPSHOT with citations[0, 1]
+          // Run 2: user message + STATE_DELTA citing chunk-2 (index cumulative)
           when(
             () => mockTransport.request<Map<String, dynamic>>(
               'GET',
@@ -3842,26 +3848,30 @@ void main() {
               },
               'events': [
                 {
-                  'type': 'STATE_SNAPSHOT',
-                  'snapshot': {
-                    'rag': {
-                      'citation_index': {
-                        'chunk-1': {
-                          'document_id': 'doc-1',
-                          'chunk_id': 'chunk-1',
-                          'document_uri': 'file:///doc1.pdf',
-                          'content': 'Citation 1 content',
+                  'type': 'STATE_DELTA',
+                  'delta': [
+                    {
+                      'op': 'add',
+                      'path': '/rag',
+                      'value': {
+                        'citation_index': {
+                          'chunk-1': {
+                            'document_id': 'doc-1',
+                            'chunk_id': 'chunk-1',
+                            'document_uri': 'file:///doc1.pdf',
+                            'content': 'Citation 1 content',
+                          },
+                          'chunk-2': {
+                            'document_id': 'doc-2',
+                            'chunk_id': 'chunk-2',
+                            'document_uri': 'file:///doc2.pdf',
+                            'content': 'Citation 2 content',
+                          },
                         },
-                        'chunk-2': {
-                          'document_id': 'doc-2',
-                          'chunk_id': 'chunk-2',
-                          'document_uri': 'file:///doc2.pdf',
-                          'content': 'Citation 2 content',
-                        },
+                        'citations': ['chunk-2'],
                       },
-                      'citations': ['chunk-2'],
                     },
-                  },
+                  ],
                 },
                 {
                   'type': 'TEXT_MESSAGE_START',
@@ -3906,8 +3916,313 @@ void main() {
         },
       );
 
-      test('messageStates is empty when no STATE_SNAPSHOT events', () async {
-        // Thread with one run, no STATE_SNAPSHOT
+      test(
+        'run 2 keeps a chunk re-cited from run 1 (no cross-run subtraction)',
+        () async {
+          when(
+            () => mockTransport.request<Map<String, dynamic>>(
+              'GET',
+              Uri.parse(
+                'https://api.example.com/api/v1/rooms/room-123/agui/thread-456',
+              ),
+              cancelToken: any(named: 'cancelToken'),
+              fromJson: any(named: 'fromJson'),
+              body: any(named: 'body'),
+              headers: any(named: 'headers'),
+              timeout: any(named: 'timeout'),
+            ),
+          ).thenAnswer(
+            (_) async => {
+              'room_id': 'room-123',
+              'thread_id': 'thread-456',
+              'runs': {
+                'run-1': {
+                  'run_id': 'run-1',
+                  'created': '2026-01-07T01:00:00.000Z',
+                  'finished': '2026-01-07T01:01:00.000Z',
+                },
+                'run-2': {
+                  'run_id': 'run-2',
+                  'created': '2026-01-07T02:00:00.000Z',
+                  'finished': '2026-01-07T02:01:00.000Z',
+                },
+              },
+            },
+          );
+
+          // Run 1 cites chunk-1.
+          when(
+            () => mockTransport.request<Map<String, dynamic>>(
+              'GET',
+              Uri.parse(
+                'https://api.example.com/api/v1/rooms/room-123/'
+                'agui/thread-456/run-1',
+              ),
+              cancelToken: any(named: 'cancelToken'),
+              fromJson: any(named: 'fromJson'),
+              body: any(named: 'body'),
+              headers: any(named: 'headers'),
+              timeout: any(named: 'timeout'),
+            ),
+          ).thenAnswer(
+            (_) async => {
+              'run_id': 'run-1',
+              'run_input': {
+                'messages': [
+                  {'id': 'user-1', 'role': 'user', 'content': 'Question 1'},
+                ],
+              },
+              'events': [
+                {
+                  'type': 'STATE_DELTA',
+                  'delta': [
+                    {
+                      'op': 'add',
+                      'path': '/rag',
+                      'value': {
+                        'citation_index': {
+                          'chunk-1': {
+                            'document_id': 'doc-1',
+                            'chunk_id': 'chunk-1',
+                            'document_uri': 'file:///doc1.pdf',
+                            'content': 'Citation 1 content',
+                          },
+                        },
+                        'citations': ['chunk-1'],
+                      },
+                    },
+                  ],
+                },
+                {'type': 'TEXT_MESSAGE_START', 'messageId': 'asst-1'},
+                {
+                  'type': 'TEXT_MESSAGE_CONTENT',
+                  'messageId': 'asst-1',
+                  'delta': 'Answer 1',
+                },
+                {'type': 'TEXT_MESSAGE_END', 'messageId': 'asst-1'},
+                {
+                  'type': 'RUN_FINISHED',
+                  'thread_id': 'thread-456',
+                  'run_id': 'run-1',
+                },
+              ],
+            },
+          );
+
+          // Run 2 re-cites chunk-1 and adds chunk-2 (index session-cumulative).
+          when(
+            () => mockTransport.request<Map<String, dynamic>>(
+              'GET',
+              Uri.parse(
+                'https://api.example.com/api/v1/rooms/room-123/'
+                'agui/thread-456/run-2',
+              ),
+              cancelToken: any(named: 'cancelToken'),
+              fromJson: any(named: 'fromJson'),
+              body: any(named: 'body'),
+              headers: any(named: 'headers'),
+              timeout: any(named: 'timeout'),
+            ),
+          ).thenAnswer(
+            (_) async => {
+              'run_id': 'run-2',
+              'run_input': {
+                'messages': [
+                  {'id': 'user-1', 'role': 'user', 'content': 'Question 1'},
+                  {'id': 'asst-1', 'role': 'assistant', 'content': 'Answer 1'},
+                  {'id': 'user-2', 'role': 'user', 'content': 'Question 2'},
+                ],
+              },
+              'events': [
+                {
+                  'type': 'STATE_DELTA',
+                  'delta': [
+                    {
+                      'op': 'add',
+                      'path': '/rag',
+                      'value': {
+                        'citation_index': {
+                          'chunk-1': {
+                            'document_id': 'doc-1',
+                            'chunk_id': 'chunk-1',
+                            'document_uri': 'file:///doc1.pdf',
+                            'content': 'Citation 1 content',
+                          },
+                          'chunk-2': {
+                            'document_id': 'doc-2',
+                            'chunk_id': 'chunk-2',
+                            'document_uri': 'file:///doc2.pdf',
+                            'content': 'Citation 2 content',
+                          },
+                        },
+                        'citations': ['chunk-1', 'chunk-2'],
+                      },
+                    },
+                  ],
+                },
+                {'type': 'TEXT_MESSAGE_START', 'messageId': 'asst-2'},
+                {
+                  'type': 'TEXT_MESSAGE_CONTENT',
+                  'messageId': 'asst-2',
+                  'delta': 'Answer 2',
+                },
+                {'type': 'TEXT_MESSAGE_END', 'messageId': 'asst-2'},
+                {
+                  'type': 'RUN_FINISHED',
+                  'thread_id': 'thread-456',
+                  'run_id': 'run-2',
+                },
+              ],
+            },
+          );
+
+          final history = await api.getThreadHistory('room-123', 'thread-456');
+
+          expect(history.messageStates, hasLength(2));
+
+          final state1 = history.messageStates['user-1']!;
+          expect(state1.sourceReferences.map((r) => r.chunkId), ['chunk-1']);
+          expect(state1.runId, 'run-1');
+
+          // Run 2 re-cited chunk-1; it must NOT be subtracted just because
+          // run 1 cited it (Issues 1 + 4).
+          final state2 = history.messageStates['user-2']!;
+          expect(
+            state2.sourceReferences.map((r) => r.chunkId),
+            containsAll(<String>['chunk-1', 'chunk-2']),
+          );
+          expect(state2.sourceReferences, hasLength(2));
+          expect(state2.runId, 'run-2');
+        },
+      );
+
+      test('unions multiple STATE_DELTA events within a single run', () async {
+        // One run, two skill invocations → two deltas; each carries only its
+        // invocation's citations (index session-cumulative). The turn's
+        // resolved set is the union of both deltas, not just the last.
+        when(
+          () => mockTransport.request<Map<String, dynamic>>(
+            'GET',
+            Uri.parse(
+              'https://api.example.com/api/v1/rooms/room-123/agui/thread-456',
+            ),
+            cancelToken: any(named: 'cancelToken'),
+            fromJson: any(named: 'fromJson'),
+            body: any(named: 'body'),
+            headers: any(named: 'headers'),
+            timeout: any(named: 'timeout'),
+          ),
+        ).thenAnswer(
+          (_) async => {
+            'room_id': 'room-123',
+            'thread_id': 'thread-456',
+            'runs': {
+              'run-1': {
+                'run_id': 'run-1',
+                'created': '2026-01-07T01:00:00.000Z',
+                'finished': '2026-01-07T01:01:00.000Z',
+              },
+            },
+          },
+        );
+
+        when(
+          () => mockTransport.request<Map<String, dynamic>>(
+            'GET',
+            Uri.parse(
+              'https://api.example.com/api/v1/rooms/room-123/'
+              'agui/thread-456/run-1',
+            ),
+            cancelToken: any(named: 'cancelToken'),
+            fromJson: any(named: 'fromJson'),
+            body: any(named: 'body'),
+            headers: any(named: 'headers'),
+            timeout: any(named: 'timeout'),
+          ),
+        ).thenAnswer(
+          (_) async => {
+            'run_id': 'run-1',
+            'run_input': {
+              'messages': [
+                {'id': 'user-1', 'role': 'user', 'content': 'Question 1'},
+              ],
+            },
+            'events': [
+              {
+                'type': 'STATE_DELTA',
+                'delta': [
+                  {
+                    'op': 'add',
+                    'path': '/rag',
+                    'value': {
+                      'citation_index': {
+                        'chunk-1': {
+                          'document_id': 'doc-1',
+                          'chunk_id': 'chunk-1',
+                          'document_uri': 'file:///doc1.pdf',
+                          'content': 'Citation 1 content',
+                        },
+                      },
+                      'citations': ['chunk-1'],
+                    },
+                  },
+                ],
+              },
+              {
+                'type': 'STATE_DELTA',
+                'delta': [
+                  {
+                    'op': 'add',
+                    'path': '/rag',
+                    'value': {
+                      'citation_index': {
+                        'chunk-1': {
+                          'document_id': 'doc-1',
+                          'chunk_id': 'chunk-1',
+                          'document_uri': 'file:///doc1.pdf',
+                          'content': 'Citation 1 content',
+                        },
+                        'chunk-2': {
+                          'document_id': 'doc-2',
+                          'chunk_id': 'chunk-2',
+                          'document_uri': 'file:///doc2.pdf',
+                          'content': 'Citation 2 content',
+                        },
+                      },
+                      'citations': ['chunk-2'],
+                    },
+                  },
+                ],
+              },
+              {'type': 'TEXT_MESSAGE_START', 'messageId': 'asst-1'},
+              {
+                'type': 'TEXT_MESSAGE_CONTENT',
+                'messageId': 'asst-1',
+                'delta': 'Answer',
+              },
+              {'type': 'TEXT_MESSAGE_END', 'messageId': 'asst-1'},
+              {
+                'type': 'RUN_FINISHED',
+                'thread_id': 'thread-456',
+                'run_id': 'run-1',
+              },
+            ],
+          },
+        );
+
+        final history = await api.getThreadHistory('room-123', 'thread-456');
+
+        expect(history.messageStates, hasLength(1));
+        final state = history.messageStates['user-1']!;
+        expect(
+          state.sourceReferences.map((r) => r.chunkId),
+          containsAll(<String>['chunk-1', 'chunk-2']),
+        );
+        expect(state.sourceReferences, hasLength(2));
+      });
+
+      test('messageStates carries runId with no citation events', () async {
+        // Thread with one run, no STATE_DELTA
         when(
           () => mockTransport.request<Map<String, dynamic>>(
             'GET',
@@ -3983,6 +4298,267 @@ void main() {
         expect(history.messageStates, hasLength(1));
         expect(history.messageStates['user-1']!.sourceReferences, isEmpty);
         expect(history.messageStates['user-1']!.runId, 'run-1');
+      });
+
+      group('per-turn citation scoping', () {
+        // Stubs a GET on the room/thread base for [path], returning [response].
+        void stubGet(String path, Map<String, dynamic> response) {
+          when(
+            () => mockTransport.request<Map<String, dynamic>>(
+              'GET',
+              Uri.parse(
+                'https://api.example.com/api/v1/rooms/room-123/agui/$path',
+              ),
+              cancelToken: any(named: 'cancelToken'),
+              fromJson: any(named: 'fromJson'),
+              body: any(named: 'body'),
+              headers: any(named: 'headers'),
+              timeout: any(named: 'timeout'),
+            ),
+          ).thenAnswer((_) async => response);
+        }
+
+        Map<String, dynamic> twoRunThread() => {
+              'room_id': 'room-123',
+              'thread_id': 'thread-456',
+              'runs': {
+                'run-1': {
+                  'run_id': 'run-1',
+                  'created': '2026-01-07T01:00:00.000Z',
+                  'finished': '2026-01-07T01:01:00.000Z',
+                },
+                'run-2': {
+                  'run_id': 'run-2',
+                  'created': '2026-01-07T02:00:00.000Z',
+                  'finished': '2026-01-07T02:01:00.000Z',
+                },
+              },
+            };
+
+        test('run 2 (analysis only) does not inherit run 1 rag citations',
+            () async {
+          stubGet('thread-456', twoRunThread());
+          // Run 1: the rag skill cites chunk-1.
+          stubGet('thread-456/run-1', {
+            'run_id': 'run-1',
+            'run_input': {
+              'messages': [
+                {'id': 'user-1', 'role': 'user', 'content': 'Q1'},
+              ],
+            },
+            'events': [
+              {
+                'type': 'STATE_DELTA',
+                'delta': [
+                  {
+                    'op': 'add',
+                    'path': '/rag',
+                    'value': {
+                      'citation_index': {
+                        'chunk-1': {
+                          'document_id': 'doc-1',
+                          'chunk_id': 'chunk-1',
+                          'document_uri': 'file:///doc1.pdf',
+                          'content': 'Citation 1',
+                        },
+                      },
+                      'citations': ['chunk-1'],
+                    },
+                  },
+                ],
+              },
+              {
+                'type': 'RUN_FINISHED',
+                'thread_id': 'thread-456',
+                'run_id': 'run-1',
+              },
+            ],
+          });
+          // Run 2: only the analysis skill runs (cites chunk-2). The rebase
+          // snapshot round-trips run 1's rag block (citations=[chunk-1]), which
+          // run 2 never touches — so chunk-1 must not be attributed to run 2.
+          stubGet('thread-456/run-2', {
+            'run_id': 'run-2',
+            'run_input': {
+              'messages': [
+                {'id': 'user-1', 'role': 'user', 'content': 'Q1'},
+                {'id': 'asst-1', 'role': 'assistant', 'content': 'A1'},
+                {'id': 'user-2', 'role': 'user', 'content': 'Q2'},
+              ],
+            },
+            'events': [
+              {
+                'type': 'STATE_SNAPSHOT',
+                'snapshot': {
+                  'rag': {
+                    'citation_index': {
+                      'chunk-1': {
+                        'document_id': 'doc-1',
+                        'chunk_id': 'chunk-1',
+                        'document_uri': 'file:///doc1.pdf',
+                        'content': 'Citation 1',
+                      },
+                    },
+                    'citations': ['chunk-1'],
+                  },
+                },
+              },
+              {
+                'type': 'STATE_DELTA',
+                'delta': [
+                  {
+                    'op': 'add',
+                    'path': '/analysis',
+                    'value': {
+                      'citation_index': {
+                        'chunk-2': {
+                          'document_id': 'doc-2',
+                          'chunk_id': 'chunk-2',
+                          'document_uri': 'file:///doc2.pdf',
+                          'content': 'Citation 2',
+                        },
+                      },
+                      'citations': ['chunk-2'],
+                    },
+                  },
+                ],
+              },
+              {
+                'type': 'RUN_FINISHED',
+                'thread_id': 'thread-456',
+                'run_id': 'run-2',
+              },
+            ],
+          });
+
+          final history = await api.getThreadHistory('room-123', 'thread-456');
+
+          expect(
+            history.messageStates['user-1']!.sourceReferences
+                .map((r) => r.chunkId),
+            ['chunk-1'],
+          );
+          expect(
+            history.messageStates['user-2']!.sourceReferences
+                .map((r) => r.chunkId),
+            ['chunk-2'],
+          );
+        });
+
+        test(
+            'an earlier turn keeps its figure bytes after a later turn wipes '
+            'searches', () async {
+          stubGet('thread-456', twoRunThread());
+          // Run 1: cites chunk-1, whose figure bytes live in this run's
+          // searches (stage-1 image_data).
+          stubGet('thread-456/run-1', {
+            'run_id': 'run-1',
+            'run_input': {
+              'messages': [
+                {'id': 'user-1', 'role': 'user', 'content': 'Q1'},
+              ],
+            },
+            'events': [
+              {
+                'type': 'STATE_DELTA',
+                'delta': [
+                  {
+                    'op': 'add',
+                    'path': '/rag',
+                    'value': {
+                      'citation_index': {
+                        'chunk-1': {
+                          'document_id': 'doc-1',
+                          'chunk_id': 'chunk-1',
+                          'document_uri': 'file:///doc1.pdf',
+                          'content': 'cites Fig 1',
+                          'picture_refs': ['#/pictures/0'],
+                        },
+                      },
+                      'citations': ['chunk-1'],
+                      'searches': {
+                        'q1': [
+                          {
+                            'content': 'cites Fig 1',
+                            'document_id': 'doc-1',
+                            'image_data': {'#/pictures/0': 'aGVsbG8='},
+                          },
+                        ],
+                      },
+                    },
+                  },
+                ],
+              },
+              {
+                'type': 'RUN_FINISHED',
+                'thread_id': 'thread-456',
+                'run_id': 'run-1',
+              },
+            ],
+          });
+          // Run 2: cites chunk-9 and replaces the rag block — citation_index
+          // stays cumulative, but searches now holds only run 2's results, so
+          // chunk-1's figure is gone from the thread's final state. Resolving
+          // run 1 against the final state would drop its figure; resolving
+          // against run 1's own end-of-turn state keeps it.
+          stubGet('thread-456/run-2', {
+            'run_id': 'run-2',
+            'run_input': {
+              'messages': [
+                {'id': 'user-1', 'role': 'user', 'content': 'Q1'},
+                {'id': 'asst-1', 'role': 'assistant', 'content': 'A1'},
+                {'id': 'user-2', 'role': 'user', 'content': 'Q2'},
+              ],
+            },
+            'events': [
+              {
+                'type': 'STATE_DELTA',
+                'delta': [
+                  {
+                    'op': 'add',
+                    'path': '/rag',
+                    'value': {
+                      'citation_index': {
+                        'chunk-1': {
+                          'document_id': 'doc-1',
+                          'chunk_id': 'chunk-1',
+                          'document_uri': 'file:///doc1.pdf',
+                          'content': 'cites Fig 1',
+                          'picture_refs': ['#/pictures/0'],
+                        },
+                        'chunk-9': {
+                          'document_id': 'doc-9',
+                          'chunk_id': 'chunk-9',
+                          'document_uri': 'file:///doc9.pdf',
+                          'content': 'Citation 9',
+                        },
+                      },
+                      'citations': ['chunk-9'],
+                      'searches': {
+                        'q2': [
+                          {'content': 'Citation 9', 'document_id': 'doc-9'},
+                        ],
+                      },
+                    },
+                  },
+                ],
+              },
+              {
+                'type': 'RUN_FINISHED',
+                'thread_id': 'thread-456',
+                'run_id': 'run-2',
+              },
+            ],
+          });
+
+          final history = await api.getThreadHistory('room-123', 'thread-456');
+
+          final ref = history.messageStates['user-1']!.sourceReferences.single;
+          expect(ref.chunkId, 'chunk-1');
+          expect(ref.figures, hasLength(1));
+          expect(ref.figures.single.ref, '#/pictures/0');
+          expect(ref.figures.single.bytes, base64Decode('aGVsbG8='));
+        });
       });
 
       test('populates runs with decoded events in arrival order', () async {

--- a/packages/soliplex_client/test/application/citation_extractor_picture_bytes_test.dart
+++ b/packages/soliplex_client/test/application/citation_extractor_picture_bytes_test.dart
@@ -33,7 +33,8 @@ void main() {
       },
     };
 
-    final refs = CitationExtractor().extractNew(const {}, current);
+    final extractor = CitationExtractor();
+    final refs = extractor.resolve(extractor.citationIds(current), current);
 
     expect(refs, hasLength(1));
     final ref = refs.single;

--- a/packages/soliplex_client/test/application/citation_extractor_test.dart
+++ b/packages/soliplex_client/test/application/citation_extractor_test.dart
@@ -1,4 +1,7 @@
+import 'package:ag_ui/ag_ui.dart';
 import 'package:soliplex_client/src/application/citation_extractor.dart';
+import 'package:soliplex_client/src/domain/source_reference.dart';
+import 'package:soliplex_logging/soliplex_logging.dart';
 import 'package:test/test.dart';
 
 void main() {
@@ -8,6 +11,11 @@ void main() {
     setUp(() {
       extractor = CitationExtractor();
     });
+
+    /// Resolves every id cited in [state] — the common case where the caller
+    /// has no accumulated set and just wants what the state itself carries.
+    List<SourceReference> extract(Map<String, dynamic> state) =>
+        extractor.resolve(extractor.citationIds(state), state);
 
     group('wire shape', () {
       Map<String, dynamic> createCitation({
@@ -53,29 +61,14 @@ void main() {
         };
       }
 
-      test('returns empty when no state change', () {
+      test('resolves empty when the state has no citations', () {
+        final refs = extract(createState());
+
+        expect(refs, isEmpty);
+      });
+
+      test('resolves a citation with all its fields', () {
         final state = createState(
-          citationIndex: {'c1': createCitation(chunkId: 'c1')},
-          citations: ['c1'],
-        );
-
-        final refs = extractor.extractNew(state, state);
-
-        expect(refs, isEmpty);
-      });
-
-      test('returns empty when previous state is empty', () {
-        final previous = createState();
-        final current = createState();
-
-        final refs = extractor.extractNew(previous, current);
-
-        expect(refs, isEmpty);
-      });
-
-      test('extracts citations when previous is empty', () {
-        final previous = createState();
-        final current = createState(
           citationIndex: {
             'chunk-1': createCitation(
               chunkId: 'chunk-1',
@@ -91,7 +84,7 @@ void main() {
           citations: ['chunk-1'],
         );
 
-        final refs = extractor.extractNew(previous, current);
+        final refs = extract(state);
 
         expect(refs, hasLength(1));
         expect(refs[0].chunkId, 'chunk-1');
@@ -108,8 +101,7 @@ void main() {
       });
 
       test('reads sourceUrl from the citation document_meta', () {
-        final previous = createState();
-        final current = createState(
+        final state = createState(
           citationIndex: {
             'c1': createCitation(
               chunkId: 'c1',
@@ -119,14 +111,13 @@ void main() {
           citations: ['c1'],
         );
 
-        final refs = extractor.extractNew(previous, current);
+        final refs = extract(state);
 
         expect(refs.single.sourceUrl, Uri.parse('https://example.test/a/view'));
       });
 
       test('sourceUrl is null when document_meta carries no usable url', () {
-        final previous = createState();
-        final current = createState(
+        final state = createState(
           citationIndex: {
             'c1': createCitation(
               chunkId: 'c1',
@@ -137,31 +128,29 @@ void main() {
           citations: ['c1', 'c2'],
         );
 
-        final refs = extractor.extractNew(previous, current);
+        final refs = extract(state);
 
         expect(refs.every((r) => r.sourceUrl == null), isTrue);
       });
 
       test('defaults headings and pageNumbers to empty lists when absent', () {
-        final previous = createState();
-        final current = createState(
+        final state = createState(
           citationIndex: {'c1': createCitation(chunkId: 'c1')},
           citations: ['c1'],
         );
 
-        final refs = extractor.extractNew(previous, current);
+        final refs = extract(state);
 
         expect(refs, hasLength(1));
         expect(refs[0].headings, isEmpty);
         expect(refs[0].pageNumbers, isEmpty);
       });
 
-      test('extracts only ids not already in previous', () {
-        final previous = createState(
-          citationIndex: {'old-chunk': createCitation(chunkId: 'old-chunk')},
-          citations: ['old-chunk'],
-        );
-        final current = createState(
+      test('resolves a re-cited id — no subtraction of prior ids', () {
+        // A chunk cited in an earlier turn is still resolved when re-cited.
+        // The extractor never subtracts; cross-turn accumulation is the
+        // caller's job.
+        final state = createState(
           citationIndex: {
             'old-chunk': createCitation(chunkId: 'old-chunk'),
             'new-chunk': createCitation(chunkId: 'new-chunk'),
@@ -169,24 +158,21 @@ void main() {
           citations: ['old-chunk', 'new-chunk'],
         );
 
-        final refs = extractor.extractNew(previous, current);
+        final refs = extract(state);
 
-        expect(refs, hasLength(1));
-        expect(refs[0].chunkId, 'new-chunk');
+        expect(
+          refs.map((r) => r.chunkId),
+          unorderedEquals(['old-chunk', 'new-chunk']),
+        );
       });
 
-      test('extracts new ids across invocation reset', () {
-        // Prior invocation's citations are cleared by the lifespan hook;
-        // the new invocation's ids should still be extracted even though
-        // the previous snapshot held different ids.
-        final previous = createState(
-          citationIndex: {
-            'a': createCitation(chunkId: 'a'),
-            'b': createCitation(chunkId: 'b'),
-          },
-          citations: ['a', 'b'],
-        );
-        final current = createState(
+      test('resolves accumulated ids absent from the current citations list',
+          () {
+        // The backend clears `citations` per invocation but keeps
+        // `citation_index` session-cumulative. The caller hands resolve() the
+        // full accumulated set; every id still resolves against the index even
+        // though `citations` holds only the last invocation's id.
+        final state = createState(
           citationIndex: {
             'a': createCitation(chunkId: 'a'),
             'b': createCitation(chunkId: 'b'),
@@ -195,15 +181,13 @@ void main() {
           citations: ['c'],
         );
 
-        final refs = extractor.extractNew(previous, current);
+        final refs = extractor.resolve({'a', 'b', 'c'}, state);
 
-        expect(refs, hasLength(1));
-        expect(refs[0].chunkId, 'c');
+        expect(refs.map((r) => r.chunkId), unorderedEquals(['a', 'b', 'c']));
       });
 
-      test('extracts multiple new ids at once', () {
-        final previous = createState();
-        final current = createState(
+      test('resolves multiple ids at once', () {
+        final state = createState(
           citationIndex: {
             'chunk-1': createCitation(chunkId: 'chunk-1'),
             'chunk-2': createCitation(chunkId: 'chunk-2'),
@@ -212,143 +196,293 @@ void main() {
           citations: ['chunk-1', 'chunk-2', 'chunk-3'],
         );
 
-        final refs = extractor.extractNew(previous, current);
+        final refs = extract(state);
 
-        expect(refs, hasLength(3));
-        expect(refs.map((r) => r.chunkId), ['chunk-1', 'chunk-2', 'chunk-3']);
+        expect(
+          refs.map((r) => r.chunkId),
+          unorderedEquals(['chunk-1', 'chunk-2', 'chunk-3']),
+        );
       });
 
-      test('returns empty when current has no citations', () {
-        final previous = createState();
-        final current = createState();
-
-        final refs = extractor.extractNew(previous, current);
-
-        expect(refs, isEmpty);
-      });
-
-      test('extracts citations from STATE_DELTA with minimal keys', () {
-        final previous = createState();
-        final current = <String, dynamic>{
+      test('resolves against a minimally-shaped rag block', () {
+        final state = <String, dynamic>{
           'rag': {
             'citation_index': {'c1': createCitation(chunkId: 'c1')},
             'citations': ['c1'],
           },
         };
 
-        final refs = extractor.extractNew(previous, current);
+        final refs = extract(state);
 
         expect(refs, hasLength(1));
         expect(refs[0].chunkId, 'c1');
       });
 
       test('skips citation ids missing from citation_index', () {
-        final previous = createState();
-        final current = createState(
+        final state = createState(
           citationIndex: {'c1': createCitation(chunkId: 'c1')},
           citations: ['c1', 'missing'],
         );
 
-        final refs = extractor.extractNew(previous, current);
+        final refs = extract(state);
 
         expect(refs, hasLength(1));
         expect(refs[0].chunkId, 'c1');
       });
     });
 
-    group('edge cases', () {
-      test('returns empty for unknown state format', () {
-        final previous = <String, dynamic>{};
-        final current = <String, dynamic>{'unknown_key': <String, dynamic>{}};
+    group('citationIds', () {
+      Map<String, dynamic> citation(String chunkId) => {
+            'chunk_id': chunkId,
+            'content': 'content for $chunkId',
+            'document_id': 'doc-1',
+            'document_uri': 'https://example.com/doc.pdf',
+          };
 
-        final refs = extractor.extractNew(previous, current);
+      Map<String, dynamic> block(List<String> citations) => {
+            'citation_index': {for (final id in citations) id: citation(id)},
+            'citations': citations,
+          };
 
-        expect(refs, isEmpty);
-      });
-
-      test('returns empty when current citations are a subset of previous', () {
-        // Happens when lifespan resets to empty mid-stream, or when ids from
-        // previous are no longer present in current.
-        final previous = <String, dynamic>{
-          'rag': {
-            'citation_index': <String, dynamic>{},
-            'citations': ['a', 'b'],
-          },
-        };
-        final current = <String, dynamic>{
-          'rag': {
-            'citation_index': <String, dynamic>{},
-            'citations': ['a'],
-          },
+      test('unions ids across every citation-bearing namespace', () {
+        final state = <String, dynamic>{
+          'rag': block(const ['a', 'b']),
+          'analysis': block(const ['b', 'c']),
         };
 
-        final refs = extractor.extractNew(previous, current);
-
-        expect(refs, isEmpty);
+        expect(extractor.citationIds(state), {'a', 'b', 'c'});
       });
 
-      test('returns empty when current citations are cleared', () {
-        final previous = <String, dynamic>{};
-        final current = <String, dynamic>{
-          'rag': {
-            'citation_index': <String, dynamic>{},
-            'citations': <String>[],
-          },
+      test('skips namespaces without a citation_index', () {
+        final state = <String, dynamic>{
+          'rag': block(const ['a']),
+          'bubble-sandbox': {'foo': 'bar'},
         };
 
-        final refs = extractor.extractNew(previous, current);
-        expect(refs, isEmpty);
+        expect(extractor.citationIds(state), {'a'});
       });
 
-      test('returns empty when rag key is not a Map', () {
-        final previous = <String, dynamic>{};
-        final current = <String, dynamic>{'rag': 'not a map'};
-
-        final refs = extractor.extractNew(previous, current);
-        expect(refs, isEmpty);
-      });
-
-      test('treats non-Map previous rag key as empty', () {
-        final previous = <String, dynamic>{'rag': 42};
-        final current = <String, dynamic>{
+      test('tolerates a malformed citations list', () {
+        final state = <String, dynamic>{
           'rag': {
             'citation_index': <String, dynamic>{},
-            'citations': <String>[],
+            'citations': 'not a list',
           },
         };
 
-        // Previous coerced to empty; current has no citations either.
-        final refs = extractor.extractNew(previous, current);
-        expect(refs, isEmpty);
+        expect(extractor.citationIds(state), isEmpty);
       });
 
-      test('returns empty when citations is not a List', () {
-        final previous = <String, dynamic>{};
-        final current = <String, dynamic>{
-          'rag': {'citations': 'not a list'},
-        };
-
-        final refs = extractor.extractNew(previous, current);
-        expect(refs, isEmpty);
+      test('is empty when the state has no citation namespaces', () {
+        expect(extractor.citationIds(const {'unknown': 42}), isEmpty);
       });
+    });
+
+    group('citationIdsInDelta', () {
+      Map<String, dynamic> citation(String chunkId) => {
+            'chunk_id': chunkId,
+            'content': 'content for $chunkId',
+            'document_id': 'doc-1',
+            'document_uri': 'https://example.com/doc.pdf',
+          };
+
+      Map<String, dynamic> block(List<String> citations) => {
+            'citation_index': {for (final id in citations) id: citation(id)},
+            'citations': citations,
+          };
+
+      StateDeltaEvent deltaTouching(List<String> paths) => StateDeltaEvent(
+            delta: [
+              for (final path in paths)
+                {'op': 'add', 'path': path, 'value': 'x'},
+            ],
+          );
 
       test(
-        'tolerates non-string entries in the citations list',
-        () {
-          // citations is supposed to be List<String>. Any other shape
-          // (ints, nulls, nested lists) must not crash the extractor.
-          final previous = <String, dynamic>{};
-          final current = <String, dynamic>{
+          'scopes to the namespace the delta touched, ignoring a stale '
+          'sibling', () {
+        // rag carries a prior turn's citations that ride the rebase snapshot;
+        // this delta invoked only analysis, so rag's ids are not this turn's.
+        final state = <String, dynamic>{
+          'rag': block(const ['a']),
+          'analysis': block(const ['b']),
+        };
+
+        final ids = extractor.citationIdsInDelta(
+          state,
+          deltaTouching(const ['/analysis/citations/-']),
+        );
+
+        expect(ids, {'b'});
+      });
+
+      test('unions across every namespace the delta touched', () {
+        final state = <String, dynamic>{
+          'rag': block(const ['a']),
+          'analysis': block(const ['b']),
+        };
+
+        final ids = extractor.citationIdsInDelta(
+          state,
+          deltaTouching(const ['/rag/citations/0', '/analysis/citations/0']),
+        );
+
+        expect(ids, {'a', 'b'});
+      });
+
+      test('is empty when the delta touches no citation-bearing namespace', () {
+        final state = <String, dynamic>{
+          'rag': block(const ['a']),
+        };
+
+        final ids = extractor.citationIdsInDelta(
+          state,
+          deltaTouching(const ['/document_filter']),
+        );
+
+        expect(ids, isEmpty);
+      });
+
+      test('skips malformed ops with a warning', () {
+        // A non-Map op and a pathless op are both malformed JSON-Patch. They
+        // must be skipped (touching no namespace) and each logged, so a
+        // drifting wire shape can't lose a namespace's citations silently.
+        final sink = _RecordingSink();
+        LogManager.instance.addSink(sink);
+        addTearDown(() => LogManager.instance.removeSink(sink));
+
+        // State is never read: malformed ops touch no namespace, so
+        // citationIdsInDelta returns before consulting it.
+        final ids = extractor.citationIdsInDelta(
+          const {},
+          const StateDeltaEvent(
+            delta: [
+              'not-a-map',
+              <String, dynamic>{'op': 'add', 'value': 'x'},
+            ],
+          ),
+        );
+
+        expect(ids, isEmpty);
+        expect(sink.records, hasLength(2));
+        expect(sink.records.every((r) => r.level == LogLevel.warning), isTrue);
+      });
+
+      test('skips a rooted op that names no namespace, with a warning', () {
+        // A valid String path that yields no namespace segment ("/", "") is
+        // degenerate JSON-Patch. Like the other malformed shapes it must be
+        // skipped and logged, not silently dropped.
+        final sink = _RecordingSink();
+        LogManager.instance.addSink(sink);
+        addTearDown(() => LogManager.instance.removeSink(sink));
+
+        final ids = extractor.citationIdsInDelta(
+          const {},
+          deltaTouching(const ['/']),
+        );
+
+        expect(ids, isEmpty);
+        expect(sink.records, hasLength(1));
+        expect(sink.records.single.level, LogLevel.warning);
+      });
+    });
+
+    group('resolve', () {
+      Map<String, dynamic> citation(String chunkId) => {
+            'chunk_id': chunkId,
+            'content': 'content for $chunkId',
+            'document_id': 'doc-1',
+            'document_uri': 'https://example.com/doc.pdf',
+          };
+
+      Map<String, dynamic> stateWith(List<String> ids) => {
             'rag': {
-              'citation_index': <String, dynamic>{},
-              'citations': <dynamic>[123, null, <String>[]],
+              'citation_index': {for (final id in ids) id: citation(id)},
+              'citations': ids,
             },
           };
 
-          final refs = extractor.extractNew(previous, current);
-          expect(refs, isEmpty);
-        },
-      );
+      test('dedups repeated ids', () {
+        final refs = extractor.resolve(['a', 'a'], stateWith(['a']));
+
+        expect(refs, hasLength(1));
+        expect(refs.single.chunkId, 'a');
+      });
+
+      test('skips ids absent from every citation_index', () {
+        final refs = extractor.resolve(['a', 'ghost'], stateWith(['a']));
+
+        expect(refs.map((r) => r.chunkId), ['a']);
+      });
+
+      test('warns when a cited id is absent from every citation_index', () {
+        // A cited id missing from the cumulative index means the source list
+        // is silently short — a backend contract violation the caller can't
+        // otherwise see. It must be logged.
+        final sink = _RecordingSink();
+        LogManager.instance.addSink(sink);
+        addTearDown(() => LogManager.instance.removeSink(sink));
+
+        extractor.resolve(['a', 'ghost'], stateWith(['a']));
+
+        expect(sink.records, hasLength(1));
+        expect(sink.records.single.level, LogLevel.warning);
+        expect(sink.records.single.message, contains('ghost'));
+      });
+
+      test('is empty when the state carries no citation namespace', () {
+        final refs = extractor.resolve(['a'], const {'unknown': 42});
+
+        expect(refs, isEmpty);
+      });
+    });
+
+    group('edge cases', () {
+      test('resolves empty for unknown state format', () {
+        final refs = extract(
+          <String, dynamic>{'unknown_key': <String, dynamic>{}},
+        );
+
+        expect(refs, isEmpty);
+      });
+
+      test('resolves empty when the citations list is empty', () {
+        final refs = extract(<String, dynamic>{
+          'rag': {
+            'citation_index': <String, dynamic>{},
+            'citations': <String>[],
+          },
+        });
+
+        expect(refs, isEmpty);
+      });
+
+      test('resolves empty when rag key is not a Map', () {
+        final refs = extract(<String, dynamic>{'rag': 'not a map'});
+
+        expect(refs, isEmpty);
+      });
+
+      test('resolves empty when citations is not a List', () {
+        final refs = extract(<String, dynamic>{
+          'rag': {'citations': 'not a list'},
+        });
+
+        expect(refs, isEmpty);
+      });
+
+      test('tolerates non-string entries in the citations list', () {
+        // citations is supposed to be List<String>. Any other shape
+        // (ints, nulls, nested lists) must not crash the extractor.
+        final refs = extract(<String, dynamic>{
+          'rag': {
+            'citation_index': <String, dynamic>{},
+            'citations': <dynamic>[123, null, <String>[]],
+          },
+        });
+
+        expect(refs, isEmpty);
+      });
     });
 
     group('multiple namespaces', () {
@@ -364,32 +498,49 @@ void main() {
             'citations': citations,
           };
 
-      test('extracts citations from the analysis namespace', () {
-        final previous = <String, dynamic>{'analysis': block(const [])};
-        final current = <String, dynamic>{
+      test('resolves citations from the analysis namespace', () {
+        final state = <String, dynamic>{
           'analysis': block(const ['a1']),
         };
 
-        final refs = extractor.extractNew(previous, current);
+        final refs = extract(state);
 
         expect(refs, hasLength(1));
         expect(refs.single.chunkId, 'a1');
       });
 
       test('deduplicates a chunk cited in both rag and analysis', () {
-        final previous = <String, dynamic>{
-          'rag': block(const []),
-          'analysis': block(const []),
-        };
-        final current = <String, dynamic>{
+        final state = <String, dynamic>{
           'rag': block(const ['shared']),
           'analysis': block(const ['shared', 'analysis-only']),
         };
 
-        final refs = extractor.extractNew(previous, current);
+        final refs = extract(state);
 
-        expect(refs.map((r) => r.chunkId), ['shared', 'analysis-only']);
+        expect(
+          refs.map((r) => r.chunkId),
+          unorderedEquals(['shared', 'analysis-only']),
+        );
       });
     });
   });
+}
+
+/// Captures records from the citation extractor's logger, ignoring all other
+/// log traffic the singleton sees so assertions stay strict.
+class _RecordingSink implements LogSink {
+  final List<LogRecord> records = [];
+
+  @override
+  void write(LogRecord record) {
+    if (record.loggerName == 'soliplex_client.citation_extractor') {
+      records.add(record);
+    }
+  }
+
+  @override
+  Future<void> flush() async {}
+
+  @override
+  Future<void> close() async {}
 }

--- a/packages/soliplex_client/test/application/rag_snapshot_test.dart
+++ b/packages/soliplex_client/test/application/rag_snapshot_test.dart
@@ -1,4 +1,5 @@
 import 'package:soliplex_client/src/application/rag_snapshot.dart';
+import 'package:soliplex_logging/soliplex_logging.dart';
 import 'package:test/test.dart';
 
 void main() {
@@ -83,6 +84,41 @@ void main() {
       expect(snapshot.resolveCitation('c2'), isNotNull);
     });
 
+    test('warns when citations is present but not a List', () {
+      // Container drift (a Map/String where a list is expected) drops every
+      // id for the namespace. Left silent, the source list renders short with
+      // no trace — so it must be surfaced.
+      final sink = _RecordingSink();
+      LogManager.instance.addSink(sink);
+      addTearDown(() => LogManager.instance.removeSink(sink));
+
+      final snapshot = RagSnapshot.fromJson(<String, dynamic>{
+        'citation_index': <String, dynamic>{},
+        'citations': {'wrong': 'shape'},
+      });
+
+      expect(snapshot.citationIds, isEmpty);
+      expect(sink.records, hasLength(1));
+      expect(sink.records.single.level, LogLevel.warning);
+      expect(sink.records.single.message, contains('citations'));
+    });
+
+    test('warns when citation_index is present but not a Map', () {
+      final sink = _RecordingSink();
+      LogManager.instance.addSink(sink);
+      addTearDown(() => LogManager.instance.removeSink(sink));
+
+      final snapshot = RagSnapshot.fromJson(<String, dynamic>{
+        'citation_index': ['wrong', 'shape'],
+        'citations': ['a'],
+      });
+
+      expect(snapshot.resolveCitation('a'), isNull);
+      expect(sink.records, hasLength(1));
+      expect(sink.records.single.level, LogLevel.warning);
+      expect(sink.records.single.message, contains('citation_index'));
+    });
+
     test('tolerates malformed citation_index entries', () {
       // One valid entry, one non-Map, one missing required field.
       final json = <String, dynamic>{
@@ -133,4 +169,23 @@ void main() {
       expect(rag.keys, equals(['document_filter']));
     });
   });
+}
+
+/// Captures records from the rag snapshot's logger, ignoring all other log
+/// traffic the singleton sees so assertions stay strict.
+class _RecordingSink implements LogSink {
+  final List<LogRecord> records = [];
+
+  @override
+  void write(LogRecord record) {
+    if (record.loggerName == 'soliplex_client.rag_snapshot') {
+      records.add(record);
+    }
+  }
+
+  @override
+  Future<void> flush() async {}
+
+  @override
+  Future<void> close() async {}
 }


### PR DESCRIPTION
## What & why

Each run's reply must display **exactly** the sources that run cited — including
chunks re-cited from earlier runs — and nothing the backend did not cite. Three
frontend root causes broke this:

- **Cross-run subtraction.** The old extractor returned only ids in the current
  state not already in the previous, so a re-cited chunk was silently dropped.
- **Final-snapshot-only read.** Extraction ran once at run end and read only the
  final `citations` list; the backend clears that list at each skill invocation,
  so a multi-invocation run kept only the last invocation's ids.
- **Live/replay divergence.** The live path merged per-turn while replay
  overwrote per-run, so the same thread looked different live vs. on reload.

## Approach

Both paths now share one rule over the shared `CitationExtractor`: on each
`StateDeltaEvent`, accumulate `citationIdsInDelta(state, event)` into a per-turn
set (scoped to the namespaces the delta touched, so a stale prior-turn namespace
isn't attributed to this run); at each terminal, `resolve(ids, state)` that set
against the current AG-UI state. Snapshots are applied but never accumulated.
`citation_index` is session-cumulative, so accumulated ids always resolve.

Full design and the live-vs-replay walkthrough:
`docs/plans/per-run-citation-completeness-codepaths.md`.

## Known limitation (deferred)

Inline figure *bytes* for chunks cited by an *earlier invocation of a
multi-invocation run* are dropped (text/metadata unaffected; single-invocation
runs unaffected). Not a regression — those citations were not shown at all
before. Follow-up: `docs/plans/per-run-citation-completeness-figures-followup.md`.

## Tests

- Extractor units: re-cite retention, multi-invocation union, delta-namespace
  scoping, cumulative-index resolution, unresolved-id warning, container-drift
  warnings.
- Live (`RunOrchestrator`) and replay (`_replayEventsToHistory`) each covered
  for re-cites, multi-invocation, snapshot-not-accumulated, and figure-byte
  retention across turns.
- `flutter analyze` clean; suites green (pre-existing `test/http/` TCP-socket
  flakiness is unrelated to this change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
