### PR TITLE
fix: source execution timeline detail from tool call events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,22 +53,23 @@ Versions follow the `version+build` scheme from `pubspec.yaml`, bumped via
   takes no arguments yields no block rather than an empty one, and while a call
   is still streaming its arguments are a JSON prefix, which renders as-is rather
   than being withheld until it parses. The result body is included because it is
-  the only place a tool's failure message reaches the user at all: AG-UI has no
-  way to express a failed outcome, so a search that hit its limit or a code
-  execution that raised returns its message through the ordinary result field,
-  indistinguishable from success. Both blocks clamp to eight lines with a
-  show-more control, since a retrieval result runs to tens of thousands of
-  characters and would otherwise bury every row after it; the control appears
+  the only place in the chat UI a tool's failure message reaches the user at
+  all: AG-UI has no way to express a failed outcome, so a search that hit its
+  limit or a code execution that raised returns its message through the ordinary
+  result field, indistinguishable from success. Both blocks clamp to eight lines
+  with a show-more control, since a retrieval result runs to tens of thousands
+  of characters and would otherwise bury every row after it; the control appears
   only when the body is measured — at the text scale it will render at — to
   overflow, and copying still takes the whole body.
 - A tool call's result and its completion tick now settle on the same row. Both
   are addressed by tool-call id, where completion previously settled whichever
   step started most recently; a toolset that does not declare itself sequential
-  can overlap calls, which put one call's result on its own row and its check
-  mark on another's, leaving the first row running forever. A run that finishes
-  having opened a call whose result never arrived now says so, which is the
-  reporting gap that let the timeline's detail rows sit empty unnoticed in the
-  first place.
+  can overlap calls, so one call's result arriving would put a check mark and an
+  elapsed time on a sibling call's row that was still running. A result for a
+  call the timeline never opened now settles nothing at all, rather than
+  crediting whichever row happened to be last. A run that finishes having opened
+  a call whose result never arrived logs it, so detail lost in transit is not
+  silent.
 
 ## [0.98.0+76] - 2026-07-30
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,26 @@ Versions follow the `version+build` scheme from `pubspec.yaml`, bumped via
   chunk-id preview in room info; that preview highlights the chunk itself rather
   than re-expanding the section around it. Previews opened from a citation
   supply refs and are unaffected.
+- The execution timeline carries a tool call's arguments and result again. The
+  nested detail rows were fed by `skill_tool_call` / `skill_tool_result`
+  `ACTIVITY_SNAPSHOT` events emitted by the sub-agent runtime the backend
+  replaced; nothing constructs one any more, so every nested row rendered blank
+  and the timeline was a flat list of names. Retrievals now arrive as ordinary
+  tool calls, so the detail comes from `TOOL_CALL_ARGS` and `TOOL_CALL_RESULT`
+  and expands from the step row that already represents that call — one row per
+  call rather than a row nested beneath itself, because the two-level call tree
+  the nesting mirrored no longer exists. Arguments display the field carrying
+  the intent when there is one (a query, executed code, a script, a shell
+  command) and the whole object otherwise; while the call is still streaming its
+  arguments are a JSON prefix, which renders as-is rather than being withheld
+  until it parses. The result body is included because it is the only place a
+  tool's failure message reaches the user at all: AG-UI has no way to express a
+  failed outcome, so a search that hit its limit or a code execution that raised
+  returns its message through the ordinary result field, indistinguishable from
+  success. Both blocks clamp to eight lines with a show-more control, since a
+  retrieval result runs to tens of thousands of characters and would otherwise
+  bury every row after it; the control appears only when the body is measured to
+  overflow, and copying still takes the whole body.
 
 ## [0.98.0+76] - 2026-07-30
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,23 +42,33 @@ Versions follow the `version+build` scheme from `pubspec.yaml`, bumped via
 - The execution timeline carries a tool call's arguments and result again. The
   nested detail rows were fed by `skill_tool_call` / `skill_tool_result`
   `ACTIVITY_SNAPSHOT` events emitted by the sub-agent runtime the backend
-  replaced; nothing constructs one any more, so every nested row rendered blank
-  and the timeline was a flat list of names. Retrievals now arrive as ordinary
-  tool calls, so the detail comes from `TOOL_CALL_ARGS` and `TOOL_CALL_RESULT`
-  and expands from the step row that already represents that call — one row per
-  call rather than a row nested beneath itself, because the two-level call tree
-  the nesting mirrored no longer exists. Arguments display the field carrying
-  the intent when there is one (a query, executed code, a script, a shell
-  command) and the whole object otherwise; while the call is still streaming its
-  arguments are a JSON prefix, which renders as-is rather than being withheld
-  until it parses. The result body is included because it is the only place a
-  tool's failure message reaches the user at all: AG-UI has no way to express a
-  failed outcome, so a search that hit its limit or a code execution that raised
-  returns its message through the ordinary result field, indistinguishable from
-  success. Both blocks clamp to eight lines with a show-more control, since a
-  retrieval result runs to tens of thousands of characters and would otherwise
-  bury every row after it; the control appears only when the body is measured to
+  replaced; nothing constructs one any more, so no nested row was produced at
+  all and the timeline was a flat list of tool names. Retrievals now arrive as
+  ordinary tool calls, so the detail comes from `TOOL_CALL_ARGS` and
+  `TOOL_CALL_RESULT` and expands from the step row that already represents that
+  call — one row per call rather than a row nested beneath itself, because the
+  two-level call tree the nesting mirrored no longer exists. Arguments display
+  the field carrying the intent when there is one (a script, executed code, a
+  search query, a shell command) and the whole object otherwise; a tool that
+  takes no arguments yields no block rather than an empty one, and while a call
+  is still streaming its arguments are a JSON prefix, which renders as-is rather
+  than being withheld until it parses. The result body is included because it is
+  the only place a tool's failure message reaches the user at all: AG-UI has no
+  way to express a failed outcome, so a search that hit its limit or a code
+  execution that raised returns its message through the ordinary result field,
+  indistinguishable from success. Both blocks clamp to eight lines with a
+  show-more control, since a retrieval result runs to tens of thousands of
+  characters and would otherwise bury every row after it; the control appears
+  only when the body is measured — at the text scale it will render at — to
   overflow, and copying still takes the whole body.
+- A tool call's result and its completion tick now settle on the same row. Both
+  are addressed by tool-call id, where completion previously settled whichever
+  step started most recently; a toolset that does not declare itself sequential
+  can overlap calls, which put one call's result on its own row and its check
+  mark on another's, leaving the first row running forever. A run that finishes
+  having opened a call whose result never arrived now says so, which is the
+  reporting gap that let the timeline's detail rows sit empty unnoticed in the
+  first place.
 
 ## [0.98.0+76] - 2026-07-30
 

