### PR TITLE
fix: preserve inline figures cited by an earlier skill invocation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,6 +79,11 @@ Versions follow the `version+build` scheme from `pubspec.yaml`, bumped via
   an earlier turn could be dropped, and a reply whose agent searched several
   times kept only its last batch of sources; both now render in full, and a
   thread shows the same sources live and after a reload.
+- A cited source's inline figures now render even when the reply's agent
+  searched several times. Previously, when a later search reused the retrieval
+  slot, figures for a source found by an earlier search of the same reply were
+  dropped and it rendered text-only; those figures are now preserved, live and
+  after a reload.
 
 ## [0.94.0+68] - 2026-07-17
 

--- a/packages/soliplex_agent/lib/src/orchestration/run_orchestrator.dart
+++ b/packages/soliplex_agent/lib/src/orchestration/run_orchestrator.dart
@@ -84,12 +84,13 @@ class RunOrchestrator {
 
   final CitationExtractor _citationExtractor = CitationExtractor();
 
-  /// Union of citation ids seen in this turn's `StateDeltaEvent`s. Each delta's
-  /// touched namespace holds one skill invocation's absolute cited set (via
-  /// [CitationExtractor.citationIdsInDelta]); the union across the turn is its
-  /// complete set. Cleared at turn start (and on reset/sync). See
-  /// [_extractCitations].
-  final Set<String> _turnCitationIds = <String>{};
+  /// Citations accumulated across this turn's `StateDeltaEvent`s — the union of
+  /// cited ids and inline figures. Each delta's touched namespace holds one
+  /// skill invocation's absolute cited set and figures (via
+  /// [CitationExtractor.accumulate]); the union across the turn is its complete
+  /// set, preserving figures a later invocation's `searches` clear would drop.
+  /// Cleared at turn start (and on reset/sync). See [_extractCitations].
+  TurnCitations _turnCitations = const TurnCitations.empty();
   String? _userMessageId;
 
   final StreamController<RunState> _controller =
@@ -333,7 +334,7 @@ class RunOrchestrator {
     _guardNotDisposed();
     _cancelToken?.cancel();
     _cleanup();
-    _turnCitationIds.clear();
+    _turnCitations = const TurnCitations.empty();
     _userMessageId = null;
     _setState(const IdleState());
   }
@@ -350,7 +351,7 @@ class RunOrchestrator {
     if (_currentState is RunningState || _currentState is ToolYieldingState) {
       throw StateError('Cannot sync while a run is active');
     }
-    _turnCitationIds.clear();
+    _turnCitations = const TurnCitations.empty();
     _userMessageId = null;
     _setState(const IdleState());
   }
@@ -813,7 +814,7 @@ class RunOrchestrator {
     final baseState = cachedHistory?.aguiState ?? const {};
     final aguiState =
         stateOverlay == null ? baseState : _mergeState(baseState, stateOverlay);
-    _turnCitationIds.clear();
+    _turnCitations = const TurnCitations.empty();
     _userMessageId = userMsg.id;
     return Conversation(
       threadId: key.threadId,
@@ -917,22 +918,21 @@ class RunOrchestrator {
         try {
           final result =
               processEvent(running.conversation, running.streaming, event);
-          // Accumulate the citation ids this StateDeltaEvent cited, scoped to
-          // the namespaces it touched — one skill invocation's absolute cited
-          // set. Snapshots are intentionally not accumulated: they only echo
-          // the round-tripped seed. Fail-soft because citations are a derived
-          // projection.
+          // Accumulate the citations and inline figures this StateDeltaEvent
+          // cited, scoped to the namespaces it touched — one skill invocation's
+          // absolute cited set. Snapshots are intentionally not accumulated:
+          // they only echo the round-tripped seed. Fail-soft because citations
+          // are a derived projection.
           if (event is StateDeltaEvent) {
             try {
-              _turnCitationIds.addAll(
-                _citationExtractor.citationIdsInDelta(
-                  result.conversation.aguiState,
-                  event,
-                ),
+              _turnCitations = _citationExtractor.accumulate(
+                _turnCitations,
+                result.conversation.aguiState,
+                event,
               );
             } on Object catch (e, st) {
               _logger.error(
-                'Citation id accumulation failed on run ${running.runId}',
+                'Citation accumulation failed on run ${running.runId}',
                 error: e,
                 stackTrace: st,
               );
@@ -1085,7 +1085,7 @@ class RunOrchestrator {
     }
   }
 
-  /// Resolves this turn's accumulated citation ids ([_turnCitationIds]) against
+  /// Resolves this turn's accumulated citations ([_turnCitations]) against
   /// the current AG-UI state and writes them to the turn's [MessageState].
   ///
   /// Always creates a [MessageState] with the [runId] so downstream consumers
@@ -1114,7 +1114,7 @@ class RunOrchestrator {
     var citations = const <SourceReference>[];
     try {
       citations = _citationExtractor.resolve(
-        _turnCitationIds,
+        _turnCitations,
         conversation.aguiState,
         logContext: 'run $runId',
       );

--- a/packages/soliplex_agent/test/orchestration/run_orchestrator_test.dart
+++ b/packages/soliplex_agent/test/orchestration/run_orchestrator_test.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+import 'dart:convert';
 
 import 'package:mocktail/mocktail.dart';
 import 'package:soliplex_agent/soliplex_agent.dart';
@@ -2323,6 +2324,7 @@ void main() {
       String namespace, {
       required Map<String, Map<String, dynamic>> citationIndex,
       required List<String> citations,
+      Map<String, dynamic>? searches,
     }) =>
         StateDeltaEvent(
           delta: [
@@ -2332,6 +2334,7 @@ void main() {
               'value': {
                 'citation_index': citationIndex,
                 'citations': citations,
+                if (searches != null) 'searches': searches,
               },
             },
           ],
@@ -2340,18 +2343,43 @@ void main() {
     StateDeltaEvent ragDelta({
       required Map<String, Map<String, dynamic>> citationIndex,
       required List<String> citations,
+      Map<String, dynamic>? searches,
     }) =>
         namespaceDelta(
           'rag',
           citationIndex: citationIndex,
           citations: citations,
+          searches: searches,
         );
 
-    Map<String, dynamic> citation(String chunkId) => {
+    Map<String, dynamic> citation(
+      String chunkId, {
+      String documentId = 'doc-1',
+      List<String>? pictureRefs,
+    }) =>
+        {
           'chunk_id': chunkId,
           'content': 'Citation text',
-          'document_id': 'doc-1',
+          'document_id': documentId,
           'document_uri': 'https://example.com/doc.pdf',
+          if (pictureRefs != null) 'picture_refs': pictureRefs,
+        };
+
+    /// One retrieval row carrying an inline figure's base64 bytes, shaped like
+    /// a `rag.searches` entry.
+    Map<String, dynamic> figureSearch(
+      String documentId,
+      String ref,
+      String base64Bytes,
+    ) =>
+        {
+          'q': [
+            {
+              'content': 'row',
+              'document_id': documentId,
+              'image_data': {ref: base64Bytes},
+            },
+          ],
         };
 
     List<BaseEvent> citationEvents() => [
@@ -2438,6 +2466,54 @@ void main() {
         refs.map((r) => r.chunkId),
         containsAll(<String>['chunk-1', 'chunk-2']),
       );
+    });
+
+    test('keeps an earlier invocation figure after a later one wipes searches',
+        () async {
+      // Two skill invocations in one run. Invocation 1 cites chunk-1, whose
+      // inline figure bytes ride its searches; invocation 2 cites chunk-2 and
+      // REPLACES the rag block, so searches no longer holds chunk-1's figure.
+      // The turn-level figure accumulator must preserve it.
+      stubCreateRun();
+      stubRunAgent(
+        stream: Stream.fromIterable(<BaseEvent>[
+          const RunStartedEvent(threadId: 'thread-1', runId: _runId),
+          const TextMessageStartEvent(messageId: 'msg-1'),
+          const TextMessageContentEvent(messageId: 'msg-1', delta: 'Answer'),
+          ragDelta(
+            citationIndex: {
+              'chunk-1': citation('chunk-1', pictureRefs: ['#/pictures/0']),
+            },
+            citations: ['chunk-1'],
+            searches: figureSearch('doc-1', '#/pictures/0', 'aGVsbG8='),
+          ),
+          ragDelta(
+            citationIndex: {
+              'chunk-1': citation('chunk-1', pictureRefs: ['#/pictures/0']),
+              'chunk-2': citation('chunk-2', documentId: 'doc-2'),
+            },
+            citations: ['chunk-2'],
+            searches: const {
+              'q': [
+                {'content': 'row', 'document_id': 'doc-2'},
+              ],
+            },
+          ),
+          const TextMessageEndEvent(messageId: 'msg-1'),
+          const RunFinishedEvent(threadId: 'thread-1', runId: _runId),
+        ]),
+      );
+
+      await orchestrator.startRun(key: _key, userMessage: 'Search');
+      await Future<void>.delayed(Duration.zero);
+
+      final completed = orchestrator.currentState as CompletedState;
+      final refs =
+          completed.conversation.messageStates.values.first.sourceReferences;
+      final chunk1 = refs.firstWhere((r) => r.chunkId == 'chunk-1');
+      expect(chunk1.figures, hasLength(1));
+      expect(chunk1.figures.single.ref, '#/pictures/0');
+      expect(chunk1.figures.single.bytes, utf8.encode('hello'));
     });
 
     test('excludes a stale sibling namespace this run never invoked', () async {

--- a/packages/soliplex_client/lib/src/api/soliplex_api.dart
+++ b/packages/soliplex_client/lib/src/api/soliplex_api.dart
@@ -970,9 +970,11 @@ class SoliplexApi {
     var streaming = const AwaitingText() as StreamingState;
     final extractor = CitationExtractor();
     final messageStates = <String, MessageState>{};
-    // Citation ids accumulated per turn (keyed by the run's last user message
-    // id), unioned across every run of the turn — mirroring the live path.
-    final citationIdsByUserMessage = <String, Set<String>>{};
+    // Citations accumulated per turn (keyed by the run's last user message id),
+    // unioned across every run of the turn — mirroring the live path. Carries
+    // cited ids and inline figures so an earlier invocation's figure survives a
+    // later invocation's `searches` clear.
+    final turnsByUserMessage = <String, TurnCitations>{};
     final runs = <RunEventBundle>[];
 
     for (final (:runId, :events, :fetchError, :created) in eventsPerRun) {
@@ -1113,21 +1115,24 @@ class SoliplexApi {
               );
               conversation = result.conversation;
               streaming = result.streaming;
-              // Accumulate the citation ids this StateDeltaEvent cited, scoped
-              // to the namespaces it touched, into the turn's set — one skill
-              // invocation's absolute cited set. Snapshots echo the
-              // round-tripped seed and are intentionally not accumulated. Own
-              // fail-soft guard (log-only, never a drop tile): the event
-              // already processed, and citations are a derived projection.
+              // Accumulate the citations and inline figures this
+              // StateDeltaEvent cited, scoped to the namespaces it touched,
+              // into the turn's accumulator — one skill invocation's absolute
+              // cited set. Snapshots echo the round-tripped seed and are
+              // intentionally not accumulated. Own fail-soft guard (log-only,
+              // never a drop tile): the event already processed, and citations
+              // are a derived projection.
               if (event is StateDeltaEvent && userMessageId != null) {
                 try {
-                  (citationIdsByUserMessage[userMessageId] ??= <String>{})
-                      .addAll(
-                    extractor.citationIdsInDelta(conversation.aguiState, event),
+                  turnsByUserMessage[userMessageId] = extractor.accumulate(
+                    turnsByUserMessage[userMessageId] ??
+                        const TurnCitations.empty(),
+                    conversation.aguiState,
+                    event,
                   );
                 } on Object catch (error, stackTrace) {
                   _logger.error(
-                    'replay: citation id accumulation failed in run $runId of '
+                    'replay: citation accumulation failed in run $runId of '
                     'thread $threadId.',
                     error: error,
                     stackTrace: stackTrace,
@@ -1159,7 +1164,7 @@ class SoliplexApi {
         var sourceReferences = const <SourceReference>[];
         try {
           sourceReferences = extractor.resolve(
-            citationIdsByUserMessage[userMessageId] ?? const <String>{},
+            turnsByUserMessage[userMessageId] ?? const TurnCitations.empty(),
             conversation.aguiState,
             logContext: 'run $runId, thread $threadId',
           );

--- a/packages/soliplex_client/lib/src/application/citation_extractor.dart
+++ b/packages/soliplex_client/lib/src/application/citation_extractor.dart
@@ -1,4 +1,5 @@
 import 'package:ag_ui/ag_ui.dart';
+import 'package:meta/meta.dart';
 import 'package:soliplex_client/src/application/rag_snapshot.dart';
 import 'package:soliplex_client/src/domain/source_reference.dart';
 import 'package:soliplex_client/src/schema/agui_features/rag.dart';
@@ -16,46 +17,59 @@ final _logger =
 /// are confined to `rag_snapshot.dart`.
 ///
 /// Each RAG-producing skill (`rag`, `analysis`, …) publishes its own
-/// citation-bearing namespace. [citationIdsInDelta] collects the ids a single
-/// `StateDeltaEvent` cited; [resolve] turns a set of ids into full
-/// [SourceReference]s using the state's session-cumulative `citation_index`.
-/// Neither subtracts a prior turn's ids — accumulation across a turn is the
-/// caller's responsibility.
+/// citation-bearing namespace. [accumulate] folds each `StateDeltaEvent`'s
+/// cited ids and inline figures into a running [TurnCitations]; [resolve] turns
+/// an accumulated [TurnCitations] into full [SourceReference]s using the
+/// state's session-cumulative `citation_index`. No subtraction of a prior
+/// turn's ids is applied — the caller owns the turn-scoped accumulator.
 class CitationExtractor {
-  /// The union of chunk ids cited in [state], restricted to [namespaces] when
-  /// given, else across every citation-bearing namespace.
+  /// The [TurnCitations] carried by [state] across every citation-bearing
+  /// namespace — every cited id and every inline figure the state itself holds.
   ///
-  /// The backend clears a namespace's `citations` list only when that skill is
-  /// invoked, so an untouched namespace's list is a prior turn's. Prefer
-  /// [citationIdsInDelta] during accumulation, which scopes to the namespaces a
-  /// delta actually touched.
-  Set<String> citationIds(
-    Map<String, dynamic> state, {
-    Set<String>? namespaces,
-  }) {
-    return <String>{
-      for (final snapshot
-          in RagSnapshot.extractAll(state, namespaces: namespaces))
-        ...snapshot.citationIds,
-    };
-  }
+  /// This reads the whole state, so a namespace's stale `citations` (left by a
+  /// prior turn and riding the rebase snapshot) is included. Use it only when
+  /// [state] is a self-contained unit to resolve; during a turn's delta stream,
+  /// use [accumulate], which scopes to the namespaces each delta touched.
+  TurnCitations citationsInState(Map<String, dynamic> state) => _extract(state);
 
-  /// The union of chunk ids cited in the namespaces that [delta] modified.
+  /// Folds the citations and figures [delta] contributes into [current],
+  /// returning the extended accumulator.
   ///
-  /// The backend re-emits every namespace's block in `state` — including a
-  /// prior turn's untouched one, whose stale `citations` ride the run's rebase
-  /// snapshot — but clears and repopulates `citations` only in the invoked
-  /// skill's namespace. So a namespace this delta did not touch carries a prior
-  /// turn's ids and must not be attributed to this one. Scoping to the
-  /// delta's touched namespaces is what keeps re-cited chunks and
-  /// multi-invocation runs while not inventing a stale namespace's citations.
-  Set<String> citationIdsInDelta(
+  /// Scoped to the namespaces [delta]'s JSON-Patch touched. The backend
+  /// re-emits every namespace's block in `state` — including a prior turn's
+  /// untouched one, whose stale `citations` ride the run's rebase snapshot —
+  /// but clears and repopulates `citations` and `searches` only in the invoked
+  /// skill's namespace. Scoping keeps re-cited chunks and multi-invocation runs
+  /// while never crediting a namespace this delta did not invoke.
+  ///
+  /// Both ids and figure bytes are read from the same touched-namespace
+  /// snapshots in one pass, so every accumulated id's figure (if any) is
+  /// captured alongside it — even after a later invocation clears `searches`.
+  TurnCitations accumulate(
+    TurnCitations current,
     Map<String, dynamic> state,
     StateDeltaEvent delta,
   ) {
     final namespaces = _touchedNamespaces(delta);
-    if (namespaces.isEmpty) return const <String>{};
-    return citationIds(state, namespaces: namespaces);
+    if (namespaces.isEmpty) return current;
+    return current.merge(_extract(state, namespaces: namespaces));
+  }
+
+  /// One pass over [state]'s citation-bearing namespaces (all, or only
+  /// [namespaces] when given), unioning each snapshot's cited ids and merging
+  /// its inline figures.
+  TurnCitations _extract(
+    Map<String, dynamic> state, {
+    Set<String>? namespaces,
+  }) {
+    final ids = <String>{};
+    var figures = const CitedFigures.empty();
+    for (final snapshot
+        in RagSnapshot.extractAll(state, namespaces: namespaces)) {
+      ids.addAll(snapshot.citationIds);
+      figures = figures.merge(snapshot.figures);
+    }
+    return TurnCitations(ids, figures);
   }
 
   /// The top-level state keys touched by [delta]'s JSON-Patch ops, e.g.
@@ -66,20 +80,20 @@ class CitationExtractor {
     final namespaces = <String>{};
     for (final op in delta.delta) {
       if (op is! Map) {
-        _logger.warning('citationIdsInDelta: skipping non-Map delta op: $op');
+        _logger.warning('_touchedNamespaces: skipping non-Map delta op: $op');
         continue;
       }
       final path = op['path'];
       if (path is! String) {
         _logger.warning(
-          'citationIdsInDelta: skipping delta op with non-String path: $op',
+          '_touchedNamespaces: skipping delta op with non-String path: $op',
         );
         continue;
       }
       final segments = path.split('/').where((s) => s.isNotEmpty);
       if (segments.isEmpty) {
         _logger.warning(
-          'citationIdsInDelta: skipping delta op with no namespace segment '
+          '_touchedNamespaces: skipping delta op with no namespace segment '
           'in path: $op',
         );
         continue;
@@ -89,37 +103,41 @@ class CitationExtractor {
     return namespaces;
   }
 
-  /// Resolves [ids] to full [SourceReference]s against the citation index in
-  /// [state], deduping ids and logging then omitting any absent from every
-  /// namespace's index — an absent cited id signals a backend contract
-  /// violation (the index is cumulative), so it is surfaced, not dropped
-  /// silently.
+  /// Resolves [citations] to full [SourceReference]s: each cited id's text and
+  /// metadata come from the citation index in [finalState], and its inline
+  /// figure bytes from [citations]'s accumulated figure union.
+  ///
+  /// Ids are deduped; any absent from every namespace's index is logged then
+  /// omitted — an absent cited id signals a backend contract violation (the
+  /// index is cumulative), so it is surfaced, not dropped silently.
   ///
   /// Ids are looked up in `citation_index`, which is session-cumulative, so an
   /// id cited in an earlier invocation still resolves even when it is no longer
-  /// in the current `citations` list. No subtraction of any kind is applied.
+  /// in the current `citations` list. Figure bytes come from
+  /// [citations].figures rather than [finalState]'s `searches`, which the
+  /// backend clears each invocation — the accumulated union is a superset, so
+  /// this recovers figures a later invocation would otherwise have wiped. No
+  /// subtraction of any kind is applied.
   ///
   /// Never throws: a namespace whose block fails to parse is skipped by
   /// [RagSnapshot.extractAll], everything after operates on already-parsed
-  /// snapshots, and the one render-time decode ([RagSnapshot.pictureBytes]'s
+  /// snapshots, and the one render-time decode ([CitedFigures.pictureBytes]'s
   /// base64 decode) is itself guarded.
   List<SourceReference> resolve(
-    Iterable<String> ids,
-    Map<String, dynamic> state, {
+    TurnCitations citations,
+    Map<String, dynamic> finalState, {
     String? logContext,
   }) {
-    final snapshots = RagSnapshot.extractAll(state);
+    final snapshots = RagSnapshot.extractAll(finalState);
 
     final refs = <SourceReference>[];
-    final seen = <String>{};
     final unresolved = <String>[];
-    for (final id in ids) {
-      if (!seen.add(id)) continue;
+    for (final id in citations.ids) {
       var resolved = false;
       for (final snapshot in snapshots) {
         final citation = snapshot.resolveCitation(id);
         if (citation != null) {
-          refs.add(_citationToSourceReference(citation, snapshot));
+          refs.add(_citationToSourceReference(citation, citations.figures));
           resolved = true;
           break;
         }
@@ -139,12 +157,12 @@ class CitationExtractor {
     return refs;
   }
 
-  SourceReference _citationToSourceReference(Citation c, RagSnapshot rag) {
+  SourceReference _citationToSourceReference(Citation c, CitedFigures cited) {
     final figures = <Figure>[];
     for (final ref in c.pictureRefs ?? const <String>[]) {
-      final bytes = rag.pictureBytes(c.documentId, ref);
+      final bytes = cited.pictureBytes(c.documentId, ref);
       if (bytes == null) continue;
-      final caption = rag.pictureCaption(c.documentId, ref);
+      final caption = cited.pictureCaption(c.documentId, ref);
       figures.add(
         Figure(
           ref: ref,
@@ -174,4 +192,38 @@ class CitationExtractor {
       index: c.index,
     );
   }
+}
+
+/// A turn's accumulated citations: the union of cited chunk [ids] and the
+/// union of inline [figures] observed across the turn's `StateDeltaEvent`s.
+///
+/// Bundling the two keeps them in lockstep — the live orchestrator and the
+/// history replay both fold with [CitationExtractor.accumulate] and read back
+/// with [CitationExtractor.resolve], so they cannot drift. Immutable; [merge]
+/// returns a new union.
+@immutable
+class TurnCitations {
+  /// Wraps an already-computed [ids] set and [figures] union. [ids] is copied
+  /// into an unmodifiable set so the instance cannot be mutated through the
+  /// reference passed in.
+  TurnCitations(Set<String> ids, this.figures) : ids = Set.unmodifiable(ids);
+
+  /// An empty accumulator — the identity element for [merge] and the turn-start
+  /// value.
+  const TurnCitations.empty()
+      : ids = const {},
+        figures = const CitedFigures.empty();
+
+  /// Chunk ids cited so far this turn.
+  final Set<String> ids;
+
+  /// Inline figure bytes and captions retrieved so far this turn. The citing
+  /// subset is selected later, when a citation's `pictureRefs` are resolved.
+  final CitedFigures figures;
+
+  /// The union of this and [other]'s ids and figures.
+  TurnCitations merge(TurnCitations other) => TurnCitations(
+        {...ids, ...other.ids},
+        figures.merge(other.figures),
+      );
 }

--- a/packages/soliplex_client/lib/src/application/rag_snapshot.dart
+++ b/packages/soliplex_client/lib/src/application/rag_snapshot.dart
@@ -1,6 +1,7 @@
 import 'dart:convert';
 import 'dart:typed_data';
 
+import 'package:meta/meta.dart';
 import 'package:soliplex_client/src/domain/surface.dart';
 import 'package:soliplex_client/src/schema/agui_features/rag.dart';
 import 'package:soliplex_logging/soliplex_logging.dart';
@@ -37,96 +38,127 @@ typedef _PictureKey = ({String documentId, String ref});
 _PictureKey _pictureKey(String documentId, String ref) =>
     (documentId: documentId, ref: ref);
 
-/// The two picture indexes built from a `rag` state's `searches`, both keyed
-/// by [_pictureKey]: base64 `bytes` for directly-retrieved figures and their
-/// `captions`. Captions are indexed only for rows that carry `image_data`, so
-/// a caption only surfaces for a figure that renders inline.
-typedef _PictureIndex = ({
-  Map<_PictureKey, String> bytes,
-  Map<_PictureKey, String> captions,
-});
-
-/// Builds the picture indexes from a `rag` state's `searches`.
+/// A union of inline figure bytes and captions retrieved across some scope,
+/// keyed by [_pictureKey] (`(documentId, ref)`): base64 `bytes` for directly-
+/// retrieved figures and their `captions`. Captions are indexed only for rows
+/// that carry `image_data`, so a caption only surfaces for a figure that
+/// renders inline. The index holds every retrieved figure; the citing subset
+/// is selected later, when a citation's `pictureRefs` are resolved.
 ///
-/// The builder reads only the fields it needs — `document_id` (raw),
-/// `image_data`, and `picture_captions` (via the shared parsers) — rather than
-/// building a whole [SearchResult], so an unrelated malformed field on a row
-/// can't drop that row's figures. A malformed shape is skipped and logged; a
-/// row that simply carries no `image_data` is silently ignored (the normal
-/// figure-less case).
-_PictureIndex _indexPictures(Map<String, dynamic> json) {
-  final bytes = <_PictureKey, String>{};
-  final captions = <_PictureKey, String>{};
-  final raw = json['searches'];
-  if (raw is! Map) {
-    if (raw != null) {
-      _logger.warning(
-        'RagSnapshot: expected `searches` to be a Map, '
-        'got ${raw.runtimeType}; no cited-figure bytes indexed.',
-      );
-    }
-    return (bytes: bytes, captions: captions);
-  }
-  for (final search in raw.entries) {
-    final results = search.value;
-    if (results is! List) {
-      _logger.warning(
-        'RagSnapshot: skipping searches[${search.key}] with non-List value '
-        '(runtimeType=${results.runtimeType}).',
-      );
-      continue;
-    }
-    for (var i = 0; i < results.length; i++) {
-      final item = results[i];
-      if (item is! Map<String, dynamic>) {
-        _logger.warning(
-          'RagSnapshot: skipping non-Map searches[${search.key}][$i] '
-          '(runtimeType=${item.runtimeType}).',
-        );
-        continue;
-      }
-      final imageData = SearchResult.parseImageData(item['image_data']);
-      if (imageData.isEmpty) continue;
-      final docId = item['document_id'];
-      if (docId is! String) {
-        _logger.warning(
-          'RagSnapshot: dropping figures on searches[${search.key}][$i] '
-          'with non-String document_id (runtimeType=${docId.runtimeType}).',
-        );
-        continue;
-      }
-      final captionData =
-          SearchResult.parsePictureCaptions(item['picture_captions']);
-      imageData.forEach((ref, b64) {
-        bytes.putIfAbsent(_pictureKey(docId, ref), () => b64);
-      });
-      captionData.forEach((ref, text) {
-        if (text.isNotEmpty) {
-          captions.putIfAbsent(_pictureKey(docId, ref), () => text);
-        }
-      });
-    }
-  }
-  return (bytes: bytes, captions: captions);
-}
+/// The backend clears a `rag` state's `searches` — the only source of these
+/// bytes — at the start of every skill invocation, so the last invocation's
+/// state carries only its own figures. Accumulating a [CitedFigures] union
+/// across a turn's invocations preserves earlier invocations' figures. Bytes
+/// for a given `(documentId, ref)` are identity-stable, so [merge] is an
+/// unambiguous union (no precedence to resolve).
+@immutable
+class CitedFigures {
+  const CitedFigures._(this._bytes, this._captions);
 
-/// Decodes an indexed picture ref to bytes, or null when absent / undecodable.
-Uint8List? _decodePicture(
-  Map<_PictureKey, String> index,
-  String documentId,
-  String ref,
-) {
-  final b64 = index[_pictureKey(documentId, ref)];
-  if (b64 == null) return null;
-  try {
-    return base64Decode(b64);
-  } on FormatException catch (error) {
-    _logger.warning(
-      'RagSnapshot: picture ref "$ref" has undecodable base64; dropped.',
-      error: error,
-    );
-    return null;
+  /// An empty union — the identity element for [merge].
+  const CitedFigures.empty()
+      : _bytes = const {},
+        _captions = const {};
+
+  /// Builds the figure union from a single `rag` state block's `searches`.
+  ///
+  /// Reads only the fields it needs — `document_id` (raw), `image_data`, and
+  /// `picture_captions` (via the shared parsers) — rather than building a whole
+  /// [SearchResult], so an unrelated malformed field on a row can't drop that
+  /// row's figures. A malformed shape is skipped and logged; a row that simply
+  /// carries no `image_data` is silently ignored (the normal figure-less case).
+  factory CitedFigures.fromSearches(Map<String, dynamic> ragBlock) {
+    final bytes = <_PictureKey, String>{};
+    final captions = <_PictureKey, String>{};
+    final raw = ragBlock['searches'];
+    if (raw is! Map) {
+      if (raw != null) {
+        _logger.warning(
+          'RagSnapshot: expected `searches` to be a Map, '
+          'got ${raw.runtimeType}; no cited-figure bytes indexed.',
+        );
+      }
+      return CitedFigures._(bytes, captions);
+    }
+    for (final search in raw.entries) {
+      final results = search.value;
+      if (results is! List) {
+        _logger.warning(
+          'RagSnapshot: skipping searches[${search.key}] with non-List value '
+          '(runtimeType=${results.runtimeType}).',
+        );
+        continue;
+      }
+      for (var i = 0; i < results.length; i++) {
+        final item = results[i];
+        if (item is! Map<String, dynamic>) {
+          _logger.warning(
+            'RagSnapshot: skipping non-Map searches[${search.key}][$i] '
+            '(runtimeType=${item.runtimeType}).',
+          );
+          continue;
+        }
+        final imageData = SearchResult.parseImageData(item['image_data']);
+        if (imageData.isEmpty) continue;
+        final docId = item['document_id'];
+        if (docId is! String) {
+          _logger.warning(
+            'RagSnapshot: dropping figures on searches[${search.key}][$i] '
+            'with non-String document_id (runtimeType=${docId.runtimeType}).',
+          );
+          continue;
+        }
+        final captionData =
+            SearchResult.parsePictureCaptions(item['picture_captions']);
+        imageData.forEach((ref, b64) {
+          bytes.putIfAbsent(_pictureKey(docId, ref), () => b64);
+        });
+        captionData.forEach((ref, text) {
+          if (text.isNotEmpty) {
+            captions.putIfAbsent(_pictureKey(docId, ref), () => text);
+          }
+        });
+      }
+    }
+    return CitedFigures._(bytes, captions);
   }
+
+  final Map<_PictureKey, String> _bytes;
+  final Map<_PictureKey, String> _captions;
+
+  /// The union of this and [other]. Identity-stable bytes make this
+  /// unambiguous, so an existing entry is kept (first-wins == last-wins).
+  /// Short-circuits when either side is empty.
+  CitedFigures merge(CitedFigures other) {
+    if (other._bytes.isEmpty && other._captions.isEmpty) return this;
+    if (_bytes.isEmpty && _captions.isEmpty) return other;
+    return CitedFigures._(
+      {...other._bytes, ..._bytes},
+      {...other._captions, ..._captions},
+    );
+  }
+
+  /// Decoded bytes for a directly-retrieved (stage-1) picture ref, or null when
+  /// the union carries no bytes for it (stage-2 / unknown) or they don't decode.
+  Uint8List? pictureBytes(String documentId, String ref) {
+    final b64 = _bytes[_pictureKey(documentId, ref)];
+    if (b64 == null) return null;
+    try {
+      return base64Decode(b64);
+    } on FormatException catch (error) {
+      _logger.warning(
+        'RagSnapshot: picture ref "$ref" for document "$documentId" has '
+        'undecodable base64; dropped.',
+        error: error,
+      );
+      return null;
+    }
+  }
+
+  /// Caption text for a directly-retrieved picture ref, or null when the union
+  /// carries none.
+  String? pictureCaption(String documentId, String ref) =>
+      _captions[_pictureKey(documentId, ref)];
 }
 
 /// A read-model view of a RAG skill's AG-UI state slice.
@@ -145,7 +177,7 @@ Uint8List? _decodePicture(
 /// taking down an otherwise-valid snapshot. The snapshot contract is narrow,
 /// so a resilient per-entry parse is the right trade here.
 class RagSnapshot {
-  RagSnapshot._(this._citationIds, this._index, this._pictures);
+  RagSnapshot._(this._citationIds, this._index, this._figures);
 
   /// Parses a `rag`-namespaced state map, with per-entry resilience:
   /// malformed entries in `citations` / `citation_index` are logged and
@@ -212,7 +244,7 @@ class RagSnapshot {
       }
     }
 
-    return RagSnapshot._(ids, index, _indexPictures(json));
+    return RagSnapshot._(ids, index, CitedFigures.fromSearches(json));
   }
 
   /// Wire key marking a citation-bearing skill-state block: the
@@ -257,7 +289,7 @@ class RagSnapshot {
 
   final List<String> _citationIds;
   final Map<String, Citation> _index;
-  final _PictureIndex _pictures;
+  final CitedFigures _figures;
 
   /// Chunk ids of the citations present in the current state. The backend's
   /// state lifecycle clears these at each invocation start.
@@ -266,15 +298,8 @@ class RagSnapshot {
   /// Resolves a chunk id to a full [Citation], or null if not present.
   Citation? resolveCitation(String id) => _index[id];
 
-  /// Decoded bytes for a directly-retrieved (stage-1) picture ref, or null
-  /// when the state carries no bytes for it (stage-2 / unknown).
-  Uint8List? pictureBytes(String documentId, String ref) =>
-      _decodePicture(_pictures.bytes, documentId, ref);
-
-  /// Caption text for a directly-retrieved picture ref, or null when the state
-  /// carries none.
-  String? pictureCaption(String documentId, String ref) =>
-      _pictures.captions[_pictureKey(documentId, ref)];
+  /// Inline figure bytes and captions carried by this snapshot's `searches`.
+  CitedFigures get figures => _figures;
 }
 
 /// Projects a [RagSnapshot] from the full agent-state map.

--- a/packages/soliplex_client/test/api/soliplex_api_test.dart
+++ b/packages/soliplex_client/test/api/soliplex_api_test.dart
@@ -4559,6 +4559,112 @@ void main() {
           expect(ref.figures.single.ref, '#/pictures/0');
           expect(ref.figures.single.bytes, base64Decode('aGVsbG8='));
         });
+
+        test(
+            'an earlier invocation of one run keeps its figure after a later '
+            'invocation wipes searches', () async {
+          // A single run with TWO skill invocations (two STATE_DELTAs).
+          // Invocation 1 cites chunk-1, whose figure rides its searches;
+          // invocation 2 cites chunk-2 and REPLACES the rag block, so the run's
+          // end state no longer holds chunk-1's figure. The per-turn figure
+          // accumulator must preserve it.
+          stubGet('thread-456', {
+            'room_id': 'room-123',
+            'thread_id': 'thread-456',
+            'runs': {
+              'run-1': {
+                'run_id': 'run-1',
+                'created': '2026-01-07T01:00:00.000Z',
+                'finished': '2026-01-07T01:01:00.000Z',
+              },
+            },
+          });
+          stubGet('thread-456/run-1', {
+            'run_id': 'run-1',
+            'run_input': {
+              'messages': [
+                {'id': 'user-1', 'role': 'user', 'content': 'Q1'},
+              ],
+            },
+            'events': [
+              {
+                'type': 'STATE_DELTA',
+                'delta': [
+                  {
+                    'op': 'add',
+                    'path': '/rag',
+                    'value': {
+                      'citation_index': {
+                        'chunk-1': {
+                          'document_id': 'doc-1',
+                          'chunk_id': 'chunk-1',
+                          'document_uri': 'file:///doc1.pdf',
+                          'content': 'cites Fig 1',
+                          'picture_refs': ['#/pictures/0'],
+                        },
+                      },
+                      'citations': ['chunk-1'],
+                      'searches': {
+                        'q1': [
+                          {
+                            'content': 'cites Fig 1',
+                            'document_id': 'doc-1',
+                            'image_data': {'#/pictures/0': 'aGVsbG8='},
+                          },
+                        ],
+                      },
+                    },
+                  },
+                ],
+              },
+              {
+                'type': 'STATE_DELTA',
+                'delta': [
+                  {
+                    'op': 'add',
+                    'path': '/rag',
+                    'value': {
+                      'citation_index': {
+                        'chunk-1': {
+                          'document_id': 'doc-1',
+                          'chunk_id': 'chunk-1',
+                          'document_uri': 'file:///doc1.pdf',
+                          'content': 'cites Fig 1',
+                          'picture_refs': ['#/pictures/0'],
+                        },
+                        'chunk-2': {
+                          'document_id': 'doc-2',
+                          'chunk_id': 'chunk-2',
+                          'document_uri': 'file:///doc2.pdf',
+                          'content': 'Citation 2',
+                        },
+                      },
+                      'citations': ['chunk-2'],
+                      'searches': {
+                        'q2': [
+                          {'content': 'Citation 2', 'document_id': 'doc-2'},
+                        ],
+                      },
+                    },
+                  },
+                ],
+              },
+              {
+                'type': 'RUN_FINISHED',
+                'thread_id': 'thread-456',
+                'run_id': 'run-1',
+              },
+            ],
+          });
+
+          final history = await api.getThreadHistory('room-123', 'thread-456');
+
+          final refs = history.messageStates['user-1']!.sourceReferences;
+          final chunk1 = refs.firstWhere((r) => r.chunkId == 'chunk-1');
+          expect(chunk1.figures, hasLength(1));
+          expect(chunk1.figures.single.ref, '#/pictures/0');
+          expect(chunk1.figures.single.bytes, base64Decode('aGVsbG8='));
+        });
       });
 
       test('populates runs with decoded events in arrival order', () async {

--- a/packages/soliplex_client/test/application/citation_extractor_figures_test.dart
+++ b/packages/soliplex_client/test/application/citation_extractor_figures_test.dart
@@ -1,0 +1,223 @@
+import 'dart:convert';
+
+import 'package:ag_ui/ag_ui.dart';
+import 'package:soliplex_client/src/application/citation_extractor.dart';
+import 'package:test/test.dart';
+
+/// A `rag` namespace block plus the STATE_DELTA that carries it. The backend
+/// re-emits the whole `rag` block on each skill invocation's delta, so the
+/// delta's only op replaces `/rag`.
+({Map<String, dynamic> state, StateDeltaEvent delta}) ragInvocation({
+  required Map<String, Map<String, dynamic>> citationIndex,
+  required List<String> citations,
+  required Map<String, dynamic> searches,
+}) {
+  final block = <String, dynamic>{
+    'citation_index': citationIndex,
+    'citations': citations,
+    'searches': searches,
+  };
+  return (
+    state: {'rag': block},
+    delta: StateDeltaEvent(
+      delta: [
+        {'op': 'add', 'path': '/rag', 'value': block},
+      ],
+    ),
+  );
+}
+
+Map<String, dynamic> citation(
+  String chunkId, {
+  String documentId = 'doc-1',
+  List<String>? pictureRefs,
+}) =>
+    {
+      'chunk_id': chunkId,
+      'content': 'Citation $chunkId',
+      'document_id': documentId,
+      'document_uri': 'https://example.com/$documentId.pdf',
+      if (pictureRefs != null) 'picture_refs': pictureRefs,
+    };
+
+/// One retrieval row carrying an inline figure's base64 bytes.
+Map<String, dynamic> figureSearch(
+  String documentId,
+  String ref,
+  String base64Bytes, {
+  String? caption,
+}) =>
+    {
+      'q': [
+        {
+          'content': 'row',
+          'document_id': documentId,
+          'image_data': {ref: base64Bytes},
+          if (caption != null) 'picture_captions': {ref: caption},
+        },
+      ],
+    };
+
+void main() {
+  group('CitationExtractor figure accumulation across a turn', () {
+    late CitationExtractor extractor;
+
+    setUp(() {
+      extractor = CitationExtractor();
+    });
+
+    test(
+        'preserves an earlier invocation figure bytes after a later '
+        'invocation wipes searches', () {
+      // Invocation 1 cites chunk-1, whose figure bytes ride its searches.
+      final inv1 = ragInvocation(
+        citationIndex: {
+          'chunk-1': citation('chunk-1', pictureRefs: ['#/pictures/0']),
+        },
+        citations: ['chunk-1'],
+        searches: figureSearch(
+          'doc-1',
+          '#/pictures/0',
+          'aGVsbG8=', // "hello"
+          caption: 'Figure 1',
+        ),
+      );
+
+      // Invocation 2 cites chunk-2 and REPLACES the rag block: citation_index
+      // stays cumulative, but searches now holds only invocation 2's rows —
+      // chunk-1's figure bytes are gone from the state.
+      final inv2 = ragInvocation(
+        citationIndex: {
+          'chunk-1': citation('chunk-1', pictureRefs: ['#/pictures/0']),
+          'chunk-2': citation('chunk-2', documentId: 'doc-2'),
+        },
+        citations: ['chunk-2'],
+        searches: const {
+          'q': [
+            {'content': 'row', 'document_id': 'doc-2'},
+          ],
+        },
+      );
+
+      var turn = extractor.accumulate(
+        const TurnCitations.empty(),
+        inv1.state,
+        inv1.delta,
+      );
+      turn = extractor.accumulate(turn, inv2.state, inv2.delta);
+
+      // Resolve against the run's END state (invocation 2's), where
+      // chunk-1's figure no longer exists in searches.
+      final refs = extractor.resolve(turn, inv2.state);
+
+      expect(refs.map((r) => r.chunkId), containsAll(['chunk-1', 'chunk-2']));
+      final chunk1 = refs.firstWhere((r) => r.chunkId == 'chunk-1');
+      expect(chunk1.figures, hasLength(1));
+      expect(chunk1.figures.single.ref, '#/pictures/0');
+      expect(chunk1.figures.single.bytes, utf8.encode('hello'));
+      // The caption is unioned independently of the bytes and must survive too.
+      expect(chunk1.figures.single.caption, 'Figure 1');
+    });
+
+    test('unions distinct figures cited by different invocations', () {
+      // Both invocations retrieve a figure (for different documents). Neither
+      // side of the union is empty, so this exercises the merge union itself,
+      // not its empty short-circuits: both figures must resolve.
+      final inv1 = ragInvocation(
+        citationIndex: {
+          'chunk-1': citation('chunk-1', pictureRefs: ['#/pictures/0']),
+        },
+        citations: ['chunk-1'],
+        searches: figureSearch('doc-1', '#/pictures/0', 'aGVsbG8='), // "hello"
+      );
+      final inv2 = ragInvocation(
+        citationIndex: {
+          'chunk-1': citation('chunk-1', pictureRefs: ['#/pictures/0']),
+          'chunk-2': citation(
+            'chunk-2',
+            documentId: 'doc-2',
+            pictureRefs: ['#/pictures/0'],
+          ),
+        },
+        citations: ['chunk-2'],
+        searches: figureSearch('doc-2', '#/pictures/0', 'd29ybGQ='), // "world"
+      );
+
+      var turn = extractor.accumulate(
+        const TurnCitations.empty(),
+        inv1.state,
+        inv1.delta,
+      );
+      turn = extractor.accumulate(turn, inv2.state, inv2.delta);
+      final refs = extractor.resolve(turn, inv2.state);
+
+      final chunk1 = refs.firstWhere((r) => r.chunkId == 'chunk-1');
+      final chunk2 = refs.firstWhere((r) => r.chunkId == 'chunk-2');
+      expect(chunk1.figures.single.bytes, utf8.encode('hello'));
+      expect(chunk2.figures.single.bytes, utf8.encode('world'));
+    });
+
+    test('single-invocation run still resolves its figure (regression)', () {
+      final inv = ragInvocation(
+        citationIndex: {
+          'chunk-1': citation('chunk-1', pictureRefs: ['#/pictures/0']),
+        },
+        citations: ['chunk-1'],
+        searches: figureSearch('doc-1', '#/pictures/0', 'aGVsbG8='),
+      );
+
+      final turn = extractor.accumulate(
+        const TurnCitations.empty(),
+        inv.state,
+        inv.delta,
+      );
+      final refs = extractor.resolve(turn, inv.state);
+
+      expect(refs, hasLength(1));
+      expect(refs.single.figures.single.bytes, utf8.encode('hello'));
+    });
+
+    test('resolves both figures of one citation fed by different invocations',
+        () {
+      // One citation (chunk-1) declares two picture refs, but each ref's bytes
+      // arrive on a DIFFERENT invocation's searches: ref 0 on invocation 1,
+      // ref 1 on invocation 2. The turn union must carry both so the single
+      // citation resolves to two figures — exercising the per-ref figure loop
+      // with more than one surviving ref, which no other test does.
+      final inv1 = ragInvocation(
+        citationIndex: {
+          'chunk-1': citation(
+            'chunk-1',
+            pictureRefs: ['#/pictures/0', '#/pictures/1'],
+          ),
+        },
+        citations: ['chunk-1'],
+        searches: figureSearch('doc-1', '#/pictures/0', 'aGVsbG8='), // "hello"
+      );
+      final inv2 = ragInvocation(
+        citationIndex: {
+          'chunk-1': citation(
+            'chunk-1',
+            pictureRefs: ['#/pictures/0', '#/pictures/1'],
+          ),
+        },
+        citations: ['chunk-1'],
+        searches: figureSearch('doc-1', '#/pictures/1', 'd29ybGQ='), // "world"
+      );
+
+      var turn = extractor.accumulate(
+        const TurnCitations.empty(),
+        inv1.state,
+        inv1.delta,
+      );
+      turn = extractor.accumulate(turn, inv2.state, inv2.delta);
+      final refs = extractor.resolve(turn, inv2.state);
+
+      final chunk1 = refs.firstWhere((r) => r.chunkId == 'chunk-1');
+      expect(chunk1.figures, hasLength(2));
+      final byRef = {for (final f in chunk1.figures) f.ref: f.bytes};
+      expect(byRef['#/pictures/0'], utf8.encode('hello'));
+      expect(byRef['#/pictures/1'], utf8.encode('world'));
+    });
+  });
+}

--- a/packages/soliplex_client/test/application/citation_extractor_picture_bytes_test.dart
+++ b/packages/soliplex_client/test/application/citation_extractor_picture_bytes_test.dart
@@ -34,7 +34,8 @@ void main() {
     };
 
     final extractor = CitationExtractor();
-    final refs = extractor.resolve(extractor.citationIds(current), current);
+    final refs =
+        extractor.resolve(extractor.citationsInState(current), current);
 
     expect(refs, hasLength(1));
     final ref = refs.single;

--- a/packages/soliplex_client/test/application/citation_extractor_test.dart
+++ b/packages/soliplex_client/test/application/citation_extractor_test.dart
@@ -1,5 +1,6 @@
 import 'package:ag_ui/ag_ui.dart';
 import 'package:soliplex_client/src/application/citation_extractor.dart';
+import 'package:soliplex_client/src/application/rag_snapshot.dart';
 import 'package:soliplex_client/src/domain/source_reference.dart';
 import 'package:soliplex_logging/soliplex_logging.dart';
 import 'package:test/test.dart';
@@ -12,10 +13,15 @@ void main() {
       extractor = CitationExtractor();
     });
 
+    /// A [TurnCitations] over [ids] with no figures — for resolve() cases that
+    /// exercise id resolution against the index, not figure preservation.
+    TurnCitations turnOf(Set<String> ids) =>
+        TurnCitations(ids, const CitedFigures.empty());
+
     /// Resolves every id cited in [state] — the common case where the caller
     /// has no accumulated set and just wants what the state itself carries.
     List<SourceReference> extract(Map<String, dynamic> state) =>
-        extractor.resolve(extractor.citationIds(state), state);
+        extractor.resolve(extractor.citationsInState(state), state);
 
     group('wire shape', () {
       Map<String, dynamic> createCitation({
@@ -181,7 +187,7 @@ void main() {
           citations: ['c'],
         );
 
-        final refs = extractor.resolve({'a', 'b', 'c'}, state);
+        final refs = extractor.resolve(turnOf({'a', 'b', 'c'}), state);
 
         expect(refs.map((r) => r.chunkId), unorderedEquals(['a', 'b', 'c']));
       });
@@ -250,7 +256,7 @@ void main() {
           'analysis': block(const ['b', 'c']),
         };
 
-        expect(extractor.citationIds(state), {'a', 'b', 'c'});
+        expect(extractor.citationsInState(state).ids, {'a', 'b', 'c'});
       });
 
       test('skips namespaces without a citation_index', () {
@@ -259,7 +265,7 @@ void main() {
           'bubble-sandbox': {'foo': 'bar'},
         };
 
-        expect(extractor.citationIds(state), {'a'});
+        expect(extractor.citationsInState(state).ids, {'a'});
       });
 
       test('tolerates a malformed citations list', () {
@@ -270,15 +276,15 @@ void main() {
           },
         };
 
-        expect(extractor.citationIds(state), isEmpty);
+        expect(extractor.citationsInState(state).ids, isEmpty);
       });
 
       test('is empty when the state has no citation namespaces', () {
-        expect(extractor.citationIds(const {'unknown': 42}), isEmpty);
+        expect(extractor.citationsInState(const {'unknown': 42}).ids, isEmpty);
       });
     });
 
-    group('citationIdsInDelta', () {
+    group('accumulate (delta scoping)', () {
       Map<String, dynamic> citation(String chunkId) => {
             'chunk_id': chunkId,
             'content': 'content for $chunkId',
@@ -308,12 +314,13 @@ void main() {
           'analysis': block(const ['b']),
         };
 
-        final ids = extractor.citationIdsInDelta(
+        final turn = extractor.accumulate(
+          const TurnCitations.empty(),
           state,
           deltaTouching(const ['/analysis/citations/-']),
         );
 
-        expect(ids, {'b'});
+        expect(turn.ids, {'b'});
       });
 
       test('unions across every namespace the delta touched', () {
@@ -322,12 +329,13 @@ void main() {
           'analysis': block(const ['b']),
         };
 
-        final ids = extractor.citationIdsInDelta(
+        final turn = extractor.accumulate(
+          const TurnCitations.empty(),
           state,
           deltaTouching(const ['/rag/citations/0', '/analysis/citations/0']),
         );
 
-        expect(ids, {'a', 'b'});
+        expect(turn.ids, {'a', 'b'});
       });
 
       test('is empty when the delta touches no citation-bearing namespace', () {
@@ -335,12 +343,13 @@ void main() {
           'rag': block(const ['a']),
         };
 
-        final ids = extractor.citationIdsInDelta(
+        final turn = extractor.accumulate(
+          const TurnCitations.empty(),
           state,
           deltaTouching(const ['/document_filter']),
         );
 
-        expect(ids, isEmpty);
+        expect(turn.ids, isEmpty);
       });
 
       test('skips malformed ops with a warning', () {
@@ -352,8 +361,9 @@ void main() {
         addTearDown(() => LogManager.instance.removeSink(sink));
 
         // State is never read: malformed ops touch no namespace, so
-        // citationIdsInDelta returns before consulting it.
-        final ids = extractor.citationIdsInDelta(
+        // accumulate returns before consulting it.
+        final turn = extractor.accumulate(
+          const TurnCitations.empty(),
           const {},
           const StateDeltaEvent(
             delta: [
@@ -363,7 +373,7 @@ void main() {
           ),
         );
 
-        expect(ids, isEmpty);
+        expect(turn.ids, isEmpty);
         expect(sink.records, hasLength(2));
         expect(sink.records.every((r) => r.level == LogLevel.warning), isTrue);
       });
@@ -376,12 +386,13 @@ void main() {
         LogManager.instance.addSink(sink);
         addTearDown(() => LogManager.instance.removeSink(sink));
 
-        final ids = extractor.citationIdsInDelta(
+        final turn = extractor.accumulate(
+          const TurnCitations.empty(),
           const {},
           deltaTouching(const ['/']),
         );
 
-        expect(ids, isEmpty);
+        expect(turn.ids, isEmpty);
         expect(sink.records, hasLength(1));
         expect(sink.records.single.level, LogLevel.warning);
       });
@@ -402,15 +413,9 @@ void main() {
             },
           };
 
-      test('dedups repeated ids', () {
-        final refs = extractor.resolve(['a', 'a'], stateWith(['a']));
-
-        expect(refs, hasLength(1));
-        expect(refs.single.chunkId, 'a');
-      });
-
       test('skips ids absent from every citation_index', () {
-        final refs = extractor.resolve(['a', 'ghost'], stateWith(['a']));
+        final refs =
+            extractor.resolve(turnOf({'a', 'ghost'}), stateWith(['a']));
 
         expect(refs.map((r) => r.chunkId), ['a']);
       });
@@ -423,7 +428,7 @@ void main() {
         LogManager.instance.addSink(sink);
         addTearDown(() => LogManager.instance.removeSink(sink));
 
-        extractor.resolve(['a', 'ghost'], stateWith(['a']));
+        extractor.resolve(turnOf({'a', 'ghost'}), stateWith(['a']));
 
         expect(sink.records, hasLength(1));
         expect(sink.records.single.level, LogLevel.warning);
@@ -431,7 +436,7 @@ void main() {
       });
 
       test('is empty when the state carries no citation namespace', () {
-        final refs = extractor.resolve(['a'], const {'unknown': 42});
+        final refs = extractor.resolve(turnOf({'a'}), const {'unknown': 42});
 
         expect(refs, isEmpty);
       });

--- a/packages/soliplex_client/test/application/rag_snapshot_picture_bytes_test.dart
+++ b/packages/soliplex_client/test/application/rag_snapshot_picture_bytes_test.dart
@@ -32,17 +32,20 @@ void main() {
 
     test('returns decoded bytes for a stage-1 ref', () {
       final snap = RagSnapshot.fromJson(rag);
-      expect(snap.pictureBytes('doc-1', '#/pictures/0'), utf8.encode('hello'));
+      expect(
+        snap.figures.pictureBytes('doc-1', '#/pictures/0'),
+        utf8.encode('hello'),
+      );
     });
 
     test('returns null for a stage-2 ref (ref present, no bytes)', () {
       final snap = RagSnapshot.fromJson(rag);
-      expect(snap.pictureBytes('doc-1', '#/pictures/1'), isNull);
+      expect(snap.figures.pictureBytes('doc-1', '#/pictures/1'), isNull);
     });
 
     test('returns null for the wrong document', () {
       final snap = RagSnapshot.fromJson(rag);
-      expect(snap.pictureBytes('doc-2', '#/pictures/0'), isNull);
+      expect(snap.figures.pictureBytes('doc-2', '#/pictures/0'), isNull);
     });
 
     test('indexes image_data even when unrelated fields are malformed', () {
@@ -60,7 +63,10 @@ void main() {
         ],
       };
       final snap = RagSnapshot.fromJson(bad);
-      expect(snap.pictureBytes('doc-1', '#/pictures/0'), utf8.encode('hello'));
+      expect(
+        snap.figures.pictureBytes('doc-1', '#/pictures/0'),
+        utf8.encode('hello'),
+      );
     });
 
     test('returns null for an undecodable base64 image_data value', () {
@@ -76,7 +82,7 @@ void main() {
         ],
       };
       final snap = RagSnapshot.fromJson(bad);
-      expect(snap.pictureBytes('doc-1', '#/pictures/0'), isNull);
+      expect(snap.figures.pictureBytes('doc-1', '#/pictures/0'), isNull);
     });
 
     test('drops only the figures of a row whose document_id is not a string',
@@ -101,8 +107,11 @@ void main() {
         ],
       };
       final snap = RagSnapshot.fromJson(bad);
-      expect(snap.pictureBytes('doc-1', '#/pictures/0'), isNull);
-      expect(snap.pictureBytes('doc-1', '#/pictures/1'), utf8.encode('world'));
+      expect(snap.figures.pictureBytes('doc-1', '#/pictures/0'), isNull);
+      expect(
+        snap.figures.pictureBytes('doc-1', '#/pictures/1'),
+        utf8.encode('world'),
+      );
     });
 
     test('skips a malformed search entry without throwing', () {
@@ -119,7 +128,10 @@ void main() {
         ],
       };
       final snap = RagSnapshot.fromJson(bad);
-      expect(snap.pictureBytes('doc-1', '#/pictures/9'), utf8.encode('world'));
+      expect(
+        snap.figures.pictureBytes('doc-1', '#/pictures/9'),
+        utf8.encode('world'),
+      );
     });
   });
 }

--- a/packages/soliplex_client/test/application/rag_snapshot_picture_captions_test.dart
+++ b/packages/soliplex_client/test/application/rag_snapshot_picture_captions_test.dart
@@ -32,17 +32,20 @@ void main() {
 
     test('returns the caption for a captioned ref', () {
       final snap = RagSnapshot.fromJson(rag);
-      expect(snap.pictureCaption('doc-1', '#/pictures/0'), 'Figure 1: revenue');
+      expect(
+        snap.figures.pictureCaption('doc-1', '#/pictures/0'),
+        'Figure 1: revenue',
+      );
     });
 
     test('returns null for a ref with bytes but no caption', () {
       final snap = RagSnapshot.fromJson(rag);
-      expect(snap.pictureCaption('doc-1', '#/pictures/1'), isNull);
+      expect(snap.figures.pictureCaption('doc-1', '#/pictures/1'), isNull);
     });
 
     test('returns null for the wrong document', () {
       final snap = RagSnapshot.fromJson(rag);
-      expect(snap.pictureCaption('doc-2', '#/pictures/0'), isNull);
+      expect(snap.figures.pictureCaption('doc-2', '#/pictures/0'), isNull);
     });
   });
 }


### PR DESCRIPTION
## Summary

A cited source's inline figures were dropped when a reply's agent searched
several times within one run. The backend clears `rag.searches` — the only
source of inline figure bytes — at the start of every skill invocation, while
`citation_index` stays session-cumulative. Citations were resolved once at the
run terminal against the end state, so figures for chunks cited by an *earlier*
invocation rendered text-only.

## Fix

Accumulate a turn-level figure-bytes union (`CitedFigures`) alongside the
cited-id set in a single `TurnCitations` accumulator, folded per
`StateDeltaEvent` on both the live (`RunOrchestrator`) and replay
(`SoliplexApi._replayEventsToHistory`) paths, and resolve figures from that
union rather than the run's end-state `searches`. A source now renders its
figures in full both live and after a reload.

`CitedFigures` also replaces the former `_PictureIndex` typedef + free functions
with an encapsulated, immutable value type (private maps, `fromSearches`
factory, `merge`, `pictureBytes`/`pictureCaption`).

## Tests

- `citation_extractor_figures_test.dart` (new): cross-invocation figure
  preservation, distinct-figure union, single-invocation regression, and one
  citation whose two figures arrive on different invocations (exercises the
  per-ref figure loop with >1 surviving ref).
- Live-path (`run_orchestrator_test.dart`) and replay-path
  (`soliplex_api_test.dart`) integration tests for the multi-invocation
  scenario.
- Existing snapshot/accessor tests rerouted through `CitedFigures`.

`flutter analyze` clean; all affected suites green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
