### PR TITLE
feat(room): expand the citations section by default

### DIFF
--- a/lib/src/modules/room/ui/citations_section.dart
+++ b/lib/src/modules/room/ui/citations_section.dart
@@ -53,7 +53,11 @@ class CitationsSection extends StatefulWidget {
 }
 
 class _CitationsSectionState extends State<CitationsSection> {
-  bool _sectionExpanded = false;
+  // Expanded by default so each source's filename and page numbers are visible
+  // without a click — there are only ever a handful of citations (issue #463).
+  // Each individual transcript still starts collapsed; the reader opts into a
+  // single passage's full text on demand.
+  bool _sectionExpanded = true;
   final Set<int> _expandedIndices = {};
 
   @override

--- a/test/modules/room/ui/citations_figures_test.dart
+++ b/test/modules/room/ui/citations_figures_test.dart
@@ -102,10 +102,9 @@ void main() {
     await tester.pumpWidget(host(_ref(
       figures: [Figure(ref: '#/pictures/0', bytes: _png)],
     )));
-    // Expand the citations section, then the citation row (title falls back
-    // to the document URI's filename since documentTitle isn't set).
-    await tester.tap(find.text('1 source'));
-    await tester.pump();
+    // The section is expanded by default (issue #463); open the citation row
+    // (title falls back to the document URI's filename since documentTitle
+    // isn't set).
     await tester.tap(find.text('doc-1.pdf'));
     await tester.pump();
 
@@ -117,8 +116,6 @@ void main() {
     await tester.pumpWidget(host(_ref(
       figures: [Figure(ref: '#/pictures/0', bytes: _png)],
     )));
-    await tester.tap(find.text('1 source'));
-    await tester.pump();
     await tester.tap(find.text('doc-1.pdf'));
     await tester.pump();
 
@@ -140,8 +137,6 @@ void main() {
         Figure(ref: '#/pictures/1', bytes: _png),
       ],
     )));
-    await tester.tap(find.text('1 source'));
-    await tester.pump();
     await tester.tap(find.text('doc-1.pdf'));
     await tester.pump();
 
@@ -163,8 +158,6 @@ void main() {
         Figure(ref: '#/pictures/1', bytes: _png, caption: 'cap-one'),
       ],
     )));
-    await tester.tap(find.text('1 source'));
-    await tester.pump();
     await tester.tap(find.text('doc-1.pdf'));
     await tester.pump();
 
@@ -186,8 +179,6 @@ void main() {
             ref: '#/pictures/0', bytes: Uint8List.fromList(const [1, 2, 3, 4])),
       ],
     )));
-    await tester.tap(find.text('1 source'));
-    await tester.pump();
     await tester.tap(find.text('doc-1.pdf'));
     await tester.pump();
 
@@ -201,8 +192,6 @@ void main() {
   testWidgets('renders no figure strip when there are no figures',
       (tester) async {
     await tester.pumpWidget(host(_ref(figures: const [])));
-    await tester.tap(find.text('1 source'));
-    await tester.pump();
     await tester.tap(find.text('doc-1.pdf'));
     await tester.pump();
 
@@ -216,8 +205,6 @@ void main() {
         Figure(ref: '#/pictures/0', bytes: _png, caption: 'Figure 1: revenue'),
       ],
     )));
-    await tester.tap(find.text('1 source'));
-    await tester.pump();
     await tester.tap(find.text('doc-1.pdf'));
     await tester.pump();
     await tester.tap(find.byType(Image));
@@ -231,8 +218,6 @@ void main() {
     await tester.pumpWidget(host(_ref(
       figures: [Figure(ref: '#/pictures/0', bytes: _png)],
     )));
-    await tester.tap(find.text('1 source'));
-    await tester.pump();
     await tester.tap(find.text('doc-1.pdf'));
     await tester.pump();
     await tester.tap(find.byType(Image));
@@ -250,8 +235,6 @@ void main() {
     await tester.pumpWidget(host(_ref(
       figures: [Figure(ref: '#/pictures/0', bytes: _png, caption: long)],
     )));
-    await tester.tap(find.text('1 source'));
-    await tester.pump();
     await tester.tap(find.text('doc-1.pdf'));
     await tester.pump();
     await tester.tap(find.byType(Image));
@@ -270,8 +253,6 @@ void main() {
         Figure(ref: '#/pictures/0', bytes: _png, caption: 'Figure 1: revenue'),
       ],
     )));
-    await tester.tap(find.text('1 source'));
-    await tester.pump();
     await tester.tap(find.text('doc-1.pdf'));
     await tester.pump();
 

--- a/test/modules/room/ui/citations_section_source_url_test.dart
+++ b/test/modules/room/ui/citations_section_source_url_test.dart
@@ -28,9 +28,8 @@ Future<void> _pump(
       home: Scaffold(body: CitationsSection(sourceReferences: [ref])),
     ),
   ));
-  await tester.tap(find.text('1 source')); // expand the section
-  await tester.pump();
-  await tester.tap(find.text('Alpha')); // expand the row
+  // The section is expanded by default (issue #463); open the row.
+  await tester.tap(find.text('Alpha'));
   await tester.pump();
 }
 

