### PR TITLE
feat: carry ordered image parts on a user message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,19 @@ Versions follow the `version+build` scheme from `pubspec.yaml`, bumped via
 
 ## [Unreleased]
 
+### Added
+
+- **Library consumers:** `soliplex_client` exports a `MessagePart` type —
+  `TextPart` for a run of text, `ImagePart` for image bytes with their MIME
+  type — and an optional `parts` list on `TextMessage`. A user message carrying
+  parts is sent as AG-UI multimodal content with each image inlined as base64,
+  so text and images reach the model interleaved in the order given. A message
+  without parts is unchanged on the wire. The multimodal form is used only when
+  a part is not text: a list holding nothing but text, or nothing at all, falls
+  back to the plain string, because an empty content array makes the backend
+  discard the message's turn without reporting an error. Nothing in the app
+  populates `parts` yet, so no screen behaves differently.
+
 ### Fixed
 
 - Pressing the platform's paste chord in a room — Cmd+V on macOS and iOS, Ctrl+V

--- a/packages/soliplex_client/lib/src/api/agui_message_mapper.dart
+++ b/packages/soliplex_client/lib/src/api/agui_message_mapper.dart
@@ -49,11 +49,57 @@ List<Message> convertToAgui(List<ChatMessage> chatMessages) {
 Message _convertTextMessage(TextMessage message) {
   switch (message.user) {
     case ChatUser.user:
-      return UserMessage(id: message.id, content: message.text);
+      final multimodalParts = _multimodalParts(message.parts);
+      if (multimodalParts == null) {
+        return UserMessage(id: message.id, content: message.text);
+      }
+      return UserMessage.multimodal(id: message.id, parts: multimodalParts);
     case ChatUser.assistant:
       return AssistantMessage(id: message.id, content: message.text);
     case ChatUser.system:
       return SystemMessage(id: message.id, content: message.text);
+  }
+}
+
+/// Content parts for a multimodal `UserMessage`, or null when [parts] has
+/// nothing the bare-string form cannot carry.
+///
+/// The multimodal arm of `content` is only worth using when a part isn't text;
+/// a text-only list buys nothing the bare string does not already give us. An
+/// *empty* array is worse than useless: `pydantic_ai`'s AG-UI adapter builds
+/// the user's prompt only when the decoded content is non-empty, so an empty
+/// array discards the turn with no error anywhere. Empty text runs are dropped
+/// for the same reason in miniature — the OpenAI paths forward them verbatim
+/// as empty text blocks instead of skipping them.
+List<InputContent>? _multimodalParts(List<MessagePart>? parts) {
+  if (parts == null) return null;
+
+  final content = <InputContent>[];
+  var hasNonTextPart = false;
+  for (final part in parts) {
+    switch (part) {
+      case TextPart(:final text):
+        if (text.isEmpty) continue;
+      case ImagePart():
+        hasNonTextPart = true;
+    }
+    content.add(_convertMessagePart(part));
+  }
+
+  return hasNonTextPart ? content : null;
+}
+
+InputContent _convertMessagePart(MessagePart part) {
+  switch (part) {
+    case TextPart():
+      return TextInputContent(part.text);
+    case ImagePart():
+      return ImageInputContent(
+        source: DataSource(
+          value: base64Encode(part.bytes),
+          mimeType: part.mimeType,
+        ),
+      );
   }
 }
 

--- a/packages/soliplex_client/lib/src/domain/chat_message.dart
+++ b/packages/soliplex_client/lib/src/domain/chat_message.dart
@@ -1,4 +1,40 @@
+import 'dart:typed_data';
+
 import 'package:meta/meta.dart';
+
+/// One element of a user message's ordered content.
+///
+/// Carried by [TextMessage.parts] when a message interleaves text with
+/// images. One list serves both the optimistic echo and the AG-UI wire
+/// mapping, so what the sender sees and what the model receives cannot drift.
+@immutable
+sealed class MessagePart {
+  /// Creates a message part.
+  const MessagePart();
+}
+
+/// A run of text within a message's ordered content.
+@immutable
+final class TextPart extends MessagePart {
+  /// Creates a text part carrying [text].
+  const TextPart(this.text);
+
+  /// The text payload.
+  final String text;
+}
+
+/// An image within a message's ordered content.
+@immutable
+final class ImagePart extends MessagePart {
+  /// Creates an image part from raw [bytes] of type [mimeType].
+  const ImagePart({required this.bytes, required this.mimeType});
+
+  /// The encoded image file bytes — not decoded pixels.
+  final Uint8List bytes;
+
+  /// The MIME type of [bytes], e.g. `image/png`.
+  final String mimeType;
+}
 
 /// User type for messages.
 enum ChatUser {
@@ -77,6 +113,7 @@ class TextMessage extends ChatMessage {
     required this.text,
     this.isStreaming = false,
     this.thinkingText = '',
+    this.parts,
   });
 
   /// Creates a text message with the given ID. [createdAt] is the
@@ -89,6 +126,7 @@ class TextMessage extends ChatMessage {
     DateTime? createdAt,
     bool isStreaming = false,
     String thinkingText = '',
+    List<MessagePart>? parts,
   }) {
     return TextMessage(
       id: id,
@@ -97,11 +135,22 @@ class TextMessage extends ChatMessage {
       isStreaming: isStreaming,
       thinkingText: thinkingText,
       createdAt: createdAt,
+      parts: parts,
     );
   }
 
   /// The message text content.
   final String text;
+
+  /// Ordered content parts, set only when a user message interleaves text
+  /// with images. Null for a plain-text message, which travels the wire as a
+  /// bare string; only honoured for user messages, ignored elsewhere.
+  ///
+  /// When set, [text] must hold the flattened text of these parts. The mapper
+  /// falls back to [text] for any parts list it cannot send as multimodal, and
+  /// the timeline and copy button read [text] directly, so a [text] that
+  /// disagrees silently changes what the user copies or the model receives.
+  final List<MessagePart>? parts;
 
   /// Whether this message is currently streaming.
   final bool isStreaming;
@@ -120,6 +169,7 @@ class TextMessage extends ChatMessage {
     String? text,
     bool? isStreaming,
     String? thinkingText,
+    List<MessagePart>? parts,
   }) {
     return TextMessage(
       id: id ?? this.id,
@@ -128,6 +178,7 @@ class TextMessage extends ChatMessage {
       text: text ?? this.text,
       isStreaming: isStreaming ?? this.isStreaming,
       thinkingText: thinkingText ?? this.thinkingText,
+      parts: parts ?? this.parts,
     );
   }
 

--- a/packages/soliplex_client/test/api/agui_message_mapper_test.dart
+++ b/packages/soliplex_client/test/api/agui_message_mapper_test.dart
@@ -1,3 +1,6 @@
+import 'dart:convert';
+import 'dart:typed_data';
+
 import 'package:ag_ui/ag_ui.dart';
 import 'package:soliplex_client/src/api/agui_message_mapper.dart';
 import 'package:soliplex_client/src/domain/chat_message.dart';
@@ -23,6 +26,9 @@ void main() {
         final userMsg = aguiMessages[0] as UserMessage;
         expect(userMsg.id, equals('msg-1'));
         expect(userMsg.content, equals('Hello, assistant!'));
+        // A message without parts serializes `content` as a bare string, not
+        // a one-element array.
+        expect(userMsg.toJson()['content'], equals('Hello, assistant!'));
       });
 
       test('converts assistant TextMessage to AssistantMessage', () {
@@ -61,6 +67,118 @@ void main() {
         final systemMsg = aguiMessages[0] as SystemMessage;
         expect(systemMsg.id, equals('msg-3'));
         expect(systemMsg.content, equals('System notification'));
+      });
+    });
+
+    group('message parts', () {
+      // Every part maps to its AG-UI `InputContent` with an inline `data`
+      // source and camelCase keys. Two images of different types pin the
+      // per-part mime; the leading space in ' then tell me' pins that text
+      // runs reach the wire untrimmed.
+      test('serializes parts as an ordered multimodal content array', () {
+        final png = Uint8List.fromList([0x89, 0x50, 0x4e, 0x47]);
+        final jpeg = Uint8List.fromList([0xff, 0xd8, 0xff, 0xe0]);
+
+        final aguiMessages = convertToAgui([
+          TextMessage(
+            id: 'msg-parts',
+            user: ChatUser.user,
+            text: 'look at these then tell me',
+            createdAt: DateTime.now(),
+            parts: [
+              const TextPart('look at these'),
+              ImagePart(bytes: png, mimeType: 'image/png'),
+              ImagePart(bytes: jpeg, mimeType: 'image/jpeg'),
+              const TextPart(' then tell me'),
+            ],
+          ),
+        ]);
+
+        expect(aguiMessages, hasLength(1));
+        final userMsg = aguiMessages[0] as UserMessage;
+        expect(
+          userMsg.toJson()['content'],
+          equals([
+            {'type': 'text', 'text': 'look at these'},
+            {
+              'type': 'image',
+              'source': {
+                'type': 'data',
+                'value': base64Encode(png),
+                'mimeType': 'image/png',
+              },
+            },
+            {
+              'type': 'image',
+              'source': {
+                'type': 'data',
+                'value': base64Encode(jpeg),
+                'mimeType': 'image/jpeg',
+              },
+            },
+            {'type': 'text', 'text': ' then tell me'},
+          ]),
+        );
+      });
+
+      // An empty text block would be forwarded to the model verbatim rather
+      // than skipped, so empty runs must never reach the wire.
+      test('omits empty text runs from multimodal content', () {
+        final bytes = Uint8List.fromList([0x89, 0x50]);
+
+        final aguiMessages = convertToAgui([
+          TextMessage(
+            id: 'msg-empty-runs',
+            user: ChatUser.user,
+            text: 'look',
+            createdAt: DateTime.now(),
+            parts: [
+              const TextPart(''),
+              ImagePart(bytes: bytes, mimeType: 'image/png'),
+              const TextPart('look'),
+              const TextPart(''),
+            ],
+          ),
+        ]);
+
+        final content = (aguiMessages[0] as UserMessage).toJson()['content']
+            as List<Map<String, dynamic>>;
+        expect(content, hasLength(2));
+        expect(content[0]['type'], equals('image'));
+        expect(content[1], equals({'type': 'text', 'text': 'look'}));
+      });
+
+      // An image-less message keeps exactly the wire shape it has today.
+      test('falls back to plain text when parts carry no image', () {
+        final aguiMessages = convertToAgui([
+          TextMessage(
+            id: 'msg-text-only',
+            user: ChatUser.user,
+            text: 'no images here',
+            createdAt: DateTime.now(),
+            parts: const [TextPart('no images here')],
+          ),
+        ]);
+
+        final userMsg = aguiMessages[0] as UserMessage;
+        expect(userMsg.toJson()['content'], equals('no images here'));
+      });
+
+      // An empty array makes the backend discard the user's turn entirely,
+      // with no error anywhere — the one degenerate case that loses data.
+      test('never serializes an empty content array', () {
+        final aguiMessages = convertToAgui([
+          TextMessage(
+            id: 'msg-no-parts',
+            user: ChatUser.user,
+            text: 'still says something',
+            createdAt: DateTime.now(),
+            parts: const [],
+          ),
+        ]);
+
+        final userMsg = aguiMessages[0] as UserMessage;
+        expect(userMsg.toJson()['content'], equals('still says something'));
       });
     });
 


