### PR TITLE
fix(room): collapse the citation transcript so it stops trapping scroll

### DIFF
--- a/lib/src/modules/room/ui/citations_section.dart
+++ b/lib/src/modules/room/ui/citations_section.dart
@@ -22,6 +22,15 @@ final _logger = LogManager.instance.getLogger('soliplex_frontend.citations');
 /// Not on the spacing scale — a component dimension, kept in one place.
 const double _figureThumbnailSize = 120;
 
+/// Height of the cited transcript when collapsed: a few lines of the passage,
+/// shown *non-scrolling* so scrolling the thread past a run of expanded
+/// citations doesn't get trapped in a nested scrollbox (issue #451).
+/// A component dimension, off the spacing scale, kept beside its expanded peer.
+const double _transcriptCollapsedHeight = 72;
+
+/// Max height of the expanded, internally-scrollable transcript band.
+const double _transcriptExpandedMaxHeight = 250;
+
 /// Fallback label shown when a cited figure can't be decoded.
 const String _figureUnavailableLabel = 'Figure unavailable';
 
@@ -297,20 +306,7 @@ class _SourceReferenceRow extends StatelessWidget {
             if (sourceReference.figures.isNotEmpty &&
                 sourceReference.headings.isEmpty)
               const SizedBox(height: SoliplexSpacing.s2),
-            Container(
-              constraints: const BoxConstraints(maxHeight: 250),
-              padding: const EdgeInsets.all(SoliplexSpacing.s2),
-              decoration: BoxDecoration(
-                color: theme.colorScheme.surfaceContainerHighest,
-                borderRadius: BorderRadius.circular(context.radii.md),
-              ),
-              child: SingleChildScrollView(
-                child: FlutterMarkdownPlusRenderer(
-                  data: sourceReference.content,
-                  selectable: false,
-                ),
-              ),
-            ),
+            _CitationTranscript(content: sourceReference.content),
           ],
           const SizedBox(height: SoliplexSpacing.s2),
           _metaLine(context, theme, 'chunk id', sourceReference.chunkId),
@@ -347,6 +343,103 @@ class _SourceReferenceRow extends StatelessWidget {
               ),
             ),
           ],
