### PR TITLE
fix: restore citation rendering from the run's terminal state snapshot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,8 +27,8 @@ Versions follow the `version+build` scheme from `pubspec.yaml`, bumped via
   a room that routes more than one retrieval capability: its stored snapshot
   really does echo a prior run's `citations`, and nothing in the record
   distinguishes that echo from a genuine retrieval, so a turn whose namespace
-  was never invoked can show one extra stale source. Rooms with a single
-  retrieval capability are unaffected.
+  was never invoked can show the stale sources that namespace last cited. Rooms
+  with a single retrieval capability are unaffected.
 
 ## [0.98.0+76] - 2026-07-30
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,28 @@ Versions follow the `version+build` scheme from `pubspec.yaml`, bumped via
 
 ## [Unreleased]
 
+### Fixed
+
+- Citations render again. The backend now carries a run's cited set in a single
+  `STATE_SNAPSHOT` emitted just before `RUN_FINISHED`, in place of the
+  per-invocation `STATE_DELTA` stream it used to emit. Both frontend
+  accumulation sites were gated on `STATE_DELTA`, so every turn resolved zero
+  sources — live and on reload, with nothing logged. A turn now seeds the
+  run-scoped state keys (`citations`, `searches`, `executions`) empty, which
+  makes any namespace carrying citations in the terminal snapshot definitionally
+  that run's, and both the live orchestrator and thread replay accumulate the
+  snapshot. Requests shrink as a side effect: `searches` carries base64 figure
+  bytes and `executions` captured stdout, and neither is echoed back for the
+  backend to discard any more.
+- The state-delta path is unchanged and still needed — the run-feedback tool
+  emits a state delta of its own, and a thread recorded before the backend
+  change replays as deltas. One limitation comes with replaying such a thread in
+  a room that routes more than one retrieval capability: its stored snapshot
+  really does echo a prior run's `citations`, and nothing in the record
+  distinguishes that echo from a genuine retrieval, so a turn whose namespace
+  was never invoked can show one extra stale source. Rooms with a single
+  retrieval capability are unaffected.
+
 ## [0.98.0+76] - 2026-07-30
 
 ### Changed