### PR DESCRIPTION
PR 1 of 5 for inline image attachments. Purely additive to `soliplex_client`: it
adds the domain type and the wire mapping, and nothing else. **Nothing constructs
`parts` yet, so no screen behaves differently and no wire byte changes for any
message sent today.**

## What's here

- **Domain model** (`chat_message.dart`) — a sealed `MessagePart`
  (`TextPart(String text)` | `ImagePart({bytes, mimeType})`) and an optional
  `List<MessagePart>? parts` on `TextMessage`, threaded through `create` and
  `copyWith`. Exported transitively via the existing `domain.dart` barrel.
- **Wire mapping** (`agui_message_mapper.dart`) — a parts-bearing user message
  maps to `UserMessage.multimodal`, each `ImagePart` serialized as a base64
  `DataSource`. No hand-rolled serialization; `ag_ui`'s `toJson` emits the array.

One model feeds both the optimistic echo and the mapper, so a later PR can render
an image before the server responds.

## Why the multimodal arm is used only when a part isn't text

Three behaviours verified by reading the backend's locked dependency source
(`pydantic_ai` 2.21.0, `ag_ui` protocol 0.1.18) rather than inferred:

| Wire `content` | What the backend does |
| --- | --- |
| `"hi"` | `UserPromptPart(content='hi')`, added unconditionally |
| `[{"type":"text","text":"hi"}]` | **Identical** — a single-element string list collapses back to the string |
| `[]` | **The user's turn is silently discarded** — the prompt is built only when the decoded content is non-empty |
| `{"type":"text","text":""}` | Forwarded to the model verbatim; the OpenAI paths don't skip empty text blocks (Anthropic's does) |

