### PR TITLE
fix(room): drop the duplicate room header at narrow widths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,11 @@ Versions follow the `version+build` scheme from `pubspec.yaml`, bumped via
 - In an expanded citation, the cited figures now appear above the source text
   rather than below it.
 - The lobby sort options are shortened to "None", "Recent", and "Unread".
+- A room's welcome screen no longer repeats the room name above its welcome
+  message — the room header already carries the name directly above it. Its
+  sections (welcome message, suggestions, quizzes) are now separated only from
+  one another, so a room without a welcome message no longer opens with an
+  extra gap above its first section.
 
 ### Fixed
 
@@ -84,6 +89,11 @@ Versions follow the `version+build` scheme from `pubspec.yaml`, bumped via
   slot, figures for a source found by an earlier search of the same reply were
   dropped and it rendered text-only; those figures are now preserved, live and
   after a reload.
+- The chat screen no longer shows the room title twice at phone and narrow web
+  widths. The app bar title was repeated by an in-page header directly beneath
+  it; narrow layouts now drop that header and move its controls — the
+  attached-files toggle and room info — up beside the app bar title. Wide
+  layouts, which have no app bar, keep the in-page header as before.
 
 ## [0.94.0+68] - 2026-07-17
 

--- a/lib/src/modules/room/ui/room_screen.dart
+++ b/lib/src/modules/room/ui/room_screen.dart
@@ -1422,9 +1422,8 @@ class _RoomScreenState extends State<RoomScreen> {
         builder: (context, constraints) {
           final isWide = constraints.maxWidth >= SoliplexBreakpoints.tablet;
           // Wide layouts have no AppBar, so the in-page header carries the room
-          // title. Narrow layouts already show the title in the AppBar, so they
-          // drop the in-page header and take its actions into the AppBar
-          // instead (issue #465).
+          // title and its trailing actions. Narrow layouts show the title in
+          // the AppBar and hoist those actions up beside it (issue #465).
           final built = _buildContent(room, showHeader: isWide);
           final content = built.content;
 
@@ -1590,11 +1589,11 @@ class _RoomScreenState extends State<RoomScreen> {
     });
   }
 
