### PR TITLE
fix(lobby): add a gutter below the filter row

### DIFF
--- a/lib/src/modules/lobby/ui/lobby_screen.dart
+++ b/lib/src/modules/lobby/ui/lobby_screen.dart
@@ -564,8 +564,13 @@ class _RoomContent extends StatelessWidget {
               ),
             ],
             Padding(
+              // A non-scrolling bottom gap (matching the list's item spacing)
+              // so scrolled room titles/descriptions keep a gutter under the
+              // filter row instead of butting flush against it (issue #464).
+              // The ListView's own top padding scrolls away, so the gap has to
+              // live here, outside the scroll view.
               padding: const EdgeInsets.fromLTRB(SoliplexSpacing.s4,
-                  SoliplexSpacing.s2, SoliplexSpacing.s4, 0),
+                  SoliplexSpacing.s2, SoliplexSpacing.s4, SoliplexSpacing.s3),
               child: _LobbyControls(
                 viewMode: viewMode,
                 onViewModeChanged: onViewModeChanged,

--- a/test/modules/lobby/ui/lobby_screen_test.dart
+++ b/test/modules/lobby/ui/lobby_screen_test.dart
@@ -4,6 +4,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:go_router/go_router.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:soliplex_agent/soliplex_agent.dart' show Room, RoomStats;
+import 'package:soliplex_design/soliplex_design.dart' show SoliplexSpacing;
 import 'package:soliplex_frontend/src/modules/auth/auth_session.dart';
 import 'package:soliplex_frontend/src/modules/auth/auth_tokens.dart';
 import 'package:soliplex_frontend/src/modules/auth/server_manager.dart';
@@ -477,6 +478,36 @@ void main() {
       expect(
         tester.getCenter(find.byIcon(Icons.sort)).dy,
         closeTo(tester.getCenter(find.byIcon(Icons.search)).dy, 4),
+      );
+    });
+
+    testWidgets('filter row keeps a gutter above the room list (issue #464)',
+        (tester) async {
+      tester.view.physicalSize = const Size(900, 600);
+      tester.view.devicePixelRatio = 1.0;
+      addTearDown(tester.view.resetPhysicalSize);
+
+      final manager = _createManager();
+      manager.addServer(
+        serverId: 'local',
+        serverUrl: Uri.parse('http://localhost:8000'),
+        requiresAuth: false,
+      );
+      final fakeApi = FakeSoliplexApi()
+        ..nextRooms = const [Room(id: 'r1', name: 'General')];
+
+      await tester.pumpWidget(_buildApp(manager, apiResolver: (_) => fakeApi));
+      await tester.pumpAndSettle();
+
+      // The room list must not butt against the filter row: at least the
+      // list's item gap (s3) of vertical space sits between the search field
+      // and the first card.
+      final searchFieldBottom =
+          tester.getRect(find.widgetWithIcon(TextField, Icons.search)).bottom;
+      final firstCardTop = tester.getRect(find.byType(RoomCard).first).top;
+      expect(
+        firstCardTop - searchFieldBottom,
+        greaterThanOrEqualTo(SoliplexSpacing.s3),
       );
     });
 


### PR DESCRIPTION
## What

The lobby's **Filter rooms** search row had no padding below it. The only gap to the room list came from the `ListView`'s own top padding — which is *inside* the scroll view, so it scrolls away with the content. Once the list was scrolled, room titles/descriptions butted flush against the filter row and read as clipped (John saw "Analysis" cut off on iPad/light, "document retrieval" cut off on Android/dark).

## Fix

Add a non-scrolling bottom gap under the filter row, sized to the list's item spacing (`SoliplexSpacing.s3` = 12). The gap lives outside the scroll view in the shared `_RoomContent` layout, so it holds across scroll on every breakpoint and both themes.

## Test

Adds a geometry regression test asserting at least `s3` of vertical space between the filter field and the first room card.

Addresses #464

🤖 Generated with [Claude Code](https://claude.com/claude-code)