So a text-only list buys nothing the bare string doesn't already give us, and an
empty array is actively destructive — there is no error, no log, and the model
answers the *previous* turn. The mapper therefore emits multimodal only when a
non-text part survives, drops empty text runs, and lets every degenerate list
fall through to the existing plain-string path.

The empty-array guard is the only thing standing between a producer bug and that
silent loss: `ag_ui`'s own `Validators.validateUserMessageContent` does reject an
empty `MultimodalContent`, but it's only called from `AGUIClient`, which this repo
doesn't use — we build the request ourselves.

## Tests

Four new tests in `agui_message_mapper_test.dart`, each pinning one rule:
ordered interleaved serialization with two images of *different* MIME types,
empty text runs omitted, image-less parts falling back to a bare string, and an
empty array never reaching the wire. The bare-string regression assertion was
folded into the pre-existing plain-text test rather than duplicated.

The two-MIME case is load-bearing and was verified by mutation: hardcoding
`mimeType: 'image/png'` in the mapper passes the suite *without* it and fails
*with* it. A mislabelled image is unreadable to the model while the turn still
succeeds — a silent failure worth a test.

## Explicitly not in this PR

No send-path threading, composer, picker, bubble rendering, or history
hydration — and **no validation of any kind**: no MIME allow-list, no size cap,
no downscaling. Those are PRs 2–4, which means `parts` should not be populated
until PR 4's validation lands. AG-UI has no representation for multimodal
*assistant* content (the union field exists only on `UserMessage`), so `parts` is
honoured for user messages and ignored elsewhere.

## Verification

- `dart format --set-exit-if-changed` — 0 changed
- `dart analyze --fatal-infos lib test` — no issues
- `soliplex_client` suite as CI runs it (`--exclude-tags integration`) — **1621 pass**
- App suite — **2254 pass**, matching `main`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