--- a/test/modules/room/ui/citations_section_test.dart
+++ b/test/modules/room/ui/citations_section_test.dart
@@ -53,8 +53,8 @@ void main() {
       ),
     ));
 
-    await tester.tap(find.text('1 source'));
-    await tester.pump();
+    // The section is expanded by default (issue #463), so the source title is
+    // visible without a tap; tapping it opens the row to render the content.
     await tester.tap(find.text('Alpha'));
     await tester.pump();
 
@@ -81,7 +81,8 @@ void main() {
     expect(find.text('1 source'), findsOneWidget);
   });
 
-  testWidgets('tapping header expands to show source titles', (tester) async {
+  testWidgets('sources are expanded and visible by default (issue #463)',
+      (tester) async {
     await tester.pumpWidget(_wrap(
       CitationsSection(
         sourceReferences: [
@@ -91,27 +92,28 @@ void main() {
       ),
     ));
 
-    expect(find.text('Alpha'), findsNothing);
-
-    await tester.tap(find.text('2 sources'));
-    await tester.pump();
-
+    // No tap needed — each source's filename shows immediately.
     expect(find.text('Alpha'), findsOneWidget);
     expect(find.text('Beta'), findsOneWidget);
   });
 
-  testWidgets('tapping header again collapses section', (tester) async {
+  testWidgets('tapping the header collapses then re-expands the section',
+      (tester) async {
     await tester.pumpWidget(_wrap(
       CitationsSection(sourceReferences: [_ref(index: 1, title: 'Alpha')]),
     ));
 
-    await tester.tap(find.text('1 source'));
-    await tester.pump();
+    // Starts expanded (issue #463); the header still toggles it closed...
     expect(find.text('Alpha'), findsOneWidget);
 
     await tester.tap(find.text('1 source'));
     await tester.pump();
     expect(find.text('Alpha'), findsNothing);
+
+    // ...and back open.
+    await tester.tap(find.text('1 source'));
+    await tester.pump();
+    expect(find.text('Alpha'), findsOneWidget);
   });
 
   testWidgets('displays badge number from SourceReference.index',
@@ -119,9 +121,6 @@ void main() {
     await tester.pumpWidget(_wrap(
       CitationsSection(sourceReferences: [_ref(index: 4, title: 'Fourth')]),
     ));
-
-    await tester.tap(find.text('1 source'));
-    await tester.pump();
 
     expect(find.text('4'), findsOneWidget);
   });
@@ -141,9 +140,8 @@ void main() {
       ),
     ));
 
-    await tester.tap(find.text('1 source'));
-    await tester.pump();
-
+    // Section expanded by default (issue #463); the row's heading breadcrumb
+    // stays hidden until the row itself is tapped open.
     expect(find.text('Chapter 1 > Section 2'), findsNothing);
 
     await tester.tap(find.text('Doc'));
@@ -167,8 +165,7 @@ void main() {
       ),
     ));
 
-    await tester.tap(find.text('1 source'));
-    await tester.pump();
+    // Expanded by default (issue #463); open the single source's row.
     await tester.tap(find.text('Doc'));
     await tester.pump();
 
@@ -207,8 +204,6 @@ void main() {
       ),
     ));
 
-    await tester.tap(find.text('1 source'));
-    await tester.pump();
     await tester.tap(find.text('Doc'));
     await tester.pump();
 
@@ -223,9 +218,6 @@ void main() {
         ],
       ),
     ));
-
-    await tester.tap(find.text('1 source'));
-    await tester.pump();
 
     expect(find.text('p.5-6'), findsOneWidget);
   });
@@ -244,10 +236,7 @@ void main() {
       ),
     ));
 
-    // Expand section
-    await tester.tap(find.text('2 sources'));
-    await tester.pump();
-
+    // Section is expanded by default (issue #463), so both rows are visible.
     // Only the PDF source exposes the eye affordance, and it sits in
     // the source's header row (no need to expand the row to reveal it).
     expect(find.byTooltip('View source PDF'), findsOneWidget);


### PR DESCRIPTION
## What

Alan: *"I have to click the citations button to see the citations — just to see the filename. At most we'll have 5–7 citations."* Seeing a message's sources required a click on the **N sources** header, even though a message only ever carries a handful.

## Fix

Default `_sectionExpanded` to `true`, so each source's filename and page numbers show without any click. Each **individual transcript still starts collapsed** — the reader opts into a single passage's full text on demand — and the header still toggles the whole section closed. This pairs cleanly with the already-merged #451 work (collapsed transcripts no longer trap scroll), so a screen full of default-expanded citations scrolls fine.

## Tests

Several existing tests tapped the header to *expand* before asserting; with the section open by default that tap now *collapses*, so they were updated to assert the default-open state (or drop the redundant tap). One test keeps an explicit collapse/re-expand toggle. Full room suite green (1103).

Addresses #463

> Note: this issue is assigned to @91jaeminjo — opening the PR for coordination rather than to step on the assignment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)