### PR TITLE
fix: paste into the room composer while it is unfocused

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,25 @@ Versions follow the `version+build` scheme from `pubspec.yaml`, bumped via
 
 ## [Unreleased]
 
+### Fixed
+
+- Pressing the platform's paste chord in a room — Cmd+V on macOS and iOS, Ctrl+V
+  elsewhere — no longer does nothing when the composer is unfocused. One keypress
+  now moves focus to the composer and inserts the clipboard's text, over the
+  composer's selection when it has one. Every other chord keeps its meaning: copy
+  and select-all still belong to the transcript, and a chord that is not the
+  running platform's paste chord is left alone. Only text is read: with no text
+  on the clipboard focus still moves and nothing is inserted. The chord does
+  nothing at all while a thread is still loading its messages or while a reply is
+  streaming, since the composer takes no text in either state. Each press inserts
+  the clipboard once, including a second press made while the first is still
+  waiting on a slow clipboard; holding the chord down repeats through the
+  platform's own paste, as it does in any focused field. On browsers that withhold
+  clipboard reads from a page, the first press moves focus and a second pastes
+  through the browser's own path.
+- Typing or pasting with the navigation drawer open no longer moves focus to the
+  composer behind it, or routes clipboard text there.
+
 ## [0.98.2+78] - 2026-08-04
 
 ### Changed

--- a/lib/src/modules/room/ui/chat_input.dart
+++ b/lib/src/modules/room/ui/chat_input.dart
@@ -7,6 +7,24 @@ import '../../../shared/document_display.dart';
 import 'document_label.dart';
 import 'package:soliplex_design/soliplex_design.dart';
 
