### PR TITLE
fix: name and type an embedded file as itself, not its container

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,24 @@ Versions follow the `version+build` scheme from `pubspec.yaml`, bumped via
   `content['tool_name']`, announcing a tool call from a payload the protocol says
   nothing about; `TOOL_CALL_START` is the event that names a tool, and it already
   sets the label.
+- A citation is labelled by its document's filename in preference to the
+  document's title; the title is the fallback when the URI names no file. The
+  filename identifies the file a chunk came from — it names an embedded file
+  rather than the PDF it was found in, and it matches how the same document is
+  labelled in the list and the picker. *The preference itself* has no visible
+  effect unless the backend is configured to generate document titles, since it
+  otherwise sends none; **a deployment that does have titles will see every
+  citation relabelled**, in the citation row, in a copied citation, and in the
+  chunk preview's heading.
+- Every document's display name is percent-decoded and has any query string or
+  fragment dropped, not just an attachment's, since all of them now read one
+  parse of the URI. `annual%20report.pdf` reads `annual report.pdf`, and
+  `handbook.pdf#page=3` reads `handbook.pdf`. A URI that carries its filename in
+  a query string rather than its path shows the last path segment instead —
+  `/download?file=report.pdf` shows `download`. A filename holding an unescaped
+  `#` is cut there, so `invoice#1234.xlsx` reads `invoice`: from the URI string
+  alone that `#` and a `#page=` fragment are the same shape, and two such
+  documents differing only after the `#` become one label and one glyph.
 
 ### Fixed
 
@@ -55,6 +73,25 @@ Versions follow the `version+build` scheme from `pubspec.yaml`, bumped via
   true while the row showed a query, false once it showed a whole content payload
   with a retrieval result inside, at which point one open row buried every row
   below it.
+- A file embedded in a PDF is named and typed as itself. The backend ingests one
+  as its own document and records the relationship in the document URI, which
+  three separate places used to interpret three different ways: the document list
+  and picker showed the container's name with the whole URI fragment glued on, the
+  file-type glyph described the container rather than the embedded file, and a
+  citation of the embedded file was labelled with the container's name. All three
+  now read one parse of the URI, so an attachment shows its own decoded filename
+  and its own glyph wherever it appears, and a citation names the document the
+  text actually came from.
+- A document whose URI names no file — one ending in a slash — no longer renders a
+  blank label in the list, the picker or the attachment chips, and no longer
+  renders a blank citation. In the list it falls back to the document's title,
+  which is the raw URI string unless the backend is configured to generate
+  titles; a citation with no title reads "Unknown Document". A name that decodes
+  to nothing but whitespace falls back the same way, rather than rendering as an
+  invisible label.
+- A display name is trimmed, so a filename delivered with escaped padding
+  (`report.pdf%20`) no longer renders with invisible whitespace, nor loses its
+  file-type glyph to an extension that still carried the padding.
 
 ## [0.98.1+77] - 2026-07-31
 