-  /// Builds the chat content column together with the header's trailing
-  /// actions (documents toggle + room info). [showHeader] draws the in-page
-  /// header inside the column on wide layouts; narrow layouts pass `false` and
-  /// hand the returned [headerActions] to the AppBar instead, so the room
-  /// title isn't rendered twice (issue #465).
+  /// Builds the chat content column. [showHeader] draws the in-page header
+  /// inside the column; callers that suppress it show the room title elsewhere
+  /// and place [headerActions] beside it. [headerActions] is built either way,
+  /// so callers that keep the in-page header can ignore it — the header builds
+  /// its own copy.
   ({Widget content, List<Widget> headerActions}) _buildContent(
     Room? room, {
     required bool showHeader,
@@ -1674,10 +1673,8 @@ class _RoomScreenState extends State<RoomScreen> {
     );
   }
 
-  /// The header's trailing controls: the attached-files toggle (only when a
-  /// scope has files) and the room-info button. Shared so wide layouts place
-  /// them in the in-page header while narrow layouts hoist them into the
-  /// AppBar, beside the room title (issue #465).
+  /// The header's trailing controls: the attached-files toggle (hidden when
+  /// both upload scopes are Loaded-empty) and the room-info button.
   List<Widget> _buildRoomHeaderActions(
     UploadsStatus roomStatus,
     UploadsStatus threadStatus,

--- a/lib/src/modules/room/ui/room_screen.dart
+++ b/lib/src/modules/room/ui/room_screen.dart
@@ -1421,7 +1421,12 @@ class _RoomScreenState extends State<RoomScreen> {
       child: LayoutBuilder(
         builder: (context, constraints) {
           final isWide = constraints.maxWidth >= SoliplexBreakpoints.tablet;
-          final content = _buildContent(room);
+          // Wide layouts have no AppBar, so the in-page header carries the room
+          // title. Narrow layouts already show the title in the AppBar, so they
+          // drop the in-page header and take its actions into the AppBar
+          // instead (issue #465).
+          final built = _buildContent(room, showHeader: isWide);
+          final content = built.content;
 
           if (isWide) {
             final sidebar = ThreadSidebar(
@@ -1470,6 +1475,7 @@ class _RoomScreenState extends State<RoomScreen> {
                 ),
               ),
               title: _roomTitle(roomName),
+              actions: built.headerActions,
             ),
             drawer: Drawer(
               child: Builder(
@@ -1584,7 +1590,15 @@ class _RoomScreenState extends State<RoomScreen> {
     });
   }
 
-  Widget _buildContent(Room? room) {
+  /// Builds the chat content column together with the header's trailing
+  /// actions (documents toggle + room info). [showHeader] draws the in-page
+  /// header inside the column on wide layouts; narrow layouts pass `false` and
+  /// hand the returned [headerActions] to the AppBar instead, so the room
+  /// title isn't rendered twice (issue #465).
+  ({Widget content, List<Widget> headerActions}) _buildContent(
+    Room? room, {
+    required bool showHeader,
+  }) {
     final threadView = _state.activeThreadView;
     final roomAttachEnabled = room?.supportsAttachments ?? false;
     final messagesStatus = threadView?.messages.watch(context);
@@ -1605,19 +1619,23 @@ class _RoomScreenState extends State<RoomScreen> {
         ? _buildNoThreadBody(room)
         : _buildThreadBody(threadView, room, messagesStatus);
 
-    return Column(
-      children: [
-        StatusMessageBanner(
-          key: ValueKey(widget.serverEntry.serverUrl),
-          baseUrl: widget.serverEntry.serverUrl,
-          client: widget.serverEntry.httpClient,
-          serverLabel: widget.serverEntry.displayName,
-        ),
-        _buildRoomHeader(room, roomStatus, threadStatus),
-        if (_filesExpanded) _buildFilePanel(roomStatus, threadStatus),
-        Expanded(child: _capWidth(body)),
-        _capWidth(_buildChatInput(threadView, room, messagesStatus)),
-      ],
+    return (
+      content: Column(
+        children: [
+          StatusMessageBanner(
+            key: ValueKey(widget.serverEntry.serverUrl),
+            baseUrl: widget.serverEntry.serverUrl,
+            client: widget.serverEntry.httpClient,
+            serverLabel: widget.serverEntry.displayName,
+          ),
+          if (showHeader) _buildRoomHeader(room, roomStatus, threadStatus),
+          if (_filesExpanded) _buildFilePanel(roomStatus, threadStatus),
+          Expanded(child: _capWidth(body)),
+          _capWidth(_buildChatInput(threadView, room, messagesStatus)),
+        ],
+      ),
+      headerActions:
+          _buildRoomHeaderActions(roomStatus, threadStatus, Theme.of(context)),
     );
   }
 
@@ -1638,8 +1656,6 @@ class _RoomScreenState extends State<RoomScreen> {
   ) {
     final theme = Theme.of(context);
     final roomName = room?.name ?? widget.roomId;
-    final documentsButton =
-        _buildDocumentsButton(roomStatus, threadStatus, theme);
 
     return Padding(
       padding: const EdgeInsets.symmetric(
@@ -1652,16 +1668,32 @@ class _RoomScreenState extends State<RoomScreen> {
           // beside a Spacer would split the free space and leave the buttons
           // stranded mid-row.
           Expanded(child: _roomTitle(roomName)),
-          if (documentsButton != null) documentsButton,
-          IconButton(
-            icon: const Icon(Icons.info_outline),
-            tooltip: 'Room info',
-            onPressed: _onRoomInfo,
-            visualDensity: VisualDensity.compact,
-          ),
+          ..._buildRoomHeaderActions(roomStatus, threadStatus, theme),
         ],
       ),
     );
+  }
+
+  /// The header's trailing controls: the attached-files toggle (only when a
+  /// scope has files) and the room-info button. Shared so wide layouts place
+  /// them in the in-page header while narrow layouts hoist them into the
+  /// AppBar, beside the room title (issue #465).
+  List<Widget> _buildRoomHeaderActions(
+    UploadsStatus roomStatus,
+    UploadsStatus threadStatus,
+    ThemeData theme,
+  ) {
+    final documentsButton =
+        _buildDocumentsButton(roomStatus, threadStatus, theme);
+    return [
+      if (documentsButton != null) documentsButton,
+      IconButton(
+        icon: const Icon(Icons.info_outline),
+        tooltip: 'Room info',
+        onPressed: _onRoomInfo,
+        visualDensity: VisualDensity.compact,
+      ),
+    ];
   }
 
   /// The header title: the room name over the server it lives on, so a user

--- a/lib/src/modules/room/ui/room_welcome.dart
+++ b/lib/src/modules/room/ui/room_welcome.dart
@@ -34,34 +34,28 @@ class RoomWelcome extends StatelessWidget {
     return SingleChildScrollView(
       child: Padding(
         padding: const EdgeInsets.all(SoliplexSpacing.s6),
+        // Spacing sits on the Column so gaps fall only between the sections
+        // that actually render — any of them can be absent.
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.center,
           mainAxisSize: MainAxisSize.min,
+          spacing: SoliplexSpacing.s6,
           children: [
-            if (currentRoom.name.isNotEmpty)
-              Text(
-                currentRoom.name,
-                style: theme.textTheme.titleMedium?.copyWith(
-                  fontWeight: FontWeight.w600,
-                ),
-                textAlign: TextAlign.center,
-              ),
-            if (currentRoom.hasWelcomeMessage) ...[
-              const SizedBox(height: SoliplexSpacing.s2),
+            // The room name is not repeated here: the room header carries it
+            // in every layout, and this block sits directly beneath it.
+            if (currentRoom.hasWelcomeMessage)
               ConstrainedBox(
                 constraints: const BoxConstraints(maxWidth: 480),
                 child: FlutterMarkdownPlusRenderer(
                   data: currentRoom.welcomeMessage,
                 ),
               ),
-            ],
-            if (currentRoom.hasSuggestions) ...[
-              const SizedBox(height: SoliplexSpacing.s6),
+            if (currentRoom.hasSuggestions)
               ConstrainedBox(
                 constraints: const BoxConstraints(maxWidth: 520),
                 child: Wrap(
-                  spacing: 8,
-                  runSpacing: 8,
+                  spacing: SoliplexSpacing.s2,
+                  runSpacing: SoliplexSpacing.s2,
                   alignment: WrapAlignment.center,
                   children: [
                     for (final suggestion in currentRoom.suggestions)
@@ -74,12 +68,11 @@ class RoomWelcome extends StatelessWidget {
                   ],
                 ),
               ),
-            ],
-            if (currentRoom.hasQuizzes) ...[
-              const SizedBox(height: SoliplexSpacing.s6),
+            if (currentRoom.hasQuizzes)
               ConstrainedBox(
                 constraints: const BoxConstraints(maxWidth: 520),
                 child: Column(
+                  spacing: SoliplexSpacing.s2,
                   children: [
                     Row(
                       mainAxisSize: MainAxisSize.min,
@@ -95,10 +88,9 @@ class RoomWelcome extends StatelessWidget {
                         ),
                       ],
                     ),
-                    const SizedBox(height: SoliplexSpacing.s2),
                     Wrap(
-                      spacing: 8,
-                      runSpacing: 8,
+                      spacing: SoliplexSpacing.s2,
+                      runSpacing: SoliplexSpacing.s2,
                       alignment: WrapAlignment.center,
                       children: [
                         for (final entry in currentRoom.quizzes.entries)
@@ -118,7 +110,6 @@ class RoomWelcome extends StatelessWidget {
                   ],
                 ),
               ),
-            ],
           ],
         ),
       ),

--- a/test/modules/room/ui/room_screen_test.dart
+++ b/test/modules/room/ui/room_screen_test.dart
@@ -376,20 +376,18 @@ void main() {
     });
   });
 
-  group('duplicate header (issue #465)', () {
-    testWidgets(
-        'narrow layout draws the room title once and hoists actions into the '
-        'AppBar', (tester) async {
-      tester.view.physicalSize = const Size(400, 800);
+  group('room header placement', () {
+    Future<void> pumpRoom(
+      WidgetTester tester, {
+      required double width,
+    }) async {
+      tester.view.physicalSize = Size(width, 800);
       tester.view.devicePixelRatio = 1.0;
       addTearDown(tester.view.resetPhysicalSize);
 
-      api.nextRoom = const Room(id: 'room-1', name: 'General');
-      final namedEntry = createTestServerEntry(api: api, name: 'Prod API');
-
       await tester.pumpWidget(MaterialApp(
         home: RoomScreen(
-          serverEntry: namedEntry,
+          serverEntry: entry,
           roomId: 'room-1',
           threadId: null,
           runtimeManager: runtimeManager,
@@ -399,15 +397,20 @@ void main() {
         ),
       ));
       await tester.pumpAndSettle();
+    }
 
-      // The title lives only in the AppBar — no second in-page header below it.
+    // The title assertions below count matches across the whole tree, which is
+    // unambiguous only for a fixture like this one: the rail names its room
+    // 'Test Room', and RoomWelcome prints the room name a second time for a
+    // room carrying a welcome message, suggestions, or quizzes.
+    testWidgets('narrow layout draws the room title once, in the AppBar',
+        (tester) async {
+      api.nextRoom = const Room(id: 'room-1', name: 'General');
+
+      await pumpRoom(tester, width: 400);
+
+      // One title in the whole tree — no in-page header repeating the AppBar's.
       expect(find.text('General'), findsOneWidget);
-      expect(
-        find.descendant(
-            of: find.byType(AppBar), matching: find.text('General')),
-        findsOneWidget,
-      );
-      // The room-info action moves into the AppBar with the title.
       expect(
         find.descendant(
           of: find.byType(AppBar),
@@ -417,34 +420,54 @@ void main() {
       );
     });
 
-    testWidgets(
-        'wide layout keeps the in-page header carrying the title and info '
-        'action', (tester) async {
-      tester.view.physicalSize = const Size(1200, 800);
-      tester.view.devicePixelRatio = 1.0;
-      addTearDown(tester.view.resetPhysicalSize);
-
+    testWidgets('wide layout draws the room title once, in the in-page header',
+        (tester) async {
       api.nextRoom = const Room(id: 'room-1', name: 'General');
-      final namedEntry = createTestServerEntry(api: api, name: 'Prod API');
 
-      await tester.pumpWidget(MaterialApp(
-        home: RoomScreen(
-          serverEntry: namedEntry,
-          roomId: 'room-1',
-          threadId: null,
-          runtimeManager: runtimeManager,
-          registry: registry,
-          uploadRegistry: uploadRegistry,
-          documentSelections: DocumentSelections(),
-        ),
-      ));
-      await tester.pumpAndSettle();
+      await pumpRoom(tester, width: 1200);
 
       // No AppBar on wide, so the in-page header is the sole title and the
-      // info action stays in the body.
+      // info action is in the body.
       expect(find.byType(AppBar), findsNothing);
       expect(find.text('General'), findsOneWidget);
       expect(find.byIcon(Icons.info_outline), findsOneWidget);
+    });
+
+    testWidgets(
+        'narrow layout hoists the documents toggle into the AppBar, where it '
+        'still opens the file panel', (tester) async {
+      api.nextRoom = const Room(
+        id: 'room-1',
+        name: 'Attachable',
+        skills: {sandboxSkillName: _sandboxSkill},
+      );
+      api.nextThreads = const [];
+      api.nextRoomUploads = [
+        FileUpload(
+          filename: 'shared.pdf',
+          url: Uri.parse('https://example.com/shared.pdf'),
+        ),
+      ];
+
+      // The narrowest supported width, where the two-line title and both
+      // actions compete for the toolbar.
+      await pumpRoom(tester, width: 320);
+
+      expect(
+        find.descendant(
+          of: find.byType(AppBar),
+          matching: find.byIcon(Icons.folder_outlined),
+        ),
+        findsOneWidget,
+      );
+
+      // The toggle sits in the AppBar while the panel it opens renders in the
+      // body column, so the tap has to carry across subtrees.
+      await tester.tap(find.byIcon(Icons.folder_outlined));
+      await tester.pumpAndSettle();
+
+      expect(find.text('shared.pdf'), findsOneWidget);
+      expect(tester.takeException(), isNull);
     });
   });
 

--- a/test/modules/room/ui/room_screen_test.dart
+++ b/test/modules/room/ui/room_screen_test.dart
@@ -376,6 +376,78 @@ void main() {
     });
   });
 
+  group('duplicate header (issue #465)', () {
+    testWidgets(
+        'narrow layout draws the room title once and hoists actions into the '
+        'AppBar', (tester) async {
+      tester.view.physicalSize = const Size(400, 800);
+      tester.view.devicePixelRatio = 1.0;
+      addTearDown(tester.view.resetPhysicalSize);
+
+      api.nextRoom = const Room(id: 'room-1', name: 'General');
+      final namedEntry = createTestServerEntry(api: api, name: 'Prod API');
+
+      await tester.pumpWidget(MaterialApp(
+        home: RoomScreen(
+          serverEntry: namedEntry,
+          roomId: 'room-1',
+          threadId: null,
+          runtimeManager: runtimeManager,
+          registry: registry,
+          uploadRegistry: uploadRegistry,
+          documentSelections: DocumentSelections(),
+        ),
+      ));
+      await tester.pumpAndSettle();
+
+      // The title lives only in the AppBar — no second in-page header below it.
+      expect(find.text('General'), findsOneWidget);
+      expect(
+        find.descendant(
+            of: find.byType(AppBar), matching: find.text('General')),
+        findsOneWidget,
+      );
+      // The room-info action moves into the AppBar with the title.
+      expect(
+        find.descendant(
+          of: find.byType(AppBar),
+          matching: find.byIcon(Icons.info_outline),
+        ),
+        findsOneWidget,
+      );
+    });
+
+    testWidgets(
+        'wide layout keeps the in-page header carrying the title and info '
+        'action', (tester) async {
+      tester.view.physicalSize = const Size(1200, 800);
+      tester.view.devicePixelRatio = 1.0;
+      addTearDown(tester.view.resetPhysicalSize);
+
+      api.nextRoom = const Room(id: 'room-1', name: 'General');
+      final namedEntry = createTestServerEntry(api: api, name: 'Prod API');
+
+      await tester.pumpWidget(MaterialApp(
+        home: RoomScreen(
+          serverEntry: namedEntry,
+          roomId: 'room-1',
+          threadId: null,
+          runtimeManager: runtimeManager,
+          registry: registry,
+          uploadRegistry: uploadRegistry,
+          documentSelections: DocumentSelections(),
+        ),
+      ));
+      await tester.pumpAndSettle();
+
+      // No AppBar on wide, so the in-page header is the sole title and the
+      // info action stays in the body.
+      expect(find.byType(AppBar), findsNothing);
+      expect(find.text('General'), findsOneWidget);
+      expect(find.byIcon(Icons.info_outline), findsOneWidget);
+    });
+  });
+
   testWidgets(
       'narrow layout: tapping drawer icon opens drawer with thread list',
       (tester) async {

--- a/test/modules/room/ui/room_welcome_test.dart
+++ b/test/modules/room/ui/room_welcome_test.dart
@@ -98,8 +98,9 @@ void main() {
         fallback: Text('fallback'),
       ),
     ));
-    expect(find.text('Research Bot'), findsOneWidget);
     expect(find.text('Welcome! Ask me anything.'), findsOneWidget);
+    // The room name is not repeated here — the room header already carries it.
+    expect(find.text('Research Bot'), findsNothing);
   });
 
   testWidgets('shows suggestion chips when room has suggestions',


### PR DESCRIPTION
## What

At phone and narrow web widths the chat screen rendered the room title **twice**,
stacked: once in the AppBar and again in an in-page header directly below it.
Wide layouts have no AppBar, so there the in-page header is the *only* title —
the duplication was narrow-only.

Addresses #465.

## Fix

Per John's recommendation: at narrow widths the in-page header is suppressed and
its trailing controls move into `AppBar.actions`, beside the title already there.
Both controls move — the room-info (ⓘ) button and the attached-files toggle,
since the toggle is the only affordance for viewing attachments and would
otherwise disappear on mobile. Wide layouts are unchanged.

Mechanically: `_buildContent` takes a `showHeader` flag and returns
`({Widget content, List<Widget> headerActions})`; a shared
`_buildRoomHeaderActions` builds the trailing controls for either placement, so
there is one definition rather than two copies.

## Also in this PR

With the header now guaranteed to carry the room name in both layouts,
`RoomWelcome` no longer repeats it above the welcome message. Its section gaps
moved onto `Column(spacing:)` so they fall only *between* rendered sections —
previously a room with suggestions but no welcome message opened with a stray
24px gap — and four magic `spacing: 8` values became `SoliplexSpacing.s2`.

## Tests

`room_screen_test.dart`, group `room header placement` (shared local `pumpRoom`
helper):

- Narrow: the room title is found exactly once, in the AppBar, with the info
  action inside it.
- Wide: no AppBar; the in-page header carries both the title and the info action.
- Narrow with an upload seeded: the documents toggle renders as an AppBar
  descendant at 320px and still opens the file panel down in the body column.

`room_welcome_test.dart` asserts the room name is no longer rendered inside the
welcome block.

## Verification

`flutter analyze` clean, `dart format` clean, full suite **2181 pass**.

The tests were confirmed to have teeth: deleting `actions: built.headerActions`
makes both narrow tests fail and correctly leaves the wide one green.

Wide/narrow parity was also checked across 11 fixtures — attachments
present/absent/loading/failed, welcome message, suggestions, quizzes, long
welcome text, active thread — and the header inventory (room name, server label,
info button, documents toggle) is identical at both widths in every case.

## Follow-ups filed

Pre-existing issues surfaced while working here, none of them fixed in this PR:
#477, #478, #479, #480, #481.

🤖 Generated with [Claude Code](https://claude.com/claude-code)