### PR TITLE
fix(design): lower dialogs, drawers, and rail avatars to the brand shape

### DIFF
--- a/lib/src/modules/room/ui/room_rail.dart
+++ b/lib/src/modules/room/ui/room_rail.dart
@@ -252,10 +252,11 @@ class _RoomAvatarTile extends StatelessWidget {
                       Positioned.fill(
                         child: Material(
                           color: bg,
-                          // A selected avatar squares off (smaller radius) so the
-                          // shape shift reinforces the leading bar.
-                          borderRadius: BorderRadius.circular(
-                              selected ? context.radii.md : _avatar / 2),
+                          // Every avatar takes the brand shape (`radii.md`), so
+                          // `BrandShape.square()` squares the rail off. Selection
+                          // is carried by the leading bar and fill, not a
+                          // circle→rounded-square morph (issue #456).
+                          borderRadius: BorderRadius.circular(context.radii.md),
                           clipBehavior: Clip.antiAlias,
                           child: InkWell(
                             onTap: onTap,

--- a/lib/src/modules/room/ui/room_rail.dart
+++ b/lib/src/modules/room/ui/room_rail.dart
@@ -253,9 +253,9 @@ class _RoomAvatarTile extends StatelessWidget {
                         child: Material(
                           color: bg,
                           // Every avatar takes the brand shape (`radii.md`), so
-                          // `BrandShape.square()` squares the rail off. Selection
-                          // is carried by the leading bar and fill, not a
-                          // circle→rounded-square morph (issue #456).
+                          // `BrandShape.square()` squares the rail off; selection
+                          // is carried by the leading bar, not the avatar shape
+                          // (issue #456).
                           borderRadius: BorderRadius.circular(context.radii.md),
                           clipBehavior: Clip.antiAlias,
                           child: InkWell(

--- a/packages/soliplex_design/lib/src/theme/theme.dart
+++ b/packages/soliplex_design/lib/src/theme/theme.dart
@@ -275,6 +275,24 @@ ThemeData buildSoliplexThemeData({
       ),
       textStyle: textTheme.bodyMedium,
     ),
+    // Dialogs and drawers otherwise fall through to Material's own rounded
+    // defaults (28 / 16), skipping the brand shape. Lower both to `radii.md`
+    // so `BrandShape.square()` squares them off like every other surface
+    // (issue #456).
+    dialogTheme: DialogThemeData(
+      shape: RoundedRectangleBorder(
+        borderRadius: BorderRadius.circular(radii.md),
+      ),
+    ),
+    // Round only the trailing edge, mirroring Material's drawer default: the
+    // leading edge is flush to the screen and stays square.
+    drawerTheme: DrawerThemeData(
+      shape: RoundedRectangleBorder(
+        borderRadius: BorderRadiusDirectional.horizontal(
+          end: Radius.circular(radii.md),
+        ),
+      ),
+    ),
     scaffoldBackgroundColor: colors.background,
     useMaterial3: true,
     textTheme: textTheme,

--- a/packages/soliplex_design/test/brand/brand_lowering_test.dart
+++ b/packages/soliplex_design/test/brand/brand_lowering_test.dart
@@ -238,6 +238,17 @@ void main() {
         (theme.cardTheme.shape! as RoundedRectangleBorder).borderRadius,
         BorderRadius.circular(0),
       );
+      // Dialogs and drawers lower to the brand shape too, so they square off
+      // with everything else rather than keeping Material's rounded defaults
+      // (issue #456).
+      expect(
+        (theme.dialogTheme.shape! as RoundedRectangleBorder).borderRadius,
+        BorderRadius.circular(0),
+      );
+      expect(
+        (theme.drawerTheme.shape! as RoundedRectangleBorder).borderRadius,
+        BorderRadiusDirectional.zero,
+      );
     });
 
     test('body and display families flow into the text theme', () {


### PR DESCRIPTION
## What

Three surfaces ignored `BrandShape` and kept Material's rounded defaults, so a `BrandShape.square()` brand couldn't square them off (issue #456, confirmed by John on Chrome, Android, iPhone, iPad):

- **Dialogs & drawers** — no `dialogTheme` / `drawerTheme` was set, so alert dialogs ("Leave Quiz?", the document picker) and the mobile drawer stayed rounded. Lowered both to `radii.md` at the theme funnel; the drawer rounds only its trailing edge (mirroring Material's default), so the edge flush to the screen stays square.
- **Rail avatars** — hardcoded a full circle when unselected and a rounded square when selected, mixing two off-contract shapes. Every avatar now takes `radii.md`; the leading selection bar and fill carry selection instead of a circle→rounded-square morph.

Under the default `rounded()` brand everything keeps its rounded look; under `square()` it all squares off with the rest of the surfaces.

## Notes

- John's report pointed at `lib/theme.dart` / `BrandShape.square()`; the token actually lives in `soliplex_design`'s `BrandShape`, but his diagnosis — buttons/inputs/cards/menus honor the shape, the surfaces below don't — was exactly right.
- The dialog/drawer fix is a single theme-funnel edit, so it covers every dialog and both drawers on all platforms at once.

## Tests

- `brand_lowering_test`: dialogs and drawers lower to a zero radius under `BrandShape.square()`.
- Existing rail and theme suites pass.

Addresses #456

🤖 Generated with [Claude Code](https://claude.com/claude-code)