--- a/lib/src/modules/room/ui/chat_input.dart
+++ b/lib/src/modules/room/ui/chat_input.dart
@@ -183,7 +183,7 @@ class _ChatInputState extends State<ChatInput> {
                                 for (final doc in widget.selectedDocuments)
                                   SoliplexChip(
                                     icon: Icon(
-                                      getFileTypeIcon(documentIconPath(doc)),
+                                      documentTypeIcon(doc),
                                     ),
                                     label: Text(documentDisplayName(doc)),
                                     onDeleted:

--- a/lib/src/modules/room/ui/document_picker.dart
+++ b/lib/src/modules/room/ui/document_picker.dart
@@ -117,7 +117,7 @@ class _DocumentPickerState extends State<DocumentPicker> {
                     final doc = filtered[index];
                     final selected = widget.selected.contains(doc);
                     return CheckboxListTile(
-                      secondary: Icon(getFileTypeIcon(documentIconPath(doc))),
+                      secondary: Icon(documentTypeIcon(doc)),
                       title: Text(
                         documentDisplayName(doc),
                         overflow: TextOverflow.ellipsis,

--- a/lib/src/modules/room/ui/room_info/documents_card.dart
+++ b/lib/src/modules/room/ui/room_info/documents_card.dart
@@ -164,7 +164,7 @@ class _DocumentsCardState extends State<DocumentsCard> {
             Row(
               children: [
                 Icon(
-                  getFileTypeIcon(documentIconPath(doc)),
+                  documentTypeIcon(doc),
                   size: 22,
                 ),
                 const SizedBox(width: SoliplexSpacing.s2),

--- a/lib/src/shared/file_type_icons.dart
+++ b/lib/src/shared/file_type_icons.dart
@@ -1,49 +1,22 @@
 import 'package:flutter/material.dart';
 import 'package:soliplex_client/soliplex_client.dart';
 
-/// Returns the appropriate icon for a document based on its file extension.
+/// Maps a lowercase file extension to a recognizable Material icon, falling
+/// back to [Icons.insert_drive_file] for an unknown or missing one.
+IconData _iconForExtension(String extension) => switch (extension) {
+      'pdf' => Icons.picture_as_pdf,
+      'doc' || 'docx' => Icons.description,
+      'xls' || 'xlsx' => Icons.table_chart,
+      'ppt' || 'pptx' => Icons.slideshow,
+      'png' || 'jpg' || 'jpeg' || 'gif' || 'webp' || 'bmp' => Icons.image,
+      'txt' || 'md' => Icons.article,
+      _ => Icons.insert_drive_file,
+    };
+
+/// Extracts the lowercase extension from [filename].
 ///
-/// Maps common file types to recognizable Material icons:
-/// - PDF files: [Icons.picture_as_pdf]
-/// - Word documents (.doc, .docx): [Icons.description]
-/// - Excel spreadsheets (.xls, .xlsx): [Icons.table_chart]
-/// - PowerPoint presentations (.ppt, .pptx): [Icons.slideshow]
-/// - Images (.png, .jpg, .jpeg, .gif, .webp, .bmp): [Icons.image]
-/// - Text/markdown (.txt, .md): [Icons.article]
-/// - Unknown/missing extensions: [Icons.insert_drive_file]
-///
-/// Extension matching is case-insensitive.
-IconData getFileTypeIcon(String path) {
-  final extension = _extractExtension(path);
-
-  return switch (extension) {
-    'pdf' => Icons.picture_as_pdf,
-    'doc' || 'docx' => Icons.description,
-    'xls' || 'xlsx' => Icons.table_chart,
-    'ppt' || 'pptx' => Icons.slideshow,
-    'png' || 'jpg' || 'jpeg' || 'gif' || 'webp' || 'bmp' => Icons.image,
-    'txt' || 'md' => Icons.article,
-    _ => Icons.insert_drive_file,
-  };
-}
-
-/// Extracts the lowercase file extension from a path.
-///
-/// Returns an empty string if no extension is found.
-String _extractExtension(String path) {
-  // Remove query strings and fragments
-  var cleanPath = path.split('?').first.split('#').first;
-
-  // Remove file:// prefix if present
-  if (cleanPath.startsWith('file://')) {
-    cleanPath = cleanPath.substring(7);
-  }
-
-  // Get the filename (last path segment)
-  final segments = cleanPath.split('/');
-  final filename = segments.isNotEmpty ? segments.last : cleanPath;
-
-  // Find the last dot that has characters after it
+/// Returns an empty string when there is no dot with characters after it.
+String _extensionOfName(String filename) {
   final lastDot = filename.lastIndexOf('.');
   if (lastDot == -1 || lastDot == filename.length - 1) {
     return '';
@@ -52,33 +25,29 @@ String _extractExtension(String path) {
   return filename.substring(lastDot + 1).toLowerCase();
 }
 
+/// The filename [doc]'s URI addresses, or null when the URI names none.
+///
+/// An empty URI and a bare UUID are ids rather than paths, so they are rejected
+/// before parsing — a UUID would otherwise read as a perfectly good filename.
+String? _fileName(RagDocument doc) => doc.uri.isEmpty || _isUuid(doc.uri)
+    ? null
+    : DocumentRef.parse(doc.uri).displayName;
+
 /// Returns a user-friendly display name for a [RagDocument].
 ///
-/// Uses the filename from [RagDocument.uri] when it contains a file
-/// path. Falls back to [RagDocument.title] when the URI is empty or
-/// a bare UUID (e.g. quiz items).
-String documentDisplayName(RagDocument doc) {
-  final uri = doc.uri;
-  if (uri.isEmpty || _isUuid(uri)) {
-    return doc.title;
-  }
-  var path = uri;
-  if (path.startsWith('file://')) {
-    path = path.substring(7);
-  }
-  final lastSlash = path.lastIndexOf('/');
-  if (lastSlash == -1) return path;
-  return path.substring(lastSlash + 1);
-}
+/// Uses the filename from [RagDocument.uri] — the attachment's own name when
+/// the URI addresses a file embedded in another document. Falls back to
+/// [RagDocument.title] when the URI names no file, and when it is an id rather
+/// than a path (an empty URI or a bare UUID, e.g. quiz items).
+String documentDisplayName(RagDocument doc) => _fileName(doc) ?? doc.title;
 
-/// Returns the path used for file-type icon detection from a
-/// [RagDocument]. Uses [RagDocument.uri] when available, falling
-/// back to [RagDocument.title] for UUID or empty URIs.
-String documentIconPath(RagDocument doc) {
-  final uri = doc.uri;
-  if (uri.isEmpty || _isUuid(uri)) return doc.title;
-  return uri;
-}
+/// Returns the file-type icon for a [RagDocument].
+///
+/// Reads the extension off the name [documentDisplayName] renders, so the glyph
+/// always describes the file the row is labelled with: an attachment reflects
+/// the embedded file's type, not its container's.
+IconData documentTypeIcon(RagDocument doc) =>
+    _iconForExtension(_extensionOfName(documentDisplayName(doc)));
 
 /// Filters [docs] by matching [query] against display name and URI.
 ///

--- a/packages/soliplex_client/lib/src/domain/document_ref.dart
+++ b/packages/soliplex_client/lib/src/domain/document_ref.dart
@@ -1,0 +1,135 @@
+import 'dart:convert';
+
+import 'package:meta/meta.dart';
+
+/// The marker the backend appends to a container's URI for each file embedded
+/// in it, with the name percent-encoded (`quote(name, safe='')`).
+const _attachmentMarker = '#attachment=';
+
+/// A document URI decomposed into the document it lives in and the chain of
+/// attachment names leading to it.
+///
+/// The backend ingests files embedded in a PDF as separate, first-class
+/// documents and encodes the relationship in the URI:
+///
+/// ```text
+/// file:///docs/annual-report.pdf#attachment=budget.xlsx
+/// file:///docs/a.pdf#attachment=b.pdf#attachment=inner.xlsx
+/// ```
+///
+/// This is pure URI structure and knows nothing about document titles;
+/// callers compose the two.
+@immutable
+class DocumentRef {
+  const DocumentRef._({required this.rootUri, required this.attachmentPath});
+
+  /// Decomposes [uri] into its root and attachment names.
+  ///
+  /// Splits on the literal `#attachment=` rather than reading [Uri.fragment],
+  /// because a nested URI carries two unencoded `#` separators and URI parsing
+  /// re-encodes the second one as `%23`.
+  ///
+  /// Every [String] yields a ref and none throws: a string with no marker
+  /// simply has no attachments.
+  ///
+  /// A segment that decodes to nothing is dropped rather than kept as a level,
+  /// so a trailing `#attachment=` degrades to the containing document.
+  factory DocumentRef.parse(String uri) {
+    final segments = uri.split(_attachmentMarker);
+    return DocumentRef._(
+      rootUri: segments.first,
+      attachmentPath: List.unmodifiable(
+        segments.skip(1).map(_decode).where((name) => name.isNotEmpty),
+      ),
+    );
+  }
+
+  /// The URI of the outermost document, with every attachment segment
+  /// stripped. A fragment ahead of the first attachment marker (e.g.
+  /// `#page=3`) is left in place; anything after one belongs to that
+  /// attachment's name.
+  final String rootUri;
+
+  /// Decoded attachment names from [rootUri] down to this document, outermost
+  /// first. Empty for a plain document; no entry is the empty string, though
+  /// one can be blank, since [DocumentRef.parse] drops only empty segments.
+  ///
+  /// One entry per nesting level, not a set of siblings: files embedded
+  /// alongside each other are separate documents with separate URIs, each
+  /// holding its own path off the same [rootUri].
+  final List<String> attachmentPath;
+
+  /// Whether this URI addresses a file embedded in another document.
+  bool get isAttachment => attachmentPath.isNotEmpty;
+
+  /// The innermost attachment name, or the decoded filename of [rootUri] when
+  /// this is a plain document, trimmed of surrounding whitespace.
+  ///
+  /// Null when the name reads blank, so a caller that needs a label has to
+  /// supply its own fallback rather than render an invisible one. For a plain
+  /// document that covers a [rootUri] ending in a separator, or naming no path
+  /// at all.
+  ///
+  /// Two surprises reach a plain document's name: an unescaped `?` or `#`
+  /// truncates it, and a URI with no path (`https://example.test`) yields its
+  /// host.
+  String? get displayName {
+    final name = (isAttachment ? attachmentPath.last : _rootFileName).trim();
+    return name.isEmpty ? null : name;
+  }
+
+  /// The documents containing this one, outermost first, each trimmed the way
+  /// [displayName] trims.
+  ///
+  /// For `a.pdf#attachment=b.pdf#attachment=c.xlsx` this is `[a.pdf, b.pdf]`.
+  /// Empty when this is not an attachment. A name that reads blank contributes
+  /// no entry, at any level, so joining these never yields a dangling
+  /// separator.
+  List<String> get ancestorNames {
+    if (!isAttachment) return const [];
+    return [
+      _rootFileName,
+      ...attachmentPath.take(attachmentPath.length - 1),
+    ].map((name) => name.trim()).where((name) => name.isNotEmpty).toList();
+  }
+
+  /// [rootUri]'s decoded filename, with any query or fragment dropped.
+  ///
+  /// Split before decoding: a `?` or `#` that is part of a filename arrives
+  /// percent-escaped, and decoding first would turn it into a delimiter that
+  /// truncates the name. The split therefore runs on the raw string, so an
+  /// *unescaped* `?` or `#` does delimit — which is what resolves
+  /// `a.pdf#page=3` to `a.pdf`, and what truncates a name that really contained
+  /// one. Only a source storing already-decoded paths can hit the latter.
+  ///
+  /// Taking the last `/`-separated segment cannot tell an authority from a path,
+  /// so a URI with no path at all (`https://example.test`) yields its host.
+  String get _rootFileName {
+    final path = rootUri.split('#').first.split('?').first;
+    final lastSlash = path.lastIndexOf('/');
+    return _decode(lastSlash == -1 ? path : path.substring(lastSlash + 1));
+  }
+}
+
+/// One or more consecutive percent escapes, carrying a UTF-8 byte sequence.
+/// Matched as a run so a multi-byte code point decodes as a unit.
+final _escapeRun = RegExp('(?:%[0-9a-fA-F]{2})+');
+
+/// Percent-decodes the escapes in [segment], leaving everything else alone.
+///
+/// Text outside an escape run is passed through untouched — including a raw
+/// non-ASCII character or a `%` that begins no escape (`100%`) — and bytes that
+/// are not legal UTF-8 become U+FFFD instead of aborting the name. That is what
+/// makes [DocumentRef.parse] total.
+///
+/// [Uri.decodeComponent] is unusable here: it rejects a lone `%`, a raw
+/// non-ASCII character, and any byte sequence that is not valid UTF-8, each by
+/// throwing.
+String _decode(String segment) => segment.replaceAllMapped(_escapeRun, (match) {
+      final escapes = match[0]!;
+      final bytes = [
+        for (var i = 1; i < escapes.length; i += 3)
+          int.parse(escapes.substring(i, i + 2), radix: 16),
+      ];
+      return utf8.decode(bytes, allowMalformed: true);
+    });

--- a/packages/soliplex_client/lib/src/domain/domain.dart
+++ b/packages/soliplex_client/lib/src/domain/domain.dart
@@ -5,6 +5,7 @@ export 'backend_version_info.dart';
 export 'chat_message.dart';
 export 'chunk_visualization.dart';
 export 'conversation.dart';
+export 'document_ref.dart';
 export 'feedback_type.dart';
 export 'file_upload.dart';
 export 'llm_event.dart';

--- a/packages/soliplex_client/lib/src/domain/source_reference.dart
+++ b/packages/soliplex_client/lib/src/domain/source_reference.dart
@@ -2,6 +2,7 @@ import 'dart:typed_data';
 
 import 'package:collection/collection.dart';
 import 'package:meta/meta.dart';
+import 'package:soliplex_client/src/domain/document_ref.dart';
 
 /// A cited figure the backend shipped inline: a picture [ref] with its decoded
 /// [bytes] and optional [caption].
@@ -136,16 +137,25 @@ class SourceReference {
 
   /// Returns a display-friendly title for the source reference.
   ///
-  /// Uses [documentTitle] if present, otherwise extracts filename from
-  /// [documentUri]. Falls back to "Unknown Document" if neither works.
+  /// Uses the filename from [documentUri] — the attachment's own name when the
+  /// URI addresses a file embedded in another document. Falls back to
+  /// [documentTitle], then to "Unknown Document".
+  ///
+  /// The filename wins because it identifies the file the chunk came from: it
+  /// names a cited attachment rather than the document it was embedded in.
+  /// [documentTitle] is absent unless the backend is configured to generate
+  /// titles, and a generated title is non-deterministic and can collide across
+  /// documents.
+  ///
+  /// Unlike the document listing, this applies no id-shaped-URI guard, so a
+  /// [documentUri] that is a bare UUID reads as the name. Citations are built
+  /// only from backend retrieval payloads, which carry paths.
   String get displayTitle {
+    final fileName = DocumentRef.parse(documentUri).displayName;
+    if (fileName != null) return fileName;
+
     if (documentTitle != null && documentTitle!.isNotEmpty) {
       return documentTitle!;
-    }
-
-    final uri = Uri.tryParse(documentUri);
-    if (uri != null && uri.pathSegments.isNotEmpty) {
-      return uri.pathSegments.last;
     }
 
     return 'Unknown Document';

--- a/packages/soliplex_client/test/domain/document_ref_test.dart
+++ b/packages/soliplex_client/test/domain/document_ref_test.dart
@@ -1,0 +1,219 @@
+import 'package:soliplex_client/soliplex_client.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('DocumentRef.parse', () {
+    test('treats a uri with no fragment as a plain document', () {
+      final ref = DocumentRef.parse('file:///docs/annual-report.pdf');
+
+      expect(ref.rootUri, 'file:///docs/annual-report.pdf');
+      expect(ref.attachmentPath, isEmpty);
+      expect(ref.isAttachment, isFalse);
+      expect(ref.displayName, 'annual-report.pdf');
+      expect(ref.ancestorNames, isEmpty);
+    });
+
+    test('splits a single attachment segment off the root uri', () {
+      final ref = DocumentRef.parse(
+        'file:///docs/annual-report.pdf#attachment=budget.xlsx',
+      );
+
+      expect(ref.rootUri, 'file:///docs/annual-report.pdf');
+      expect(ref.attachmentPath, ['budget.xlsx']);
+      expect(ref.isAttachment, isTrue);
+      expect(ref.displayName, 'budget.xlsx');
+      expect(ref.ancestorNames, ['annual-report.pdf']);
+    });
+
+    test('splits both segments of a nested attachment uri', () {
+      final ref = DocumentRef.parse(
+        'file:///docs/a.pdf#attachment=b.pdf#attachment=inner.xlsx',
+      );
+
+      expect(ref.rootUri, 'file:///docs/a.pdf');
+      expect(ref.attachmentPath, ['b.pdf', 'inner.xlsx']);
+      expect(ref.displayName, 'inner.xlsx');
+      expect(ref.ancestorNames, ['a.pdf', 'b.pdf']);
+    });
+
+    test('decodes percent-escaped spaces and parentheses', () {
+      final ref = DocumentRef.parse(
+        'file:///docs/annual-report.pdf'
+        '#attachment=my%20report%20%28final%29.pdf',
+      );
+
+      expect(ref.displayName, 'my report (final).pdf');
+    });
+
+    test('decodes a non-ASCII name delivered decomposed', () {
+      final ref = DocumentRef.parse(
+        'file:///docs/annual-report.pdf#attachment=resume%CC%81.pdf',
+      );
+
+      // This name arrives decomposed: `e` plus combining acute U+0301, which
+      // renders as an accented e but does not equal the precomposed form. The
+      // expectation spells the combining mark out so the two cannot be
+      // confused by a reader or an editor that normalises the file.
+      expect(ref.displayName, 'resume\u0301.pdf');
+    });
+
+    test('keeps a segment verbatim when it is not valid percent-encoding', () {
+      final ref = DocumentRef.parse('file:///docs/a.pdf#attachment=100%.xlsx');
+
+      expect(ref.displayName, '100%.xlsx');
+    });
+
+    test('substitutes bytes that are not legal utf-8', () {
+      // Correct escape syntax, so these decode to bytes, but %FF is not a legal
+      // UTF-8 byte and %C3 opens a sequence that never finishes. Each bad byte
+      // becomes U+FFFD rather than aborting the whole name.
+      expect(
+        DocumentRef.parse('file:///docs/a.pdf#attachment=%FF.xlsx').displayName,
+        '\uFFFD.xlsx',
+      );
+      expect(
+        DocumentRef.parse('file:///docs/%C3.pdf').displayName,
+        '\uFFFD.pdf',
+      );
+    });
+
+    test('decodes lowercase escapes', () {
+      // Escape matching is case-insensitive: the backend's `quote` emits
+      // uppercase, but an ingested http URL can carry either.
+      final ref = DocumentRef.parse('file:///docs/caf%c3%a9.pdf');
+
+      expect(ref.displayName, 'café.pdf');
+    });
+
+    test('keeps a raw non-ASCII character', () {
+      final ref = DocumentRef.parse('file:///docs/\u{1F642}.pdf');
+
+      expect(ref.displayName, '\u{1F642}.pdf');
+    });
+
+    test('ignores an empty attachment name', () {
+      final ref = DocumentRef.parse('file:///docs/a.pdf#attachment=');
+
+      expect(ref.rootUri, 'file:///docs/a.pdf');
+      expect(ref.attachmentPath, isEmpty);
+      expect(ref.isAttachment, isFalse);
+      expect(ref.displayName, 'a.pdf');
+    });
+
+    test('has no name for an attachment named only whitespace', () {
+      // Unlike the empty segment above, this is a real name, so the level is
+      // kept and the ancestors still say where the file came from. Only the
+      // label is unusable, and it has to read as absent rather than as a name
+      // that happens to render as nothing.
+      final ref = DocumentRef.parse('file:///docs/a.pdf#attachment=%20%20');
+
+      expect(ref.isAttachment, isTrue);
+      expect(ref.displayName, isNull);
+      expect(ref.ancestorNames, ['a.pdf']);
+    });
+
+    test('trims a name padded with escaped whitespace', () {
+      // The padding is invisible in a label, and it would otherwise reach the
+      // extension logic, which reads 'xlsx ' and matches no file-type glyph.
+      expect(
+        DocumentRef.parse('file:///docs/a.pdf#attachment=%20budget.xlsx%20')
+            .displayName,
+        'budget.xlsx',
+      );
+      expect(
+        DocumentRef.parse('file:///docs/report.pdf%20').displayName,
+        'report.pdf',
+      );
+    });
+
+    test('parses a string that is not a valid uri', () {
+      final ref = DocumentRef.parse('::not a uri::#attachment=budget.xlsx');
+
+      expect(ref.rootUri, '::not a uri::');
+      expect(ref.displayName, 'budget.xlsx');
+    });
+
+    test('does not treat a page fragment as an attachment', () {
+      final ref = DocumentRef.parse('file:///docs/a.pdf#page=3');
+
+      expect(ref.isAttachment, isFalse);
+      expect(ref.attachmentPath, isEmpty);
+      expect(ref.displayName, 'a.pdf');
+      // The fragment stays on rootUri: only attachment segments are stripped,
+      // so a resolver receives the URI it was given.
+      expect(ref.rootUri, 'file:///docs/a.pdf#page=3');
+    });
+
+    test('drops a query string from the name', () {
+      final ref = DocumentRef.parse('https://example.test/docs/doc.pdf?v=1');
+
+      expect(ref.displayName, 'doc.pdf');
+    });
+
+    test('keeps an escaped delimiter inside a plain document name', () {
+      // The split must run on the encoded form. Decoding first would turn
+      // these escapes into delimiters and truncate both names to 'my'.
+      expect(
+        DocumentRef.parse('file:///docs/my%23file.pdf').displayName,
+        'my#file.pdf',
+      );
+      expect(
+        DocumentRef.parse('file:///docs/my%3Ffile.pdf').displayName,
+        'my?file.pdf',
+      );
+    });
+
+    test('truncates a name at an unescaped delimiter', () {
+      // Pins the trade documented on `_rootFileName`: the same split that
+      // resolves `a.pdf#page=3` to `a.pdf` also ends a name at a `#` that was
+      // really part of it.
+      expect(
+        DocumentRef.parse('https://dav.test/docs/report #2.pdf').displayName,
+        'report',
+      );
+      expect(
+        DocumentRef.parse('s3://bucket/summary#final.pdf').displayName,
+        'summary',
+      );
+    });
+
+    test('does not fabricate a nesting level from an escaped marker', () {
+      // `parse` splits before decoding for the same reason the name logic
+      // does. Decoding first would read this single attachment as two levels.
+      final ref = DocumentRef.parse(
+        'file:///docs/a.pdf#attachment=notes%23attachment%3Dx.pdf',
+      );
+
+      expect(ref.attachmentPath, ['notes#attachment=x.pdf']);
+      expect(ref.displayName, 'notes#attachment=x.pdf');
+      expect(ref.ancestorNames, ['a.pdf']);
+    });
+
+    test('has no name when the root names no file', () {
+      // Callers supply their own label; nothing here invents one.
+      expect(DocumentRef.parse('file:///docs/').displayName, isNull);
+      expect(DocumentRef.parse('').displayName, isNull);
+    });
+
+    test('ancestorNames omits a level with a blank name', () {
+      // A blank entry would render as a dangling separator once these are
+      // joined, so it is dropped at every level, not only at the root.
+      expect(
+        DocumentRef.parse('file:///docs/#attachment=b.xlsx').ancestorNames,
+        isEmpty,
+      );
+      expect(
+        DocumentRef.parse(
+          'file:///docs/a.pdf#attachment=%20%20#attachment=c.xlsx',
+        ).ancestorNames,
+        ['a.pdf'],
+      );
+    });
+
+    test('reads a bare filename with no path separator', () {
+      final ref = DocumentRef.parse('slides.pptx');
+
+      expect(ref.displayName, 'slides.pptx');
+    });
+  });
+}

--- a/packages/soliplex_client/test/domain/source_reference_test.dart
+++ b/packages/soliplex_client/test/domain/source_reference_test.dart
@@ -253,10 +253,33 @@ void main() {
     });
 
     group('displayTitle', () {
-      test('returns documentTitle when present', () {
+      test('prefers the filename from the uri over documentTitle', () {
         const ref = SourceReference(
           documentId: 'doc-1',
           documentUri: 'https://example.com/doc.pdf',
+          content: 'content',
+          chunkId: 'chunk-1',
+          documentTitle: 'My Document',
+        );
+
+        expect(ref.displayTitle, 'doc.pdf');
+      });
+
+      test('names the attachment, not the document containing it', () {
+        const ref = SourceReference(
+          documentId: 'doc-1',
+          documentUri: 'file:///docs/annual-report.pdf#attachment=budget.xlsx',
+          content: 'content',
+          chunkId: 'chunk-1',
+        );
+
+        expect(ref.displayTitle, 'budget.xlsx');
+      });
+
+      test('falls back to documentTitle when the uri is empty', () {
+        const ref = SourceReference(
+          documentId: 'doc-1',
+          documentUri: '',
           content: 'content',
           chunkId: 'chunk-1',
           documentTitle: 'My Document',
@@ -287,7 +310,18 @@ void main() {
         expect(ref.displayTitle, 'report.md');
       });
 
-      test('returns Unknown Document for empty title and invalid URI', () {
+      test('falls back rather than labelling a directory uri with nothing', () {
+        const ref = SourceReference(
+          documentId: 'doc-1',
+          documentUri: 'file:///docs/',
+          content: 'content',
+          chunkId: 'chunk-1',
+        );
+
+        expect(ref.displayTitle, 'Unknown Document');
+      });
+
+      test('returns Unknown Document when neither uri nor title names one', () {
         const ref = SourceReference(
           documentId: 'doc-1',
           documentUri: '',

--- a/test/modules/room/ui/citations_section_source_url_test.dart
+++ b/test/modules/room/ui/citations_section_source_url_test.dart
@@ -28,8 +28,9 @@ Future<void> _pump(
       home: Scaffold(body: CitationsSection(sourceReferences: [ref])),
     ),
   ));
-  // The section is expanded by default (issue #463); open the row.
-  await tester.tap(find.text('Alpha'));
+  // The section is expanded by default (issue #463); open the row, which is
+  // labelled by the document's filename rather than its title.
+  await tester.tap(find.text('foo.pdf'));
   await tester.pump();
 }
 

--- a/test/modules/room/ui/citations_section_test.dart
+++ b/test/modules/room/ui/citations_section_test.dart
@@ -6,24 +6,31 @@ import 'package:soliplex_agent/soliplex_agent.dart' hide State;
 import 'package:soliplex_frontend/src/modules/room/ui/citations_section.dart';
 import 'package:soliplex_frontend/src/modules/room/ui/markdown/flutter_markdown_plus_renderer.dart';
 
+/// Builds a reference labelled by its filename, with a distinct
+/// [SourceReference.documentTitle] the row is expected not to show.
+///
+/// The URI ends in [fileName], so the name drives both the label and the PDF
+/// affordance — though [SourceReference.isPdf] reads the whole URI, not the
+/// name. Callers vary the name, not the URI.
 SourceReference _ref({
   required int index,
-  String? title,
-  bool pdf = false,
+  String? fileName,
   List<String> headings = const [],
   String content = 'Test content',
   List<int> pageNumbers = const [],
-}) =>
-    SourceReference(
-      documentId: 'doc-$index',
-      documentUri: pdf ? 's3://bucket/doc-$index.pdf' : 'file://doc-$index.txt',
-      content: content,
-      chunkId: 'chunk-$index',
-      documentTitle: title ?? 'Document $index',
-      headings: headings,
-      pageNumbers: pageNumbers,
-      index: index,
-    );
+}) {
+  final name = fileName ?? 'doc-$index.txt';
+  return SourceReference(
+    documentId: 'doc-$index',
+    documentUri: 'file:///docs/$name',
+    content: content,
+    chunkId: 'chunk-$index',
+    documentTitle: 'Document $index',
+    headings: headings,
+    pageNumbers: pageNumbers,
+    index: index,
+  );
+}
 
 Widget _wrap(Widget child) => ProviderScope(
       child: MaterialApp(home: Scaffold(body: child)),
@@ -44,7 +51,7 @@ void main() {
             child: SingleChildScrollView(
               child: CitationsSection(
                 sourceReferences: [
-                  _ref(index: 1, title: 'Alpha', content: 'cited body'),
+                  _ref(index: 1, fileName: 'Alpha.txt', content: 'cited body'),
                 ],
               ),
             ),
@@ -55,7 +62,7 @@ void main() {
 
     // The section is expanded by default (issue #463), so the source title is
     // visible without a tap; tapping it opens the row to render the content.
-    await tester.tap(find.text('Alpha'));
+    await tester.tap(find.text('Alpha.txt'));
     await tester.pump();
 
     expect(tester.takeException(), isNull);
@@ -86,40 +93,44 @@ void main() {
     await tester.pumpWidget(_wrap(
       CitationsSection(
         sourceReferences: [
-          _ref(index: 1, title: 'Alpha'),
-          _ref(index: 2, title: 'Beta'),
+          _ref(index: 1, fileName: 'Alpha.txt'),
+          _ref(index: 2, fileName: 'Beta.txt'),
         ],
       ),
     ));
 
-    // No tap needed — each source's filename shows immediately.
-    expect(find.text('Alpha'), findsOneWidget);
-    expect(find.text('Beta'), findsOneWidget);
+    // No tap needed — each source's filename shows immediately, and the
+    // document title is not what labels the row.
+    expect(find.text('Alpha.txt'), findsOneWidget);
+    expect(find.text('Beta.txt'), findsOneWidget);
+    expect(find.text('Document 1'), findsNothing);
   });
 
   testWidgets('tapping the header collapses then re-expands the section',
       (tester) async {
     await tester.pumpWidget(_wrap(
-      CitationsSection(sourceReferences: [_ref(index: 1, title: 'Alpha')]),
+      CitationsSection(
+          sourceReferences: [_ref(index: 1, fileName: 'Alpha.txt')]),
     ));
 
     // Starts expanded (issue #463); the header still toggles it closed...
-    expect(find.text('Alpha'), findsOneWidget);
+    expect(find.text('Alpha.txt'), findsOneWidget);
 
     await tester.tap(find.text('1 source'));
     await tester.pump();
-    expect(find.text('Alpha'), findsNothing);
+    expect(find.text('Alpha.txt'), findsNothing);
 
     // ...and back open.
     await tester.tap(find.text('1 source'));
     await tester.pump();
-    expect(find.text('Alpha'), findsOneWidget);
+    expect(find.text('Alpha.txt'), findsOneWidget);
   });
 
   testWidgets('displays badge number from SourceReference.index',
       (tester) async {
     await tester.pumpWidget(_wrap(
-      CitationsSection(sourceReferences: [_ref(index: 4, title: 'Fourth')]),
+      CitationsSection(
+          sourceReferences: [_ref(index: 4, fileName: 'Fourth.txt')]),
     ));
 
     expect(find.text('4'), findsOneWidget);
@@ -132,7 +143,7 @@ void main() {
         sourceReferences: [
           _ref(
             index: 1,
-            title: 'Doc',
+            fileName: 'Doc.txt',
             headings: ['Chapter 1', 'Section 2'],
             content: 'Preview text here',
           ),
@@ -144,7 +155,7 @@ void main() {
     // stays hidden until the row itself is tapped open.
     expect(find.text('Chapter 1 > Section 2'), findsNothing);
 
-    await tester.tap(find.text('Doc'));
+    await tester.tap(find.text('Doc.txt'));
     await tester.pump();
 
     expect(find.text('Chapter 1 > Section 2'), findsOneWidget);
@@ -160,13 +171,13 @@ void main() {
     await tester.pumpWidget(_wrap(
       CitationsSection(
         sourceReferences: [
-          _ref(index: 1, title: 'Doc', content: 'Cited passage body'),
+          _ref(index: 1, fileName: 'Doc.txt', content: 'Cited passage body'),
         ],
       ),
     ));
 
     // Expanded by default (issue #463); open the single source's row.
-    await tester.tap(find.text('Doc'));
+    await tester.tap(find.text('Doc.txt'));
     await tester.pump();
 
     SingleChildScrollView transcriptScroller() => tester.widget(
@@ -200,11 +211,11 @@ void main() {
   testWidgets('expanded row shows the chunk id', (tester) async {
     await tester.pumpWidget(_wrap(
       CitationsSection(
-        sourceReferences: [_ref(index: 1, title: 'Doc')],
+        sourceReferences: [_ref(index: 1, fileName: 'Doc.txt')],
       ),
     ));
 
-    await tester.tap(find.text('Doc'));
+    await tester.tap(find.text('Doc.txt'));
     await tester.pump();
 
     expect(find.textContaining('chunk-1'), findsOneWidget);
@@ -229,8 +240,8 @@ void main() {
     await tester.pumpWidget(_wrap(
       CitationsSection(
         sourceReferences: [
-          _ref(index: 1, title: 'Text File', pdf: false),
-          _ref(index: 2, title: 'PDF File', pdf: true),
+          _ref(index: 1, fileName: 'Text File.txt'),
+          _ref(index: 2, fileName: 'PDF File.pdf'),
         ],
         onShowChunkVisualization: (ref) => tappedRef = ref,
       ),
@@ -251,7 +262,7 @@ void main() {
     test('emits title, headings, pages, uri, and content in order', () {
       final ref = _ref(
         index: 1,
-        title: 'Doc',
+        fileName: 'Doc.txt',
         headings: ['Chapter 1', 'Section 2'],
         pageNumbers: [5, 6],
         content: 'Preview text here',
@@ -259,10 +270,10 @@ void main() {
 
       expect(
         formatCitationForClipboard(ref),
-        'Doc\n'
+        'Doc.txt\n'
         'Chapter 1 > Section 2\n'
         'p.5-6\n'
-        'file://doc-1.txt\n'
+        'file:///docs/Doc.txt\n'
         'chunk id: chunk-1\n'
         '\n'
         'Preview text here',
@@ -289,17 +300,17 @@ void main() {
     test('formats a single ref without trailing separator', () {
       expect(
         formatAllCitationsForClipboard([
-          _ref(index: 1, title: 'Alpha', content: 'first'),
+          _ref(index: 1, fileName: 'Alpha.txt', content: 'first'),
         ]),
         formatCitationForClipboard(
-          _ref(index: 1, title: 'Alpha', content: 'first'),
+          _ref(index: 1, fileName: 'Alpha.txt', content: 'first'),
         ),
       );
     });
 
     test('joins multiple refs with a blank-line/rule/blank-line separator', () {
-      final alpha = _ref(index: 1, title: 'Alpha', content: 'first');
-      final beta = _ref(index: 2, title: 'Beta', content: 'second');
+      final alpha = _ref(index: 1, fileName: 'Alpha.txt', content: 'first');
+      final beta = _ref(index: 2, fileName: 'Beta.txt', content: 'second');
 
       expect(
         formatAllCitationsForClipboard([alpha, beta]),

--- a/test/shared/file_type_icons_test.dart
+++ b/test/shared/file_type_icons_test.dart
@@ -4,165 +4,60 @@ import 'package:soliplex_client/soliplex_client.dart';
 import 'package:soliplex_frontend/src/shared/file_type_icons.dart';
 
 void main() {
-  group('getFileTypeIcon', () {
-    group('PDF files', () {
-      test('returns PDF icon for .pdf extension', () {
-        expect(getFileTypeIcon('document.pdf'), equals(Icons.picture_as_pdf));
-      });
+  group('documentTypeIcon file-type mapping', () {
+    // The title carries no extension, so a fallback to it would surface as the
+    // generic glyph rather than silently matching the expected one.
+    IconData iconFor(String uri) =>
+        documentTypeIcon(RagDocument(id: 'doc-1', title: 'untitled', uri: uri));
 
-      test('handles full path with .pdf', () {
-        expect(
-          getFileTypeIcon('/path/to/document.pdf'),
-          equals(Icons.picture_as_pdf),
-        );
-      });
+    const byExtension = {
+      'pdf': Icons.picture_as_pdf,
+      'doc': Icons.description,
+      'docx': Icons.description,
+      'xls': Icons.table_chart,
+      'xlsx': Icons.table_chart,
+      'ppt': Icons.slideshow,
+      'pptx': Icons.slideshow,
+      'png': Icons.image,
+      'jpg': Icons.image,
+      'jpeg': Icons.image,
+      'gif': Icons.image,
+      'webp': Icons.image,
+      'bmp': Icons.image,
+      'txt': Icons.article,
+      'md': Icons.article,
+      'xyz': Icons.insert_drive_file,
+    };
 
-      test('handles file:// URI with .pdf', () {
-        expect(
-          getFileTypeIcon('file:///path/to/document.pdf'),
-          equals(Icons.picture_as_pdf),
-        );
-      });
-    });
-
-    group('Word documents', () {
-      test('returns description icon for .doc extension', () {
-        expect(getFileTypeIcon('document.doc'), equals(Icons.description));
-      });
-
-      test('returns description icon for .docx extension', () {
-        expect(getFileTypeIcon('document.docx'), equals(Icons.description));
-      });
-    });
-
-    group('Excel spreadsheets', () {
-      test('returns table_chart icon for .xls extension', () {
-        expect(getFileTypeIcon('spreadsheet.xls'), equals(Icons.table_chart));
-      });
-
-      test('returns table_chart icon for .xlsx extension', () {
-        expect(getFileTypeIcon('spreadsheet.xlsx'), equals(Icons.table_chart));
+    byExtension.forEach((extension, icon) {
+      test('maps .$extension', () {
+        expect(iconFor('document.$extension'), equals(icon));
       });
     });
 
-    group('PowerPoint presentations', () {
-      test('returns slideshow icon for .ppt extension', () {
-        expect(getFileTypeIcon('presentation.ppt'), equals(Icons.slideshow));
-      });
-
-      test('returns slideshow icon for .pptx extension', () {
-        expect(getFileTypeIcon('presentation.pptx'), equals(Icons.slideshow));
-      });
+    test('matches the extension case-insensitively', () {
+      expect(iconFor('document.PdF'), equals(Icons.picture_as_pdf));
     });
 
-    group('Image files', () {
-      test('returns image icon for .png extension', () {
-        expect(getFileTypeIcon('image.png'), equals(Icons.image));
-      });
-
-      test('returns image icon for .jpg extension', () {
-        expect(getFileTypeIcon('photo.jpg'), equals(Icons.image));
-      });
-
-      test('returns image icon for .jpeg extension', () {
-        expect(getFileTypeIcon('photo.jpeg'), equals(Icons.image));
-      });
-
-      test('returns image icon for .gif extension', () {
-        expect(getFileTypeIcon('animation.gif'), equals(Icons.image));
-      });
-
-      test('returns image icon for .webp extension', () {
-        expect(getFileTypeIcon('photo.webp'), equals(Icons.image));
-      });
-
-      test('returns image icon for .bmp extension', () {
-        expect(getFileTypeIcon('bitmap.bmp'), equals(Icons.image));
-      });
+    test('reads the last of several dots', () {
+      expect(iconFor('report.final.v2.pdf'), equals(Icons.picture_as_pdf));
     });
 
-    group('Text files', () {
-      test('returns article icon for .txt extension', () {
-        expect(getFileTypeIcon('notes.txt'), equals(Icons.article));
-      });
-
-      test('returns article icon for .md extension', () {
-        expect(getFileTypeIcon('readme.md'), equals(Icons.article));
-      });
+    test('reads the extension of a dotfile that has one', () {
+      expect(iconFor('.hidden.txt'), equals(Icons.article));
     });
 
-    group('Unknown/generic files', () {
-      test('returns generic file icon for unknown extension', () {
-        expect(getFileTypeIcon('data.xyz'), equals(Icons.insert_drive_file));
+    group('names with no usable extension', () {
+      test('no dot at all', () {
+        expect(iconFor('README'), equals(Icons.insert_drive_file));
       });
 
-      test('returns generic file icon for no extension', () {
-        expect(getFileTypeIcon('README'), equals(Icons.insert_drive_file));
+      test('nothing after the dot', () {
+        expect(iconFor('file.'), equals(Icons.insert_drive_file));
       });
 
-      test('returns generic file icon for empty string', () {
-        expect(getFileTypeIcon(''), equals(Icons.insert_drive_file));
-      });
-
-      test('returns generic file icon for path ending in slash', () {
-        expect(getFileTypeIcon('/path/to/'), equals(Icons.insert_drive_file));
-      });
-
-      test('returns generic file icon for file ending with dot', () {
-        expect(getFileTypeIcon('file.'), equals(Icons.insert_drive_file));
-      });
-    });
-
-    group('case-insensitive matching', () {
-      test('handles uppercase .PDF', () {
-        expect(getFileTypeIcon('document.PDF'), equals(Icons.picture_as_pdf));
-      });
-
-      test('handles mixed case .PdF', () {
-        expect(getFileTypeIcon('document.PdF'), equals(Icons.picture_as_pdf));
-      });
-
-      test('handles uppercase .DOCX', () {
-        expect(getFileTypeIcon('document.DOCX'), equals(Icons.description));
-      });
-
-      test('handles uppercase .TXT', () {
-        expect(getFileTypeIcon('notes.TXT'), equals(Icons.article));
-      });
-
-      test('handles uppercase .PNG', () {
-        expect(getFileTypeIcon('image.PNG'), equals(Icons.image));
-      });
-    });
-
-    group('edge cases', () {
-      test('handles path with query string', () {
-        expect(
-          getFileTypeIcon('document.pdf?version=1'),
-          equals(Icons.picture_as_pdf),
-        );
-      });
-
-      test('handles path with fragment', () {
-        expect(
-          getFileTypeIcon('document.pdf#page=5'),
-          equals(Icons.picture_as_pdf),
-        );
-      });
-
-      test('handles filename with multiple dots', () {
-        expect(
-          getFileTypeIcon('report.final.v2.pdf'),
-          equals(Icons.picture_as_pdf),
-        );
-      });
-
-      test('handles hidden file with extension', () {
-        expect(getFileTypeIcon('.hidden.txt'), equals(Icons.article));
-      });
-
-      test('handles hidden file without extension', () {
-        expect(getFileTypeIcon('.gitignore'), equals(Icons.insert_drive_file));
+      test('a leading dot and nothing else', () {
+        expect(iconFor('.gitignore'), equals(Icons.insert_drive_file));
       });
     });
   });
@@ -171,10 +66,10 @@ void main() {
     test('returns filename from uri for file-path uri', () {
       const doc = RagDocument(
         id: 'doc-1',
-        title: 'COMPLIANCE WITH THIS PUBLICATION IS MANDATORY',
-        uri: 'airpubs/27sog/foo/afman_10-206.pdf',
+        title: 'Facilities Handbook',
+        uri: 'manuals/facilities/handbook.pdf',
       );
-      expect(documentDisplayName(doc), equals('afman_10-206.pdf'));
+      expect(documentDisplayName(doc), equals('handbook.pdf'));
     });
 
     test('falls back to title when uri is empty', () {
@@ -194,10 +89,10 @@ void main() {
     test('handles file:// prefixed uri', () {
       const doc = RagDocument(
         id: 'doc-4',
-        title: 'BY ORDER OF THE SECRETARY OF THE AIR FORCE',
-        uri: 'file:///data/airpubs/27sog/afman_10-206.pdf',
+        title: 'Facilities Handbook',
+        uri: 'file:///data/manuals/facilities/handbook.pdf',
       );
-      expect(documentDisplayName(doc), equals('afman_10-206.pdf'));
+      expect(documentDisplayName(doc), equals('handbook.pdf'));
     });
 
     test('returns just filename for short uri', () {
@@ -217,30 +112,131 @@ void main() {
       );
       expect(documentDisplayName(doc), equals('Question 2'));
     });
+
+    test('names an attachment, not the document containing it', () {
+      const doc = RagDocument(
+        id: 'doc-7',
+        title: 'file:///docs/annual-report.pdf#attachment=budget.xlsx',
+        uri: 'file:///docs/annual-report.pdf#attachment=budget.xlsx',
+      );
+      expect(documentDisplayName(doc), equals('budget.xlsx'));
+    });
+
+    test('falls back to title when the uri names no file', () {
+      const doc = RagDocument(
+        id: 'doc-11',
+        title: 'Annual Report',
+        uri: 'file:///docs/',
+      );
+      expect(documentDisplayName(doc), equals('Annual Report'));
+    });
   });
 
-  group('documentIconPath', () {
-    test('returns uri when it is a file path', () {
+  group('documentTypeIcon', () {
+    test('resolves a regular document from its uri', () {
       const doc = RagDocument(
         id: 'doc-1',
-        title: 'COMPLIANCE',
-        uri: 'airpubs/foo/afman.pdf',
+        title: 'Facilities Handbook',
+        uri: 'manuals/facilities/handbook.pdf',
       );
-      expect(documentIconPath(doc), equals('airpubs/foo/afman.pdf'));
+      expect(documentTypeIcon(doc), equals(Icons.picture_as_pdf));
     });
 
     test('falls back to title when uri is empty', () {
       const doc = RagDocument(id: 'doc-2', title: 'report.pdf');
-      expect(documentIconPath(doc), equals('report.pdf'));
+      expect(documentTypeIcon(doc), equals(Icons.picture_as_pdf));
     });
 
     test('falls back to title when uri is a UUID', () {
       const doc = RagDocument(
         id: 'doc-3',
-        title: 'Question 1',
+        title: 'Question 1.docx',
         uri: '4e8bf0c7-f504-4ffc-b647-a9f8f255bea5',
       );
-      expect(documentIconPath(doc), equals('Question 1'));
+      expect(documentTypeIcon(doc), equals(Icons.description));
+    });
+
+    test('resolves an attachment to its own file type', () {
+      const doc = RagDocument(
+        id: 'doc-4',
+        title: 'attachment',
+        uri: 'file:///docs/annual-report.pdf#attachment=budget.xlsx',
+      );
+      expect(documentTypeIcon(doc), equals(Icons.table_chart));
+    });
+
+    test('falls back to title when the uri names no file', () {
+      // The row is labelled from the title here, so the glyph has to come
+      // from the title too or it would describe a different file.
+      const doc = RagDocument(
+        id: 'doc-9',
+        title: 'Budget.xlsx',
+        uri: 'file:///docs/',
+      );
+      expect(documentDisplayName(doc), equals('Budget.xlsx'));
+      expect(documentTypeIcon(doc), equals(Icons.table_chart));
+    });
+
+    test('resolves an attachment whose name contains a literal hash', () {
+      // A decoded name is not a URI: splitting it at '#' would strip the
+      // extension and fall through to the generic glyph.
+      const doc = RagDocument(
+        id: 'doc-6',
+        title: 'hashed',
+        uri: 'file:///docs/a.pdf#attachment=invoice%231234.xlsx',
+      );
+      expect(documentDisplayName(doc), equals('invoice#1234.xlsx'));
+      expect(documentTypeIcon(doc), equals(Icons.table_chart));
+    });
+
+    test('ignores a page fragment on a regular document', () {
+      const doc = RagDocument(
+        id: 'doc-8',
+        title: 'paged',
+        uri: 'file:///docs/handbook.pdf#page=3',
+      );
+      expect(documentTypeIcon(doc), equals(Icons.picture_as_pdf));
+    });
+  });
+
+  group('name derivation across surfaces', () {
+    test('the document list and a citation name an attachment identically', () {
+      const uri = 'file:///docs/annual-report.pdf#attachment=budget.xlsx';
+      const doc = RagDocument(id: 'doc-1', title: uri, uri: uri);
+      const ref = SourceReference(
+        documentId: 'doc-1',
+        documentUri: uri,
+        content: 'content',
+        chunkId: 'chunk-1',
+      );
+
+      // Assert the value on both sides, not just that they agree — agreement
+      // alone also holds if both regress to the container's name.
+      expect(documentDisplayName(doc), equals('budget.xlsx'));
+      expect(ref.displayTitle, equals('budget.xlsx'));
+    });
+  });
+
+  group('filterDocuments', () {
+    const container = RagDocument(
+      id: 'doc-1',
+      title: 'container',
+      uri: 'file:///docs/annual-report.pdf',
+    );
+    const attachment = RagDocument(
+      id: 'doc-2',
+      title: 'attachment',
+      uri: 'file:///docs/annual-report.pdf#attachment=my%20budget.xlsx',
+    );
+
+    test('matches an attachment by its decoded name', () {
+      // 'my budget' appears in neither uri: the container's name does not
+      // contain it and the attachment's is escaped. Matching depends on the
+      // display name, which is what lets search work with no custom matcher.
+      expect(
+        filterDocuments(const [container, attachment], 'my budget'),
+        equals(const [attachment]),
+      );
     });
   });
 }


### PR DESCRIPTION
## What

The backend ingests a file embedded in a PDF (`/EmbeddedFiles`) as its own
first-class RAG document and records the relationship in the document URI as
`#attachment=<percent-encoded-name>` segments. The frontend knew nothing about
that convention, and three surfaces each derived a document's display name
independently. For `file:///docs/annual-report.pdf#attachment=budget.xlsx`:

| Surface | Before | After |
| --- | --- | --- |
| List / picker / chips | `annual-report.pdf#attachment=budget.xlsx` | `budget.xlsx` |
| File-type glyph | PDF | spreadsheet |
| Citation | `annual-report.pdf` | `budget.xlsx` |

Each predates attachments and mishandled the fragment differently by accident:
one ignored it, one stripped it, one discarded it via URI parsing. The root
defect is the absence of a single definition of a document's display name;
attachments merely exposed it.

This adds `DocumentRef`, which decomposes a document URI into the document it
lives in and the chain of attachment names leading to it, and routes every
display-name and file-type decision through it.

## Design notes

- **Splits on the literal `#attachment=` before percent-decoding.** `Uri.fragment`
  is unusable: a depth-2 URI carries two unencoded `#` separators, and URI
  parsing re-encodes the second as `%23`. Splitting before decoding is also what
  keeps an escaped delimiter inside a filename (`invoice%231234.xlsx`) intact,
  and what stops an escaped marker from fabricating a nesting level.
- **`parse` is total** — there is no unparseable-URI state. `Uri.decodeComponent`
  throws on malformed escapes (`100%`), on invalid UTF-8 (`%FF`), and on a raw
  non-ASCII character with no `%` at all, so the decoder walks `(%HH)+` runs and
  passes other text through, with `allowMalformed` mapping bad bytes to U+FFFD.
- **`displayName` is nullable**, so the compiler forces each caller to supply its
  own label rather than let a blank one through.
- **The glyph reads the extension off `documentDisplayName`'s own return value**,
  so the label and the icon cannot come from two different filename algorithms —
  the agreement is structural rather than two branches kept in step. That retires
  the URI-shaped extension logic (`getFileTypeIcon`, `_extractExtension`), which
  had no other caller.
- **Nothing hardcodes a depth.** The parser splits on every occurrence of the
  marker, so a change to the backend's `MAX_ATTACHMENT_DEPTH` needs no frontend
  change.

## Scope

First of three stacked PRs, but it fixes all three reported defects on its own.
Pure logic — no layout change.

Deliberately **not** here: the citation provenance line and its `Row` → `Column`
restructure (PR B), and the container-adjacent sort, provenance subtitle and
title row (PR C).

Also included: sanitized customer-identifying fixtures in the one test file this
already rewrites.

## Review focus

`SourceReference.displayTitle` flips to **filename first, title as fallback**.
The filename identifies the file a chunk came from, which is the fix for citing
a container instead of the cited document, and it matches how the list and the
picker label the same document. With no backend-generated titles this is
invisible; a deployment that *does* have titles will see every citation
relabelled — in the citation row, in a copied citation, and in the chunk
preview's heading — until PR B lands the title row. Recorded in `CHANGELOG.md`.

That premise was checked rather than assumed. `auto_title` is settable per
installation *and* per room via `haiku.rag.yaml`, so grepping the backend source
does not settle it. But `AppConfig`/`ProcessingConfig` are plain pydantic
`BaseModel`s and `BaseSettings` appears nowhere in `haiku/rag`, so YAML is the
only channel — and no `haiku.rag.yaml` in any checkout enables it, including one
deployment config with a fully populated `processing:` block.

## Verification

- `flutter analyze` 0 issues; `dart format --set-exit-if-changed` clean;
  `markdownlint-cli2` clean.
- App suite **2205 passed**; `soliplex_client` **1611 passed**. The only failures
  in the repo are `stream_cancel_behavior_test.dart`, which is
  `@Tags(['integration'])` and needs a live backend.
- `getFileTypeIcon`, `documentIconPath` and `_extractExtension` have zero
  remaining references, and `file_type_icons.dart` is not exported from
  `lib/soliplex_frontend.dart`, so deleting them is not a public-API break for a
  fork.
- The `uri.isEmpty || _isUuid(uri)` guard still runs *before* parsing, so the
  document-filter hydration placeholders keep their label.

## Accepted trade

The split runs on the raw string, so an unescaped `#` in a filename truncates the
name: `invoice#1234.xlsx` reads `invoice`, and two documents differing only after
the `#` collapse to one label and one glyph. That is the same split that resolves
`a.pdf#page=3` to `a.pdf` — from the string alone a stray fragment and a `#`
inside a filename are the same shape. Both the `#attachment=` builder and
`Path.as_uri()` percent-encode, so neither can produce it. Accepted rather than
fixed with a heuristic that would guess; pinned by test and noted in the
changelog.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
