### PR TITLE
chore(deps): bump ag_ui to hosted ^0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,73 @@ Versions follow the `version+build` scheme from `pubspec.yaml`, bumped via
 
 ### Changed
 
+- The `ag_ui` dependency moved to hosted `^0.3.0` (from a git ref on 0.1.0),
+  which adds multimodal `UserMessage` input, fractional `timestamp` coercion,
+  and `encryptedValue` snake_case parity. On the SSE path this app uses, 0.3.0
+  also flushes a final unterminated event at end-of-stream, corrects WHATWG
+  handling of an empty leading `data:` line and of repeated `event:` lines, and
+  strips a byte-order mark only at the start of the stream rather than from
+  every line.
+- **Breaking (library consumers):** `LlmUserMessage.content` and the `content`
+  field of `ChatFn`'s message records are now `String?`. A null means a **user**
+  message whose wire content was a parts list rather than text (AG-UI returns
+  null for any such message, keeping the parts on
+  `UserMessage.messageContent`), or — in `ChatFn`'s records only — an
+  **assistant** turn carrying neither text nor tool calls. Neither coalesces to
+  `''`, which is itself a sendable message that several chat APIs reject:
+  callers substitute a placeholder or reject the turn. The app itself is
+  unaffected — it neither implements `ChatFn` nor reads `LlmUserMessage`.
+- An activity snapshot whose `content` is not a JSON object still surfaces as a
+  dropped-event tile. 0.3.0 widened `ActivitySnapshotEvent.content` to `Object?`
+  and dropped the decoder's Map validation, so a payload that 0.1.0 rejected at
+  the wire boundary now decodes cleanly; Soliplex stores activity content as a
+  JSON object, so it has nowhere to go. The guard moved to the application seam
+  to keep the tile. Without it the row would strand — a dropped
+  `skill_tool_result` leaves its `skill_tool_call` at in-progress with nothing on
+  screen saying why.
+- A `MESSAGES_SNAPSHOT` event is now logged on arrival. It carries AG-UI's
+  authoritative message list, which this client does not reconcile against, so a
+  server-side prune or rewrite of history would otherwise leave a divergent view
+  with no trace.
+- A response body that closes cleanly part-way through an SSE event no longer
+  discards the partial payload: 0.3.0's parser flushes it at end-of-stream, so
+  it surfaces as a dropped-event tile. If the cut lands mid-multi-byte
+  character the stream errors instead, which resume recovers from when a
+  `Last-Event-ID` cursor is available.
+- AG-UI messages the in-process LLM providers do not project into their text
+  transcript (`DeveloperMessage`, `ActivityMessage`, `ReasoningMessage`) are now
+  logged when dropped, and the conversion switches enumerate every `Message`
+  subtype so a type added upstream is a compile error rather than a silent
+  omission. `ReasoningMessage` is new in 0.3.0; on 0.1.0 the role did not exist,
+  so such a message failed to decode and became a drop tile.
+- SSE parsing now goes through AG-UI's public `SseClient` rather than a deep
+  import of its private `src/sse/sse_parser.dart`, so this package depends only
+  on ag_ui's semver-covered surface. Both routes reach the same parser, so the
+  swap changes nothing beyond the `data:` cap described below.
+- A single SSE event's `data:` is now capped at roughly 8M UTF-16 code units
+  (ag_ui's default; 0.1.0 had no cap). The cap bounds **inbound** events that
+  carry conversation state — a `MESSAGES_SNAPSHOT` or `TOOL_CALL_RESULT`
+  echoing image data — and leaves room for roughly 6 MB of binary after base64.
+  Outbound attachments travel in the request body and are unaffected.
+- A stream that fails at the same point on every resume attempt now ends after
+  the retry budget instead of reconnecting forever. The budget resets only when
+  an attempt advances the `Last-Event-ID` cursor, so a drop that follows fresh
+  progress gets a full budget while a permanently rejected event — one over the
+  new `data:` cap, which the server re-sends verbatim on each resume — is
+  allowed to exhaust it and surface as a resume failure carrying the parser's
+  message. The cursor is an imperfect proxy for progress: a server that emits
+  `id:` sparsely charges real progress against the budget, as does a drop that
+  lands before the first new id.
+- **Breaking (library consumers), transitively:** `soliplex_client`'s barrel
+  re-exports `package:ag_ui/ag_ui.dart` (less `CancelToken`), so every ag_ui
+  0.3.0 breaking change reaches anything importing it — not just the two `String?`
+  types above. Notably `RunStartedEvent` and `UserMessage`'s text constructor
+  are no longer `const` (`UserMessage.fromContent` still is),
+  `ActivitySnapshotEvent.content` widened to `Object?`, and
+  `StateDeltaEvent.delta` / `ActivityDeltaEvent.patch` narrowed to
+  `List<Map<String, dynamic>>`. Library code here needed no changes for the
+  `const` break; forks should expect it to reach their tests and any
+  `const`-constructed events.
 - File attachments now appear based on the `bubble-sandbox` skill — the room's
   configured skills for room-level (admin) uploads, and a thread's AG-UI state
   for thread-level uploads — instead of an `enable_attachments` room flag the

--- a/packages/soliplex_agent/lib/src/orchestration/chat_fn_llm_provider.dart
+++ b/packages/soliplex_agent/lib/src/orchestration/chat_fn_llm_provider.dart
@@ -24,8 +24,24 @@ final Logger _logger =
 ///       ollama.chat(msgs, systemPrompt: systemPrompt, maxTokens: maxTokens),
 /// );
 /// ```
+///
+/// `role` is one of `user`, `assistant`, or `system`. Tool results are
+/// deliberately flattened into `user` turns carrying an interpolated
+/// `[Tool result for …]` string, so a `user` role does not always mean the
+/// human spoke.
+///
+/// A null `content` arises two ways, and `role` tells them apart: a `user` turn
+/// whose content was a list of parts rather than text, or an `assistant` turn
+/// carrying neither text nor a tool call. Every other case is non-null by
+/// construction — system and tool messages carry a non-nullable `String`
+/// upstream, the flattened tool arm interpolates, and a tool-calling assistant
+/// turn is synthesized into a `[Called tool …]` string. A producer arm added
+/// here must keep `content` non-null or extend this contract.
+///
+/// A null is distinct from `''`, which is a sendable empty message: the
+/// callback substitutes a placeholder or rejects the turn.
 typedef ChatFn = Future<String> Function(
-  List<({String role, String content})> messages, {
+  List<({String role, String? content})> messages, {
   String? systemPrompt,
   int? maxTokens,
 });
@@ -142,10 +158,10 @@ class ChatFnLlmProvider implements AgentLlmProvider {
 
   /// Converts AG-UI messages to simple role/content pairs for the
   /// [ChatFn].
-  List<({String role, String content})> _convertMessages(
+  List<({String role, String? content})> _convertMessages(
     SimpleRunAgentInput input,
   ) {
-    final result = <({String role, String content})>[];
+    final result = <({String role, String? content})>[];
     final messages = input.messages;
     if (messages == null) return result;
     for (final msg in messages) {
@@ -164,7 +180,7 @@ class ChatFnLlmProvider implements AgentLlmProvider {
               ),
             );
           } else {
-            result.add((role: 'assistant', content: m.content ?? ''));
+            result.add((role: 'assistant', content: m.content));
           }
         case final ToolMessage m:
           result.add(
@@ -177,8 +193,17 @@ class ChatFnLlmProvider implements AgentLlmProvider {
           result.add(
             (role: 'system', content: m.content),
           );
-        default:
-          break;
+        // Listed explicitly so a new upstream `Message` subtype is a compile
+        // error rather than a silent omission from the transcript.
+        case DeveloperMessage() || ActivityMessage() || ReasoningMessage():
+          _logger.warning(
+            '${msg.runtimeType} not projected into the ChatFn transcript; '
+            'dropped (messageId: ${msg.id})',
+            attributes: {
+              'messageType': msg.runtimeType.toString(),
+              'messageId': msg.id,
+            },
+          );
       }
     }
     return result;

--- a/packages/soliplex_agent/lib/src/orchestration/streaming_llm_provider.dart
+++ b/packages/soliplex_agent/lib/src/orchestration/streaming_llm_provider.dart
@@ -184,8 +184,17 @@ class StreamingLlmProvider implements AgentLlmProvider {
           );
         case final SystemMessage m:
           result.add(LlmSystemMessage(m.content));
-        default:
-          break;
+        // Listed explicitly so a new upstream `Message` subtype is a compile
+        // error rather than a silent omission from the transcript.
+        case DeveloperMessage() || ActivityMessage() || ReasoningMessage():
+          _logger.warning(
+            '${msg.runtimeType} not projected into the LLM transcript; '
+            'dropped (messageId: ${msg.id})',
+            attributes: {
+              'messageType': msg.runtimeType.toString(),
+              'messageId': msg.id,
+            },
+          );
       }
     }
     return result;

--- a/packages/soliplex_agent/lib/src/runtime/agent_session.dart
+++ b/packages/soliplex_agent/lib/src/runtime/agent_session.dart
@@ -1,3 +1,14 @@
+// Four upstream types are deprecated, scheduled for removal in ag_ui 1.0.0:
+// THINKING_TEXT_MESSAGE_{START,CONTENT,END} and THINKING_CONTENT.
+// `ThinkingStartEvent` and `ThinkingEndEvent` are NOT deprecated and their arms
+// stay regardless — a removal sweep grepping "THINKING" must not touch them.
+// The THINKING_TEXT_MESSAGE_* arms stay because stored threads still decode to
+// them; the THINKING_CONTENT arm stays only to keep `bridgeBaseEvent`'s switch
+// over sealed `BaseEvent` exhaustive (upstream documents it as Dart-only legacy
+// that was never part of the canonical protocol). Suppressed per line so the
+// 1.0.0 sweep can enumerate them and an unrelated deprecation here still
+// raises.
+
 import 'dart:async';
 
 import 'package:meta/meta.dart';
@@ -633,12 +644,18 @@ List<ActivityRecord> conversationActivitiesOf(RunState runState) =>
 ExecutionEvent? bridgeBaseEvent(BaseEvent event) {
   return switch (event) {
     TextMessageContentEvent(:final delta) => TextDelta(delta: delta),
+    // Deprecated upstream; retained to decode stored threads.
+    // ignore: deprecated_member_use
     ThinkingTextMessageStartEvent() ||
     ReasoningMessageStartEvent() =>
       const ThinkingStarted(),
+    // Deprecated upstream; retained to decode stored threads.
+    // ignore: deprecated_member_use
     ThinkingTextMessageContentEvent(:final delta) ||
     ReasoningMessageContentEvent(:final delta) =>
       ThinkingContent(delta: delta),
+    // Deprecated upstream; retained to decode stored threads.
+    // ignore: deprecated_member_use
     ThinkingTextMessageEndEvent() ||
     ThinkingEndEvent() ||
     ReasoningEndEvent() ||
@@ -653,7 +670,7 @@ ExecutionEvent? bridgeBaseEvent(BaseEvent event) {
     ActivitySnapshotEvent(
       :final messageId,
       :final activityType,
-      :final content,
+      content: final Map<String, dynamic> content,
       :final timestamp,
       :final replace,
     ) =>
@@ -673,15 +690,27 @@ ExecutionEvent? bridgeBaseEvent(BaseEvent event) {
     // patch to `Conversation.activities`, and the tracker observes
     // activities reactively via the resulting signal. Bridging the
     // delta into an `ExecutionEvent` would duplicate that work.
+    //
+    // The bare `ActivitySnapshotEvent` reaches here only when `content` is not
+    // a `Map<String, dynamic>`, which AG-UI's `Object?` typing permits. Such a
+    // snapshot is dropped rather than synthesized into an empty one: the
+    // tracker must not hold an entry with no matching `ActivityRecord`. The
+    // live path never reaches this arm — `processEvent` throws on that shape
+    // and the orchestrator returns before republishing the event. Historical
+    // replay does reach it and drops silently by design, because the
+    // chat-message side already mints one tile for the same event.
     RunStartedEvent() ||
     TextMessageStartEvent() ||
     TextMessageEndEvent() ||
     ThinkingStartEvent() ||
+    // Deprecated upstream; arm only keeps the sealed switch exhaustive.
+    // ignore: deprecated_member_use
     ThinkingContentEvent() ||
     ToolCallArgsEvent() ||
     ToolCallEndEvent() ||
     StateSnapshotEvent() ||
     StateDeltaEvent() ||
+    ActivitySnapshotEvent() ||
     StepFinishedEvent() ||
     TextMessageChunkEvent() ||
     ToolCallChunkEvent() ||

--- a/packages/soliplex_agent/test/host/runtime_agent_api_test.dart
+++ b/packages/soliplex_agent/test/host/runtime_agent_api_test.dart
@@ -38,7 +38,7 @@ ThreadInfo _threadInfo() =>
     ThreadInfo(id: _threadId, roomId: _roomId, createdAt: DateTime(2026));
 
 List<BaseEvent> _happyPathEvents(String text) => [
-      const RunStartedEvent(threadId: _threadId, runId: _runId),
+      RunStartedEvent(threadId: _threadId, runId: _runId),
       const TextMessageStartEvent(messageId: 'msg-1'),
       TextMessageContentEvent(messageId: 'msg-1', delta: text),
       const TextMessageEndEvent(messageId: 'msg-1'),
@@ -155,7 +155,7 @@ void main() {
       ).thenAnswer((_) => _wrap(controller.stream));
 
       final handle = await agentApi.spawnAgent(_roomId, 'test');
-      controller.add(const RunStartedEvent(threadId: _threadId, runId: _runId));
+      controller.add(RunStartedEvent(threadId: _threadId, runId: _runId));
       await Future<void>.delayed(Duration.zero);
 
       await agentApi.cancelAgent(handle);
@@ -206,7 +206,7 @@ void main() {
       ).thenAnswer((_) => _wrap(controller.stream));
 
       final handle = await agentApi.spawnAgent(_roomId, 'test');
-      controller.add(const RunStartedEvent(threadId: _threadId, runId: _runId));
+      controller.add(RunStartedEvent(threadId: _threadId, runId: _runId));
       await Future<void>.delayed(Duration.zero);
 
       await agentApi.cancelAgent(handle);

--- a/packages/soliplex_agent/test/orchestration/chat_fn_llm_provider_test.dart
+++ b/packages/soliplex_agent/test/orchestration/chat_fn_llm_provider_test.dart
@@ -9,7 +9,7 @@ void main() {
       return SimpleRunAgentInput(
         threadId: key.threadId,
         runId: 'run-1',
-        messages: messages ?? [const UserMessage(id: 'u1', content: 'Hello')],
+        messages: messages ?? [UserMessage(id: 'u1', content: 'Hello')],
         tools: tools,
       );
     }
@@ -198,7 +198,7 @@ Let me check.
     });
 
     test('converts AG-UI messages to role/content pairs', () async {
-      List<({String role, String content})>? capturedMessages;
+      List<({String role, String? content})>? capturedMessages;
       final provider = ChatFnLlmProvider(
         chatFn: (messages, {systemPrompt, maxTokens}) async {
           capturedMessages = messages;
@@ -208,9 +208,9 @@ Let me check.
 
       final input = input0(
         messages: [
-          const UserMessage(id: 'u1', content: 'Hello'),
+          UserMessage(id: 'u1', content: 'Hello'),
           const AssistantMessage(id: 'a1', content: 'Hi there'),
-          const UserMessage(id: 'u2', content: 'Thanks'),
+          UserMessage(id: 'u2', content: 'Thanks'),
         ],
       );
 
@@ -229,8 +229,70 @@ Let me check.
       expect(capturedMessages![2].content, 'Thanks');
     });
 
+    test('multimodal user content projects to a null content', () async {
+      // The record carries text only, so a list-encoded content has no text
+      // projection. Reporting `''` would claim the user sent an empty message
+      // — itself a sendable value — so null is passed through instead and the
+      // ChatFn decides what to do.
+      List<({String role, String? content})>? capturedMessages;
+      final provider = ChatFnLlmProvider(
+        chatFn: (messages, {systemPrompt, maxTokens}) async {
+          capturedMessages = messages;
+          return 'ok';
+        },
+      );
+
+      final input = input0(
+        messages: [
+          UserMessage.multimodal(
+            id: 'u1',
+            parts: const [
+              TextInputContent('what is this?'),
+              ImageInputContent(
+                source: UrlSource(value: 'https://example.com/cat.png'),
+              ),
+            ],
+          ),
+        ],
+      );
+
+      final handle = await provider.startRun(key: key, input: input);
+      await handle.events.drain<void>();
+
+      expect(capturedMessages, hasLength(1));
+      expect(capturedMessages![0].role, 'user');
+      expect(capturedMessages![0].content, isNull);
+    });
+
+    test('assistant with neither text nor tool calls projects to null',
+        () async {
+      // Not coalesced to `''`: that would pre-decide what the callback should
+      // decide, and several chat APIs reject an empty assistant `content`.
+      // Mirrors `LlmAssistantMessage.content`, which is nullable. Reachable in
+      // production: `convertToAgui` emits an AssistantMessage carrying only
+      // toolCalls, so an empty toolCalls list lands here.
+      List<({String role, String? content})>? capturedMessages;
+      final provider = ChatFnLlmProvider(
+        chatFn: (messages, {systemPrompt, maxTokens}) async {
+          capturedMessages = messages;
+          return 'ok';
+        },
+      );
+
+      final input = input0(
+        messages: [const AssistantMessage(id: 'a1')],
+      );
+
+      final handle = await provider.startRun(key: key, input: input);
+      await handle.events.drain<void>();
+
+      expect(capturedMessages, hasLength(1));
+      expect(capturedMessages![0].role, 'assistant');
+      expect(capturedMessages![0].content, isNull);
+    });
+
     test('tool result messages formatted with prefix', () async {
-      List<({String role, String content})>? capturedMessages;
+      List<({String role, String? content})>? capturedMessages;
       final provider = ChatFnLlmProvider(
         chatFn: (messages, {systemPrompt, maxTokens}) async {
           capturedMessages = messages;

--- a/packages/soliplex_agent/test/orchestration/run_orchestrator_test.dart
+++ b/packages/soliplex_agent/test/orchestration/run_orchestrator_test.dart
@@ -1,3 +1,8 @@
+// These fixtures construct ag_ui 0.3.0's deprecated THINKING_TEXT_MESSAGE_*
+// and THINKING_CONTENT events, exercising handling that is kept because a
+// producer negotiating ag-ui-protocol below 0.1.13 emits that family live.
+// Removal at ag_ui 1.0.0 surfaces as a compile error at these constructors.
+
 import 'dart:async';
 import 'dart:convert';
 
@@ -38,7 +43,7 @@ RunInfo _runInfo() =>
     RunInfo(id: _runId, threadId: _key.threadId, createdAt: DateTime(2026));
 
 List<BaseEvent> _happyPathEvents() => [
-      const RunStartedEvent(threadId: 'thread-1', runId: _runId),
+      RunStartedEvent(threadId: 'thread-1', runId: _runId),
       const TextMessageStartEvent(messageId: 'msg-1'),
       const TextMessageContentEvent(messageId: 'msg-1', delta: 'Hello'),
       const TextMessageEndEvent(messageId: 'msg-1'),
@@ -46,7 +51,7 @@ List<BaseEvent> _happyPathEvents() => [
     ];
 
 List<BaseEvent> _toolCallEvents({String toolName = 'weather'}) => [
-      const RunStartedEvent(threadId: 'thread-1', runId: _runId),
+      RunStartedEvent(threadId: 'thread-1', runId: _runId),
       ToolCallStartEvent(toolCallId: 'tc-1', toolCallName: toolName),
       const ToolCallArgsEvent(toolCallId: 'tc-1', delta: '{"city":"NYC"}'),
       const ToolCallEndEvent(toolCallId: 'tc-1'),
@@ -54,7 +59,7 @@ List<BaseEvent> _toolCallEvents({String toolName = 'weather'}) => [
     ];
 
 List<BaseEvent> _resumeTextEvents() => [
-      const RunStartedEvent(threadId: 'thread-1', runId: _runId),
+      RunStartedEvent(threadId: 'thread-1', runId: _runId),
       const TextMessageStartEvent(messageId: 'msg-2'),
       const TextMessageContentEvent(messageId: 'msg-2', delta: 'Sunny'),
       const TextMessageEndEvent(messageId: 'msg-2'),
@@ -193,7 +198,7 @@ void main() {
       stubCreateRun();
       stubRunAgent(
         stream: Stream.fromIterable([
-          const RunStartedEvent(
+          RunStartedEvent(
             threadId: 'thread-1',
             runId: _runId,
             timestamp: startMs,
@@ -224,7 +229,7 @@ void main() {
       stubCreateRun();
       stubRunAgent(
         stream: Stream.fromIterable([
-          const RunStartedEvent(threadId: 'thread-1', runId: _runId),
+          RunStartedEvent(threadId: 'thread-1', runId: _runId),
           const RunErrorEvent(message: 'backend error'),
         ]),
       );
@@ -282,7 +287,7 @@ void main() {
         stubCreateRun();
         stubRunAgent(
           stream: Stream.fromIterable([
-            const RunStartedEvent(threadId: 'thread-1', runId: _runId),
+            RunStartedEvent(threadId: 'thread-1', runId: _runId),
             const TextMessageStartEvent(messageId: 'msg-1'),
           ]),
         );
@@ -321,7 +326,7 @@ void main() {
         await orchestrator.startRun(key: _key, userMessage: 'Hi');
 
         controller
-          ..add(const RunStartedEvent(threadId: 'thread-1', runId: _runId))
+          ..add(RunStartedEvent(threadId: 'thread-1', runId: _runId))
           ..add(const TextMessageStartEvent(messageId: 'msg-1'))
           ..add(const TextMessageContentEvent(messageId: 'msg-1', delta: 'Hi'))
           ..add(const TextMessageEndEvent(messageId: 'msg-1'))
@@ -389,10 +394,16 @@ void main() {
       stubCreateRun();
       stubRunAgent(
         stream: Stream.fromIterable([
-          const RunStartedEvent(threadId: 'thread-1', runId: _runId),
+          RunStartedEvent(threadId: 'thread-1', runId: _runId),
           const ThinkingStartEvent(),
+          // Deprecated upstream; exercises the pre-REASONING_* replay path.
+          // ignore: deprecated_member_use
           const ThinkingTextMessageStartEvent(),
+          // Deprecated upstream; exercises the pre-REASONING_* replay path.
+          // ignore: deprecated_member_use
           const ThinkingTextMessageContentEvent(delta: 'partial reasoning'),
+          // Deprecated upstream; exercises the pre-REASONING_* replay path.
+          // ignore: deprecated_member_use
           const ThinkingTextMessageEndEvent(),
           const RunErrorEvent(message: 'boom'),
         ]),
@@ -419,7 +430,7 @@ void main() {
       stubCreateRun();
       stubRunAgent(
         stream: Stream.fromIterable([
-          const RunStartedEvent(threadId: 'thread-1', runId: _runId),
+          RunStartedEvent(threadId: 'thread-1', runId: _runId),
           const RunErrorEvent(message: 'rate limited'),
         ]),
       );
@@ -442,7 +453,7 @@ void main() {
       stubCreateRun();
       stubRunAgent(
         stream: Stream.fromIterable([
-          const RunStartedEvent(threadId: 'thread-1', runId: _runId),
+          RunStartedEvent(threadId: 'thread-1', runId: _runId),
           const TextMessageStartEvent(messageId: 'msg-1'),
           const TextMessageContentEvent(messageId: 'msg-1', delta: 'partial'),
           const RunErrorEvent(message: 'connection lost'),
@@ -473,7 +484,7 @@ void main() {
       stubCreateRun();
       stubRunAgent(
         stream: Stream.fromIterable([
-          const RunStartedEvent(threadId: 'thread-1', runId: _runId),
+          RunStartedEvent(threadId: 'thread-1', runId: _runId),
           const TextMessageStartEvent(messageId: 'msg-1'),
           const TextMessageContentEvent(
             messageId: 'msg-1',
@@ -506,7 +517,7 @@ void main() {
 
       await orchestrator.startRun(key: _key, userMessage: 'Hi');
       controller.add(
-        const RunStartedEvent(threadId: 'thread-1', runId: _runId),
+        RunStartedEvent(threadId: 'thread-1', runId: _runId),
       );
       await Future<void>.delayed(Duration.zero);
 
@@ -545,7 +556,7 @@ void main() {
       stubCreateRun();
       stubRunAgent(
         stream: Stream.fromIterable([
-          const RunStartedEvent(threadId: 'thread-1', runId: _runId),
+          RunStartedEvent(threadId: 'thread-1', runId: _runId),
           const RunErrorEvent(message: 'backend error'),
         ]),
       );
@@ -566,7 +577,7 @@ void main() {
 
       await orchestrator.startRun(key: _key, userMessage: 'Hi');
       controller.add(
-        const RunStartedEvent(threadId: 'thread-1', runId: _runId),
+        RunStartedEvent(threadId: 'thread-1', runId: _runId),
       );
       await Future<void>.delayed(Duration.zero);
 
@@ -589,14 +600,20 @@ void main() {
       final staleTs = DateTime.utc(2026).millisecondsSinceEpoch;
       await orchestrator.startRun(key: _key, userMessage: 'Hi');
       controller
-        ..add(const RunStartedEvent(threadId: 'thread-1', runId: _runId))
+        ..add(RunStartedEvent(threadId: 'thread-1', runId: _runId))
         ..add(const ThinkingStartEvent())
+        // Deprecated upstream; exercises the pre-REASONING_* replay path.
+        // ignore: deprecated_member_use
         ..add(const ThinkingTextMessageStartEvent())
         ..add(
+          // Deprecated upstream; exercises the pre-REASONING_* replay path.
+          // ignore: deprecated_member_use
           const ThinkingTextMessageContentEvent(
             delta: 'considering options',
           ),
         )
+        // Deprecated upstream; exercises the pre-REASONING_* replay path.
+        // ignore: deprecated_member_use
         ..add(ThinkingTextMessageEndEvent(timestamp: staleTs));
       await Future<void>.delayed(Duration.zero);
 
@@ -633,7 +650,7 @@ void main() {
       final lastChunkTime = DateTime.utc(2026, 1, 1, 12);
       await orchestrator.startRun(key: _key, userMessage: 'Hi');
       controller
-        ..add(const RunStartedEvent(threadId: 'thread-1', runId: _runId))
+        ..add(RunStartedEvent(threadId: 'thread-1', runId: _runId))
         ..add(const TextMessageStartEvent(messageId: 'reply-1'))
         ..add(
           const TextMessageContentEvent(
@@ -683,7 +700,7 @@ void main() {
 
       await orchestrator.startRun(key: _key, userMessage: 'Hi');
       controller.add(
-        const RunStartedEvent(threadId: 'thread-1', runId: _runId),
+        RunStartedEvent(threadId: 'thread-1', runId: _runId),
       );
       await Future<void>.delayed(Duration.zero);
 
@@ -1944,7 +1961,7 @@ void main() {
 
       await orchestrator.startRun(key: _key, userMessage: 'Hi');
       controller.add(
-        const RunStartedEvent(threadId: 'thread-1', runId: _runId),
+        RunStartedEvent(threadId: 'thread-1', runId: _runId),
       );
       await Future<void>.delayed(Duration.zero);
 
@@ -1973,7 +1990,7 @@ void main() {
 
       await orchestrator.startRun(key: _key, userMessage: 'Hi');
       controller
-        ..add(const RunStartedEvent(threadId: 'thread-1', runId: _runId))
+        ..add(RunStartedEvent(threadId: 'thread-1', runId: _runId))
         ..add(const RunErrorEvent(message: 'backend error'));
       await Future<void>.delayed(Duration.zero);
 
@@ -2065,7 +2082,7 @@ void main() {
             // First run: emit state snapshot + tool call.
             return _wrap(
               Stream<BaseEvent>.fromIterable([
-                const RunStartedEvent(threadId: 'thread-1', runId: _runId),
+                RunStartedEvent(threadId: 'thread-1', runId: _runId),
                 const StateSnapshotEvent(
                   snapshot: {'rag_context': 'doc-42', 'turn': 1},
                 ),
@@ -2138,7 +2155,7 @@ void main() {
           // Run 1: set initial state + yield tool.
           return _wrap(
             Stream<BaseEvent>.fromIterable([
-              const RunStartedEvent(threadId: 'thread-1', runId: _runId),
+              RunStartedEvent(threadId: 'thread-1', runId: _runId),
               const StateSnapshotEvent(
                 snapshot: {'turn': 1, 'docs': <String>[]},
               ),
@@ -2159,7 +2176,7 @@ void main() {
           // Run 2: update state via new snapshot + yield tool again.
           return _wrap(
             Stream<BaseEvent>.fromIterable([
-              const RunStartedEvent(threadId: 'thread-1', runId: _runId),
+              RunStartedEvent(threadId: 'thread-1', runId: _runId),
               const StateSnapshotEvent(
                 snapshot: {
                   'turn': 2,
@@ -2383,7 +2400,7 @@ void main() {
         };
 
     List<BaseEvent> citationEvents() => [
-          const RunStartedEvent(threadId: 'thread-1', runId: _runId),
+          RunStartedEvent(threadId: 'thread-1', runId: _runId),
           const TextMessageStartEvent(messageId: 'msg-1'),
           const TextMessageContentEvent(messageId: 'msg-1', delta: 'Answer'),
           ragDelta(
@@ -2436,7 +2453,7 @@ void main() {
       stubCreateRun();
       stubRunAgent(
         stream: Stream.fromIterable(<BaseEvent>[
-          const RunStartedEvent(threadId: 'thread-1', runId: _runId),
+          RunStartedEvent(threadId: 'thread-1', runId: _runId),
           const TextMessageStartEvent(messageId: 'msg-1'),
           const TextMessageContentEvent(messageId: 'msg-1', delta: 'Answer'),
           ragDelta(
@@ -2477,7 +2494,7 @@ void main() {
       stubCreateRun();
       stubRunAgent(
         stream: Stream.fromIterable(<BaseEvent>[
-          const RunStartedEvent(threadId: 'thread-1', runId: _runId),
+          RunStartedEvent(threadId: 'thread-1', runId: _runId),
           const TextMessageStartEvent(messageId: 'msg-1'),
           const TextMessageContentEvent(messageId: 'msg-1', delta: 'Answer'),
           ragDelta(
@@ -2524,7 +2541,7 @@ void main() {
       stubCreateRun();
       stubRunAgent(
         stream: Stream.fromIterable(<BaseEvent>[
-          const RunStartedEvent(threadId: 'thread-1', runId: _runId),
+          RunStartedEvent(threadId: 'thread-1', runId: _runId),
           const StateSnapshotEvent(
             snapshot: {
               'rag': {
@@ -2569,7 +2586,7 @@ void main() {
       stubCreateRun();
       stubRunAgent(
         stream: Stream.fromIterable(<BaseEvent>[
-          const RunStartedEvent(threadId: 'thread-1', runId: _runId),
+          RunStartedEvent(threadId: 'thread-1', runId: _runId),
           const StateSnapshotEvent(
             snapshot: {
               'rag': {
@@ -2612,7 +2629,7 @@ void main() {
       stubCreateRun();
       stubRunAgent(
         stream: Stream.fromIterable(<BaseEvent>[
-          const RunStartedEvent(threadId: 'thread-1', runId: _runId),
+          RunStartedEvent(threadId: 'thread-1', runId: _runId),
           const StateSnapshotEvent(
             snapshot: {
               'rag': {
@@ -2656,7 +2673,7 @@ void main() {
       stubCreateRun();
 
       final toolCallWithCitations = <BaseEvent>[
-        const RunStartedEvent(threadId: 'thread-1', runId: _runId),
+        RunStartedEvent(threadId: 'thread-1', runId: _runId),
         ragDelta(
           citationIndex: {'chunk-1': citation('chunk-1')},
           citations: ['chunk-1'],
@@ -2711,7 +2728,7 @@ void main() {
           // Invocation 1 cites chunk-1.
           return _wrap(
             Stream<BaseEvent>.fromIterable([
-              const RunStartedEvent(threadId: 'thread-1', runId: _runId),
+              RunStartedEvent(threadId: 'thread-1', runId: _runId),
               ragDelta(
                 citationIndex: {'chunk-1': citation('chunk-1')},
                 citations: ['chunk-1'],
@@ -2733,7 +2750,7 @@ void main() {
         // stays session-cumulative.
         return _wrap(
           Stream<BaseEvent>.fromIterable([
-            const RunStartedEvent(threadId: 'thread-1', runId: _runId),
+            RunStartedEvent(threadId: 'thread-1', runId: _runId),
             const TextMessageStartEvent(messageId: 'msg-2'),
             const TextMessageContentEvent(messageId: 'msg-2', delta: 'Done'),
             ragDelta(
@@ -2800,7 +2817,7 @@ void main() {
           // Invocation 1 cites chunk-1 and chunk-2.
           return _wrap(
             Stream<BaseEvent>.fromIterable([
-              const RunStartedEvent(threadId: 'thread-1', runId: _runId),
+              RunStartedEvent(threadId: 'thread-1', runId: _runId),
               ragDelta(
                 citationIndex: {
                   'chunk-1': citation('chunk-1'),
@@ -2824,7 +2841,7 @@ void main() {
         // Invocation 2 re-cites chunk-2 (duplicate) and adds chunk-3.
         return _wrap(
           Stream<BaseEvent>.fromIterable([
-            const RunStartedEvent(threadId: 'thread-1', runId: _runId),
+            RunStartedEvent(threadId: 'thread-1', runId: _runId),
             const TextMessageStartEvent(messageId: 'msg-2'),
             const TextMessageContentEvent(
               messageId: 'msg-2',
@@ -2909,7 +2926,7 @@ void main() {
 
       stubRunAgent(
         stream: Stream.fromIterable(<BaseEvent>[
-          const RunStartedEvent(threadId: 'thread-1', runId: _runId),
+          RunStartedEvent(threadId: 'thread-1', runId: _runId),
           StateSnapshotEvent(
             snapshot: {
               'rag': {
@@ -2937,7 +2954,7 @@ void main() {
       stubCreateRun();
 
       final events = <BaseEvent>[
-        const RunStartedEvent(threadId: 'thread-1', runId: _runId),
+        RunStartedEvent(threadId: 'thread-1', runId: _runId),
         const TextMessageStartEvent(messageId: 'msg-1'),
         const TextMessageContentEvent(messageId: 'msg-1', delta: 'Partial'),
         const RunErrorEvent(message: 'server error'),
@@ -2962,7 +2979,7 @@ void main() {
 
       await orchestrator.startRun(key: _key, userMessage: 'Search');
       controller.add(
-        const RunStartedEvent(threadId: 'thread-1', runId: _runId),
+        RunStartedEvent(threadId: 'thread-1', runId: _runId),
       );
       await Future<void>.delayed(Duration.zero);
 
@@ -2986,7 +3003,7 @@ void main() {
 
       await orchestrator.startRun(key: _key, userMessage: 'Search');
       controller.add(
-        const RunStartedEvent(threadId: 'thread-1', runId: _runId),
+        RunStartedEvent(threadId: 'thread-1', runId: _runId),
       );
       await Future<void>.delayed(Duration.zero);
 
@@ -3028,9 +3045,9 @@ void main() {
         // structurally-valid text turn, then RunFinished.
         controller
           ..add(
-            const DecodedEvent(
+            DecodedEvent(
               RunStartedEvent(threadId: 'thread-1', runId: _runId),
-              {'type': 'RUN_STARTED'},
+              const {'type': 'RUN_STARTED'},
             ),
           )
           ..add(
@@ -3130,9 +3147,9 @@ void main() {
         await orchestrator.startRun(key: _key, userMessage: 'Hi');
         controller
           ..add(
-            const DecodedEvent(
+            DecodedEvent(
               RunStartedEvent(threadId: 'thread-1', runId: _runId),
-              {'type': 'RUN_STARTED'},
+              const {'type': 'RUN_STARTED'},
             ),
           )
           // Non-Map snapshot triggers the cast throw inside
@@ -3227,9 +3244,9 @@ void main() {
         await orchestrator.startRun(key: _key, userMessage: 'Hi');
         controller
           ..add(
-            const DecodedEvent(
+            DecodedEvent(
               RunStartedEvent(threadId: 'thread-1', runId: _runId),
-              {'type': 'RUN_STARTED'},
+              const {'type': 'RUN_STARTED'},
             ),
           )
           ..add(
@@ -3285,9 +3302,9 @@ void main() {
         // 3 STATE_SNAPSHOT (throws inside processEvent), 4 RunFinished.
         controller
           ..add(
-            const DecodedEvent(
+            DecodedEvent(
               RunStartedEvent(threadId: 'thread-1', runId: _runId),
-              {'type': 'RUN_STARTED'},
+              const {'type': 'RUN_STARTED'},
             ),
           )
           ..add(

--- a/packages/soliplex_agent/test/orchestration/run_to_completion_test.dart
+++ b/packages/soliplex_agent/test/orchestration/run_to_completion_test.dart
@@ -43,7 +43,7 @@ RunInfo _runInfo() =>
     RunInfo(id: _runId, threadId: _key.threadId, createdAt: DateTime(2026));
 
 List<BaseEvent> _happyPathEvents() => [
-      const RunStartedEvent(threadId: 'thread-1', runId: _runId),
+      RunStartedEvent(threadId: 'thread-1', runId: _runId),
       const TextMessageStartEvent(messageId: 'msg-1'),
       const TextMessageContentEvent(messageId: 'msg-1', delta: 'Hello'),
       const TextMessageEndEvent(messageId: 'msg-1'),
@@ -51,7 +51,7 @@ List<BaseEvent> _happyPathEvents() => [
     ];
 
 List<BaseEvent> _toolCallEvents({String toolName = 'weather'}) => [
-      const RunStartedEvent(threadId: 'thread-1', runId: _runId),
+      RunStartedEvent(threadId: 'thread-1', runId: _runId),
       ToolCallStartEvent(toolCallId: 'tc-1', toolCallName: toolName),
       const ToolCallArgsEvent(toolCallId: 'tc-1', delta: '{"city":"NYC"}'),
       const ToolCallEndEvent(toolCallId: 'tc-1'),
@@ -59,7 +59,7 @@ List<BaseEvent> _toolCallEvents({String toolName = 'weather'}) => [
     ];
 
 List<BaseEvent> _resumeTextEvents() => [
-      const RunStartedEvent(threadId: 'thread-1', runId: _runId),
+      RunStartedEvent(threadId: 'thread-1', runId: _runId),
       const TextMessageStartEvent(messageId: 'msg-2'),
       const TextMessageContentEvent(messageId: 'msg-2', delta: 'Sunny'),
       const TextMessageEndEvent(messageId: 'msg-2'),
@@ -183,7 +183,7 @@ void main() {
       );
 
       controller
-        ..add(const RunStartedEvent(threadId: 'thread-1', runId: _runId))
+        ..add(RunStartedEvent(threadId: 'thread-1', runId: _runId))
         ..add(const TextMessageStartEvent(messageId: 'msg-1'))
         ..add(const TextMessageContentEvent(messageId: 'msg-1', delta: 'Done'))
         ..add(const TextMessageEndEvent(messageId: 'msg-1'))
@@ -323,7 +323,7 @@ void main() {
 
       // Emit RunStarted so we're in RunningState.
       controller.add(
-        const RunStartedEvent(threadId: 'thread-1', runId: _runId),
+        RunStartedEvent(threadId: 'thread-1', runId: _runId),
       );
       await Future<void>.delayed(Duration.zero);
 
@@ -477,7 +477,7 @@ void main() {
       );
 
       controller.add(
-        const RunStartedEvent(threadId: 'thread-1', runId: _runId),
+        RunStartedEvent(threadId: 'thread-1', runId: _runId),
       );
       await Future<void>.delayed(Duration.zero);
 
@@ -518,7 +518,7 @@ void main() {
       );
 
       controller.add(
-        const RunStartedEvent(threadId: 'thread-1', runId: _runId),
+        RunStartedEvent(threadId: 'thread-1', runId: _runId),
       );
       await Future<void>.delayed(Duration.zero);
 
@@ -625,7 +625,7 @@ void main() {
       stubCreateRun();
       stubRunAgent(
         stream: Stream<BaseEvent>.fromIterable([
-          const RunStartedEvent(threadId: 'thread-1', runId: _runId),
+          RunStartedEvent(threadId: 'thread-1', runId: _runId),
           const RunErrorEvent(message: 'backend error'),
         ]),
       );

--- a/packages/soliplex_agent/test/orchestration/streaming_llm_provider_test.dart
+++ b/packages/soliplex_agent/test/orchestration/streaming_llm_provider_test.dart
@@ -27,7 +27,7 @@ void main() {
 
         final handle = await provider.startRun(
           key: key,
-          input: const SimpleRunAgentInput(
+          input: SimpleRunAgentInput(
             messages: [UserMessage(id: 'u1', content: 'Hi')],
           ),
         );
@@ -72,9 +72,9 @@ void main() {
 
       final handle = await provider.startRun(
         key: key,
-        input: const SimpleRunAgentInput(
+        input: SimpleRunAgentInput(
           messages: [UserMessage(id: 'u1', content: 'Run code')],
-          tools: [
+          tools: const [
             Tool(name: 'execute_python', description: 'Execute Python code'),
           ],
         ),
@@ -109,7 +109,7 @@ void main() {
 
       final handle = await provider.startRun(
         key: key,
-        input: const SimpleRunAgentInput(
+        input: SimpleRunAgentInput(
           messages: [UserMessage(id: 'u1', content: 'Hi')],
         ),
       );
@@ -140,7 +140,7 @@ void main() {
 
       final handle = await provider.startRun(
         key: key,
-        input: const SimpleRunAgentInput(
+        input: SimpleRunAgentInput(
           messages: [UserMessage(id: 'u1', content: 'Hi')],
         ),
       );
@@ -167,7 +167,7 @@ void main() {
 
       final handle = await provider.startRun(
         key: key,
-        input: const SimpleRunAgentInput(
+        input: SimpleRunAgentInput(
           messages: [UserMessage(id: 'u1', content: 'Hi')],
         ),
       );
@@ -195,7 +195,7 @@ void main() {
 
       final handle = await provider.startRun(
         key: key,
-        input: const SimpleRunAgentInput(
+        input: SimpleRunAgentInput(
           messages: [UserMessage(id: 'u1', content: 'Hi')],
         ),
       );
@@ -225,7 +225,7 @@ void main() {
 
       final handle = await provider.startRun(
         key: key,
-        input: const SimpleRunAgentInput(
+        input: SimpleRunAgentInput(
           messages: [UserMessage(id: 'u1', content: 'Hi')],
         ),
       );
@@ -251,11 +251,11 @@ void main() {
 
       final handle = await provider.startRun(
         key: key,
-        input: const SimpleRunAgentInput(
+        input: SimpleRunAgentInput(
           messages: [
-            SystemMessage(id: 's1', content: 'Be helpful'),
+            const SystemMessage(id: 's1', content: 'Be helpful'),
             UserMessage(id: 'u1', content: 'Hello'),
-            AssistantMessage(
+            const AssistantMessage(
               id: 'a1',
               content: 'I will search',
               toolCalls: [
@@ -268,7 +268,7 @@ void main() {
                 ),
               ],
             ),
-            ToolMessage(
+            const ToolMessage(
               id: 't1',
               toolCallId: 'tc_1',
               content: 'Found 5 results',
@@ -294,6 +294,48 @@ void main() {
       expect(toolResult.output, 'Found 5 results');
     });
 
+    test('multimodal user content projects to a null content', () async {
+      // `LlmUserMessage` carries text only. A multimodal message has no
+      // text projection, and reporting `''` would claim the user sent an
+      // empty message; null says "not text" so the provider decides.
+      List<LlmChatMessage>? receivedMessages;
+      final provider = StreamingLlmProvider(
+        chatFn: ({
+          required messages,
+          tools,
+          systemPrompt,
+          maxTokens,
+          abortTrigger,
+        }) async* {
+          receivedMessages = messages;
+          yield const LlmDone();
+        },
+      );
+
+      final handle = await provider.startRun(
+        key: key,
+        input: SimpleRunAgentInput(
+          messages: [
+            UserMessage.multimodal(
+              id: 'u1',
+              parts: const [
+                TextInputContent('what is this?'),
+                ImageInputContent(
+                  source: UrlSource(value: 'https://example.com/cat.png'),
+                ),
+              ],
+            ),
+          ],
+        ),
+      );
+
+      await handle.events.drain<void>();
+
+      expect(receivedMessages, hasLength(1));
+      expect(receivedMessages![0], isA<LlmUserMessage>());
+      expect((receivedMessages![0] as LlmUserMessage).content, isNull);
+    });
+
     test('converts AG-UI tools to LlmToolDef correctly', () async {
       List<LlmToolDef>? receivedTools;
       final provider = StreamingLlmProvider(
@@ -311,9 +353,9 @@ void main() {
 
       final handle = await provider.startRun(
         key: key,
-        input: const SimpleRunAgentInput(
+        input: SimpleRunAgentInput(
           messages: [UserMessage(id: 'u1', content: 'Hi')],
-          tools: [
+          tools: const [
             Tool(
               name: 'execute_python',
               description: 'Execute Python code',
@@ -359,7 +401,7 @@ void main() {
 
       final handle = await provider.startRun(
         key: key,
-        input: const SimpleRunAgentInput(
+        input: SimpleRunAgentInput(
           messages: [UserMessage(id: 'u1', content: 'Hi')],
         ),
         cancelToken: token,
@@ -394,7 +436,7 @@ void main() {
 
       final handle = await provider.startRun(
         key: key,
-        input: const SimpleRunAgentInput(
+        input: SimpleRunAgentInput(
           messages: [UserMessage(id: 'u1', content: 'Hi')],
         ),
         existingRunId: 'existing-123',

--- a/packages/soliplex_agent/test/runtime/agent_runtime_signal_test.dart
+++ b/packages/soliplex_agent/test/runtime/agent_runtime_signal_test.dart
@@ -35,7 +35,7 @@ RunInfo _runInfo() =>
     RunInfo(id: _runId, threadId: _threadId, createdAt: DateTime(2026));
 
 List<BaseEvent> _happyPathEvents() => [
-      const RunStartedEvent(threadId: _threadId, runId: _runId),
+      RunStartedEvent(threadId: _threadId, runId: _runId),
       const TextMessageStartEvent(messageId: 'msg-1'),
       const TextMessageContentEvent(messageId: 'msg-1', delta: 'Hello'),
       const TextMessageEndEvent(messageId: 'msg-1'),
@@ -125,7 +125,7 @@ void main() {
 
       expect(runtime.sessions.value, hasLength(1));
 
-      controller.add(const RunStartedEvent(threadId: _threadId, runId: _runId));
+      controller.add(RunStartedEvent(threadId: _threadId, runId: _runId));
       await controller.close();
     });
 
@@ -161,7 +161,7 @@ void main() {
 
       expect(runtime.sessions.value, equals(runtime.activeSessions));
 
-      controller.add(const RunStartedEvent(threadId: _threadId, runId: _runId));
+      controller.add(RunStartedEvent(threadId: _threadId, runId: _runId));
       await controller.close();
     });
 

--- a/packages/soliplex_agent/test/runtime/agent_runtime_test.dart
+++ b/packages/soliplex_agent/test/runtime/agent_runtime_test.dart
@@ -82,7 +82,7 @@ RunInfo _runInfo() =>
     RunInfo(id: _runId, threadId: _threadId, createdAt: DateTime(2026));
 
 List<BaseEvent> _happyPathEvents() => [
-      const RunStartedEvent(threadId: _threadId, runId: _runId),
+      RunStartedEvent(threadId: _threadId, runId: _runId),
       const TextMessageStartEvent(messageId: 'msg-1'),
       const TextMessageContentEvent(messageId: 'msg-1', delta: 'Hello'),
       const TextMessageEndEvent(messageId: 'msg-1'),
@@ -90,7 +90,7 @@ List<BaseEvent> _happyPathEvents() => [
     ];
 
 List<BaseEvent> _toolCallEvents() => [
-      const RunStartedEvent(threadId: _threadId, runId: _runId),
+      RunStartedEvent(threadId: _threadId, runId: _runId),
       const ToolCallStartEvent(toolCallId: 'tc-1', toolCallName: 'weather'),
       const ToolCallArgsEvent(toolCallId: 'tc-1', delta: '{"city":"NYC"}'),
       const ToolCallEndEvent(toolCallId: 'tc-1'),
@@ -98,7 +98,7 @@ List<BaseEvent> _toolCallEvents() => [
     ];
 
 List<BaseEvent> _resumeTextEvents() => [
-      const RunStartedEvent(threadId: _threadId, runId: _runId),
+      RunStartedEvent(threadId: _threadId, runId: _runId),
       const TextMessageStartEvent(messageId: 'msg-2'),
       const TextMessageContentEvent(messageId: 'msg-2', delta: 'Sunny'),
       const TextMessageEndEvent(messageId: 'msg-2'),
@@ -326,7 +326,7 @@ void main() {
 
       expect(runtime.activeSessions, contains(session));
 
-      controller.add(const RunStartedEvent(threadId: _threadId, runId: _runId));
+      controller.add(RunStartedEvent(threadId: _threadId, runId: _runId));
       await Future<void>.delayed(Duration.zero);
 
       await controller.close();
@@ -405,7 +405,7 @@ void main() {
       final found = runtime.getSession(session.threadKey);
       expect(found, equals(session));
 
-      controller.add(const RunStartedEvent(threadId: _threadId, runId: _runId));
+      controller.add(RunStartedEvent(threadId: _threadId, runId: _runId));
       await controller.close();
       await session.result;
     });
@@ -448,7 +448,7 @@ void main() {
       expect(runtime.sessions.value, contains(session));
       expect(runtime.sessions.value, equals(runtime.activeSessions));
 
-      controller.add(const RunStartedEvent(threadId: _threadId, runId: _runId));
+      controller.add(RunStartedEvent(threadId: _threadId, runId: _runId));
       await controller.close();
       await session.result;
     });
@@ -756,7 +756,7 @@ void main() {
       stubDeleteThread();
       // Stream that never completes — session stays running until timeout
       final controller = StreamController<BaseEvent>.broadcast()
-        ..add(const RunStartedEvent(threadId: _threadId, runId: _runId));
+        ..add(RunStartedEvent(threadId: _threadId, runId: _runId));
       stubRunAgent(stream: controller.stream);
 
       final session = await runtime.spawn(roomId: _roomId, prompt: 'Slow');
@@ -812,7 +812,7 @@ void main() {
       stubCreateRun();
       stubDeleteThread();
       final controller = StreamController<BaseEvent>.broadcast()
-        ..add(const RunStartedEvent(threadId: _threadId, runId: _runId));
+        ..add(RunStartedEvent(threadId: _threadId, runId: _runId));
       stubRunAgent(stream: controller.stream);
 
       final parent = await runtime.spawn(roomId: _roomId, prompt: 'Parent');
@@ -876,7 +876,7 @@ void main() {
       final s1 = await runtime.spawn(roomId: _roomId, prompt: 'A');
       final s2 = await runtime.spawn(roomId: _roomId, prompt: 'B');
 
-      controller.add(const RunStartedEvent(threadId: _threadId, runId: _runId));
+      controller.add(RunStartedEvent(threadId: _threadId, runId: _runId));
       await Future<void>.delayed(Duration.zero);
 
       await runtime.cancelAll();
@@ -915,7 +915,7 @@ void main() {
       stubRunAgent(stream: controller.stream);
 
       await runtime.spawn(roomId: _roomId, prompt: 'A', ephemeral: true);
-      controller.add(const RunStartedEvent(threadId: _threadId, runId: _runId));
+      controller.add(RunStartedEvent(threadId: _threadId, runId: _runId));
       await Future<void>.delayed(Duration.zero);
 
       await runtime.dispose();
@@ -977,7 +977,7 @@ void main() {
       // Deliver partial events then error
       controller1
         ..add(
-          const RunStartedEvent(
+          RunStartedEvent(
             threadId: 'thread-fail',
             runId: _runId,
           ),
@@ -1011,7 +1011,7 @@ void main() {
             invocation.positionalArguments[1] as SimpleRunAgentInput;
         return _wrap(
           Stream<BaseEvent>.fromIterable([
-            const RunStartedEvent(
+            RunStartedEvent(
               threadId: 'thread-fail',
               runId: 'run-2',
             ),
@@ -1185,7 +1185,7 @@ void main() {
         return callCount == 1
             ? _wrap(
                 Stream<BaseEvent>.fromIterable([
-                  const RunStartedEvent(threadId: _threadId, runId: _runId),
+                  RunStartedEvent(threadId: _threadId, runId: _runId),
                   const ToolCallStartEvent(
                     toolCallId: 'tc-py',
                     toolCallName: 'execute_python',

--- a/packages/soliplex_agent/test/runtime/agent_session_signal_test.dart
+++ b/packages/soliplex_agent/test/runtime/agent_session_signal_test.dart
@@ -39,7 +39,7 @@ RunInfo _runInfo() =>
     RunInfo(id: _runId, threadId: _key.threadId, createdAt: DateTime(2026));
 
 List<BaseEvent> _happyPathEvents() => [
-      const RunStartedEvent(threadId: 'thread-1', runId: _runId),
+      RunStartedEvent(threadId: 'thread-1', runId: _runId),
       const TextMessageStartEvent(messageId: 'msg-1'),
       const TextMessageContentEvent(messageId: 'msg-1', delta: 'Hello world'),
       const TextMessageEndEvent(messageId: 'msg-1'),
@@ -151,7 +151,7 @@ void main() {
       stubCreateRun();
       stubRunAgent(
         stream: Stream.fromIterable([
-          const RunStartedEvent(threadId: 'thread-1', runId: _runId),
+          RunStartedEvent(threadId: 'thread-1', runId: _runId),
           const RunErrorEvent(message: 'backend error'),
         ]),
       );
@@ -183,7 +183,7 @@ void main() {
 
       await session.start(userMessage: 'Hi');
       controller.add(
-        const RunStartedEvent(threadId: 'thread-1', runId: _runId),
+        RunStartedEvent(threadId: 'thread-1', runId: _runId),
       );
       await Future<void>.delayed(Duration.zero);
 
@@ -225,7 +225,7 @@ void main() {
 
       await session.start(userMessage: 'Hi');
       controller.add(
-        const RunStartedEvent(threadId: 'thread-1', runId: _runId),
+        RunStartedEvent(threadId: 'thread-1', runId: _runId),
       );
       await Future<void>.delayed(Duration.zero);
       expect(session.sessionState.value, equals(AgentSessionState.running));
@@ -241,7 +241,7 @@ void main() {
       stubCreateRun();
       stubRunAgent(
         stream: Stream.fromIterable([
-          const RunStartedEvent(threadId: 'thread-1', runId: _runId),
+          RunStartedEvent(threadId: 'thread-1', runId: _runId),
           const RunErrorEvent(message: 'backend error'),
         ]),
       );
@@ -273,7 +273,7 @@ void main() {
 
       await session.start(userMessage: 'Hi');
       controller.add(
-        const RunStartedEvent(threadId: 'thread-1', runId: _runId),
+        RunStartedEvent(threadId: 'thread-1', runId: _runId),
       );
       await Future<void>.delayed(Duration.zero);
 
@@ -302,7 +302,7 @@ void main() {
       stubCreateRun();
       stubRunAgent(
         stream: Stream.fromIterable([
-          const RunStartedEvent(threadId: 'thread-1', runId: _runId),
+          RunStartedEvent(threadId: 'thread-1', runId: _runId),
           const StateSnapshotEvent(
             snapshot: {
               'ui': {
@@ -339,7 +339,7 @@ void main() {
       stubCreateRun();
       stubRunAgent(
         stream: Stream.fromIterable([
-          const RunStartedEvent(threadId: 'thread-1', runId: _runId),
+          RunStartedEvent(threadId: 'thread-1', runId: _runId),
           const StateSnapshotEvent(
             snapshot: {
               'ui': {'narrations': <dynamic>[]},

--- a/packages/soliplex_agent/test/runtime/agent_session_test.dart
+++ b/packages/soliplex_agent/test/runtime/agent_session_test.dart
@@ -45,7 +45,7 @@ RunInfo _runInfo() =>
     RunInfo(id: _runId, threadId: _key.threadId, createdAt: DateTime(2026));
 
 List<BaseEvent> _happyPathEvents() => [
-      const RunStartedEvent(threadId: 'thread-1', runId: _runId),
+      RunStartedEvent(threadId: 'thread-1', runId: _runId),
       const TextMessageStartEvent(messageId: 'msg-1'),
       const TextMessageContentEvent(messageId: 'msg-1', delta: 'Hello world'),
       const TextMessageEndEvent(messageId: 'msg-1'),
@@ -53,7 +53,7 @@ List<BaseEvent> _happyPathEvents() => [
     ];
 
 List<BaseEvent> _toolCallEvents({String toolName = 'weather'}) => [
-      const RunStartedEvent(threadId: 'thread-1', runId: _runId),
+      RunStartedEvent(threadId: 'thread-1', runId: _runId),
       ToolCallStartEvent(toolCallId: 'tc-1', toolCallName: toolName),
       const ToolCallArgsEvent(toolCallId: 'tc-1', delta: '{"city":"NYC"}'),
       const ToolCallEndEvent(toolCallId: 'tc-1'),
@@ -61,7 +61,7 @@ List<BaseEvent> _toolCallEvents({String toolName = 'weather'}) => [
     ];
 
 List<BaseEvent> _resumeTextEvents() => [
-      const RunStartedEvent(threadId: 'thread-1', runId: _runId),
+      RunStartedEvent(threadId: 'thread-1', runId: _runId),
       const TextMessageStartEvent(messageId: 'msg-2'),
       const TextMessageContentEvent(messageId: 'msg-2', delta: 'Sunny'),
       const TextMessageEndEvent(messageId: 'msg-2'),
@@ -248,7 +248,7 @@ void main() {
 
       await session.start(userMessage: 'Hi');
       controller.add(
-        const RunStartedEvent(threadId: 'thread-1', runId: _runId),
+        RunStartedEvent(threadId: 'thread-1', runId: _runId),
       );
       await Future<void>.delayed(Duration.zero);
       expect(session.state, equals(AgentSessionState.running));
@@ -390,7 +390,7 @@ void main() {
 
       await session.start(userMessage: 'Hi');
       controller.add(
-        const RunStartedEvent(threadId: 'thread-1', runId: _runId),
+        RunStartedEvent(threadId: 'thread-1', runId: _runId),
       );
       await Future<void>.delayed(Duration.zero);
 
@@ -430,7 +430,7 @@ void main() {
       stubCreateRun();
       stubRunAgent(
         stream: Stream<BaseEvent>.fromIterable([
-          const RunStartedEvent(threadId: 'thread-1', runId: _runId),
+          RunStartedEvent(threadId: 'thread-1', runId: _runId),
           const RunErrorEvent(message: 'backend error'),
         ]),
       );
@@ -470,7 +470,7 @@ void main() {
 
       await session.start(userMessage: 'Hi');
       controller.add(
-        const RunStartedEvent(threadId: 'thread-1', runId: _runId),
+        RunStartedEvent(threadId: 'thread-1', runId: _runId),
       );
       await Future<void>.delayed(Duration.zero);
 
@@ -653,7 +653,7 @@ void main() {
         return callCount == 1
             ? _wrap(
                 Stream<BaseEvent>.fromIterable([
-                  const RunStartedEvent(threadId: 'thread-1', runId: _runId),
+                  RunStartedEvent(threadId: 'thread-1', runId: _runId),
                   const ToolCallStartEvent(
                     toolCallId: 'tc-ext',
                     toolCallName: 'ext_tool',
@@ -948,7 +948,7 @@ void main() {
       stubCreateRun();
       stubRunAgent(
         stream: Stream<BaseEvent>.fromIterable([
-          const RunStartedEvent(threadId: 'thread-1', runId: _runId),
+          RunStartedEvent(threadId: 'thread-1', runId: _runId),
           const ActivitySnapshotEvent(
             messageId: 'msg-1',
             activityType: 'skill_tool_call',
@@ -987,7 +987,7 @@ void main() {
       stubCreateRun();
       stubRunAgent(
         stream: Stream<BaseEvent>.fromIterable([
-          const RunStartedEvent(threadId: 'thread-1', runId: _runId),
+          RunStartedEvent(threadId: 'thread-1', runId: _runId),
           const StepStartedEvent(stepName: 'planning'),
           const TextMessageStartEvent(messageId: 'msg-1'),
           const TextMessageContentEvent(messageId: 'msg-1', delta: 'Hi'),

--- a/packages/soliplex_agent/test/runtime/bridge_base_event_test.dart
+++ b/packages/soliplex_agent/test/runtime/bridge_base_event_test.dart
@@ -1,3 +1,8 @@
+// These fixtures construct ag_ui 0.3.0's deprecated THINKING_TEXT_MESSAGE_*
+// events, exercising the arms kept for replaying stored threads that predate
+// REASONING_*. The backend emits REASONING_* live, never THINKING_*. Removal at
+// ag_ui 1.0.0 surfaces as a compile error at these constructors.
+
 import 'package:soliplex_agent/src/orchestration/execution_event.dart';
 import 'package:soliplex_agent/src/runtime/agent_session.dart';
 import 'package:soliplex_client/soliplex_client.dart';
@@ -22,17 +27,23 @@ void main() {
     });
 
     test('routes ThinkingTextMessageStartEvent to ThinkingStarted', () {
+      // Deprecated upstream; exercises the pre-REASONING_* replay path.
+      // ignore: deprecated_member_use
       const event = ThinkingTextMessageStartEvent();
       expect(bridgeBaseEvent(event), const ThinkingStarted());
     });
 
     test('routes ThinkingTextMessageContentEvent delta to ThinkingContent', () {
+      // Deprecated upstream; exercises the pre-REASONING_* replay path.
+      // ignore: deprecated_member_use
       const event = ThinkingTextMessageContentEvent(delta: 'hmm');
       expect(bridgeBaseEvent(event), const ThinkingContent(delta: 'hmm'));
     });
 
     test('routes all four thinking-end variants to ThinkingEnded', () {
       const events = <BaseEvent>[
+        // Deprecated upstream; exercises the pre-REASONING_* replay path.
+        // ignore: deprecated_member_use
         ThinkingTextMessageEndEvent(),
         ThinkingEndEvent(),
         ReasoningEndEvent(messageId: 'reas-1'),
@@ -58,6 +69,40 @@ void main() {
       );
 
       expect(bridgeBaseEvent(event), isNull);
+    });
+
+    test('ActivitySnapshotEvent with non-object content returns null', () {
+      // AG-UI types `content` as `Object?`; `ActivitySnapshot.content` is
+      // a map, so a non-object payload does not bridge. This arm logs nothing:
+      // on the live path `processEvent` throws on that shape before the event
+      // reaches here, and historical replay logs it separately when it folds
+      // the same event through `applyActivityEvent`.
+      const event = ActivitySnapshotEvent(
+        messageId: 'rag:call_1',
+        activityType: 'skill_tool_call',
+        content: 'not-a-map',
+      );
+
+      expect(bridgeBaseEvent(event), isNull);
+    });
+
+    test('ActivitySnapshotEvent with object content bridges', () {
+      const event = ActivitySnapshotEvent(
+        messageId: 'rag:call_1',
+        activityType: 'skill_tool_call',
+        content: {'tool_name': 'ask'},
+        timestamp: 7,
+      );
+
+      expect(
+        bridgeBaseEvent(event),
+        const ActivitySnapshot(
+          messageId: 'rag:call_1',
+          activityType: 'skill_tool_call',
+          content: {'tool_name': 'ask'},
+          timestamp: 7,
+        ),
+      );
     });
   });
 }

--- a/packages/soliplex_agent/test/runtime/concurrency_experiments_test.dart
+++ b/packages/soliplex_agent/test/runtime/concurrency_experiments_test.dart
@@ -129,7 +129,7 @@ RunInfo _runInfo() =>
     RunInfo(id: _runId, threadId: _threadId, createdAt: DateTime(2026));
 
 List<BaseEvent> _happyPathEvents() => [
-      const RunStartedEvent(threadId: _threadId, runId: _runId),
+      RunStartedEvent(threadId: _threadId, runId: _runId),
       const TextMessageStartEvent(messageId: 'msg-1'),
       const TextMessageContentEvent(messageId: 'msg-1', delta: 'Hello'),
       const TextMessageEndEvent(messageId: 'msg-1'),
@@ -137,7 +137,7 @@ List<BaseEvent> _happyPathEvents() => [
     ];
 
 List<BaseEvent> _toolCallEvents({String toolName = 'execute_python'}) => [
-      const RunStartedEvent(threadId: _threadId, runId: _runId),
+      RunStartedEvent(threadId: _threadId, runId: _runId),
       ToolCallStartEvent(toolCallId: 'tc-1', toolCallName: toolName),
       const ToolCallArgsEvent(toolCallId: 'tc-1', delta: '{}'),
       const ToolCallEndEvent(toolCallId: 'tc-1'),
@@ -145,7 +145,7 @@ List<BaseEvent> _toolCallEvents({String toolName = 'execute_python'}) => [
     ];
 
 List<BaseEvent> _resumeTextEvents() => [
-      const RunStartedEvent(threadId: _threadId, runId: _runId),
+      RunStartedEvent(threadId: _threadId, runId: _runId),
       const TextMessageStartEvent(messageId: 'msg-2'),
       const TextMessageContentEvent(messageId: 'msg-2', delta: 'Done'),
       const TextMessageEndEvent(messageId: 'msg-2'),

--- a/packages/soliplex_agent/test/runtime/multi_server_runtime_test.dart
+++ b/packages/soliplex_agent/test/runtime/multi_server_runtime_test.dart
@@ -427,9 +427,9 @@ void main() {
       );
 
       // Let runs start.
-      prodCtl.add(const RunStartedEvent(threadId: 'prod-t1', runId: _runId));
+      prodCtl.add(RunStartedEvent(threadId: 'prod-t1', runId: _runId));
       stagingCtl.add(
-        const RunStartedEvent(threadId: 'staging-t1', runId: _runId),
+        RunStartedEvent(threadId: 'staging-t1', runId: _runId),
       );
       await Future<void>.delayed(Duration.zero);
 

--- a/packages/soliplex_agent/test/runtime/session_children_test.dart
+++ b/packages/soliplex_agent/test/runtime/session_children_test.dart
@@ -42,7 +42,7 @@ RunInfo _runInfo() =>
     RunInfo(id: _runId, threadId: _threadId, createdAt: DateTime(2026));
 
 List<BaseEvent> _happyPathEvents() => [
-      const RunStartedEvent(threadId: _threadId, runId: _runId),
+      RunStartedEvent(threadId: _threadId, runId: _runId),
       const TextMessageStartEvent(messageId: 'msg-1'),
       const TextMessageContentEvent(messageId: 'msg-1', delta: 'Hello'),
       const TextMessageEndEvent(messageId: 'msg-1'),
@@ -192,7 +192,7 @@ void main() {
       );
 
       // Move both to running state
-      controller.add(const RunStartedEvent(threadId: _threadId, runId: _runId));
+      controller.add(RunStartedEvent(threadId: _threadId, runId: _runId));
       await Future<void>.delayed(Duration.zero);
 
       parent.cancel();
@@ -296,7 +296,7 @@ void main() {
       final parent = await runtime.spawn(roomId: _roomA, prompt: 'Hello');
       await runtime.spawn(roomId: _roomA, prompt: 'Sub-task', parent: parent);
 
-      controller.add(const RunStartedEvent(threadId: _threadId, runId: _runId));
+      controller.add(RunStartedEvent(threadId: _threadId, runId: _runId));
       await Future<void>.delayed(Duration.zero);
 
       await runtime.cancelAll();
@@ -354,7 +354,7 @@ void main() {
         parent: parent,
       );
 
-      controller.add(const RunStartedEvent(threadId: _threadId, runId: _runId));
+      controller.add(RunStartedEvent(threadId: _threadId, runId: _runId));
       await Future<void>.delayed(Duration.zero);
 
       grandparent.cancel();

--- a/packages/soliplex_client/lib/src/application/activity_events.dart
+++ b/packages/soliplex_client/lib/src/application/activity_events.dart
@@ -31,7 +31,7 @@ List<ActivityRecord> applyActivityEvent(
 }) {
   final log = logger ?? _defaultLogger;
   return switch (event) {
-    ActivitySnapshotEvent() => _applySnapshot(current, event),
+    ActivitySnapshotEvent() => _applySnapshot(current, event, log),
     ActivityDeltaEvent() => _applyDelta(current, event, log),
     _ => current,
   };
@@ -40,13 +40,36 @@ List<ActivityRecord> applyActivityEvent(
 List<ActivityRecord> _applySnapshot(
   List<ActivityRecord> current,
   ActivitySnapshotEvent event,
+  Logger log,
 ) {
+  // `content` is `Object?` upstream, but `ActivityRecord.content` is a
+  // `Map<String, dynamic>`. This fold stays non-throwing, so it warns and
+  // leaves the list untouched. A caller that needs a non-object payload
+  // surfaced to the user checks `content` before folding.
+  final eventContent = event.content;
+  if (eventContent is! Map<String, dynamic>) {
+    log.warning(
+      'ActivitySnapshotEvent dropped: content is '
+      '${eventContent.runtimeType}, not a Map<String, dynamic> '
+      '(messageId: ${event.messageId}, activityType: ${event.activityType})',
+      attributes: {
+        'messageId': event.messageId,
+        'activityType': event.activityType,
+        'contentType': eventContent.runtimeType.toString(),
+      },
+    );
+    return current;
+  }
   final resolvedTimestamp =
       event.timestamp ?? DateTime.now().millisecondsSinceEpoch;
   final idx = current.indexWhere((a) => a.messageId == event.messageId);
   if (idx >= 0) {
     if (!event.replace) return current;
-    final content = _mergeContentAcrossReplace(current[idx], event);
+    final content = _mergeContentAcrossReplace(
+      current[idx],
+      event.activityType,
+      eventContent,
+    );
     return [...current]..[idx] = ActivityRecord(
         messageId: event.messageId,
         activityType: event.activityType,
@@ -59,7 +82,7 @@ List<ActivityRecord> _applySnapshot(
     ActivityRecord(
       messageId: event.messageId,
       activityType: event.activityType,
-      content: event.content,
+      content: eventContent,
       timestamp: resolvedTimestamp,
     ),
   ];
@@ -72,14 +95,15 @@ List<ActivityRecord> _applySnapshot(
 /// the inputs that produced the result.
 Map<String, dynamic> _mergeContentAcrossReplace(
   ActivityRecord prior,
-  ActivitySnapshotEvent event,
+  String activityType,
+  Map<String, dynamic> content,
 ) {
-  if (event.activityType != kSkillToolResultActivityType) return event.content;
-  if (prior.activityType != kSkillToolCallActivityType) return event.content;
-  if (event.content.containsKey('args')) return event.content;
+  if (activityType != kSkillToolResultActivityType) return content;
+  if (prior.activityType != kSkillToolCallActivityType) return content;
+  if (content.containsKey('args')) return content;
   final priorArgs = prior.content['args'];
-  if (priorArgs == null) return event.content;
-  return {...event.content, 'args': priorArgs};
+  if (priorArgs == null) return content;
+  return {...content, 'args': priorArgs};
 }
 
 // AG-UI protocol violations on the delta path (missing prior snapshot,

--- a/packages/soliplex_client/lib/src/application/agui_event_processor.dart
+++ b/packages/soliplex_client/lib/src/application/agui_event_processor.dart
@@ -1,3 +1,14 @@
+// Four upstream types are deprecated, scheduled for removal in ag_ui 1.0.0:
+// THINKING_TEXT_MESSAGE_{START,CONTENT,END} and THINKING_CONTENT.
+// `ThinkingStartEvent` and `ThinkingEndEvent` are NOT deprecated and their arms
+// stay regardless — a removal sweep grepping "THINKING" must not touch them.
+// The THINKING_TEXT_MESSAGE_* arms stay because stored threads still decode to
+// them; the THINKING_CONTENT arm stays only to keep `processEvent`'s switch
+// over sealed `BaseEvent` exhaustive (upstream documents it as Dart-only legacy
+// that was never part of the canonical protocol). Suppressed per line so the
+// 1.0.0 sweep can enumerate them and an unrelated deprecation here still
+// raises.
+
 import 'package:ag_ui/ag_ui.dart';
 import 'package:meta/meta.dart';
 import 'package:soliplex_client/src/application/activity_events.dart';
@@ -9,6 +20,7 @@ import 'package:soliplex_client/src/domain/chat_message.dart';
 import 'package:soliplex_client/src/domain/conversation.dart';
 import 'package:soliplex_client/src/domain/skill_tool_call_activity.dart'
     show kSkillToolCallActivityType, kSkillToolCallActivityTypes;
+import 'package:soliplex_client/src/errors/exceptions.dart';
 import 'package:soliplex_logging/soliplex_logging.dart';
 
 final Logger _logger =
@@ -78,6 +90,8 @@ EventProcessingResult processEvent(
     // idempotent handlers.
     ThinkingStartEvent() ||
     ReasoningStartEvent() ||
+    // Deprecated upstream; retained to decode stored threads.
+    // ignore: deprecated_member_use
     ThinkingTextMessageStartEvent() ||
     ReasoningMessageStartEvent() =>
       _processThinkingStart(
@@ -86,9 +100,13 @@ EventProcessingResult processEvent(
       ),
     ThinkingEndEvent() ||
     ReasoningEndEvent() ||
+    // Deprecated upstream; retained to decode stored threads.
+    // ignore: deprecated_member_use
     ThinkingTextMessageEndEvent() ||
     ReasoningMessageEndEvent() =>
       _processThinkingEnd(conversation, streaming),
+    // Deprecated upstream; retained to decode stored threads.
+    // ignore: deprecated_member_use
     ThinkingTextMessageContentEvent(:final delta) ||
     ReasoningMessageContentEvent(
       :final delta,
@@ -171,13 +189,16 @@ EventProcessingResult processEvent(
     // mirroring how StateDeltaEvent patches aguiState.
     ActivityDeltaEvent() =>
       _processActivityDelta(conversation, streaming, event),
+    MessagesSnapshotEvent(:final messages) =>
+      _processMessagesSnapshot(conversation, streaming, messages),
 
     // Unhandled event types — pass through unchanged.
     // Explicit cases ensure a compile error if ag_ui adds new event types.
+    // Deprecated upstream; arm only keeps the sealed switch exhaustive.
+    // ignore: deprecated_member_use
     ThinkingContentEvent() ||
     TextMessageChunkEvent() ||
     ToolCallChunkEvent() ||
-    MessagesSnapshotEvent() ||
     StepStartedEvent() ||
     StepFinishedEvent() ||
     RawEvent() ||
@@ -188,6 +209,34 @@ EventProcessingResult processEvent(
         streaming: streaming,
       ),
   };
+}
+
+/// Passes the snapshot through unreconciled.
+///
+/// AG-UI treats `MESSAGES_SNAPSHOT` as the authoritative message list, but this
+/// client does not rebuild `conversation.messages` from it, so a server-side
+/// prune or rewrite of history diverges here. Logged rather than surfaced as a
+/// drop tile: a producer that emits snapshots routinely would mint a tile on
+/// every run.
+EventProcessingResult _processMessagesSnapshot(
+  Conversation conversation,
+  StreamingState streaming,
+  List<Message> messages,
+) {
+  _logger.warning(
+    'MessagesSnapshotEvent received but not reconciled against '
+    'conversation.messages; client may now hold a divergent history '
+    '(snapshot: ${messages.length} messages, local: '
+    '${conversation.messages.length})',
+    attributes: {
+      'snapshotMessageCount': messages.length,
+      'localMessageCount': conversation.messages.length,
+    },
+  );
+  return EventProcessingResult(
+    conversation: conversation,
+    streaming: streaming,
+  );
 }
 
 EventProcessingResult _processThinkingStart(
@@ -462,6 +511,21 @@ EventProcessingResult _processActivitySnapshot(
   StreamingState streaming,
   ActivitySnapshotEvent event,
 ) {
+  // `content` is `Object?` upstream, but `ActivityRecord.content` is a
+  // `Map<String, dynamic>`, so a non-object payload has nowhere to go. Thrown
+  // so the caller mints a drop tile, which is the only thing on screen saying
+  // the event arrived at all. It does not settle the row the event belonged to:
+  // a dropped `skill_tool_result` leaves its `skill_tool_call` record at
+  // `inProgress`, and nothing later rewrites it.
+  final content = event.content;
+  if (content is! Map<String, dynamic>) {
+    throw MalformedResponseException(
+      message: 'ActivitySnapshotEvent content must be a JSON object, got '
+          '${content.runtimeType} (messageId: ${event.messageId}, '
+          'activityType: ${event.activityType})',
+    );
+  }
+
   final updatedActivities = applyActivityEvent(
     conversation.activities,
     event,
@@ -473,7 +537,7 @@ EventProcessingResult _processActivitySnapshot(
           : conversation.copyWith(activities: updatedActivities);
 
   if (event.activityType == kSkillToolCallActivityType) {
-    final toolName = event.content['tool_name'];
+    final toolName = content['tool_name'];
     // Pass through if tool_name is missing or not a String — the backend
     // contract requires it, so this guards against schema drift.
     if (toolName is! String) {
@@ -499,9 +563,13 @@ EventProcessingResult _processActivitySnapshot(
   // streaming phase untouched (the call phase already set it).
   if (!kSkillToolCallActivityTypes.contains(event.activityType)) {
     _logger.info(
-      'ActivitySnapshotEvent: activityType has no decoder; '
-      'persisted to conversation.activities only',
-      attributes: {'activityType': event.activityType},
+      'ActivitySnapshotEvent: activityType has no decoder',
+      attributes: {
+        'activityType': event.activityType,
+        // False when the fold kept an existing record for this messageId
+        // instead of storing this snapshot (a repeat with `replace: false`).
+        'persisted': !identical(updatedActivities, conversation.activities),
+      },
     );
   }
   return EventProcessingResult(

--- a/packages/soliplex_client/lib/src/application/citation_extractor.dart
+++ b/packages/soliplex_client/lib/src/application/citation_extractor.dart
@@ -79,10 +79,6 @@ class CitationExtractor {
   Set<String> _touchedNamespaces(StateDeltaEvent delta) {
     final namespaces = <String>{};
     for (final op in delta.delta) {
-      if (op is! Map) {
-        _logger.warning('_touchedNamespaces: skipping non-Map delta op: $op');
-        continue;
-      }
       final path = op['path'];
       if (path is! String) {
         _logger.warning(

--- a/packages/soliplex_client/lib/src/domain/llm_tool.dart
+++ b/packages/soliplex_client/lib/src/domain/llm_tool.dart
@@ -59,8 +59,14 @@ class LlmUserMessage extends LlmChatMessage {
   /// Creates an [LlmUserMessage].
   const LlmUserMessage(this.content);
 
-  /// The message text.
-  final String content;
+  /// The message text, or `null` when the source message has no plain-text
+  /// projection — AG-UI reports null for a `content` encoded as a list of
+  /// parts, even one holding only text.
+  ///
+  /// This type carries text only, so a null says nothing about what the message
+  /// held. It is distinct from `''`, which is a sendable empty message: a
+  /// consumer substitutes a placeholder or rejects the turn.
+  final String? content;
 }
 
 /// An assistant message, optionally with tool calls.

--- a/packages/soliplex_client/lib/src/http/agui_stream_client.dart
+++ b/packages/soliplex_client/lib/src/http/agui_stream_client.dart
@@ -3,8 +3,6 @@ import 'dart:convert';
 import 'dart:developer' as developer;
 
 import 'package:ag_ui/ag_ui.dart' hide CancelToken;
-// ignore: implementation_imports
-import 'package:ag_ui/src/sse/sse_parser.dart';
 import 'package:meta/meta.dart';
 import 'package:soliplex_client/src/application/decode_outcome.dart';
 import 'package:soliplex_client/src/errors/exceptions.dart';
@@ -19,6 +17,19 @@ import 'package:soliplex_client/src/utils/url_builder.dart';
 /// readability; consumers should match on [StreamResumeFailedException]
 /// rather than this string.
 const String streamResumeFailedPrefix = 'Stream resume failed:';
+
+/// Byte-stream-to-[SseMessage] parser, reached through the public [SseClient]
+/// façade because ag_ui does not export `SseParser` itself.
+///
+/// Shared because [SseClient.parseStream] is stateless — it builds a fresh
+/// parser per call — while each `SseClient` allocates an `http.Client` that
+/// parsing never uses. One instance for the process beats one per request.
+///
+/// `maxDataCodeUnits` is left at ag_ui's default: ~8M UTF-16 code units per
+/// event, roughly 6 MB of binary after base64. It bounds inbound events that
+/// echo conversation state — a `MESSAGES_SNAPSHOT` or `TOOL_CALL_RESULT`
+/// carrying image data. Outbound attachments travel in the request body.
+final SseClient _sseParser = SseClient();
 
 /// Streams AG-UI events using the Soliplex HTTP stack directly.
 ///
@@ -81,6 +92,7 @@ class AgUiStreamClient {
 
     while (true) {
       final isResumeRequest = lastEventId != null;
+      final resumedFrom = lastEventId;
       final StreamedHttpResponse response;
       try {
         response = await _attempt(uri, body, lastEventId, cancelToken);
@@ -117,10 +129,7 @@ class AgUiStreamClient {
       StackTrace? streamErrorStack;
 
       try {
-        // Construct the parser inside the try so a synchronous throw
-        // from `parseBytes` is caught by the same handler as mid-stream
-        // errors.
-        final messages = SseParser().parseBytes(response.body);
+        final messages = _sseParser.parseStream(response.body);
         await for (final message in messages) {
           if (message.id != null && message.id!.isNotEmpty) {
             lastEventId = message.id;
@@ -134,7 +143,6 @@ class AgUiStreamClient {
             _logSuccess(attempt, lastEventId);
             onReconnectStatus?.call(Reconnected(attempt: attempt));
             announcedResume = true;
-            attempt = 0;
           }
           for (final outcome in outcomes) {
             if (outcome is DecodedEvent) {
@@ -172,6 +180,17 @@ class AgUiStreamClient {
           streamErrorStack ?? StackTrace.current,
         );
       }
+
+      // The retry budget is spent per failure point, not per run. An attempt
+      // that advanced the cursor hit a fresh failure, so it earns a full
+      // budget; one that ended where it began cannot be distinguished from a
+      // permanent failure (an event the parser rejects outright, such as one
+      // over its size cap, is re-sent verbatim on every resume) and must be
+      // allowed to exhaust. The cursor is the only progress signal available
+      // here, and it is imperfect: a server that emits `id:` sparsely charges
+      // real progress against the budget, as does a drop that lands before the
+      // first new id.
+      if (lastEventId != resumedFrom) attempt = 0;
 
       if (!_canRetry(policy, attempt)) {
         onReconnectStatus?.call(

--- a/packages/soliplex_client/pubspec.yaml
+++ b/packages/soliplex_client/pubspec.yaml
@@ -8,16 +8,7 @@ environment:
   sdk: ^3.6.0
 
 dependencies:
-  ag_ui:
-    git:
-      url: https://github.com/ag-ui-protocol/ag-ui.git
-      path: sdks/community/dart
-      # Pin to a fixed ref. Without it the dep floats to upstream HEAD: a
-      # fresh resolution (e.g. an external consumer with no lockfile) pulls
-      # ag_ui 0.3.0, which retyped ActivitySnapshotEvent.content from
-      # Map<String, dynamic> to Object? and fails to web-compile here. This
-      # is the commit already in pubspec.lock, so behavior is unchanged.
-      ref: d4552e3ad0d5e33e34a3df5325260d88ede8bff9
+  ag_ui: ^0.3.0
   collection: ^1.19.1
   http: ^1.2.0
   meta: ^1.9.0

--- a/packages/soliplex_client/test/application/activity_events_test.dart
+++ b/packages/soliplex_client/test/application/activity_events_test.dart
@@ -149,6 +149,44 @@ void main() {
       expect(result.single.content['tool_name'], 'first');
       expect(result.single.timestamp, 100);
     });
+
+    test('skips a snapshot whose content is not a JSON object', () {
+      // AG-UI types `content` as `Object?`, so the protocol permits any
+      // JSON shape. `ActivityRecord.content` is a map, so a non-object
+      // payload is dropped with a warning rather than crashing the stream.
+      final sink = _RecordingSink(forLoggerName: 'test.activity_events');
+      LogManager.instance.addSink(sink);
+      addTearDown(() => LogManager.instance.removeSink(sink));
+
+      const initial = ActivityRecord(
+        messageId: 'rag:call_1',
+        activityType: 'skill_tool_call',
+        content: {'tool_name': 'ask'},
+        timestamp: 100,
+      );
+      const event = ActivitySnapshotEvent(
+        messageId: 'rag:call_2',
+        activityType: 'skill_tool_call',
+        content: 'not-a-map',
+        timestamp: 200,
+      );
+
+      final current = [initial];
+      final result = applyActivityEvent(current, event, logger: logger);
+
+      // Identity, not just equality: callers short-circuit on
+      // `identical(updatedActivities, conversation.activities)` to avoid
+      // minting a new Conversation, so returning a fresh copy would cause
+      // silent rebuild churn downstream. This input reaches the fold only from
+      // historical replay — `_processActivitySnapshot` throws on a non-object
+      // `content` before folding.
+      expect(result, same(current));
+      expect(sink.records, hasLength(1));
+      final record = sink.records.single;
+      expect(record.level, LogLevel.warning);
+      expect(record.attributes['messageId'], 'rag:call_2');
+      expect(record.attributes['contentType'], 'String');
+    });
   });
 
   group('applyActivityEvent — delta', () {

--- a/packages/soliplex_client/test/application/agui_event_processor_test.dart
+++ b/packages/soliplex_client/test/application/agui_event_processor_test.dart
@@ -1,3 +1,8 @@
+// These fixtures construct ag_ui 0.3.0's deprecated THINKING_TEXT_MESSAGE_*
+// and THINKING_CONTENT events, exercising handling that is kept because a
+// producer negotiating ag-ui-protocol below 0.1.13 emits that family live.
+// Removal at ag_ui 1.0.0 surfaces as a compile error at these constructors.
+
 import 'package:ag_ui/ag_ui.dart';
 import 'package:soliplex_client/src/application/agui_event_processor.dart';
 import 'package:soliplex_client/src/application/no_response_synthesis.dart';
@@ -8,6 +13,7 @@ import 'package:soliplex_client/src/application/streaming_state.dart'
 import 'package:soliplex_client/src/domain/activity_record.dart';
 import 'package:soliplex_client/src/domain/chat_message.dart';
 import 'package:soliplex_client/src/domain/conversation.dart';
+import 'package:soliplex_client/src/errors/exceptions.dart';
 import 'package:test/test.dart';
 
 const _defaultUser = ChatUser.assistant;
@@ -24,7 +30,7 @@ void main() {
 
     group('run lifecycle events', () {
       test('RunStartedEvent sets status to Running', () {
-        const event = RunStartedEvent(threadId: 'thread-1', runId: 'run-1');
+        final event = RunStartedEvent(threadId: 'thread-1', runId: 'run-1');
 
         final result = processEvent(conversation, streaming, event);
 
@@ -1497,6 +1503,59 @@ void main() {
         expect(result.conversation.activities, hasLength(1));
         expect(result.conversation.activities.first.messageId, 'rag:call_x');
       });
+
+      test('non-object content throws so the caller mints a drop tile', () {
+        // AG-UI types `content` as `Object?`, but a non-object payload can
+        // neither be stored in `ActivityRecord.content` nor decoded into a
+        // tool-call phase — the activity is lost. Throwing is what makes that
+        // visible: both callers wrap `processEvent` and turn a throw into a
+        // `DropSource.eventProcessing` tile. Skipping instead would strand a
+        // `skill_tool_call` row at in-progress with nothing on screen.
+        const event = ActivitySnapshotEvent(
+          messageId: 'rag:call_bad',
+          activityType: 'skill_tool_call',
+          content: 42,
+          timestamp: 9,
+        );
+
+        expect(
+          () => processEvent(conversation, streaming, event),
+          throwsA(
+            isA<MalformedResponseException>().having(
+              (e) => e.message,
+              'message',
+              allOf(contains('int'), contains('rag:call_bad')),
+            ),
+          ),
+        );
+      });
+
+      test('non-object content on a result snapshot also throws', () {
+        // The `skill_tool_result` path is the one that strands a row: the prior
+        // `skill_tool_call` record survives with its old activityType, so
+        // without a throw the tool row sits at in-progress forever.
+        final seeded = conversation.copyWith(
+          activities: [
+            const ActivityRecord(
+              messageId: 'rag:call_1',
+              activityType: 'skill_tool_call',
+              content: {'tool_name': 'ask'},
+              timestamp: 100,
+            ),
+          ],
+        );
+        const event = ActivitySnapshotEvent(
+          messageId: 'rag:call_1',
+          activityType: 'skill_tool_result',
+          content: 'not-a-map',
+          timestamp: 200,
+        );
+
+        expect(
+          () => processEvent(seeded, streaming, event),
+          throwsA(isA<MalformedResponseException>()),
+        );
+      });
     });
 
     group('activity delta events', () {
@@ -1639,6 +1698,8 @@ void main() {
       test(
         'ThinkingTextMessageStartEvent sets isThinkingStreaming and phase',
         () {
+          // Deprecated upstream; exercises the pre-REASONING_* replay path.
+          // ignore: deprecated_member_use
           const event = ThinkingTextMessageStartEvent();
 
           final result = processEvent(conversation, streaming, event);
@@ -1656,6 +1717,8 @@ void main() {
         const startedState = app_streaming.AwaitingText(
           isThinkingStreaming: true,
         );
+        // Deprecated upstream; exercises the pre-REASONING_* replay path.
+        // ignore: deprecated_member_use
         const event = ThinkingTextMessageContentEvent(delta: 'Thinking...');
 
         final result = processEvent(conversation, startedState, event);
@@ -1669,6 +1732,8 @@ void main() {
           isThinkingStreaming: true,
           bufferedThinkingText: 'Part 1. ',
         );
+        // Deprecated upstream; exercises the pre-REASONING_* replay path.
+        // ignore: deprecated_member_use
         const event = ThinkingTextMessageContentEvent(delta: 'Part 2.');
 
         final result = processEvent(conversation, startedState, event);
@@ -1684,6 +1749,8 @@ void main() {
           isThinkingStreaming: true,
           bufferedThinkingText: 'Done thinking',
         );
+        // Deprecated upstream; exercises the pre-REASONING_* replay path.
+        // ignore: deprecated_member_use
         const event = ThinkingTextMessageEndEvent();
 
         final result = processEvent(conversation, startedState, event);
@@ -1723,6 +1790,8 @@ void main() {
             thinkingText: 'Initial thinking',
             isThinkingStreaming: true,
           );
+          // Deprecated upstream; exercises the pre-REASONING_* replay path.
+          // ignore: deprecated_member_use
           const event = ThinkingTextMessageContentEvent(
             delta: ' more thinking',
           );

--- a/packages/soliplex_client/test/application/citation_extractor_test.dart
+++ b/packages/soliplex_client/test/application/citation_extractor_test.dart
@@ -352,10 +352,10 @@ void main() {
         expect(turn.ids, isEmpty);
       });
 
-      test('skips malformed ops with a warning', () {
-        // A non-Map op and a pathless op are both malformed JSON-Patch. They
-        // must be skipped (touching no namespace) and each logged, so a
-        // drifting wire shape can't lose a namespace's citations silently.
+      test('skips a pathless op with a warning', () {
+        // An op with no `path` is malformed JSON-Patch. It must be skipped
+        // (touching no namespace) and logged, so a drifting wire shape
+        // can't lose a namespace's citations silently.
         final sink = _RecordingSink();
         LogManager.instance.addSink(sink);
         addTearDown(() => LogManager.instance.removeSink(sink));
@@ -367,15 +367,14 @@ void main() {
           const {},
           const StateDeltaEvent(
             delta: [
-              'not-a-map',
               <String, dynamic>{'op': 'add', 'value': 'x'},
             ],
           ),
         );
 
         expect(turn.ids, isEmpty);
-        expect(sink.records, hasLength(2));
-        expect(sink.records.every((r) => r.level == LogLevel.warning), isTrue);
+        expect(sink.records, hasLength(1));
+        expect(sink.records.single.level, LogLevel.warning);
       });
 
       test('skips a rooted op that names no namespace, with a warning', () {

--- a/packages/soliplex_client/test/http/agui_stream_client_test.dart
+++ b/packages/soliplex_client/test/http/agui_stream_client_test.dart
@@ -69,6 +69,20 @@ Stream<List<int>> sseByteStreamThenError(
   return controller.stream;
 }
 
+/// Emits [raw] SSE text verbatim, then errors. For bodies the JSON-encoding
+/// helpers cannot express, such as an `id:` paired with an empty `data:`.
+Stream<List<int>> sseRawThenError(String raw, Object error) {
+  final controller = StreamController<List<int>>();
+  Future<void>(() async {
+    controller.add(utf8.encode(raw));
+    // Yield so the parser can process before we inject the error.
+    await Future<void>.delayed(Duration.zero);
+    controller.addError(error);
+    await controller.close();
+  });
+  return controller.stream;
+}
+
 /// Fast policy for unit tests — minimal backoff, no jitter.
 const _fastPolicy = ResumePolicy(
   initialBackoff: Duration(milliseconds: 1),
@@ -363,6 +377,51 @@ void main() {
         );
         expect(result[1], isA<DecodedEvent>());
         expect((result[1] as DecodedEvent).event, isA<RunStartedEvent>());
+      });
+
+      test('yields DecodeFailed for a body that ends mid-event', () async {
+        // A body closing cleanly part-way through an event: the parser flushes
+        // the buffered `data:` at end-of-stream, so the truncated payload
+        // surfaces as a drop tile. It must not be discarded silently — a clean
+        // close leaves no stream error, so no resume is attempted, making this
+        // the only signal that the backend sent something that was lost.
+        final truncated = StringBuffer()
+          ..writeln(
+            'data: ${json.encode({
+                  'type': 'RUN_STARTED',
+                  'threadId': 't-1',
+                  'runId': 'r-1',
+                })}',
+          )
+          ..writeln()
+          // No trailing blank line: this event is never terminated.
+          ..write('data: {"type":"TEXT_MESSAGE_CON');
+
+        when(
+          () => mockTransport.requestStream(
+            any(),
+            any(),
+            headers: any(named: 'headers'),
+            body: any(named: 'body'),
+            cancelToken: any(named: 'cancelToken'),
+          ),
+        ).thenAnswer(
+          (_) async => StreamedHttpResponse(
+            statusCode: 200,
+            body: Stream.value(utf8.encode(truncated.toString())),
+          ),
+        );
+
+        final result = await client.runAgent(endpoint, input).toList();
+
+        expect(result, hasLength(2));
+        expect(result[0], isA<DecodedEvent>());
+        expect((result[0] as DecodedEvent).event, isA<RunStartedEvent>());
+        expect(result[1], isA<DecodeFailed>());
+        expect(
+          (result[1] as DecodeFailed).rawData,
+          equals('{"type":"TEXT_MESSAGE_CON'),
+        );
       });
 
       test(
@@ -982,6 +1041,171 @@ void main() {
               cancelToken: any(named: 'cancelToken'),
             ),
           ).called(1);
+        },
+      );
+
+      test(
+        'a mid-stream parse failure is retried and keeps the parser detail',
+        () async {
+          // A FormatException out of the parser is not classified apart from a
+          // network drop: the same exception is raised both by the per-event
+          // `data:` cap and by a response that closes cleanly mid-multi-byte
+          // character, and the latter is recoverable by resume. So it retries,
+          // and the parser's message must survive into the final error so an
+          // oversized event is still diagnosable.
+          final resumeClient = AgUiStreamClient(
+            httpTransport: mockTransport,
+            urlBuilder: UrlBuilder(baseUrl),
+            resumePolicy: _fastPolicy,
+          );
+          addTearDown(resumeClient.close);
+
+          Stream<List<int>> parseFailingBody() async* {
+            // An id is emitted first, so a cursor exists and the resume path
+            // is eligible. Every attempt fails the same way.
+            yield utf8.encode(
+              'id: e1\ndata: ${json.encode({
+                    'type': 'RUN_STARTED',
+                    'threadId': 't-1',
+                    'runId': 'r-1',
+                  })}\n\n',
+            );
+            throw const FormatException(
+              'SSE data field exceeds 8388608-code-unit limit',
+            );
+          }
+
+          when(
+            () => mockTransport.requestStream(
+              any(),
+              any(),
+              headers: any(named: 'headers'),
+              body: any(named: 'body'),
+              cancelToken: any(named: 'cancelToken'),
+            ),
+          ).thenAnswer(
+            (_) async => StreamedHttpResponse(
+              statusCode: 200,
+              body: parseFailingBody(),
+            ),
+          );
+
+          await expectLater(
+            resumeClient.runAgent(endpoint, input).toList(),
+            throwsA(
+              isA<StreamResumeFailedException>()
+                  .having(
+                    (e) => e.message,
+                    'message',
+                    allOf(
+                      startsWith(streamResumeFailedPrefix),
+                      // The cap and its overage stay visible for diagnosis.
+                      contains('8388608-code-unit limit'),
+                    ),
+                  )
+                  .having(
+                    (e) => e.originalError,
+                    'originalError',
+                    isA<FormatException>(),
+                  ),
+            ),
+          );
+
+          // The initial attempt plus the full resume budget.
+          verify(
+            () => mockTransport.requestStream(
+              any(),
+              any(),
+              headers: any(named: 'headers'),
+              body: any(named: 'body'),
+              cancelToken: any(named: 'cancelToken'),
+            ),
+          ).called(_fastPolicy.maxAttempts + 1);
+        },
+      );
+
+      test(
+        'a resume that advances the cursor without decoding anything earns '
+        'a fresh budget',
+        () async {
+          // The budget is keyed to the resume cursor, not to decodable
+          // output. A message carrying an `id:` with an empty `data:` moves
+          // the cursor while yielding no outcome, so the drop after it is a
+          // new failure point and earns a full budget. Only an attempt that
+          // ends on the cursor it started from is treated as permanent.
+          final resumeClient = AgUiStreamClient(
+            httpTransport: mockTransport,
+            urlBuilder: UrlBuilder(baseUrl),
+            resumePolicy: _fastPolicy,
+          );
+          addTearDown(resumeClient.close);
+
+          var callCount = 0;
+          when(
+            () => mockTransport.requestStream(
+              any(),
+              any(),
+              headers: any(named: 'headers'),
+              body: any(named: 'body'),
+              cancelToken: any(named: 'cancelToken'),
+            ),
+          ).thenAnswer((_) async {
+            callCount++;
+            if (callCount == 1) {
+              return StreamedHttpResponse(
+                statusCode: 200,
+                body: sseByteStreamThenError(
+                  [
+                    (
+                      'e1',
+                      {
+                        'type': 'RUN_STARTED',
+                        'threadId': 't-1',
+                        'runId': 'r-1',
+                      },
+                    ),
+                  ],
+                  const NetworkException(message: 'drop at e1'),
+                ),
+              );
+            }
+            if (callCount == 2) {
+              // Cursor e1 → e2 with nothing decodable in between.
+              return StreamedHttpResponse(
+                statusCode: 200,
+                body: sseRawThenError(
+                  'id: e2\ndata:\n\n',
+                  const NetworkException(message: 'drop at e2'),
+                ),
+              );
+            }
+            // Emits no id, so the cursor stays at e2 from here on and the
+            // budget counts down to exhaustion.
+            return StreamedHttpResponse(
+              statusCode: 200,
+              body: sseByteStreamThenError(
+                const [],
+                const NetworkException(message: 'stuck at e2'),
+              ),
+            );
+          });
+
+          await expectLater(
+            resumeClient.runAgent(endpoint, input).toList(),
+            throwsA(isA<StreamResumeFailedException>()),
+          );
+
+          // The initial attempt, the cursor-advancing resume that reset the
+          // budget, then the full budget spent at a cursor that never moves.
+          verify(
+            () => mockTransport.requestStream(
+              any(),
+              any(),
+              headers: any(named: 'headers'),
+              body: any(named: 'body'),
+              cancelToken: any(named: 'cancelToken'),
+            ),
+          ).called(_fastPolicy.maxAttempts + 2);
         },
       );
 

--- a/packages/soliplex_client/test/http/stream_cancel_behavior_test.dart
+++ b/packages/soliplex_client/test/http/stream_cancel_behavior_test.dart
@@ -5,8 +5,6 @@ import 'dart:async';
 import 'dart:convert';
 import 'dart:io' as io;
 
-// ignore: implementation_imports
-import 'package:ag_ui/src/sse/sse_parser.dart';
 import 'package:soliplex_client/soliplex_client.dart';
 import 'package:test/test.dart';
 
@@ -121,7 +119,7 @@ void main() {
           .asFuture<void>();
 
       // Parse to verify we got events.
-      final sseMessages = SseParser().parseBytes(Stream.value(allBytes));
+      final sseMessages = SseClient().parseStream(Stream.value(allBytes));
       final eventTypes = <String>[];
       await for (final msg in sseMessages) {
         if (msg.data == null || msg.data!.isEmpty) continue;
@@ -150,7 +148,7 @@ void main() {
 
       expect(response.statusCode, 200);
 
-      final sseMessages = SseParser().parseBytes(response.body);
+      final sseMessages = SseClient().parseStream(response.body);
       const decoder = EventDecoder();
       final eventTypes = <String>[];
       var cancelledAfterFinish = false;

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -12,12 +12,11 @@ packages:
   ag_ui:
     dependency: transitive
     description:
-      path: "sdks/community/dart"
-      ref: d4552e3ad0d5e33e34a3df5325260d88ede8bff9
-      resolved-ref: d4552e3ad0d5e33e34a3df5325260d88ede8bff9
-      url: "https://github.com/ag-ui-protocol/ag-ui.git"
-    source: git
-    version: "0.1.0"
+      name: ag_ui
+      sha256: f963810252e5c080af0ff779b03949ac8d45362042bf2ec2b7c711737d3e6457
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.3.0"
   analyzer:
     dependency: transitive
     description:

--- a/test/modules/room/agui_events_presentation_bugs_test.dart
+++ b/test/modules/room/agui_events_presentation_bugs_test.dart
@@ -24,6 +24,11 @@
 /// tool-call timeline that was visible during the live run.
 library;
 
+// These fixtures construct ag_ui 0.3.0's deprecated THINKING_TEXT_MESSAGE_*
+// and THINKING_CONTENT events, exercising handling that is kept because a
+// producer negotiating ag-ui-protocol below 0.1.13 emits that family live.
+// Removal at ag_ui 1.0.0 surfaces as a compile error at these constructors.
+
 import 'package:flutter_test/flutter_test.dart';
 import 'package:soliplex_agent/soliplex_agent.dart';
 
@@ -205,17 +210,23 @@ void main() {
         final runs = [
           RunEventBundle(
             runId: 'run-stuck',
-            events: const [
+            events: [
               RunStartedEvent(threadId: 't-1', runId: 'run-stuck'),
-              ThinkingTextMessageStartEvent(),
-              ThinkingTextMessageContentEvent(delta: 'reasoning'),
-              ThinkingTextMessageEndEvent(),
-              ToolCallStartEvent(
+              // Deprecated upstream; exercises the pre-REASONING_* replay path.
+              // ignore: deprecated_member_use
+              const ThinkingTextMessageStartEvent(),
+              // Deprecated upstream; exercises the pre-REASONING_* replay path.
+              // ignore: deprecated_member_use
+              const ThinkingTextMessageContentEvent(delta: 'reasoning'),
+              // Deprecated upstream; exercises the pre-REASONING_* replay path.
+              // ignore: deprecated_member_use
+              const ThinkingTextMessageEndEvent(),
+              const ToolCallStartEvent(
                 toolCallId: 'tc-1',
                 toolCallName: 'search',
               ),
-              ToolCallEndEvent(toolCallId: 'tc-1'),
-              ToolCallResultEvent(
+              const ToolCallEndEvent(toolCallId: 'tc-1'),
+              const ToolCallResultEvent(
                 toolCallId: 'tc-1',
                 content: 'partial',
                 messageId: 'tool-1',
@@ -264,8 +275,14 @@ void main() {
           RunEventBundle(
             runId: 'run-stuck',
             events: const [
+              // Deprecated upstream; exercises the pre-REASONING_* replay path.
+              // ignore: deprecated_member_use
               ThinkingTextMessageStartEvent(),
+              // Deprecated upstream; exercises the pre-REASONING_* replay path.
+              // ignore: deprecated_member_use
               ThinkingTextMessageContentEvent(delta: 'mid'),
+              // Deprecated upstream; exercises the pre-REASONING_* replay path.
+              // ignore: deprecated_member_use
               ThinkingTextMessageEndEvent(),
               ToolCallStartEvent(toolCallId: 'tc-1', toolCallName: 'search'),
               ToolCallEndEvent(toolCallId: 'tc-1'),

--- a/test/modules/room/historical_replay_test.dart
+++ b/test/modules/room/historical_replay_test.dart
@@ -1,3 +1,8 @@
+// These fixtures construct ag_ui 0.3.0's deprecated THINKING_TEXT_MESSAGE_*
+// and THINKING_CONTENT events, exercising handling that is kept because a
+// producer negotiating ag-ui-protocol below 0.1.13 emits that family live.
+// Removal at ag_ui 1.0.0 surfaces as a compile error at these constructors.
+
 import 'package:flutter_test/flutter_test.dart';
 import 'package:soliplex_agent/soliplex_agent.dart';
 
@@ -26,12 +31,12 @@ void main() {
       final runs = [
         RunEventBundle(
           runId: 'run-1',
-          events: const [
+          events: [
             RunStartedEvent(threadId: 't-1', runId: 'run-1'),
-            TextMessageStartEvent(messageId: 'msg-1'),
-            TextMessageContentEvent(messageId: 'msg-1', delta: 'hi'),
-            TextMessageEndEvent(messageId: 'msg-1'),
-            RunFinishedEvent(threadId: 't-1', runId: 'run-1'),
+            const TextMessageStartEvent(messageId: 'msg-1'),
+            const TextMessageContentEvent(messageId: 'msg-1', delta: 'hi'),
+            const TextMessageEndEvent(messageId: 'msg-1'),
+            const RunFinishedEvent(threadId: 't-1', runId: 'run-1'),
           ],
         ),
       ];
@@ -151,8 +156,14 @@ void main() {
               role: TextMessageRole.user,
             ),
             TextMessageEndEvent(messageId: 'user-1'),
+            // Deprecated upstream; exercises the pre-REASONING_* replay path.
+            // ignore: deprecated_member_use
             ThinkingTextMessageStartEvent(),
+            // Deprecated upstream; exercises the pre-REASONING_* replay path.
+            // ignore: deprecated_member_use
             ThinkingTextMessageContentEvent(delta: 'reasoning'),
+            // Deprecated upstream; exercises the pre-REASONING_* replay path.
+            // ignore: deprecated_member_use
             ThinkingTextMessageEndEvent(),
             RunFinishedEvent(threadId: 't', runId: 'run-1'),
           ],
@@ -174,8 +185,14 @@ void main() {
         RunEventBundle(
           runId: 'run-yield',
           events: const [
+            // Deprecated upstream; exercises the pre-REASONING_* replay path.
+            // ignore: deprecated_member_use
             ThinkingTextMessageStartEvent(),
+            // Deprecated upstream; exercises the pre-REASONING_* replay path.
+            // ignore: deprecated_member_use
             ThinkingTextMessageContentEvent(delta: 'pre-tool'),
+            // Deprecated upstream; exercises the pre-REASONING_* replay path.
+            // ignore: deprecated_member_use
             ThinkingTextMessageEndEvent(),
             ToolCallStartEvent(
               toolCallId: 'tc-1',
@@ -221,8 +238,14 @@ void main() {
         RunEventBundle(
           runId: 'run-yield-only',
           events: const [
+            // Deprecated upstream; exercises the pre-REASONING_* replay path.
+            // ignore: deprecated_member_use
             ThinkingTextMessageStartEvent(),
+            // Deprecated upstream; exercises the pre-REASONING_* replay path.
+            // ignore: deprecated_member_use
             ThinkingTextMessageContentEvent(delta: 'pre-tool'),
+            // Deprecated upstream; exercises the pre-REASONING_* replay path.
+            // ignore: deprecated_member_use
             ThinkingTextMessageEndEvent(),
             ToolCallStartEvent(
               toolCallId: 'tc-1',
@@ -260,8 +283,14 @@ void main() {
         RunEventBundle(
           runId: 'run-yield',
           events: const [
+            // Deprecated upstream; exercises the pre-REASONING_* replay path.
+            // ignore: deprecated_member_use
             ThinkingTextMessageStartEvent(),
+            // Deprecated upstream; exercises the pre-REASONING_* replay path.
+            // ignore: deprecated_member_use
             ThinkingTextMessageContentEvent(delta: 'pre-tool'),
+            // Deprecated upstream; exercises the pre-REASONING_* replay path.
+            // ignore: deprecated_member_use
             ThinkingTextMessageEndEvent(),
             ToolCallStartEvent(toolCallId: 'tc-1', toolCallName: 'search'),
             ToolCallEndEvent(toolCallId: 'tc-1'),
@@ -275,8 +304,14 @@ void main() {
         RunEventBundle(
           runId: 'run-no-response',
           events: const [
+            // Deprecated upstream; exercises the pre-REASONING_* replay path.
+            // ignore: deprecated_member_use
             ThinkingTextMessageStartEvent(),
+            // Deprecated upstream; exercises the pre-REASONING_* replay path.
+            // ignore: deprecated_member_use
             ThinkingTextMessageContentEvent(delta: 'mid'),
+            // Deprecated upstream; exercises the pre-REASONING_* replay path.
+            // ignore: deprecated_member_use
             ThinkingTextMessageEndEvent(),
             RunFinishedEvent(threadId: 't', runId: 'run-no-response'),
           ],
@@ -340,21 +375,27 @@ void main() {
         final runs = [
           RunEventBundle(
             runId: 'run-1',
-            events: const [
+            events: [
               RunStartedEvent(threadId: 't-1', runId: 'run-1'),
-              ReasoningMessageStartEvent(messageId: 'think-1'),
-              ReasoningMessageContentEvent(
+              const ReasoningMessageStartEvent(messageId: 'think-1'),
+              const ReasoningMessageContentEvent(
                 messageId: 'think-1',
                 delta: 'reasoning…',
               ),
-              ReasoningMessageEndEvent(messageId: 'think-1'),
-              TextMessageStartEvent(messageId: 'asst-1'),
+              const ReasoningMessageEndEvent(messageId: 'think-1'),
+              const TextMessageStartEvent(messageId: 'asst-1'),
               // The bridger throws on this delta.
-              TextMessageContentEvent(messageId: 'asst-1', delta: 'poison'),
+              const TextMessageContentEvent(
+                messageId: 'asst-1',
+                delta: 'poison',
+              ),
               // Subsequent events must still bridge.
-              TextMessageContentEvent(messageId: 'asst-1', delta: 'survives'),
-              TextMessageEndEvent(messageId: 'asst-1'),
-              RunFinishedEvent(threadId: 't-1', runId: 'run-1'),
+              const TextMessageContentEvent(
+                messageId: 'asst-1',
+                delta: 'survives',
+              ),
+              const TextMessageEndEvent(messageId: 'asst-1'),
+              const RunFinishedEvent(threadId: 't-1', runId: 'run-1'),
             ],
           ),
         ];


### PR DESCRIPTION
## What

Moves `ag_ui` from a pinned git ref on 0.1.0 to hosted `^0.3.0`, and fixes
everything the bump broke. The motivating feature is 0.3.0's multimodal
`UserMessage` input; this PR consumes none of it yet — it only makes the
codebase compile, lint, and behave correctly on the new version.

Sourcing changed too: `ag_ui` is published on pub.dev from the same repo path,
so `soliplex_client` now depends on a semver-bounded caret range
(`>=0.3.0 <0.4.0`) instead of a floating git branch. Reproducibility comes from
the committed root `pubspec.lock`.

## The break set

`flutter analyze` immediately after the bump: 130 errors, 1 warning, 43 infos.
Of the errors, 12 were production; the rest test-side.

| Theme | Upstream change | Fix |
| ----- | --------------- | --- |
| A | `ActivitySnapshotEvent.content`: `Map<String,dynamic>` → `Object?` | Guard at each ingestion seam; the seam that can surface a loss to the user throws so the existing drop-tile path mints a tile |
| B | message `content`: `String` → `String?` (multimodal) | Propagate the nullability rather than coalesce to `''` — see below |
| C | delta/patch: `List<dynamic>` → `List<Map<String,dynamic>>` | Remove a runtime guard the type now makes dead |
| D | `RunStartedEvent` / `UserMessage` no longer `const` | 113 test sites de-`const`ed |
| E | `THINKING_*` deprecated in favour of `REASONING_*` | Keep the arms, suppress per line |

Two further changes were not forced by a diagnostic and are called out so they
aren't mistaken for part of a theme: SSE parsing now goes through ag_ui's public
`SseClient` rather than a deep import of its private `src/sse/sse_parser.dart`,
and the SSE retry budget now resets per failure point rather than per run.
Three smaller elective additions (enumerated drop arms in the two in-process LLM
providers, a `MESSAGES_SNAPSHOT` log, one extra log attribute) are likewise
recorded rather than folded in silently.

## Breaking for library consumers

- **`LlmUserMessage.content` and `ChatFn`'s record `content` are now `String?`.**
  A null means a user message whose wire content was a parts list rather than
  text, or — in `ChatFn` only — an assistant turn carrying neither text nor tool
  calls. Neither coalesces to `''`, which is itself a sendable message that
  several chat APIs reject. Callers substitute a placeholder or reject the turn.
- **Transitively:** `soliplex_client`'s barrel re-exports
  `package:ag_ui/ag_ui.dart` (less `CancelToken`), so every ag_ui 0.3.0 breaking
  change reaches anything importing it — notably the two `const` removals, which
  land hardest in downstream tests.

The app itself is unaffected: its `lib/` references neither `ChatFn` nor
`LlmUserMessage`, and re-exports neither package.

## Verification

Every gate in `.github/workflows/flutter.yaml`:

- `dart format --set-exit-if-changed .` — clean
- `flutter analyze --fatal-infos` — no issues
- `dart doc --dry-run` — exit 0
- `markdownlint-cli2 "**/*.md"` — 0 issues
- `flutter test --test-randomize-ordering-seed --coverage` — 2178 pass, 89.7%
  against the 80% threshold
- `flutter build web --release` — succeeds
- Package suites: `soliplex_client` 1607, `soliplex_agent` 497,
  `soliplex_logging` 238

Beyond CI, two things unit tests cannot cover:

1. **Cross-version decode probe.** All 34 AG-UI event types the backend can emit
   were decoded through this client's own entry point under both the old pinned
   0.1.0 ref and hosted 0.3.0, using the backend's real camelCase wire shape.
   Results are identical for every type, with one improvement: a fractional
   `timestamp` failed to decode on 0.1.0 and now succeeds.
2. **Live run against a real server**, on both macOS and Chrome, with temporary
   instrumentation at the decode and SSE-frame boundaries (since removed). A
   streamed run plus extensive thread-history replay exercised 16 event types
   with zero decode failures, zero drop tiles, and zero runtime errors.

One measured behaviour change, recorded for completeness: a `STATE_DELTA`
carrying a malformed op is now rejected whole by ag_ui's decoder, where 0.1.0
decoded it and a since-removed guard skipped just the bad op. This is upstream's
decision — the event no longer reaches our code — and it is unreachable in
practice, since RFC 6902 ops are always objects.

## Known gaps

- The SSE resume / retry-budget path is live code but was never exercised
  against a real server, because no stream dropped during testing. Fixture
  coverage only.
- The `THINKING_*` arms exist to replay threads stored before `REASONING_*`. No
  such thread appeared during live testing, so that path is fixture-tested only.
- The `MESSAGES_SNAPSHOT` handler has no test and no observed live trigger.

## Follow-ups (not in this PR)

- Render `LogRecord.attributes` — no installed sink displays them today, so the
  structured half of several diagnostics is currently invisible.
- Surface a diverging `MESSAGES_SNAPSHOT` in the UI rather than only logging it.
- Settle `in_progress` tool rows when a run ends. Pre-existing: a run that ends
  between a tool call and its result leaves a row spinning permanently, and it
  survives reload.
- Give the new SSE per-event size cap its own user-facing copy; it currently
  surfaces as a connection-lost message that invites a retry which cannot
  succeed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
