### PR TITLE
chore: version 0.98.2+78

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ Versions follow the `version+build` scheme from `pubspec.yaml`, bumped via
 
 ## [Unreleased]
 
+## [0.98.2+78] - 2026-08-04
+
 ### Changed
 
 - The execution timeline renders an activity from the AG-UI envelope rather than

--- a/lib/version.dart
+++ b/lib/version.dart
@@ -2,4 +2,4 @@
 ///
 /// Generated from pubspec.yaml. Run `dart run tool/update_version.dart` after
 /// changing the version in pubspec.yaml.
-const String soliplexVersion = '0.98.1+77';
+const String soliplexVersion = '0.98.2+78';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,7 +3,7 @@ description: Modular Flutter frontend framework for Soliplex
 publish_to: none
 # To update version, run:
 # dart run tool/bump_version.dart <major|minor|patch|build>
-version: 0.98.1+77
+version: 0.98.2+78
 
 environment:
   sdk: ^3.6.0


### PR DESCRIPTION
Bumps `soliplex_frontend` to `0.98.2+78` (patch) and closes the `[Unreleased]`
CHANGELOG block as `## [0.98.2+78]`.

The release covers the nine commits since `v0.98.1+77`: rendering execution
timeline activities from the AG-UI envelope rather than a skill-specific schema,
and the citation/document display-name work (naming an embedded file as itself,
one URI parse per citation, page previews for filenames carried in a query
string, filename-over-title labelling).

🤖 Generated with [Claude Code](https://claude.com/claude-code)