### PR TITLE
fix: name a citation's provenance, and resolve its label, title and type from one URI parse

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,15 @@ Versions follow the `version+build` scheme from `pubspec.yaml`, bumped via
   alone that `#` and a `#page=` fragment are the same shape, and two such
   documents differing only after the `#` become one label and one glyph.
 
+- An expanded citation shows the cited document's title, which nothing displayed
+  before: the row's own label is the filename, so a title had no home. The row
+  is absent entirely — its label included — for a document with no title, which
+  is every document unless the backend is configured to generate them.
+- A document's origin link carries its whole address on hover, wherever that
+  link appears — a citation, the document picker, the room's document list. The
+  link text drops the scheme, the query and the fragment and then ellipsizes
+  what remains, so the address actually being opened could not be read.
+
 ### Fixed
 
 - An expanded activity row's body clamps to eight lines with a "Show more"
@@ -82,6 +91,16 @@ Versions follow the `version+build` scheme from `pubspec.yaml`, bumped via
   now read one parse of the URI, so an attachment shows its own decoded filename
   and its own glyph wherever it appears, and a citation names the document the
   text actually came from.
+- A citation of an embedded file names the documents containing it, beneath the
+  file's own name — `in annual-report.pdf`, chaining through each level when a
+  file is embedded two deep. Now that a citation names the embedded file rather
+  than its container, nothing else said where it lives: a configured browser
+  link drops the URI fragment the relationship is encoded in, and the raw URI
+  shown in that link's absence is one ellipsized line of percent-encoded text.
+  Each line holds to one line, so a citation is the same height whatever its
+  names run to, and one hover covers both — which also recovers a long filename
+  on a citation of a document that is embedded in nothing, where before there
+  was no way to read a name once it was cut.
 - A document whose URI names no file — one ending in a slash — no longer renders a
   blank label in the list, the picker or the attachment chips, and no longer
   renders a blank citation. In the list it falls back to the document's title,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -83,8 +83,10 @@ Versions follow the `version+build` scheme from `pubspec.yaml`, bumped via
   spreadsheet inside a PDF offers no page preview.
 - A document's origin link carries its whole address on hover, wherever that
   link appears — a citation, the document picker, the room's document list. The
-  link text drops the scheme, the query and the fragment and then ellipsizes
-  what remains, so the address actually being opened could not be read.
+  link text keeps host and path alone — dropping the scheme, any credentials
+  and port, the query and the fragment — and then ellipsizes what remains, so
+  the address actually being opened could not be read. Two addresses differing
+  only by port read identically without it.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,7 +47,11 @@ Versions follow the `version+build` scheme from `pubspec.yaml`, bumped via
   nothing about; `TOOL_CALL_START` is the event that names a tool, and it already
   sets the label.
 - A citation is labelled by its document's filename in preference to the
-  document's title; the title is the fallback when the URI names no file. The
+  document's title; the title is the fallback when the URI names no file — a
+  URI that is an id rather than a path included, so a document addressed by a
+  bare UUID still reads by its title rather than by the id. A title that is
+  only whitespace is no longer a label either; such a citation reads
+  `Unknown Document` instead of rendering an empty one. The
   filename identifies the file a chunk came from — it names an embedded file
   rather than the PDF it was found in, and it matches how the same document is
   labelled in the list and the picker. *The preference itself* has no visible
@@ -68,7 +72,15 @@ Versions follow the `version+build` scheme from `pubspec.yaml`, bumped via
 - An expanded citation shows the cited document's title, which nothing displayed
   before: the row's own label is the filename, so a title had no home. The row
   is absent entirely — its label included — for a document with no title, which
-  is every document unless the backend is configured to generate them.
+  is every document unless the backend is configured to generate them, and for
+  one whose row label is already the title, so the same string is never printed
+  twice.
+- A citation's PDF preview affordance reads the cited file's name rather than
+  the raw URI, so a PDF addressed with a page fragment or a trailing escape —
+  `handbook.pdf#page=3` — keeps its preview button instead of losing it to a
+  URI that no longer ends in `.pdf`. This was the last file-type check not
+  routed through the URI parse; an embedded file is still typed as itself, so a
+  spreadsheet inside a PDF offers no page preview.
 - A document's origin link carries its whole address on hover, wherever that
   link appears — a citation, the document picker, the room's document list. The
   link text drops the scheme, the query and the fragment and then ellipsizes