--- a/lib/src/modules/room/execution_tracker.dart
+++ b/lib/src/modules/room/execution_tracker.dart
@@ -60,6 +60,9 @@ class ExecutionTracker {
   /// call's delta stream logs once rather than per delta.
   final Set<String> _loggedUnmatchedCalls = <String>{};
 
+  /// Tool call ids already reported as finishing a run without a result.
+  final Set<String> _reportedMissingResults = <String>{};
+
   final Stopwatch _stopwatch = Stopwatch();
   void Function()? _unsub;
   void Function()? _activitiesUnsub;
@@ -246,15 +249,17 @@ class ExecutionTracker {
   /// because it was dropped or the stream resumed mid-call — has nowhere to go
   /// and is discarded with a one-time warning.
   void _appendCallArgs(String toolCallId, String delta) {
-    final entry = _findCall(toolCallId);
-    if (entry == null) {
-      // `_processToolCallArgs` logs the same condition at the client layer on
-      // both the live and replay paths, so this arm need not repeat it for a
-      // reloaded thread.
-      if (!_historical) _reportUnmatchedCall(toolCallId, 'args');
+    final match = _findCall(toolCallId);
+    if (match == null) {
+      // The client layer's warning for this condition tests a weaker
+      // predicate — one `Conversation` spans a whole thread, while a tracker
+      // holds one message's bucket — so a call whose start landed in another
+      // bucket is unmatched here and known there. Report it on the replay
+      // path too, or that delta is lost with no trace anywhere.
+      _reportUnmatchedCall(toolCallId, 'args');
       return;
     }
-    _replaceEntry(entry, entry.appendArgs(delta));
+    _replaceEntry(match, match.entry.appendArgs(delta));
   }
 
   /// Attaches [result] to the call opened by [toolCallId] and completes that
@@ -265,17 +270,19 @@ class ExecutionTracker {
   /// active step instead would put the result on one row and its check mark on
   /// another.
   void _completeCall(String toolCallId, String result) {
-    final entry = _findCall(toolCallId);
-    if (entry == null) {
+    final match = _findCall(toolCallId);
+    if (match == null) {
       // No client-layer log covers an unmatched result — `_processToolCallArgs`
       // warns but `_processToolCallResult` does not — so report it on the
       // replay path too, or a stored thread that lost one is silent everywhere.
       _reportUnmatchedCall(toolCallId, 'result');
-      // Still settle whatever is running, so the row does not shimmer forever.
-      _completeActiveStep();
+      // Deliberately settles nothing: the step this result belongs to is not
+      // in the timeline, so any row settled here would be another call's.
+      // Every terminal path completes what is still active anyway.
       return;
     }
 
+    final entry = match.entry;
     final step = entry.step;
     final completed = step.status == StepStatus.active
         ? step.copyWith(
@@ -283,7 +290,7 @@ class ExecutionTracker {
             timestamp: _stopwatch.elapsed,
           )
         : step;
-    _replaceEntry(entry, entry.withResult(result).withStep(completed));
+    _replaceEntry(match, entry.withResult(result).withStep(completed));
     if (!identical(completed, step)) {
       _steps.value = [
         for (final candidate in _steps.value)
@@ -302,18 +309,21 @@ class ExecutionTracker {
   }
 
   /// A run that finished successfully having opened a call whose result never
-  /// arrived has lost detail in transit — the same silent gap that left the
-  /// timeline's rows empty when the activity events lost their producer.
-  /// Reported on the replay path as well, because a stored thread missing a
-  /// result has no other trace.
+  /// arrived has lost detail in transit. Reported on the replay path as well,
+  /// because a stored thread missing a result has no other trace.
+  ///
+  /// Scans the whole timeline rather than one run's slice, since a run's steps
+  /// are not delimited here — so each id is reported at most once, or a replay
+  /// bucket holding several runs would re-report an earlier run's gap at every
+  /// later run's completion.
   void _reportCallsMissingResult() {
-    final missing = [
-      for (final entry in _timeline.value)
-        if (entry is TimelineStep &&
-            entry.toolCallId != null &&
-            entry.result == null)
-          entry.step.label,
-    ];
+    final missing = <String>[];
+    for (final entry in _timeline.value) {
+      if (entry is! TimelineStep) continue;
+      final id = entry.toolCallId;
+      if (id == null || entry.result != null) continue;
+      if (_reportedMissingResults.add(id)) missing.add(entry.step.label);
+    }
     if (missing.isEmpty) return;
     _logger.warning(
       'ExecutionTracker: run completed with tool call(s) whose result never '
@@ -322,26 +332,31 @@ class ExecutionTracker {
     );
   }
 
-  /// The most recently opened step carrying [toolCallId], or null when none
-  /// does.
+  /// The most recently opened step carrying [toolCallId] and where it sits, or
+  /// null when no step does.
   ///
   /// Searched newest-first because the reload path can bucket several runs'
   /// events into one tracker, and a provider that reuses call ids across runs
   /// would otherwise attach the later run's detail to the earlier run's step.
-  TimelineStep? _findCall(String toolCallId) {
+  ///
+  /// Carries the position so [_replaceEntry] writes to the step that was
+  /// found, rather than re-deriving it by searching for an equal one.
+  ({int index, TimelineStep entry})? _findCall(String toolCallId) {
     final current = _timeline.value;
     for (var i = current.length - 1; i >= 0; i--) {
       final entry = current[i];
-      if (entry is TimelineStep && entry.toolCallId == toolCallId) return entry;
+      if (entry is TimelineStep && entry.toolCallId == toolCallId) {
+        return (index: i, entry: entry);
+      }
     }
     return null;
   }
 
-  void _replaceEntry(TimelineStep old, TimelineStep updated) {
-    final current = _timeline.value;
-    final index = current.indexOf(old);
-    if (index < 0) return;
-    _timeline.value = [...current]..[index] = updated;
+  void _replaceEntry(
+    ({int index, TimelineStep entry}) at,
+    TimelineStep updated,
+  ) {
+    _timeline.value = [..._timeline.value]..[at.index] = updated;
   }
 
   /// Reports detail that arrived for a call with no step, once per id and

--- a/lib/src/modules/room/execution_tracker.dart
+++ b/lib/src/modules/room/execution_tracker.dart
@@ -56,8 +56,8 @@ class ExecutionTracker {
   /// every thread reload.
   final bool _historical;
 
-  /// Ids already reported as having no step, so one call's delta stream logs
-  /// once rather than per delta.
+  /// `<toolCallId>#<phase>` keys already reported as having no step, so one
+  /// call's delta stream logs once rather than per delta.
   final Set<String> _loggedUnmatchedCalls = <String>{};
 
   final Stopwatch _stopwatch = Stopwatch();
@@ -163,8 +163,7 @@ class ExecutionTracker {
       case ServerToolCallArgs(:final toolCallId, :final delta):
         _appendCallArgs(toolCallId, delta);
       case ServerToolCallCompleted(:final toolCallId, :final result):
-        _attachCallResult(toolCallId, result);
-        _completeActiveStep();
+        _completeCall(toolCallId, result);
       case ClientToolExecuting(:final toolName):
         _completeActiveStep();
         _isThinkingStreaming.value = false;
@@ -174,6 +173,7 @@ class ExecutionTracker {
       case RunCompleted():
         _completeAllSteps(StepStatus.completed);
         _isThinkingStreaming.value = false;
+        _reportCallsMissingResult();
       case RunFailed(:final error):
         // Backend RunErrorEvent surfaces here as `RunFailed`. The
         // application layer (`agui_event_processor._processRunError`) only
@@ -242,60 +242,123 @@ class ExecutionTracker {
 
   /// Appends an args delta to the step opened by [toolCallId].
   ///
-  /// A delta for an id with no step — its `TOOL_CALL_START` was dropped, or
-  /// the stream reconnected mid-call — has nowhere to go and is discarded.
+  /// A delta for an id with no step — no `TOOL_CALL_START` was observed for it,
+  /// because it was dropped or the stream resumed mid-call — has nowhere to go
+  /// and is discarded with a one-time warning.
   void _appendCallArgs(String toolCallId, String delta) {
-    _updateCall(
-      toolCallId,
-      (entry) => entry.withDetail(args: entry.args + delta),
-    );
+    final entry = _findCall(toolCallId);
+    if (entry == null) {
+      // `_processToolCallArgs` logs the same condition at the client layer on
+      // both the live and replay paths, so this arm need not repeat it for a
+      // reloaded thread.
+      if (!_historical) _reportUnmatchedCall(toolCallId, 'args');
+      return;
+    }
+    _replaceEntry(entry, entry.appendArgs(delta));
   }
 
-  void _attachCallResult(String toolCallId, String result) {
-    final entry = _updateCall(
-      toolCallId,
-      (entry) => entry.withDetail(result: result),
-    );
-    if (entry == null || _historical) return;
-    // The row's whole content in one line, at info so a debug build's floor
-    // admits it. Lengths only: the args carry the user's query and the result
-    // carries retrieved document text, neither of which belongs in a log.
+  /// Attaches [result] to the call opened by [toolCallId] and completes that
+  /// call's step.
+  ///
+  /// Completion is by id rather than by position: a toolset that does not
+  /// declare itself sequential can overlap calls, and settling the newest
+  /// active step instead would put the result on one row and its check mark on
+  /// another.
+  void _completeCall(String toolCallId, String result) {
+    final entry = _findCall(toolCallId);
+    if (entry == null) {
+      // No client-layer log covers an unmatched result — `_processToolCallArgs`
+      // warns but `_processToolCallResult` does not — so report it on the
+      // replay path too, or a stored thread that lost one is silent everywhere.
+      _reportUnmatchedCall(toolCallId, 'result');
+      // Still settle whatever is running, so the row does not shimmer forever.
+      _completeActiveStep();
+      return;
+    }
+
+    final step = entry.step;
+    final completed = step.status == StepStatus.active
+        ? step.copyWith(
+            status: StepStatus.completed,
+            timestamp: _stopwatch.elapsed,
+          )
+        : step;
+    _replaceEntry(entry, entry.withResult(result).withStep(completed));
+    if (!identical(completed, step)) {
+      _steps.value = [
+        for (final candidate in _steps.value)
+          identical(candidate, step) ? completed : candidate,
+      ];
+    }
+
+    if (_historical) return;
+    // Confirms the detail reached the row, which is the question to ask when a
+    // source block comes up empty. Lengths only: the args carry the user's
+    // query and the result carries retrieved document text.
     _logger.info(
       'Timeline detail: ${entry.step.label} captured '
       '${entry.args.length} args chars, ${result.length} result chars.',
     );
   }
 
-  /// Applies [update] to the step opened by [toolCallId] and returns the
-  /// updated entry, or null when no step carries that id.
-  TimelineStep? _updateCall(
-    String toolCallId,
-    TimelineStep Function(TimelineStep) update,
-  ) {
+  /// A run that finished successfully having opened a call whose result never
+  /// arrived has lost detail in transit — the same silent gap that left the
+  /// timeline's rows empty when the activity events lost their producer.
+  /// Reported on the replay path as well, because a stored thread missing a
+  /// result has no other trace.
+  void _reportCallsMissingResult() {
+    final missing = [
+      for (final entry in _timeline.value)
+        if (entry is TimelineStep &&
+            entry.toolCallId != null &&
+            entry.result == null)
+          entry.step.label,
+    ];
+    if (missing.isEmpty) return;
+    _logger.warning(
+      'ExecutionTracker: run completed with tool call(s) whose result never '
+      'arrived; their rows render without a result.',
+      attributes: {'tools': missing.join(', '), 'count': missing.length},
+    );
+  }
+
+  /// The most recently opened step carrying [toolCallId], or null when none
+  /// does.
+  ///
+  /// Searched newest-first because the reload path can bucket several runs'
+  /// events into one tracker, and a provider that reuses call ids across runs
+  /// would otherwise attach the later run's detail to the earlier run's step.
+  TimelineStep? _findCall(String toolCallId) {
     final current = _timeline.value;
     for (var i = current.length - 1; i >= 0; i--) {
       final entry = current[i];
-      if (entry is TimelineStep && entry.toolCallId == toolCallId) {
-        final updated = update(entry);
-        _timeline.value = [...current]..[i] = updated;
-        return updated;
-      }
-    }
-    // Otherwise the detail is dropped and the row silently lacks the args or
-    // result it should have shown. Warning level so it survives the release
-    // floor; once per id so a delta stream can't flood the sink, and live-only
-    // so reloading a thread with a truncated stream doesn't re-log every time.
-    if (!_historical && _loggedUnmatchedCalls.add(toolCallId)) {
-      _logger.warning(
-        'ExecutionTracker: tool call detail arrived for an id with no step; '
-        'the row will render without its args or result.',
-        attributes: {
-          'toolCallId': toolCallId,
-          'stepCount': current.whereType<TimelineStep>().length,
-        },
-      );
+      if (entry is TimelineStep && entry.toolCallId == toolCallId) return entry;
     }
     return null;
+  }
+
+  void _replaceEntry(TimelineStep old, TimelineStep updated) {
+    final current = _timeline.value;
+    final index = current.indexOf(old);
+    if (index < 0) return;
+    _timeline.value = [...current]..[index] = updated;
+  }
+
+  /// Reports detail that arrived for a call with no step, once per id and
+  /// phase. Warning level so it survives the release floor; throttled so a
+  /// delta stream cannot flood the sink, and keyed by phase so a lost result is
+  /// still reported for an id whose args were already lost.
+  void _reportUnmatchedCall(String toolCallId, String phase) {
+    if (!_loggedUnmatchedCalls.add('$toolCallId#$phase')) return;
+    _logger.warning(
+      'ExecutionTracker: tool call $phase arrived for an id with no step; '
+      'the row will render without it.',
+      attributes: {
+        'toolCallId': toolCallId,
+        'phase': phase,
+        'stepCount': _timeline.value.whereType<TimelineStep>().length,
+      },
+    );
   }
 
   void _addStep(String label, StepType type, {String? toolCallId}) {

--- a/lib/src/modules/room/execution_tracker.dart
+++ b/lib/src/modules/room/execution_tracker.dart
@@ -56,6 +56,10 @@ class ExecutionTracker {
   /// every thread reload.
   final bool _historical;
 
+  /// Ids already reported as having no step, so one call's delta stream logs
+  /// once rather than per delta.
+  final Set<String> _loggedUnmatchedCalls = <String>{};
+
   final Stopwatch _stopwatch = Stopwatch();
   void Function()? _unsub;
   void Function()? _activitiesUnsub;
@@ -152,11 +156,14 @@ class ExecutionTracker {
         // tool call, and completing the step now would split a single
         // logical step into two timeline entries.
         _isThinkingStreaming.value = false;
-      case ServerToolCallStarted(:final toolName):
+      case ServerToolCallStarted(:final toolName, :final toolCallId):
         _completeActiveStep();
         _isThinkingStreaming.value = false;
-        _addStep(toolName, StepType.toolCall);
-      case ServerToolCallCompleted():
+        _addStep(toolName, StepType.toolCall, toolCallId: toolCallId);
+      case ServerToolCallArgs(:final toolCallId, :final delta):
+        _appendCallArgs(toolCallId, delta);
+      case ServerToolCallCompleted(:final toolCallId, :final result):
+        _attachCallResult(toolCallId, result);
         _completeActiveStep();
       case ClientToolExecuting(:final toolName):
         _completeActiveStep();
@@ -233,7 +240,65 @@ class ExecutionTracker {
     ];
   }
 
-  void _addStep(String label, StepType type) {
+  /// Appends an args delta to the step opened by [toolCallId].
+  ///
+  /// A delta for an id with no step — its `TOOL_CALL_START` was dropped, or
+  /// the stream reconnected mid-call — has nowhere to go and is discarded.
+  void _appendCallArgs(String toolCallId, String delta) {
+    _updateCall(
+      toolCallId,
+      (entry) => entry.withDetail(args: entry.args + delta),
+    );
+  }
+
+  void _attachCallResult(String toolCallId, String result) {
+    final entry = _updateCall(
+      toolCallId,
+      (entry) => entry.withDetail(result: result),
+    );
+    if (entry == null || _historical) return;
+    // The row's whole content in one line, at info so a debug build's floor
+    // admits it. Lengths only: the args carry the user's query and the result
+    // carries retrieved document text, neither of which belongs in a log.
+    _logger.info(
+      'Timeline detail: ${entry.step.label} captured '
+      '${entry.args.length} args chars, ${result.length} result chars.',
+    );
+  }
+
+  /// Applies [update] to the step opened by [toolCallId] and returns the
+  /// updated entry, or null when no step carries that id.
+  TimelineStep? _updateCall(
+    String toolCallId,
+    TimelineStep Function(TimelineStep) update,
+  ) {
+    final current = _timeline.value;
+    for (var i = current.length - 1; i >= 0; i--) {
+      final entry = current[i];
+      if (entry is TimelineStep && entry.toolCallId == toolCallId) {
+        final updated = update(entry);
+        _timeline.value = [...current]..[i] = updated;
+        return updated;
+      }
+    }
+    // Otherwise the detail is dropped and the row silently lacks the args or
+    // result it should have shown. Warning level so it survives the release
+    // floor; once per id so a delta stream can't flood the sink, and live-only
+    // so reloading a thread with a truncated stream doesn't re-log every time.
+    if (!_historical && _loggedUnmatchedCalls.add(toolCallId)) {
+      _logger.warning(
+        'ExecutionTracker: tool call detail arrived for an id with no step; '
+        'the row will render without its args or result.',
+        attributes: {
+          'toolCallId': toolCallId,
+          'stepCount': current.whereType<TimelineStep>().length,
+        },
+      );
+    }
+    return null;
+  }
+
+  void _addStep(String label, StepType type, {String? toolCallId}) {
     final step = ExecutionStep(
       label: label,
       type: type,
@@ -241,7 +306,10 @@ class ExecutionTracker {
       timestamp: _stopwatch.elapsed,
     );
     _steps.value = [..._steps.value, step];
-    _timeline.value = [..._timeline.value, TimelineStep(step: step)];
+    _timeline.value = [
+      ..._timeline.value,
+      TimelineStep(step: step, toolCallId: toolCallId),
+    ];
   }
 
   void _completeActiveStep() {

--- a/lib/src/modules/room/message_expansions.dart
+++ b/lib/src/modules/room/message_expansions.dart
@@ -1,7 +1,7 @@
 import 'compute_display_messages.dart' show loadingMessageId;
 
 /// Per-message UI expansion state for assistant responses — whether each
-/// message's execution timeline, thinking block, and activity source rows
+/// message's execution timeline, thinking block, and expandable source blocks
 /// are open. Owned by `roomModule()`; outlives widget rebuilds, thread
 /// switches, and room navigations within the room module.
 ///
@@ -75,17 +75,17 @@ class MessageExpansion {
   bool get thinkingExpanded => _entry?.thinking ?? false;
   set thinkingExpanded(bool value) => _ensureEntry().thinking = value;
 
-  bool isSourceExpanded(String activityId) =>
-      _entry?.sources.contains(activityId) ?? false;
+  bool isSourceExpanded(String sourceKey) =>
+      _entry?.sources.contains(sourceKey) ?? false;
 
-  void setSourceExpanded(String activityId, bool value) {
+  void setSourceExpanded(String sourceKey, bool value) {
     if (value) {
-      _ensureEntry().sources.add(activityId);
+      _ensureEntry().sources.add(sourceKey);
       return;
     }
-    _entry?.sources.remove(activityId);
+    _entry?.sources.remove(sourceKey);
   }
 
-  void toggleSource(String activityId) =>
-      setSourceExpanded(activityId, !isSourceExpanded(activityId));
+  void toggleSource(String sourceKey) =>
+      setSourceExpanded(sourceKey, !isSourceExpanded(sourceKey));
 }

--- a/lib/src/modules/room/ui/execution/execution_timeline.dart
+++ b/lib/src/modules/room/ui/execution/execution_timeline.dart
@@ -18,19 +18,31 @@ import 'package:soliplex_design/soliplex_design.dart';
 final Logger _logger =
     LogManager.instance.getLogger('soliplex_frontend.execution_timeline');
 
-/// Argument names whose value is the point of the call, in preference order —
-/// a RAG query, executed code, a sandbox script, a shell command. When an args
-/// object carries one, showing it beats showing the whole object.
+/// Argument names whose value is the point of the call, in the order they are
+/// preferred — a sandbox script, executed code, a search query, a shell
+/// command. When an args object carries one, showing it beats showing the whole
+/// object.
 const List<String> _sourceKeys = ['script', 'code', 'query', 'command'];
 
-/// Left inset of a row nested under a step, clearing the step's own chevron
-/// and status icon so the nesting stays legible.
-const double _nestedIndent = 38;
+/// Left inset of a row nested under a step, clearing the step's own disclosure
+/// chevron and status icon so the nesting stays legible. Written as the sum it
+/// clears so it cannot drift from the row it is measured against.
+const double _nestedIndent = _disclosureWidth +
+    SoliplexSpacing.s1 +
+    _statusIconSize +
+    SoliplexSpacing.s2;
+
+/// Width reserved for a row's disclosure chevron, kept even when the row has
+/// nothing to disclose so status icons stay column-aligned.
+const double _disclosureWidth = 14;
+
+/// Size of a row's status icon, and of the disclosure chevron drawn beside it.
+const double _statusIconSize = 12;
 
 /// Lines of a source body shown before the reader asks for the rest. A
 /// retrieval result runs to tens of thousands of characters, which would bury
-/// every row after it. Clamped by line count rather than pixels so the block
-/// keeps its shape under text scaling.
+/// every row after it. Clamped by line count rather than pixels so the clamp
+/// holds the same shape at every text scale.
 const int _collapsedSourceLines = 8;
 
 /// Suffixes distinguishing the two things a tool call row can disclose, so each
@@ -38,10 +50,10 @@ const int _collapsedSourceLines = 8;
 const String _argsClampSuffix = '#args';
 const String _resultClampSuffix = '#result';
 
-/// Unified execution timeline — single collapsible that nests activities
-/// under their owning step. Activity rows with source (script/code/query
-/// args, or any args map) can expand to a monospace preview with a copy
-/// button.
+/// Execution timeline — a single collapsible listing a run's steps, nesting
+/// any activity rows under their owning step. A step row carrying a server tool
+/// call, and an activity row carrying a source, expand to a monospace preview
+/// with a copy button.
 class ExecutionTimeline extends ConsumerStatefulWidget {
   const ExecutionTimeline({
     super.key,
@@ -100,22 +112,22 @@ class _ExecutionTimelineState extends ConsumerState<ExecutionTimeline> {
     });
   }
 
-  void _toggleSource(String activityId) {
+  void _toggleSource(String sourceKey) {
     setState(() {
       final expansion = _expansion;
       if (expansion != null) {
-        expansion.toggleSource(activityId);
+        expansion.toggleSource(sourceKey);
         return;
       }
-      if (!_loadingPhaseSources.remove(activityId)) {
-        _loadingPhaseSources.add(activityId);
+      if (!_loadingPhaseSources.remove(sourceKey)) {
+        _loadingPhaseSources.add(sourceKey);
       }
     });
   }
 
-  bool _isSourceExpanded(String activityId) =>
-      _expansion?.isSourceExpanded(activityId) ??
-      _loadingPhaseSources.contains(activityId);
+  bool _isSourceExpanded(String sourceKey) =>
+      _expansion?.isSourceExpanded(sourceKey) ??
+      _loadingPhaseSources.contains(sourceKey);
 
   @override
   Widget build(BuildContext context) {
@@ -233,8 +245,8 @@ class _ExecutionTimelineState extends ConsumerState<ExecutionTimeline> {
     final args = entry.args.isEmpty ? null : _formatArgs(entry.args);
     final result = (entry.result?.isEmpty ?? true) ? null : entry.result;
     // A server tool call's args and result are the call's own detail, so the
-    // step expands in place. Steps without an id (thinking, client tools)
-    // carry no detail and keep the slot only so icons stay column-aligned.
+    // step expands in place. A step with no id carries no detail of its own and
+    // keeps the slot only so icons stay column-aligned.
     final hasDetail = id != null && (args != null || result != null);
     final isExpanded = hasDetail && _isSourceExpanded(id);
 
@@ -249,11 +261,11 @@ class _ExecutionTimelineState extends ConsumerState<ExecutionTimeline> {
             child: Row(
               children: [
                 SizedBox(
-                  width: 14,
+                  width: _disclosureWidth,
                   child: hasDetail
                       ? Icon(
                           isExpanded ? Icons.expand_more : Icons.chevron_right,
-                          size: 14,
+                          size: _disclosureWidth,
                           color: theme.colorScheme.onSurfaceVariant,
                         )
                       : const SizedBox.shrink(),
@@ -285,9 +297,9 @@ class _ExecutionTimelineState extends ConsumerState<ExecutionTimeline> {
                 label: 'Arguments',
                 clampId: '$id$_argsClampSuffix',
               ),
-            // AG-UI cannot express a failed tool outcome, so a `ToolFailed`
-            // message arrives here looking like any other result. Rendering it
-            // is the only way it reaches the user at all.
+            // AG-UI carries no field for a failed outcome, so a tool that hit a
+            // limit or raised delivers its message through the ordinary result
+            // string. Rendering it is the only way that text reaches the user.
             if (result != null)
               _sourceBlock(
                 result,
@@ -363,8 +375,8 @@ class _ExecutionTimelineState extends ConsumerState<ExecutionTimeline> {
   /// reader asks for the rest.
   ///
   /// [clampId] keys that per block, so expanding one call's result leaves every
-  /// other row alone. Pass null to render the body in full — a block whose
-  /// content is bounded by construction has nothing to disclose.
+  /// other row alone. Pass null to render the body in full, which the activity
+  /// path does because this change leaves its rendering as it was.
   Widget _sourceBlock(
     String source,
     ThemeData theme, {
@@ -413,17 +425,19 @@ class _ExecutionTimelineState extends ConsumerState<ExecutionTimeline> {
     if (clampId == null) return Text(source, style: style);
 
     final expanded = _isSourceExpanded(clampId);
+    // Read outside the builder so layout does not take a MediaQuery dependency.
+    final textScaler = MediaQuery.textScalerOf(context);
     // Measure before deciding: a body that fits shows no control, for the same
     // reason a step with no detail shows no chevron.
     return LayoutBuilder(
       builder: (context, constraints) {
-        final painter = TextPainter(
-          text: TextSpan(text: source, style: style),
-          maxLines: _collapsedSourceLines,
-          textDirection: Directionality.of(context),
-        )..layout(maxWidth: constraints.maxWidth);
-        final overflows = painter.didExceedMaxLines;
-        painter.dispose();
+        final overflows = _overflowsClamp(
+          source,
+          style,
+          textScaler,
+          Directionality.of(context),
+          constraints.maxWidth,
+        );
         final clamped = overflows && !expanded;
 
         return Column(
@@ -470,7 +484,7 @@ class _ExecutionTimelineState extends ConsumerState<ExecutionTimeline> {
   }
 
   /// The primary label of a timeline row. While the row is [running] the text
-  /// shimmers (a calm stand-in for the old per-row spinner) and settles back to
+  /// shimmers (a calmer signal than a per-row spinner) and settles back to
   /// the plain muted label — same resting color — once the step completes.
   Widget _rowLabel(String label, ThemeData theme, {required bool running}) {
     final text = Text(
@@ -488,13 +502,20 @@ class _ExecutionTimelineState extends ConsumerState<ExecutionTimeline> {
       case StepStatus.active:
         // No spinner: the shimmering label carries the "in progress" signal.
         // Keep the slot so completed rows' check icons stay column-aligned.
-        return const SizedBox(width: 12, height: 12);
+        return const SizedBox(
+          width: _statusIconSize,
+          height: _statusIconSize,
+        );
       case StepStatus.failed:
-        return Icon(Icons.error, size: 12, color: theme.colorScheme.error);
+        return Icon(
+          Icons.error,
+          size: _statusIconSize,
+          color: theme.colorScheme.error,
+        );
       case StepStatus.completed:
         return Icon(
           Icons.check_circle,
-          size: 12,
+          size: _statusIconSize,
           // A completed action is a success result → SymbolicColors.success.
           // Thinking keeps a tertiary accent to read as reflection, not a
           // pass/fail outcome.
@@ -527,15 +548,53 @@ class _ExecutionTimelineState extends ConsumerState<ExecutionTimeline> {
     }
   }
 
-  /// Renders a tool call's accumulated `TOOL_CALL_ARGS` for display.
+  /// Whether [source] needs more than [_collapsedSourceLines] to render at
+  /// [maxWidth], and so warrants a disclosure control.
   ///
-  /// Prefers the one field that carries the intent — the query, the code, the
-  /// script, the command — over the whole object. Falls back to the raw string
+  /// Counts explicit line breaks first: a body already carrying that many
+  /// provably overflows, and the bodies that do — tens of KB of retrieved chunk
+  /// text — are the ones whose measurement is expensive. Laying one out is a
+  /// full line-break pass on the UI thread, repeated for every expanded block
+  /// each time an args delta rebuilds the timeline.
+  ///
+  /// [textScaler] must be the one the rendered [Text] will use; measuring
+  /// unscaled would report a body as fitting that the reader sees overflow.
+  static bool _overflowsClamp(
+    String source,
+    TextStyle style,
+    TextScaler textScaler,
+    TextDirection textDirection,
+    double maxWidth,
+  ) {
+    var breaks = 0;
+    for (var i = 0; i < source.length; i++) {
+      if (source.codeUnitAt(i) != 0x0A) continue;
+      if (++breaks >= _collapsedSourceLines) return true;
+    }
+    final painter = TextPainter(
+      text: TextSpan(text: source, style: style),
+      maxLines: _collapsedSourceLines,
+      textDirection: textDirection,
+      textScaler: textScaler,
+    )..layout(maxWidth: maxWidth);
+    final overflows = painter.didExceedMaxLines;
+    painter.dispose();
+    return overflows;
+  }
+
+  /// Renders a tool call's accumulated `TOOL_CALL_ARGS` for display, or null
+  /// when there is nothing worth showing.
+  ///
+  /// Prefers the one field that carries the intent — the script, the code, the
+  /// query, the command — over the whole object. Falls back to the raw string
   /// when it does not parse: while the call is still streaming the accumulation
   /// is a JSON prefix, and a partial payload is more useful shown than hidden.
-  static String _formatArgs(String args) {
+  /// A tool that takes no arguments sends `{}`, which yields no block rather
+  /// than an empty one.
+  static String? _formatArgs(String args) {
     final decoded = _tryDecodeObject(args);
     if (decoded == null) return args;
+    if (decoded.isEmpty) return null;
     for (final key in _sourceKeys) {
       final value = decoded[key];
       if (value is String && value.isNotEmpty) return value;

--- a/lib/src/modules/room/ui/execution/execution_timeline.dart
+++ b/lib/src/modules/room/ui/execution/execution_timeline.dart
@@ -36,7 +36,8 @@ const double _nestedIndent = _disclosureWidth +
 /// nothing to disclose so status icons stay column-aligned.
 const double _disclosureWidth = 14;
 
-/// Size of a row's status icon, and of the disclosure chevron drawn beside it.
+/// Size of a row's status icon. The disclosure chevron beside it is
+/// [_disclosureWidth], which is wider.
 const double _statusIconSize = 12;
 
 /// Lines of a source body shown before the reader asks for the rest. A
@@ -49,6 +50,11 @@ const int _collapsedSourceLines = 8;
 /// keys its own entry in the expansion store.
 const String _argsClampSuffix = '#args';
 const String _resultClampSuffix = '#result';
+
+/// The braces bounding a JSON object, so an empty one is recognised by scan
+/// rather than by decoding it.
+const int _leftBrace = 0x7B;
+const int _rightBrace = 0x7D;
 
 /// Execution timeline — a single collapsible listing a run's steps, nesting
 /// any activity rows under their owning step. A step row carrying a server tool
@@ -242,12 +248,14 @@ class _ExecutionTimelineState extends ConsumerState<ExecutionTimeline> {
   Widget _stepRow(TimelineStep entry, ThemeData theme) {
     final step = entry.step;
     final id = entry.toolCallId;
-    final args = entry.args.isEmpty ? null : _formatArgs(entry.args);
+    // Whether there is detail is decided without formatting it: this runs for
+    // every row on every rebuild, and an args delta rebuilds the timeline.
+    final hasArgs = entry.args.isNotEmpty && !_isEmptyArgsObject(entry.args);
     final result = (entry.result?.isEmpty ?? true) ? null : entry.result;
     // A server tool call's args and result are the call's own detail, so the
     // step expands in place. A step with no id carries no detail of its own and
     // keeps the slot only so icons stay column-aligned.
-    final hasDetail = id != null && (args != null || result != null);
+    final hasDetail = id != null && (hasArgs || result != null);
     final isExpanded = hasDetail && _isSourceExpanded(id);
 
     return Padding(
@@ -290,16 +298,17 @@ class _ExecutionTimelineState extends ConsumerState<ExecutionTimeline> {
             ),
           ),
           if (isExpanded) ...[
-            if (args != null)
+            if (hasArgs)
               _sourceBlock(
-                args,
+                _formatArgs(entry.args),
                 theme,
                 label: 'Arguments',
                 clampId: '$id$_argsClampSuffix',
               ),
             // AG-UI carries no field for a failed outcome, so a tool that hit a
             // limit or raised delivers its message through the ordinary result
-            // string. Rendering it is the only way that text reaches the user.
+            // string. Rendering it is the only way that text reaches the user
+            // in the chat UI.
             if (result != null)
               _sourceBlock(
                 result,
@@ -337,11 +346,11 @@ class _ExecutionTimelineState extends ConsumerState<ExecutionTimeline> {
             child: Row(
               children: [
                 SizedBox(
-                  width: 14,
+                  width: _disclosureWidth,
                   child: hasSource
                       ? Icon(
                           isExpanded ? Icons.expand_more : Icons.chevron_right,
-                          size: 14,
+                          size: _disclosureWidth,
                           color: theme.colorScheme.onSurfaceVariant,
                         )
                       : const SizedBox.shrink(),
@@ -375,8 +384,8 @@ class _ExecutionTimelineState extends ConsumerState<ExecutionTimeline> {
   /// reader asks for the rest.
   ///
   /// [clampId] keys that per block, so expanding one call's result leaves every
-  /// other row alone. Pass null to render the body in full, which the activity
-  /// path does because this change leaves its rendering as it was.
+  /// other row alone. Null renders the body in full — an activity row's source
+  /// is a script or query short enough not to need a clamp.
   Widget _sourceBlock(
     String source,
     ThemeData theme, {
@@ -449,33 +458,21 @@ class _ExecutionTimelineState extends ConsumerState<ExecutionTimeline> {
               maxLines: clamped ? _collapsedSourceLines : null,
               overflow: clamped ? TextOverflow.ellipsis : TextOverflow.clip,
             ),
+            // A labelled control rather than a bare tap target, so it carries
+            // button semantics and the design system's minimum tap target.
             if (overflows)
-              GestureDetector(
-                onTap: () => _toggleSource(clampId),
-                behavior: HitTestBehavior.opaque,
-                child: Padding(
-                  padding: const EdgeInsets.only(top: SoliplexSpacing.s1),
-                  child: Row(
-                    children: [
-                      // The row disclosures elsewhere encode state (right when
-                      // closed, down when open) because they carry no words.
-                      // This one is labelled with a verb, so the arrow points
-                      // at what the tap does: down to reveal, up to collapse.
-                      Icon(
-                        expanded ? Icons.expand_less : Icons.expand_more,
-                        size: 14,
-                        color: theme.colorScheme.onSurfaceVariant,
-                      ),
-                      const SizedBox(width: SoliplexSpacing.s1),
-                      Text(
-                        expanded ? 'Show less' : 'Show more',
-                        style: theme.textTheme.labelSmall?.copyWith(
-                          color: theme.colorScheme.onSurfaceVariant,
-                        ),
-                      ),
-                    ],
-                  ),
+              SoliplexButton.text(
+                onPressed: () => _toggleSource(clampId),
+                isCompact: true,
+                // The row disclosures elsewhere encode state (right when
+                // closed, down when open) because they carry no words. This
+                // one is labelled with a verb, so the arrow points at what the
+                // tap does: down to reveal, up to collapse.
+                icon: Icon(
+                  expanded ? Icons.expand_less : Icons.expand_more,
+                  size: _disclosureWidth,
                 ),
+                child: Text(expanded ? 'Show less' : 'Show more'),
               ),
           ],
         );
@@ -485,7 +482,8 @@ class _ExecutionTimelineState extends ConsumerState<ExecutionTimeline> {
 
   /// The primary label of a timeline row. While the row is [running] the text
   /// shimmers (a calmer signal than a per-row spinner) and settles back to
-  /// the plain muted label — same resting color — once the step completes.
+  /// the plain muted label — same resting color — once the step settles, on
+  /// success or failure alike.
   Widget _rowLabel(String label, ThemeData theme, {required bool running}) {
     final text = Text(
       label,
@@ -530,19 +528,26 @@ class _ExecutionTimelineState extends ConsumerState<ExecutionTimeline> {
     switch (status) {
       case SkillToolCallStatus.inProgress:
         // No spinner: the shimmering label carries the "in progress" signal.
-        return const SizedBox(width: 12, height: 12);
+        return const SizedBox(
+          width: _statusIconSize,
+          height: _statusIconSize,
+        );
       case SkillToolCallStatus.error:
-        return Icon(Icons.error, size: 12, color: theme.colorScheme.error);
+        return Icon(
+          Icons.error,
+          size: _statusIconSize,
+          color: theme.colorScheme.error,
+        );
       case SkillToolCallStatus.done:
         return Icon(
           Icons.check_circle,
-          size: 12,
+          size: _statusIconSize,
           color: context.success,
         );
       case SkillToolCallStatus.unknown:
         return Icon(
           Icons.circle_outlined,
-          size: 12,
+          size: _statusIconSize,
           color: theme.colorScheme.outline,
         );
     }
@@ -582,24 +587,54 @@ class _ExecutionTimelineState extends ConsumerState<ExecutionTimeline> {
     return overflows;
   }
 
-  /// Renders a tool call's accumulated `TOOL_CALL_ARGS` for display, or null
-  /// when there is nothing worth showing.
+  /// Renders a tool call's accumulated `TOOL_CALL_ARGS` for display.
   ///
   /// Prefers the one field that carries the intent — the script, the code, the
   /// query, the command — over the whole object. Falls back to the raw string
   /// when it does not parse: while the call is still streaming the accumulation
   /// is a JSON prefix, and a partial payload is more useful shown than hidden.
-  /// A tool that takes no arguments sends `{}`, which yields no block rather
-  /// than an empty one.
-  static String? _formatArgs(String args) {
+  ///
+  /// Called only for a row the reader has expanded, and only once
+  /// [_isEmptyArgsObject] has ruled out the payload of a tool that takes no
+  /// arguments — which is why every path here yields something to show.
+  static String _formatArgs(String args) {
     final decoded = _tryDecodeObject(args);
     if (decoded == null) return args;
-    if (decoded.isEmpty) return null;
     for (final key in _sourceKeys) {
       final value = decoded[key];
       if (value is String && value.isNotEmpty) return value;
     }
     return const JsonEncoder.withIndent('  ').convert(decoded);
+  }
+
+  /// Whether [args] is a JSON object with no members — what a tool that takes
+  /// no arguments sends, and which yields no block rather than an empty one.
+  ///
+  /// Decided by scanning rather than by decoding because every step row asks
+  /// this on every rebuild, expanded or not, and an args delta rebuilds the
+  /// timeline. Bails at the first member, so a real payload costs a few
+  /// character reads rather than a parse.
+  static bool _isEmptyArgsObject(String args) {
+    var index = _skipJsonSpace(args, 0);
+    if (index == args.length || args.codeUnitAt(index) != _leftBrace) {
+      return false;
+    }
+    index = _skipJsonSpace(args, index + 1);
+    if (index == args.length || args.codeUnitAt(index) != _rightBrace) {
+      return false;
+    }
+    return _skipJsonSpace(args, index + 1) == args.length;
+  }
+
+  static int _skipJsonSpace(String source, int from) {
+    var index = from;
+    while (index < source.length) {
+      final unit = source.codeUnitAt(index);
+      // The four code points JSON counts as insignificant whitespace.
+      if (unit != 0x20 && unit != 0x09 && unit != 0x0A && unit != 0x0D) break;
+      index++;
+    }
+    return index;
   }
 
   static Map<String, dynamic>? _tryDecodeObject(String raw) {

--- a/lib/src/modules/room/ui/execution/execution_timeline.dart
+++ b/lib/src/modules/room/ui/execution/execution_timeline.dart
@@ -18,6 +18,26 @@ import 'package:soliplex_design/soliplex_design.dart';
 final Logger _logger =
     LogManager.instance.getLogger('soliplex_frontend.execution_timeline');
 
+/// Argument names whose value is the point of the call, in preference order —
+/// a RAG query, executed code, a sandbox script, a shell command. When an args
+/// object carries one, showing it beats showing the whole object.
+const List<String> _sourceKeys = ['script', 'code', 'query', 'command'];
+
+/// Left inset of a row nested under a step, clearing the step's own chevron
+/// and status icon so the nesting stays legible.
+const double _nestedIndent = 38;
+
+/// Lines of a source body shown before the reader asks for the rest. A
+/// retrieval result runs to tens of thousands of characters, which would bury
+/// every row after it. Clamped by line count rather than pixels so the block
+/// keeps its shape under text scaling.
+const int _collapsedSourceLines = 8;
+
+/// Suffixes distinguishing the two things a tool call row can disclose, so each
+/// keys its own entry in the expansion store.
+const String _argsClampSuffix = '#args';
+const String _resultClampSuffix = '#result';
+
 /// Unified execution timeline — single collapsible that nests activities
 /// under their owning step. Activity rows with source (script/code/query
 /// args, or any args map) can expand to a monospace preview with a copy
@@ -159,14 +179,14 @@ class _ExecutionTimelineState extends ConsumerState<ExecutionTimeline> {
     List<SkillToolCallActivity> calls,
   ) {
     switch (entry) {
-      case TimelineStep(:final step, :final activityIds):
+      case TimelineStep(:final activityIds):
         return Column(
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
-            _stepRow(step, theme),
+            _stepRow(entry, theme),
             for (final id in activityIds)
               if (_resolveActivity(id, calls) case final activity?)
-                _activityRow(activity, theme, indent: 20),
+                _activityRow(activity, theme, indent: _nestedIndent),
           ],
         );
       case TimelineStandaloneActivity(:final activityId):
@@ -207,26 +227,75 @@ class _ExecutionTimelineState extends ConsumerState<ExecutionTimeline> {
     return null;
   }
 
-  Widget _stepRow(ExecutionStep step, ThemeData theme) {
+  Widget _stepRow(TimelineStep entry, ThemeData theme) {
+    final step = entry.step;
+    final id = entry.toolCallId;
+    final args = entry.args.isEmpty ? null : _formatArgs(entry.args);
+    final result = (entry.result?.isEmpty ?? true) ? null : entry.result;
+    // A server tool call's args and result are the call's own detail, so the
+    // step expands in place. Steps without an id (thinking, client tools)
+    // carry no detail and keep the slot only so icons stay column-aligned.
+    final hasDetail = id != null && (args != null || result != null);
+    final isExpanded = hasDetail && _isSourceExpanded(id);
+
     return Padding(
       padding: const EdgeInsets.symmetric(vertical: SoliplexSpacing.s1),
-      child: Row(
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
         children: [
-          _stepIcon(step, theme),
-          const SizedBox(width: SoliplexSpacing.s2),
-          Expanded(
-            child: _rowLabel(
-              step.label,
-              theme,
-              running: step.status == StepStatus.active,
+          GestureDetector(
+            onTap: hasDetail ? () => _toggleSource(id) : null,
+            behavior: HitTestBehavior.opaque,
+            child: Row(
+              children: [
+                SizedBox(
+                  width: 14,
+                  child: hasDetail
+                      ? Icon(
+                          isExpanded ? Icons.expand_more : Icons.chevron_right,
+                          size: 14,
+                          color: theme.colorScheme.onSurfaceVariant,
+                        )
+                      : const SizedBox.shrink(),
+                ),
+                const SizedBox(width: SoliplexSpacing.s1),
+                _stepIcon(step, theme),
+                const SizedBox(width: SoliplexSpacing.s2),
+                Expanded(
+                  child: _rowLabel(
+                    step.label,
+                    theme,
+                    running: step.status == StepStatus.active,
+                  ),
+                ),
+                Text(
+                  _formatDuration(step.timestamp),
+                  style: theme.textTheme.labelSmall?.copyWith(
+                    color: theme.colorScheme.outline,
+                  ),
+                ),
+              ],
             ),
           ),
-          Text(
-            _formatDuration(step.timestamp),
-            style: theme.textTheme.labelSmall?.copyWith(
-              color: theme.colorScheme.outline,
-            ),
-          ),
+          if (isExpanded) ...[
+            if (args != null)
+              _sourceBlock(
+                args,
+                theme,
+                label: 'Arguments',
+                clampId: '$id$_argsClampSuffix',
+              ),
+            // AG-UI cannot express a failed tool outcome, so a `ToolFailed`
+            // message arrives here looking like any other result. Rendering it
+            // is the only way it reaches the user at all.
+            if (result != null)
+              _sourceBlock(
+                result,
+                theme,
+                label: 'Result',
+                clampId: '$id$_resultClampSuffix',
+              ),
+          ],
         ],
       ),
     );
@@ -290,7 +359,18 @@ class _ExecutionTimelineState extends ConsumerState<ExecutionTimeline> {
     );
   }
 
-  Widget _sourceBlock(String source, ThemeData theme) {
+  /// A source block whose body clamps to [_collapsedSourceLines] until the
+  /// reader asks for the rest.
+  ///
+  /// [clampId] keys that per block, so expanding one call's result leaves every
+  /// other row alone. Pass null to render the body in full — a block whose
+  /// content is bounded by construction has nothing to disclose.
+  Widget _sourceBlock(
+    String source,
+    ThemeData theme, {
+    String? label,
+    String? clampId,
+  }) {
     return Padding(
       padding: const EdgeInsets.only(
         top: SoliplexSpacing.s1,
@@ -306,19 +386,86 @@ class _ExecutionTimelineState extends ConsumerState<ExecutionTimeline> {
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.stretch,
           children: [
-            Align(
-              alignment: Alignment.centerRight,
-              child: CopyButton(text: source, iconSize: 14),
+            Row(
+              children: [
+                if (label != null)
+                  Text(
+                    label,
+                    style: theme.textTheme.labelSmall?.copyWith(
+                      color: theme.colorScheme.onSurfaceVariant,
+                    ),
+                  ),
+                const Spacer(),
+                // Copies the whole body regardless of what is on screen.
+                CopyButton(text: source, iconSize: 14),
+              ],
             ),
-            Text(
-              source,
-              style: context
-                  .monospaceOn(theme.textTheme.labelSmall)
-                  .copyWith(height: 1.3),
-            ),
+            _sourceBody(source, theme, clampId),
           ],
         ),
       ),
+    );
+  }
+
+  Widget _sourceBody(String source, ThemeData theme, String? clampId) {
+    final style =
+        context.monospaceOn(theme.textTheme.labelSmall).copyWith(height: 1.3);
+    if (clampId == null) return Text(source, style: style);
+
+    final expanded = _isSourceExpanded(clampId);
+    // Measure before deciding: a body that fits shows no control, for the same
+    // reason a step with no detail shows no chevron.
+    return LayoutBuilder(
+      builder: (context, constraints) {
+        final painter = TextPainter(
+          text: TextSpan(text: source, style: style),
+          maxLines: _collapsedSourceLines,
+          textDirection: Directionality.of(context),
+        )..layout(maxWidth: constraints.maxWidth);
+        final overflows = painter.didExceedMaxLines;
+        painter.dispose();
+        final clamped = overflows && !expanded;
+
+        return Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(
+              source,
+              style: style,
+              maxLines: clamped ? _collapsedSourceLines : null,
+              overflow: clamped ? TextOverflow.ellipsis : TextOverflow.clip,
+            ),
+            if (overflows)
+              GestureDetector(
+                onTap: () => _toggleSource(clampId),
+                behavior: HitTestBehavior.opaque,
+                child: Padding(
+                  padding: const EdgeInsets.only(top: SoliplexSpacing.s1),
+                  child: Row(
+                    children: [
+                      // The row disclosures elsewhere encode state (right when
+                      // closed, down when open) because they carry no words.
+                      // This one is labelled with a verb, so the arrow points
+                      // at what the tap does: down to reveal, up to collapse.
+                      Icon(
+                        expanded ? Icons.expand_less : Icons.expand_more,
+                        size: 14,
+                        color: theme.colorScheme.onSurfaceVariant,
+                      ),
+                      const SizedBox(width: SoliplexSpacing.s1),
+                      Text(
+                        expanded ? 'Show less' : 'Show more',
+                        style: theme.textTheme.labelSmall?.copyWith(
+                          color: theme.colorScheme.onSurfaceVariant,
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+              ),
+          ],
+        );
+      },
     );
   }
 
@@ -380,8 +527,33 @@ class _ExecutionTimelineState extends ConsumerState<ExecutionTimeline> {
     }
   }
 
+  /// Renders a tool call's accumulated `TOOL_CALL_ARGS` for display.
+  ///
+  /// Prefers the one field that carries the intent — the query, the code, the
+  /// script, the command — over the whole object. Falls back to the raw string
+  /// when it does not parse: while the call is still streaming the accumulation
+  /// is a JSON prefix, and a partial payload is more useful shown than hidden.
+  static String _formatArgs(String args) {
+    final decoded = _tryDecodeObject(args);
+    if (decoded == null) return args;
+    for (final key in _sourceKeys) {
+      final value = decoded[key];
+      if (value is String && value.isNotEmpty) return value;
+    }
+    return const JsonEncoder.withIndent('  ').convert(decoded);
+  }
+
+  static Map<String, dynamic>? _tryDecodeObject(String raw) {
+    try {
+      final decoded = jsonDecode(raw);
+      return decoded is Map<String, dynamic> ? decoded : null;
+    } on FormatException {
+      return null;
+    }
+  }
+
   static String? _pickSource(SkillToolCallActivity activity) {
-    for (final key in const ['script', 'code', 'query']) {
+    for (final key in _sourceKeys) {
       final value = activity.args[key];
       if (value is String && value.isNotEmpty) return value;
     }

--- a/lib/src/modules/room/ui/execution/timeline_entry.dart
+++ b/lib/src/modules/room/ui/execution/timeline_entry.dart
@@ -20,7 +20,8 @@ sealed class TimelineEntry {
   const TimelineEntry();
 }
 
-/// A step and the detail of the server tool call it represents.
+/// A timeline step, plus the detail of the server tool call it represents when
+/// it is one.
 ///
 /// [args] and [result] belong to the call itself, so they are held on the
 /// entry rather than resolved from a separate store: a `TOOL_CALL_START`
@@ -28,8 +29,8 @@ sealed class TimelineEntry {
 /// `TOOL_CALL_RESULT` sets [result] once. Nothing rewrites them afterwards,
 /// which is why they need none of the id-resolution the activity path uses.
 ///
-/// [toolCallId] is null for steps that are not server tool calls (thinking,
-/// client-side tool execution); those have no args or result to show.
+/// [toolCallId] is null when the step is not a server tool call, in which case
+/// it carries no detail of its own.
 @immutable
 final class TimelineStep extends TimelineEntry {
   const TimelineStep({
@@ -44,10 +45,15 @@ final class TimelineStep extends TimelineEntry {
   final List<String> activityIds;
   final String? toolCallId;
 
-  /// Accumulated `TOOL_CALL_ARGS` deltas. Not valid JSON until the call ends.
+  /// Accumulated `TOOL_CALL_ARGS` deltas. May be a partial JSON prefix while
+  /// the call streams, so callers must tolerate a parse failure — the frontend
+  /// never observes the end of the args stream, because `TOOL_CALL_END` does
+  /// not bridge to an execution event.
   final String args;
 
-  /// The call's result body, or null until `TOOL_CALL_RESULT` arrives.
+  /// The call's result body. Null until `TOOL_CALL_RESULT` arrives, which is
+  /// what distinguishes a call still in flight from one that returned an empty
+  /// body.
   final String? result;
 
   TimelineStep withStep(ExecutionStep step) => _copyWith(step: step);
@@ -55,8 +61,11 @@ final class TimelineStep extends TimelineEntry {
   TimelineStep withActivities(List<String> activityIds) =>
       _copyWith(activityIds: activityIds);
 
-  TimelineStep withDetail({String? args, String? result}) =>
-      _copyWith(args: args, result: result);
+  /// Extends [args] by [delta]. Append-only lives here rather than at the call
+  /// site so no caller can truncate what a call has already streamed.
+  TimelineStep appendArgs(String delta) => _copyWith(args: args + delta);
+
+  TimelineStep withResult(String result) => _copyWith(result: result);
 
   TimelineStep _copyWith({
     ExecutionStep? step,

--- a/lib/src/modules/room/ui/execution/timeline_entry.dart
+++ b/lib/src/modules/room/ui/execution/timeline_entry.dart
@@ -20,18 +20,57 @@ sealed class TimelineEntry {
   const TimelineEntry();
 }
 
+/// A step and the detail of the server tool call it represents.
+///
+/// [args] and [result] belong to the call itself, so they are held on the
+/// entry rather than resolved from a separate store: a `TOOL_CALL_START`
+/// opens the step, its `TOOL_CALL_ARGS` deltas append to [args], and its
+/// `TOOL_CALL_RESULT` sets [result] once. Nothing rewrites them afterwards,
+/// which is why they need none of the id-resolution the activity path uses.
+///
+/// [toolCallId] is null for steps that are not server tool calls (thinking,
+/// client-side tool execution); those have no args or result to show.
 @immutable
 final class TimelineStep extends TimelineEntry {
-  const TimelineStep({required this.step, this.activityIds = const []});
+  const TimelineStep({
+    required this.step,
+    this.activityIds = const [],
+    this.toolCallId,
+    this.args = '',
+    this.result,
+  });
 
   final ExecutionStep step;
   final List<String> activityIds;
+  final String? toolCallId;
 
-  TimelineStep withStep(ExecutionStep step) =>
-      TimelineStep(step: step, activityIds: activityIds);
+  /// Accumulated `TOOL_CALL_ARGS` deltas. Not valid JSON until the call ends.
+  final String args;
+
+  /// The call's result body, or null until `TOOL_CALL_RESULT` arrives.
+  final String? result;
+
+  TimelineStep withStep(ExecutionStep step) => _copyWith(step: step);
 
   TimelineStep withActivities(List<String> activityIds) =>
-      TimelineStep(step: step, activityIds: activityIds);
+      _copyWith(activityIds: activityIds);
+
+  TimelineStep withDetail({String? args, String? result}) =>
+      _copyWith(args: args, result: result);
+
+  TimelineStep _copyWith({
+    ExecutionStep? step,
+    List<String>? activityIds,
+    String? args,
+    String? result,
+  }) =>
+      TimelineStep(
+        step: step ?? this.step,
+        activityIds: activityIds ?? this.activityIds,
+        toolCallId: toolCallId,
+        args: args ?? this.args,
+        result: result ?? this.result,
+      );
 }
 
 @immutable

--- a/lib/src/modules/room/ui/execution/timeline_entry.dart
+++ b/lib/src/modules/room/ui/execution/timeline_entry.dart
@@ -23,11 +23,12 @@ sealed class TimelineEntry {
 /// A timeline step, plus the detail of the server tool call it represents when
 /// it is one.
 ///
-/// [args] and [result] belong to the call itself, so they are held on the
-/// entry rather than resolved from a separate store: a `TOOL_CALL_START`
-/// opens the step, its `TOOL_CALL_ARGS` deltas append to [args], and its
-/// `TOOL_CALL_RESULT` sets [result] once. Nothing rewrites them afterwards,
-/// which is why they need none of the id-resolution the activity path uses.
+/// [args] and [result] belong to the call itself, so they are folded onto the
+/// entry rather than resolved at paint time the way an activity id is: a
+/// `TOOL_CALL_START` opens the step, its `TOOL_CALL_ARGS` deltas append to
+/// [args], and its `TOOL_CALL_RESULT` sets [result]. There is no separate
+/// store that could rewrite them in place, so the renderer has nothing to
+/// re-resolve them against.
 ///
 /// [toolCallId] is null when the step is not a server tool call, in which case
 /// it carries no detail of its own.
@@ -52,8 +53,9 @@ final class TimelineStep extends TimelineEntry {
   final String args;
 
   /// The call's result body. Null until `TOOL_CALL_RESULT` arrives, which is
-  /// what distinguishes a call still in flight from one that returned an empty
-  /// body.
+  /// how a run's completion tells a call still in flight from one that returned
+  /// an empty body and warns only about the former. The renderer draws no
+  /// result block for either.
   final String? result;
 
   TimelineStep withStep(ExecutionStep step) => _copyWith(step: step);
@@ -61,12 +63,14 @@ final class TimelineStep extends TimelineEntry {
   TimelineStep withActivities(List<String> activityIds) =>
       _copyWith(activityIds: activityIds);
 
-  /// Extends [args] by [delta]. Append-only lives here rather than at the call
-  /// site so no caller can truncate what a call has already streamed.
+  /// Extends [args] by [delta], so the tracker's delta arm cannot accidentally
+  /// assign in place of appending.
   TimelineStep appendArgs(String delta) => _copyWith(args: args + delta);
 
   TimelineStep withResult(String result) => _copyWith(result: result);
 
+  /// [toolCallId] is deliberately not a parameter: a row's identity as a tool
+  /// call is fixed when it opens, and every copy carries it through.
   TimelineStep _copyWith({
     ExecutionStep? step,
     List<String>? activityIds,

--- a/packages/soliplex_agent/lib/src/orchestration/execution_event.dart
+++ b/packages/soliplex_agent/lib/src/orchestration/execution_event.dart
@@ -91,6 +91,30 @@ class ServerToolCallStarted extends ExecutionEvent {
   int get hashCode => Object.hash(toolName, toolCallId);
 }
 
+/// One chunk of a server-side tool call's arguments.
+///
+/// Arguments stream as deltas, so a consumer accumulates them per
+/// [toolCallId]. Until the call ends the accumulation is not valid JSON.
+class ServerToolCallArgs extends ExecutionEvent {
+  const ServerToolCallArgs({
+    required this.toolCallId,
+    required this.delta,
+  });
+
+  final String toolCallId;
+  final String delta;
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is ServerToolCallArgs &&
+          toolCallId == other.toolCallId &&
+          delta == other.delta;
+
+  @override
+  int get hashCode => Object.hash(toolCallId, delta);
+}
+
 /// A server-side tool call has completed.
 class ServerToolCallCompleted extends ExecutionEvent {
   const ServerToolCallCompleted({

--- a/packages/soliplex_agent/lib/src/orchestration/execution_event.dart
+++ b/packages/soliplex_agent/lib/src/orchestration/execution_event.dart
@@ -94,7 +94,8 @@ class ServerToolCallStarted extends ExecutionEvent {
 /// One chunk of a server-side tool call's arguments.
 ///
 /// Arguments stream as deltas, so a consumer accumulates them per
-/// [toolCallId]. Until the call ends the accumulation is not valid JSON.
+/// [toolCallId]. A partial accumulation may not parse as JSON, so a consumer
+/// must tolerate a decode failure.
 class ServerToolCallArgs extends ExecutionEvent {
   const ServerToolCallArgs({
     required this.toolCallId,

--- a/packages/soliplex_agent/lib/src/runtime/agent_session.dart
+++ b/packages/soliplex_agent/lib/src/runtime/agent_session.dart
@@ -663,6 +663,8 @@ ExecutionEvent? bridgeBaseEvent(BaseEvent event) {
       const ThinkingEnded(),
     ToolCallStartEvent(:final toolCallId, :final toolCallName) =>
       ServerToolCallStarted(toolCallId: toolCallId, toolName: toolCallName),
+    ToolCallArgsEvent(:final toolCallId, :final delta) =>
+      ServerToolCallArgs(toolCallId: toolCallId, delta: delta),
     ToolCallResultEvent(:final toolCallId, :final content) =>
       ServerToolCallCompleted(toolCallId: toolCallId, result: content),
     RunFinishedEvent() => const RunCompleted(),
@@ -706,7 +708,6 @@ ExecutionEvent? bridgeBaseEvent(BaseEvent event) {
     // Deprecated upstream; arm only keeps the sealed switch exhaustive.
     // ignore: deprecated_member_use
     ThinkingContentEvent() ||
-    ToolCallArgsEvent() ||
     ToolCallEndEvent() ||
     StateSnapshotEvent() ||
     StateDeltaEvent() ||

--- a/packages/soliplex_agent/test/runtime/bridge_base_event_test.dart
+++ b/packages/soliplex_agent/test/runtime/bridge_base_event_test.dart
@@ -55,6 +55,24 @@ void main() {
       }
     });
 
+    test('routes ToolCallArgsEvent to ServerToolCallArgs', () {
+      // The arguments are the most useful thing in a tool-call row — for a
+      // RAG search they are the query. Without this arm the delta reaches no
+      // consumer and the row can only show the tool's name.
+      const event = ToolCallArgsEvent(
+        toolCallId: 'tc-1',
+        delta: '{"query":"pump maintenance interval"}',
+      );
+
+      expect(
+        bridgeBaseEvent(event),
+        const ServerToolCallArgs(
+          toolCallId: 'tc-1',
+          delta: '{"query":"pump maintenance interval"}',
+        ),
+      );
+    });
+
     test('ActivityDeltaEvent returns null', () {
       // The bridge intentionally drops ActivityDeltaEvent: the domain
       // layer applies the patch to Conversation.activities, and the

--- a/test/modules/room/execution_tracker_test.dart
+++ b/test/modules/room/execution_tracker_test.dart
@@ -209,6 +209,122 @@ void main() {
     expect(tracker.steps.value, isEmpty);
   });
 
+  group('tool call detail', () {
+    // The args and the result are attributes of the call the step row already
+    // represents, so the tracker folds them onto that step rather than
+    // nesting a second row under it.
+    List<TimelineStep> steps() =>
+        tracker.timeline.value.whereType<TimelineStep>().toList();
+
+    test('ServerToolCallStarted records the toolCallId on its step', () {
+      events.value = const ServerToolCallStarted(
+        toolName: 'rag_search',
+        toolCallId: 'tc-1',
+      );
+
+      expect(steps().single.toolCallId, 'tc-1');
+    });
+
+    test('thinking and client-tool steps carry no toolCallId', () {
+      // Only a server tool call has args and a result to show, so only its
+      // step is expandable. A null id is what makes the chevron absent.
+      events.value = const ThinkingStarted();
+      events.value = const ClientToolExecuting(
+        toolName: 'local_tool',
+        toolCallId: 'tc-client',
+      );
+
+      expect(steps().map((s) => s.toolCallId), [null, null]);
+    });
+
+    test('args deltas concatenate onto the step in arrival order', () {
+      events.value = const ServerToolCallStarted(
+        toolName: 'rag_search',
+        toolCallId: 'tc-1',
+      );
+      events.value = const ServerToolCallArgs(
+        toolCallId: 'tc-1',
+        delta: '{"query":"pump ',
+      );
+      events.value = const ServerToolCallArgs(
+        toolCallId: 'tc-1',
+        delta: 'maintenance"}',
+      );
+
+      expect(steps().single.args, '{"query":"pump maintenance"}');
+    });
+
+    test('ServerToolCallCompleted attaches its result to the same call', () {
+      events.value = const ServerToolCallStarted(
+        toolName: 'rag_cite',
+        toolCallId: 'tc-1',
+      );
+      events.value = const ServerToolCallCompleted(
+        toolCallId: 'tc-1',
+        result: 'Registered 2 citation(s).',
+      );
+
+      expect(steps().single.result, 'Registered 2 citation(s).');
+      expect(steps().single.step.status, StepStatus.completed);
+    });
+
+    test('a second call accumulates onto its own step', () {
+      // Post-upgrade runs make many top-level calls in one run, so a delta
+      // must land on the step that opened it, not the newest one.
+      events.value = const ServerToolCallStarted(
+        toolName: 'rag_search',
+        toolCallId: 'tc-1',
+      );
+      events.value = const ServerToolCallArgs(
+        toolCallId: 'tc-1',
+        delta: '{"query":"first"}',
+      );
+      events.value = const ServerToolCallCompleted(
+        toolCallId: 'tc-1',
+        result: 'first result',
+      );
+      events.value = const ServerToolCallStarted(
+        toolName: 'rag_search',
+        toolCallId: 'tc-2',
+      );
+      events.value = const ServerToolCallArgs(
+        toolCallId: 'tc-2',
+        delta: '{"query":"second"}',
+      );
+
+      expect(steps().map((s) => s.args), [
+        '{"query":"first"}',
+        '{"query":"second"}',
+      ]);
+      expect(steps().map((s) => s.result), ['first result', null]);
+    });
+
+    test('detail for an unknown toolCallId is dropped, not thrown', () {
+      // A dropped TOOL_CALL_START (reconnect, truncated stream) leaves later
+      // events with no step to attach to. The tracker asserts on any throw
+      // from _dispatch, so a lookup miss must be a no-op.
+      events.value = const ThinkingStarted();
+
+      expect(
+        () => events.value = const ServerToolCallArgs(
+          toolCallId: 'tc-missing',
+          delta: '{"query":"orphan"}',
+        ),
+        returnsNormally,
+      );
+      expect(
+        () => events.value = const ServerToolCallCompleted(
+          toolCallId: 'tc-missing',
+          result: 'orphan result',
+        ),
+        returnsNormally,
+      );
+
+      expect(steps().single.args, isEmpty);
+      expect(steps().single.result, isNull);
+    });
+  });
+
   group('skillToolCalls signal', () {
     test('starts empty', () {
       expect(tracker.skillToolCalls.value, isEmpty);

--- a/test/modules/room/execution_tracker_test.dart
+++ b/test/modules/room/execution_tracker_test.dart
@@ -216,15 +216,6 @@ void main() {
     List<TimelineStep> steps() =>
         tracker.timeline.value.whereType<TimelineStep>().toList();
 
-    test('ServerToolCallStarted records the toolCallId on its step', () {
-      events.value = const ServerToolCallStarted(
-        toolName: 'rag_search',
-        toolCallId: 'tc-1',
-      );
-
-      expect(steps().single.toolCallId, 'tc-1');
-    });
-
     test('thinking and client-tool steps carry no toolCallId', () {
       // Only a server tool call has args and a result to show, so only its
       // step is expandable. A null id is what makes the chevron absent.
@@ -268,9 +259,50 @@ void main() {
       expect(steps().single.step.status, StepStatus.completed);
     });
 
+    test('overlapping calls each settle their own step', () {
+      // A toolset that does not declare itself sequential can overlap calls, so
+      // both the detail and the completion must follow the id. Resolving either
+      // by position puts one call's result or check mark on the other's row.
+      events.value = const ServerToolCallStarted(
+        toolName: 'run_python',
+        toolCallId: 'tc-1',
+      );
+      events.value = const ServerToolCallStarted(
+        toolName: 'run',
+        toolCallId: 'tc-2',
+      );
+      events.value = const ServerToolCallArgs(
+        toolCallId: 'tc-1',
+        delta: '{"script":"print(1)"}',
+      );
+      events.value = const ServerToolCallCompleted(
+        toolCallId: 'tc-1',
+        result: 'first done',
+      );
+
+      final byId = {for (final s in steps()) s.toolCallId: s};
+      expect(byId['tc-1']!.args, '{"script":"print(1)"}');
+      expect(byId['tc-1']!.result, 'first done');
+      expect(
+        byId['tc-1']!.step.status,
+        StepStatus.completed,
+        reason: 'The call that returned is the one that should settle.',
+      );
+      expect(
+        byId['tc-2']!.result,
+        isNull,
+        reason: 'tc-2 has not returned, so it must carry no result.',
+      );
+      expect(
+        byId['tc-2']!.step.status,
+        StepStatus.active,
+        reason: 'Completing by position would settle tc-2 here instead.',
+      );
+    });
+
     test('a second call accumulates onto its own step', () {
-      // Post-upgrade runs make many top-level calls in one run, so a delta
-      // must land on the step that opened it, not the newest one.
+      // A run makes many top-level calls, so a delta must land on the step that
+      // opened it, not the newest one.
       events.value = const ServerToolCallStarted(
         toolName: 'rag_search',
         toolCallId: 'tc-1',
@@ -299,25 +331,18 @@ void main() {
       expect(steps().map((s) => s.result), ['first result', null]);
     });
 
-    test('detail for an unknown toolCallId is dropped, not thrown', () {
-      // A dropped TOOL_CALL_START (reconnect, truncated stream) leaves later
-      // events with no step to attach to. The tracker asserts on any throw
-      // from _dispatch, so a lookup miss must be a no-op.
+    test('detail for an unknown toolCallId is not applied to another step', () {
+      // Without an observed TOOL_CALL_START there is no step to attach to. The
+      // orphan must be discarded rather than landing on whichever step happens
+      // to be present — here the thinking step.
       events.value = const ThinkingStarted();
-
-      expect(
-        () => events.value = const ServerToolCallArgs(
-          toolCallId: 'tc-missing',
-          delta: '{"query":"orphan"}',
-        ),
-        returnsNormally,
+      events.value = const ServerToolCallArgs(
+        toolCallId: 'tc-missing',
+        delta: '{"query":"orphan"}',
       );
-      expect(
-        () => events.value = const ServerToolCallCompleted(
-          toolCallId: 'tc-missing',
-          result: 'orphan result',
-        ),
-        returnsNormally,
+      events.value = const ServerToolCallCompleted(
+        toolCallId: 'tc-missing',
+        result: 'orphan result',
       );
 
       expect(steps().single.args, isEmpty);

--- a/test/modules/room/execution_tracker_test.dart
+++ b/test/modules/room/execution_tracker_test.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 
 import 'package:flutter_test/flutter_test.dart';
 import 'package:soliplex_agent/soliplex_agent.dart';
+import 'package:soliplex_logging/soliplex_logging.dart';
 
 import 'package:soliplex_frontend/src/modules/room/execution_step.dart';
 import 'package:soliplex_frontend/src/modules/room/execution_tracker.dart';
@@ -300,9 +301,10 @@ void main() {
       );
     });
 
-    test('a second call accumulates onto its own step', () {
-      // A run makes many top-level calls, so a delta must land on the step that
-      // opened it, not the newest one.
+    test('a call id reused by a later run resolves to the later step', () {
+      // The reload path buckets several runs' events into one tracker, so the
+      // same id can open two steps. Detail must land on the one that opened
+      // most recently, or the later run's args overwrite the earlier run's row.
       events.value = const ServerToolCallStarted(
         toolName: 'rag_search',
         toolCallId: 'tc-1',
@@ -315,20 +317,26 @@ void main() {
         toolCallId: 'tc-1',
         result: 'first result',
       );
+      events.value = const RunCompleted();
       events.value = const ServerToolCallStarted(
         toolName: 'rag_search',
-        toolCallId: 'tc-2',
+        toolCallId: 'tc-1',
       );
       events.value = const ServerToolCallArgs(
-        toolCallId: 'tc-2',
+        toolCallId: 'tc-1',
         delta: '{"query":"second"}',
       );
+      events.value = const ServerToolCallCompleted(
+        toolCallId: 'tc-1',
+        result: 'second result',
+      );
 
-      expect(steps().map((s) => s.args), [
-        '{"query":"first"}',
-        '{"query":"second"}',
-      ]);
-      expect(steps().map((s) => s.result), ['first result', null]);
+      expect(
+        steps().map((s) => s.args),
+        ['{"query":"first"}', '{"query":"second"}'],
+        reason: 'Resolving oldest-first would append both onto run 1.',
+      );
+      expect(steps().map((s) => s.result), ['first result', 'second result']);
     });
 
     test('detail for an unknown toolCallId is not applied to another step', () {
@@ -347,6 +355,104 @@ void main() {
 
       expect(steps().single.args, isEmpty);
       expect(steps().single.result, isNull);
+      expect(
+        steps().single.step.status,
+        StepStatus.active,
+        reason: 'An orphan result must not credit an unrelated step with a '
+            'check mark and an elapsed time it did not earn.',
+      );
+    });
+  });
+
+  group('lost tool call detail is reported', () {
+    // These warnings are the only trace a dropped TOOL_CALL_ARGS or
+    // TOOL_CALL_RESULT leaves, so they are asserted rather than assumed.
+    const loggerName = 'execution_tracker_diagnostics';
+    late _RecordingSink sink;
+    late ExecutionTracker subject;
+
+    setUp(() {
+      sink = _RecordingSink(loggerName);
+      LogManager.instance.addSink(sink);
+      addTearDown(() => LogManager.instance.removeSink(sink));
+      subject = ExecutionTracker(
+        executionEvents: events,
+        activities: activities,
+        logger: testLogger(loggerName),
+      );
+      addTearDown(subject.dispose);
+    });
+
+    test('a run completing with no result for a call warns once', () {
+      events.value = const ServerToolCallStarted(
+        toolName: 'rag_search',
+        toolCallId: 'tc-1',
+      );
+      events.value = const RunCompleted();
+
+      final record = sink.warnings.single;
+      expect(record.attributes['tools'], 'rag_search');
+      expect(record.attributes['count'], 1);
+    });
+
+    test('a later run does not re-report an earlier run\'s gap', () {
+      // A replay bucket holds several runs, and the scan covers the whole
+      // timeline, so without per-id dedup run 1's gap is reported again at
+      // every later run's completion.
+      events.value = const ServerToolCallStarted(
+        toolName: 'rag_search',
+        toolCallId: 'tc-1',
+      );
+      events.value = const RunCompleted();
+      events.value = const ServerToolCallStarted(
+        toolName: 'rag_cite',
+        toolCallId: 'tc-2',
+      );
+      events.value = const RunCompleted();
+
+      expect(
+        sink.warnings.map((r) => r.attributes['tools']),
+        ['rag_search', 'rag_cite'],
+        reason: "Run 2's report must name only run 2's call.",
+      );
+    });
+
+    test('a call that returned a result is not reported', () {
+      events.value = const ServerToolCallStarted(
+        toolName: 'rag_search',
+        toolCallId: 'tc-1',
+      );
+      events.value = const ServerToolCallCompleted(
+        toolCallId: 'tc-1',
+        result: '',
+      );
+      events.value = const RunCompleted();
+
+      expect(
+        sink.warnings,
+        isEmpty,
+        reason: 'An empty result body is a result, not a missing one.',
+      );
+    });
+
+    test('an unmatched call is reported once per phase, not per delta', () {
+      // The delta stream would flood the sink unthrottled, but a lost result
+      // still has to be reported for an id whose args were already lost.
+      for (var i = 0; i < 5; i++) {
+        events.value = ServerToolCallArgs(
+          toolCallId: 'tc-missing',
+          delta: 'chunk$i',
+        );
+      }
+      events.value = const ServerToolCallCompleted(
+        toolCallId: 'tc-missing',
+        result: 'orphan',
+      );
+
+      expect(
+        sink.warnings.map((r) => r.attributes['phase']),
+        ['args', 'result'],
+      );
     });
   });
 
@@ -758,4 +864,29 @@ void main() {
 extension on StepStatus {
   bool get isTerminal =>
       this == StepStatus.completed || this == StepStatus.failed;
+}
+
+/// Captures records from one tracker's logger, ignoring the other traffic the
+/// shared `LogManager` sees so assertions stay strict.
+class _RecordingSink implements LogSink {
+  _RecordingSink(this.loggerName);
+
+  final String loggerName;
+  final List<LogRecord> records = [];
+
+  /// The lost-detail reports, separated from the per-call confirmation the
+  /// tracker also logs at info level.
+  List<LogRecord> get warnings =>
+      records.where((r) => r.level == LogLevel.warning).toList();
+
+  @override
+  void write(LogRecord record) {
+    if (record.loggerName == loggerName) records.add(record);
+  }
+
+  @override
+  Future<void> flush() async {}
+
+  @override
+  Future<void> close() async {}
 }

--- a/test/modules/room/historical_replay_test.dart
+++ b/test/modules/room/historical_replay_test.dart
@@ -83,6 +83,10 @@ void main() {
               toolCallId: 'tc-1',
               toolCallName: 'search',
             ),
+            ToolCallArgsEvent(
+              toolCallId: 'tc-1',
+              delta: '{"query":"pumps"}',
+            ),
             ToolCallResultEvent(
               messageId: 'result-1',
               toolCallId: 'tc-1',
@@ -99,6 +103,14 @@ void main() {
       expect(trackers.keys, containsAll(['msg-1', 'msg-2']));
       final first = trackers['msg-1']!;
       expect(first.steps.value.map((s) => s.label), ['search']);
+      // A reloaded thread must carry the call's detail, not just its name. The
+      // args and the start have to land in the same bucket for that to work, so
+      // this also pins the bucketing against a row that reloads with a result
+      // and no arguments.
+      final step = first.timeline.value.single as TimelineStep;
+      expect(step.toolCallId, 'tc-1');
+      expect(step.args, '{"query":"pumps"}');
+      expect(step.result, 'ok');
       final second = trackers['msg-2']!;
       expect(second.steps.value, isEmpty);
     });

--- a/test/modules/room/ui/execution/execution_timeline_test.dart
+++ b/test/modules/room/ui/execution/execution_timeline_test.dart
@@ -68,12 +68,17 @@ void main() {
 
   tearDown(() => tracker.dispose());
 
+  // Scrollable because the timeline lives inside the message list in
+  // production; without one, an expanded source block overflows the test
+  // viewport and the rendering assertion masks what is being asserted.
   Widget wrap(Widget child, {MessageExpansions? storeOverride}) =>
       ProviderScope(
         overrides: [
           messageExpansionsProvider.overrideWithValue(storeOverride ?? store),
         ],
-        child: MaterialApp(home: Scaffold(body: child)),
+        child: MaterialApp(
+          home: Scaffold(body: SingleChildScrollView(child: child)),
+        ),
       );
 
   ExecutionTimeline build({
@@ -479,6 +484,181 @@ void main() {
 
       // Safety invariant for source rows — no writes to the store.
       expect(store.debugHasStateFor(_roomId, loadingMessageId), isFalse);
+    });
+  });
+
+  group('server tool call detail on the step row', () {
+    // Post-upgrade, a retrieval is a first-class tool call: one step row per
+    // call, carrying its own args and result. No nested row — the step *is*
+    // the call.
+    Future<void> expand(WidgetTester tester, String stepLabel) async {
+      await tester.tap(find.text('1 event'));
+      await tester.pump();
+      await tester.tap(find.text(stepLabel));
+      await tester.pump();
+    }
+
+    testWidgets('expands to show arguments and result', (tester) async {
+      events.value = const ServerToolCallStarted(
+        toolName: 'analysis_execute_code',
+        toolCallId: 'tc-1',
+      );
+      events.value = const ServerToolCallArgs(
+        toolCallId: 'tc-1',
+        delta: '{"code":"df.groupby(\'site\').mean()"}',
+      );
+      events.value = const ServerToolCallCompleted(
+        toolCallId: 'tc-1',
+        result: 'site   value\nA      12.4',
+      );
+
+      await tester.pumpWidget(wrap(build()));
+      await tester.pump();
+      await expand(tester, 'analysis_execute_code');
+
+      // `code` is preferred over dumping the whole args object.
+      expect(find.text("df.groupby('site').mean()"), findsOneWidget);
+      // The result is the only place a code execution's stdout — or a
+      // ToolFailed message — reaches the user.
+      expect(find.text('site   value\nA      12.4'), findsOneWidget);
+    });
+
+    testWidgets('a step with no detail is not expandable', (tester) async {
+      events.value = const ThinkingStarted();
+
+      await tester.pumpWidget(wrap(build()));
+      await tester.pump();
+      await tester.tap(find.text('1 event'));
+      await tester.pump();
+
+      // The header now shows expand_more; a step with neither args nor a
+      // result contributes no chevron of its own.
+      expect(find.byIcon(Icons.chevron_right), findsNothing);
+    });
+
+    testWidgets('partial JSON args render raw rather than throwing',
+        (tester) async {
+      // While TOOL_CALL_ARGS is still streaming, the accumulated string is not
+      // valid JSON. The old activity path never saw this — args arrived whole.
+      events.value = const ServerToolCallStarted(
+        toolName: 'rag_search',
+        toolCallId: 'tc-1',
+      );
+      events.value = const ServerToolCallArgs(
+        toolCallId: 'tc-1',
+        delta: '{"query":"Soli',
+      );
+
+      await tester.pumpWidget(wrap(build()));
+      await tester.pump();
+      await expand(tester, 'rag_search');
+
+      expect(find.text('{"query":"Soli'), findsOneWidget);
+    });
+
+    testWidgets('a long result is clamped until expanded', (tester) async {
+      // A rag_search result is 20-35 KB of chunk text. Showing all of it by
+      // default buries the rest of the timeline.
+      final long = List.generate(40, (i) => 'chunk line $i').join('\n');
+      events.value = const ServerToolCallStarted(
+        toolName: 'rag_search',
+        toolCallId: 'tc-1',
+      );
+      events.value = ServerToolCallCompleted(
+        toolCallId: 'tc-1',
+        result: long,
+      );
+
+      await tester.pumpWidget(wrap(build()));
+      await tester.pump();
+      await expand(tester, 'rag_search');
+
+      expect(tester.widget<Text>(find.text(long)).maxLines, 8);
+      expect(find.text('Show more'), findsOneWidget);
+
+      await tester.tap(find.text('Show more'));
+      await tester.pump();
+
+      expect(tester.widget<Text>(find.text(long)).maxLines, isNull);
+      expect(find.text('Show less'), findsOneWidget);
+      // The arrow points at what the tap does, so collapsing points up. A
+      // down arrow beside "Show less" contradicts its own label.
+      expect(find.byIcon(Icons.expand_less), findsOneWidget);
+    });
+
+    testWidgets('a short result is not clamped and offers no disclosure',
+        (tester) async {
+      // Same principle as the step row's chevron: no affordance where nothing
+      // is hidden.
+      events.value = const ServerToolCallStarted(
+        toolName: 'rag_cite',
+        toolCallId: 'tc-1',
+      );
+      events.value = const ServerToolCallCompleted(
+        toolCallId: 'tc-1',
+        result: 'Registered 2 citation(s).',
+      );
+
+      await tester.pumpWidget(wrap(build()));
+      await tester.pump();
+      await expand(tester, 'rag_cite');
+
+      expect(
+        tester.widget<Text>(find.text('Registered 2 citation(s).')).maxLines,
+        isNull,
+      );
+      expect(find.text('Show more'), findsNothing);
+    });
+
+    testWidgets("one call's result expansion does not affect another's",
+        (tester) async {
+      // The clamp is keyed per call, so expanding one long result must not
+      // unclamp every other row in the run.
+      final long = List.generate(40, (i) => 'line $i').join('\n');
+      for (final id in ['tc-1', 'tc-2']) {
+        events.value = ServerToolCallStarted(
+          toolName: 'rag_search_$id',
+          toolCallId: id,
+        );
+        events.value = ServerToolCallCompleted(toolCallId: id, result: long);
+      }
+
+      await tester.pumpWidget(wrap(build()));
+      await tester.pump();
+      await tester.tap(find.text('2 events'));
+      await tester.pump();
+      await tester.tap(find.text('rag_search_tc-1'));
+      await tester.tap(find.text('rag_search_tc-2'));
+      await tester.pump();
+
+      await tester.tap(find.text('Show more').first);
+      await tester.pump();
+
+      expect(find.text('Show less'), findsOneWidget);
+      expect(find.text('Show more'), findsOneWidget);
+    });
+
+    testWidgets('args with no recognised key fall back to pretty JSON',
+        (tester) async {
+      // The shape a pre-upgrade thread's outer `execute_skill` call carries.
+      events.value = const ServerToolCallStarted(
+        toolName: 'execute_skill',
+        toolCallId: 'tc-1',
+      );
+      events.value = const ServerToolCallArgs(
+        toolCallId: 'tc-1',
+        delta: '{"request":"Search the docs","skill_name":"rag"}',
+      );
+
+      await tester.pumpWidget(wrap(build()));
+      await tester.pump();
+      await expand(tester, 'execute_skill');
+
+      expect(
+        find.text('{\n  "request": "Search the docs",\n'
+            '  "skill_name": "rag"\n}'),
+        findsOneWidget,
+      );
     });
   });
 }

--- a/test/modules/room/ui/execution/execution_timeline_test.dart
+++ b/test/modules/room/ui/execution/execution_timeline_test.dart
@@ -1,3 +1,5 @@
+import 'dart:convert';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -517,8 +519,8 @@ void main() {
 
       // `code` is preferred over dumping the whole args object.
       expect(find.text("df.groupby('site').mean()"), findsOneWidget);
-      // The result is the only place a code execution's stdout — or a
-      // ToolFailed message — reaches the user.
+      // The result is the only place in the chat UI that a code execution's
+      // stdout — or the message from a tool that raised — reaches the user.
       expect(find.text('site   value\nA      12.4'), findsOneWidget);
     });
 
@@ -711,6 +713,43 @@ void main() {
         isNull,
       );
       expect(find.text('Show more'), findsNothing);
+    });
+
+    testWidgets("a call's args and result clamp independently", (tester) async {
+      // One row discloses two bodies, so each needs its own clamp key. Sharing
+      // one would make "Show more" under Arguments unclamp the Result too.
+      final script = List.generate(40, (i) => 'script line $i').join('\n');
+      final result = List.generate(40, (i) => 'result line $i').join('\n');
+      events.value = const ServerToolCallStarted(
+        toolName: 'run_python',
+        toolCallId: 'tc-1',
+      );
+      events.value = ServerToolCallArgs(
+        toolCallId: 'tc-1',
+        delta: jsonEncode({'script': script}),
+      );
+      events.value = ServerToolCallCompleted(
+        toolCallId: 'tc-1',
+        result: result,
+      );
+
+      await tester.pumpWidget(wrap(build()));
+      await tester.pump();
+      await expand(tester, 'run_python');
+
+      expect(tester.widget<Text>(find.text(script)).maxLines, 8);
+      expect(tester.widget<Text>(find.text(result)).maxLines, 8);
+
+      // The Arguments block renders first, so its control comes first.
+      await tester.tap(find.text('Show more').first);
+      await tester.pump();
+
+      expect(tester.widget<Text>(find.text(script)).maxLines, isNull);
+      expect(
+        tester.widget<Text>(find.text(result)).maxLines,
+        8,
+        reason: 'Sharing one clamp key would unclamp the result as well.',
+      );
     });
 
     testWidgets("one call's result expansion does not affect another's",

--- a/test/modules/room/ui/execution/execution_timeline_test.dart
+++ b/test/modules/room/ui/execution/execution_timeline_test.dart
@@ -488,9 +488,8 @@ void main() {
   });
 
   group('server tool call detail on the step row', () {
-    // Post-upgrade, a retrieval is a first-class tool call: one step row per
-    // call, carrying its own args and result. No nested row — the step *is*
-    // the call.
+    // A retrieval is a first-class tool call: one step row per call, carrying
+    // its own args and result. No nested row — the step *is* the call.
     Future<void> expand(WidgetTester tester, String stepLabel) async {
       await tester.tap(find.text('1 event'));
       await tester.pump();
@@ -523,6 +522,110 @@ void main() {
       expect(find.text('site   value\nA      12.4'), findsOneWidget);
     });
 
+    testWidgets('a call with no args and no result is not expandable',
+        (tester) async {
+      // The state of every tool call row between its start and its first delta,
+      // of a call whose stream was truncated, and of a tool returning no output.
+      // An empty grey block would be worse than no block.
+      events.value = const ServerToolCallStarted(
+        toolName: 'list_environments',
+        toolCallId: 'tc-1',
+      );
+      events.value = const ServerToolCallCompleted(
+        toolCallId: 'tc-1',
+        result: '',
+      );
+
+      await tester.pumpWidget(wrap(build()));
+      await tester.pump();
+      await tester.tap(find.text('1 event'));
+      await tester.pump();
+
+      expect(find.byIcon(Icons.chevron_right), findsNothing);
+      expect(find.text('Arguments'), findsNothing);
+      expect(find.text('Result'), findsNothing);
+    });
+
+    testWidgets('args of a tool that takes none yield no block',
+        (tester) async {
+      // A no-argument tool sends `{}`. Pretty-printing that produces a block
+      // whose entire content is `{}` — an affordance hiding nothing.
+      events.value = const ServerToolCallStarted(
+        toolName: 'list_environments',
+        toolCallId: 'tc-1',
+      );
+      events.value = const ServerToolCallArgs(toolCallId: 'tc-1', delta: '{}');
+
+      await tester.pumpWidget(wrap(build()));
+      await tester.pump();
+      await tester.tap(find.text('1 event'));
+      await tester.pump();
+
+      expect(find.byIcon(Icons.chevron_right), findsNothing);
+      expect(find.text('{}'), findsNothing);
+    });
+
+    testWidgets('the clamp still applies when text is scaled up',
+        (tester) async {
+      // The clamp decision has to be measured at the scale the text renders at.
+      // Measuring unscaled reports a scaled-up body as fitting, so it renders
+      // in full with no control — the outcome the clamp exists to prevent.
+      //
+      // Deliberately one unbroken line: a body carrying explicit line breaks is
+      // known to overflow without measuring, which would skip the path under
+      // test. Its length has to straddle the clamp — short enough to fit
+      // unscaled, long enough to overflow scaled — so both directions are
+      // asserted and a length that drifts out of that band fails loudly.
+      final wrapping = 'wrapped ' * 40;
+      events.value = const ServerToolCallStarted(
+        toolName: 'rag_search',
+        toolCallId: 'tc-1',
+      );
+      events.value =
+          ServerToolCallCompleted(toolCallId: 'tc-1', result: wrapping);
+
+      await tester.pumpWidget(wrap(build()));
+      await tester.pump();
+      await expand(tester, 'rag_search');
+
+      expect(
+        tester.widget<Text>(find.text(wrapping)).maxLines,
+        isNull,
+        reason: 'Unscaled this body fits, so nothing should be clamped.',
+      );
+      expect(find.text('Show more'), findsNothing);
+
+      // Scale the same open row in place. Set on the dispatcher, not as an
+      // ancestor MediaQuery: MaterialApp installs its own from the view and
+      // would override one above it.
+      tester.platformDispatcher.textScaleFactorTestValue = 3;
+      addTearDown(tester.platformDispatcher.clearTextScaleFactorTestValue);
+      await tester.pump();
+
+      expect(tester.widget<Text>(find.text(wrapping)).maxLines, 8);
+      expect(find.text('Show more'), findsOneWidget);
+    });
+
+    testWidgets('a recognised argument key wins over the whole object',
+        (tester) async {
+      // `command` is the sandbox shell tool's argument; the preference list is
+      // shared with the activity rows, so its contents are load-bearing twice.
+      events.value = const ServerToolCallStarted(
+        toolName: 'run',
+        toolCallId: 'tc-1',
+      );
+      events.value = const ServerToolCallArgs(
+        toolCallId: 'tc-1',
+        delta: '{"command":"ls -la","environment_name":"default"}',
+      );
+
+      await tester.pumpWidget(wrap(build()));
+      await tester.pump();
+      await expand(tester, 'run');
+
+      expect(find.text('ls -la'), findsOneWidget);
+    });
+
     testWidgets('a step with no detail is not expandable', (tester) async {
       events.value = const ThinkingStarted();
 
@@ -531,15 +634,15 @@ void main() {
       await tester.tap(find.text('1 event'));
       await tester.pump();
 
-      // The header now shows expand_more; a step with neither args nor a
+      // The expanded header shows expand_more; a step with neither args nor a
       // result contributes no chevron of its own.
       expect(find.byIcon(Icons.chevron_right), findsNothing);
     });
 
     testWidgets('partial JSON args render raw rather than throwing',
         (tester) async {
-      // While TOOL_CALL_ARGS is still streaming, the accumulated string is not
-      // valid JSON. The old activity path never saw this — args arrived whole.
+      // While TOOL_CALL_ARGS is still streaming, the accumulated string is a
+      // JSON prefix, so the formatter must not require it to parse.
       events.value = const ServerToolCallStarted(
         toolName: 'rag_search',
         toolCallId: 'tc-1',
@@ -640,7 +743,8 @@ void main() {
 
     testWidgets('args with no recognised key fall back to pretty JSON',
         (tester) async {
-      // The shape a pre-upgrade thread's outer `execute_skill` call carries.
+      // Args carrying no recognised key: the whole object is the only thing
+      // worth showing.
       events.value = const ServerToolCallStarted(
         toolName: 'execute_skill',
         toolCallId: 'tc-1',


### PR DESCRIPTION
## What

The execution timeline's nested detail rows were fed by `skill_tool_call` /
`skill_tool_result` `ACTIVITY_SNAPSHOT` events from the sub-agent runtime the
backend replaced. Nothing constructs one any more, so no nested row was
produced at all and the timeline rendered as a flat list of tool names.

Retrievals now arrive as ordinary tool calls, so the detail comes from
`TOOL_CALL_ARGS` and `TOOL_CALL_RESULT` and expands from the step row that
already represents that call — one row per call, rather than a row nested
beneath itself.

## How

- A new `ServerToolCallArgs` execution event, bridged from `ToolCallArgsEvent`.
- `TimelineStep` carries the call's `toolCallId`, accumulated `args`, and
  `result`, folded on as the events arrive rather than resolved at paint time.
- Both the result body and the completion tick are addressed by tool-call id.
  A toolset that does not declare itself sequential can overlap calls, so
  settling by position put a check mark and an elapsed time on a sibling
  call's row that was still running. A result for a call the timeline never
  opened settles nothing at all.
- Arguments show the field carrying the intent (script, code, query, command)
  and the whole object otherwise. A tool taking no arguments yields no block;
  a still-streaming JSON prefix renders as-is rather than being withheld.
- Both blocks clamp to eight lines with a show-more control, measured at the
  text scale the body will actually render at. Copying takes the whole body.
- Detail lost in transit is reported: an unmatched args delta or result, and a
  run finishing with a call whose result never arrived. Lengths and ids only —
  no payload bodies, since args carry the user's query and results carry
  retrieved document text.

## Notes

- Deciding whether a row has detail no longer decodes and re-encodes the
  payload; that ran for every row on every rebuild, once per args delta.
- The show-more control is a `SoliplexButton`, so it carries button semantics
  and the minimum tap target.
- The activity pipeline is left in place; retiring it is tracked separately.

## Verification

- `dart format` clean, `flutter analyze` reports no issues
- 2204 frontend tests pass; `soliplex_agent` passes with
  `--exclude-tags integration` (its integration tests need a live backend)
- New tests were mutation-checked — each was confirmed to fail against a
  deliberately broken version of the code it covers

🤖 Generated with [Claude Code](https://claude.com/claude-code)