+        ),
+      ),
+    );
+  }
+}
+
+/// The cited passage's transcript.
+///
+/// Collapsed by default to a few non-scrolling lines, so scrolling the thread
+/// past a run of expanded citations passes straight through instead of getting
+/// trapped in a nested scrollbox (issue #451). Expanding lifts it to a bounded,
+/// internally-scrollable band — the reader opts into the inner scroll only for
+/// the one passage they want to read in full.
+class _CitationTranscript extends StatefulWidget {
+  const _CitationTranscript({required this.content});
+
+  final String content;
+
+  @override
+  State<_CitationTranscript> createState() => _CitationTranscriptState();
+}
+
+class _CitationTranscriptState extends State<_CitationTranscript> {
+  bool _expanded = false;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final markdown = FlutterMarkdownPlusRenderer(
+      data: widget.content,
+      selectable: false,
+    );
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        DecoratedBox(
+          decoration: BoxDecoration(
+            color: theme.colorScheme.surfaceContainerHighest,
+            borderRadius: BorderRadius.circular(context.radii.md),
+          ),
+          child: Padding(
+            padding: const EdgeInsets.all(SoliplexSpacing.s2),
+            child: _expanded
+                ? ConstrainedBox(
+                    constraints: const BoxConstraints(
+                      maxHeight: _transcriptExpandedMaxHeight,
+                    ),
+                    child: SingleChildScrollView(child: markdown),
+                  )
+                : _CollapsedTranscript(child: markdown),
+          ),
+        ),
+        // Toggle mirrors the figure caption's more/less idiom below.
+        GestureDetector(
+          behavior: HitTestBehavior.opaque,
+          onTap: () => setState(() => _expanded = !_expanded),
+          child: Padding(
+            padding: const EdgeInsets.only(top: SoliplexSpacing.s1),
+            child: Text(
+              _expanded ? 'Show less' : 'Show full transcript',
+              style: theme.textTheme.labelSmall?.copyWith(
+                color: theme.colorScheme.primary,
+              ),
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+/// A fixed-height, non-scrolling preview of the transcript. The
+/// [NeverScrollableScrollPhysics] clips the overflow to the band *without*
+/// consuming scroll gestures, so the surrounding thread keeps scrolling; a
+/// bottom fade signals that the passage continues (issue #451).
+class _CollapsedTranscript extends StatelessWidget {
+  const _CollapsedTranscript({required this.child});
+
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context) {
+    return SizedBox(
+      height: _transcriptCollapsedHeight,
+      child: ShaderMask(
+        blendMode: BlendMode.dstIn,
+        shaderCallback: (rect) => const LinearGradient(
+          begin: Alignment.topCenter,
+          end: Alignment.bottomCenter,
+          colors: [Colors.black, Colors.black, Colors.transparent],
+          stops: [0.0, 0.6, 1.0],
+        ).createShader(rect),
+        child: SingleChildScrollView(
+          physics: const NeverScrollableScrollPhysics(),
+          child: child,
         ),
       ),
     );

--- a/lib/src/modules/room/ui/citations_section.dart
+++ b/lib/src/modules/room/ui/citations_section.dart
@@ -29,6 +29,7 @@ const double _figureThumbnailSize = 120;
 const double _transcriptCollapsedHeight = 72;
 
 /// Max height of the expanded, internally-scrollable transcript band.
+/// Off the spacing scale — a component dimension, like its collapsed peer.
 const double _transcriptExpandedMaxHeight = 250;
 
 /// Fallback label shown when a cited figure can't be decoded.
@@ -397,16 +398,24 @@ class _CitationTranscriptState extends State<_CitationTranscript> {
                 : _CollapsedTranscript(child: markdown),
           ),
         ),
-        // Toggle mirrors the figure caption's more/less idiom below.
-        GestureDetector(
-          behavior: HitTestBehavior.opaque,
-          onTap: () => setState(() => _expanded = !_expanded),
-          child: Padding(
-            padding: const EdgeInsets.only(top: SoliplexSpacing.s1),
-            child: Text(
-              _expanded ? 'Show less' : 'Show full transcript',
-              style: theme.textTheme.labelSmall?.copyWith(
-                color: theme.colorScheme.primary,
+        // Toggle mirrors the figure caption's more/less idiom below. A pointer
+        // cursor and tooltip on hover mark it as the clickable expand control;
+        // the padding both spaces it below the box and gives the hover
+        // highlight a balanced pill around the label.
+        Tooltip(
+          message: _expanded
+              ? 'Collapse the cited passage'
+              : 'Expand the full cited passage',
+          child: InkWell(
+            onTap: () => setState(() => _expanded = !_expanded),
+            borderRadius: BorderRadius.circular(context.radii.sm),
+            child: Padding(
+              padding: const EdgeInsets.all(SoliplexSpacing.s1),
+              child: Text(
+                _expanded ? 'Show less' : 'Show full transcript',
+                style: theme.textTheme.labelSmall?.copyWith(
+                  color: theme.colorScheme.primary,
+                ),
               ),
             ),
           ),
@@ -416,10 +425,10 @@ class _CitationTranscriptState extends State<_CitationTranscript> {
   }
 }
 
-/// A fixed-height, non-scrolling preview of the transcript. The
-/// [NeverScrollableScrollPhysics] clips the overflow to the band *without*
-/// consuming scroll gestures, so the surrounding thread keeps scrolling; a
-/// bottom fade signals that the passage continues (issue #451).
+/// A fixed-height, non-scrolling preview of the transcript. The fixed-height
+/// box clips the overflow to the band; [NeverScrollableScrollPhysics] keeps the
+/// inner view from consuming scroll gestures, so the surrounding thread keeps
+/// scrolling. A bottom fade signals that the passage continues (issue #451).
 class _CollapsedTranscript extends StatelessWidget {
   const _CollapsedTranscript({required this.child});
 

--- a/test/modules/room/ui/citations_section_test.dart
+++ b/test/modules/room/ui/citations_section_test.dart
@@ -153,6 +153,53 @@ void main() {
     expect(find.text('Preview text here'), findsOneWidget);
   });
 
+  testWidgets(
+      'transcript stays collapsed and non-scrolling until asked to expand',
+      (tester) async {
+    // Issue #451: an expanded citation must not trap the thread's scroll. The
+    // transcript preview is non-scrolling by default; only an explicit expand
+    // turns it into an internally-scrollable band.
+    await tester.pumpWidget(_wrap(
+      CitationsSection(
+        sourceReferences: [
+          _ref(index: 1, title: 'Doc', content: 'Cited passage body'),
+        ],
+      ),
+    ));
+
+    await tester.tap(find.text('1 source'));
+    await tester.pump();
+    await tester.tap(find.text('Doc'));
+    await tester.pump();
+
+    SingleChildScrollView transcriptScroller() => tester.widget(
+          find.ancestor(
+            of: find.byType(FlutterMarkdownPlusRenderer),
+            matching: find.byType(SingleChildScrollView),
+          ),
+        );
+
+    // Collapsed: the invite shows and the preview can't consume scroll, so the
+    // thread scrolls straight past it.
+    expect(find.text('Show full transcript'), findsOneWidget);
+    expect(find.text('Show less'), findsNothing);
+    expect(
+      transcriptScroller().physics,
+      isA<NeverScrollableScrollPhysics>(),
+    );
+
+    // Expanded: the reader opts into the inner scroll for this one passage.
+    await tester.tap(find.text('Show full transcript'));
+    await tester.pump();
+
+    expect(find.text('Show less'), findsOneWidget);
+    expect(find.text('Show full transcript'), findsNothing);
+    expect(
+      transcriptScroller().physics,
+      isNot(isA<NeverScrollableScrollPhysics>()),
+    );
+  });
+
   testWidgets('expanded row shows the chunk id', (tester) async {
     await tester.pumpWidget(_wrap(
       CitationsSection(


### PR DESCRIPTION
## What

Scrolling the thread past an expanded citation got trapped (issue #451, from Alan): the transcript rendered in an always-on `maxHeight: 250` scrollbox that captured the wheel/touch scroll instead of letting the thread move.

Per Alan's second suggestion, the transcript is now **collapsed by default** to a short, *non-scrolling* preview:

- The markdown is clipped to a fixed band by a `SingleChildScrollView` with `NeverScrollableScrollPhysics` — it clips the overflow but passes scroll gestures straight through to the thread, so there's no trap.
- A bottom fade and a "Show full transcript" toggle invite expansion.
- Expanding lifts it into the bounded, internally-scrollable band — the reader opts into the inner scroll only for the one passage they want to read in full.

Most citations stay collapsed, so scrolling past a run of them no longer catches — which is exactly the "if a user wants the 2nd citation they don't encounter this scroll issue" outcome Alan described.

## Tests

- New: the transcript's scroll view uses `NeverScrollableScrollPhysics` until "Show full transcript" is tapped, then becomes scrollable.
- Existing citation suites pass (full room suite green).

Addresses #451

🤖 Generated with [Claude Code](https://claude.com/claude-code)