### PR TITLE
fix: send chunk visualization expand explicitly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,16 @@ Versions follow the `version+build` scheme from `pubspec.yaml`, bumped via
   distinguishes that echo from a genuine retrieval, so a turn whose namespace
   was never invoked can show the stale sources that namespace last cited. Rooms
   with a single retrieval capability are unaffected.
+- Chunk previews no longer inherit a server-side default. `expand` was declared
+  `true` on `getChunkVisualization` but only transmitted when it was `false`, so
+  the default path sent no parameter at all and took whatever the server picked
+  — a default that has since flipped to `false`. The client now always transmits
+  the value and declares `false`, so the value on the wire is the value applied
+  and it agrees with the backend rather than depending on it. `expand` has an
+  effect only when no doc item refs are supplied, which is exactly the bare
+  chunk-id preview in room info; that preview highlights the chunk itself rather
+  than re-expanding the section around it. Previews opened from a citation
+  supply refs and are unaffected.
 
 ## [0.98.0+76] - 2026-07-30
 

--- a/packages/soliplex_client/lib/src/api/soliplex_api.dart
+++ b/packages/soliplex_client/lib/src/api/soliplex_api.dart
@@ -1438,6 +1438,11 @@ class SoliplexApi {
   /// Parameters:
   /// - [roomId]: The room ID (must not be empty)
   /// - [chunkId]: The chunk ID (must not be empty)
+  /// - [refs]: Doc item refs to highlight. When supplied, the server highlights
+  ///   exactly these items and [expand] has no effect.
+  /// - [expand]: Whether the server widens the highlight from the chunk to the
+  ///   section containing it, yielding more page images. Ignored when [refs] is
+  ///   supplied. Always transmitted, so the value here is the value applied.
   ///
   /// Returns [ChunkVisualization] containing base64-encoded page images.
   ///
@@ -1452,18 +1457,15 @@ class SoliplexApi {
     String roomId,
     String chunkId, {
     List<String>? refs,
-    bool expand = true,
+    bool expand = false,
     CancelToken? cancelToken,
   }) async {
     _requireNonEmpty(roomId, 'roomId');
     _requireNonEmpty(chunkId, 'chunkId');
 
-    final queryParameters = <String, String>{};
+    final queryParameters = <String, String>{'expand': '$expand'};
     if (refs != null && refs.isNotEmpty) {
       queryParameters['refs'] = jsonEncode(refs);
-    }
-    if (!expand) {
-      queryParameters['expand'] = 'false';
     }
 
     return _transport.request<ChunkVisualization>(

--- a/packages/soliplex_client/test/api/soliplex_api_test.dart
+++ b/packages/soliplex_client/test/api/soliplex_api_test.dart
@@ -5717,6 +5717,54 @@ void main() {
       });
     });
 
+    group('getChunkVisualization query parameters', () {
+      late Uri? capturedUri;
+
+      setUp(() {
+        capturedUri = null;
+        when(
+          () => mockTransport.request<ChunkVisualization>(
+            'GET',
+            any(),
+            cancelToken: any(named: 'cancelToken'),
+            fromJson: any(named: 'fromJson'),
+            body: any(named: 'body'),
+            headers: any(named: 'headers'),
+            timeout: any(named: 'timeout'),
+          ),
+        ).thenAnswer((invocation) async {
+          capturedUri = invocation.positionalArguments[1] as Uri;
+          return ChunkVisualization(
+            chunkId: 'chunk-1',
+            documentUri: null,
+            imagesBase64: const [],
+          );
+        });
+      });
+
+      test('always sends expand', () async {
+        await api.getChunkVisualization('room-1', 'chunk-1');
+
+        expect(capturedUri?.queryParameters['expand'], equals('false'));
+      });
+
+      test('sends expand=true when asked', () async {
+        await api.getChunkVisualization('room-1', 'chunk-1', expand: true);
+
+        expect(capturedUri?.queryParameters['expand'], equals('true'));
+      });
+
+      test('json-encodes refs when supplied', () async {
+        await api.getChunkVisualization(
+          'room-1',
+          'chunk-1',
+          refs: const ['#/x/0'],
+        );
+
+        expect(capturedUri?.queryParameters['refs'], equals('["#/x/0"]'));
+      });
+    });
+
     // ============================================================
     // Installation Info
     // ============================================================


### PR DESCRIPTION
PR B of the backend capability migration. Stops the frontend depending on a
server-side default that changed.

## Problem

`SoliplexApi.getChunkVisualization` declared `bool expand = true` but only put
the parameter on the query string when it was `false`:

```dart
if (!expand) {
  queryParameters['expand'] = 'false';
}
```

So the default path transmitted nothing and inherited whatever the server chose.
The backend flipped its own default from `True` to `False` in `e375d3ce` (#1163),
which left the Dart signature advertising behaviour the wire did not deliver.

## Fix

Always transmit the parameter, and declare `false` so the signature matches the
backend rather than depending on it. The parameter stays, so a caller that wants
re-expansion can still ask.

`expand` has an effect only when `refs` is absent — with refs the backend
highlights exactly the cited doc items instead of re-expanding. That scopes this
to exactly one surface: the bare chunk-id preview in room info (`ChunkLookupCard`).
Previews opened from a citation supply refs and are unaffected.

**No observable change against a current backend.** The old code sent no
`expand`, so the server's `False` default already applied; this makes the wire
explicit.

## Verification

Measured against a live backend, 22 real citations from a figure-bearing PDF:

| Mode | Total page images | Matches citation page count |
| ---- | ----------------- | --------------------------- |
| citation path (refs supplied) | 40 | — |
| `expand=true` | 40 | 22/22 |
| `expand=false` (shipping) | 24 | 13/22 |

Worth recording, because it inverts an assumption in the planning notes:
re-expansion is what *agrees* with the grounded citation, since a citation's
`doc_item_refs` span roughly the chunk's expanded section. `expand=false`
highlights the bare chunk and returns fewer pages. That is not an argument
against this change — matching the backend is — but the "collapses the
divergence" rationale does not hold and is deliberately absent from the
CHANGELOG.

The page-count assertion that `ChunkVisualizationPage` once tripped no longer
exists: the widget has zero `assert`s, `_pageLabel` degrades to `"Image N of M"`
on a mismatch, and the affected entry point passes `pageNumbers: const []`, so
the mismatch is unreachable there.

- `soliplex_client`: 1619 passed (4 pre-existing network-dependent failures in
  `stream_cancel_behavior_test.dart`, unrelated)
- Root Flutter suite: 2182 passed
- `flutter analyze`: clean; `dart format --set-exit-if-changed`: clean

`soliplex_agent` has no caller of this method, so it is untouched.

## Tests

Three assertions on the query string: `expand` is always sent, `expand: true` is
honoured when asked, and `refs` is JSON-encoded (the only test pinning that
encoding, added because this method's query building is being changed).

## Backend follow-up

`views/rooms.py:230` is `expand: bool = False`, but the docstring at lines
241-242 still reads "``expand`` (default true)". Prose only; for the backend team.

🤖 Generated with [Claude Code](https://claude.com/claude-code)