### PR TITLE
chore: version 0.98.1+77

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ Versions follow the `version+build` scheme from `pubspec.yaml`, bumped via
 
 ## [Unreleased]
 
+## [0.98.1+77] - 2026-07-31
+
 ### Fixed
 
 - Citations render again. The backend now carries a run's cited set in a single

--- a/lib/version.dart
+++ b/lib/version.dart
@@ -2,4 +2,4 @@
 ///
 /// Generated from pubspec.yaml. Run `dart run tool/update_version.dart` after
 /// changing the version in pubspec.yaml.
-const String soliplexVersion = '0.98.0+76';
+const String soliplexVersion = '0.98.1+77';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,7 +3,7 @@ description: Modular Flutter frontend framework for Soliplex
 publish_to: none
 # To update version, run:
 # dart run tool/bump_version.dart <major|minor|patch|build>
-version: 0.98.0+76
+version: 0.98.1+77
 
 environment:
   sdk: ^3.6.0


### PR DESCRIPTION
Cuts release `0.98.1+77` (patch).

- `pubspec.yaml` / `lib/version.dart` bumped via `dart run tool/bump_version.dart patch`.
- `CHANGELOG.md` stamps `[0.98.1+77] - 2026-07-31` over the accumulated `[Unreleased]` block.

The `[Unreleased]` block was empty at `v0.98.0+76`, so its entire contents belong to this release — the citation state-snapshot fixes, the explicit chunk-visualization `expand`, and the execution-timeline tool-call detail work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)