--- a/packages/soliplex_agent/lib/src/orchestration/run_orchestrator.dart
+++ b/packages/soliplex_agent/lib/src/orchestration/run_orchestrator.dart
@@ -91,6 +91,16 @@ class RunOrchestrator {
   /// [CitationExtractor.accumulate]). The union across the turn is its complete
   /// set, preserving figures a later run's `searches` clear would drop. Cleared
   /// at turn start (and on reset/sync). See [_extractCitations].
+  ///
+  /// Spanning more than one run is what makes the union load-bearing rather
+  /// than incidental: `citation_index` is session-cumulative so an earlier
+  /// run's ids still resolve, but `searches` — the sole source of inline figure
+  /// bytes — is cleared per run, so only this accumulator carries an earlier
+  /// run's figures to [_extractCitations]. A turn spans several runs only when
+  /// the model calls a client-side tool and the run yields for
+  /// [submitToolOutputs]. Hosts registering an empty [ToolRegistry] never
+  /// reach that path, so it is exercised only by hosts that register tools;
+  /// verify figures survive the yield/resume boundary when adding one.
   TurnCitations _turnCitations = const TurnCitations.empty();
   String? _userMessageId;
 
@@ -948,9 +958,15 @@ class RunOrchestrator {
             }
           } else if (event is StateSnapshotEvent) {
             try {
+              final before = _turnCitations.ids.length;
               _turnCitations = _citationExtractor.accumulateSnapshot(
                 _turnCitations,
                 result.conversation.aguiState,
+              );
+              _logger.debug(
+                'Citations: state snapshot on run ${running.runId} took the '
+                'turn from $before to ${_turnCitations.ids.length} '
+                'cited id(s).',
               );
             } on Object catch (e, st) {
               _logger.error(
@@ -1147,6 +1163,11 @@ class RunOrchestrator {
         stackTrace: st,
       );
     }
+    _logger.info(
+      'Citations: run $runId resolved ${citations.length} source(s) from '
+      '${_turnCitations.ids.length} cited id(s), '
+      '${citations.where((c) => c.figures.isNotEmpty).length} with figures.',
+    );
 
     final messageState = MessageState(
       userMessageId: userMessageId,

--- a/packages/soliplex_agent/lib/src/orchestration/run_orchestrator.dart
+++ b/packages/soliplex_agent/lib/src/orchestration/run_orchestrator.dart
@@ -92,15 +92,12 @@ class RunOrchestrator {
   /// set, preserving figures a later run's `searches` clear would drop. Cleared
   /// at turn start (and on reset/sync). See [_extractCitations].
   ///
-  /// Spanning more than one run is what makes the union load-bearing rather
-  /// than incidental: `citation_index` is session-cumulative so an earlier
-  /// run's ids still resolve, but `searches` — the sole source of inline figure
-  /// bytes — is cleared per run, so only this accumulator carries an earlier
-  /// run's figures to [_extractCitations]. A turn spans several runs only when
-  /// the model calls a client-side tool and the run yields for
-  /// [submitToolOutputs]. Hosts registering an empty [ToolRegistry] never
-  /// reach that path, so it is exercised only by hosts that register tools;
-  /// verify figures survive the yield/resume boundary when adding one.
+  /// The union spans runs, not just events: `citation_index` is
+  /// session-cumulative so an earlier run's ids still resolve, but `searches` —
+  /// the sole source of inline figure bytes — is cleared per run, so this
+  /// accumulator is the only carrier of an earlier run's figures into
+  /// [_extractCitations]. A turn spans several runs when the model calls a
+  /// client-side tool and the tool loop resumes into a continuation run.
   TurnCitations _turnCitations = const TurnCitations.empty();
   String? _userMessageId;
 
@@ -951,7 +948,8 @@ class RunOrchestrator {
               );
             } on Object catch (e, st) {
               _logger.error(
-                'Citation accumulation failed on run ${running.runId}',
+                'Citation accumulation failed on run ${running.runId} '
+                '(${event.runtimeType})',
                 error: e,
                 stackTrace: st,
               );
@@ -970,7 +968,8 @@ class RunOrchestrator {
               );
             } on Object catch (e, st) {
               _logger.error(
-                'Citation accumulation failed on run ${running.runId}',
+                'Citation accumulation failed on run ${running.runId} '
+                '(${event.runtimeType})',
                 error: e,
                 stackTrace: st,
               );
@@ -1168,6 +1167,7 @@ class RunOrchestrator {
       '${_turnCitations.ids.length} cited id(s), '
       '${citations.where((c) => c.figures.isNotEmpty).length} with figures.',
     );
+    _warnOnUncreditedIds(conversation.aguiState, 'run $runId');
 
     final messageState = MessageState(
       userMessageId: userMessageId,
@@ -1175,6 +1175,37 @@ class RunOrchestrator {
       runId: runId,
     );
     return conversation.withMessageState(userMessageId, messageState);
+  }
+
+  /// Warns when [state] names cited ids the turn's accumulator never saw.
+  ///
+  /// The accumulator is fed only by the state carriers this build recognises,
+  /// while `citations` in the end-of-turn state is the backend's own account of
+  /// what the run cited. An id in the second but not the first means a carrier
+  /// reached the wire that nothing here folds in, which otherwise costs the
+  /// turn its sources with no error and no empty-result signal — the counts in
+  /// the summary above all derive from the accumulator, so they report the loss
+  /// as if it were a turn that simply cited nothing.
+  void _warnOnUncreditedIds(Map<String, dynamic> state, String context) {
+    final Set<String> uncredited;
+    try {
+      uncredited = _citationExtractor.citationsInState(state).ids.difference(
+            _turnCitations.ids,
+          );
+    } on Object catch (e, st) {
+      _logger.error(
+        'Citations: uncredited-id check failed for $context',
+        error: e,
+        stackTrace: st,
+      );
+      return;
+    }
+    if (uncredited.isEmpty) return;
+    _logger.warning(
+      'Citations: $context ended with ${uncredited.length} cited id(s) present '
+      'in state but never accumulated; the rendered source list is short. '
+      'ids: $uncredited',
+    );
   }
 
   void _onStreamDone() {

--- a/packages/soliplex_agent/lib/src/orchestration/run_orchestrator.dart
+++ b/packages/soliplex_agent/lib/src/orchestration/run_orchestrator.dart
@@ -84,12 +84,13 @@ class RunOrchestrator {
 
   final CitationExtractor _citationExtractor = CitationExtractor();
 
-  /// Citations accumulated across this turn's `StateDeltaEvent`s — the union of
-  /// cited ids and inline figures. Each delta's touched namespace holds one
-  /// skill invocation's absolute cited set and figures (via
-  /// [CitationExtractor.accumulate]); the union across the turn is its complete
-  /// set, preserving figures a later invocation's `searches` clear would drop.
-  /// Cleared at turn start (and on reset/sync). See [_extractCitations].
+  /// Citations accumulated across this turn's state events — the union of cited
+  /// ids and inline figures. A run's cited set arrives either as one terminal
+  /// `StateSnapshotEvent` (via [CitationExtractor.accumulateSnapshot]) or as
+  /// `StateDeltaEvent`s, each scoped to the namespaces it touched (via
+  /// [CitationExtractor.accumulate]). The union across the turn is its complete
+  /// set, preserving figures a later run's `searches` clear would drop. Cleared
+  /// at turn start (and on reset/sync). See [_extractCitations].
   TurnCitations _turnCitations = const TurnCitations.empty();
   String? _userMessageId;
 
@@ -811,7 +812,13 @@ class RunOrchestrator {
       user: ChatUser.user,
       text: userMessage,
     );
-    final baseState = cachedHistory?.aguiState ?? const {};
+    // Seeding with the run-scoped keys emptied is what makes a namespace's
+    // non-empty `citations` in the run's terminal snapshot definitionally this
+    // turn's. The overlay merges on top, so a caller-set `document_filter`
+    // still applies.
+    final baseState = RagSnapshot.withEmptyRunScopedKeys(
+      cachedHistory?.aguiState ?? const {},
+    );
     final aguiState =
         stateOverlay == null ? baseState : _mergeState(baseState, stateOverlay);
     _turnCitations = const TurnCitations.empty();
@@ -918,17 +925,32 @@ class RunOrchestrator {
         try {
           final result =
               processEvent(running.conversation, running.streaming, event);
-          // Accumulate the citations and inline figures this StateDeltaEvent
-          // cited, scoped to the namespaces it touched — one skill invocation's
-          // absolute cited set. Snapshots are intentionally not accumulated:
-          // they only echo the round-tripped seed. Fail-soft because citations
-          // are a derived projection.
+          // Accumulate the citations and inline figures this run cited, from
+          // whichever carrier brings them: a terminal snapshot holds the run's
+          // complete cited set, while a delta holds one contribution and is
+          // scoped to the namespaces it touched. Reading the post-event
+          // conversation state rather than the event keeps the source of truth
+          // single — a malformed snapshot has already been rejected there.
+          // Fail-soft because citations are a derived projection.
           if (event is StateDeltaEvent) {
             try {
               _turnCitations = _citationExtractor.accumulate(
                 _turnCitations,
                 result.conversation.aguiState,
                 event,
+              );
+            } on Object catch (e, st) {
+              _logger.error(
+                'Citation accumulation failed on run ${running.runId}',
+                error: e,
+                stackTrace: st,
+              );
+            }
+          } else if (event is StateSnapshotEvent) {
+            try {
+              _turnCitations = _citationExtractor.accumulateSnapshot(
+                _turnCitations,
+                result.conversation.aguiState,
               );
             } on Object catch (e, st) {
               _logger.error(

--- a/packages/soliplex_agent/test/orchestration/run_orchestrator_test.dart
+++ b/packages/soliplex_agent/test/orchestration/run_orchestrator_test.dart
@@ -2826,6 +2826,115 @@ void main() {
       expect(entry.sourceReferences[1].chunkId, 'chunk-2');
     });
 
+    test("keeps both runs' figures across a snapshot-carried tool resume",
+        () async {
+      // A turn spanning two runs, each carrying its cited set in its own
+      // terminal snapshot. `citation_index` is session-cumulative, so run 1's
+      // chunk still resolves from run 2's snapshot — but `searches` is cleared
+      // per run, so run 2's snapshot holds none of run 1's figure bytes. The
+      // turn accumulator is the only thing that can still supply them, which
+      // makes this the case where a lost merge is silent: the citation renders
+      // with its text intact and its image missing.
+      orchestrator = RunOrchestrator(
+        llmProvider: AgUiLlmProvider(
+          api: api,
+          agUiStreamClient: agUiStreamClient,
+        ),
+        toolRegistry: _registryWith(),
+        logger: logger,
+      );
+      stubCreateRun();
+      var callCount = 0;
+      when(
+        () => agUiStreamClient.runAgent(
+          any(),
+          any(),
+          cancelToken: any(named: 'cancelToken'),
+          resumePolicy: any(named: 'resumePolicy'),
+          onReconnectStatus: any(named: 'onReconnectStatus'),
+        ),
+      ).thenAnswer((_) {
+        callCount++;
+        if (callCount == 1) {
+          return _wrap(
+            Stream<BaseEvent>.fromIterable([
+              RunStartedEvent(threadId: 'thread-1', runId: _runId),
+              const ToolCallStartEvent(
+                toolCallId: 'tc-1',
+                toolCallName: 'weather',
+              ),
+              const ToolCallArgsEvent(
+                toolCallId: 'tc-1',
+                delta: '{"city":"NYC"}',
+              ),
+              const ToolCallEndEvent(toolCallId: 'tc-1'),
+              StateSnapshotEvent(
+                snapshot: {
+                  'rag': {
+                    'citation_index': {
+                      'chunk-1':
+                          citation('chunk-1', pictureRefs: ['#/pictures/0']),
+                    },
+                    'citations': ['chunk-1'],
+                    'searches':
+                        figureSearch('doc-1', '#/pictures/0', 'aGVsbG8='),
+                  },
+                },
+              ),
+              const RunFinishedEvent(threadId: 'thread-1', runId: _runId),
+            ]),
+          );
+        }
+        return _wrap(
+          Stream<BaseEvent>.fromIterable([
+            RunStartedEvent(threadId: 'thread-1', runId: _runId),
+            const TextMessageStartEvent(messageId: 'msg-2'),
+            const TextMessageContentEvent(messageId: 'msg-2', delta: 'Done'),
+            StateSnapshotEvent(
+              snapshot: {
+                'rag': {
+                  'citation_index': {
+                    'chunk-1':
+                        citation('chunk-1', pictureRefs: ['#/pictures/0']),
+                    'chunk-2': citation(
+                      'chunk-2',
+                      documentId: 'doc-2',
+                      pictureRefs: ['#/pictures/0'],
+                    ),
+                  },
+                  'citations': ['chunk-2'],
+                  'searches': figureSearch('doc-2', '#/pictures/0', 'd29ybGQ='),
+                },
+              },
+            ),
+            const TextMessageEndEvent(messageId: 'msg-2'),
+            const RunFinishedEvent(threadId: 'thread-1', runId: _runId),
+          ]),
+        );
+      });
+
+      final result = await orchestrator.runToCompletion(
+        key: _key,
+        userMessage: 'Search',
+        toolExecutor: (pending) async => pending
+            .map(
+              (tc) => tc.copyWith(
+                status: ToolCallStatus.completed,
+                result: 'result',
+              ),
+            )
+            .toList(),
+      );
+
+      final completed = result as CompletedState;
+      final refs =
+          completed.conversation.messageStates.values.first.sourceReferences;
+
+      expect(refs.map((r) => r.chunkId), ['chunk-1', 'chunk-2']);
+      expect(refs[0].figures.single.bytes, base64Decode('aGVsbG8='));
+      expect(refs[1].figures.single.bytes, base64Decode('d29ybGQ='));
+    });
+
     test('duplicate chunks across segments are deduplicated', () async {
       orchestrator = RunOrchestrator(
         llmProvider: AgUiLlmProvider(

--- a/packages/soliplex_agent/test/orchestration/run_orchestrator_test.dart
+++ b/packages/soliplex_agent/test/orchestration/run_orchestrator_test.dart
@@ -2332,11 +2332,12 @@ void main() {
   });
 
   group('citation extraction', () {
-    // Each skill invocation emits one StateDeltaEvent whose post-delta
-    // rag.citations is that invocation's absolute set; citation_index is
-    // session-cumulative. Citations never arrive via StateSnapshotEvent (the
-    // only snapshot is the RUN_STARTED rebase echoing the round-tripped seed),
-    // so tests deliver citations exclusively via StateDeltaEvent.
+    // A run's cited set arrives either in one terminal StateSnapshotEvent or,
+    // for a thread recorded before the backend switched carriers, as
+    // StateDeltaEvents whose post-delta `citations` is that contribution's
+    // absolute set. Either way `citations` is run-scoped — the turn seeds it
+    // empty — while `citation_index` is session-cumulative, so an id cited by
+    // an earlier run still resolves.
     StateDeltaEvent namespaceDelta(
       String namespace, {
       required Map<String, Map<String, dynamic>> citationIndex,
@@ -2427,6 +2428,40 @@ void main() {
       expect(entry.runId, _runId);
       expect(entry.sourceReferences, hasLength(1));
       expect(entry.sourceReferences[0].chunkId, 'chunk-1');
+    });
+
+    test("credits citations from the run's terminal state snapshot", () async {
+      // The backend carries a run's cited set in one StateSnapshotEvent
+      // emitted just before RUN_FINISHED, with no deltas at all.
+      stubCreateRun();
+      stubRunAgent(
+        stream: Stream.fromIterable(<BaseEvent>[
+          RunStartedEvent(threadId: 'thread-1', runId: _runId),
+          const TextMessageStartEvent(messageId: 'msg-1'),
+          const TextMessageContentEvent(messageId: 'msg-1', delta: 'Answer'),
+          const TextMessageEndEvent(messageId: 'msg-1'),
+          StateSnapshotEvent(
+            snapshot: {
+              'rag': {
+                'citation_index': {'chunk-1': citation('chunk-1')},
+                'citations': ['chunk-1'],
+              },
+            },
+          ),
+          const RunFinishedEvent(threadId: 'thread-1', runId: _runId),
+        ]),
+      );
+
+      await orchestrator.startRun(key: _key, userMessage: 'Search');
+      await Future<void>.delayed(Duration.zero);
+
+      expect(orchestrator.currentState, isA<CompletedState>());
+      final completed = orchestrator.currentState as CompletedState;
+      final refs =
+          completed.conversation.messageStates.values.first.sourceReferences;
+
+      expect(refs, hasLength(1));
+      expect(refs[0].chunkId, 'chunk-1');
     });
 
     test('populates messageStates with runId even without citations', () async {
@@ -2534,10 +2569,10 @@ void main() {
     });
 
     test('excludes a stale sibling namespace this run never invoked', () async {
-      // Prior turn left rag.citations=[seed-chunk]; the RUN_STARTED rebase
-      // echoes it (round-tripped seed). This run invokes only the analysis
-      // skill, so its delta touches /analysis alone. rag was never invoked
-      // this run — its stale citations must not be attributed here.
+      // rag's cumulative citation_index still resolves a chunk a prior turn
+      // cited, but rag was not invoked this run, so its run-scoped citations
+      // comes back as the turn seeded it: empty. Only the analysis namespace
+      // this run's delta touched may be credited.
       stubCreateRun();
       stubRunAgent(
         stream: Stream.fromIterable(<BaseEvent>[
@@ -2553,7 +2588,7 @@ void main() {
                     'document_uri': 'https://example.com/seed.pdf',
                   },
                 },
-                'citations': ['seed-chunk'],
+                'citations': <String>[],
               },
             },
           ),
@@ -2578,11 +2613,10 @@ void main() {
       expect(refs.map((r) => r.chunkId), ['chunk-2']);
     });
 
-    test('keeps a chunk re-cited from the round-tripped seed', () async {
-      // The RUN_STARTED rebase snapshot echoes the round-tripped seed (a prior
-      // turn's leftover citations). When the run re-cites one of those chunks
-      // the delta carries it, so it must appear — no baseline subtraction
-      // (Issue 1).
+    test('keeps a chunk re-cited from the cumulative index', () async {
+      // A chunk a prior turn cited is still in the cumulative citation_index.
+      // When this run re-cites it, it must appear — the run's cited set is
+      // credited as-is, with no subtraction of what the index already knew.
       stubCreateRun();
       stubRunAgent(
         stream: Stream.fromIterable(<BaseEvent>[
@@ -2598,7 +2632,7 @@ void main() {
                     'document_uri': 'https://example.com/seed.pdf',
                   },
                 },
-                'citations': ['seed-chunk'],
+                'citations': <String>[],
               },
             },
           ),
@@ -2622,10 +2656,10 @@ void main() {
       expect(refs.map((r) => r.chunkId), ['seed-chunk']);
     });
 
-    test('excludes a seed citation the run never re-cites', () async {
-      // A StateSnapshotEvent echoes the round-tripped seed, but the run cites
-      // nothing. Snapshots are not accumulated, so the seed leftover must not
-      // surface as this run's citation.
+    test('credits nothing when the terminal snapshot cites nothing', () async {
+      // The snapshot's cumulative citation_index can resolve a chunk, but the
+      // run cited none. Credit follows what `citations` says was cited, not
+      // what the index happens to be able to resolve.
       stubCreateRun();
       stubRunAgent(
         stream: Stream.fromIterable(<BaseEvent>[
@@ -2641,7 +2675,7 @@ void main() {
                     'document_uri': 'https://example.com/seed.pdf',
                   },
                 },
-                'citations': ['seed-chunk'],
+                'citations': <String>[],
               },
             },
           ),
@@ -2910,13 +2944,12 @@ void main() {
 
     test("does not leak a prior turn's citations into the next turn", () async {
       // Two turns back-to-back with no reset between them. Turn 1 cites
-      // chunk-1; turn 2 cites nothing, but its RUN_STARTED rebase snapshot
-      // echoes the round-tripped seed (chunk-1 still in the cumulative
-      // citation_index). The turn accumulator is cleared at turn start, so
-      // turn 2 shows no sources — otherwise turn 1's id would resolve against
-      // turn 2's state and leak in. This isolates the turn-start clear: reset
-      // and syncToThread also null _userMessageId (short-circuiting resolve),
-      // so only a back-to-back run exercises it.
+      // chunk-1; turn 2 cites nothing, but chunk-1 is still in turn 2's
+      // cumulative citation_index. The turn accumulator is cleared at turn
+      // start, so turn 2 shows no sources — otherwise turn 1's id would
+      // resolve against turn 2's state and leak in. This isolates the
+      // turn-start clear: reset and syncToThread also null _userMessageId
+      // (short-circuiting resolve), so only a back-to-back run exercises it.
       stubCreateRun();
       stubRunAgent(stream: Stream.fromIterable(citationEvents()));
 
@@ -2931,7 +2964,7 @@ void main() {
             snapshot: {
               'rag': {
                 'citation_index': {'chunk-1': citation('chunk-1')},
-                'citations': ['chunk-1'],
+                'citations': <String>[],
               },
             },
           ),

--- a/packages/soliplex_agent/test/orchestration/run_orchestrator_test.dart
+++ b/packages/soliplex_agent/test/orchestration/run_orchestrator_test.dart
@@ -2055,6 +2055,93 @@ void main() {
       );
     });
 
+    test('seeds the run with every citation-bearing run-scoped key emptied',
+        () async {
+      // The premise the whole citation path rests on: because the outbound
+      // state carries no `citations`, a namespace with a non-empty `citations`
+      // in the run's terminal snapshot populated it during that run, which is
+      // what lets the extractor credit a snapshot unscoped. The cumulative
+      // index must survive or cited ids stop resolving, and `document_filter`
+      // must survive or document filtering silently stops.
+      orchestrator = RunOrchestrator(
+        llmProvider: AgUiLlmProvider(
+          api: api,
+          agUiStreamClient: agUiStreamClient,
+        ),
+        toolRegistry: const ToolRegistry(),
+        logger: logger,
+      );
+      stubCreateRun();
+      stubRunAgent(stream: Stream.fromIterable(_happyPathEvents()));
+
+      final history = ThreadHistory(
+        messages: [
+          TextMessage.create(
+            id: 'prior-user',
+            user: ChatUser.user,
+            text: 'Search',
+          ),
+        ],
+        aguiState: const {
+          'rag': {
+            'citation_index': {
+              'chunk-1': {
+                'chunk_id': 'chunk-1',
+                'content': 'Citation text',
+                'document_id': 'doc-1',
+                'document_uri': 'https://example.com/doc.pdf',
+              },
+            },
+            'citations': ['chunk-1'],
+            'searches': {'q': <dynamic>[]},
+            'document_filter': "id = 'doc-1'",
+          },
+          // Only `analysis` carries `executions`, so the two namespaces must
+          // come back cleared of different key sets.
+          'analysis': {
+            'citation_index': <String, dynamic>{},
+            'citations': ['stale-chunk'],
+            'searches': <String, dynamic>{},
+            'executions': [
+              {'code': 'print(1)', 'stdout': '1'},
+            ],
+          },
+          'bubble-sandbox': {'anything': 1},
+        },
+      );
+
+      await orchestrator.startRun(
+        key: _key,
+        userMessage: 'More',
+        cachedHistory: history,
+      );
+      await Future<void>.delayed(Duration.zero);
+
+      final captured = verify(
+        () => agUiStreamClient.runAgent(
+          any(),
+          captureAny(),
+          cancelToken: any(named: 'cancelToken'),
+          resumePolicy: any(named: 'resumePolicy'),
+          onReconnectStatus: any(named: 'onReconnectStatus'),
+        ),
+      ).captured;
+      final state =
+          (captured.first as SimpleRunAgentInput).state as Map<String, dynamic>;
+
+      final rag = state['rag'] as Map<String, dynamic>;
+      expect(rag['citations'], isEmpty);
+      expect(rag['searches'], isEmpty);
+      expect(rag['citation_index'], hasLength(1));
+      expect(rag['document_filter'], "id = 'doc-1'");
+
+      final analysis = state['analysis'] as Map<String, dynamic>;
+      expect(analysis['citations'], isEmpty);
+      expect(analysis['executions'], isEmpty);
+
+      expect(state['bubble-sandbox'], equals({'anything': 1}));
+    });
+
     test(
       'state accumulated via StateSnapshotEvent survives to resume run',
       () async {
@@ -2568,11 +2655,13 @@ void main() {
       expect(chunk1.figures.single.bytes, utf8.encode('hello'));
     });
 
-    test('excludes a stale sibling namespace this run never invoked', () async {
-      // rag's cumulative citation_index still resolves a chunk a prior turn
-      // cited, but rag was not invoked this run, so its run-scoped citations
-      // comes back as the turn seeded it: empty. Only the analysis namespace
-      // this run's delta touched may be credited.
+    test('credits both carriers when a snapshot and a delta share one run',
+        () async {
+      // A run can carry both: the terminal snapshot, and a delta from the
+      // feedback tool. rag's cumulative citation_index still resolves a chunk a
+      // prior turn cited, but rag was not invoked this run, so its run-scoped
+      // citations comes back as the turn seeded it — empty — and only the
+      // analysis namespace the delta touched may be credited.
       stubCreateRun();
       stubRunAgent(
         stream: Stream.fromIterable(<BaseEvent>[
@@ -2611,49 +2700,6 @@ void main() {
       final refs =
           completed.conversation.messageStates.values.first.sourceReferences;
       expect(refs.map((r) => r.chunkId), ['chunk-2']);
-    });
-
-    test('keeps a chunk re-cited from the cumulative index', () async {
-      // A chunk a prior turn cited is still in the cumulative citation_index.
-      // When this run re-cites it, it must appear — the run's cited set is
-      // credited as-is, with no subtraction of what the index already knew.
-      stubCreateRun();
-      stubRunAgent(
-        stream: Stream.fromIterable(<BaseEvent>[
-          RunStartedEvent(threadId: 'thread-1', runId: _runId),
-          const StateSnapshotEvent(
-            snapshot: {
-              'rag': {
-                'citation_index': {
-                  'seed-chunk': {
-                    'chunk_id': 'seed-chunk',
-                    'content': 'Seed citation',
-                    'document_id': 'doc-seed',
-                    'document_uri': 'https://example.com/seed.pdf',
-                  },
-                },
-                'citations': <String>[],
-              },
-            },
-          ),
-          const TextMessageStartEvent(messageId: 'msg-1'),
-          const TextMessageContentEvent(messageId: 'msg-1', delta: 'Answer'),
-          ragDelta(
-            citationIndex: {'seed-chunk': citation('seed-chunk')},
-            citations: ['seed-chunk'],
-          ),
-          const TextMessageEndEvent(messageId: 'msg-1'),
-          const RunFinishedEvent(threadId: 'thread-1', runId: _runId),
-        ]),
-      );
-
-      await orchestrator.startRun(key: _key, userMessage: 'Search');
-      await Future<void>.delayed(Duration.zero);
-
-      final completed = orchestrator.currentState as CompletedState;
-      final refs =
-          completed.conversation.messageStates.values.first.sourceReferences;
-      expect(refs.map((r) => r.chunkId), ['seed-chunk']);
     });
 
     test('credits nothing when the terminal snapshot cites nothing', () async {

--- a/packages/soliplex_client/lib/src/api/soliplex_api.dart
+++ b/packages/soliplex_client/lib/src/api/soliplex_api.dart
@@ -1134,7 +1134,7 @@ class SoliplexApi {
                 } on Object catch (error, stackTrace) {
                   _logger.error(
                     'replay: citation accumulation failed in run $runId of '
-                    'thread $threadId.',
+                    'thread $threadId (${event.runtimeType}).',
                     error: error,
                     stackTrace: stackTrace,
                   );
@@ -1150,7 +1150,7 @@ class SoliplexApi {
                 } on Object catch (error, stackTrace) {
                   _logger.error(
                     'replay: citation accumulation failed in run $runId of '
-                    'thread $threadId.',
+                    'thread $threadId (${event.runtimeType}).',
                     error: error,
                     stackTrace: stackTrace,
                   );
@@ -1174,7 +1174,7 @@ class SoliplexApi {
       // and (re)emit its MessageState — the turn's last run wins, mirroring the
       // live path's resolve-at-every-terminal. Resolving against the run's own
       // state is what preserves a turn's inline figure bytes: `searches` is
-      // per-invocation and a later turn overwrites it, while `citation_index`
+      // cleared per run and a later run overwrites it, while `citation_index`
       // stays session-cumulative so the ids still resolve. A turn that cited
       // nothing still gets a MessageState carrying its runId.
       if (userMessageId != null) {
@@ -1203,6 +1203,31 @@ class SoliplexApi {
           '${sourceReferences.where((r) => r.figures.isNotEmpty).length} '
           'with figures.',
         );
+        // An id the stored state says was cited but that no carrier fed into
+        // the accumulator means this build cannot read the record's carrier.
+        // The counts above all derive from the accumulator, so without this the
+        // shortfall reads as a turn that simply cited nothing.
+        try {
+          final uncredited =
+              extractor.citationsInState(conversation.aguiState).ids.difference(
+                    turnsByUserMessage[userMessageId]?.ids ?? const {},
+                  );
+          if (uncredited.isNotEmpty) {
+            _logger.warning(
+              'replay: run $runId of thread $threadId ended with '
+              '${uncredited.length} cited id(s) present in state but never '
+              'accumulated; the rendered source list is short. '
+              'ids: $uncredited',
+            );
+          }
+        } on Object catch (error, stackTrace) {
+          _logger.error(
+            'replay: uncredited-id check failed in run $runId of thread '
+            '$threadId.',
+            error: error,
+            stackTrace: stackTrace,
+          );
+        }
         messageStates[userMessageId] = MessageState(
           userMessageId: userMessageId,
           sourceReferences: sourceReferences,

--- a/packages/soliplex_client/lib/src/api/soliplex_api.dart
+++ b/packages/soliplex_client/lib/src/api/soliplex_api.dart
@@ -1196,6 +1196,13 @@ class SoliplexApi {
             stackTrace: stackTrace,
           );
         }
+        _logger.info(
+          'replay: run $runId resolved ${sourceReferences.length} source(s) '
+          'from ${turnsByUserMessage[userMessageId]?.ids.length ?? 0} cited '
+          'id(s), '
+          '${sourceReferences.where((r) => r.figures.isNotEmpty).length} '
+          'with figures.',
+        );
         messageStates[userMessageId] = MessageState(
           userMessageId: userMessageId,
           sourceReferences: sourceReferences,

--- a/packages/soliplex_client/lib/src/api/soliplex_api.dart
+++ b/packages/soliplex_client/lib/src/api/soliplex_api.dart
@@ -1115,13 +1115,14 @@ class SoliplexApi {
               );
               conversation = result.conversation;
               streaming = result.streaming;
-              // Accumulate the citations and inline figures this
-              // StateDeltaEvent cited, scoped to the namespaces it touched,
-              // into the turn's accumulator — one skill invocation's absolute
-              // cited set. Snapshots echo the round-tripped seed and are
-              // intentionally not accumulated. Own fail-soft guard (log-only,
-              // never a drop tile): the event already processed, and citations
-              // are a derived projection.
+              // Accumulate this run's cited ids and inline figures into the
+              // turn's accumulator, from whichever carrier the run recorded:
+              // a terminal snapshot holds the run's complete cited set, having
+              // been seeded with the run-scoped keys emptied, while a delta
+              // holds one contribution and is scoped to the namespaces it
+              // touched. Own fail-soft guard (log-only, never a drop tile):
+              // the event already processed, and citations are a derived
+              // projection.
               if (event is StateDeltaEvent && userMessageId != null) {
                 try {
                   turnsByUserMessage[userMessageId] = extractor.accumulate(
@@ -1129,6 +1130,22 @@ class SoliplexApi {
                         const TurnCitations.empty(),
                     conversation.aguiState,
                     event,
+                  );
+                } on Object catch (error, stackTrace) {
+                  _logger.error(
+                    'replay: citation accumulation failed in run $runId of '
+                    'thread $threadId.',
+                    error: error,
+                    stackTrace: stackTrace,
+                  );
+                }
+              } else if (event is StateSnapshotEvent && userMessageId != null) {
+                try {
+                  turnsByUserMessage[userMessageId] =
+                      extractor.accumulateSnapshot(
+                    turnsByUserMessage[userMessageId] ??
+                        const TurnCitations.empty(),
+                    conversation.aguiState,
                   );
                 } on Object catch (error, stackTrace) {
                   _logger.error(

--- a/packages/soliplex_client/lib/src/application/citation_extractor.dart
+++ b/packages/soliplex_client/lib/src/application/citation_extractor.dart
@@ -16,35 +16,36 @@ final _logger =
 /// types in `rag.dart`. When the backend citation shape changes, updates
 /// are confined to `rag_snapshot.dart`.
 ///
-/// Each RAG-producing skill (`rag`, `analysis`, …) publishes its own
-/// citation-bearing namespace. [accumulate] folds each `StateDeltaEvent`'s
-/// cited ids and inline figures into a running [TurnCitations]; [resolve] turns
-/// an accumulated [TurnCitations] into full [SourceReference]s using the
-/// state's session-cumulative `citation_index`. No subtraction of a prior
-/// turn's ids is applied — the caller owns the turn-scoped accumulator.
+/// Each RAG-producing capability (`rag`, `analysis`, …) publishes its own
+/// citation-bearing namespace. A run's cited set reaches the client either as a
+/// terminal `StateSnapshotEvent` ([accumulateSnapshot]) or as a stream of
+/// `StateDeltaEvent`s ([accumulate]); both fold into a running [TurnCitations],
+/// and [resolve] turns that into full [SourceReference]s using the state's
+/// session-cumulative `citation_index`. No subtraction of a prior turn's ids is
+/// applied — the caller owns the turn-scoped accumulator.
 class CitationExtractor {
   /// The [TurnCitations] carried by [state] across every citation-bearing
   /// namespace — every cited id and every inline figure the state itself holds.
   ///
-  /// This reads the whole state, so a namespace's stale `citations` (left by a
-  /// prior turn and riding the rebase snapshot) is included. Use it only when
-  /// [state] is a self-contained unit to resolve; during a turn's delta stream,
-  /// use [accumulate], which scopes to the namespaces each delta touched.
+  /// This reads the whole state unscoped, so a namespace's `citations` is
+  /// credited whoever populated it. Use it only when [state] is a
+  /// self-contained unit to resolve — a run's terminal snapshot seeded via
+  /// [RagSnapshot.withEmptyRunScopedKeys] is one, which is what
+  /// [accumulateSnapshot] relies on. During a delta stream use [accumulate],
+  /// which scopes to the namespaces each delta touched.
   TurnCitations citationsInState(Map<String, dynamic> state) => _extract(state);
 
   /// Folds the citations and figures [delta] contributes into [current],
   /// returning the extended accumulator.
   ///
-  /// Scoped to the namespaces [delta]'s JSON-Patch touched. The backend
-  /// re-emits every namespace's block in `state` — including a prior turn's
-  /// untouched one, whose stale `citations` ride the run's rebase snapshot —
-  /// but clears and repopulates `citations` and `searches` only in the invoked
-  /// skill's namespace. Scoping keeps re-cited chunks and multi-invocation runs
-  /// while never crediting a namespace this delta did not invoke.
+  /// Scoped to the namespaces [delta]'s JSON-Patch touched. `state` carries
+  /// every namespace's block, including ones this delta had nothing to do with,
+  /// so scoping is what keeps a delta from crediting a namespace it did not
+  /// populate.
   ///
   /// Both ids and figure bytes are read from the same touched-namespace
   /// snapshots in one pass, so every accumulated id's figure (if any) is
-  /// captured alongside it — even after a later invocation clears `searches`.
+  /// captured alongside it — even after a later run clears `searches`.
   TurnCitations accumulate(
     TurnCitations current,
     Map<String, dynamic> state,
@@ -54,6 +55,21 @@ class CitationExtractor {
     if (namespaces.isEmpty) return current;
     return current.merge(_extract(state, namespaces: namespaces));
   }
+
+  /// Folds the citations and figures [snapshot] contributes into [current].
+  ///
+  /// Unlike [accumulate], this credits every citation-bearing namespace rather
+  /// than scoping to the ones a delta touched. That is safe because the turn is
+  /// seeded via [RagSnapshot.withEmptyRunScopedKeys]: a namespace the model did
+  /// not invoke arrives back with an empty `citations`, so it contributes
+  /// nothing. Merging (rather than replacing) is what keeps a turn spanning
+  /// several runs complete — `citation_index` is session-cumulative, so ids
+  /// from an earlier run still resolve.
+  TurnCitations accumulateSnapshot(
+    TurnCitations current,
+    Map<String, dynamic> snapshot,
+  ) =>
+      current.merge(citationsInState(snapshot));
 
   /// One pass over [state]'s citation-bearing namespaces (all, or only
   /// [namespaces] when given), unioning each snapshot's cited ids and merging
@@ -108,12 +124,12 @@ class CitationExtractor {
   /// index is cumulative), so it is surfaced, not dropped silently.
   ///
   /// Ids are looked up in `citation_index`, which is session-cumulative, so an
-  /// id cited in an earlier invocation still resolves even when it is no longer
-  /// in the current `citations` list. Figure bytes come from
-  /// [citations].figures rather than [finalState]'s `searches`, which the
-  /// backend clears each invocation — the accumulated union is a superset, so
-  /// this recovers figures a later invocation would otherwise have wiped. No
-  /// subtraction of any kind is applied.
+  /// id cited in an earlier run still resolves even when it is no longer in the
+  /// current `citations` list. Figure bytes come from [citations].figures
+  /// rather than [finalState]'s `searches`, which the backend clears at the
+  /// start of every run — the accumulated union is a superset, so this recovers
+  /// figures a later run would otherwise have wiped. No subtraction of any kind
+  /// is applied.
   ///
   /// Never throws: a namespace whose block fails to parse is skipped by
   /// [RagSnapshot.extractAll], everything after operates on already-parsed

--- a/packages/soliplex_client/lib/src/application/citation_extractor.dart
+++ b/packages/soliplex_client/lib/src/application/citation_extractor.dart
@@ -28,11 +28,12 @@ class CitationExtractor {
   /// namespace — every cited id and every inline figure the state itself holds.
   ///
   /// This reads the whole state unscoped, so a namespace's `citations` is
-  /// credited whoever populated it. Use it only when [state] is a
-  /// self-contained unit to resolve — a run's terminal snapshot seeded via
-  /// [RagSnapshot.withEmptyRunScopedKeys] is one, which is what
-  /// [accumulateSnapshot] relies on. During a delta stream use [accumulate],
-  /// which scopes to the namespaces each delta touched.
+  /// credited no matter which turn populated it — including a prior turn's,
+  /// when [state] carries one. Use it only when [state] is a self-contained
+  /// unit to resolve: a run's terminal snapshot is one, because the turn seeds
+  /// the run-scoped keys empty via [RagSnapshot.withEmptyRunScopedKeys], which
+  /// is what [accumulateSnapshot] relies on. During a delta stream use
+  /// [accumulate], which scopes to the namespaces each delta touched.
   TurnCitations citationsInState(Map<String, dynamic> state) => _extract(state);
 
   /// Folds the citations and figures [delta] contributes into [current],
@@ -59,12 +60,15 @@ class CitationExtractor {
   /// Folds the citations and figures [snapshot] contributes into [current].
   ///
   /// Unlike [accumulate], this credits every citation-bearing namespace rather
-  /// than scoping to the ones a delta touched. That is safe because the turn is
-  /// seeded via [RagSnapshot.withEmptyRunScopedKeys]: a namespace the model did
-  /// not invoke arrives back with an empty `citations`, so it contributes
-  /// nothing. Merging (rather than replacing) is what keeps a turn spanning
-  /// several runs complete — `citation_index` is session-cumulative, so ids
-  /// from an earlier run still resolve.
+  /// than scoping to the ones a delta touched. That is safe because the
+  /// guarantee is turn-scoped: the turn's first run is seeded via
+  /// [RagSnapshot.withEmptyRunScopedKeys], and a continuation run inherits that
+  /// turn's own state, so a non-empty `citations` in any of the turn's
+  /// snapshots was populated during the turn. A namespace the model never
+  /// invoked arrives back empty and contributes nothing. Merging (rather than
+  /// replacing) is what keeps a turn spanning several runs complete —
+  /// `citation_index` is session-cumulative, so ids from an earlier run still
+  /// resolve.
   TurnCitations accumulateSnapshot(
     TurnCitations current,
     Map<String, dynamic> snapshot,
@@ -207,11 +211,12 @@ class CitationExtractor {
 }
 
 /// A turn's accumulated citations: the union of cited chunk [ids] and the
-/// union of inline [figures] observed across the turn's `StateDeltaEvent`s.
+/// union of inline [figures] observed across the turn's state events.
 ///
 /// Bundling the two keeps them in lockstep — the live orchestrator and the
-/// history replay both fold with [CitationExtractor.accumulate] and read back
-/// with [CitationExtractor.resolve], so they cannot drift. Immutable; [merge]
+/// history replay both fold with [CitationExtractor.accumulateSnapshot] or
+/// [CitationExtractor.accumulate] and read back with
+/// [CitationExtractor.resolve], so they cannot drift. Immutable; [merge]
 /// returns a new union.
 @immutable
 class TurnCitations {

--- a/packages/soliplex_client/lib/src/application/rag_snapshot.dart
+++ b/packages/soliplex_client/lib/src/application/rag_snapshot.dart
@@ -315,6 +315,7 @@ class RagSnapshot {
     Map<String, dynamic> state,
   ) {
     final result = Map<String, dynamic>.of(state);
+    final cleared = <String>[];
     for (final entry in state.entries) {
       final raw = entry.value;
       // Deliberately the same predicate `extractAll` uses, so the two cannot
@@ -322,13 +323,35 @@ class RagSnapshot {
       if (raw is! Map<String, dynamic> || raw[_citationIndexKey] is! Map) {
         continue;
       }
-      result[entry.key] = <String, dynamic>{
+      final keys = [
+        if (raw.containsKey(_citationsKey)) _citationsKey,
+        if (raw.containsKey(_searchesKey)) _searchesKey,
+        if (raw.containsKey(_executionsKey)) _executionsKey,
+      ];
+      final seeded = <String, dynamic>{
         ...raw,
         if (raw.containsKey(_citationsKey)) _citationsKey: <String>[],
         if (raw.containsKey(_searchesKey)) _searchesKey: <String, dynamic>{},
         if (raw.containsKey(_executionsKey)) _executionsKey: <dynamic>[],
       };
+      final filter = seeded[_ragDocumentFilterKey];
+      final index = raw[_citationIndexKey];
+      final filterNote = filter is String
+          ? '$_ragDocumentFilterKey: ${filter.length} chars'
+          : 'no $_ragDocumentFilterKey';
+      cleared.add(
+        '${entry.key}(cleared: ${keys.join(',')}; '
+        'kept $_citationIndexKey: ${index is Map ? index.length : 0} '
+        'entries; $filterNote)',
+      );
+      result[entry.key] = seeded;
     }
+    _logger.debug(
+      cleared.isEmpty
+          ? 'Seeded a run with no citation-bearing namespace to clear.'
+          : 'Seeded a run with run-scoped keys cleared: '
+              '${cleared.join(' ')}.',
+    );
     return result;
   }
 

--- a/packages/soliplex_client/lib/src/application/rag_snapshot.dart
+++ b/packages/soliplex_client/lib/src/application/rag_snapshot.dart
@@ -46,9 +46,9 @@ _PictureKey _pictureKey(String documentId, String ref) =>
 /// is selected later, when a citation's `pictureRefs` are resolved.
 ///
 /// The backend clears a `rag` state's `searches` — the only source of these
-/// bytes — at the start of every skill invocation, so the last invocation's
-/// state carries only its own figures. Accumulating a [CitedFigures] union
-/// across a turn's invocations preserves earlier invocations' figures. Bytes
+/// bytes — at the start of every run, so a run's state carries only its own
+/// figures. Accumulating a [CitedFigures] union across a turn's runs preserves
+/// earlier runs' figures. Bytes
 /// for a given `(documentId, ref)` are identity-stable, so [merge] is an
 /// unambiguous union (no precedence to resolve).
 @immutable
@@ -70,7 +70,7 @@ class CitedFigures {
   factory CitedFigures.fromSearches(Map<String, dynamic> ragBlock) {
     final bytes = <_PictureKey, String>{};
     final captions = <_PictureKey, String>{};
-    final raw = ragBlock['searches'];
+    final raw = ragBlock[RagSnapshot._searchesKey];
     if (raw is! Map) {
       if (raw != null) {
         _logger.warning(
@@ -184,7 +184,7 @@ class RagSnapshot {
   /// skipped so one bad entry does not take down the whole snapshot.
   factory RagSnapshot.fromJson(Map<String, dynamic> json) {
     final ids = <String>[];
-    final rawCitations = json['citations'];
+    final rawCitations = json[_citationsKey];
     if (rawCitations is List) {
       for (var i = 0; i < rawCitations.length; i++) {
         final entry = rawCitations[i];
@@ -251,6 +251,14 @@ class RagSnapshot {
   /// `id → Citation` map the extractor needs to render a source.
   static const _citationIndexKey = 'citation_index';
 
+  /// Wire keys the backend clears at the start of every run, so their contents
+  /// are scoped to a single run: the cited chunk ids, the retrieval results
+  /// their inline figures come from, and the analysis namespace's
+  /// code-execution log.
+  static const _citationsKey = 'citations';
+  static const _searchesKey = 'searches';
+  static const _executionsKey = 'executions';
+
   /// Every citation-bearing namespace block in a full agent-state map,
   /// identified by a [`_citationIndexKey`] map. Non-citation namespaces
   /// (e.g. `bubble-sandbox`) and non-Map or mistyped blocks are skipped,
@@ -287,12 +295,50 @@ class RagSnapshot {
     return snapshots;
   }
 
+  /// [state] with every citation-bearing namespace's run-scoped keys emptied.
+  ///
+  /// The cumulative `citation_index` and every other field (notably
+  /// `document_filter`) are preserved, and non-citation namespaces are copied
+  /// through untouched. Seeding a run with this guarantees that any namespace
+  /// carrying a non-empty `citations` in the run's terminal state snapshot
+  /// populated it during that run, which is what lets the extractor credit a
+  /// snapshot without knowing which capabilities the model actually invoked.
+  ///
+  /// Also keeps the request small: `searches` carries base64 figure bytes and
+  /// `executions` captured stdout, both of which the backend discards on
+  /// arrival.
+  ///
+  /// A key is only emptied when the namespace already carries it, mirroring the
+  /// backend's per-field lookup — `rag` has no `executions`, and inventing one
+  /// would make the outbound request misleading to read.
+  static Map<String, dynamic> withEmptyRunScopedKeys(
+    Map<String, dynamic> state,
+  ) {
+    final result = Map<String, dynamic>.of(state);
+    for (final entry in state.entries) {
+      final raw = entry.value;
+      // Deliberately the same predicate `extractAll` uses, so the two cannot
+      // drift on what counts as a citation-bearing block.
+      if (raw is! Map<String, dynamic> || raw[_citationIndexKey] is! Map) {
+        continue;
+      }
+      result[entry.key] = <String, dynamic>{
+        ...raw,
+        if (raw.containsKey(_citationsKey)) _citationsKey: <String>[],
+        if (raw.containsKey(_searchesKey)) _searchesKey: <String, dynamic>{},
+        if (raw.containsKey(_executionsKey)) _executionsKey: <dynamic>[],
+      };
+    }
+    return result;
+  }
+
   final List<String> _citationIds;
   final Map<String, Citation> _index;
   final CitedFigures _figures;
 
   /// Chunk ids of the citations present in the current state. The backend's
-  /// state lifecycle clears these at each invocation start.
+  /// state lifecycle clears these at the start of every run, so they are the
+  /// ids cited by the run this state came from.
   List<String> get citationIds => _citationIds;
 
   /// Resolves a chunk id to a full [Citation], or null if not present.

--- a/packages/soliplex_client/lib/src/application/rag_snapshot.dart
+++ b/packages/soliplex_client/lib/src/application/rag_snapshot.dart
@@ -10,7 +10,8 @@ final _logger = LogManager.instance.getLogger('soliplex_client.rag_snapshot');
 
 /// The AG-UI state namespace key for RAG state.
 ///
-/// Must match the backend's `STATE_NAMESPACE` in `haiku.rag.skills.rag`.
+/// Must match the backend's `STATE_NAMESPACE` in
+/// `haiku.rag.capabilities.rag`.
 const ragStateKey = 'rag';
 
 const String _ragDocumentFilterKey = 'document_filter';
@@ -48,9 +49,9 @@ _PictureKey _pictureKey(String documentId, String ref) =>
 /// The backend clears a `rag` state's `searches` — the only source of these
 /// bytes — at the start of every run, so a run's state carries only its own
 /// figures. Accumulating a [CitedFigures] union across a turn's runs preserves
-/// earlier runs' figures. Bytes
-/// for a given `(documentId, ref)` are identity-stable, so [merge] is an
-/// unambiguous union (no precedence to resolve).
+/// earlier runs' figures. Bytes for a given `(documentId, ref)` are
+/// identity-stable, so [merge] is an unambiguous union (no precedence to
+/// resolve).
 @immutable
 class CitedFigures {
   const CitedFigures._(this._bytes, this._captions);
@@ -161,9 +162,9 @@ class CitedFigures {
       _captions[_pictureKey(documentId, ref)];
 }
 
-/// A read-model view of a RAG skill's AG-UI state slice.
+/// A read-model view of a RAG capability's AG-UI state slice.
 ///
-/// Every RAG-producing skill publishes the same citation shape under its
+/// Every RAG-producing capability publishes the same citation shape under its
 /// own namespace — `rag` and `analysis` both carry `citations` as a list
 /// of chunk ids and a `citation_index` map resolving each id to a full
 /// [Citation]. This snapshot exposes only what citation extraction and
@@ -247,17 +248,27 @@ class RagSnapshot {
     return RagSnapshot._(ids, index, CitedFigures.fromSearches(json));
   }
 
-  /// Wire key marking a citation-bearing skill-state block: the
+  /// Wire key marking a citation-bearing capability-state block: the
   /// `id → Citation` map the extractor needs to render a source.
   static const _citationIndexKey = 'citation_index';
 
-  /// Wire keys the backend clears at the start of every run, so their contents
-  /// are scoped to a single run: the cited chunk ids, the retrieval results
-  /// their inline figures come from, and the analysis namespace's
-  /// code-execution log.
+  /// Wire keys the backend clears at the start of every run in which the
+  /// owning capability loads, so their contents are scoped to a single run: the
+  /// cited chunk ids, the retrieval results their inline figures come from, and
+  /// the analysis namespace's code-execution log. A capability that never loads
+  /// never clears, which is why a run is seeded via [withEmptyRunScopedKeys]
+  /// rather than trusting the backend to have cleared.
   static const _citationsKey = 'citations';
   static const _searchesKey = 'searches';
   static const _executionsKey = 'executions';
+
+  /// Whether [raw] is a citation-bearing namespace block — the single predicate
+  /// [extractAll] and [withEmptyRunScopedKeys] share, so what one extracts from
+  /// and what the other clears cannot drift apart. Drift is silent in both
+  /// directions: clearing less than is extracted over-credits stale citations,
+  /// clearing more loses live ones.
+  static bool _isCitationBearing(Object? raw) =>
+      raw is Map<String, dynamic> && raw[_citationIndexKey] is Map;
 
   /// Every citation-bearing namespace block in a full agent-state map,
   /// identified by a [`_citationIndexKey`] map. Non-citation namespaces
@@ -279,11 +290,9 @@ class RagSnapshot {
     for (final entry in state.entries) {
       if (namespaces != null && !namespaces.contains(entry.key)) continue;
       final raw = entry.value;
-      if (raw is! Map<String, dynamic> || raw[_citationIndexKey] is! Map) {
-        continue;
-      }
+      if (!_isCitationBearing(raw)) continue;
       try {
-        snapshots.add(RagSnapshot.fromJson(raw));
+        snapshots.add(RagSnapshot.fromJson(raw as Map<String, dynamic>));
       } on Object catch (error, stackTrace) {
         _logger.warning(
           'RagSnapshot: skipping a citation namespace that failed to parse.',
@@ -318,11 +327,8 @@ class RagSnapshot {
     final cleared = <String>[];
     for (final entry in state.entries) {
       final raw = entry.value;
-      // Deliberately the same predicate `extractAll` uses, so the two cannot
-      // drift on what counts as a citation-bearing block.
-      if (raw is! Map<String, dynamic> || raw[_citationIndexKey] is! Map) {
-        continue;
-      }
+      if (!_isCitationBearing(raw)) continue;
+      raw as Map<String, dynamic>;
       final keys = [
         if (raw.containsKey(_citationsKey)) _citationsKey,
         if (raw.containsKey(_searchesKey)) _searchesKey,
@@ -359,9 +365,10 @@ class RagSnapshot {
   final Map<String, Citation> _index;
   final CitedFigures _figures;
 
-  /// Chunk ids of the citations present in the current state. The backend's
-  /// state lifecycle clears these at the start of every run, so they are the
-  /// ids cited by the run this state came from.
+  /// Chunk ids of the citations present in the current state. These are
+  /// run-scoped: for a state that was seeded via [withEmptyRunScopedKeys] or
+  /// produced by a capability that loaded, they are the ids cited by the run
+  /// this state came from.
   List<String> get citationIds => _citationIds;
 
   /// Resolves a chunk id to a full [Citation], or null if not present.

--- a/packages/soliplex_client/test/api/soliplex_api_test.dart
+++ b/packages/soliplex_client/test/api/soliplex_api_test.dart
@@ -4335,8 +4335,91 @@ void main() {
               },
             };
 
-        test('run 2 (analysis only) does not inherit run 1 rag citations',
-            () async {
+        test(
+            'resolves citations from a run whose only state event is a '
+            'terminal snapshot', () async {
+          // How the backend records a run now: no deltas, one STATE_SNAPSHOT
+          // just before RUN_FINISHED carrying the run's cited set.
+          stubGet('thread-456', {
+            'room_id': 'room-123',
+            'thread_id': 'thread-456',
+            'runs': {
+              'run-1': {
+                'run_id': 'run-1',
+                'created': '2026-01-07T01:00:00.000Z',
+                'finished': '2026-01-07T01:01:00.000Z',
+              },
+            },
+          });
+          stubGet('thread-456/run-1', {
+            'run_id': 'run-1',
+            'run_input': {
+              'messages': [
+                {'id': 'user-1', 'role': 'user', 'content': 'Q1'},
+              ],
+            },
+            'events': [
+              {
+                'type': 'TEXT_MESSAGE_START',
+                'messageId': 'asst-1',
+                'role': 'assistant',
+              },
+              {
+                'type': 'TEXT_MESSAGE_CONTENT',
+                'messageId': 'asst-1',
+                'delta': 'Answer',
+              },
+              {'type': 'TEXT_MESSAGE_END', 'messageId': 'asst-1'},
+              {
+                'type': 'STATE_SNAPSHOT',
+                'snapshot': {
+                  'rag': {
+                    'citation_index': {
+                      'chunk-1': {
+                        'document_id': 'doc-1',
+                        'chunk_id': 'chunk-1',
+                        'document_uri': 'file:///doc1.pdf',
+                        'content': 'Citation 1',
+                      },
+                    },
+                    'citations': ['chunk-1'],
+                  },
+                },
+              },
+              {
+                'type': 'RUN_FINISHED',
+                'thread_id': 'thread-456',
+                'run_id': 'run-1',
+              },
+            ],
+          });
+
+          final history = await api.getThreadHistory('room-123', 'thread-456');
+
+          expect(
+            history.messageStates['user-1']!.sourceReferences
+                .map((r) => r.chunkId),
+            ['chunk-1'],
+          );
+        });
+
+        test(
+            'over-credits a deferred namespace replaying a thread recorded '
+            'before the seed was cleared', () async {
+          // An accepted limitation, pinned so it cannot change unnoticed.
+          //
+          // A live turn seeds the run-scoped keys empty, so a namespace the
+          // model never invoked comes back with an empty `citations` and is
+          // credited nothing. A thread recorded before that seeding cannot be
+          // repaired on replay: its stored rebase snapshot really does echo a
+          // prior run's `citations`, and nothing in the record distinguishes
+          // that echo from a genuine retrieval. So run 2 here reports run 1's
+          // chunk-1 alongside its own chunk-2.
+          //
+          // Only multi-capability rooms are affected — the backend defers
+          // capability loading solely when a room routes more than one, and a
+          // deferred capability that is never invoked never clears. The cost is
+          // one extra stale source on a historical turn.
           stubGet('thread-456', twoRunThread());
           // Run 1: the rag skill cites chunk-1.
           stubGet('thread-456/run-1', {
@@ -4374,9 +4457,8 @@ void main() {
               },
             ],
           });
-          // Run 2: only the analysis skill runs (cites chunk-2). The rebase
-          // snapshot round-trips run 1's rag block (citations=[chunk-1]), which
-          // run 2 never touches — so chunk-1 must not be attributed to run 2.
+          // Run 2: only the analysis skill runs (cites chunk-2). The stored
+          // rebase snapshot still carries run 1's rag block.
           stubGet('thread-456/run-2', {
             'run_id': 'run-2',
             'run_input': {
@@ -4400,6 +4482,119 @@ void main() {
                       },
                     },
                     'citations': ['chunk-1'],
+                  },
+                },
+              },
+              {
+                'type': 'STATE_DELTA',
+                'delta': [
+                  {
+                    'op': 'add',
+                    'path': '/analysis',
+                    'value': {
+                      'citation_index': {
+                        'chunk-2': {
+                          'document_id': 'doc-2',
+                          'chunk_id': 'chunk-2',
+                          'document_uri': 'file:///doc2.pdf',
+                          'content': 'Citation 2',
+                        },
+                      },
+                      'citations': ['chunk-2'],
+                    },
+                  },
+                ],
+              },
+              {
+                'type': 'RUN_FINISHED',
+                'thread_id': 'thread-456',
+                'run_id': 'run-2',
+              },
+            ],
+          });
+
+          final history = await api.getThreadHistory('room-123', 'thread-456');
+
+          expect(
+            history.messageStates['user-1']!.sourceReferences
+                .map((r) => r.chunkId),
+            ['chunk-1'],
+          );
+          expect(
+            history.messageStates['user-2']!.sourceReferences
+                .map((r) => r.chunkId),
+            ['chunk-1', 'chunk-2'],
+          );
+        });
+
+        test('run 2 (analysis only) does not inherit run 1 rag citations',
+            () async {
+          // The same two-capability thread as above, recorded with the
+          // run-scoped keys seeded empty: rag's block comes back carrying its
+          // cumulative index but no citations, so run 2 credits only analysis.
+          stubGet('thread-456', twoRunThread());
+          // Run 1: the rag skill cites chunk-1.
+          stubGet('thread-456/run-1', {
+            'run_id': 'run-1',
+            'run_input': {
+              'messages': [
+                {'id': 'user-1', 'role': 'user', 'content': 'Q1'},
+              ],
+            },
+            'events': [
+              {
+                'type': 'STATE_DELTA',
+                'delta': [
+                  {
+                    'op': 'add',
+                    'path': '/rag',
+                    'value': {
+                      'citation_index': {
+                        'chunk-1': {
+                          'document_id': 'doc-1',
+                          'chunk_id': 'chunk-1',
+                          'document_uri': 'file:///doc1.pdf',
+                          'content': 'Citation 1',
+                        },
+                      },
+                      'citations': ['chunk-1'],
+                    },
+                  },
+                ],
+              },
+              {
+                'type': 'RUN_FINISHED',
+                'thread_id': 'thread-456',
+                'run_id': 'run-1',
+              },
+            ],
+          });
+          // Run 2: only the analysis skill runs (cites chunk-2). The snapshot
+          // carries rag's cumulative index but no citations, so chunk-1 must
+          // not be attributed to run 2.
+          stubGet('thread-456/run-2', {
+            'run_id': 'run-2',
+            'run_input': {
+              'messages': [
+                {'id': 'user-1', 'role': 'user', 'content': 'Q1'},
+                {'id': 'asst-1', 'role': 'assistant', 'content': 'A1'},
+                {'id': 'user-2', 'role': 'user', 'content': 'Q2'},
+              ],
+            },
+            'events': [
+              {
+                'type': 'STATE_SNAPSHOT',
+                'snapshot': {
+                  'rag': {
+                    'citation_index': {
+                      'chunk-1': {
+                        'document_id': 'doc-1',
+                        'chunk_id': 'chunk-1',
+                        'document_uri': 'file:///doc1.pdf',
+                        'content': 'Citation 1',
+                      },
+                    },
+                    'citations': <String>[],
                   },
                 },
               },

--- a/packages/soliplex_client/test/api/soliplex_api_test.dart
+++ b/packages/soliplex_client/test/api/soliplex_api_test.dart
@@ -4527,7 +4527,7 @@ void main() {
           );
         });
 
-        test('run 2 (analysis only) does not inherit run 1 rag citations',
+        test('credits nothing for a namespace whose citations came back empty',
             () async {
           // The same two-capability thread as above, recorded with the
           // run-scoped keys seeded empty: rag's block comes back carrying its

--- a/packages/soliplex_client/test/application/citation_extractor_test.dart
+++ b/packages/soliplex_client/test/application/citation_extractor_test.dart
@@ -397,6 +397,53 @@ void main() {
       });
     });
 
+    group('accumulateSnapshot', () {
+      Map<String, dynamic> citation(String chunkId) => {
+            'chunk_id': chunkId,
+            'content': 'content for $chunkId',
+            'document_id': 'doc-1',
+            'document_uri': 'https://example.com/doc.pdf',
+          };
+
+      /// A citation-bearing namespace block whose cumulative [indexed] index
+      /// resolves every id, and whose run-scoped `citations` is [cited].
+      Map<String, dynamic> block({
+        required List<String> indexed,
+        required List<String> cited,
+      }) =>
+          {
+            'citation_index': {for (final id in indexed) id: citation(id)},
+            'citations': cited,
+          };
+
+      test("unions cited ids across a turn's runs", () {
+        var turn = const TurnCitations.empty();
+
+        turn = extractor.accumulateSnapshot(turn, {
+          'rag': block(indexed: const ['a'], cited: const ['a']),
+        });
+        // The next run's snapshot carries only its own `citations`, while
+        // `citation_index` keeps growing — merging is what keeps 'a'.
+        turn = extractor.accumulateSnapshot(turn, {
+          'rag': block(indexed: const ['a', 'b'], cited: const ['b']),
+        });
+
+        expect(turn.ids, {'a', 'b'});
+      });
+
+      test('credits nothing for a namespace with an empty citations list', () {
+        // The over-crediting guard: a deferred capability the model never
+        // invoked echoes back the seed, which was cleared, so its stale index
+        // entries must not be credited to this turn.
+        final turn = extractor.accumulateSnapshot(const TurnCitations.empty(), {
+          'rag': block(indexed: const ['a'], cited: const ['a']),
+          'analysis': block(indexed: const ['stale'], cited: const []),
+        });
+
+        expect(turn.ids, {'a'});
+      });
+    });
+
     group('resolve', () {
       Map<String, dynamic> citation(String chunkId) => {
             'chunk_id': chunkId,

--- a/packages/soliplex_client/test/application/citation_extractor_test.dart
+++ b/packages/soliplex_client/test/application/citation_extractor_test.dart
@@ -1,3 +1,5 @@
+import 'dart:convert';
+
 import 'package:ag_ui/ag_ui.dart';
 import 'package:soliplex_client/src/application/citation_extractor.dart';
 import 'package:soliplex_client/src/application/rag_snapshot.dart';
@@ -429,6 +431,39 @@ void main() {
         });
 
         expect(turn.ids, {'a', 'b'});
+      });
+
+      test("carries a snapshot's inline figure bytes into the turn", () {
+        // The snapshot is the carrier for figure bytes as well as ids, and
+        // `searches` is the only source of them. Crediting the ids while
+        // dropping the figures renders a citation with its text intact and its
+        // image missing — no error, nothing logged.
+        final turn = extractor.accumulateSnapshot(const TurnCitations.empty(), {
+          'rag': {
+            'citation_index': {
+              'a': {
+                ...citation('a'),
+                'picture_refs': ['#/pictures/0'],
+              },
+            },
+            'citations': ['a'],
+            'searches': {
+              'q': [
+                {
+                  'content': 'row',
+                  'document_id': 'doc-1',
+                  'image_data': {'#/pictures/0': 'aGVsbG8='},
+                },
+              ],
+            },
+          },
+        });
+
+        expect(turn.ids, {'a'});
+        expect(
+          turn.figures.pictureBytes('doc-1', '#/pictures/0'),
+          base64Decode('aGVsbG8='),
+        );
       });
 
       test('credits nothing for a namespace with an empty citations list', () {

--- a/packages/soliplex_client/test/application/rag_snapshot_test.dart
+++ b/packages/soliplex_client/test/application/rag_snapshot_test.dart
@@ -142,6 +142,62 @@ void main() {
     });
   });
 
+  group('withEmptyRunScopedKeys', () {
+    test('empties the run-scoped keys, preserves the cumulative index', () {
+      final cleared = RagSnapshot.withEmptyRunScopedKeys({
+        'analysis': {
+          'citation_index': {'a': <String, dynamic>{}},
+          'citations': ['a'],
+          'searches': {'q': <dynamic>[]},
+          'executions': [
+            {'code': 'print(1)', 'stdout': '1'},
+          ],
+          'document_filter': 'id IN (1)',
+        },
+      });
+
+      final analysis = cleared['analysis'] as Map<String, dynamic>;
+      expect(analysis['citations'], isEmpty);
+      expect(analysis['searches'], isEmpty);
+      expect(analysis['executions'], isEmpty);
+      expect(analysis['citation_index'], equals({'a': <String, dynamic>{}}));
+      expect(analysis['document_filter'], equals('id IN (1)'));
+    });
+
+    test('leaves non-citation namespaces untouched', () {
+      final cleared = RagSnapshot.withEmptyRunScopedKeys({
+        'bubble-sandbox': {'anything': 1},
+      });
+      expect(cleared['bubble-sandbox'], equals({'anything': 1}));
+    });
+
+    test('does not add a key the namespace does not carry', () {
+      // `rag` has no `executions`; inventing one makes the outbound
+      // run_input.state misleading to read in the network inspector.
+      final cleared = RagSnapshot.withEmptyRunScopedKeys({
+        'rag': {
+          'citation_index': <String, dynamic>{},
+          'citations': ['a'],
+        },
+      });
+      expect(
+        (cleared['rag'] as Map<String, dynamic>).keys,
+        equals(['citation_index', 'citations']),
+      );
+    });
+
+    test('does not mutate the input', () {
+      final original = <String, dynamic>{
+        'rag': {
+          'citation_index': <String, dynamic>{},
+          'citations': ['a'],
+        },
+      };
+      RagSnapshot.withEmptyRunScopedKeys(original);
+      expect((original['rag'] as Map)['citations'], equals(['a']));
+    });
+  });
+
   group('buildRagDocumentFilterOverlay', () {
     test('wraps a filter string under rag.document_filter', () {
       final overlay = buildRagDocumentFilterOverlay("id = 'abc'");

--- a/packages/soliplex_client/test/application/rag_snapshot_test.dart
+++ b/packages/soliplex_client/test/application/rag_snapshot_test.dart
@@ -165,10 +165,22 @@ void main() {
     });
 
     test('leaves non-citation namespaces untouched', () {
+      // A namespace without a `citation_index` is not citation-bearing, so it
+      // is copied through whole — even when it happens to carry a key name the
+      // run-scoped clear would otherwise empty.
       final cleared = RagSnapshot.withEmptyRunScopedKeys({
-        'bubble-sandbox': {'anything': 1},
+        'bubble-sandbox': {
+          'anything': 1,
+          'citations': ['not-a-citation'],
+        },
       });
-      expect(cleared['bubble-sandbox'], equals({'anything': 1}));
+      expect(
+        cleared['bubble-sandbox'],
+        equals({
+          'anything': 1,
+          'citations': ['not-a-citation'],
+        }),
+      );
     });
 
     test('does not add a key the namespace does not carry', () {


### PR DESCRIPTION
Sources currently render as **zero on every run**, live and on reload, with nothing logged. This restores them.

PR **A** of four for the backend capability migration, and the only P0. Independent of B–D; nothing needs rebasing on it.

## Root cause

The backend replaced its per-invocation `StateDeltaEvent` stream with a single terminal `StateSnapshotEvent` emitted immediately before `RUN_FINISHED` (`views/agui.py:672` is the only emitter, and `STATE_SNAPSHOT` carries no `delta` so `compact_event_stream` passes it through untouched). Both frontend accumulation sites were gated on `event is StateDeltaEvent`, so `TurnCitations` stayed empty and `resolve` returned `[]`.

## Approach

Clear the run-scoped keys (`citations`, `searches`, `executions`) in the state we *seed* at turn start, so any namespace carrying a non-empty `citations` in the terminal snapshot definitionally populated it during that run. Then accumulate the whole snapshot at both call sites. No namespace diffing, no backend dependency.

That seeding is the load-bearing half: it is what makes crediting a snapshot *unscoped* sound, because a capability the model never invoked arrives back empty. It also shrinks every request — `searches` carries base64 figure bytes and `executions` captured stdout, and neither is read back.

**The delta path is kept deliberately.** The run-feedback tool still emits a state delta, and threads recorded before the backend change replay as deltas. Deleting it would lose sources on every old thread.

## Verified against a live backend

| Claim | Evidence |
| --- | --- |
| Seed clears the run-scoped keys | `rag(cleared: citations,searches)` and `analysis(cleared: citations,searches,executions)` in one two-capability room |
| `rag` has no `executions`, `analysis` does | the two namespaces cleared different key sets in the same request |
| `citation_index` survives seeding | `kept citation_index: N entries`, growing across turns |
| `document_filter` survives seeding | preserved through the clear |
| One `STATE_SNAPSHOT` per run, before `RUN_FINISHED` | one accumulation per run |
| Sources render live and survive reopen | live `0 → N`; replay resolved 1, 2 and 4 sources |
| Figures render | 3 of 3 sources with figures live, and on replay |
| Extraction is namespace-agnostic | an `analysis`-only room resolved citations and figures with no `rag` present |

## Not verified on the wire, and why

**The cross-run figure merge.** A turn spans two runs only when the model calls a client-side tool, and `lib/src/flavors/standard_kit.dart:123` resolves `const ToolRegistry()` for every room — so `run_input.tools` is always empty and the path is unreachable in the standard flavor. It matters for hosts that register their own tools. Covered by `keeps both runs' figures across a snapshot-carried tool resume`, which asserts decoded bytes so crediting the wrong run's figure also fails.

**The strong form of the over-crediting guard.** `analysis` was never observed holding a populated stale index while uninvoked. The weak form did occur and behaved correctly.

## Known limitation

Replaying a thread recorded *before* this change, in a room routing more than one retrieval capability, can show stale sources on a turn whose namespace was never invoked: the stored snapshot genuinely echoes a prior run's `citations`, and nothing in the record distinguishes that echo from a retrieval. Not repairable on replay. Pinned by a test of its own rather than left to be rediscovered, and noted in the CHANGELOG. Single-capability rooms are unaffected.

## Review notes

Every guard in the final commit is mutation-verified — each was confirmed to fail when the behaviour it protects is broken, including two paths the suite previously could not distinguish from working code:

- deleting the seed call passed 191 orchestrator + 568 client tests
- dropping a snapshot's figures passed every `soliplex_client` test

One test was deleted rather than repaired (`keeps a chunk re-cited from the cumulative index`): seeding `citations` empty removes the subtraction hazard it guarded, leaving a test no mutation distinguished from its neighbour.

The last commit is comments, logging and tests only — no behavioural change.

Filed separately while verifying, not fixed here: #483 (document filter builds an exact `id` match while the backend's own builder is a fuzzy `uri`/`title` match, and `buildRagDocumentFilterOverlay` is dead while `room_screen.dart:912` hardcodes the wire keys).

## Checks

`flutter analyze` clean · `dart format --set-exit-if-changed` clean · `soliplex_agent` 191 · `soliplex_client` 569 · app 2182 · markdownlint clean · CHANGELOG updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)