+/// Whether the composer takes text right now. It refuses while the screen has
+/// it disabled and while a run is in flight, because both render it read-only —
+/// text routed in during either state could not be edited or removed until the
+/// composer came back.
+///
+/// [ChatInput] gates its text field, send button, document filter, attach
+/// control, and chip removal on this. The Stop button sits outside it by
+/// necessity: it renders only while a run holds the composer, which is one of the
+/// states this refuses.
+bool composerAcceptsText({
+  required bool enabled,
+  required AgentSessionState? sessionState,
+}) =>
+    enabled && !_isRunActive(sessionState);
+
+bool _isRunActive(AgentSessionState? state) =>
+    state == AgentSessionState.spawning || state == AgentSessionState.running;
+
 class ChatInput extends StatefulWidget {
   const ChatInput({
     super.key,
@@ -111,8 +129,10 @@ class _ChatInputState extends State<ChatInput> {
   void _send() {
     final text = _controller.text.trim();
     if (text.isEmpty ||
-        !widget.enabled ||
-        _isActive(widget.sessionState?.peek())) {
+        !composerAcceptsText(
+          enabled: widget.enabled,
+          sessionState: widget.sessionState?.peek(),
+        )) {
       return;
     }
     widget.onSend(text);
@@ -120,14 +140,12 @@ class _ChatInputState extends State<ChatInput> {
     _focusNode.requestFocus();
   }
 
-  bool _isActive(AgentSessionState? state) =>
-      state == AgentSessionState.spawning || state == AgentSessionState.running;
-
   @override
   Widget build(BuildContext context) {
     final state = widget.sessionState?.watch(context);
-    final active = _isActive(state);
-    final disabled = !widget.enabled || active;
+    final active = _isRunActive(state);
+    final disabled =
+        !composerAcceptsText(enabled: widget.enabled, sessionState: state);
     final cancelEnabled = widget.cancelEnabled?.watch(context) ?? true;
 
     return Padding(

--- a/lib/src/modules/room/ui/room_screen.dart
+++ b/lib/src/modules/room/ui/room_screen.dart
@@ -2,11 +2,13 @@ import 'dart:async';
 import 'dart:convert';
 
 import 'package:clock/clock.dart';
+import 'package:flutter/foundation.dart' show defaultTargetPlatform;
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:go_router/go_router.dart';
 import 'package:signals_flutter/signals_flutter.dart';
-import 'package:soliplex_agent/soliplex_agent.dart' show ThreadKey;
+import 'package:soliplex_agent/soliplex_agent.dart'
+    show AgentSessionState, ThreadKey;
 import 'package:soliplex_client/soliplex_client.dart'
     show
         AuthException,
@@ -84,15 +86,16 @@ final _modifierKeys = <LogicalKeyboardKey>{
 
 /// Whether a key press should pull focus into the chat composer
 /// ("type to focus"). Only real typing does — never a bare modifier, and never
-/// while a copy/select command modifier is held (meta, or control on its own),
-/// so shortcuts like copy and select-all leave the transcript's
-/// [SelectionArea] selection intact instead of clearing it by moving focus.
+/// while a shortcut modifier is held, so shortcuts like copy and select-all
+/// leave the transcript's [SelectionArea] selection intact instead of clearing
+/// it by moving focus.
 ///
 /// Control *combined with* alt is treated as typing, not a shortcut: Windows
 /// synthesizes AltGr as Ctrl+Alt to compose special characters (`@`, `€`, `{`,
 /// …), so those keystrokes must still focus-and-type. Plain Alt/Option is
-/// likewise typing. A genuine Ctrl+Alt shortcut is rare and — since this only
-/// moves focus without consuming the event — harmless if it also focuses.
+/// likewise typing. A genuine Ctrl+Alt shortcut therefore focuses the composer
+/// too, which is harmless: callers move focus and leave the keystroke to run its
+/// normal course, so the shortcut still fires.
 bool shouldFocusChatInputOnKey(
   KeyEvent event, {
   required bool isMetaPressed,
@@ -103,8 +106,68 @@ bool shouldFocusChatInputOnKey(
   if (_modifierKeys.contains(event.logicalKey)) return false;
   final shortcutModifierActive =
       isMetaPressed || (isControlPressed && !isAltPressed);
-  if (shortcutModifierActive) return false;
-  return true;
+  return !shortcutModifierActive;
+}
+
+/// Whether a key press is [platform]'s paste chord: `V` under the command
+/// modifier that platform pastes with — meta on Apple, control elsewhere — and
+/// not the other one, and not alt. Matching one chord per platform leaves the
+/// rest alone rather than claiming one the host may define for itself.
+///
+/// Shift is not consulted: a plain-text composer has no paste-and-match-style
+/// variant to tell apart. That differs from the `SingleActivator` Flutter binds
+/// for a focused field, which matches shift exactly, so the two paths answer
+/// slightly different sets of keystrokes.
+///
+/// Repeats answer only when [includeRepeats] is set. A held chord should start one
+/// clipboard read rather than one per repeat, so the press that claims a chord
+/// counts key-downs alone; once focus lands, further repeats belong to the
+/// focused field's own binding, which does repeat. A caller reconciling itself
+/// with that binding — retiring a read the field is about to answer — passes
+/// true.
+///
+/// [shouldFocusChatInputOnKey] refuses shortcut modifiers so transcript copy and
+/// select-all keep their selection, which leaves paste with no editable target
+/// while the composer is unfocused. This names paste as the one command the
+/// composer answers for itself, and matches exactly rather than broadly so every
+/// other chord keeps the meaning its platform gives it.
+bool shouldPasteIntoChatInputOnKey(
+  KeyEvent event, {
+  required TargetPlatform platform,
+  required bool isMetaPressed,
+  required bool isControlPressed,
+  required bool isAltPressed,
+  bool includeRepeats = false,
+}) {
+  final isPress =
+      event is KeyDownEvent || (includeRepeats && event is KeyRepeatEvent);
+  if (!isPress) return false;
+  if (event.logicalKey != LogicalKeyboardKey.keyV) return false;
+  if (isAltPressed) return false;
+  return switch (platform) {
+    TargetPlatform.macOS ||
+    TargetPlatform.iOS =>
+      isMetaPressed && !isControlPressed,
+    _ => isControlPressed && !isMetaPressed,
+  };
+}
+
+/// Replaces [value]'s selection with [pasted] when it has one, otherwise
+/// inserts [pasted] at the caret. The caret ends up after the pasted text.
+///
+/// A selection the text cannot accommodate — never placed, which is where a
+/// composer that has not been focused yet starts, or reaching past the end —
+/// appends instead, keeping this total for any [TextEditingValue] a caller hands
+/// it.
+TextEditingValue insertPastedText(TextEditingValue value, String pasted) {
+  final length = value.text.length;
+  final selection = value.selection.isValid && value.selection.end <= length
+      ? value.selection
+      : TextSelection.collapsed(offset: length);
+  return TextEditingValue(
+    text: value.text.replaceRange(selection.start, selection.end, pasted),
+    selection: TextSelection.collapsed(offset: selection.start + pasted.length),
+  );
 }
 
 const double _sidebarWidth = 300;
@@ -1246,9 +1309,48 @@ class _RoomScreenState extends State<RoomScreen> {
   }
 
   bool _handleKey(KeyEvent event) {
-    if (_chatFocusNode.hasFocus) return false;
-    if (ModalRoute.of(context)?.isCurrent != true) return false;
     final keyboard = HardwareKeyboard.instance;
+    bool isPasteChord({bool includeRepeats = false}) =>
+        shouldPasteIntoChatInputOnKey(
+          event,
+          platform: defaultTargetPlatform,
+          isMetaPressed: keyboard.isMetaPressed,
+          isControlPressed: keyboard.isControlPressed,
+          isAltPressed: keyboard.isAltPressed,
+          includeRepeats: includeRepeats,
+        );
+    if (_chatFocusNode.hasFocus) {
+      // The focused composer answers this chord with the platform's own paste,
+      // which runs whatever this handler returns. A read still owed an answer
+      // would insert the same clipboard a second time, so retire it — but only
+      // while the composer would honour that paste. A read-only one refuses it,
+      // and retiring then would have the pending read report a handoff that
+      // never happened in place of the loss that did.
+      //
+      // Repeats count here though they cannot claim a chord of their own: the
+      // binding Flutter gives a focused field repeats, so a held chord keeps
+      // pasting, and each one owes a pending read the same answer a fresh press
+      // would.
+      if (isPasteChord(includeRepeats: true) && _composerAcceptsText) {
+        _latestPasteChord = Object();
+      }
+      return false;
+    }
+    if (!_roomIsFrontmost) return false;
+    if (isPasteChord()) {
+      // Abstain rather than claim a chord the composer won't act on, so
+      // whatever else would answer it still can.
+      if (!_composerAcceptsText) return false;
+      _chatFocusNode.requestFocus();
+      final chord = _latestPasteChord = Object();
+      unawaited(_pasteClipboardIntoComposer(chord));
+      // Reporting the chord handled answers the platform, not Flutter, whose own
+      // dispatch runs either way. Nothing pastes twice because focus applies a
+      // microtask later than this keystroke's shortcut dispatch, so the composer
+      // is not yet the focused field that paste would reach. On web this also
+      // stops the browser adding a copy of its own.
+      return true;
+    }
     if (!shouldFocusChatInputOnKey(
       event,
       isMetaPressed: keyboard.isMetaPressed,
@@ -1259,6 +1361,164 @@ class _RoomScreenState extends State<RoomScreen> {
     }
     _chatFocusNode.requestFocus();
     return false;
+  }
+
+  /// Whether the composer would take pasted text right now, reading the same
+  /// state the chat input renders itself from.
+  bool get _composerAcceptsText => composerAcceptsText(
+        enabled: _composerEnabled(_state.activeThreadView?.messages.peek()),
+        sessionState: _composerSessionState.peek(),
+      );
+
+  /// The session state the composer renders from: the active thread's while
+  /// there is one, otherwise the room's own state for a first message.
+  ReadonlySignal<AgentSessionState?> get _composerSessionState =>
+      _state.activeThreadView?.sessionState ?? _state.sessionState;
+
+  /// Whether the thread is far enough along to compose into. A thread holds the
+  /// composer shut until its messages load, and keeps it shut if they failed. A
+  /// null [status] is no thread at all — every thread has a messages signal — and
+  /// composes into a first message.
+  bool _composerEnabled(ThreadViewStatus? status) =>
+      status == null || status is MessagesLoaded;
+
+  /// The draft's owner. A room or thread switch replaces one of these and
+  /// clears the composer, so a change across an await means the draft a paste
+  /// measured may be gone. Deleting the last thread in a room also replaces the
+  /// view while leaving the draft alone, and a paste caught by that is dropped
+  /// though it could have been kept.
+  (RoomState, ThreadViewState?) get _composerTarget =>
+      (_state, _state.activeThreadView);
+
+  /// Identifies the paste chord whose read is owed an answer. Every chord
+  /// replaces it, so a read that resolves late can tell that a later chord took
+  /// over — answered either by the platform's paste into the focused composer or
+  /// by a read of its own — and leave the insert to whichever did.
+  ///
+  /// A token per chord rather than a flag, because two reads can be in flight at
+  /// once: one flag would let whichever finished first speak for the other.
+  Object? _latestPasteChord;
+
+  /// Marks the drawer so [_roomIsFrontmost] can tell whether it is on screen.
+  /// `Scaffold` builds the drawer's own subtree only while it is showing, so this
+  /// key holds a context from the first frame of opening until the last frame of
+  /// closing, and none while the layout has no drawer at all.
+  final _drawerKey = GlobalKey();
+
+  /// Whether the room is the surface the user is typing at: its route on top,
+  /// and no drawer over it.
+  ///
+  /// A drawer hides the composer without pushing a route, so [ModalRoute.isCurrent]
+  /// still reports the room as current while text routed in would land where the
+  /// user cannot see it. Neither the drawer's own state nor
+  /// `Scaffold.onDrawerChanged` can answer for it: the notification is skipped
+  /// once the drawer widget goes away, so a viewport crossing
+  /// [SoliplexBreakpoints.tablet] never reports the close, and a drag that closes
+  /// the drawer outright settles it without one either. Asking whether the
+  /// drawer's subtree is mounted sidesteps both.
+  bool get _roomIsFrontmost =>
+      ModalRoute.of(context)?.isCurrent == true &&
+      _drawerKey.currentContext == null;
+
+  /// Pastes the clipboard's text into the composer, unless a later chord
+  /// identified by something other than [chord] has taken the paste over.
+  /// [_handleKey] establishes before calling this that the composer is unfocused
+  /// and that no drawer, dialog, or route sits above this one.
+  ///
+  /// A failed read is logged and swallowed; the composer keeps whatever it
+  /// already held. Pressing the chord again with the composer focused reaches
+  /// the platform's own paste, which is the recovery from a refused read.
+  Future<void> _pasteClipboardIntoComposer(Object chord) async {
+    // The read can take arbitrarily long — a platform may gate it behind a
+    // consent prompt, as the browser's clipboard permission does — so record
+    // what the chord aimed at and re-check it once the text arrives.
+    final target = _composerTarget;
+    final attributes = <String, Object?>{
+      'serverId': widget.serverEntry.serverId,
+      'roomId': widget.roomId,
+      'threadId': _state.activeThreadView?.threadId,
+    };
+    final ClipboardData? data;
+    try {
+      data = await Clipboard.getData(Clipboard.kTextPlain);
+    } on PlatformException catch (e, st) {
+      // A browser that withholds `readText` from page content. A steady state
+      // rather than a malfunction, and one the user meets on every keypress, so
+      // it is reported below the error level. Any embedder's clipboard failure
+      // arrives this way too, so the code is recorded to tell an outright broken
+      // channel from the routine refusal.
+      _logger.warning(
+        'The platform refused a clipboard read for a composer paste',
+        error: e,
+        stackTrace: st,
+        attributes: {...attributes, 'code': e.code},
+      );
+      return;
+    } catch (e, st) {
+      _logger.error(
+        'Failed to read the clipboard for a composer paste',
+        error: e,
+        stackTrace: st,
+        attributes: attributes,
+      );
+      return;
+    }
+    if (!mounted) return;
+
+    // Records why a read that arrived too late went nowhere. This is the only
+    // account of a paste the user watched themselves ask for, so it names which
+    // obstacle it hit and where the composer had got to.
+    void drop(String reason, {bool costsText = false}) {
+      final message = 'Dropped a composer paste: $reason';
+      final where = {
+        ...attributes,
+        'landedOnThreadId': _state.activeThreadView?.threadId,
+      };
+      if (costsText) {
+        _logger.warning(message, attributes: where);
+      } else {
+        _logger.info(message, attributes: where);
+      }
+    }
+
+    // A later chord already collected this clipboard, so inserting here would
+    // repeat it. Costs the user nothing: the text they asked for did land.
+    if (_latestPasteChord != chord) {
+      return drop('a later paste chord took it over');
+    }
+
+    // Before the obstacles below, because with nothing to insert every one of
+    // them ends the same way, and reporting one would claim the paste was
+    // thwarted rather than empty.
+    final text = data?.text;
+    if (text == null || text.isEmpty) {
+      // An image-only clipboard lands here, as does an iOS read the user
+      // declined and a platform with no clipboard channel at all — none of them
+      // carry a text flavor. A browser refusal throws instead and is caught
+      // above. `hadData` separates a missing text flavor from a clipboard that
+      // really does hold an empty string.
+      _logger.info(
+        'Paste chord found no clipboard text',
+        attributes: {...attributes, 'hadData': data != null},
+      );
+      return;
+    }
+
+    // A dialog, a pushed route, or a drawer that arrived during the read owns the
+    // screen now, and text belongs wherever the user is looking instead.
+    if (!_roomIsFrontmost) {
+      return drop('the room stopped being the frontmost surface');
+    }
+    if (_composerTarget != target) {
+      return drop('the draft it measured was replaced');
+    }
+    // The composer is read-only until the run settles, so text put there now
+    // could be neither edited nor sent — and this is the one obstacle that costs
+    // the user text they asked for while the draft is still on screen.
+    if (!_composerAcceptsText) {
+      return drop('a run took the composer', costsText: true);
+    }
+    _chatController.value = insertPastedText(_chatController.value, text);
   }
 
   void _onBackToLobby() => context.go(AppRoutes.lobby);
@@ -1477,6 +1737,7 @@ class _RoomScreenState extends State<RoomScreen> {
               actions: built.headerActions,
             ),
             drawer: Drawer(
+              key: _drawerKey,
               child: Builder(
                 builder: (drawerContext) => SafeArea(
                   // Both panels fold into the drawer on narrow viewports: the
@@ -2178,11 +2439,11 @@ class _RoomScreenState extends State<RoomScreen> {
         }
       },
       onCancel: threadView != null ? threadView.cancelRun : _state.cancelSpawn,
-      sessionState: threadView?.sessionState ?? _state.sessionState,
+      sessionState: _composerSessionState,
       cancelEnabled: threadView?.isCancellable,
       controller: _chatController,
       focusNode: _chatFocusNode,
-      enabled: threadView == null || status is MessagesLoaded,
+      enabled: _composerEnabled(status),
       selectedDocuments: _selectedDocuments,
       onFilterTap: _showDocumentFilter ? _openDocumentPicker : null,
       onDocumentRemoved: _filterEnabled

--- a/test/helpers/fakes.dart
+++ b/test/helpers/fakes.dart
@@ -483,6 +483,8 @@ class ManualAgentSession implements AgentSession {
     cancelCalled = true;
   }
 
+  void emit(RunState state) => _runState.value = state;
+
   void completeAsCancelled() {
     _runState.value = CancelledState.preRun(threadKey: threadKey);
     _resultCompleter.complete(AgentFailure(

--- a/test/modules/room/ui/chat_input_test.dart
+++ b/test/modules/room/ui/chat_input_test.dart
@@ -8,6 +8,42 @@ import 'package:soliplex_design/soliplex_design.dart';
 import 'package:soliplex_frontend/src/modules/room/ui/chat_input.dart';
 
 void main() {
+  group('composerAcceptsText', () {
+    test('refuses while a run holds the composer read-only', () {
+      // Typed characters are swallowed in these states, so text routed in from
+      // elsewhere would be stuck there until the run ended.
+      for (final state in [
+        AgentSessionState.spawning,
+        AgentSessionState.running,
+      ]) {
+        expect(
+          composerAcceptsText(enabled: true, sessionState: state),
+          isFalse,
+          reason: '$state should hold the composer',
+        );
+      }
+    });
+
+    test('refuses while the screen has the composer disabled', () {
+      // A thread still loading its messages, whatever the session is doing.
+      for (final state in [null, AgentSessionState.completed]) {
+        expect(
+          composerAcceptsText(enabled: false, sessionState: state),
+          isFalse,
+          reason: 'disabled should refuse with session $state',
+        );
+      }
+    });
+
+    test('takes text with no session yet', () {
+      // A room's first message, before anything has spawned.
+      expect(
+        composerAcceptsText(enabled: true, sessionState: null),
+        isTrue,
+      );
+    });
+  });
+
   testWidgets('send button dispatches text and clears field', (tester) async {
     String? sentText;
     final sessionState = signal<AgentSessionState?>(null);

--- a/test/modules/room/ui/room_screen_test.dart
+++ b/test/modules/room/ui/room_screen_test.dart
@@ -2,12 +2,15 @@ import 'dart:async';
 import 'dart:convert';
 
 import 'package:clock/clock.dart';
+import 'package:flutter/foundation.dart'
+    show debugDefaultTargetPlatformOverride;
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:go_router/go_router.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:soliplex_agent/soliplex_agent.dart';
+import 'package:soliplex_logging/soliplex_logging.dart';
 
 import 'package:soliplex_frontend/src/modules/lobby/lobby_read_markers.dart';
 import 'package:soliplex_frontend/src/modules/lobby/ui/unread_dot.dart';
@@ -198,6 +201,181 @@ void main() {
         ),
         isFalse,
       );
+    });
+  });
+
+  group('shouldPasteIntoChatInputOnKey', () {
+    KeyDownEvent down(LogicalKeyboardKey key) => KeyDownEvent(
+          physicalKey: PhysicalKeyboardKey.keyV,
+          logicalKey: key,
+          timeStamp: Duration.zero,
+        );
+
+    KeyRepeatEvent repeat(LogicalKeyboardKey key) => KeyRepeatEvent(
+          physicalKey: PhysicalKeyboardKey.keyV,
+          logicalKey: key,
+          timeStamp: Duration.zero,
+        );
+
+    bool shouldPaste(
+      KeyEvent event, {
+      TargetPlatform platform = TargetPlatform.macOS,
+      bool meta = false,
+      bool control = false,
+      bool alt = false,
+      bool includeRepeats = false,
+    }) =>
+        shouldPasteIntoChatInputOnKey(
+          event,
+          platform: platform,
+          isMetaPressed: meta,
+          isControlPressed: control,
+          isAltPressed: alt,
+          includeRepeats: includeRepeats,
+        );
+
+    test('each platform pastes with its own command modifier', () {
+      // Matching the chord Flutter binds for a focused field, so the composer
+      // answers the same keystroke whether or not it has focus.
+      for (final platform in [TargetPlatform.macOS, TargetPlatform.iOS]) {
+        expect(
+          shouldPaste(down(LogicalKeyboardKey.keyV),
+              platform: platform, meta: true),
+          isTrue,
+          reason: '$platform pastes with meta',
+        );
+        expect(
+          shouldPaste(down(LogicalKeyboardKey.keyV),
+              platform: platform, control: true),
+          isFalse,
+          reason: '$platform reads control+V as scroll-page-down',
+        );
+      }
+      for (final platform in [
+        TargetPlatform.linux,
+        TargetPlatform.windows,
+        TargetPlatform.android,
+        TargetPlatform.fuchsia,
+      ]) {
+        expect(
+          shouldPaste(down(LogicalKeyboardKey.keyV),
+              platform: platform, control: true),
+          isTrue,
+          reason: '$platform pastes with control',
+        );
+        expect(
+          shouldPaste(down(LogicalKeyboardKey.keyV),
+              platform: platform, meta: true),
+          isFalse,
+          reason: '$platform leaves meta+V alone',
+        );
+      }
+    });
+
+    test('holding both command modifiers does not paste', () {
+      // Neither platform's paste chord, so it belongs to whatever else answers
+      // it — the composer reports a match handled, so it matches exactly.
+      expect(
+        shouldPaste(down(LogicalKeyboardKey.keyV), meta: true, control: true),
+        isFalse,
+      );
+      expect(
+        shouldPaste(down(LogicalKeyboardKey.keyV),
+            platform: TargetPlatform.linux, meta: true, control: true),
+        isFalse,
+      );
+    });
+
+    test('control+alt+V does not paste', () {
+      expect(
+        shouldPaste(down(LogicalKeyboardKey.keyV),
+            platform: TargetPlatform.linux, control: true, alt: true),
+        isFalse,
+      );
+    });
+
+    test('a bare V does not paste', () {
+      expect(shouldPaste(down(LogicalKeyboardKey.keyV)), isFalse);
+    });
+
+    test('meta with another character does not paste', () {
+      // Cmd+C and Cmd+A must stay with the transcript's selection.
+      expect(shouldPaste(down(LogicalKeyboardKey.keyC), meta: true), isFalse);
+      expect(shouldPaste(down(LogicalKeyboardKey.keyA), meta: true), isFalse);
+    });
+
+    test('a key-up event does not paste', () {
+      expect(
+        shouldPaste(
+          KeyUpEvent(
+            physicalKey: PhysicalKeyboardKey.keyV,
+            logicalKey: LogicalKeyboardKey.keyV,
+            timeStamp: Duration.zero,
+          ),
+          meta: true,
+        ),
+        isFalse,
+      );
+    });
+
+    test('a repeat claims no chord of its own', () {
+      // Every repeat while the chord is held would otherwise start a clipboard
+      // read of its own and pour the same text in again.
+      expect(shouldPaste(repeat(LogicalKeyboardKey.keyV), meta: true), isFalse);
+    });
+
+    test('a repeat counts for a caller that asks for repeats', () {
+      // Retiring a read in flight has to answer the same repeats the focused
+      // field's own binding does, which is a broader set than this claims.
+      expect(
+        shouldPaste(
+          repeat(LogicalKeyboardKey.keyV),
+          meta: true,
+          includeRepeats: true,
+        ),
+        isTrue,
+      );
+    });
+  });
+
+  group('insertPastedText', () {
+    test('appends when the composer has never held a selection', () {
+      // Where a TextEditingValue starts before anything places a caret in it.
+      const value = TextEditingValue(
+        text: 'draft',
+        selection: TextSelection.collapsed(offset: -1),
+      );
+
+      final pasted = insertPastedText(value, ' pasted');
+
+      expect(pasted.text, 'draft pasted');
+      expect(pasted.selection, const TextSelection.collapsed(offset: 12));
+    });
+
+    test('appends when the selection outruns the text', () {
+      // The offsets are non-negative, so the selection reads as valid, but
+      // replaceRange would throw on them.
+      const value = TextEditingValue(
+        text: 'short',
+        selection: TextSelection(baseOffset: 0, extentOffset: 99),
+      );
+
+      final pasted = insertPastedText(value, '!');
+
+      expect(pasted.text, 'short!');
+      expect(pasted.selection, const TextSelection.collapsed(offset: 6));
+    });
+
+    test('inserts at the caret', () {
+      const value = TextEditingValue(
+        text: 'ac',
+        selection: TextSelection.collapsed(offset: 1),
+      );
+
+      final pasted = insertPastedText(value, 'b');
+
+      expect(pasted.text, 'abc');
+      expect(pasted.selection, const TextSelection.collapsed(offset: 2));
     });
   });
 
@@ -2441,4 +2619,626 @@ void main() {
 
     expect(find.text('room info page'), findsOneWidget);
   });
+
+  group('paste into the unfocused composer', () {
+    /// Declares a test that presses a chord on [platform], which decides which
+    /// chord the screen reads as paste. Defaults to a platform that pastes with
+    /// meta, since that is the modifier [sendChord] holds.
+    ///
+    /// The override has to be undone inside the body — the test binding checks
+    /// the foundation debug variables before any `tearDown` runs.
+    void testChord(
+      String description,
+      Future<void> Function(WidgetTester) body, {
+      TargetPlatform platform = TargetPlatform.macOS,
+    }) {
+      testWidgets(description, (tester) async {
+        debugDefaultTargetPlatformOverride = platform;
+        try {
+          await body(tester);
+        } finally {
+          debugDefaultTargetPlatformOverride = null;
+        }
+      });
+    }
+
+    /// Answers `Clipboard.getData` with whatever [respond] returns. Throwing
+    /// from [respond] stands in for a platform that refuses the read.
+    void mockClipboard(FutureOr<Object?> Function() respond) {
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .setMockMethodCallHandler(SystemChannels.platform, (call) async {
+        if (call.method == 'Clipboard.getData') return await respond();
+        return null;
+      });
+      addTearDown(
+        () => TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+            .setMockMethodCallHandler(SystemChannels.platform, null),
+      );
+    }
+
+    void mockClipboardText(String text) =>
+        mockClipboard(() => <String, Object?>{'text': text});
+
+    /// A thread still loading its messages, and a thread streaming a run, both
+    /// animate a spinner forever, so `settle: false` callers drain a couple of
+    /// frames instead of waiting for quiet.
+    Future<void> drainFrames(WidgetTester tester,
+        {required bool settle}) async {
+      if (settle) {
+        await tester.pumpAndSettle();
+      } else {
+        await tester.pump();
+        await tester.pump();
+      }
+    }
+
+    /// Holds [modifier] down over [key]. Reports whether anything claimed the
+    /// [key] press, which is what decides between the composer acting on a
+    /// chord and the platform keeping its own meaning for it.
+    Future<bool> sendChord(
+      WidgetTester tester,
+      LogicalKeyboardKey key, {
+      LogicalKeyboardKey modifier = LogicalKeyboardKey.metaLeft,
+    }) async {
+      await tester.sendKeyDownEvent(modifier);
+      final claimed = await tester.sendKeyDownEvent(key);
+      await tester.sendKeyUpEvent(key);
+      await tester.sendKeyUpEvent(modifier);
+      return claimed;
+    }
+
+    Future<bool> pressChord(
+      WidgetTester tester,
+      LogicalKeyboardKey key, {
+      LogicalKeyboardKey modifier = LogicalKeyboardKey.metaLeft,
+      bool settle = true,
+    }) async {
+      final claimed = await sendChord(tester, key, modifier: modifier);
+      await drainFrames(tester, settle: settle);
+      return claimed;
+    }
+
+    Future<TextField> pumpRoom(WidgetTester tester,
+        {bool settle = true, Size? surfaceSize}) async {
+      if (surfaceSize != null) {
+        await tester.binding.setSurfaceSize(surfaceSize);
+        addTearDown(() => tester.binding.setSurfaceSize(null));
+      }
+      await tester.pumpWidget(MaterialApp(
+        home: RoomScreen(
+          serverEntry: entry,
+          roomId: 'room-1',
+          threadId: 'thread-1',
+          runtimeManager: runtimeManager,
+          registry: registry,
+          uploadRegistry: uploadRegistry,
+          documentSelections: DocumentSelections(),
+        ),
+      ));
+      await drainFrames(tester, settle: settle);
+      return tester.widget<TextField>(find.byType(TextField));
+    }
+
+    testChord('one paste chord focuses the composer and inserts the text',
+        (tester) async {
+      mockClipboardText('from the clipboard');
+      final composer = await pumpRoom(tester);
+      expect(composer.focusNode!.hasFocus, isFalse);
+
+      final claimed = await pressChord(tester, LogicalKeyboardKey.keyV);
+
+      expect(composer.focusNode!.hasFocus, isTrue);
+      expect(composer.controller!.text, 'from the clipboard');
+      // Claiming reports that the composer answered the chord, so nothing else
+      // treats it as unhandled. On web it also suppresses the browser's own
+      // paste, which would otherwise add a second copy.
+      expect(claimed, isTrue);
+    });
+
+    testChord('control+V pastes on a platform that pastes with control',
+        (tester) async {
+      // The screen reads each modifier off the keyboard separately and hands
+      // them to the predicate; only pressing the chord proves control reaches
+      // it, and with it every non-Apple platform.
+      mockClipboardText('from the clipboard');
+      final composer = await pumpRoom(tester);
+
+      await pressChord(tester, LogicalKeyboardKey.keyV,
+          modifier: LogicalKeyboardKey.controlLeft);
+
+      expect(composer.controller!.text, 'from the clipboard');
+    }, platform: TargetPlatform.linux);
+
+    testChord(
+        'pastes over the composer selection, keeping the rest of the '
+        'draft', (tester) async {
+      mockClipboardText('take');
+      final composer = await pumpRoom(tester);
+      composer.controller!.value = const TextEditingValue(
+        text: 'keep drop keep',
+        selection: TextSelection(baseOffset: 5, extentOffset: 9),
+      );
+
+      await pressChord(tester, LogicalKeyboardKey.keyV);
+
+      expect(composer.controller!.text, 'keep take keep');
+      expect(
+        composer.controller!.selection,
+        const TextSelection.collapsed(offset: 9),
+      );
+    });
+
+    testChord('copy leaves the composer unfocused and empty', (tester) async {
+      mockClipboardText('from the clipboard');
+      final composer = await pumpRoom(tester);
+
+      await pressChord(tester, LogicalKeyboardKey.keyC);
+
+      expect(composer.focusNode!.hasFocus, isFalse);
+      expect(composer.controller!.text, isEmpty);
+    });
+
+    testChord('a dialog above the room keeps the chord', (tester) async {
+      // Whatever the dialog puts in front of the user owns the keyboard. Text
+      // routed into the draft behind it would land where the caret is not, and
+      // the dialog's own field would come up empty.
+      mockClipboardText('from the clipboard');
+      final composer = await pumpRoom(tester);
+      unawaited(showDialog<void>(
+        context: tester.element(find.byType(RoomScreen)),
+        builder: (_) => const AlertDialog(content: Text('above the room')),
+      ));
+      await tester.pumpAndSettle();
+
+      final claimed = await pressChord(tester, LogicalKeyboardKey.keyV);
+
+      expect(claimed, isFalse);
+      expect(composer.controller!.text, isEmpty);
+      expect(composer.focusNode!.hasFocus, isFalse);
+    });
+
+    testChord(
+        'a thread still loading its messages takes neither the text '
+        'nor the chord', (tester) async {
+      mockClipboardText('from the clipboard');
+      final blockingApi = _BlockingThreadsApi();
+      blockingApi.nextThreads = [
+        ThreadInfo(
+          id: 'thread-1',
+          roomId: 'room-1',
+          name: 'Test thread',
+          createdAt: DateTime(2026, 3, 1),
+        ),
+      ];
+      await tester.pumpWidget(MaterialApp(
+        home: RoomScreen(
+          serverEntry: createTestServerEntry(api: blockingApi),
+          roomId: 'room-1',
+          threadId: 'thread-1',
+          runtimeManager: runtimeManager,
+          registry: registry,
+          uploadRegistry: uploadRegistry,
+          documentSelections: DocumentSelections(),
+        ),
+      ));
+      await tester.pump();
+      final composer = tester.widget<TextField>(find.byType(TextField));
+      expect(composer.readOnly, isTrue);
+
+      final claimed =
+          await pressChord(tester, LogicalKeyboardKey.keyV, settle: false);
+
+      expect(composer.controller!.text, isEmpty);
+      expect(composer.focusNode!.hasFocus, isFalse);
+      expect(claimed, isFalse);
+
+      blockingApi.completeThreads(blockingApi.nextThreads!);
+    });
+
+    testChord('a run in flight takes neither the text nor the chord',
+        (tester) async {
+      mockClipboardText('from the clipboard');
+      api.nextThreads = const [];
+      final key =
+          (serverId: entry.serverId, roomId: 'room-1', threadId: 'thread-1');
+      final session = ManualAgentSession(key);
+      registry.register(key, session);
+      final composer = await pumpRoom(tester, settle: false);
+
+      // A RunningState loads the messages and marks the run live in one step,
+      // so the composer is enabled and the run alone holds it read-only —
+      // otherwise this could not tell the two halves of the guard apart.
+      session.emit(RunningState(
+        threadKey: key,
+        runId: 'run-1',
+        conversation: Conversation(threadId: 'thread-1', messages: const []),
+        streaming: const AwaitingText(),
+      ));
+      await tester.pump();
+      expect(tester.widget<TextField>(find.byType(TextField)).readOnly, isTrue);
+
+      final claimed =
+          await pressChord(tester, LogicalKeyboardKey.keyV, settle: false);
+
+      expect(composer.controller!.text, isEmpty);
+      expect(composer.focusNode!.hasFocus, isFalse);
+      expect(claimed, isFalse);
+    });
+
+    testChord('an image-only clipboard moves focus and inserts nothing',
+        (tester) async {
+      mockClipboard(() => null);
+      final composer = await pumpRoom(tester);
+      composer.controller!.text = 'draft';
+
+      await pressChord(tester, LogicalKeyboardKey.keyV);
+
+      expect(composer.focusNode!.hasFocus, isTrue);
+      expect(composer.controller!.text, 'draft');
+    });
+
+    testChord('an empty clipboard leaves a selected draft in place',
+        (tester) async {
+      // Pasting nothing over a selection would delete it. The clipboard is the
+      // one place that text could have come from, so there is nothing to
+      // replace it with and the selection stands.
+      mockClipboardText('');
+      final composer = await pumpRoom(tester);
+      composer.controller!.value = const TextEditingValue(
+        text: 'keep drop keep',
+        selection: TextSelection(baseOffset: 5, extentOffset: 9),
+      );
+
+      await pressChord(tester, LogicalKeyboardKey.keyV);
+
+      expect(composer.controller!.text, 'keep drop keep');
+    });
+
+    testChord('a refused clipboard read leaves the draft alone',
+        (tester) async {
+      // A browser withholding `readText` is a steady state the user meets on
+      // every keypress, so it is reported below the error level, and carries the
+      // code that separates it from a genuinely broken clipboard channel.
+      final sink = _RecordingSink('soliplex_frontend.room_screen');
+      LogManager.instance.addSink(sink);
+      addTearDown(() => LogManager.instance.removeSink(sink));
+      mockClipboard(
+        () => throw PlatformException(code: 'paste_fail'),
+      );
+      final composer = await pumpRoom(tester);
+      composer.controller!.text = 'draft';
+
+      await pressChord(tester, LogicalKeyboardKey.keyV);
+
+      expect(composer.controller!.text, 'draft');
+      final refusal = sink.records.singleWhere(
+        (r) => r.message.contains('refused a clipboard read'),
+      );
+      expect(refusal.level, LogLevel.warning);
+      expect(refusal.attributes['code'], 'paste_fail');
+    });
+
+    testChord('a thread switch during the read drops the paste',
+        (tester) async {
+      final read = Completer<Map<String, Object?>>();
+      mockClipboard(() => read.future);
+      final composer = await pumpRoom(tester);
+
+      await sendChord(tester, LogicalKeyboardKey.keyV);
+      await tester.pump();
+
+      // The clipboard answers only after the user has moved on. The draft the
+      // chord measured is gone, so its text must not land in the new one.
+      await tester.pumpWidget(MaterialApp(
+        home: RoomScreen(
+          serverEntry: entry,
+          roomId: 'room-1',
+          threadId: 'thread-2',
+          runtimeManager: runtimeManager,
+          registry: registry,
+          uploadRegistry: uploadRegistry,
+          documentSelections: DocumentSelections(),
+        ),
+      ));
+      await tester.pumpAndSettle();
+      read.complete(<String, Object?>{'text': 'from the clipboard'});
+      await tester.pumpAndSettle();
+
+      expect(composer.controller!.text, isEmpty);
+    });
+
+    testChord('a dialog opened during the read drops the paste',
+        (tester) async {
+      // The chord was legal when it was pressed; by the time the clipboard
+      // answers, a dialog owns the keyboard and its field is where the user is
+      // typing. The draft behind it must not collect the text.
+      final read = Completer<Map<String, Object?>>();
+      mockClipboard(() => read.future);
+      final composer = await pumpRoom(tester);
+
+      await sendChord(tester, LogicalKeyboardKey.keyV);
+      await tester.pump();
+      unawaited(showDialog<void>(
+        context: tester.element(find.byType(RoomScreen)),
+        builder: (_) => const AlertDialog(content: Text('above the room')),
+      ));
+      await tester.pumpAndSettle();
+      read.complete(<String, Object?>{'text': 'from the clipboard'});
+      await tester.pumpAndSettle();
+
+      expect(composer.controller!.text, isEmpty);
+    });
+
+    testChord('leaving the room during the read throws nothing',
+        (tester) async {
+      // The composer's controller is disposed with the screen, and reading the
+      // clipboard can outlast a consent prompt, so the paste has to notice the
+      // screen is gone rather than write into a disposed controller.
+      final read = Completer<Map<String, Object?>>();
+      var reads = 0;
+      mockClipboard(() {
+        reads++;
+        return read.future;
+      });
+      await pumpRoom(tester);
+
+      await sendChord(tester, LogicalKeyboardKey.keyV);
+      await tester.pump();
+
+      await tester.pumpWidget(const MaterialApp(home: SizedBox()));
+      await tester.pumpAndSettle();
+      read.complete(<String, Object?>{'text': 'from the clipboard'});
+      await tester.pumpAndSettle();
+
+      // Without the read there is nothing to survive, so name it rather than
+      // let the test pass for having done nothing.
+      expect(reads, 1);
+      expect(tester.takeException(), isNull);
+    });
+
+    testChord('a focused composer pastes once, through the platform',
+        (tester) async {
+      // The screen abstains once the composer has focus, and that abstention is
+      // load-bearing: claiming the chord does not stop the focused field's own
+      // paste, so answering it here too would insert the clipboard twice.
+      mockClipboardText('from the clipboard');
+      final composer = await pumpRoom(tester);
+      composer.focusNode!.requestFocus();
+      await tester.pumpAndSettle();
+
+      await pressChord(tester, LogicalKeyboardKey.keyV);
+
+      expect(composer.controller!.text, 'from the clipboard');
+    });
+
+    testChord('a second chord during the read pastes once, not twice',
+        (tester) async {
+      // The first chord moves focus and leaves a read in flight, so the second
+      // reaches the focused field and pastes through the platform. The read
+      // still owed an answer must not insert the same clipboard again.
+      final read = Completer<Map<String, Object?>>();
+      mockClipboard(() => read.future);
+      final composer = await pumpRoom(tester);
+
+      await sendChord(tester, LogicalKeyboardKey.keyV);
+      await tester.pump();
+      expect(composer.focusNode!.hasFocus, isTrue);
+
+      await sendChord(tester, LogicalKeyboardKey.keyV);
+      await tester.pump();
+      read.complete(<String, Object?>{'text': 'from the clipboard'});
+      await tester.pumpAndSettle();
+
+      expect(composer.controller!.text, 'from the clipboard');
+    });
+
+    testChord('the open drawer keeps the chord and the clipboard out',
+        (tester) async {
+      // The drawer covers the composer without pushing a route, so the room
+      // still reads as the current one. Text routed into the composer now would
+      // land where the user cannot see it.
+      mockClipboardText('from the clipboard');
+      final composer =
+          await pumpRoom(tester, surfaceSize: const Size(400, 800));
+      tester.state<ScaffoldState>(find.byType(Scaffold)).openDrawer();
+      await tester.pumpAndSettle();
+
+      final claimed = await pressChord(tester, LogicalKeyboardKey.keyV);
+
+      expect(composer.controller!.text, isEmpty);
+      expect(composer.focusNode!.hasFocus, isFalse);
+      expect(claimed, isFalse);
+    });
+
+    testChord('a drawer opened during the read drops the paste',
+        (tester) async {
+      // Same obstacle arriving mid-read as the dialog case: by the time the
+      // clipboard answers, the composer is behind the scrim.
+      final read = Completer<Map<String, Object?>>();
+      mockClipboard(() => read.future);
+      final composer =
+          await pumpRoom(tester, surfaceSize: const Size(400, 800));
+
+      await sendChord(tester, LogicalKeyboardKey.keyV);
+      await tester.pump();
+
+      tester.state<ScaffoldState>(find.byType(Scaffold)).openDrawer();
+      await tester.pumpAndSettle();
+      read.complete(<String, Object?>{'text': 'from the clipboard'});
+      await tester.pumpAndSettle();
+
+      expect(composer.controller!.text, isEmpty);
+    });
+
+    testChord('widening away from an open drawer keeps the chord working',
+        (tester) async {
+      // The drawer only exists in the narrow layout, and its removal reports no
+      // close. A guard that took the Scaffold's word for it would stay shut here
+      // for the life of the screen.
+      mockClipboardText('from the clipboard');
+      final composer =
+          await pumpRoom(tester, surfaceSize: const Size(400, 800));
+      tester.state<ScaffoldState>(find.byType(Scaffold)).openDrawer();
+      await tester.pumpAndSettle();
+      await tester.binding.setSurfaceSize(const Size(1200, 800));
+      await tester.pumpAndSettle();
+
+      await pressChord(tester, LogicalKeyboardKey.keyV);
+
+      expect(composer.controller!.text, 'from the clipboard');
+    });
+
+    testChord('the open drawer keeps plain typing out of the composer too',
+        (tester) async {
+      // Type-to-focus shares the guard the chord uses, so a composer behind the
+      // scrim must not take focus from an ordinary keystroke either.
+      final composer =
+          await pumpRoom(tester, surfaceSize: const Size(400, 800));
+      tester.state<ScaffoldState>(find.byType(Scaffold)).openDrawer();
+      await tester.pumpAndSettle();
+
+      await tester.sendKeyDownEvent(LogicalKeyboardKey.keyA);
+      await tester.pumpAndSettle();
+
+      expect(composer.focusNode!.hasFocus, isFalse);
+    });
+
+    testChord('a drawer dragged shut lets the chord through again',
+        (tester) async {
+      // A drag that carries the drawer the whole way closed settles it without
+      // running the close animation, so neither the drawer's own state nor the
+      // route it borrows announces the close. Only whether the drawer is on
+      // screen answers for this one.
+      mockClipboardText('from the clipboard');
+      final composer =
+          await pumpRoom(tester, surfaceSize: const Size(400, 800));
+      tester.state<ScaffoldState>(find.byType(Scaffold)).openDrawer();
+      await tester.pumpAndSettle();
+
+      // Slowly, and ending at rest: a flick would settle it by animation
+      // instead, which is the path that does announce itself.
+      final gesture = await tester.startGesture(const Offset(150, 400));
+      for (var i = 0; i < 14; i++) {
+        await gesture.moveBy(const Offset(-30, 0));
+        await tester.pump(const Duration(milliseconds: 16));
+      }
+      await gesture.up();
+      await tester.pumpAndSettle();
+      expect(find.byType(Drawer), findsNothing);
+
+      await pressChord(tester, LogicalKeyboardKey.keyV);
+
+      expect(composer.controller!.text, 'from the clipboard');
+    }, platform: TargetPlatform.iOS);
+
+    testChord('a room with no thread yet takes the paste for its first message',
+        (tester) async {
+      // Opening a room and pasting straight into the welcome composer, before
+      // any thread exists. The composer is enabled by the absence of a thread
+      // rather than by a loaded one, and reads its session state from the room.
+      mockClipboardText('from the clipboard');
+      api.nextThreads = const [];
+      await tester.pumpWidget(MaterialApp(
+        home: RoomScreen(
+          serverEntry: entry,
+          roomId: 'room-1',
+          threadId: null,
+          runtimeManager: runtimeManager,
+          registry: registry,
+          uploadRegistry: uploadRegistry,
+          documentSelections: DocumentSelections(),
+        ),
+      ));
+      await tester.pumpAndSettle();
+      final composer = tester.widget<TextField>(find.byType(TextField));
+      expect(composer.focusNode!.hasFocus, isFalse);
+
+      await pressChord(tester, LogicalKeyboardKey.keyV);
+
+      expect(composer.focusNode!.hasFocus, isTrue);
+      expect(composer.controller!.text, 'from the clipboard');
+    });
+
+    testChord('a room switch during the read drops the paste, threads or not',
+        (tester) async {
+      // Neither room has a thread, so the draft changes owner by the room alone.
+      // Comparing the active thread would see null on both sides and let the
+      // text land in a room the user never pasted into.
+      final read = Completer<Map<String, Object?>>();
+      mockClipboard(() => read.future);
+      api.nextThreads = const [];
+      Widget room(String id) => MaterialApp(
+            home: RoomScreen(
+              serverEntry: entry,
+              roomId: id,
+              threadId: null,
+              runtimeManager: runtimeManager,
+              registry: registry,
+              uploadRegistry: uploadRegistry,
+              documentSelections: DocumentSelections(),
+            ),
+          );
+      await tester.pumpWidget(room('room-1'));
+      await tester.pumpAndSettle();
+
+      await sendChord(tester, LogicalKeyboardKey.keyV);
+      await tester.pump();
+
+      await tester.pumpWidget(room('room-2'));
+      await tester.pumpAndSettle();
+      read.complete(<String, Object?>{'text': 'from the clipboard'});
+      await tester.pumpAndSettle();
+
+      expect(
+        tester.widget<TextField>(find.byType(TextField)).controller!.text,
+        isEmpty,
+      );
+    });
+
+    testChord('a repeat while the read is pending pastes once, not twice',
+        (tester) async {
+      // Holding the chord repeats, and Flutter's binding for a focused field
+      // answers repeats with a paste of its own. The read the first press
+      // started must stand down rather than insert on top of it.
+      final firstRead = Completer<Map<String, Object?>>();
+      var reads = 0;
+      mockClipboard(
+        () => reads++ == 0 ? firstRead.future : <String, Object?>{'text': 'X'},
+      );
+      final composer = await pumpRoom(tester);
+
+      await tester.sendKeyDownEvent(LogicalKeyboardKey.metaLeft);
+      await tester.sendKeyDownEvent(LogicalKeyboardKey.keyV);
+      await tester.pump();
+      await tester.sendKeyRepeatEvent(LogicalKeyboardKey.keyV);
+      await tester.pumpAndSettle();
+      await tester.sendKeyUpEvent(LogicalKeyboardKey.keyV);
+      await tester.sendKeyUpEvent(LogicalKeyboardKey.metaLeft);
+      expect(composer.controller!.text, 'X',
+          reason: 'the repeat pastes through the platform');
+
+      firstRead.complete(<String, Object?>{'text': 'X'});
+      await tester.pumpAndSettle();
+
+      expect(composer.controller!.text, 'X');
+    });
+  });
+}
+
+class _RecordingSink implements LogSink {
+  _RecordingSink(this.loggerName);
+
+  final String loggerName;
+  final List<LogRecord> records = [];
+
+  @override
+  void write(LogRecord record) {
+    if (record.loggerName == loggerName) records.add(record);
+  }
+
+  @override
+  Future<void> flush() async {}
+
+  @override
+  Future<void> close() async {}
 }


### PR DESCRIPTION
## What

Cmd/Ctrl+V with the room composer unfocused did nothing. The room screen refuses
shortcut modifiers so transcript copy and select-all keep their `SelectionArea`
selection, which left paste with no editable target to reach. One keypress now
focuses the composer and performs the paste itself.

## Behaviour

**Claimed:** the running platform's chord only — meta on Apple, control
elsewhere, neither with alt. Cmd+Ctrl+V, Ctrl+Alt+V (Windows AltGr), a bare V,
key-ups, and repeats are all left alone, so every other chord keeps its platform
meaning and the transcript keeps copy and select-all.

**Where the text lands:** over the composer's selection when it has one,
otherwise at the caret; appended when the selection was never placed. An
image-only or empty clipboard still moves focus and inserts nothing.

**Refused outright** (chord not claimed, so whatever else would answer it still
can): composer already focused, drawer open, dialog or pushed route above the
room, thread still loading its messages, run in flight.

**Dropped after a slow read**, because the clipboard read is async and a platform
may gate it behind a consent prompt: a later chord took over, a route or drawer
arrived, the room or thread switched (which clears the draft), or a run took the
composer. Each is logged with the obstacle it hit; the last is the only one that
costs the user text they asked for, so it alone is logged above `info`.

**Exactly once:** a second press while the first read is outstanding inserts one
copy, not two. Holding the chord repeats through the platform's own paste, as in
any focused field, without this adding a copy of its own.

## Why not the obvious approaches

A reviewer will reasonably reach for these first; each was tried or measured and
does not work:

- **Track the drawer with `Scaffold.onDrawerChanged`** — `_drawerOpenedCallback`
  is gated on `_drawerKey.currentState != null`, so a viewport crossing
  `SoliplexBreakpoints.tablet` with the drawer open never reports the close and
  the flag strands on, killing type-to-focus for the life of the screen.
- **`ScaffoldState.isDrawerOpen`** — written by that same gated callback, and the
  `ScaffoldState` survives the resize (measured: same instance), so it goes stale
  identically.
- **`ModalRoute.willHandlePopInternally`** — a drag that closes the drawer settles
  on `dismissed`; `_settle` returns early without `close()`, and only `close()`
  flings to `reverse`, which is the sole path that drops the history entry.
- **A `GlobalKey` on the narrow `Scaffold`** — correct only because a key on one
  sibling forces an unmount, which tears down the transcript subtree on every
  breakpoint crossing.

What works is asking whether the drawer's own subtree is mounted: `Scaffold`
builds it only while the drawer is showing, so the answer holds however the
drawer went away.

Likewise, reporting the chord handled answers the *platform*, not Flutter — in-app
dispatch runs either way. A single press does not double-paste because
`requestFocus()` applies a microtask later than that keystroke's shortcut
dispatch, so the composer is not yet the field paste would reach.

## Verification

- `flutter analyze` clean, `dart format` clean, markdownlint clean
- `flutter test --exclude-tags golden`: **2254 pass** (2245 before)
- Mutation-tested: 42 single-edit mutations of the feature's decisions, **39
  killed**. 18 are caught by exactly one test each. The 3 survivors all sit in one
  corner — a run starting or in flight while a clipboard read is outstanding —
  which the harness cannot reach without mutating a shared fake's contract.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