--- a/lib/src/modules/room/ui/citations_section.dart
+++ b/lib/src/modules/room/ui/citations_section.dart
@@ -277,8 +277,14 @@ class _SourceReferenceRow extends StatelessWidget {
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
-          // The row's label is the filename, so the title has no home there.
-          DocumentTitleLine(title: sourceReference.documentTitle),
+          // The row's label is the filename, so the title has no home there —
+          // unless the URI named no file, in which case the label already is
+          // the title and repeating it would print the same string twice.
+          DocumentTitleLine(
+            title: sourceReference.fileName == null
+                ? null
+                : sourceReference.documentTitle,
+          ),
           // The cited document's source link: the viewer `source_url`, else a
           // resolver-derived URL from the document URI, else the raw URI as
           // text (it is never itself launchable). A fork supplies the resolver

--- a/lib/src/modules/room/ui/citations_section.dart
+++ b/lib/src/modules/room/ui/citations_section.dart
@@ -341,10 +341,11 @@ class _SourceReferenceRow extends StatelessWidget {
 /// when it is embedded in one — `in annual-report.pdf`, chaining when it is
 /// embedded two deep.
 ///
-/// Each line is capped at one, so a citation occupies the same two rows however
-/// long its names run. Several citations sit inline in a single message, and
-/// document filenames are routinely long enough to wrap, so letting them do so
-/// would size each row by whichever name happened to be longest.
+/// Each line is capped at one, so a citation is one row for a plain document
+/// and two for an embedded one, whatever its names run to. Several citations
+/// sit inline in a single message, and document filenames are routinely long
+/// enough to wrap, so letting them do so would size each row by whichever name
+/// happened to be longest.
 ///
 /// One tooltip covers both, because both are cut by the same cap and neither is
 /// readable anywhere else: a configured browser link renders only host and

--- a/lib/src/modules/room/ui/citations_section.dart
+++ b/lib/src/modules/room/ui/citations_section.dart
@@ -10,6 +10,7 @@ import '../../../shared/preview_icon_button.dart';
 import '../../../shared/zoomable_image.dart';
 import '../../../shared/zoomable_view.dart';
 import '../document_browser_url.dart';
+import 'document_metadata_line.dart';
 import 'document_source.dart';
 import 'markdown/flutter_markdown_plus_renderer.dart';
 import 'markdown/log_source.dart';
@@ -182,6 +183,12 @@ class _SourceReferenceRow extends StatelessWidget {
                     padding: const EdgeInsets.symmetric(
                         vertical: SoliplexSpacing.s1),
                     child: Row(
+                      // The badge and the page range read against the cited
+                      // file's name, so they sit on its baseline. Centring
+                      // instead lands them level with the provenance line
+                      // beneath it, numbering the containing document.
+                      crossAxisAlignment: CrossAxisAlignment.baseline,
+                      textBaseline: TextBaseline.alphabetic,
                       children: [
                         Container(
                           width: 24,
@@ -202,11 +209,9 @@ class _SourceReferenceRow extends StatelessWidget {
                         ),
                         const SizedBox(width: SoliplexSpacing.s2),
                         Expanded(
-                          child: Text(
-                            sourceReference.displayTitle,
-                            style: theme.textTheme.bodySmall,
-                            maxLines: 1,
-                            overflow: TextOverflow.ellipsis,
+                          child: _SourceLabel(
+                            displayTitle: sourceReference.displayTitle,
+                            ancestorNames: sourceReference.ancestorNames,
                           ),
                         ),
                         if (sourceReference.formattedPageNumbers != null) ...[
@@ -272,6 +277,8 @@ class _SourceReferenceRow extends StatelessWidget {
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
+          // The row's label is the filename, so the title has no home there.
+          DocumentTitleLine(title: sourceReference.documentTitle),
           // The cited document's source link: the viewer `source_url`, else a
           // resolver-derived URL from the document URI, else the raw URI as
           // text (it is never itself launchable). A fork supplies the resolver
@@ -314,41 +321,74 @@ class _SourceReferenceRow extends StatelessWidget {
             _CitationTranscript(content: sourceReference.content),
           ],
           const SizedBox(height: SoliplexSpacing.s2),
-          _metaLine(context, theme, 'chunk id', sourceReference.chunkId),
+          DocumentMetadataLine.identifier(
+            label: 'chunk id',
+            value: sourceReference.chunkId,
+          ),
         ],
       ),
     );
   }
+}
 
-  /// A single provenance line: a muted-bold [label] lead-in followed by a
-  /// monospace [value] that wraps to the margin, so the full uri / chunk id
-  /// stays visible without a hanging indent.
-  Widget _metaLine(
-    BuildContext context,
-    ThemeData theme,
-    String label,
-    String value,
-  ) {
-    return Padding(
-      padding: const EdgeInsets.only(bottom: SoliplexSpacing.s1),
-      child: Text.rich(
-        TextSpan(
-          style: theme.textTheme.labelSmall?.copyWith(
-            fontWeight: FontWeight.w700,
-            color: theme.colorScheme.onSurfaceVariant,
+/// A citation's label: the cited file's name, over the documents containing it
+/// when it is embedded in one — `in annual-report.pdf`, chaining when it is
+/// embedded two deep.
+///
+/// Each line is capped at one, so a citation occupies the same two rows however
+/// long its names run. Several citations sit inline in a single message, and
+/// document filenames are routinely long enough to wrap, so letting them do so
+/// would size each row by whichever name happened to be longest.
+///
+/// One tooltip covers both, because both are cut by the same cap and neither is
+/// readable anywhere else: a configured browser link renders only host and
+/// path, dropping the fragment the containing document is named in.
+class _SourceLabel extends StatelessWidget {
+  const _SourceLabel({
+    required this.displayTitle,
+    required this.ancestorNames,
+  });
+
+  final String displayTitle;
+
+  /// The documents containing the cited file, outermost first. Empty when it is
+  /// not embedded in one, which renders the name alone.
+  final List<String> ancestorNames;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final provenance =
+        ancestorNames.isEmpty ? null : 'in ${ancestorNames.join(' > ')}';
+
+    return Tooltip(
+      // Spelled as a sentence rather than stacked the way the label is, so the
+      // relationship between the two names is stated instead of implied by
+      // their arrangement.
+      message: ancestorNames.isEmpty
+          ? displayTitle
+          : '$displayTitle embedded in ${ancestorNames.join(' > ')}',
+      waitDuration: const Duration(milliseconds: 500),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Text(
+            displayTitle,
+            style: theme.textTheme.bodySmall,
+            maxLines: 1,
+            overflow: TextOverflow.ellipsis,
           ),
-          children: [
-            TextSpan(text: '$label  '),
-            TextSpan(
-              text: value,
-              style: context.monospaceOn(
-                theme.textTheme.labelSmall?.copyWith(
-                  color: theme.colorScheme.onSurfaceVariant,
-                ),
+          if (provenance != null)
+            Text(
+              provenance,
+              style: theme.textTheme.labelSmall?.copyWith(
+                color: theme.colorScheme.onSurfaceVariant,
               ),
+              maxLines: 1,
+              overflow: TextOverflow.ellipsis,
             ),
-          ],
-        ),
+        ],
       ),
     );
   }

--- a/lib/src/modules/room/ui/document_metadata_line.dart
+++ b/lib/src/modules/room/ui/document_metadata_line.dart
@@ -17,9 +17,9 @@ class DocumentMetadataLine extends StatelessWidget {
 
   /// A line whose value is an identifier — a chunk id, a document id.
   ///
-  /// Monospaced, and wrapped to the margin rather than clipped: an identifier
-  /// is only useful entire, so hiding its tail behind an ellipsis would leave
-  /// nothing worth reading.
+  /// Monospaced, and wrapped to the margin rather than ellipsized: an
+  /// identifier is only useful entire, so hiding its tail behind an ellipsis
+  /// would leave nothing worth reading.
   const DocumentMetadataLine.identifier({
     required this.label,
     required this.value,

--- a/lib/src/modules/room/ui/document_metadata_line.dart
+++ b/lib/src/modules/room/ui/document_metadata_line.dart
@@ -1,0 +1,94 @@
+import 'package:flutter/material.dart';
+import 'package:soliplex_design/soliplex_design.dart';
+
+/// One labelled fact about a document: a muted-bold [label] lead-in followed by
+/// its [value] on the same line.
+///
+/// A null or blank [value] renders nothing, the lead-in included, so a fact the
+/// document does not carry leaves no label announcing an empty value.
+class DocumentMetadataLine extends StatelessWidget {
+  /// A line whose value is prose — a title, a caption — capped at [maxLines].
+  const DocumentMetadataLine({
+    required this.label,
+    required this.value,
+    this.maxLines = 2,
+    super.key,
+  }) : _isIdentifier = false;
+
+  /// A line whose value is an identifier — a chunk id, a document id.
+  ///
+  /// Monospaced, and wrapped to the margin rather than clipped: an identifier
+  /// is only useful entire, so hiding its tail behind an ellipsis would leave
+  /// nothing worth reading.
+  const DocumentMetadataLine.identifier({
+    required this.label,
+    required this.value,
+    super.key,
+  })  : maxLines = null,
+        _isIdentifier = true;
+
+  /// The fact's name, rendered as the lead-in.
+  final String label;
+
+  /// The fact, or null when the document does not carry it.
+  final String? value;
+
+  /// How many lines the value may occupy before it ellipsizes. Null lets it
+  /// wrap freely.
+  final int? maxLines;
+
+  final bool _isIdentifier;
+
+  @override
+  Widget build(BuildContext context) {
+    final resolved = value?.trim();
+    if (resolved == null || resolved.isEmpty) return const SizedBox.shrink();
+
+    final theme = Theme.of(context);
+    final labelStyle = theme.textTheme.labelSmall?.copyWith(
+      fontWeight: FontWeight.w700,
+      color: theme.colorScheme.onSurfaceVariant,
+    );
+
+    return Padding(
+      padding: const EdgeInsets.only(bottom: SoliplexSpacing.s1),
+      child: Text.rich(
+        TextSpan(
+          style: labelStyle,
+          children: [
+            TextSpan(text: '$label  '),
+            TextSpan(
+              text: resolved,
+              style: _isIdentifier
+                  ? context.monospaceOn(
+                      theme.textTheme.labelSmall?.copyWith(
+                        color: theme.colorScheme.onSurfaceVariant,
+                      ),
+                    )
+                  : theme.textTheme.bodySmall,
+            ),
+          ],
+        ),
+        maxLines: maxLines,
+        overflow: maxLines == null ? TextOverflow.clip : TextOverflow.ellipsis,
+      ),
+    );
+  }
+}
+
+/// A document's title, on a [DocumentMetadataLine].
+///
+/// Exists so the two surfaces that show a title label it and style it
+/// identically without either restating the choice.
+class DocumentTitleLine extends StatelessWidget {
+  const DocumentTitleLine({required this.title, super.key});
+
+  /// The document's title, or null when it has none. A caller whose title
+  /// field stands in a placeholder when the backend sent none has to resolve
+  /// that to null first; blank is the only absence this reads.
+  final String? title;
+
+  @override
+  Widget build(BuildContext context) =>
+      DocumentMetadataLine(label: 'title', value: title);
+}

--- a/lib/src/modules/room/ui/document_metadata_line.dart
+++ b/lib/src/modules/room/ui/document_metadata_line.dart
@@ -78,8 +78,8 @@ class DocumentMetadataLine extends StatelessWidget {
 
 /// A document's title, on a [DocumentMetadataLine].
 ///
-/// Exists so the two surfaces that show a title label it and style it
-/// identically without either restating the choice.
+/// A title row reads the same wherever one appears: same lead-in, same style,
+/// chosen once here.
 class DocumentTitleLine extends StatelessWidget {
   const DocumentTitleLine({required this.title, super.key});
 

--- a/lib/src/shared/browser_url_link.dart
+++ b/lib/src/shared/browser_url_link.dart
@@ -10,6 +10,10 @@ String browserUrlDisplay(Uri url) => '${url.host}${url.path}';
 /// A clickable document origin link: a link icon plus the scheme-stripped
 /// origin, opening [url] in the platform's default handler (a new browser tab
 /// on web). The raw `https://` is hidden to reduce noise.
+///
+/// The whole address is on the link's tooltip, since the displayed text drops
+/// the scheme, the query and the fragment and then ellipsizes what is left —
+/// so the tooltip is the only place the address being opened reads in full.
 class BrowserUrlLink extends StatelessWidget {
   const BrowserUrlLink({required this.url, super.key});
 
@@ -29,12 +33,16 @@ class BrowserUrlLink extends StatelessWidget {
             Icon(Icons.link, size: 14, color: theme.colorScheme.primary),
             const SizedBox(width: SoliplexSpacing.s1),
             Flexible(
-              child: Text(
-                browserUrlDisplay(url),
-                maxLines: 1,
-                overflow: TextOverflow.ellipsis,
-                style: theme.textTheme.labelSmall?.copyWith(
-                  color: theme.colorScheme.primary,
+              child: Tooltip(
+                message: url.toString(),
+                waitDuration: const Duration(milliseconds: 500),
+                child: Text(
+                  browserUrlDisplay(url),
+                  maxLines: 1,
+                  overflow: TextOverflow.ellipsis,
+                  style: theme.textTheme.labelSmall?.copyWith(
+                    color: theme.colorScheme.primary,
+                  ),
                 ),
               ),
             ),

--- a/lib/src/shared/browser_url_link.dart
+++ b/lib/src/shared/browser_url_link.dart
@@ -3,17 +3,19 @@ import 'package:soliplex_design/soliplex_design.dart';
 
 import 'markdown/launch_markdown_link.dart';
 
-/// Display text for a browser URL: scheme (and any query/fragment) removed so
-/// the origin reads as `host/path` without `https://` noise.
+/// Display text for a browser URL: `host/path` alone, so the origin reads
+/// without `https://` noise. Everything else goes — the scheme, any credentials
+/// and port, the query and the fragment.
 String browserUrlDisplay(Uri url) => '${url.host}${url.path}';
 
 /// A clickable document origin link: a link icon plus the scheme-stripped
 /// origin, opening [url] in the platform's default handler (a new browser tab
 /// on web). The raw `https://` is hidden to reduce noise.
 ///
-/// The whole address is on the link's tooltip, since the displayed text drops
-/// the scheme, the query and the fragment and then ellipsizes what is left —
-/// so the tooltip is the only place the address being opened reads in full.
+/// The whole address is on the link's tooltip, since the displayed text keeps
+/// host and path alone and then ellipsizes what is left. Two addresses that
+/// differ only by port read identically, so the tooltip is the only place the
+/// address being opened reads in full.
 class BrowserUrlLink extends StatelessWidget {
   const BrowserUrlLink({required this.url, super.key});
 

--- a/lib/src/shared/file_type_icons.dart
+++ b/lib/src/shared/file_type_icons.dart
@@ -30,7 +30,9 @@ String _extensionOfName(String filename) {
 /// Uses the filename from [RagDocument.uri] — the attachment's own name when
 /// the URI addresses a file embedded in another document. Falls back to
 /// [RagDocument.title] when the URI names no file, which covers a URI that is
-/// an id rather than a path (an empty URI or a bare UUID, e.g. quiz items).
+/// an id rather than a path. The empty one arrives from a document stored with
+/// no URI at all; a URI that is a bare id is read the same way, though nothing
+/// in the backend addresses a document that way.
 String documentDisplayName(RagDocument doc) =>
     DocumentRef.parse(doc.uri).displayName ?? doc.title;
 

--- a/lib/src/shared/file_type_icons.dart
+++ b/lib/src/shared/file_type_icons.dart
@@ -25,21 +25,14 @@ String _extensionOfName(String filename) {
   return filename.substring(lastDot + 1).toLowerCase();
 }
 
-/// The filename [doc]'s URI addresses, or null when the URI names none.
-///
-/// An empty URI and a bare UUID are ids rather than paths, so they are rejected
-/// before parsing — a UUID would otherwise read as a perfectly good filename.
-String? _fileName(RagDocument doc) => doc.uri.isEmpty || _isUuid(doc.uri)
-    ? null
-    : DocumentRef.parse(doc.uri).displayName;
-
 /// Returns a user-friendly display name for a [RagDocument].
 ///
 /// Uses the filename from [RagDocument.uri] — the attachment's own name when
 /// the URI addresses a file embedded in another document. Falls back to
-/// [RagDocument.title] when the URI names no file, and when it is an id rather
-/// than a path (an empty URI or a bare UUID, e.g. quiz items).
-String documentDisplayName(RagDocument doc) => _fileName(doc) ?? doc.title;
+/// [RagDocument.title] when the URI names no file, which covers a URI that is
+/// an id rather than a path (an empty URI or a bare UUID, e.g. quiz items).
+String documentDisplayName(RagDocument doc) =>
+    DocumentRef.parse(doc.uri).displayName ?? doc.title;
 
 /// Returns the file-type icon for a [RagDocument].
 ///
@@ -63,10 +56,3 @@ List<RagDocument> filterDocuments(List<RagDocument> docs, String query) {
       )
       .toList();
 }
-
-final _uuidPattern = RegExp(
-  r'^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$',
-  caseSensitive: false,
-);
-
-bool _isUuid(String s) => _uuidPattern.hasMatch(s);

--- a/packages/soliplex_client/lib/src/domain/document_ref.dart
+++ b/packages/soliplex_client/lib/src/domain/document_ref.dart
@@ -33,7 +33,10 @@ class DocumentRef {
   /// simply has no attachments.
   ///
   /// A segment that decodes to nothing is dropped rather than kept as a level,
-  /// so a trailing `#attachment=` degrades to the containing document.
+  /// so a trailing `#attachment=` degrades to the containing document. An
+  /// unnamed segment between two named ones is dropped the same way, which
+  /// shortens the chain [ancestorNames] reports without making any entry in it
+  /// untrue.
   factory DocumentRef.parse(String uri) {
     final segments = uri.split(_attachmentMarker);
     return DocumentRef._(
@@ -65,16 +68,23 @@ class DocumentRef {
   /// The innermost attachment name, or the decoded filename of [rootUri] when
   /// this is a plain document, trimmed of surrounding whitespace.
   ///
-  /// Null when the name reads blank, so a caller that needs a label has to
-  /// supply its own fallback rather than render an invisible one. For a plain
-  /// document that covers a [rootUri] ending in a separator, or naming no path
-  /// at all.
+  /// Null when no name reads, so a caller that needs a label supplies its own
+  /// rather than rendering an empty one. For a plain document that covers a
+  /// [rootUri] that is empty, ends in a separator, or is a bare id rather than
+  /// a path; for an attachment, a name that reads blank.
   ///
   /// Two surprises reach a plain document's name: an unescaped `?` or `#`
-  /// truncates it, and a URI with no path (`https://example.test`) yields its
-  /// host.
+  /// truncates it, and a URI with an authority but no path
+  /// (`https://example.test`) yields its host.
   String? get displayName {
-    final name = (isAttachment ? attachmentPath.last : _rootFileName).trim();
+    if (isAttachment) {
+      final name = attachmentPath.last.trim();
+      return name.isEmpty ? null : name;
+    }
+    // An id standing in for a path names no file. Without this a bare UUID
+    // reads as a perfectly good filename and outranks a real title.
+    if (_bareUuid.hasMatch(rootUri)) return null;
+    final name = _rootFileName.trim();
     return name.isEmpty ? null : name;
   }
 
@@ -112,6 +122,12 @@ class DocumentRef {
     return _decode(lastSlash == -1 ? path : path.substring(lastSlash + 1));
   }
 }
+
+/// A URI that is nothing but a UUID: an id standing in for a path.
+final _bareUuid = RegExp(
+  r'^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$',
+  caseSensitive: false,
+);
 
 /// One or more consecutive percent escapes, carrying a UTF-8 byte sequence.
 /// Matched as a run so a multi-byte code point decodes as a unit.

--- a/packages/soliplex_client/lib/src/domain/document_ref.dart
+++ b/packages/soliplex_client/lib/src/domain/document_ref.dart
@@ -87,10 +87,12 @@ class DocumentRef {
   /// separator.
   List<String> get ancestorNames {
     if (!isAttachment) return const [];
-    return [
-      _rootFileName,
-      ...attachmentPath.take(attachmentPath.length - 1),
-    ].map((name) => name.trim()).where((name) => name.isNotEmpty).toList();
+    return List.unmodifiable(
+      [
+        _rootFileName,
+        ...attachmentPath.take(attachmentPath.length - 1),
+      ].map((name) => name.trim()).where((name) => name.isNotEmpty),
+    );
   }
 
   /// [rootUri]'s decoded filename, with any query or fragment dropped.

--- a/packages/soliplex_client/lib/src/domain/source_reference.dart
+++ b/packages/soliplex_client/lib/src/domain/source_reference.dart
@@ -179,7 +179,16 @@ class SourceReference {
   ///
   /// Reads the extension off [fileName], so a page fragment does not hide it
   /// and an embedded file is typed as itself rather than as its container.
-  bool get isPdf => fileName?.toLowerCase().endsWith('.pdf') ?? false;
+  /// [documentUri] is consulted as well, because a URI that carries its
+  /// filename in a query string names no `.pdf` file — dropping the raw test
+  /// would take the page preview away from one.
+  ///
+  /// Either signal is enough: a missing preview is a feature silently gone,
+  /// while an offered one that has no rasters lands on an empty state that
+  /// already exists.
+  bool get isPdf =>
+      (fileName?.toLowerCase().endsWith('.pdf') ?? false) ||
+      documentUri.toLowerCase().endsWith('.pdf');
 
   @override
   bool operator ==(Object other) {

--- a/packages/soliplex_client/lib/src/domain/source_reference.dart
+++ b/packages/soliplex_client/lib/src/domain/source_reference.dart
@@ -161,6 +161,14 @@ class SourceReference {
     return 'Unknown Document';
   }
 
+  /// The documents the cited file is embedded in, outermost first, or empty
+  /// when it is not embedded in one.
+  ///
+  /// Read out of [documentUri], so these are names rather than verified
+  /// documents: nothing here confirms one exists or is retrievable.
+  List<String> get ancestorNames =>
+      DocumentRef.parse(documentUri).ancestorNames;
+
   /// Whether this source reference points to a PDF document.
   bool get isPdf => documentUri.toLowerCase().endsWith('.pdf');
 

--- a/packages/soliplex_client/lib/src/domain/source_reference.dart
+++ b/packages/soliplex_client/lib/src/domain/source_reference.dart
@@ -135,28 +135,35 @@ class SourceReference {
     }
   }
 
+  /// [documentUri] decomposed into the document it lives in and the chain of
+  /// attachment names leading to it.
+  DocumentRef get _document => DocumentRef.parse(documentUri);
+
+  /// The filename [documentUri] addresses — the attachment's own name when the
+  /// URI addresses a file embedded in another document — or null when the URI
+  /// names no file.
+  ///
+  /// Null is also what tells a surface rendering both a label and a title row
+  /// that [displayTitle] has fallen back to [documentTitle], and so is already
+  /// showing it.
+  String? get fileName => _document.displayName;
+
   /// Returns a display-friendly title for the source reference.
   ///
-  /// Uses the filename from [documentUri] — the attachment's own name when the
-  /// URI addresses a file embedded in another document. Falls back to
-  /// [documentTitle], then to "Unknown Document".
+  /// Uses [fileName], falling back to [documentTitle], then to
+  /// "Unknown Document".
   ///
   /// The filename wins because it identifies the file the chunk came from: it
   /// names a cited attachment rather than the document it was embedded in.
   /// [documentTitle] is absent unless the backend is configured to generate
   /// titles, and a generated title is non-deterministic and can collide across
   /// documents.
-  ///
-  /// Unlike the document listing, this applies no id-shaped-URI guard, so a
-  /// [documentUri] that is a bare UUID reads as the name. Citations are built
-  /// only from backend retrieval payloads, which carry paths.
   String get displayTitle {
-    final fileName = DocumentRef.parse(documentUri).displayName;
-    if (fileName != null) return fileName;
+    final name = fileName;
+    if (name != null) return name;
 
-    if (documentTitle != null && documentTitle!.isNotEmpty) {
-      return documentTitle!;
-    }
+    final title = documentTitle?.trim();
+    if (title != null && title.isNotEmpty) return title;
 
     return 'Unknown Document';
   }
@@ -166,11 +173,13 @@ class SourceReference {
   ///
   /// Read out of [documentUri], so these are names rather than verified
   /// documents: nothing here confirms one exists or is retrievable.
-  List<String> get ancestorNames =>
-      DocumentRef.parse(documentUri).ancestorNames;
+  List<String> get ancestorNames => _document.ancestorNames;
 
-  /// Whether this source reference points to a PDF document.
-  bool get isPdf => documentUri.toLowerCase().endsWith('.pdf');
+  /// Whether the cited file is a PDF.
+  ///
+  /// Reads the extension off [fileName], so a page fragment does not hide it
+  /// and an embedded file is typed as itself rather than as its container.
+  bool get isPdf => fileName?.toLowerCase().endsWith('.pdf') ?? false;
 
   @override
   bool operator ==(Object other) {

--- a/packages/soliplex_client/test/domain/document_ref_test.dart
+++ b/packages/soliplex_client/test/domain/document_ref_test.dart
@@ -195,6 +195,30 @@ void main() {
       expect(DocumentRef.parse('').displayName, isNull);
     });
 
+    test('has no name when the root is a bare id', () {
+      // An id standing in for a path names no file. Without this the UUID
+      // reads as a perfectly good filename and outranks a real title.
+      expect(
+        DocumentRef.parse('4e8bf0c7-f504-4ffc-b647-a9f8f255bea5').displayName,
+        isNull,
+      );
+      expect(
+        DocumentRef.parse('4E8BF0C7-F504-4FFC-B647-A9F8F255BEA5').displayName,
+        isNull,
+      );
+    });
+
+    test('reads a uuid that names a file rather than standing in for one', () {
+      // The guard reads the whole uri, so a file *named* after a uuid keeps
+      // its name.
+      expect(
+        DocumentRef.parse(
+          'file:///docs/4e8bf0c7-f504-4ffc-b647-a9f8f255bea5.pdf',
+        ).displayName,
+        '4e8bf0c7-f504-4ffc-b647-a9f8f255bea5.pdf',
+      );
+    });
+
     test('ancestorNames omits a level with a blank name', () {
       // A blank entry would render as a dangling separator once these are
       // joined, so it is dropped at every level, not only at the root.

--- a/packages/soliplex_client/test/domain/source_reference_test.dart
+++ b/packages/soliplex_client/test/domain/source_reference_test.dart
@@ -416,6 +416,19 @@ void main() {
         expect(ref.isPdf, isTrue);
       });
 
+      test('keeps the preview for a filename carried in a query string', () {
+        // The path names `download`, so the name alone reads as no PDF; the
+        // raw URI is what identifies this one.
+        const ref = SourceReference(
+          documentId: 'doc-1',
+          documentUri: 'https://example.test/download?file=report.pdf',
+          content: 'content',
+          chunkId: 'chunk-1',
+        );
+
+        expect(ref.isPdf, isTrue);
+      });
+
       test('types an embedded file as itself, not its container', () {
         const ref = SourceReference(
           documentId: 'doc-1',

--- a/packages/soliplex_client/test/domain/source_reference_test.dart
+++ b/packages/soliplex_client/test/domain/source_reference_test.dart
@@ -332,6 +332,30 @@ void main() {
         expect(ref.displayTitle, 'Unknown Document');
       });
 
+      test('prefers documentTitle over a uri that is a bare id', () {
+        const ref = SourceReference(
+          documentId: 'doc-1',
+          documentUri: '4e8bf0c7-f504-4ffc-b647-a9f8f255bea5',
+          content: 'content',
+          chunkId: 'chunk-1',
+          documentTitle: 'Question 1',
+        );
+
+        expect(ref.displayTitle, 'Question 1');
+      });
+
+      test('ignores a documentTitle that reads blank', () {
+        const ref = SourceReference(
+          documentId: 'doc-1',
+          documentUri: 'file:///docs/',
+          content: 'content',
+          chunkId: 'chunk-1',
+          documentTitle: '   ',
+        );
+
+        expect(ref.displayTitle, 'Unknown Document');
+      });
+
       test('ignores empty documentTitle', () {
         const ref = SourceReference(
           documentId: 'doc-1',
@@ -372,6 +396,30 @@ void main() {
         const ref = SourceReference(
           documentId: 'doc-1',
           documentUri: 'https://example.com/doc.md',
+          content: 'content',
+          chunkId: 'chunk-1',
+        );
+
+        expect(ref.isPdf, isFalse);
+      });
+
+      test('reads the extension off the name, not the raw uri', () {
+        // A page fragment leaves the uri no longer ending in .pdf, but the
+        // row is still labelled handbook.pdf and still has pages to preview.
+        const ref = SourceReference(
+          documentId: 'doc-1',
+          documentUri: 'file:///docs/handbook.pdf#page=3',
+          content: 'content',
+          chunkId: 'chunk-1',
+        );
+
+        expect(ref.isPdf, isTrue);
+      });
+
+      test('types an embedded file as itself, not its container', () {
+        const ref = SourceReference(
+          documentId: 'doc-1',
+          documentUri: 'file:///docs/annual-report.pdf#attachment=budget.xlsx',
           content: 'content',
           chunkId: 'chunk-1',
         );

--- a/test/modules/room/ui/citations_section_test.dart
+++ b/test/modules/room/ui/citations_section_test.dart
@@ -7,14 +7,18 @@ import 'package:soliplex_frontend/src/modules/room/ui/citations_section.dart';
 import 'package:soliplex_frontend/src/modules/room/ui/markdown/flutter_markdown_plus_renderer.dart';
 
 /// Builds a reference labelled by its filename, with a distinct
-/// [SourceReference.documentTitle] the row is expected not to show.
+/// [SourceReference.documentTitle] the collapsed row is expected not to show —
+/// the title surfaces only in the expanded area.
 ///
 /// The URI ends in [fileName], so the name drives both the label and the PDF
 /// affordance — though [SourceReference.isPdf] reads the whole URI, not the
-/// name. Callers vary the name, not the URI.
+/// name. Callers usually vary the name; pass [uri] outright to address a file
+/// embedded in another document.
 SourceReference _ref({
   required int index,
   String? fileName,
+  String? uri,
+  Object? documentTitle = _unset,
   List<String> headings = const [],
   String content = 'Test content',
   List<int> pageNumbers = const [],
@@ -22,15 +26,21 @@ SourceReference _ref({
   final name = fileName ?? 'doc-$index.txt';
   return SourceReference(
     documentId: 'doc-$index',
-    documentUri: 'file:///docs/$name',
+    documentUri: uri ?? 'file:///docs/$name',
     content: content,
     chunkId: 'chunk-$index',
-    documentTitle: 'Document $index',
+    documentTitle: identical(documentTitle, _unset)
+        ? 'Document $index'
+        : documentTitle as String?,
     headings: headings,
     pageNumbers: pageNumbers,
     index: index,
   );
 }
+
+/// Sentinel distinguishing "caller passed null" from "caller passed nothing",
+/// so a test can ask for a reference with no title at all.
+const Object _unset = Object();
 
 Widget _wrap(Widget child) => ProviderScope(
       child: MaterialApp(home: Scaffold(body: child)),
@@ -231,6 +241,145 @@ void main() {
     ));
 
     expect(find.text('p.5-6'), findsOneWidget);
+  });
+
+  testWidgets('an attachment citation names the document it is embedded in',
+      (tester) async {
+    await tester.pumpWidget(_wrap(
+      CitationsSection(
+        sourceReferences: [
+          _ref(
+            index: 1,
+            uri: 'file:///docs/annual-report.pdf#attachment=budget.xlsx',
+          ),
+        ],
+      ),
+    ));
+
+    // The cited file keeps the primary slot — never the container — and states
+    // its provenance underneath.
+    expect(find.text('budget.xlsx'), findsOneWidget);
+    expect(find.text('in annual-report.pdf'), findsOneWidget);
+
+    // The provenance sits inside the row's tap target, so opening a citation
+    // by its container line works like opening it by its name.
+    await tester.tap(find.text('in annual-report.pdf'));
+    await tester.pump();
+
+    expect(find.textContaining('chunk-1'), findsOneWidget);
+  });
+
+  testWidgets('a nested attachment chains the documents containing it',
+      (tester) async {
+    await tester.pumpWidget(_wrap(
+      CitationsSection(
+        sourceReferences: [
+          _ref(
+            index: 1,
+            uri: 'file:///docs/a.pdf#attachment=b.pdf#attachment=inner.xlsx',
+          ),
+        ],
+      ),
+    ));
+
+    expect(find.text('inner.xlsx'), findsOneWidget);
+    expect(find.text('in a.pdf > b.pdf'), findsOneWidget);
+  });
+
+  testWidgets('the label tooltip carries both names in full', (tester) async {
+    await tester.pumpWidget(_wrap(
+      CitationsSection(
+        sourceReferences: [
+          _ref(
+            index: 1,
+            uri: 'file:///docs/annual-report.pdf#attachment=budget.xlsx',
+          ),
+        ],
+      ),
+    ));
+
+    // Both lines ellipsize, so a tooltip naming only the container would leave
+    // the cited file — the thing the citation is about — unreadable.
+    expect(
+      find.byTooltip('budget.xlsx embedded in annual-report.pdf'),
+      findsOneWidget,
+    );
+  });
+
+  testWidgets('the label tooltip of a plain document carries its name',
+      (tester) async {
+    await tester.pumpWidget(_wrap(
+      CitationsSection(
+        sourceReferences: [_ref(index: 1, fileName: 'standalone.pdf')],
+      ),
+    ));
+
+    expect(find.byTooltip('standalone.pdf'), findsOneWidget);
+  });
+
+  testWidgets('a citation of a plain document shows no provenance line',
+      (tester) async {
+    await tester.pumpWidget(_wrap(
+      CitationsSection(
+        sourceReferences: [_ref(index: 1, fileName: 'standalone.pdf')],
+      ),
+    ));
+
+    expect(find.text('standalone.pdf'), findsOneWidget);
+    expect(find.textContaining(RegExp('^in ')), findsNothing);
+  });
+
+  testWidgets('an expanded citation shows the document title', (tester) async {
+    await tester.pumpWidget(_wrap(
+      CitationsSection(
+        sourceReferences: [
+          _ref(
+            index: 1,
+            fileName: 'Doc.txt',
+            documentTitle: 'Annual Operations Review',
+          ),
+        ],
+      ),
+    ));
+
+    await tester.tap(find.text('Doc.txt'));
+    await tester.pump();
+
+    expect(find.textContaining('Annual Operations Review'), findsOneWidget);
+  });
+
+  testWidgets('an expanded citation with no title shows no title row',
+      (tester) async {
+    await tester.pumpWidget(_wrap(
+      CitationsSection(
+        sourceReferences: [
+          _ref(index: 1, fileName: 'Doc.txt', documentTitle: null),
+        ],
+      ),
+    ));
+
+    await tester.tap(find.text('Doc.txt'));
+    await tester.pump();
+
+    // The label goes with the value — a lone `title` lead-in announces nothing.
+    expect(find.textContaining('chunk-1'), findsOneWidget);
+    expect(find.textContaining('title  '), findsNothing);
+  });
+
+  testWidgets('a blank document title is treated as absent', (tester) async {
+    await tester.pumpWidget(_wrap(
+      CitationsSection(
+        sourceReferences: [
+          _ref(index: 1, fileName: 'Doc.txt', documentTitle: '   '),
+        ],
+      ),
+    ));
+
+    await tester.tap(find.text('Doc.txt'));
+    await tester.pump();
+
+    expect(find.textContaining('chunk-1'), findsOneWidget);
+    expect(find.textContaining('title  '), findsNothing);
   });
 
   testWidgets('shows PDF preview affordance only for PDF sources',

--- a/test/modules/room/ui/citations_section_test.dart
+++ b/test/modules/room/ui/citations_section_test.dart
@@ -11,9 +11,8 @@ import 'package:soliplex_frontend/src/modules/room/ui/markdown/flutter_markdown_
 /// the title surfaces only in the expanded area.
 ///
 /// The URI ends in [fileName], so the name drives both the label and the PDF
-/// affordance — though [SourceReference.isPdf] reads the whole URI, not the
-/// name. Callers usually vary the name; pass [uri] outright to address a file
-/// embedded in another document.
+/// affordance. Callers usually vary the name; pass [uri] outright to address a
+/// file embedded in another document.
 SourceReference _ref({
   required int index,
   String? fileName,
@@ -343,6 +342,28 @@ void main() {
     ));
 
     await tester.tap(find.text('Doc.txt'));
+    await tester.pump();
+
+    expect(find.textContaining('Annual Operations Review'), findsOneWidget);
+  });
+
+  testWidgets('an expanded citation whose label is the title shows it once',
+      (tester) async {
+    // The row label falls back to the title when the uri names no file.
+    // Repeating it under a `title` lead-in would print the same string twice.
+    await tester.pumpWidget(_wrap(
+      CitationsSection(
+        sourceReferences: [
+          _ref(
+            index: 1,
+            uri: 'file:///docs/',
+            documentTitle: 'Annual Operations Review',
+          ),
+        ],
+      ),
+    ));
+
+    await tester.tap(find.text('Annual Operations Review'));
     await tester.pump();
 
     expect(find.textContaining('Annual Operations Review'), findsOneWidget);

--- a/test/shared/browser_url_link_test.dart
+++ b/test/shared/browser_url_link_test.dart
@@ -35,5 +35,17 @@ void main() {
       expect(find.byIcon(Icons.link), findsOneWidget);
       expect(find.byType(InkWell), findsOneWidget);
     });
+
+    testWidgets('carries the whole url in a tooltip', (tester) async {
+      // The displayed text drops the scheme, the query and the fragment, and
+      // ellipsizes what is left, so the tooltip is the only place the address
+      // being opened can be read in full.
+      final url = Uri.parse('https://example.test/a/b.pdf?x=1#attachment=c');
+      await tester.pumpWidget(
+        MaterialApp(home: Scaffold(body: BrowserUrlLink(url: url))),
+      );
+
+      expect(find.byTooltip(url.toString()), findsOneWidget);
+    });
   });
 }

--- a/test/shared/file_type_icons_test.dart
+++ b/test/shared/file_type_icons_test.dart
@@ -10,29 +10,20 @@ void main() {
     IconData iconFor(String uri) =>
         documentTypeIcon(RagDocument(id: 'doc-1', title: 'untitled', uri: uri));
 
-    const byExtension = {
-      'pdf': Icons.picture_as_pdf,
-      'doc': Icons.description,
-      'docx': Icons.description,
-      'xls': Icons.table_chart,
-      'xlsx': Icons.table_chart,
-      'ppt': Icons.slideshow,
-      'pptx': Icons.slideshow,
-      'png': Icons.image,
-      'jpg': Icons.image,
-      'jpeg': Icons.image,
-      'gif': Icons.image,
-      'webp': Icons.image,
-      'bmp': Icons.image,
-      'txt': Icons.article,
-      'md': Icons.article,
-      'xyz': Icons.insert_drive_file,
-    };
+    // One representative per glyph family. A case per alias would restate the
+    // switch it is checking, so a typo there would be copied into the
+    // expectation rather than caught by it.
+    test('maps a file family to its glyph', () {
+      expect(iconFor('document.pdf'), equals(Icons.picture_as_pdf));
+      expect(iconFor('document.docx'), equals(Icons.description));
+      expect(iconFor('document.xlsx'), equals(Icons.table_chart));
+      expect(iconFor('document.pptx'), equals(Icons.slideshow));
+      expect(iconFor('document.png'), equals(Icons.image));
+      expect(iconFor('document.md'), equals(Icons.article));
+    });
 
-    byExtension.forEach((extension, icon) {
-      test('maps .$extension', () {
-        expect(iconFor('document.$extension'), equals(icon));
-      });
+    test('falls back to a generic glyph for an unrecognised extension', () {
+      expect(iconFor('document.xyz'), equals(Icons.insert_drive_file));
     });
 
     test('matches the extension case-insensitively', () {
@@ -210,10 +201,12 @@ void main() {
         chunkId: 'chunk-1',
       );
 
-      // Assert the value on both sides, not just that they agree — agreement
-      // alone also holds if both regress to the container's name.
+      // The value once, then the agreement: each surface's own test pins the
+      // value, so what only this case can catch is the two drifting apart —
+      // one side gaining a guard the other does not, which is how they came to
+      // disagree before.
       expect(documentDisplayName(doc), equals('budget.xlsx'));
-      expect(ref.displayTitle, equals('budget.xlsx'));
+      expect(ref.displayTitle, equals(documentDisplayName(doc)));
     });
   });
 


### PR DESCRIPTION
# Summary

A citation of a file embedded in a PDF now says which document it lives in, and
the three facts a citation row shows about its document — its label, its title
row and its file type — all come from one parse of the document URI instead of
three ad-hoc readings of it.

Follows #492, which unified the *document listing's* name and glyph. That left
citations naming an embedded file correctly but saying nothing about where it
came from, and left `displayTitle` as the one reader still deriving a name its
own way.

## Changes

**Provenance**

- A citation of an embedded file names the documents containing it beneath the
  file's own name — `in annual-report.pdf`, chaining when embedded two deep.
  Read off the URI via `SourceReference.ancestorNames`.
- Both lines cap at one line under a single tooltip carrying
  `<name> embedded in <chain>`; several citations sit inline in one message, so
  letting names wrap would size every row by the longest one.
- The inner `Row` aligns on `TextBaseline.alphabetic`, so the badge and page
  range sit on the filename's baseline rather than level with the provenance
  line beneath it.

**One derivation**

- New `SourceReference.fileName` exposes the filename the URI addresses, or null
  when it addresses none. `displayTitle`, `isPdf` and the title row all read it,
  replacing a `Uri.pathSegments` walk, a raw `endsWith('.pdf')` and an unguarded
  `documentTitle`.
- The id-shaped-URI guard moved into `DocumentRef.displayName`, so the citation
  and the listing resolve a name the same way. This *deletes* `_fileName`,
  `_isUuid` and `_uuidPattern` from `file_type_icons.dart` — one policy where
  there were two.
- An expanded citation shows the document's title on a shared
  `DocumentMetadataLine` (prose and `.identifier` forms, absorbing `_metaLine`).
  It is suppressed when the row label is already the title, so the same string
  is never printed twice.

**Fixes surfaced while auditing the above**

- A title that reads blank no longer renders as an empty label; the citation
  reads `Unknown Document`.
- A PDF addressed with a page fragment (`handbook.pdf#page=3`) keeps its page
  preview, which the raw-URI test withdrew.
- A PDF whose filename rides in a query string (`/download?file=report.pdf`)
  also keeps its preview — `isPdf` consults both the resolved name and the raw
  URI, because a withdrawn preview is a feature silently gone while an offered
  one without rasters lands on an empty state that already exists.
- `BrowserUrlLink` carries the whole address on hover, reaching the citation,
  picker and room-info surfaces through `DocumentSource`. Its text keeps host
  and path alone, so two addresses differing only by port read identically.

## Test Plan

- [x] Tests pass locally — 2201 app, 1618 `soliplex_client`
      (`--exclude-tags integration`, as CI runs it)
- [x] `flutter analyze` clean; `dart format` and `markdownlint-cli2` clean
- [x] Manual testing completed

**Regression audit.** Rather than reason about it, I extracted the pre-#492
implementations verbatim and diffed them against this branch over 32 URIs × 5
titles:

- `isPdf` — zero `true→false` cases. Four gains: `#page=3`, `?v=1`, a trailing
  `%20`, and a trailing `#attachment=`.
- `filterDocuments` — zero lost matches; percent-encoded names became
  searchable (`annual report`, `résumé`).
- `documentDisplayName`/glyph — 20 divergences, all either the attachment fix,
  decoding gains, or the two tradeoffs `CHANGELOG.md` documents
  (`?file=report.pdf` → `download`, `invoice#1234.xlsx` → `invoice`).
- Fallback chain — `Unknown Document` replaces what used to render as `""` or
  `"   "`; invisible labels are gone.

The pruned glyph-mapping tests were mutation-checked: breaking the `pptx` arm
and breaking the fallback each still fail.

**Not covered by that audit:** layout changes are covered by widget tests, not
differentially, and no goldens were compared (Linux baseline).

## Related Issues

Follows #492.

🤖 Generated with [Claude Code](https://claude.com/claude-code)