### PR TITLE
feat: carry an ordered part list along the send path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,8 +18,31 @@ Versions follow the `version+build` scheme from `pubspec.yaml`, bumped via
   without parts is unchanged on the wire. The multimodal form is used only when
   a part is not text: a list holding nothing but text, or nothing at all, falls
   back to the plain string, because an empty content array makes the backend
-  discard the message's turn without reporting an error. Nothing in the app
-  populates `parts` yet, so no screen behaves differently.
+  discard the message's turn without reporting an error. A message composed as
+  plain text carries a single text run, so no screen behaves differently.
+- **Library consumers:** `TextMessage.fromParts` builds a user message from an
+  ordered part list, deriving `text` from the parts so a caller of it cannot let
+  the two disagree, and a `plainText` getter on `List<MessagePart>` flattens a
+  part list to its text alone — runs concatenated in order, images dropped.
+  `fromParts` throws `ArgumentError` for a part list carrying neither an image
+  nor any text, because such a payload reaches the wire as empty content and
+  the backend discards the turn without reporting an error.
+
+### Changed
+
+- **Breaking (library consumers):** the send path carries an ordered
+  `List<MessagePart>` where it previously carried a `String`. This affects
+  `AgentRuntime.spawn` and `MultiServerRuntime.spawn` (`prompt`), and
+  `AgentSession.start` (`userMessage`). Wrap an existing call's text in a
+  single part to migrate: `prompt: 'Hello'` becomes
+  `prompt: [TextPart('Hello')]`. The text-only APIs for spawning a child agent
+  from a tool — `spawnChild`, `delegateTask` — and the `AgentApi` platform
+  callback are unchanged, since a prompt from those sources is always text.
+  Nothing about a sent message changes on the wire, and no screen behaves
+  differently: a message composed as plain text still travels as a bare string.
+  A draft held across an authentication round trip still restores its text.
+  Code reading a conversation does see one difference: the echo of a sent
+  message now always carries `parts`, where it previously carried none.
 
 ### Fixed
 

--- a/lib/src/modules/room/room_state.dart
+++ b/lib/src/modules/room/room_state.dart
@@ -295,7 +295,7 @@ class RoomState {
   /// Spawns a session which creates the thread server-side, then creates a
   /// [ThreadViewState] and attaches the session to it.
   Future<void> sendToNewThread(
-    String prompt, {
+    List<MessagePart> prompt, {
     Map<String, dynamic>? stateOverlay,
   }) =>
       _spawner.spawn(
@@ -307,11 +307,11 @@ class RoomState {
         errorSignal: _lastError,
         prompt: prompt,
         isDisposed: () => _isDisposed,
-        onAuthExpired: (text) => persistComposerDraft(
+        onAuthExpired: (parts) => persistComposerDraft(
           serverId: _connection.serverId,
           userId: _auth.currentUserId.value,
           roomId: _roomId,
-          prompt: text,
+          prompt: parts.plainText,
         ),
         onSpawned: (session) {
           // Clear room-level spawn state — the thread view takes over.

--- a/lib/src/modules/room/session_spawner.dart
+++ b/lib/src/modules/room/session_spawner.dart
@@ -61,11 +61,11 @@ class SessionSpawner {
   Future<void> spawn({
     required Future<AgentSession> Function() spawnFn,
     required Signal<SendError?> errorSignal,
-    required String prompt,
+    required List<MessagePart> prompt,
     required bool Function() isDisposed,
     required void Function(AgentSession) onSpawned,
     required void Function(AgentSessionState?) onStateTransition,
-    void Function(String prompt)? onAuthExpired,
+    void Function(List<MessagePart> prompt)? onAuthExpired,
   }) async {
     if (_pendingSpawn != null) return;
     _cancelled = false;
@@ -87,7 +87,7 @@ class SessionSpawner {
         name: 'SessionSpawner',
         level: 900,
       );
-      errorSignal.value = SendError(error, unsentText: prompt);
+      errorSignal.value = SendError(error, unsentText: prompt.plainText);
     } on AuthException catch (error) {
       if (_cancelled || isDisposed()) return;
       dev.log(
@@ -111,9 +111,18 @@ class SessionSpawner {
         );
       }
       _auth.markSessionExpired();
-    } on Object catch (error) {
+    } on Object catch (error, st) {
       if (_cancelled || isDisposed()) return;
-      errorSignal.value = SendError(error, unsentText: prompt);
+      // The banner shows only `error.toString()`, so an unanticipated failure
+      // leaves no other trace of where it came from.
+      dev.log(
+        'Spawn failed',
+        error: error,
+        stackTrace: st,
+        name: 'SessionSpawner',
+        level: 1000,
+      );
+      errorSignal.value = SendError(error, unsentText: prompt.plainText);
     } finally {
       _pendingSpawn = null;
       if (!_cancelled && !succeeded) {

--- a/lib/src/modules/room/thread_view_state.dart
+++ b/lib/src/modules/room/thread_view_state.dart
@@ -225,7 +225,7 @@ class ThreadViewState {
   Future<void> refresh() => _fetch();
 
   Future<void> sendMessage(
-    String prompt,
+    List<MessagePart> prompt,
     AgentRuntime runtime, {
     Map<String, dynamic>? stateOverlay,
   }) {
@@ -501,13 +501,15 @@ class ThreadViewState {
   /// away; non-auth errors leave the screen mounted and the in-memory
   /// [SendError.unsentText] + room-screen restore path handles
   /// restoration without touching storage.
-  void _persistComposer(String prompt) {
+  void _persistComposer(List<MessagePart> prompt) {
     if (_isDisposed) return;
     persistComposerDraft(
       serverId: _connection.serverId,
       userId: _auth.currentUserId.value,
       roomId: _roomId,
-      prompt: prompt,
+      // Storage holds a plain string, so a draft round-trips its text and
+      // drops any image.
+      prompt: prompt.plainText,
     );
   }
 }

--- a/lib/src/modules/room/ui/chat_input.dart
+++ b/lib/src/modules/room/ui/chat_input.dart
@@ -42,7 +42,7 @@ class ChatInput extends StatefulWidget {
     this.onAttachFolder,
   });
 
-  final void Function(String text) onSend;
+  final void Function(List<MessagePart> parts) onSend;
   final void Function() onCancel;
   final ReadonlySignal<AgentSessionState?>? sessionState;
 
@@ -135,7 +135,7 @@ class _ChatInputState extends State<ChatInput> {
         )) {
       return;
     }
-    widget.onSend(text);
+    widget.onSend([TextPart(text)]);
     _controller.clear();
     _focusNode.requestFocus();
   }

--- a/lib/src/modules/room/ui/room_screen.dart
+++ b/lib/src/modules/room/ui/room_screen.dart
@@ -21,6 +21,7 @@ import 'package:soliplex_client/soliplex_client.dart'
         Reconnected,
         Reconnecting,
         Room,
+        TextPart,
         ThreadHistory,
         buildDocumentFilter;
 import 'package:soliplex_logging/soliplex_logging.dart';
@@ -2272,7 +2273,7 @@ class _RoomScreenState extends State<RoomScreen> {
             onSuggestionTapped: sessionState != null
                 ? null
                 : (suggestion) => _state.sendToNewThread(
-                      suggestion,
+                      [TextPart(suggestion)],
                       stateOverlay: _buildStateOverlay(),
                     ),
             onQuizTapped: _onQuizTapped,
@@ -2343,7 +2344,7 @@ class _RoomScreenState extends State<RoomScreen> {
                           room: room,
                           onSuggestionTapped: (suggestion) =>
                               threadView.sendMessage(
-                            suggestion,
+                            [TextPart(suggestion)],
                             _state.runtime,
                             stateOverlay: _buildStateOverlay(),
                           ),
@@ -2427,15 +2428,15 @@ class _RoomScreenState extends State<RoomScreen> {
     }
 
     return ChatInput(
-      onSend: (text) {
+      onSend: (parts) {
         if (threadView != null) {
           threadView.sendMessage(
-            text,
+            parts,
             _state.runtime,
             stateOverlay: _buildStateOverlay(),
           );
         } else {
-          _state.sendToNewThread(text, stateOverlay: _buildStateOverlay());
+          _state.sendToNewThread(parts, stateOverlay: _buildStateOverlay());
         }
       },
       onCancel: threadView != null ? threadView.cancelRun : _state.cancelSpawn,

--- a/packages/soliplex_agent/README.md
+++ b/packages/soliplex_agent/README.md
@@ -77,7 +77,7 @@ Future<void> main() async {
   // 3. Spawn a session and await the result
   final session = await runtime.spawn(
     roomId: 'plain',
-    prompt: 'Hello!',
+    prompt: [const TextPart('Hello!')],
   );
 
   final result = await session.result;
@@ -102,7 +102,10 @@ before the new user message in the AG-UI payload.
 
 ```dart
 // Turn 1
-final s1 = await runtime.spawn(roomId: 'chat', prompt: 'Hi!');
+final s1 = await runtime.spawn(
+  roomId: 'chat',
+  prompt: [const TextPart('Hi!')],
+);
 final r1 = await s1.result;
 
 // Build history from the completed conversation
@@ -113,7 +116,7 @@ final history = ThreadHistory(
 // Turn 2 — carries forward turn 1 context
 final s2 = await runtime.spawn(
   roomId: 'chat',
-  prompt: 'What did I just say?',
+  prompt: [const TextPart('What did I just say?')],
   threadId: s1.threadKey.threadId,
   cachedHistory: history,
 );

--- a/packages/soliplex_agent/example/example.dart
+++ b/packages/soliplex_agent/example/example.dart
@@ -42,7 +42,7 @@ Future<void> main() async {
     // Spawn a session.
     final session = await runtime.spawn(
       roomId: 'plain',
-      prompt: 'Hello, what can you help me with?',
+      prompt: [const TextPart('Hello, what can you help me with?')],
       autoDispose: true,
     );
 

--- a/packages/soliplex_agent/example/wasm_concurrent.dart
+++ b/packages/soliplex_agent/example/wasm_concurrent.dart
@@ -46,17 +46,17 @@ Future<void> main() async {
     final sessions = await Future.wait([
       runtime.spawn(
         roomId: 'plain',
-        prompt: 'What is Dart?',
+        prompt: [const TextPart('What is Dart?')],
         autoDispose: true,
       ),
       runtime.spawn(
         roomId: 'plain',
-        prompt: 'What is WASM?',
+        prompt: [const TextPart('What is WASM?')],
         autoDispose: true,
       ),
       runtime.spawn(
         roomId: 'plain',
-        prompt: 'What is AG-UI?',
+        prompt: [const TextPart('What is AG-UI?')],
         autoDispose: true,
       ),
     ]);

--- a/packages/soliplex_agent/lib/src/host/runtime_agent_api.dart
+++ b/packages/soliplex_agent/lib/src/host/runtime_agent_api.dart
@@ -2,6 +2,7 @@ import 'package:soliplex_agent/src/host/agent_api.dart';
 import 'package:soliplex_agent/src/models/agent_result.dart';
 import 'package:soliplex_agent/src/runtime/agent_runtime.dart';
 import 'package:soliplex_agent/src/runtime/agent_session.dart';
+import 'package:soliplex_client/soliplex_client.dart' show TextPart;
 
 /// Production [AgentApi] backed by an [AgentRuntime].
 ///
@@ -26,7 +27,9 @@ class RuntimeAgentApi implements AgentApi {
   }) async {
     final session = await _runtime.spawn(
       roomId: roomId,
-      prompt: prompt,
+      // A platform callback's prompt is text: one run, rather than widening
+      // an API whose callers have no image to pass.
+      prompt: [TextPart(prompt)],
       threadId: threadId,
       timeout: timeout,
       autoDispose: true,

--- a/packages/soliplex_agent/lib/src/orchestration/run_orchestrator.dart
+++ b/packages/soliplex_agent/lib/src/orchestration/run_orchestrator.dart
@@ -29,7 +29,7 @@ typedef ToolExecutorCallback = Future<List<ToolCallInfo>> Function(
 /// ```dart
 /// final result = await orchestrator.runToCompletion(
 ///   key: key,
-///   userMessage: 'Hello',
+///   userMessage: [TextPart('Hello')],
 ///   toolExecutor: (pending) async {
 ///     return pending.map((tc) => tc.copyWith(
 ///       status: ToolCallStatus.completed,
@@ -54,7 +54,7 @@ typedef ToolExecutorCallback = Future<List<ToolCallInfo>> Function(
 /// // 3. Run to completion
 /// final result = await orchestrator.runToCompletion(
 ///   key: key,
-///   userMessage: 'Hello',
+///   userMessage: [TextPart('Hello')],
 ///   toolExecutor: myToolExecutor,
 ///   existingRunId: threadInfo.hasInitialRun ? threadInfo.initialRunId : null,
 /// );
@@ -175,7 +175,7 @@ class RunOrchestrator {
   /// While active, [startRun] and [submitToolOutputs] throw [StateError].
   Future<RunState> runToCompletion({
     required ThreadKey key,
-    required String userMessage,
+    required List<MessagePart> userMessage,
     required ToolExecutorCallback toolExecutor,
     String? existingRunId,
     ThreadHistory? cachedHistory,
@@ -219,7 +219,7 @@ class RunOrchestrator {
   /// [runToCompletion] is active.
   Future<void> startRun({
     required ThreadKey key,
-    required String userMessage,
+    required List<MessagePart> userMessage,
     String? existingRunId,
     ThreadHistory? cachedHistory,
   }) async {
@@ -439,7 +439,7 @@ class RunOrchestrator {
   /// Sets up the initial SSE subscription for [runToCompletion].
   Future<void> _initializeStream(
     ThreadKey key,
-    String userMessage,
+    List<MessagePart> userMessage,
     String? existingRunId,
     ThreadHistory? cachedHistory,
     Map<String, dynamic>? stateOverlay,
@@ -803,7 +803,7 @@ class RunOrchestrator {
 
   Conversation _buildConversation(
     ThreadKey key,
-    String userMessage,
+    List<MessagePart> userMessage,
     ThreadHistory? cachedHistory,
     Map<String, dynamic>? stateOverlay,
   ) {
@@ -814,10 +814,9 @@ class RunOrchestrator {
     // arrives, and fills from the run's server `created` on replay. The
     // frontend never displays a client-generated time. now() here is only for
     // a unique id.
-    final userMsg = TextMessage.create(
+    final userMsg = TextMessage.fromParts(
       id: 'user-${DateTime.now().microsecondsSinceEpoch}',
-      user: ChatUser.user,
-      text: userMessage,
+      parts: userMessage,
     );
     // Seeding with the run-scoped keys emptied is what makes a namespace's
     // non-empty `citations` in the run's terminal snapshot definitionally this

--- a/packages/soliplex_agent/lib/src/runtime/agent_runtime.dart
+++ b/packages/soliplex_agent/lib/src/runtime/agent_runtime.dart
@@ -15,7 +15,8 @@ import 'package:soliplex_agent/src/runtime/session_coordinator.dart';
 import 'package:soliplex_agent/src/runtime/session_extension.dart';
 import 'package:soliplex_agent/src/runtime/thread_state.dart';
 import 'package:soliplex_agent/src/tools/tool_registry_resolver.dart';
-import 'package:soliplex_client/soliplex_client.dart' show ThreadHistory;
+import 'package:soliplex_client/soliplex_client.dart'
+    show MessagePart, ThreadHistory;
 import 'package:soliplex_logging/soliplex_logging.dart';
 
 /// Facade for spawning and coordinating multiple [AgentSession]s.
@@ -34,7 +35,7 @@ import 'package:soliplex_logging/soliplex_logging.dart';
 ///
 /// final session = await runtime.spawn(
 ///   roomId: 'weather',
-///   prompt: 'Need umbrella?',
+///   prompt: [TextPart('Need umbrella?')],
 /// );
 /// final result = await session.result;
 /// ```
@@ -188,7 +189,7 @@ class AgentRuntime {
   /// all children.
   Future<AgentSession> spawn({
     required String roomId,
-    required String prompt,
+    required List<MessagePart> prompt,
     String? threadId,
     Duration? timeout,
     bool ephemeral = false,

--- a/packages/soliplex_agent/lib/src/runtime/agent_session.dart
+++ b/packages/soliplex_agent/lib/src/runtime/agent_session.dart
@@ -230,7 +230,9 @@ class AgentSession implements ToolExecutionContext {
     }
     return _runtime.spawn(
       roomId: roomId ?? threadKey.roomId,
-      prompt: prompt,
+      // A text-only signature: the prompt becomes one run rather than
+      // widening an API whose callers have no image to pass.
+      prompt: [TextPart(prompt)],
       threadId: threadId,
       timeout: timeout,
       ephemeral: ephemeral,
@@ -347,7 +349,7 @@ class AgentSession implements ToolExecutionContext {
   /// the run starts. The run is fire-and-forget — terminal states flow
   /// through [_onStateChange] into [_completeWith].
   Future<void> start({
-    required String userMessage,
+    required List<MessagePart> userMessage,
     String? existingRunId,
     ThreadHistory? cachedHistory,
     Map<String, dynamic>? stateOverlay,

--- a/packages/soliplex_agent/lib/src/runtime/multi_server_runtime.dart
+++ b/packages/soliplex_agent/lib/src/runtime/multi_server_runtime.dart
@@ -11,6 +11,7 @@ import 'package:soliplex_agent/src/runtime/server_connection.dart';
 import 'package:soliplex_agent/src/runtime/server_registry.dart';
 import 'package:soliplex_agent/src/runtime/session_extension.dart';
 import 'package:soliplex_agent/src/tools/tool_registry_resolver.dart';
+import 'package:soliplex_client/soliplex_client.dart' show MessagePart;
 import 'package:soliplex_logging/soliplex_logging.dart';
 
 /// Creates an [AgentLlmProvider] from a [ServerConnection].
@@ -84,7 +85,7 @@ class MultiServerRuntime {
   Future<AgentSession> spawn({
     required String serverId,
     required String roomId,
-    required String prompt,
+    required List<MessagePart> prompt,
     String? threadId,
     Duration? timeout,
     bool ephemeral = true,

--- a/packages/soliplex_agent/test/integration/verbose_agui_test.dart
+++ b/packages/soliplex_agent/test/integration/verbose_agui_test.dart
@@ -82,7 +82,7 @@ void main() {
 
       final session = await runtime.spawn(
         roomId: spec.roomId,
-        prompt: spec.prompt,
+        prompt: [TextPart(spec.prompt)],
       );
 
       stderr.writeln('threadId: ${session.threadKey.threadId}');

--- a/packages/soliplex_agent/test/orchestration/run_orchestrator_test.dart
+++ b/packages/soliplex_agent/test/orchestration/run_orchestrator_test.dart
@@ -5,6 +5,7 @@
 
 import 'dart:async';
 import 'dart:convert';
+import 'dart:typed_data';
 
 import 'package:mocktail/mocktail.dart';
 import 'package:soliplex_agent/soliplex_agent.dart';
@@ -38,6 +39,14 @@ const ThreadKey _key = (
 );
 
 const _runId = 'run-abc';
+
+/// The optimistic user echo the orchestrator put in the conversation.
+TextMessage _echo(RunOrchestrator orchestrator) =>
+    (orchestrator.currentState as CompletedState)
+        .conversation
+        .messages
+        .whereType<TextMessage>()
+        .firstWhere((m) => m.user == ChatUser.user);
 
 RunInfo _runInfo() =>
     RunInfo(id: _runId, threadId: _key.threadId, createdAt: DateTime(2026));
@@ -140,7 +149,8 @@ void main() {
       stubCreateRun();
       stubRunAgent(stream: Stream.fromIterable(_happyPathEvents()));
 
-      await orchestrator.startRun(key: _key, userMessage: 'Hi');
+      await orchestrator
+          .startRun(key: _key, userMessage: [const TextPart('Hi')]);
 
       // Give stream time to complete
       await Future<void>.delayed(Duration.zero);
@@ -158,7 +168,8 @@ void main() {
       final states = <RunState>[];
       orchestrator.stateChanges.listen(states.add);
 
-      await orchestrator.startRun(key: _key, userMessage: 'Hi');
+      await orchestrator
+          .startRun(key: _key, userMessage: [const TextPart('Hi')]);
       await Future<void>.delayed(Duration.zero);
 
       // Expect: RunningState (initial), then updates per event, CompletedState
@@ -173,7 +184,8 @@ void main() {
       RunState? lastEmitted;
       orchestrator.stateChanges.listen((s) => lastEmitted = s);
 
-      await orchestrator.startRun(key: _key, userMessage: 'Hi');
+      await orchestrator
+          .startRun(key: _key, userMessage: [const TextPart('Hi')]);
       await Future<void>.delayed(Duration.zero);
 
       expect(orchestrator.currentState, equals(lastEmitted));
@@ -184,7 +196,7 @@ void main() {
 
       await orchestrator.startRun(
         key: _key,
-        userMessage: 'Hi',
+        userMessage: [const TextPart('Hi')],
         existingRunId: _runId,
       );
       await Future<void>.delayed(Duration.zero);
@@ -210,7 +222,8 @@ void main() {
         ]),
       );
 
-      await orchestrator.startRun(key: _key, userMessage: 'Hi');
+      await orchestrator
+          .startRun(key: _key, userMessage: [const TextPart('Hi')]);
       await Future<void>.delayed(Duration.zero);
 
       final completed = orchestrator.currentState as CompletedState;
@@ -224,6 +237,49 @@ void main() {
     });
   });
 
+  group('optimistic echo', () {
+    // The echo is the only representation of the user's turn on screen while
+    // the run is in flight, so dropping `parts` here loses an attached image
+    // until a reload replays it from the server.
+    test('carries the payload parts in order', () async {
+      stubCreateRun();
+      stubRunAgent(stream: Stream.fromIterable(_happyPathEvents()));
+
+      final png = Uint8List.fromList([0x89, 0x50, 0x4e, 0x47]);
+      await orchestrator.startRun(
+        key: _key,
+        userMessage: [
+          const TextPart('look at '),
+          ImagePart(bytes: png, mimeType: 'image/png'),
+          const TextPart(' and say'),
+        ],
+      );
+      await Future<void>.delayed(Duration.zero);
+
+      final echo = _echo(orchestrator);
+      expect(echo.parts, hasLength(3));
+      expect((echo.parts![1] as ImagePart).mimeType, equals('image/png'));
+      // Derived, never carried alongside: the image contributes no text, and
+      // the runs join without a separator.
+      expect(echo.text, equals('look at  and say'));
+    });
+
+    // A lone text run flattens to itself, which is what every caller that
+    // sends plain text relies on.
+    test('derives text from a single text run', () async {
+      stubCreateRun();
+      stubRunAgent(stream: Stream.fromIterable(_happyPathEvents()));
+
+      await orchestrator
+          .startRun(key: _key, userMessage: [const TextPart('Hi')]);
+      await Future<void>.delayed(Duration.zero);
+
+      final echo = _echo(orchestrator);
+      expect(echo.text, equals('Hi'));
+      expect(echo.parts, hasLength(1));
+    });
+  });
+
   group('error', () {
     test('RunErrorEvent transitions to FailedState(serverError)', () async {
       stubCreateRun();
@@ -234,7 +290,8 @@ void main() {
         ]),
       );
 
-      await orchestrator.startRun(key: _key, userMessage: 'Hi');
+      await orchestrator
+          .startRun(key: _key, userMessage: [const TextPart('Hi')]);
       await Future<void>.delayed(Duration.zero);
 
       expect(orchestrator.currentState, isA<FailedState>());
@@ -253,7 +310,8 @@ void main() {
           ),
         );
 
-        await orchestrator.startRun(key: _key, userMessage: 'Hi');
+        await orchestrator
+            .startRun(key: _key, userMessage: [const TextPart('Hi')]);
         await Future<void>.delayed(Duration.zero);
 
         expect(orchestrator.currentState, isA<FailedState>());
@@ -272,7 +330,8 @@ void main() {
           ),
         );
 
-        await orchestrator.startRun(key: _key, userMessage: 'Hi');
+        await orchestrator
+            .startRun(key: _key, userMessage: [const TextPart('Hi')]);
         await Future<void>.delayed(Duration.zero);
 
         expect(orchestrator.currentState, isA<FailedState>());
@@ -292,7 +351,8 @@ void main() {
           ]),
         );
 
-        await orchestrator.startRun(key: _key, userMessage: 'Hi');
+        await orchestrator
+            .startRun(key: _key, userMessage: [const TextPart('Hi')]);
         await Future<void>.delayed(Duration.zero);
 
         expect(orchestrator.currentState, isA<FailedState>());
@@ -309,7 +369,8 @@ void main() {
         () => api.createRun(any(), any()),
       ).thenThrow(const AuthException(message: 'Token expired'));
 
-      await orchestrator.startRun(key: _key, userMessage: 'Hi');
+      await orchestrator
+          .startRun(key: _key, userMessage: [const TextPart('Hi')]);
 
       expect(orchestrator.currentState, isA<FailedState>());
       final failed = orchestrator.currentState as FailedState;
@@ -323,7 +384,8 @@ void main() {
         final controller = StreamController<BaseEvent>();
         stubRunAgent(stream: controller.stream);
 
-        await orchestrator.startRun(key: _key, userMessage: 'Hi');
+        await orchestrator
+            .startRun(key: _key, userMessage: [const TextPart('Hi')]);
 
         controller
           ..add(RunStartedEvent(threadId: 'thread-1', runId: _runId))
@@ -363,7 +425,8 @@ void main() {
         addTearDown(controller.close);
         stubRunAgent(stream: controller.stream);
 
-        await orchestrator.startRun(key: _key, userMessage: 'Hi');
+        await orchestrator
+            .startRun(key: _key, userMessage: [const TextPart('Hi')]);
         await Future<void>.delayed(Duration.zero);
 
         controller.addError(
@@ -409,7 +472,8 @@ void main() {
         ]),
       );
 
-      await orchestrator.startRun(key: _key, userMessage: 'Hi');
+      await orchestrator
+          .startRun(key: _key, userMessage: [const TextPart('Hi')]);
       await Future<void>.delayed(Duration.zero);
 
       expect(orchestrator.currentState, isA<FailedState>());
@@ -435,7 +499,8 @@ void main() {
         ]),
       );
 
-      await orchestrator.startRun(key: _key, userMessage: 'Hi');
+      await orchestrator
+          .startRun(key: _key, userMessage: [const TextPart('Hi')]);
       await Future<void>.delayed(Duration.zero);
 
       expect(orchestrator.currentState, isA<FailedState>());
@@ -460,7 +525,8 @@ void main() {
         ]),
       );
 
-      await orchestrator.startRun(key: _key, userMessage: 'Hi');
+      await orchestrator
+          .startRun(key: _key, userMessage: [const TextPart('Hi')]);
       await Future<void>.delayed(Duration.zero);
 
       expect(orchestrator.currentState, isA<FailedState>());
@@ -497,7 +563,8 @@ void main() {
         ]),
       );
 
-      await orchestrator.startRun(key: _key, userMessage: 'Hi');
+      await orchestrator
+          .startRun(key: _key, userMessage: [const TextPart('Hi')]);
       await Future<void>.delayed(Duration.zero);
 
       expect(orchestrator.currentState, isA<CompletedState>());
@@ -515,7 +582,8 @@ void main() {
       final controller = StreamController<BaseEvent>();
       stubRunAgent(stream: controller.stream);
 
-      await orchestrator.startRun(key: _key, userMessage: 'Hi');
+      await orchestrator
+          .startRun(key: _key, userMessage: [const TextPart('Hi')]);
       controller.add(
         RunStartedEvent(threadId: 'thread-1', runId: _runId),
       );
@@ -543,7 +611,8 @@ void main() {
       stubCreateRun();
       stubRunAgent(stream: Stream.fromIterable(_happyPathEvents()));
 
-      await orchestrator.startRun(key: _key, userMessage: 'Hi');
+      await orchestrator
+          .startRun(key: _key, userMessage: [const TextPart('Hi')]);
       await Future<void>.delayed(Duration.zero);
       expect(orchestrator.currentState, isA<CompletedState>());
 
@@ -561,7 +630,8 @@ void main() {
         ]),
       );
 
-      await orchestrator.startRun(key: _key, userMessage: 'Hi');
+      await orchestrator
+          .startRun(key: _key, userMessage: [const TextPart('Hi')]);
       await Future<void>.delayed(Duration.zero);
       expect(orchestrator.currentState, isA<FailedState>());
 
@@ -575,7 +645,8 @@ void main() {
       final controller = StreamController<BaseEvent>();
       stubRunAgent(stream: controller.stream);
 
-      await orchestrator.startRun(key: _key, userMessage: 'Hi');
+      await orchestrator
+          .startRun(key: _key, userMessage: [const TextPart('Hi')]);
       controller.add(
         RunStartedEvent(threadId: 'thread-1', runId: _runId),
       );
@@ -598,7 +669,8 @@ void main() {
       stubRunAgent(stream: controller.stream);
 
       final staleTs = DateTime.utc(2026).millisecondsSinceEpoch;
-      await orchestrator.startRun(key: _key, userMessage: 'Hi');
+      await orchestrator
+          .startRun(key: _key, userMessage: [const TextPart('Hi')]);
       controller
         ..add(RunStartedEvent(threadId: 'thread-1', runId: _runId))
         ..add(const ThinkingStartEvent())
@@ -648,7 +720,8 @@ void main() {
       stubRunAgent(stream: controller.stream);
 
       final lastChunkTime = DateTime.utc(2026, 1, 1, 12);
-      await orchestrator.startRun(key: _key, userMessage: 'Hi');
+      await orchestrator
+          .startRun(key: _key, userMessage: [const TextPart('Hi')]);
       controller
         ..add(RunStartedEvent(threadId: 'thread-1', runId: _runId))
         ..add(const TextMessageStartEvent(messageId: 'reply-1'))
@@ -698,14 +771,16 @@ void main() {
       final controller = StreamController<BaseEvent>();
       stubRunAgent(stream: controller.stream);
 
-      await orchestrator.startRun(key: _key, userMessage: 'Hi');
+      await orchestrator
+          .startRun(key: _key, userMessage: [const TextPart('Hi')]);
       controller.add(
         RunStartedEvent(threadId: 'thread-1', runId: _runId),
       );
       await Future<void>.delayed(Duration.zero);
 
       expect(
-        () => orchestrator.startRun(key: _key, userMessage: 'Again'),
+        () => orchestrator
+            .startRun(key: _key, userMessage: [const TextPart('Again')]),
         throwsA(
           isA<StateError>().having(
             (e) => e.message,
@@ -724,7 +799,8 @@ void main() {
       stubCreateRun();
       stubRunAgent(stream: Stream.fromIterable(_happyPathEvents()));
 
-      await orchestrator.startRun(key: _key, userMessage: 'Hi');
+      await orchestrator
+          .startRun(key: _key, userMessage: [const TextPart('Hi')]);
       await Future<void>.delayed(Duration.zero);
 
       expect(orchestrator.currentState, isA<CompletedState>());
@@ -757,7 +833,7 @@ void main() {
 
       await orchestrator.startRun(
         key: _key,
-        userMessage: 'Follow-up',
+        userMessage: [const TextPart('Follow-up')],
         cachedHistory: history,
       );
       await Future<void>.delayed(Duration.zero);
@@ -790,7 +866,8 @@ void main() {
       stubCreateRun();
       stubRunAgent(stream: Stream.fromIterable(_happyPathEvents()));
 
-      await orchestrator.startRun(key: _key, userMessage: 'Hi');
+      await orchestrator
+          .startRun(key: _key, userMessage: [const TextPart('Hi')]);
       await Future<void>.delayed(Duration.zero);
 
       expect(orchestrator.currentState, isA<CompletedState>());
@@ -822,7 +899,7 @@ void main() {
 
       await orchestrator.startRun(
         key: _key,
-        userMessage: 'More',
+        userMessage: [const TextPart('More')],
         cachedHistory: history,
       );
       await Future<void>.delayed(Duration.zero);
@@ -852,7 +929,7 @@ void main() {
 
       final result = await orchestrator.runToCompletion(
         key: _key,
-        userMessage: 'Turn 2',
+        userMessage: [const TextPart('Turn 2')],
         toolExecutor: (_) async => [],
         cachedHistory: history,
       );
@@ -916,7 +993,7 @@ void main() {
 
       await orchestrator.runToCompletion(
         key: _key,
-        userMessage: 'follow-up',
+        userMessage: [const TextPart('follow-up')],
         toolExecutor: (_) async => [],
         cachedHistory: history,
       );
@@ -956,7 +1033,7 @@ void main() {
 
       final result = await orchestrator.runToCompletion(
         key: _key,
-        userMessage: 'test',
+        userMessage: [const TextPart('test')],
         toolExecutor: (_) async => [],
         stateOverlay: {
           'rag': <String, dynamic>{'document_filter': "id = 'abc-123'"},
@@ -986,7 +1063,7 @@ void main() {
 
       final result = await orchestrator.runToCompletion(
         key: _key,
-        userMessage: 'test',
+        userMessage: [const TextPart('test')],
         toolExecutor: (_) async => [],
         cachedHistory: history,
         stateOverlay: {
@@ -1020,7 +1097,7 @@ void main() {
 
       final result = await orchestrator.runToCompletion(
         key: _key,
-        userMessage: 'test',
+        userMessage: [const TextPart('test')],
         toolExecutor: (_) async => [],
         cachedHistory: history,
         stateOverlay: {
@@ -1053,7 +1130,7 @@ void main() {
 
       final result = await orchestrator.runToCompletion(
         key: _key,
-        userMessage: 'test',
+        userMessage: [const TextPart('test')],
         toolExecutor: (_) async => [],
         cachedHistory: history,
         stateOverlay: {
@@ -1084,7 +1161,7 @@ void main() {
 
       final result = await orchestrator.runToCompletion(
         key: _key,
-        userMessage: 'test',
+        userMessage: [const TextPart('test')],
         toolExecutor: (_) async => [],
         cachedHistory: history,
         stateOverlay: {
@@ -1113,7 +1190,7 @@ void main() {
 
       final result = await orchestrator.runToCompletion(
         key: _key,
-        userMessage: 'test',
+        userMessage: [const TextPart('test')],
         toolExecutor: (_) async => [],
         cachedHistory: history,
         stateOverlay: {
@@ -1144,7 +1221,7 @@ void main() {
 
       final result = await orchestrator.runToCompletion(
         key: _key,
-        userMessage: 'test',
+        userMessage: [const TextPart('test')],
         toolExecutor: (_) async => [],
         cachedHistory: history,
         stateOverlay: {
@@ -1174,7 +1251,7 @@ void main() {
 
       final result = await orchestrator.runToCompletion(
         key: _key,
-        userMessage: 'test',
+        userMessage: [const TextPart('test')],
         toolExecutor: (_) async => [],
         cachedHistory: history,
         stateOverlay: const {},
@@ -1204,7 +1281,8 @@ void main() {
       stubCreateRun();
       stubRunAgent(stream: Stream.fromIterable(_toolCallEvents()));
 
-      await orchestrator.startRun(key: _key, userMessage: 'Weather?');
+      await orchestrator
+          .startRun(key: _key, userMessage: [const TextPart('Weather?')]);
       await Future<void>.delayed(Duration.zero);
 
       expect(orchestrator.currentState, isA<ToolYieldingState>());
@@ -1218,7 +1296,8 @@ void main() {
       stubCreateRun();
       stubRunAgent(stream: Stream.fromIterable(_toolCallEvents()));
 
-      await orchestrator.startRun(key: _key, userMessage: 'Hi');
+      await orchestrator
+          .startRun(key: _key, userMessage: [const TextPart('Hi')]);
       await Future<void>.delayed(Duration.zero);
 
       expect(orchestrator.currentState, isA<CompletedState>());
@@ -1240,7 +1319,8 @@ void main() {
         ),
       );
 
-      await orchestrator.startRun(key: _key, userMessage: 'Hi');
+      await orchestrator
+          .startRun(key: _key, userMessage: [const TextPart('Hi')]);
       await Future<void>.delayed(Duration.zero);
 
       expect(orchestrator.currentState, isA<CompletedState>());
@@ -1284,7 +1364,8 @@ void main() {
         second: Stream.fromIterable(_resumeTextEvents()),
       );
 
-      await orchestrator.startRun(key: _key, userMessage: 'Weather?');
+      await orchestrator
+          .startRun(key: _key, userMessage: [const TextPart('Weather?')]);
       await Future<void>.delayed(Duration.zero);
       expect(orchestrator.currentState, isA<ToolYieldingState>());
 
@@ -1350,7 +1431,8 @@ void main() {
         return _wrap(Stream.fromIterable(_resumeTextEvents()));
       });
 
-      await orchestrator.startRun(key: _key, userMessage: 'Weather?');
+      await orchestrator
+          .startRun(key: _key, userMessage: [const TextPart('Weather?')]);
       await Future<void>.delayed(Duration.zero);
       expect(orchestrator.currentState, isA<ToolYieldingState>());
       final yield1 = orchestrator.currentState as ToolYieldingState;
@@ -1389,7 +1471,8 @@ void main() {
         ),
       ).thenAnswer((_) => _wrap(Stream.fromIterable(_toolCallEvents())));
 
-      await orchestrator.startRun(key: _key, userMessage: 'Weather?');
+      await orchestrator
+          .startRun(key: _key, userMessage: [const TextPart('Weather?')]);
       await Future<void>.delayed(Duration.zero);
 
       for (var i = 0; i < 10; i++) {
@@ -1445,7 +1528,7 @@ void main() {
 
       final result = await orchestrator.runToCompletion(
         key: _key,
-        userMessage: 'Weather?',
+        userMessage: [const TextPart('Weather?')],
         toolExecutor: (_) async => _executedTools(),
       );
 
@@ -1473,7 +1556,8 @@ void main() {
       stubCreateRun();
       stubRunAgent(stream: Stream.fromIterable(_toolCallEvents()));
 
-      await orchestrator.startRun(key: _key, userMessage: 'Weather?');
+      await orchestrator
+          .startRun(key: _key, userMessage: [const TextPart('Weather?')]);
       await Future<void>.delayed(Duration.zero);
       expect(orchestrator.currentState, isA<ToolYieldingState>());
 
@@ -1496,12 +1580,14 @@ void main() {
       stubCreateRun();
       stubRunAgent(stream: Stream.fromIterable(_toolCallEvents()));
 
-      await orchestrator.startRun(key: _key, userMessage: 'Weather?');
+      await orchestrator
+          .startRun(key: _key, userMessage: [const TextPart('Weather?')]);
       await Future<void>.delayed(Duration.zero);
       expect(orchestrator.currentState, isA<ToolYieldingState>());
 
       expect(
-        () => orchestrator.startRun(key: _key, userMessage: 'Again'),
+        () => orchestrator
+            .startRun(key: _key, userMessage: [const TextPart('Again')]),
         throwsA(
           isA<StateError>().having(
             (e) => e.message,
@@ -1538,7 +1624,7 @@ void main() {
       unawaited(
         orchestrator.runToCompletion(
           key: _key,
-          userMessage: 'Hi',
+          userMessage: [const TextPart('Hi')],
           toolExecutor: (_) async => [],
         ),
       );
@@ -1617,7 +1703,7 @@ void main() {
       var toolExecutorCallCount = 0;
       final runFuture = orchestrator.runToCompletion(
         key: _key,
-        userMessage: 'Weather?',
+        userMessage: [const TextPart('Weather?')],
         toolExecutor: (_) async {
           toolExecutorCallCount++;
           await toolExecutorTrigger.future;
@@ -1712,7 +1798,7 @@ void main() {
       var toolExecutorCallCount = 0;
       final runFuture = orchestrator.runToCompletion(
         key: _key,
-        userMessage: 'Weather?',
+        userMessage: [const TextPart('Weather?')],
         toolExecutor: (_) async {
           toolExecutorCallCount++;
           await toolExecutorTrigger.future;
@@ -1766,7 +1852,9 @@ void main() {
       stubRunAgent(stream: Stream.fromIterable(_happyPathEvents()));
 
       // Start run — will suspend on createRun.
-      unawaited(orchestrator.startRun(key: _key, userMessage: 'Hi'));
+      unawaited(
+        orchestrator.startRun(key: _key, userMessage: [const TextPart('Hi')]),
+      );
       await Future<void>.delayed(Duration.zero);
 
       // Dispose while awaiting createRun.
@@ -1795,7 +1883,8 @@ void main() {
       stubCreateRun();
       stubRunAgent(stream: Stream.fromIterable(_toolCallEvents()));
 
-      await orchestrator.startRun(key: _key, userMessage: 'Weather?');
+      await orchestrator
+          .startRun(key: _key, userMessage: [const TextPart('Weather?')]);
       await Future<void>.delayed(Duration.zero);
       expect(orchestrator.currentState, isA<ToolYieldingState>());
 
@@ -1832,7 +1921,8 @@ void main() {
         addTearDown(controller.close);
         stubRunAgent(stream: controller.stream);
 
-        await orchestrator.startRun(key: _key, userMessage: 'Hi');
+        await orchestrator
+            .startRun(key: _key, userMessage: [const TextPart('Hi')]);
         await Future<void>.delayed(Duration.zero);
         expect(orchestrator.currentState, isA<RunningState>());
 
@@ -1852,7 +1942,8 @@ void main() {
         when(() => api.createRun(any(), any()))
             .thenThrow(const CancelledException(reason: 'user'));
 
-        await orchestrator.startRun(key: _key, userMessage: 'Hi');
+        await orchestrator
+            .startRun(key: _key, userMessage: [const TextPart('Hi')]);
 
         expect(orchestrator.currentState, isA<CancelledState>());
       },
@@ -1880,7 +1971,7 @@ void main() {
 
       final runFuture = orchestrator.runToCompletion(
         key: _key,
-        userMessage: 'Hi',
+        userMessage: [const TextPart('Hi')],
         toolExecutor: (_) async => [],
       );
       await Future<void>.delayed(Duration.zero);
@@ -1923,7 +2014,8 @@ void main() {
         );
         stubRunAgent(stream: controller.stream);
 
-        await orchestrator.startRun(key: _key, userMessage: 'Hi');
+        await orchestrator
+            .startRun(key: _key, userMessage: [const TextPart('Hi')]);
 
         // Emit a complete happy-path sequence.
         _happyPathEvents().forEach(controller.add);
@@ -1959,7 +2051,8 @@ void main() {
       );
       stubRunAgent(stream: controller.stream);
 
-      await orchestrator.startRun(key: _key, userMessage: 'Hi');
+      await orchestrator
+          .startRun(key: _key, userMessage: [const TextPart('Hi')]);
       controller.add(
         RunStartedEvent(threadId: 'thread-1', runId: _runId),
       );
@@ -1988,7 +2081,8 @@ void main() {
       );
       stubRunAgent(stream: controller.stream);
 
-      await orchestrator.startRun(key: _key, userMessage: 'Hi');
+      await orchestrator
+          .startRun(key: _key, userMessage: [const TextPart('Hi')]);
       controller
         ..add(RunStartedEvent(threadId: 'thread-1', runId: _runId))
         ..add(const RunErrorEvent(message: 'backend error'));
@@ -2031,7 +2125,7 @@ void main() {
 
       await orchestrator.startRun(
         key: _key,
-        userMessage: 'More',
+        userMessage: [const TextPart('More')],
         cachedHistory: history,
       );
       await Future<void>.delayed(Duration.zero);
@@ -2112,7 +2206,7 @@ void main() {
 
       await orchestrator.startRun(
         key: _key,
-        userMessage: 'More',
+        userMessage: [const TextPart('More')],
         cachedHistory: history,
       );
       await Future<void>.delayed(Duration.zero);
@@ -2190,7 +2284,8 @@ void main() {
           return _wrap(Stream.fromIterable(_resumeTextEvents()));
         });
 
-        await orchestrator.startRun(key: _key, userMessage: 'Weather?');
+        await orchestrator
+            .startRun(key: _key, userMessage: [const TextPart('Weather?')]);
         await Future<void>.delayed(Duration.zero);
         expect(orchestrator.currentState, isA<ToolYieldingState>());
 
@@ -2289,7 +2384,7 @@ void main() {
 
       final result = await orchestrator.runToCompletion(
         key: _key,
-        userMessage: 'Weather?',
+        userMessage: [const TextPart('Weather?')],
         toolExecutor: (pending) async {
           return pending
               .map(
@@ -2349,7 +2444,8 @@ void main() {
       stubCreateRun();
       stubRunAgent(stream: Stream.fromIterable(_happyPathEvents()));
 
-      await orchestrator.startRun(key: _key, userMessage: 'Hi');
+      await orchestrator
+          .startRun(key: _key, userMessage: [const TextPart('Hi')]);
       await Future<void>.delayed(Duration.zero);
 
       final captured = verify(
@@ -2373,7 +2469,8 @@ void main() {
       orchestrator.dispose();
 
       expect(
-        () => orchestrator.startRun(key: _key, userMessage: 'Hi'),
+        () => orchestrator
+            .startRun(key: _key, userMessage: [const TextPart('Hi')]),
         throwsA(
           isA<StateError>().having(
             (e) => e.message,
@@ -2398,7 +2495,8 @@ void main() {
       final controller = StreamController<BaseEvent>();
       stubRunAgent(stream: controller.stream);
 
-      await orchestrator.startRun(key: _key, userMessage: 'Hi');
+      await orchestrator
+          .startRun(key: _key, userMessage: [const TextPart('Hi')]);
       await Future<void>.delayed(Duration.zero);
 
       expect(orchestrator.currentState, isA<RunningState>());
@@ -2503,7 +2601,8 @@ void main() {
       stubCreateRun();
       stubRunAgent(stream: Stream.fromIterable(citationEvents()));
 
-      await orchestrator.startRun(key: _key, userMessage: 'Search');
+      await orchestrator
+          .startRun(key: _key, userMessage: [const TextPart('Search')]);
       await Future<void>.delayed(Duration.zero);
 
       expect(orchestrator.currentState, isA<CompletedState>());
@@ -2539,7 +2638,8 @@ void main() {
         ]),
       );
 
-      await orchestrator.startRun(key: _key, userMessage: 'Search');
+      await orchestrator
+          .startRun(key: _key, userMessage: [const TextPart('Search')]);
       await Future<void>.delayed(Duration.zero);
 
       expect(orchestrator.currentState, isA<CompletedState>());
@@ -2555,7 +2655,8 @@ void main() {
       stubCreateRun();
       stubRunAgent(stream: Stream.fromIterable(_happyPathEvents()));
 
-      await orchestrator.startRun(key: _key, userMessage: 'Hi');
+      await orchestrator
+          .startRun(key: _key, userMessage: [const TextPart('Hi')]);
       await Future<void>.delayed(Duration.zero);
 
       expect(orchestrator.currentState, isA<CompletedState>());
@@ -2594,7 +2695,8 @@ void main() {
         ]),
       );
 
-      await orchestrator.startRun(key: _key, userMessage: 'Search');
+      await orchestrator
+          .startRun(key: _key, userMessage: [const TextPart('Search')]);
       await Future<void>.delayed(Duration.zero);
 
       final completed = orchestrator.currentState as CompletedState;
@@ -2643,7 +2745,8 @@ void main() {
         ]),
       );
 
-      await orchestrator.startRun(key: _key, userMessage: 'Search');
+      await orchestrator
+          .startRun(key: _key, userMessage: [const TextPart('Search')]);
       await Future<void>.delayed(Duration.zero);
 
       final completed = orchestrator.currentState as CompletedState;
@@ -2693,7 +2796,8 @@ void main() {
         ]),
       );
 
-      await orchestrator.startRun(key: _key, userMessage: 'Analyze');
+      await orchestrator
+          .startRun(key: _key, userMessage: [const TextPart('Analyze')]);
       await Future<void>.delayed(Duration.zero);
 
       final completed = orchestrator.currentState as CompletedState;
@@ -2732,7 +2836,8 @@ void main() {
         ]),
       );
 
-      await orchestrator.startRun(key: _key, userMessage: 'Search');
+      await orchestrator
+          .startRun(key: _key, userMessage: [const TextPart('Search')]);
       await Future<void>.delayed(Duration.zero);
 
       final completed = orchestrator.currentState as CompletedState;
@@ -2772,7 +2877,8 @@ void main() {
 
       stubRunAgent(stream: Stream.fromIterable(toolCallWithCitations));
 
-      await orchestrator.startRun(key: _key, userMessage: 'Weather?');
+      await orchestrator
+          .startRun(key: _key, userMessage: [const TextPart('Weather?')]);
       await Future<void>.delayed(Duration.zero);
 
       expect(orchestrator.currentState, isA<ToolYieldingState>());
@@ -2848,7 +2954,7 @@ void main() {
 
       final result = await orchestrator.runToCompletion(
         key: _key,
-        userMessage: 'Search',
+        userMessage: [const TextPart('Search')],
         toolExecutor: (pending) async {
           return pending
               .map(
@@ -2961,7 +3067,7 @@ void main() {
 
       final result = await orchestrator.runToCompletion(
         key: _key,
-        userMessage: 'Search',
+        userMessage: [const TextPart('Search')],
         toolExecutor: (pending) async => pending
             .map(
               (tc) => tc.copyWith(
@@ -3052,7 +3158,7 @@ void main() {
 
       final result = await orchestrator.runToCompletion(
         key: _key,
-        userMessage: 'Search',
+        userMessage: [const TextPart('Search')],
         toolExecutor: (pending) async {
           return pending
               .map(
@@ -3081,14 +3187,16 @@ void main() {
       stubCreateRun();
       stubRunAgent(stream: Stream.fromIterable(citationEvents()));
 
-      await orchestrator.startRun(key: _key, userMessage: 'Search');
+      await orchestrator
+          .startRun(key: _key, userMessage: [const TextPart('Search')]);
       await Future<void>.delayed(Duration.zero);
       expect(orchestrator.currentState, isA<CompletedState>());
 
       orchestrator.reset();
 
       stubRunAgent(stream: Stream.fromIterable(_happyPathEvents()));
-      await orchestrator.startRun(key: _key, userMessage: 'Hi');
+      await orchestrator
+          .startRun(key: _key, userMessage: [const TextPart('Hi')]);
       await Future<void>.delayed(Duration.zero);
 
       expect(orchestrator.currentState, isA<CompletedState>());
@@ -3108,7 +3216,8 @@ void main() {
       stubCreateRun();
       stubRunAgent(stream: Stream.fromIterable(citationEvents()));
 
-      await orchestrator.startRun(key: _key, userMessage: 'Search');
+      await orchestrator
+          .startRun(key: _key, userMessage: [const TextPart('Search')]);
       await Future<void>.delayed(Duration.zero);
       expect(orchestrator.currentState, isA<CompletedState>());
 
@@ -3129,7 +3238,8 @@ void main() {
           const RunFinishedEvent(threadId: 'thread-1', runId: _runId),
         ]),
       );
-      await orchestrator.startRun(key: _key, userMessage: 'Again');
+      await orchestrator
+          .startRun(key: _key, userMessage: [const TextPart('Again')]);
       await Future<void>.delayed(Duration.zero);
 
       expect(orchestrator.currentState, isA<CompletedState>());
@@ -3149,7 +3259,8 @@ void main() {
       ];
       stubRunAgent(stream: Stream.fromIterable(events));
 
-      await orchestrator.startRun(key: _key, userMessage: 'Search');
+      await orchestrator
+          .startRun(key: _key, userMessage: [const TextPart('Search')]);
       await Future<void>.delayed(Duration.zero);
 
       expect(orchestrator.currentState, isA<FailedState>());
@@ -3165,7 +3276,8 @@ void main() {
       final controller = StreamController<BaseEvent>();
       stubRunAgent(stream: controller.stream);
 
-      await orchestrator.startRun(key: _key, userMessage: 'Search');
+      await orchestrator
+          .startRun(key: _key, userMessage: [const TextPart('Search')]);
       controller.add(
         RunStartedEvent(threadId: 'thread-1', runId: _runId),
       );
@@ -3189,7 +3301,8 @@ void main() {
       final controller = StreamController<BaseEvent>();
       stubRunAgent(stream: controller.stream);
 
-      await orchestrator.startRun(key: _key, userMessage: 'Search');
+      await orchestrator
+          .startRun(key: _key, userMessage: [const TextPart('Search')]);
       controller.add(
         RunStartedEvent(threadId: 'thread-1', runId: _runId),
       );
@@ -3228,7 +3341,8 @@ void main() {
         final trackerSub = orchestrator.baseEvents.listen(trackerEvents.add);
         addTearDown(trackerSub.cancel);
 
-        await orchestrator.startRun(key: _key, userMessage: 'Hi');
+        await orchestrator
+            .startRun(key: _key, userMessage: [const TextPart('Hi')]);
         // Backend run-started, then an undecodable payload, then a
         // structurally-valid text turn, then RunFinished.
         controller
@@ -3332,7 +3446,8 @@ void main() {
         final trackerSub = orchestrator.baseEvents.listen(trackerEvents.add);
         addTearDown(trackerSub.cancel);
 
-        await orchestrator.startRun(key: _key, userMessage: 'Hi');
+        await orchestrator
+            .startRun(key: _key, userMessage: [const TextPart('Hi')]);
         controller
           ..add(
             DecodedEvent(
@@ -3429,7 +3544,8 @@ void main() {
           ),
         ).thenAnswer((_) => controller.stream);
 
-        await orchestrator.startRun(key: _key, userMessage: 'Hi');
+        await orchestrator
+            .startRun(key: _key, userMessage: [const TextPart('Hi')]);
         controller
           ..add(
             DecodedEvent(
@@ -3485,7 +3601,8 @@ void main() {
           ),
         ).thenAnswer((_) => controller.stream);
 
-        await orchestrator.startRun(key: _key, userMessage: 'Hi');
+        await orchestrator
+            .startRun(key: _key, userMessage: [const TextPart('Hi')]);
         // Outcome positions: 0 RunStarted, 1 DecodeFailed, 2 TextStart,
         // 3 STATE_SNAPSHOT (throws inside processEvent), 4 RunFinished.
         controller

--- a/packages/soliplex_agent/test/orchestration/run_to_completion_test.dart
+++ b/packages/soliplex_agent/test/orchestration/run_to_completion_test.dart
@@ -152,7 +152,7 @@ void main() {
 
       final result = await orchestrator.runToCompletion(
         key: _key,
-        userMessage: 'Hi',
+        userMessage: [const TextPart('Hi')],
         toolExecutor: _defaultToolExecutor,
       );
 
@@ -178,7 +178,7 @@ void main() {
 
       final resultFuture = orchestrator.runToCompletion(
         key: _key,
-        userMessage: 'Hi',
+        userMessage: [const TextPart('Hi')],
         toolExecutor: _defaultToolExecutor,
       );
 
@@ -224,7 +224,7 @@ void main() {
 
       final result = await orchestrator.runToCompletion(
         key: _key,
-        userMessage: 'Weather?',
+        userMessage: [const TextPart('Weather?')],
         toolExecutor: _defaultToolExecutor,
       );
 
@@ -261,7 +261,7 @@ void main() {
 
       final result = await orchestrator.runToCompletion(
         key: _key,
-        userMessage: 'Weather?',
+        userMessage: [const TextPart('Weather?')],
         toolExecutor: _defaultToolExecutor,
       );
 
@@ -292,7 +292,7 @@ void main() {
 
       final result = await orchestrator.runToCompletion(
         key: _key,
-        userMessage: 'Weather?',
+        userMessage: [const TextPart('Weather?')],
         toolExecutor: _defaultToolExecutor,
       );
 
@@ -317,7 +317,7 @@ void main() {
 
       final future = orchestrator.runToCompletion(
         key: _key,
-        userMessage: 'Hi',
+        userMessage: [const TextPart('Hi')],
         toolExecutor: _defaultToolExecutor,
       );
 
@@ -352,7 +352,7 @@ void main() {
 
       final future = orchestrator.runToCompletion(
         key: _key,
-        userMessage: 'Weather?',
+        userMessage: [const TextPart('Weather?')],
         toolExecutor: (_) => toolCompleter.future,
       );
 
@@ -386,7 +386,7 @@ void main() {
 
       final future = orchestrator.runToCompletion(
         key: _key,
-        userMessage: 'Weather?',
+        userMessage: [const TextPart('Weather?')],
         toolExecutor: (_) => toolCompleter.future,
       );
 
@@ -417,7 +417,7 @@ void main() {
 
       final result = await orchestrator.runToCompletion(
         key: _key,
-        userMessage: 'Weather?',
+        userMessage: [const TextPart('Weather?')],
         toolExecutor: (_) async => throw Exception('tool crash'),
       );
 
@@ -446,7 +446,7 @@ void main() {
 
       final result = await orchestrator.runToCompletion(
         key: _key,
-        userMessage: 'Weather?',
+        userMessage: [const TextPart('Weather?')],
         toolExecutor: _defaultToolExecutor,
       );
 
@@ -472,7 +472,7 @@ void main() {
 
       final future = orchestrator.runToCompletion(
         key: _key,
-        userMessage: 'Hi',
+        userMessage: [const TextPart('Hi')],
         toolExecutor: _defaultToolExecutor,
       );
 
@@ -482,7 +482,8 @@ void main() {
       await Future<void>.delayed(Duration.zero);
 
       expect(
-        () => orchestrator.startRun(key: _key, userMessage: 'Again'),
+        () => orchestrator
+            .startRun(key: _key, userMessage: [const TextPart('Again')]),
         throwsA(
           isA<StateError>().having(
             (e) => e.message,
@@ -513,7 +514,7 @@ void main() {
 
       final future = orchestrator.runToCompletion(
         key: _key,
-        userMessage: 'Hi',
+        userMessage: [const TextPart('Hi')],
         toolExecutor: _defaultToolExecutor,
       );
 
@@ -571,7 +572,7 @@ void main() {
 
       final future = orchestrator.runToCompletion(
         key: _key,
-        userMessage: 'Weather?',
+        userMessage: [const TextPart('Weather?')],
         toolExecutor: _defaultToolExecutor,
       );
 
@@ -606,7 +607,7 @@ void main() {
 
       final result = await orchestrator.runToCompletion(
         key: _key,
-        userMessage: 'Hi',
+        userMessage: [const TextPart('Hi')],
         toolExecutor: _defaultToolExecutor,
       );
 
@@ -632,7 +633,7 @@ void main() {
 
       final result = await orchestrator.runToCompletion(
         key: _key,
-        userMessage: 'Hi',
+        userMessage: [const TextPart('Hi')],
         toolExecutor: _defaultToolExecutor,
       );
 
@@ -653,7 +654,7 @@ void main() {
 
       final result = await orchestrator.runToCompletion(
         key: _key,
-        userMessage: 'Hi',
+        userMessage: [const TextPart('Hi')],
         toolExecutor: _defaultToolExecutor,
       );
 
@@ -692,7 +693,7 @@ void main() {
 
       final result = await orchestrator.runToCompletion(
         key: _key,
-        userMessage: 'Weather?',
+        userMessage: [const TextPart('Weather?')],
         toolExecutor: _defaultToolExecutor,
       );
 
@@ -717,7 +718,7 @@ void main() {
       CancelToken? captured;
       final result = await orchestrator.runToCompletion(
         key: _key,
-        userMessage: 'Weather?',
+        userMessage: [const TextPart('Weather?')],
         toolExecutor: (pending) async {
           captured = orchestrator.cancelToken;
           return _defaultToolExecutor(pending);

--- a/packages/soliplex_agent/test/run/m7_room_integration_test.dart
+++ b/packages/soliplex_agent/test/run/m7_room_integration_test.dart
@@ -78,7 +78,10 @@ void main() {
     });
 
     test('sequential tool rounds → CompletedState', () async {
-      await orchestrator.startRun(key: key, userMessage: 'Run diagnostics.');
+      await orchestrator.startRun(
+        key: key,
+        userMessage: [const TextPart('Run diagnostics.')],
+      );
 
       var yieldCount = 0;
       for (var round = 0; round < 5; round++) {
@@ -139,7 +142,7 @@ void main() {
         try {
           await runtime.spawn(
             roomId: 'room-that-does-not-exist-999',
-            prompt: 'This should fail.',
+            prompt: [const TextPart('This should fail.')],
           );
         } on Object catch (e) {
           caught = e;
@@ -223,7 +226,9 @@ void main() {
     test('compound request calls correct tools', () async {
       await orchestrator.startRun(
         key: key,
-        userMessage: 'Call tool_a and tool_c. Do NOT call tool_b.',
+        userMessage: [
+          const TextPart('Call tool_a and tool_c. Do NOT call tool_b.'),
+        ],
       );
 
       final calledTools = <String>{};
@@ -287,7 +292,7 @@ void main() {
       // Turn 1.
       await orchestrator.startRun(
         key: key,
-        userMessage: 'Fact 1: The sky is blue.',
+        userMessage: [const TextPart('Fact 1: The sky is blue.')],
       );
       await waitForTerminalState(orchestrator, timeout: 60);
       expect(orchestrator.currentState, isA<CompletedState>());
@@ -300,7 +305,7 @@ void main() {
       // Turn 2 — carry forward turn 1 history.
       await orchestrator.startRun(
         key: key,
-        userMessage: 'Fact 2: Grass is green.',
+        userMessage: [const TextPart('Fact 2: Grass is green.')],
         cachedHistory: history,
       );
       await waitForTerminalState(orchestrator, timeout: 60);
@@ -314,7 +319,7 @@ void main() {
       // Turn 3 — recall only, carry forward turns 1 + 2.
       await orchestrator.startRun(
         key: key,
-        userMessage: 'What are the two facts I told you?',
+        userMessage: [const TextPart('What are the two facts I told you?')],
         cachedHistory: history,
       );
       await waitForTerminalState(orchestrator, timeout: 60);
@@ -347,7 +352,7 @@ void main() {
       // Turn 1: spawn without history.
       final s1 = await runtime.spawn(
         roomId: 'accumulator',
-        prompt: 'Fact 1: Water freezes at 0°C.',
+        prompt: [const TextPart('Fact 1: Water freezes at 0°C.')],
       );
       final r1 = await s1.awaitResult(timeout: const Duration(seconds: 60));
       expect(r1, isA<AgentSuccess>());
@@ -356,7 +361,7 @@ void main() {
       // Turn 2: same thread — runtime auto-injects history.
       final s2 = await runtime.spawn(
         roomId: 'accumulator',
-        prompt: 'Fact 2: Water boils at 100°C.',
+        prompt: [const TextPart('Fact 2: Water boils at 100°C.')],
         threadId: s1.threadKey.threadId,
       );
       final r2 = await s2.awaitResult(timeout: const Duration(seconds: 60));
@@ -366,7 +371,7 @@ void main() {
       // Turn 3: recall both facts — runtime threads history automatically.
       final s3 = await runtime.spawn(
         roomId: 'accumulator',
-        prompt: 'What are the two facts I told you?',
+        prompt: [const TextPart('What are the two facts I told you?')],
         threadId: s1.threadKey.threadId,
       );
       final r3 = await s3.awaitResult(timeout: const Duration(seconds: 60));
@@ -397,7 +402,7 @@ void main() {
       // Stage 1: write.
       final s1 = await runtime.spawn(
         roomId: 'writer',
-        prompt: 'Write one sentence about a magical forest.',
+        prompt: [const TextPart('Write one sentence about a magical forest.')],
       );
       final r1 = await s1.awaitResult(timeout: const Duration(seconds: 60));
       expect(r1, isA<AgentSuccess>());
@@ -407,7 +412,7 @@ void main() {
       // Stage 2: review.
       final s2 = await runtime.spawn(
         roomId: 'reviewer',
-        prompt: 'Review this draft: $draft',
+        prompt: [TextPart('Review this draft: $draft')],
       );
       final r2 = await s2.awaitResult(timeout: const Duration(seconds: 60));
       expect(r2, isA<AgentSuccess>());
@@ -417,7 +422,11 @@ void main() {
       // Stage 3: revise.
       final s3 = await runtime.spawn(
         roomId: 'fixer',
-        prompt: 'Draft: $draft\nCritique: $review\nProduce a revised version.',
+        prompt: [
+          TextPart(
+            'Draft: $draft\nCritique: $review\nProduce a revised version.',
+          ),
+        ],
       );
       final r3 = await s3.awaitResult(timeout: const Duration(seconds: 60));
       expect(r3, isA<AgentSuccess>());
@@ -454,7 +463,7 @@ void main() {
       for (final word in words) {
         await orchestrator.startRun(
           key: key,
-          userMessage: 'Remember the word: $word',
+          userMessage: [TextPart('Remember the word: $word')],
           cachedHistory: history,
         );
         await waitForTerminalState(orchestrator, timeout: 60);
@@ -470,7 +479,11 @@ void main() {
       // Turn 5 — recall.
       await orchestrator.startRun(
         key: key,
-        userMessage: 'List all four words I asked you to remember, in order.',
+        userMessage: [
+          const TextPart(
+            'List all four words I asked you to remember, in order.',
+          ),
+        ],
         cachedHistory: history,
       );
       await waitForTerminalState(orchestrator, timeout: 60);
@@ -530,7 +543,9 @@ void main() {
     test('fail first call → agent retries → CompletedState', () async {
       await orchestrator.startRun(
         key: key,
-        userMessage: 'Calculate something using the calculate tool.',
+        userMessage: [
+          const TextPart('Calculate something using the calculate tool.'),
+        ],
       );
 
       for (var round = 0; round < 5; round++) {
@@ -591,15 +606,15 @@ void main() {
       // Fan-out.
       final s1 = await runtime.spawn(
         roomId: 'parallel',
-        prompt: 'Say exactly: ALPHA=100',
+        prompt: [const TextPart('Say exactly: ALPHA=100')],
       );
       final s2 = await runtime.spawn(
         roomId: 'parallel',
-        prompt: 'Say exactly: BETA=200',
+        prompt: [const TextPart('Say exactly: BETA=200')],
       );
       final s3 = await runtime.spawn(
         roomId: 'parallel',
-        prompt: 'Say exactly: GAMMA=300',
+        prompt: [const TextPart('Say exactly: GAMMA=300')],
       );
 
       final results = await runtime.waitAll(
@@ -619,8 +634,11 @@ void main() {
       // Fan-in.
       final reducer = await runtime.spawn(
         roomId: 'echo',
-        prompt:
+        prompt: [
+          TextPart(
             'Given: ${outputs.join(", ")} — what is the sum of the numbers?',
+          ),
+        ],
       );
       final reduced = await reducer.awaitResult(
         timeout: const Duration(seconds: 60),
@@ -649,15 +667,19 @@ void main() {
     test('first finisher wins, losers cancel', () async {
       final fast = await runtime.spawn(
         roomId: 'parallel',
-        prompt: 'Say "done".',
+        prompt: [const TextPart('Say "done".')],
       );
       final medium = await runtime.spawn(
         roomId: 'parallel',
-        prompt: 'Write a 5 sentence story about a robot.',
+        prompt: [const TextPart('Write a 5 sentence story about a robot.')],
       );
       final slow = await runtime.spawn(
         roomId: 'parallel',
-        prompt: 'Write a detailed 3 paragraph essay about quantum computing.',
+        prompt: [
+          const TextPart(
+            'Write a detailed 3 paragraph essay about quantum computing.',
+          ),
+        ],
       );
 
       final winner = await runtime.waitAny(
@@ -727,7 +749,9 @@ void main() {
     test('search → "not found" → refine → success', () async {
       await orchestrator.startRun(
         key: key,
-        userMessage: 'Find the document about quantum error correction.',
+        userMessage: [
+          const TextPart('Find the document about quantum error correction.'),
+        ],
       );
 
       for (var round = 0; round < 5; round++) {
@@ -787,7 +811,7 @@ void main() {
       // Classify.
       final classifier = await runtime.spawn(
         roomId: 'classifier',
-        prompt: 'Tell me a joke about programming.',
+        prompt: [const TextPart('Tell me a joke about programming.')],
       );
       final cr = await classifier.awaitResult(
         timeout: const Duration(seconds: 60),
@@ -807,7 +831,7 @@ void main() {
       // Route.
       final routed = await runtime.spawn(
         roomId: targetRoom,
-        prompt: 'Hello from the routed session.',
+        prompt: [const TextPart('Hello from the routed session.')],
       );
       final rr = await routed.awaitResult(timeout: const Duration(seconds: 60));
       expect(rr, isA<AgentSuccess>());
@@ -842,7 +866,8 @@ void main() {
       final sessions = <AgentSession>[];
       for (var i = 0; i < 5; i++) {
         sessions.add(
-          await runtime.spawn(roomId: 'parallel', prompt: 'Say "$i".'),
+          await runtime
+              .spawn(roomId: 'parallel', prompt: [TextPart('Say "$i".')]),
         );
       }
 
@@ -880,7 +905,7 @@ void main() {
       // Turn 1: complete normally (non-ephemeral to preserve thread).
       final s1 = await runtime.spawn(
         roomId: 'echo',
-        prompt: 'Hello, this is a setup message.',
+        prompt: [const TextPart('Hello, this is a setup message.')],
       );
       final r1 = await s1.awaitResult(timeout: const Duration(seconds: 60));
       expect(r1, isA<AgentSuccess>());
@@ -890,7 +915,7 @@ void main() {
       // Turn 2: cancel mid-stream.
       final s2 = await runtime.spawn(
         roomId: 'echo',
-        prompt: 'Tell me a very long story about dragons.',
+        prompt: [const TextPart('Tell me a very long story about dragons.')],
         threadId: threadId,
       );
       await Future<void>.delayed(const Duration(milliseconds: 500));
@@ -901,7 +926,7 @@ void main() {
       // Turn 3: new run on the SAME thread succeeds (thread not corrupted).
       final s3 = await runtime.spawn(
         roomId: 'echo',
-        prompt: 'Tell me a one-sentence joke.',
+        prompt: [const TextPart('Tell me a one-sentence joke.')],
         threadId: threadId,
       );
       final r3 = await s3.awaitResult(timeout: const Duration(seconds: 60));
@@ -933,8 +958,10 @@ void main() {
       // Plan.
       final planner = await runtime.spawn(
         roomId: 'planner',
-        prompt: 'Describe a futuristic city in 3 aspects: '
-            'architecture, transportation, energy.',
+        prompt: [
+          const TextPart('Describe a futuristic city in 3 aspects: '
+              'architecture, transportation, energy.'),
+        ],
       );
       final pr = await planner.awaitResult(
         timeout: const Duration(seconds: 60),
@@ -962,7 +989,8 @@ void main() {
       // Fan-out — use echo room (handles full-sentence prompts).
       final workers = <AgentSession>[];
       for (final task in tasks) {
-        workers.add(await runtime.spawn(roomId: 'echo', prompt: task));
+        workers
+            .add(await runtime.spawn(roomId: 'echo', prompt: [TextPart(task)]));
       }
 
       final results = await runtime.waitAll(
@@ -978,7 +1006,9 @@ void main() {
       // Synthesize.
       final synth = await runtime.spawn(
         roomId: 'echo',
-        prompt: 'Combine into one paragraph: ${workerOutputs.join("; ")}',
+        prompt: [
+          TextPart('Combine into one paragraph: ${workerOutputs.join("; ")}'),
+        ],
       );
       final sr = await synth.awaitResult(timeout: const Duration(seconds: 60));
       expect(sr, isA<AgentSuccess>());
@@ -1004,15 +1034,27 @@ void main() {
       // Gather 3 opinions.
       final s1 = await runtime.spawn(
         roomId: 'echo',
-        prompt: 'Is Pluto a planet? Answer YES or NO with one sentence.',
+        prompt: [
+          const TextPart(
+            'Is Pluto a planet? Answer YES or NO with one sentence.',
+          ),
+        ],
       );
       final s2 = await runtime.spawn(
         roomId: 'parallel',
-        prompt: 'Is Pluto a planet? Answer YES or NO with one sentence.',
+        prompt: [
+          const TextPart(
+            'Is Pluto a planet? Answer YES or NO with one sentence.',
+          ),
+        ],
       );
       final s3 = await runtime.spawn(
         roomId: 'echo',
-        prompt: 'Is Pluto a planet? Answer YES or NO with one sentence.',
+        prompt: [
+          const TextPart(
+            'Is Pluto a planet? Answer YES or NO with one sentence.',
+          ),
+        ],
       );
 
       final results = await runtime.waitAll(
@@ -1027,11 +1069,13 @@ void main() {
       // Judge.
       final judge = await runtime.spawn(
         roomId: 'judge',
-        prompt: 'Three experts were asked "Is Pluto a planet?"\n'
-            '1: ${opinions[0]}\n'
-            '2: ${opinions[1]}\n'
-            '3: ${opinions[2]}\n'
-            'What is the consensus?',
+        prompt: [
+          TextPart('Three experts were asked "Is Pluto a planet?"\n'
+              '1: ${opinions[0]}\n'
+              '2: ${opinions[1]}\n'
+              '3: ${opinions[2]}\n'
+              'What is the consensus?'),
+        ],
       );
       final jr = await judge.awaitResult(timeout: const Duration(seconds: 60));
       expect(jr, isA<AgentSuccess>());
@@ -1057,17 +1101,19 @@ void main() {
       // Classify.
       final classifier = await runtime.spawn(
         roomId: 'classifier',
-        prompt: 'Classify: "Tell me a joke". Reply echo or parallel.',
+        prompt: [
+          const TextPart('Classify: "Tell me a joke". Reply echo or parallel.'),
+        ],
       );
 
       // Speculatively spawn both paths.
       final specEcho = await runtime.spawn(
         roomId: 'echo',
-        prompt: 'Tell me a joke.',
+        prompt: [const TextPart('Tell me a joke.')],
       );
       final specParallel = await runtime.spawn(
         roomId: 'parallel',
-        prompt: 'Tell me a joke.',
+        prompt: [const TextPart('Tell me a joke.')],
       );
 
       // Wait for classifier to decide.
@@ -1119,7 +1165,11 @@ void main() {
       // Stage 1: write.
       final writer = await runtime.spawn(
         roomId: 'writer',
-        prompt: 'Write exactly 3 bullet points about Dart programming.',
+        prompt: [
+          const TextPart(
+            'Write exactly 3 bullet points about Dart programming.',
+          ),
+        ],
       );
       final wr = await writer.awaitResult(timeout: const Duration(seconds: 60));
       expect(wr, isA<AgentSuccess>());
@@ -1131,8 +1181,10 @@ void main() {
         // Review.
         final reviewer = await runtime.spawn(
           roomId: 'reviewer',
-          prompt: 'Does this have exactly 3 bullet points? '
-              'Reply PASS or FAIL: <reason>.\n\n$draft',
+          prompt: [
+            TextPart('Does this have exactly 3 bullet points? '
+                'Reply PASS or FAIL: <reason>.\n\n$draft'),
+          ],
         );
         final rr = await reviewer.awaitResult(
           timeout: const Duration(seconds: 60),
@@ -1149,8 +1201,10 @@ void main() {
         // Fix.
         final fixer = await runtime.spawn(
           roomId: 'fixer',
-          prompt: 'Draft: $draft\nFeedback: $review\n'
-              'Produce exactly 3 bullet points about Dart.',
+          prompt: [
+            TextPart('Draft: $draft\nFeedback: $review\n'
+                'Produce exactly 3 bullet points about Dart.'),
+          ],
         );
         final fr = await fixer.awaitResult(
           timeout: const Duration(seconds: 60),
@@ -1184,7 +1238,11 @@ void main() {
       // Advocate.
       final adv = await runtime.spawn(
         roomId: 'advocate',
-        prompt: 'Argue FOR remote work being better than office work.',
+        prompt: [
+          const TextPart(
+            'Argue FOR remote work being better than office work.',
+          ),
+        ],
       );
       final ar = await adv.awaitResult(timeout: const Duration(seconds: 60));
       expect(ar, isA<AgentSuccess>());
@@ -1194,7 +1252,7 @@ void main() {
       // Critic.
       final crt = await runtime.spawn(
         roomId: 'critic',
-        prompt: 'Counter these arguments: $forArgs',
+        prompt: [TextPart('Counter these arguments: $forArgs')],
       );
       final crr = await crt.awaitResult(timeout: const Duration(seconds: 60));
       expect(crr, isA<AgentSuccess>());
@@ -1204,8 +1262,10 @@ void main() {
       // Rebuttal.
       final reb = await runtime.spawn(
         roomId: 'advocate',
-        prompt: 'A critic responded: $againstArgs\n'
-            'Defend your strongest point in 2 sentences.',
+        prompt: [
+          TextPart('A critic responded: $againstArgs\n'
+              'Defend your strongest point in 2 sentences.'),
+        ],
       );
       final rbr = await reb.awaitResult(timeout: const Duration(seconds: 60));
       expect(rbr, isA<AgentSuccess>());
@@ -1215,11 +1275,13 @@ void main() {
       // Judge.
       final jdg = await runtime.spawn(
         roomId: 'judge',
-        prompt: 'Debate: "Is remote work better than office work?"\n'
-            'FOR: $rebuttal\n'
-            'AGAINST: $againstArgs\n'
-            'Who made the stronger argument? '
-            'Reply ADVOCATE or CRITIC with justification.',
+        prompt: [
+          TextPart('Debate: "Is remote work better than office work?"\n'
+              'FOR: $rebuttal\n'
+              'AGAINST: $againstArgs\n'
+              'Who made the stronger argument? '
+              'Reply ADVOCATE or CRITIC with justification.'),
+        ],
       );
       final jr = await jdg.awaitResult(timeout: const Duration(seconds: 60));
       expect(jr, isA<AgentSuccess>());
@@ -1264,8 +1326,10 @@ void main() {
         mappers.add(
           await runtime.spawn(
             roomId: 'parallel',
-            prompt: 'Extract only the population number from: $chunk. '
-                'Reply with just the number.',
+            prompt: [
+              TextPart('Extract only the population number from: $chunk. '
+                  'Reply with just the number.'),
+            ],
           ),
         );
       }
@@ -1284,9 +1348,11 @@ void main() {
       // Reduce.
       final reducer = await runtime.spawn(
         roomId: 'echo',
-        prompt: 'Given populations: ${populations.join(", ")} — '
-            'which country has the largest and smallest population? '
-            'The data was: ${chunks.join("; ")}',
+        prompt: [
+          TextPart('Given populations: ${populations.join(", ")} — '
+              'which country has the largest and smallest population? '
+              'The data was: ${chunks.join("; ")}'),
+        ],
       );
       final rr = await reducer.awaitResult(
         timeout: const Duration(seconds: 60),

--- a/packages/soliplex_agent/test/run/run_orchestrator_integration_test.dart
+++ b/packages/soliplex_agent/test/run/run_orchestrator_integration_test.dart
@@ -66,7 +66,7 @@ void main() {
       print('Starting run: room=$roomId, thread=${sharedKey.threadId}');
       await orchestrator.startRun(
         key: sharedKey,
-        userMessage: 'Hello, what time is it?',
+        userMessage: [const TextPart('Hello, what time is it?')],
         existingRunId: initialRunId,
       );
       // Consume the initial run ID so subsequent tests create their own.
@@ -111,7 +111,7 @@ void main() {
       // Run 2 in the shared thread (no existingRunId — creates a new run).
       await orchestrator.startRun(
         key: sharedKey,
-        userMessage: 'Now say "goodbye".',
+        userMessage: [const TextPart('Now say "goodbye".')],
       );
       await waitForTerminalState(orchestrator, timeout: 60);
 
@@ -122,7 +122,8 @@ void main() {
 
     test('reset returns to IdleState and can run again', () async {
       // Run 3.
-      await orchestrator.startRun(key: sharedKey, userMessage: 'Say "ok".');
+      await orchestrator
+          .startRun(key: sharedKey, userMessage: [const TextPart('Say "ok".')]);
       await waitForTerminalState(orchestrator, timeout: 60);
       expect(orchestrator.currentState, isA<CompletedState>());
 
@@ -135,7 +136,7 @@ void main() {
       // Run 4 — same thread, after reset.
       await orchestrator.startRun(
         key: sharedKey,
-        userMessage: 'Say "ok" again.',
+        userMessage: [const TextPart('Say "ok" again.')],
       );
       await waitForTerminalState(orchestrator, timeout: 60);
       expect(orchestrator.currentState, isA<CompletedState>());
@@ -187,7 +188,9 @@ void main() {
       print('Starting M5 run: thread=${m5Key.threadId}');
       await orchestrator.startRun(
         key: m5Key,
-        userMessage: 'Call the secret_number tool and tell me the result.',
+        userMessage: [
+          const TextPart('Call the secret_number tool and tell me the result.'),
+        ],
       );
 
       // Wait for either ToolYielding or terminal state.
@@ -243,7 +246,7 @@ void main() {
 
       await orchestrator.startRun(
         key: m5Key,
-        userMessage: 'What time is it right now?',
+        userMessage: [const TextPart('What time is it right now?')],
       );
       await waitForTerminalState(orchestrator, timeout: 60);
 
@@ -296,7 +299,11 @@ void main() {
 
       final session = await runtime.spawn(
         roomId: roomId,
-        prompt: 'Call the secret_number tool and tell me what it returns.',
+        prompt: [
+          const TextPart(
+            'Call the secret_number tool and tell me what it returns.',
+          ),
+        ],
       );
 
       expect(session.threadKey.serverId, equals('default'));
@@ -321,7 +328,8 @@ void main() {
     test('spawn without tools → AgentSuccess (no yield)', () async {
       runtime = harness.createRuntime(loggerName: 'm6-no-tools');
 
-      final session = await runtime.spawn(roomId: roomId, prompt: 'Say hello.');
+      final session = await runtime
+          .spawn(roomId: roomId, prompt: [const TextPart('Say hello.')]);
 
       final result = await session.awaitResult(
         timeout: const Duration(seconds: 60),
@@ -338,7 +346,7 @@ void main() {
       try {
         session = await runtime.spawn(
           roomId: roomId,
-          prompt: 'Tell me a very long story about dragons.',
+          prompt: [const TextPart('Tell me a very long story about dragons.')],
         );
       } on Object catch (e) {
         // Backend may drop connection under load — skip gracefully.
@@ -374,8 +382,10 @@ void main() {
     test('waitAll collects results from multiple sessions', () async {
       runtime = harness.createRuntime(loggerName: 'm6-waitall');
 
-      final s1 = await runtime.spawn(roomId: roomId, prompt: 'Say "alpha".');
-      final s2 = await runtime.spawn(roomId: roomId, prompt: 'Say "beta".');
+      final s1 = await runtime
+          .spawn(roomId: roomId, prompt: [const TextPart('Say "alpha".')]);
+      final s2 = await runtime
+          .spawn(roomId: roomId, prompt: [const TextPart('Say "beta".')]);
 
       final results = await runtime.waitAll(
         [

--- a/packages/soliplex_agent/test/runtime/agent_runtime_signal_test.dart
+++ b/packages/soliplex_agent/test/runtime/agent_runtime_signal_test.dart
@@ -121,7 +121,7 @@ void main() {
       final controller = StreamController<BaseEvent>();
       stubRunAgent(stream: controller.stream);
 
-      await runtime.spawn(roomId: _roomId, prompt: 'Hello');
+      await runtime.spawn(roomId: _roomId, prompt: [const TextPart('Hello')]);
 
       expect(runtime.sessions.value, hasLength(1));
 
@@ -137,7 +137,7 @@ void main() {
 
       final session = await runtime.spawn(
         roomId: _roomId,
-        prompt: 'Hello',
+        prompt: [const TextPart('Hello')],
         autoDispose: true,
       );
 
@@ -157,7 +157,7 @@ void main() {
       final controller = StreamController<BaseEvent>();
       stubRunAgent(stream: controller.stream);
 
-      await runtime.spawn(roomId: _roomId, prompt: 'Hello');
+      await runtime.spawn(roomId: _roomId, prompt: [const TextPart('Hello')]);
 
       expect(runtime.sessions.value, equals(runtime.activeSessions));
 
@@ -174,7 +174,7 @@ void main() {
       final streamEmissions = <int>[];
       runtime.sessionChanges.listen((list) => streamEmissions.add(list.length));
 
-      await runtime.spawn(roomId: _roomId, prompt: 'Hello');
+      await runtime.spawn(roomId: _roomId, prompt: [const TextPart('Hello')]);
 
       // Signal reflects spawn immediately
       expect(runtime.sessions.value, hasLength(1));
@@ -201,7 +201,8 @@ void main() {
       final captured = <String>[];
       await runZoned(
         () async {
-          final session = await runtime.spawn(roomId: _roomId, prompt: 'Hello');
+          final session = await runtime
+              .spawn(roomId: _roomId, prompt: [const TextPart('Hello')]);
           session.dispose();
           await Future<void>.delayed(const Duration(milliseconds: 10));
         },
@@ -231,7 +232,7 @@ void main() {
 
       final session = await runtime.spawn(
         roomId: _roomId,
-        prompt: 'Hello',
+        prompt: [const TextPart('Hello')],
         autoDispose: true,
       );
       expect(runtime.sessions.value, hasLength(1));

--- a/packages/soliplex_agent/test/runtime/agent_runtime_test.dart
+++ b/packages/soliplex_agent/test/runtime/agent_runtime_test.dart
@@ -194,7 +194,8 @@ void main() {
       stubDeleteThread();
       stubRunAgent(stream: Stream.fromIterable(_happyPathEvents()));
 
-      final session = await runtime.spawn(roomId: _roomId, prompt: 'Hello');
+      final session = await runtime
+          .spawn(roomId: _roomId, prompt: [const TextPart('Hello')]);
       final result = await session.result;
 
       expect(result, isA<AgentSuccess>());
@@ -212,7 +213,7 @@ void main() {
 
       final session = await runtime.spawn(
         roomId: _roomId,
-        prompt: 'Hello',
+        prompt: [const TextPart('Hello')],
         threadId: 'existing-thread',
       );
       final result = await session.result;
@@ -227,7 +228,8 @@ void main() {
       stubDeleteThread();
       stubRunAgent(stream: Stream.fromIterable(_happyPathEvents()));
 
-      final session = await runtime.spawn(roomId: _roomId, prompt: 'Hello');
+      final session = await runtime
+          .spawn(roomId: _roomId, prompt: [const TextPart('Hello')]);
 
       await session.result;
       // Should NOT call createRun because initialRunId was provided
@@ -266,7 +268,7 @@ void main() {
 
       final session = await runtime.spawn(
         roomId: _roomId,
-        prompt: 'Hello',
+        prompt: [const TextPart('Hello')],
       );
       await session.result;
 
@@ -306,7 +308,7 @@ void main() {
 
       final session = await runtime.spawn(
         roomId: _roomId,
-        prompt: 'Hello',
+        prompt: [const TextPart('Hello')],
         threadId: _threadId,
       );
       await session.result;
@@ -322,7 +324,8 @@ void main() {
       final controller = StreamController<BaseEvent>();
       stubRunAgent(stream: controller.stream);
 
-      final session = await runtime.spawn(roomId: _roomId, prompt: 'Hello');
+      final session = await runtime
+          .spawn(roomId: _roomId, prompt: [const TextPart('Hello')]);
 
       expect(runtime.activeSessions, contains(session));
 
@@ -367,7 +370,7 @@ void main() {
 
       final session = await runtime.spawn(
         roomId: _roomId,
-        prompt: 'Hello',
+        prompt: [const TextPart('Hello')],
         stateOverlay: {
           'rag': <String, dynamic>{
             'document_filter': "id = 'abc-123'",
@@ -400,7 +403,8 @@ void main() {
       final controller = StreamController<BaseEvent>();
       stubRunAgent(stream: controller.stream);
 
-      final session = await runtime.spawn(roomId: _roomId, prompt: 'Hello');
+      final session = await runtime
+          .spawn(roomId: _roomId, prompt: [const TextPart('Hello')]);
 
       final found = runtime.getSession(session.threadKey);
       expect(found, equals(session));
@@ -426,7 +430,11 @@ void main() {
       final emissions = <List<AgentSession>>[];
       runtime.sessionChanges.listen(emissions.add);
 
-      await runtime.spawn(roomId: _roomId, prompt: 'Hello', autoDispose: true);
+      await runtime.spawn(
+        roomId: _roomId,
+        prompt: [const TextPart('Hello')],
+        autoDispose: true,
+      );
 
       // Wait for session to complete and be cleaned up
       await Future<void>.delayed(const Duration(milliseconds: 50));
@@ -442,7 +450,8 @@ void main() {
       final controller = StreamController<BaseEvent>();
       stubRunAgent(stream: controller.stream);
 
-      final session = await runtime.spawn(roomId: _roomId, prompt: 'Hello');
+      final session = await runtime
+          .spawn(roomId: _roomId, prompt: [const TextPart('Hello')]);
 
       // Signal and getter agree after spawn
       expect(runtime.sessions.value, contains(session));
@@ -461,8 +470,10 @@ void main() {
       stubDeleteThread();
       stubRunAgent(stream: Stream.fromIterable(_happyPathEvents()));
 
-      final s1 = await runtime.spawn(roomId: _roomId, prompt: 'A');
-      final s2 = await runtime.spawn(roomId: _roomId, prompt: 'B');
+      final s1 =
+          await runtime.spawn(roomId: _roomId, prompt: [const TextPart('A')]);
+      final s2 =
+          await runtime.spawn(roomId: _roomId, prompt: [const TextPart('B')]);
 
       final results = await runtime.waitAll([s1, s2]);
 
@@ -478,8 +489,10 @@ void main() {
       stubDeleteThread();
       stubRunAgent(stream: Stream.fromIterable(_happyPathEvents()));
 
-      final s1 = await runtime.spawn(roomId: _roomId, prompt: 'A');
-      final s2 = await runtime.spawn(roomId: _roomId, prompt: 'B');
+      final s1 =
+          await runtime.spawn(roomId: _roomId, prompt: [const TextPart('A')]);
+      final s2 =
+          await runtime.spawn(roomId: _roomId, prompt: [const TextPart('B')]);
 
       final result = await runtime.waitAny([s1, s2]);
 
@@ -513,8 +526,10 @@ void main() {
             : _wrap(controllerB.stream);
       });
 
-      final sessionA = await runtime.spawn(roomId: _roomId, prompt: 'A');
-      final sessionB = await runtime.spawn(roomId: _roomId, prompt: 'B');
+      final sessionA =
+          await runtime.spawn(roomId: _roomId, prompt: [const TextPart('A')]);
+      final sessionB =
+          await runtime.spawn(roomId: _roomId, prompt: [const TextPart('B')]);
 
       expect(runtime.activeSessions, hasLength(2));
 
@@ -540,10 +555,11 @@ void main() {
       final controllerA = StreamController<BaseEvent>.broadcast();
       stubRunAgent(stream: controllerA.stream);
 
-      await runtime.spawn(roomId: _roomId, prompt: 'A');
+      await runtime.spawn(roomId: _roomId, prompt: [const TextPart('A')]);
       expect(runtime.pendingSpawnCount, 0);
 
-      final spawnFuture = runtime.spawn(roomId: _roomId, prompt: 'B');
+      final spawnFuture =
+          runtime.spawn(roomId: _roomId, prompt: [const TextPart('B')]);
       await Future<void>.delayed(Duration.zero);
       expect(runtime.pendingSpawnCount, 1);
 
@@ -576,11 +592,12 @@ void main() {
       final controller = StreamController<BaseEvent>.broadcast();
       stubRunAgent(stream: controller.stream);
 
-      await runtime.spawn(roomId: _roomId, prompt: 'A');
+      await runtime.spawn(roomId: _roomId, prompt: [const TextPart('A')]);
       expect(runtime.pendingSpawnCount, 0);
 
       // Second spawn should queue, not throw.
-      final spawnFuture = runtime.spawn(roomId: _roomId, prompt: 'B');
+      final spawnFuture =
+          runtime.spawn(roomId: _roomId, prompt: [const TextPart('B')]);
       // Let microtask run so _waitForSlot enqueues.
       await Future<void>.delayed(Duration.zero);
       expect(runtime.pendingSpawnCount, 1);
@@ -616,12 +633,13 @@ void main() {
       final controller = StreamController<BaseEvent>.broadcast();
       stubRunAgent(stream: controller.stream);
 
-      await runtime.spawn(roomId: _roomId, prompt: 'A');
+      await runtime.spawn(roomId: _roomId, prompt: [const TextPart('A')]);
 
       // Queue a second spawn and immediately attach an error handler
       // so the test zone doesn't see an unhandled rejection.
       Object? caught;
-      final spawnFuture = runtime.spawn(roomId: _roomId, prompt: 'B');
+      final spawnFuture =
+          runtime.spawn(roomId: _roomId, prompt: [const TextPart('B')]);
       unawaited(
         spawnFuture.then<void>((_) {}).catchError((Object e) {
           caught = e;
@@ -648,7 +666,8 @@ void main() {
       stubDeleteThread();
       stubRunAgent(stream: Stream.fromIterable(_happyPathEvents()));
 
-      final session = await runtime.spawn(roomId: _roomId, prompt: 'Root');
+      final session = await runtime
+          .spawn(roomId: _roomId, prompt: [const TextPart('Root')]);
 
       expect(session.depth, 0);
     });
@@ -663,7 +682,8 @@ void main() {
       stubRunAgent(stream: controller.stream);
 
       // Spawn a root at depth 0
-      final root = await runtime.spawn(roomId: _roomId, prompt: 'Root');
+      final root = await runtime
+          .spawn(roomId: _roomId, prompt: [const TextPart('Root')]);
       expect(root.depth, 0);
 
       // Now create a runtime with maxSpawnDepth=1 to test the guard
@@ -683,11 +703,16 @@ void main() {
       final controller2 = StreamController<BaseEvent>.broadcast();
       stubRunAgent(stream: controller2.stream);
 
-      final parent = await runtime.spawn(roomId: _roomId, prompt: 'Parent');
+      final parent = await runtime
+          .spawn(roomId: _roomId, prompt: [const TextPart('Parent')]);
       expect(parent.depth, 0);
 
       expect(
-        () => runtime.spawn(roomId: _roomId, prompt: 'Child', parent: parent),
+        () => runtime.spawn(
+          roomId: _roomId,
+          prompt: [const TextPart('Child')],
+          parent: parent,
+        ),
         throwsA(
           isA<StateError>().having(
             (e) => e.message,
@@ -721,12 +746,13 @@ void main() {
       final controller = StreamController<BaseEvent>.broadcast();
       stubRunAgent(stream: controller.stream);
 
-      final parent = await runtime.spawn(roomId: _roomId, prompt: 'Parent');
+      final parent = await runtime
+          .spawn(roomId: _roomId, prompt: [const TextPart('Parent')]);
 
       // Should not throw even with a parent at depth 0
       final child = await runtime.spawn(
         roomId: _roomId,
-        prompt: 'Child',
+        prompt: [const TextPart('Child')],
         parent: parent,
       );
       expect(child.depth, 1);
@@ -759,7 +785,8 @@ void main() {
         ..add(RunStartedEvent(threadId: _threadId, runId: _runId));
       stubRunAgent(stream: controller.stream);
 
-      final session = await runtime.spawn(roomId: _roomId, prompt: 'Slow');
+      final session = await runtime
+          .spawn(roomId: _roomId, prompt: [const TextPart('Slow')]);
 
       final result = await session.result;
 
@@ -787,7 +814,8 @@ void main() {
       stubDeleteThread();
       stubRunAgent(stream: Stream.fromIterable(_happyPathEvents()));
 
-      final session = await runtime.spawn(roomId: _roomId, prompt: 'Fast');
+      final session = await runtime
+          .spawn(roomId: _roomId, prompt: [const TextPart('Fast')]);
 
       final result = await session.result;
 
@@ -815,8 +843,13 @@ void main() {
         ..add(RunStartedEvent(threadId: _threadId, runId: _runId));
       stubRunAgent(stream: controller.stream);
 
-      final parent = await runtime.spawn(roomId: _roomId, prompt: 'Parent');
-      await runtime.spawn(roomId: _roomId, prompt: 'Child', parent: parent);
+      final parent = await runtime
+          .spawn(roomId: _roomId, prompt: [const TextPart('Parent')]);
+      await runtime.spawn(
+        roomId: _roomId,
+        prompt: [const TextPart('Child')],
+        parent: parent,
+      );
 
       // Wait past the rootTimeout — only parent should be cancelled,
       // but since child is a child of parent, it gets cascaded
@@ -836,7 +869,7 @@ void main() {
 
       final session = await runtime.spawn(
         roomId: _roomId,
-        prompt: 'Hello',
+        prompt: [const TextPart('Hello')],
         ephemeral: true,
         autoDispose: true,
       );
@@ -854,7 +887,7 @@ void main() {
 
       final session = await runtime.spawn(
         roomId: _roomId,
-        prompt: 'Hello',
+        prompt: [const TextPart('Hello')],
         threadId: 'existing',
       );
 
@@ -873,8 +906,10 @@ void main() {
       final controller = StreamController<BaseEvent>.broadcast();
       stubRunAgent(stream: controller.stream);
 
-      final s1 = await runtime.spawn(roomId: _roomId, prompt: 'A');
-      final s2 = await runtime.spawn(roomId: _roomId, prompt: 'B');
+      final s1 =
+          await runtime.spawn(roomId: _roomId, prompt: [const TextPart('A')]);
+      final s2 =
+          await runtime.spawn(roomId: _roomId, prompt: [const TextPart('B')]);
 
       controller.add(RunStartedEvent(threadId: _threadId, runId: _runId));
       await Future<void>.delayed(Duration.zero);
@@ -896,7 +931,7 @@ void main() {
       await runtime.dispose();
 
       expect(
-        () => runtime.spawn(roomId: _roomId, prompt: 'Hello'),
+        () => runtime.spawn(roomId: _roomId, prompt: [const TextPart('Hello')]),
         throwsA(
           isA<StateError>().having(
             (e) => e.message,
@@ -914,7 +949,11 @@ void main() {
       final controller = StreamController<BaseEvent>.broadcast();
       stubRunAgent(stream: controller.stream);
 
-      await runtime.spawn(roomId: _roomId, prompt: 'A', ephemeral: true);
+      await runtime.spawn(
+        roomId: _roomId,
+        prompt: [const TextPart('A')],
+        ephemeral: true,
+      );
       controller.add(RunStartedEvent(threadId: _threadId, runId: _runId));
       await Future<void>.delayed(Duration.zero);
 
@@ -933,7 +972,7 @@ void main() {
       ).thenThrow(const AuthException(message: 'Token expired'));
 
       expect(
-        () => runtime.spawn(roomId: _roomId, prompt: 'Hello'),
+        () => runtime.spawn(roomId: _roomId, prompt: [const TextPart('Hello')]),
         throwsA(isA<AuthException>()),
       );
     });
@@ -945,7 +984,7 @@ void main() {
       stubCreateThread();
 
       expect(
-        () => runtime.spawn(roomId: _roomId, prompt: 'Hello'),
+        () => runtime.spawn(roomId: _roomId, prompt: [const TextPart('Hello')]),
         throwsA(isA<StateError>()),
       );
     });
@@ -970,7 +1009,7 @@ void main() {
 
       final s1 = await runtime.spawn(
         roomId: _roomId,
-        prompt: 'Hello',
+        prompt: [const TextPart('Hello')],
         threadId: 'thread-fail',
       );
 
@@ -1025,7 +1064,7 @@ void main() {
 
       final s2 = await runtime.spawn(
         roomId: _roomId,
-        prompt: 'Retry',
+        prompt: [const TextPart('Retry')],
         threadId: 'thread-fail',
       );
       await s2.result;
@@ -1054,7 +1093,11 @@ void main() {
       stubDeleteThread();
 
       await expectLater(
-        () => runtime.spawn(roomId: _roomId, prompt: 'Hello', ephemeral: true),
+        () => runtime.spawn(
+          roomId: _roomId,
+          prompt: [const TextPart('Hello')],
+          ephemeral: true,
+        ),
         throwsA(
           isA<StateError>().having(
             (e) => e.message,
@@ -1087,7 +1130,7 @@ void main() {
 
       // First spawn fails
       await expectLater(
-        () => runtime.spawn(roomId: _roomId, prompt: 'A'),
+        () => runtime.spawn(roomId: _roomId, prompt: [const TextPart('A')]),
         throwsA(isA<StateError>()),
       );
 
@@ -1095,7 +1138,7 @@ void main() {
       // It will still fail from the throwing extension, but the error
       // must be the extension error, not a concurrency guard error.
       await expectLater(
-        () => runtime.spawn(roomId: _roomId, prompt: 'B'),
+        () => runtime.spawn(roomId: _roomId, prompt: [const TextPart('B')]),
         throwsA(
           isA<StateError>().having(
             (e) => e.message,
@@ -1132,7 +1175,8 @@ void main() {
             : _wrap(Stream.fromIterable(_resumeTextEvents()));
       });
 
-      final session = await runtime.spawn(roomId: _roomId, prompt: 'Weather?');
+      final session = await runtime
+          .spawn(roomId: _roomId, prompt: [const TextPart('Weather?')]);
       final result = await session.result;
 
       expect(result, isA<AgentSuccess>());
@@ -1201,7 +1245,8 @@ void main() {
             : _wrap(Stream.fromIterable(_resumeTextEvents()));
       });
 
-      final session = await runtime.spawn(roomId: _roomId, prompt: 'Run code');
+      final session = await runtime
+          .spawn(roomId: _roomId, prompt: [const TextPart('Run code')]);
       final result = await session.result;
 
       expect(result, isA<AgentSuccess>());
@@ -1216,7 +1261,8 @@ void main() {
       stubDeleteThread();
       stubRunAgent(stream: Stream.fromIterable(_happyPathEvents()));
 
-      final session = await runtime.spawn(roomId: _roomId, prompt: 'Hello');
+      final session = await runtime
+          .spawn(roomId: _roomId, prompt: [const TextPart('Hello')]);
       final result = await session.result;
 
       expect(result, isA<AgentSuccess>());
@@ -1238,7 +1284,7 @@ void main() {
       stubCreateThread();
 
       expect(
-        () => runtime.spawn(roomId: _roomId, prompt: 'Hello'),
+        () => runtime.spawn(roomId: _roomId, prompt: [const TextPart('Hello')]),
         throwsA(
           isA<StateError>().having(
             (e) => e.message,
@@ -1271,7 +1317,7 @@ void main() {
       stubDeleteThread();
       stubRunAgent(stream: Stream.fromIterable(_happyPathEvents()));
 
-      await runtime.spawn(roomId: _roomId, prompt: 'Hello');
+      await runtime.spawn(roomId: _roomId, prompt: [const TextPart('Hello')]);
 
       expect(factoryCalled, isTrue);
     });
@@ -1299,7 +1345,8 @@ void main() {
       stubDeleteThread();
       stubRunAgent(stream: Stream.fromIterable(_happyPathEvents()));
 
-      final session = await runtime.spawn(roomId: _roomId, prompt: 'Hello');
+      final session = await runtime
+          .spawn(roomId: _roomId, prompt: [const TextPart('Hello')]);
 
       expect(session.threadKey.serverId, equals('staging.soliplex.io'));
       await session.result;
@@ -1339,7 +1386,8 @@ void main() {
       stubDeleteThread();
       stubRunAgent(stream: Stream.fromIterable(_happyPathEvents()));
 
-      final session = await runtime.spawn(roomId: _roomId, prompt: 'Hello');
+      final session = await runtime
+          .spawn(roomId: _roomId, prompt: [const TextPart('Hello')]);
 
       expect(session.threadKey.serverId, equals('prod'));
       await session.result;
@@ -1354,7 +1402,8 @@ void main() {
       stubRunAgent(stream: Stream.fromIterable(_happyPathEvents()));
 
       // Turn 1.
-      final s1 = await runtime.spawn(roomId: _roomId, prompt: 'Hello');
+      final s1 = await runtime
+          .spawn(roomId: _roomId, prompt: [const TextPart('Hello')]);
       await s1.result;
 
       // Stub a second run on the same thread.
@@ -1364,7 +1413,7 @@ void main() {
       // Turn 2 — same thread, runtime should auto-inject history.
       final s2 = await runtime.spawn(
         roomId: _roomId,
-        prompt: 'Follow up',
+        prompt: [const TextPart('Follow up')],
         threadId: s1.threadKey.threadId,
       );
       await s2.result;
@@ -1401,7 +1450,8 @@ void main() {
       stubDeleteThread();
       stubRunAgent(stream: Stream.fromIterable(_happyPathEvents()));
 
-      final session = await runtime.spawn(roomId: _roomId, prompt: 'Hello');
+      final session = await runtime
+          .spawn(roomId: _roomId, prompt: [const TextPart('Hello')]);
       await session.result;
 
       final captured = verify(
@@ -1428,7 +1478,7 @@ void main() {
 
       final s1 = await runtime.spawn(
         roomId: _roomId,
-        prompt: 'Ephemeral',
+        prompt: [const TextPart('Ephemeral')],
         ephemeral: true,
       );
       await s1.result;
@@ -1439,7 +1489,7 @@ void main() {
 
       final s2 = await runtime.spawn(
         roomId: _roomId,
-        prompt: 'Another',
+        prompt: [const TextPart('Another')],
         threadId: s1.threadKey.threadId,
       );
       await s2.result;
@@ -1494,7 +1544,8 @@ void main() {
       stubDeleteThread();
       stubRunAgent(stream: Stream.fromIterable(_happyPathEvents()));
 
-      final session = await runtime.spawn(roomId: _roomId, prompt: 'hi');
+      final session =
+          await runtime.spawn(roomId: _roomId, prompt: [const TextPart('hi')]);
 
       expect(session.threadKey.serverId, equals('prod'));
 

--- a/packages/soliplex_agent/test/runtime/agent_session_signal_test.dart
+++ b/packages/soliplex_agent/test/runtime/agent_session_signal_test.dart
@@ -141,7 +141,7 @@ void main() {
       );
       addTearDown(session.dispose);
 
-      await session.start(userMessage: 'Hi');
+      await session.start(userMessage: [const TextPart('Hi')]);
       await session.result;
 
       expect(session.runState.value, isA<CompletedState>());
@@ -163,7 +163,7 @@ void main() {
       );
       addTearDown(session.dispose);
 
-      await session.start(userMessage: 'Hi');
+      await session.start(userMessage: [const TextPart('Hi')]);
       await session.result;
 
       expect(session.runState.value, isA<FailedState>());
@@ -181,7 +181,7 @@ void main() {
       );
       addTearDown(session.dispose);
 
-      await session.start(userMessage: 'Hi');
+      await session.start(userMessage: [const TextPart('Hi')]);
       controller.add(
         RunStartedEvent(threadId: 'thread-1', runId: _runId),
       );
@@ -223,7 +223,7 @@ void main() {
 
       expect(session.sessionState.value, equals(AgentSessionState.spawning));
 
-      await session.start(userMessage: 'Hi');
+      await session.start(userMessage: [const TextPart('Hi')]);
       controller.add(
         RunStartedEvent(threadId: 'thread-1', runId: _runId),
       );
@@ -253,7 +253,7 @@ void main() {
       );
       addTearDown(session.dispose);
 
-      await session.start(userMessage: 'Hi');
+      await session.start(userMessage: [const TextPart('Hi')]);
       await session.result;
 
       expect(session.sessionState.value, equals(AgentSessionState.failed));
@@ -271,7 +271,7 @@ void main() {
       );
       addTearDown(session.dispose);
 
-      await session.start(userMessage: 'Hi');
+      await session.start(userMessage: [const TextPart('Hi')]);
       controller.add(
         RunStartedEvent(threadId: 'thread-1', runId: _runId),
       );
@@ -323,7 +323,7 @@ void main() {
       );
       addTearDown(session.dispose);
 
-      await session.start(userMessage: 'Hi');
+      await session.start(userMessage: [const TextPart('Hi')]);
       await session.result;
 
       final state = session.agentState.value;
@@ -365,7 +365,7 @@ void main() {
       );
       addTearDown(session.dispose);
 
-      await session.start(userMessage: 'Hi');
+      await session.start(userMessage: [const TextPart('Hi')]);
       await session.result;
 
       final ui = session.agentState.value['ui']! as Map<dynamic, dynamic>;

--- a/packages/soliplex_agent/test/runtime/agent_session_test.dart
+++ b/packages/soliplex_agent/test/runtime/agent_session_test.dart
@@ -219,7 +219,7 @@ void main() {
       );
       addTearDown(session.dispose);
 
-      await session.start(userMessage: 'Hi');
+      await session.start(userMessage: [const TextPart('Hi')]);
       final result = await session.result;
 
       expect(result, isA<AgentSuccess>());
@@ -246,7 +246,7 @@ void main() {
       expect(session.sessionState.value, equals(AgentSessionState.spawning));
       expect(session.runState.value, isA<IdleState>());
 
-      await session.start(userMessage: 'Hi');
+      await session.start(userMessage: [const TextPart('Hi')]);
       controller.add(
         RunStartedEvent(threadId: 'thread-1', runId: _runId),
       );
@@ -294,7 +294,7 @@ void main() {
       );
       addTearDown(session.dispose);
 
-      await session.start(userMessage: 'Weather?');
+      await session.start(userMessage: [const TextPart('Weather?')]);
       final result = await session.result;
 
       expect(result, isA<AgentSuccess>());
@@ -331,7 +331,7 @@ void main() {
       );
       addTearDown(session.dispose);
 
-      await session.start(userMessage: 'Weather?');
+      await session.start(userMessage: [const TextPart('Weather?')]);
       final result = await session.result;
 
       expect(result, isA<AgentSuccess>());
@@ -368,7 +368,7 @@ void main() {
       );
       addTearDown(session.dispose);
 
-      await session.start(userMessage: 'Weather?');
+      await session.start(userMessage: [const TextPart('Weather?')]);
       final result = await session.result;
 
       expect(result, isA<AgentSuccess>());
@@ -388,7 +388,7 @@ void main() {
       );
       addTearDown(session.dispose);
 
-      await session.start(userMessage: 'Hi');
+      await session.start(userMessage: [const TextPart('Hi')]);
       controller.add(
         RunStartedEvent(threadId: 'thread-1', runId: _runId),
       );
@@ -416,7 +416,7 @@ void main() {
       );
       addTearDown(session.dispose);
 
-      await session.start(userMessage: 'Hi');
+      await session.start(userMessage: [const TextPart('Hi')]);
       await session.result;
 
       expect(session.state, equals(AgentSessionState.completed));
@@ -442,7 +442,7 @@ void main() {
       );
       addTearDown(session.dispose);
 
-      await session.start(userMessage: 'Hi');
+      await session.start(userMessage: [const TextPart('Hi')]);
       final result = await session.result;
 
       expect(result, isA<AgentFailure>());
@@ -468,7 +468,7 @@ void main() {
         await controller.close();
       });
 
-      await session.start(userMessage: 'Hi');
+      await session.start(userMessage: [const TextPart('Hi')]);
       controller.add(
         RunStartedEvent(threadId: 'thread-1', runId: _runId),
       );
@@ -494,7 +494,7 @@ void main() {
         logger: logger,
       );
 
-      await session.start(userMessage: 'Hi');
+      await session.start(userMessage: [const TextPart('Hi')]);
       session.dispose();
 
       final result = await session.result;
@@ -551,7 +551,7 @@ void main() {
       final states = <RunState>[];
       session.stateChanges.listen(states.add);
 
-      await session.start(userMessage: 'Hi');
+      await session.start(userMessage: [const TextPart('Hi')]);
       await session.result;
 
       expect(states, isNotEmpty);
@@ -575,7 +575,7 @@ void main() {
       session.stateChanges.listen(states1.add);
       session.stateChanges.listen(states2.add);
 
-      await session.start(userMessage: 'Hi');
+      await session.start(userMessage: [const TextPart('Hi')]);
       await session.result;
 
       expect(states1, isNotEmpty);
@@ -603,7 +603,7 @@ void main() {
         }
       });
 
-      await session.start(userMessage: 'Hi');
+      await session.start(userMessage: [const TextPart('Hi')]);
       await session.result;
 
       expect(streamingTexts, contains('Hello world'));
@@ -624,7 +624,7 @@ void main() {
       );
       addTearDown(session.dispose);
 
-      await session.start(userMessage: 'Hi');
+      await session.start(userMessage: [const TextPart('Hi')]);
       await session.result;
 
       expect(ext.attachCount, equals(1));
@@ -677,7 +677,7 @@ void main() {
       );
       addTearDown(session.dispose);
 
-      await session.start(userMessage: 'Run ext tool');
+      await session.start(userMessage: [const TextPart('Run ext tool')]);
       final result = await session.result;
 
       expect(result, isA<AgentSuccess>());
@@ -829,7 +829,7 @@ void main() {
           if (val != null) events.add(val);
         });
 
-        await session.start(userMessage: 'Weather?');
+        await session.start(userMessage: [const TextPart('Weather?')]);
         await session.result;
 
         final executing = events.whereType<ClientToolExecuting>().toList();
@@ -877,7 +877,7 @@ void main() {
         if (val != null) events.add(val);
       });
 
-      await session.start(userMessage: 'Weather?');
+      await session.start(userMessage: [const TextPart('Weather?')]);
       await session.result;
 
       final completed = events.whereType<ClientToolCompleted>().toList();
@@ -922,7 +922,7 @@ void main() {
         if (val != null) events.add(val);
       });
 
-      await session.start(userMessage: 'Weather?');
+      await session.start(userMessage: [const TextPart('Weather?')]);
       await session.result;
 
       final completed = events.whereType<ClientToolCompleted>().toList();
@@ -974,7 +974,7 @@ void main() {
         if (val != null) events.add(val);
       });
 
-      await session.start(userMessage: 'Hi');
+      await session.start(userMessage: [const TextPart('Hi')]);
       await session.result;
 
       final snapshots = events.whereType<ActivitySnapshot>().toList();
@@ -1009,7 +1009,7 @@ void main() {
         if (val != null) events.add(val);
       });
 
-      await session.start(userMessage: 'Hi');
+      await session.start(userMessage: [const TextPart('Hi')]);
       await session.result;
 
       final steps = events.whereType<StepProgress>().toList();

--- a/packages/soliplex_agent/test/runtime/concurrency_experiments_test.dart
+++ b/packages/soliplex_agent/test/runtime/concurrency_experiments_test.dart
@@ -259,8 +259,10 @@ void main() {
             : _wrap(controllerB.stream);
       });
 
-      final sessionA = await runtime.spawn(roomId: _roomId, prompt: 'A');
-      final sessionB = await runtime.spawn(roomId: _roomId, prompt: 'B');
+      final sessionA =
+          await runtime.spawn(roomId: _roomId, prompt: [const TextPart('A')]);
+      final sessionB =
+          await runtime.spawn(roomId: _roomId, prompt: [const TextPart('B')]);
 
       expect(runtime.activeSessions, hasLength(2));
 
@@ -305,8 +307,10 @@ void main() {
             : _wrap(controllerB.stream);
       });
 
-      final sessionA = await runtime.spawn(roomId: _roomId, prompt: 'A');
-      final sessionB = await runtime.spawn(roomId: _roomId, prompt: 'B');
+      final sessionA =
+          await runtime.spawn(roomId: _roomId, prompt: [const TextPart('A')]);
+      final sessionB =
+          await runtime.spawn(roomId: _roomId, prompt: [const TextPart('B')]);
 
       expect(runtime.activeSessions, hasLength(2));
 
@@ -335,10 +339,11 @@ void main() {
       final controllerA = StreamController<BaseEvent>.broadcast();
       stubRunAgent(stream: controllerA.stream);
 
-      await runtime.spawn(roomId: _roomId, prompt: 'A');
+      await runtime.spawn(roomId: _roomId, prompt: [const TextPart('A')]);
       expect(runtime.pendingSpawnCount, 0);
 
-      final spawnFuture = runtime.spawn(roomId: _roomId, prompt: 'B');
+      final spawnFuture =
+          runtime.spawn(roomId: _roomId, prompt: [const TextPart('B')]);
       await Future<void>.delayed(Duration.zero);
       expect(runtime.pendingSpawnCount, 1);
 
@@ -368,14 +373,16 @@ void main() {
       stubDeleteThread();
       stubRunAgent(stream: Stream.fromIterable(_happyPathEvents()));
 
-      final sessionA = await runtime.spawn(roomId: _roomId, prompt: 'A');
+      final sessionA =
+          await runtime.spawn(roomId: _roomId, prompt: [const TextPart('A')]);
       await sessionA.result;
 
       // Fresh stubs for second spawn.
       stubCreateRun();
       stubRunAgent(stream: Stream.fromIterable(_happyPathEvents()));
 
-      final sessionB = await runtime.spawn(roomId: _roomId, prompt: 'B');
+      final sessionB =
+          await runtime.spawn(roomId: _roomId, prompt: [const TextPart('B')]);
       final resultB = await sessionB.result;
       expect(resultB, isA<AgentSuccess>());
     });
@@ -410,14 +417,15 @@ void main() {
       final sessions = <AgentSession>[];
       for (var i = 0; i < limit; i++) {
         sessions.add(
-          await runtime.spawn(roomId: _roomId, prompt: 'Task $i'),
+          await runtime.spawn(roomId: _roomId, prompt: [TextPart('Task $i')]),
         );
       }
 
       // Fire remaining — they queue.
       final queuedFutures = <Future<AgentSession>>[];
       for (var i = limit; i < n; i++) {
-        queuedFutures.add(runtime.spawn(roomId: _roomId, prompt: 'Task $i'));
+        queuedFutures
+            .add(runtime.spawn(roomId: _roomId, prompt: [TextPart('Task $i')]));
       }
       await Future<void>.delayed(Duration.zero);
       expect(runtime.pendingSpawnCount, n - limit);
@@ -475,7 +483,8 @@ void main() {
         stream: Stream.fromIterable(_toolCallEvents(toolName: 'delegate')),
       );
 
-      final parent = await runtime.spawn(roomId: _roomId, prompt: 'Delegate');
+      final parent = await runtime
+          .spawn(roomId: _roomId, prompt: [const TextPart('Delegate')]);
 
       // Deadlock: parent holds slot → tool calls delegateTask → spawnChild
       // → _waitForSlot queues → parent waits for child → child waits for
@@ -500,10 +509,11 @@ void main() {
       final controller = StreamController<BaseEvent>.broadcast();
       stubRunAgent(stream: controller.stream);
 
-      await runtime.spawn(roomId: _roomId, prompt: 'A');
+      await runtime.spawn(roomId: _roomId, prompt: [const TextPart('A')]);
 
       Object? caught;
-      final spawnFuture = runtime.spawn(roomId: _roomId, prompt: 'B');
+      final spawnFuture =
+          runtime.spawn(roomId: _roomId, prompt: [const TextPart('B')]);
       unawaited(
         spawnFuture.then<void>((_) {}).catchError((Object e) {
           caught = e;
@@ -531,10 +541,11 @@ void main() {
       final controller = StreamController<BaseEvent>.broadcast();
       stubRunAgent(stream: controller.stream);
 
-      await runtime.spawn(roomId: _roomId, prompt: 'A');
+      await runtime.spawn(roomId: _roomId, prompt: [const TextPart('A')]);
 
       Object? caught;
-      final spawnFuture = runtime.spawn(roomId: _roomId, prompt: 'B');
+      final spawnFuture =
+          runtime.spawn(roomId: _roomId, prompt: [const TextPart('B')]);
       unawaited(
         spawnFuture.then<void>((_) {}).catchError((Object e) {
           caught = e;
@@ -587,12 +598,14 @@ void main() {
       });
 
       // Fill slots with slow sessions.
-      await runtime.spawn(roomId: _roomId, prompt: 'Slow A');
-      await runtime.spawn(roomId: _roomId, prompt: 'Slow B');
+      await runtime.spawn(roomId: _roomId, prompt: [const TextPart('Slow A')]);
+      await runtime.spawn(roomId: _roomId, prompt: [const TextPart('Slow B')]);
 
       // Queue fast sessions.
-      final futureC = runtime.spawn(roomId: _roomId, prompt: 'Fast C');
-      final futureD = runtime.spawn(roomId: _roomId, prompt: 'Fast D');
+      final futureC =
+          runtime.spawn(roomId: _roomId, prompt: [const TextPart('Fast C')]);
+      final futureD =
+          runtime.spawn(roomId: _roomId, prompt: [const TextPart('Fast D')]);
       await Future<void>.delayed(Duration.zero);
       expect(runtime.pendingSpawnCount, 2);
 
@@ -656,8 +669,10 @@ void main() {
             : _wrap(Stream.fromIterable(_resumeTextEvents()));
       });
 
-      final sessionA = await runtime.spawn(roomId: _roomId, prompt: 'A');
-      final sessionB = await runtime.spawn(roomId: _roomId, prompt: 'B');
+      final sessionA =
+          await runtime.spawn(roomId: _roomId, prompt: [const TextPart('A')]);
+      final sessionB =
+          await runtime.spawn(roomId: _roomId, prompt: [const TextPart('B')]);
 
       final resultA = await sessionA.result;
       final resultB = await sessionB.result;
@@ -720,8 +735,10 @@ void main() {
       });
 
       final sw = Stopwatch()..start();
-      final sessionA = await runtime.spawn(roomId: _roomId, prompt: 'A');
-      final sessionB = await runtime.spawn(roomId: _roomId, prompt: 'B');
+      final sessionA =
+          await runtime.spawn(roomId: _roomId, prompt: [const TextPart('A')]);
+      final sessionB =
+          await runtime.spawn(roomId: _roomId, prompt: [const TextPart('B')]);
 
       final resultA = await sessionA.result;
       final resultB = await sessionB.result;
@@ -778,9 +795,10 @@ void main() {
             : _wrap(controllerB.stream);
       });
 
-      await runtime.spawn(roomId: _roomId, prompt: 'With bridge');
-      final sessionB =
-          await runtime.spawn(roomId: _roomId, prompt: 'HTTP only');
+      await runtime
+          .spawn(roomId: _roomId, prompt: [const TextPart('With bridge')]);
+      final sessionB = await runtime
+          .spawn(roomId: _roomId, prompt: [const TextPart('HTTP only')]);
 
       _happyPathEvents().forEach(controllerA.add);
       _happyPathEvents().forEach(controllerB.add);
@@ -831,8 +849,10 @@ void main() {
       });
 
       // Await first spawn to ensure tracking before queuing.
-      final sessionA = await runtime.spawn(roomId: _roomId, prompt: 'A');
-      final futureB = runtime.spawn(roomId: _roomId, prompt: 'B');
+      final sessionA =
+          await runtime.spawn(roomId: _roomId, prompt: [const TextPart('A')]);
+      final futureB =
+          runtime.spawn(roomId: _roomId, prompt: [const TextPart('B')]);
 
       final sessionB = await futureB;
 
@@ -897,7 +917,7 @@ void main() {
       final sessions = <AgentSession>[];
       for (var i = 0; i < n; i++) {
         sessions.add(
-          await runtime.spawn(roomId: _roomId, prompt: 'Task $i'),
+          await runtime.spawn(roomId: _roomId, prompt: [TextPart('Task $i')]),
         );
       }
 
@@ -967,7 +987,7 @@ void main() {
       final sessions = <AgentSession>[];
       for (var i = 0; i < n; i++) {
         sessions.add(
-          await runtime.spawn(roomId: _roomId, prompt: 'Task $i'),
+          await runtime.spawn(roomId: _roomId, prompt: [TextPart('Task $i')]),
         );
       }
 

--- a/packages/soliplex_agent/test/runtime/multi_server_runtime_test.dart
+++ b/packages/soliplex_agent/test/runtime/multi_server_runtime_test.dart
@@ -168,7 +168,7 @@ void main() {
       final session = await msr.spawn(
         serverId: 'prod',
         roomId: _roomId,
-        prompt: 'Hello',
+        prompt: [const TextPart('Hello')],
       );
 
       expect(session.threadKey.serverId, equals('prod'));
@@ -182,12 +182,12 @@ void main() {
       final s1 = await msr.spawn(
         serverId: 'prod',
         roomId: _roomId,
-        prompt: 'A',
+        prompt: [const TextPart('A')],
       );
       final s2 = await msr.spawn(
         serverId: 'staging',
         roomId: _roomId,
-        prompt: 'B',
+        prompt: [const TextPart('B')],
       );
 
       expect(s1.threadKey.serverId, equals('prod'));
@@ -209,7 +209,7 @@ void main() {
       final session = await msr.spawn(
         serverId: 'prod',
         roomId: _roomId,
-        prompt: 'Hello',
+        prompt: [const TextPart('Hello')],
       );
 
       final found = msr.getSession(session.threadKey);
@@ -234,7 +234,7 @@ void main() {
       final session = await msr.spawn(
         serverId: 'prod',
         roomId: _roomId,
-        prompt: 'Hello',
+        prompt: [const TextPart('Hello')],
       );
 
       // Look on staging — should not find it.
@@ -261,7 +261,11 @@ void main() {
         stream: controller.stream,
       );
 
-      await msr.spawn(serverId: 'prod', roomId: _roomId, prompt: 'Hello');
+      await msr.spawn(
+        serverId: 'prod',
+        roomId: _roomId,
+        prompt: [const TextPart('Hello')],
+      );
 
       const unknownKey = (
         serverId: 'prod',
@@ -304,13 +308,13 @@ void main() {
       await msr.spawn(
         serverId: 'prod',
         roomId: _roomId,
-        prompt: 'A',
+        prompt: [const TextPart('A')],
         autoDispose: true,
       );
       await msr.spawn(
         serverId: 'staging',
         roomId: _roomId,
-        prompt: 'B',
+        prompt: [const TextPart('B')],
         autoDispose: true,
       );
 
@@ -341,12 +345,12 @@ void main() {
       final s1 = await msr.spawn(
         serverId: 'prod',
         roomId: _roomId,
-        prompt: 'A',
+        prompt: [const TextPart('A')],
       );
       final s2 = await msr.spawn(
         serverId: 'staging',
         roomId: _roomId,
-        prompt: 'B',
+        prompt: [const TextPart('B')],
       );
 
       final results = await msr.waitAll([s1, s2]);
@@ -362,12 +366,12 @@ void main() {
       final s1 = await msr.spawn(
         serverId: 'prod',
         roomId: _roomId,
-        prompt: 'A',
+        prompt: [const TextPart('A')],
       );
       final s2 = await msr.spawn(
         serverId: 'staging',
         roomId: _roomId,
-        prompt: 'B',
+        prompt: [const TextPart('B')],
       );
 
       final result = await msr.waitAny([s1, s2]);
@@ -418,12 +422,12 @@ void main() {
       final s1 = await msr.spawn(
         serverId: 'prod',
         roomId: _roomId,
-        prompt: 'A',
+        prompt: [const TextPart('A')],
       );
       final s2 = await msr.spawn(
         serverId: 'staging',
         roomId: _roomId,
-        prompt: 'B',
+        prompt: [const TextPart('B')],
       );
 
       // Let runs start.
@@ -448,7 +452,11 @@ void main() {
     test('dispose cleans up all runtimes', () async {
       _stubHappyPath(prod.api, prod.agUi, threadId: 'prod-t1');
 
-      await msr.spawn(serverId: 'prod', roomId: _roomId, prompt: 'A');
+      await msr.spawn(
+        serverId: 'prod',
+        roomId: _roomId,
+        prompt: [const TextPart('A')],
+      );
 
       await msr.dispose();
 
@@ -464,7 +472,11 @@ void main() {
     test('concurrent dispose is safe', () async {
       _stubHappyPath(prod.api, prod.agUi, threadId: 'prod-t1');
 
-      await msr.spawn(serverId: 'prod', roomId: _roomId, prompt: 'A');
+      await msr.spawn(
+        serverId: 'prod',
+        roomId: _roomId,
+        prompt: [const TextPart('A')],
+      );
 
       // Two concurrent disposes should not throw.
       await Future.wait([msr.dispose(), msr.dispose()]);

--- a/packages/soliplex_agent/test/runtime/session_children_test.dart
+++ b/packages/soliplex_agent/test/runtime/session_children_test.dart
@@ -124,10 +124,11 @@ void main() {
       final controller = StreamController<BaseEvent>.broadcast();
       stubRunAgent(stream: controller.stream);
 
-      final parent = await runtime.spawn(roomId: _roomA, prompt: 'Hello');
+      final parent = await runtime
+          .spawn(roomId: _roomA, prompt: [const TextPart('Hello')]);
       final child = await runtime.spawn(
         roomId: _roomA,
-        prompt: 'Sub-task',
+        prompt: [const TextPart('Sub-task')],
         parent: parent,
       );
 
@@ -149,7 +150,8 @@ void main() {
       final controller = StreamController<BaseEvent>.broadcast();
       stubRunAgent(stream: controller.stream);
 
-      final parent = await runtime.spawn(roomId: _roomA, prompt: 'Hello');
+      final parent = await runtime
+          .spawn(roomId: _roomA, prompt: [const TextPart('Hello')]);
       final child = await parent.spawnChild(roomId: _roomA, prompt: 'Sub-task');
 
       expect(parent.children, contains(child));
@@ -167,7 +169,8 @@ void main() {
 
       // Parent on _roomB so a regression that hardcodes _roomA in
       // spawnChild's defaulting wouldn't pass.
-      final parent = await runtime.spawn(roomId: _roomB, prompt: 'Hello');
+      final parent = await runtime
+          .spawn(roomId: _roomB, prompt: [const TextPart('Hello')]);
       final child = await parent.spawnChild(prompt: 'Sub-task');
 
       expect(child.threadKey.roomId, equals(_roomB));
@@ -184,10 +187,11 @@ void main() {
       final controller = StreamController<BaseEvent>.broadcast();
       stubRunAgent(stream: controller.stream);
 
-      final parent = await runtime.spawn(roomId: _roomA, prompt: 'Hello');
+      final parent = await runtime
+          .spawn(roomId: _roomA, prompt: [const TextPart('Hello')]);
       final child = await runtime.spawn(
         roomId: _roomA,
-        prompt: 'Sub-task',
+        prompt: [const TextPart('Sub-task')],
         parent: parent,
       );
 
@@ -221,10 +225,11 @@ void main() {
       final controller = StreamController<BaseEvent>.broadcast();
       stubRunAgent(stream: controller.stream);
 
-      final parent = await runtime.spawn(roomId: _roomA, prompt: 'Hello');
+      final parent = await runtime
+          .spawn(roomId: _roomA, prompt: [const TextPart('Hello')]);
       final child = await runtime.spawn(
         roomId: _roomA,
-        prompt: 'Sub-task',
+        prompt: [const TextPart('Sub-task')],
         parent: parent,
       );
 
@@ -265,10 +270,11 @@ void main() {
             : _wrap(Stream.fromIterable(_happyPathEvents()));
       });
 
-      final parent = await runtime.spawn(roomId: _roomA, prompt: 'Hello');
+      final parent = await runtime
+          .spawn(roomId: _roomA, prompt: [const TextPart('Hello')]);
       final child = await runtime.spawn(
         roomId: _roomA,
-        prompt: 'Sub-task',
+        prompt: [const TextPart('Sub-task')],
         parent: parent,
       );
 
@@ -293,8 +299,13 @@ void main() {
       final controller = StreamController<BaseEvent>.broadcast();
       stubRunAgent(stream: controller.stream);
 
-      final parent = await runtime.spawn(roomId: _roomA, prompt: 'Hello');
-      await runtime.spawn(roomId: _roomA, prompt: 'Sub-task', parent: parent);
+      final parent = await runtime
+          .spawn(roomId: _roomA, prompt: [const TextPart('Hello')]);
+      await runtime.spawn(
+        roomId: _roomA,
+        prompt: [const TextPart('Sub-task')],
+        parent: parent,
+      );
 
       controller.add(RunStartedEvent(threadId: _threadId, runId: _runId));
       await Future<void>.delayed(Duration.zero);
@@ -317,10 +328,11 @@ void main() {
       final controller = StreamController<BaseEvent>.broadcast();
       stubRunAgent(stream: controller.stream);
 
-      final parent = await runtime.spawn(roomId: _roomA, prompt: 'Hello');
+      final parent = await runtime
+          .spawn(roomId: _roomA, prompt: [const TextPart('Hello')]);
       final child = await runtime.spawn(
         roomId: _roomB,
-        prompt: 'Cross-room task',
+        prompt: [const TextPart('Cross-room task')],
         parent: parent,
       );
 
@@ -341,16 +353,16 @@ void main() {
 
       final grandparent = await runtime.spawn(
         roomId: _roomA,
-        prompt: 'Level 0',
+        prompt: [const TextPart('Level 0')],
       );
       final parent = await runtime.spawn(
         roomId: _roomA,
-        prompt: 'Level 1',
+        prompt: [const TextPart('Level 1')],
         parent: grandparent,
       );
       final child = await runtime.spawn(
         roomId: _roomA,
-        prompt: 'Level 2',
+        prompt: [const TextPart('Level 2')],
         parent: parent,
       );
 

--- a/packages/soliplex_client/lib/src/domain/chat_message.dart
+++ b/packages/soliplex_client/lib/src/domain/chat_message.dart
@@ -4,8 +4,8 @@ import 'package:meta/meta.dart';
 
 /// One element of a user message's ordered content.
 ///
-/// Carried by [TextMessage.parts] when a message interleaves text with
-/// images. One list serves both the optimistic echo and the AG-UI wire
+/// Carried by [TextMessage.parts] on a user message built from an ordered
+/// payload. One list serves both the optimistic echo and the AG-UI wire
 /// mapping, so what the sender sees and what the model receives cannot drift.
 @immutable
 sealed class MessagePart {
@@ -34,6 +34,15 @@ final class ImagePart extends MessagePart {
 
   /// The MIME type of [bytes], e.g. `image/png`.
   final String mimeType;
+}
+
+/// Flattening of an ordered part list to text alone.
+extension MessagePartsText on List<MessagePart> {
+  /// Every [TextPart]'s text, concatenated in order, with no separator.
+  ///
+  /// Lossy by nature: an image carries no text and is dropped, so anything
+  /// that stores or displays this alone keeps the words and loses the images.
+  String get plainText => whereType<TextPart>().map((part) => part.text).join();
 }
 
 /// User type for messages.
@@ -126,7 +135,6 @@ class TextMessage extends ChatMessage {
     DateTime? createdAt,
     bool isStreaming = false,
     String thinkingText = '',
-    List<MessagePart>? parts,
   }) {
     return TextMessage(
       id: id,
@@ -135,16 +143,51 @@ class TextMessage extends ChatMessage {
       isStreaming: isStreaming,
       thinkingText: thinkingText,
       createdAt: createdAt,
-      parts: parts,
+    );
+  }
+
+  /// Creates a user message for an ordered [parts] payload, deriving [text]
+  /// from the parts so a caller of this factory cannot let the two disagree.
+  /// Holds an unmodifiable copy, so a caller that kept its own list cannot
+  /// mutate it afterwards and leave [text] describing different content.
+  ///
+  /// Parts are honoured only for a user message, so the role is fixed.
+  ///
+  /// Throws [ArgumentError] when [parts] carries neither an image nor any
+  /// text. Such a payload reaches the wire as empty content, which makes the
+  /// backend discard the turn without reporting an error — a throw here is
+  /// the only way the caller learns the message went nowhere.
+  factory TextMessage.fromParts({
+    required String id,
+    required List<MessagePart> parts,
+    DateTime? createdAt,
+  }) {
+    if (parts.plainText.isEmpty && parts.whereType<ImagePart>().isEmpty) {
+      throw ArgumentError.value(
+        parts,
+        'parts',
+        'must carry an image or some text',
+      );
+    }
+    return TextMessage(
+      id: id,
+      user: ChatUser.user,
+      text: parts.plainText,
+      createdAt: createdAt,
+      parts: List.unmodifiable(parts),
     );
   }
 
   /// The message text content.
   final String text;
 
-  /// Ordered content parts, set only when a user message interleaves text
-  /// with images. Null for a plain-text message, which travels the wire as a
-  /// bare string; only honoured for user messages, ignored elsewhere.
+  /// Ordered content parts, set on a user message built by
+  /// [TextMessage.fromParts] and null on one rebuilt from history by
+  /// [TextMessage.create]. A list holding nothing but text still travels the
+  /// wire as a bare string, so `parts != null` means "built from a payload",
+  /// not "has an image" — test for an image with
+  /// `parts?.whereType<ImagePart>().isNotEmpty`. Only honoured for user
+  /// messages, ignored elsewhere.
   ///
   /// When set, [text] must hold the flattened text of these parts. The mapper
   /// falls back to [text] for any parts list it cannot send as multimodal, and
@@ -169,7 +212,6 @@ class TextMessage extends ChatMessage {
     String? text,
     bool? isStreaming,
     String? thinkingText,
-    List<MessagePart>? parts,
   }) {
     return TextMessage(
       id: id ?? this.id,
@@ -178,7 +220,7 @@ class TextMessage extends ChatMessage {
       text: text ?? this.text,
       isStreaming: isStreaming ?? this.isStreaming,
       thinkingText: thinkingText ?? this.thinkingText,
-      parts: parts ?? this.parts,
+      parts: parts,
     );
   }
 

--- a/packages/soliplex_client/test/domain/chat_message_test.dart
+++ b/packages/soliplex_client/test/domain/chat_message_test.dart
@@ -1,3 +1,5 @@
+import 'dart:typed_data';
+
 import 'package:soliplex_client/soliplex_client.dart';
 import 'package:test/test.dart';
 
@@ -465,6 +467,67 @@ void main() {
       const info = ToolCallInfo(id: 'tc1', name: 'search');
 
       expect(info.hasResult, isFalse);
+    });
+  });
+
+  group('message parts', () {
+    // Several call sites derive a plain string from a parts list — the echo's
+    // `text`, the unsent-text error, and both draft-persistence paths — so the
+    // runs have to concatenate exactly, with images contributing nothing.
+    test('flattening concatenates text runs and skips images', () {
+      final parts = <MessagePart>[
+        const TextPart('look at '),
+        ImagePart(
+          bytes: Uint8List.fromList([0x89, 0x50]),
+          mimeType: 'image/png',
+        ),
+        const TextPart(' and say'),
+      ];
+
+      expect(parts.plainText, equals('look at  and say'));
+    });
+
+    // `fromParts` derives `text` once, at construction. Holding the caller's
+    // list would let a later mutation leave the two describing different
+    // content — the disagreement the factory exists to prevent.
+    test('a message keeps the parts it was built with', () {
+      final mutable = <MessagePart>[const TextPart('hello')];
+
+      final message = TextMessage.fromParts(id: 'm-1', parts: mutable);
+      mutable.clear();
+
+      expect(message.parts, hasLength(1));
+    });
+
+    // A payload with no image and no text reaches the wire as empty content,
+    // which the backend discards without reporting an error. Rejecting it at
+    // construction is the only point where the caller can still be told.
+    test('a message with neither text nor an image is rejected', () {
+      expect(
+        () => TextMessage.fromParts(id: 'm-1', parts: const []),
+        throwsArgumentError,
+      );
+      expect(
+        () => TextMessage.fromParts(id: 'm-1', parts: const [TextPart('')]),
+        throwsArgumentError,
+      );
+    });
+
+    // An image alone is a complete message: it carries no text, so `text` is
+    // empty, but the wire form is a non-empty content array.
+    test('an image with no text is accepted', () {
+      final message = TextMessage.fromParts(
+        id: 'm-1',
+        parts: [
+          ImagePart(
+            bytes: Uint8List.fromList([0x89, 0x50]),
+            mimeType: 'image/png',
+          ),
+        ],
+      );
+
+      expect(message.text, isEmpty);
+      expect(message.parts, hasLength(1));
     });
   });
 }

--- a/test/modules/room/agent_runtime_manager_test.dart
+++ b/test/modules/room/agent_runtime_manager_test.dart
@@ -108,7 +108,7 @@ void main() {
     // a disposed runtime rejects spawn. This catches a regression that evicts
     // the cache entry but skips disposal (the leak this eviction path fixes).
     await expectLater(
-      rt1.spawn(roomId: 'r', prompt: 'p', threadId: 't'),
+      rt1.spawn(roomId: 'r', prompt: [TextPart('p')], threadId: 't'),
       throwsA(
         isA<StateError>()
             .having((e) => e.toString(), 'message', contains('disposed')),

--- a/test/modules/room/room_state_test.dart
+++ b/test/modules/room/room_state_test.dart
@@ -1,4 +1,5 @@
 import 'dart:convert';
+import 'dart:typed_data';
 
 import 'package:flutter_test/flutter_test.dart';
 import 'package:shared_preferences/shared_preferences.dart';
@@ -32,7 +33,7 @@ class _AuthExceptionThrowingRuntime extends AgentRuntime {
   @override
   Future<AgentSession> spawn({
     required String roomId,
-    required String prompt,
+    required List<MessagePart> prompt,
     String? threadId,
     Duration? timeout,
     bool ephemeral = false,
@@ -218,10 +219,18 @@ void main() {
 
     // Dispose runtime so spawn throws.
     await runtimeManager.dispose();
-    await state.sendToNewThread('Hello');
+    await state.sendToNewThread([
+      const TextPart('Hello'),
+      ImagePart(bytes: Uint8List.fromList([0x89]), mimeType: 'image/png'),
+    ]);
 
     expect(state.lastError.value, isNotNull);
-    expect(state.lastError.value!.unsentText, 'Hello');
+    expect(
+      state.lastError.value!.unsentText,
+      'Hello',
+      reason: 'SendError carries a string, so the retry banner restores the '
+          'text and cannot restore the image.',
+    );
 
     state.dispose();
   });
@@ -248,7 +257,7 @@ void main() {
 
     await Future<void>.delayed(Duration.zero);
 
-    await state.sendToNewThread('Hello');
+    await state.sendToNewThread([TextPart('Hello')]);
     for (var i = 0; i < 10; i++) {
       await Future<void>.delayed(Duration.zero);
     }
@@ -274,7 +283,7 @@ void main() {
 
     await Future<void>.delayed(Duration.zero);
 
-    final sendFuture = state.sendToNewThread('Hello');
+    final sendFuture = state.sendToNewThread([TextPart('Hello')]);
     expect(state.sessionState.value, AgentSessionState.spawning);
 
     await sendFuture;
@@ -301,7 +310,7 @@ void main() {
     await Future<void>.delayed(Duration.zero);
 
     // Start sendToNewThread but dispose before spawn completes.
-    final sendFuture = state.sendToNewThread('Hello');
+    final sendFuture = state.sendToNewThread([TextPart('Hello')]);
     state.dispose();
 
     // Should complete without error — spawn runs to completion.
@@ -523,11 +532,11 @@ void main() {
 
     final runtime = runtimeManager.getRuntime(connection);
     final session1 = await runtime.spawn(
-        roomId: 'room-1', prompt: 't', threadId: 'thread-A');
+        roomId: 'room-1', prompt: [TextPart('t')], threadId: 'thread-A');
     final session2 = await runtime.spawn(
-        roomId: 'room-2', prompt: 't', threadId: 'thread-B');
+        roomId: 'room-2', prompt: [TextPart('t')], threadId: 'thread-B');
     final session3 = await runtime.spawn(
-        roomId: 'room-1', prompt: 't', threadId: 'thread-C');
+        roomId: 'room-1', prompt: [TextPart('t')], threadId: 'thread-C');
 
     registry.register(
       (serverId: 'test-server', roomId: 'room-1', threadId: 'thread-A'),
@@ -922,7 +931,10 @@ void main() {
       );
       await Future<void>.delayed(Duration.zero);
 
-      await state.sendToNewThread('half-written question');
+      await state.sendToNewThread([
+        const TextPart('half-written question'),
+        ImagePart(bytes: Uint8List.fromList([0x89]), mimeType: 'image/png'),
+      ]);
       for (var i = 0; i < 10; i++) {
         await Future<void>.delayed(Duration.zero);
       }
@@ -944,7 +956,8 @@ void main() {
         'half-written question',
         reason: 'RoomState.sendToNewThread must wire composer persistence '
             "as the spawner's onAuthExpired hook; without it the user's "
-            'draft is dropped on the floor by the redirect.',
+            'draft is dropped on the floor by the redirect. Storage holds a '
+            'string, so the text survives and the image does not.',
       );
 
       state.dispose();

--- a/test/modules/room/run_registry_test.dart
+++ b/test/modules/room/run_registry_test.dart
@@ -71,7 +71,7 @@ void main() {
   }) async {
     return runtime.spawn(
       roomId: 'room-1',
-      prompt: 'test',
+      prompt: [TextPart('test')],
       threadId: threadId,
     );
   }

--- a/test/modules/room/session_spawner_test.dart
+++ b/test/modules/room/session_spawner_test.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+import 'dart:typed_data';
 
 import 'package:flutter_test/flutter_test.dart';
 import 'package:soliplex_agent/soliplex_agent.dart';
@@ -53,7 +54,7 @@ void main() {
       await SessionSpawner(auth: _authInActiveSession()).spawn(
         spawnFn: () async => session,
         errorSignal: errorSignal,
-        prompt: 'hi',
+        prompt: [TextPart('hi')],
         isDisposed: () => false,
         onSpawned: (s) => received = s,
         onStateTransition: transitions.add,
@@ -71,7 +72,7 @@ void main() {
       await SessionSpawner(auth: _authInActiveSession()).spawn(
         spawnFn: () async => throw StateError('boom'),
         errorSignal: errorSignal,
-        prompt: 'hi',
+        prompt: [TextPart('hi')],
         isDisposed: () => false,
         onSpawned: (_) {},
         onStateTransition: transitions.add,
@@ -89,7 +90,7 @@ void main() {
       await SessionSpawner(auth: _authInActiveSession()).spawn(
         spawnFn: () async => _StubAgentSession(),
         errorSignal: errorSignal,
-        prompt: 'hi',
+        prompt: [TextPart('hi')],
         isDisposed: () => false,
         onSpawned: (_) => throw StateError('attach failed'),
         onStateTransition: transitions.add,
@@ -109,7 +110,7 @@ void main() {
       await SessionSpawner(auth: _authInActiveSession()).spawn(
         spawnFn: () async => throw StateError('boom'),
         errorSignal: errorSignal,
-        prompt: 'hi',
+        prompt: [TextPart('hi')],
         isDisposed: () => true,
         onSpawned: (_) {},
         onStateTransition: transitions.add,
@@ -131,7 +132,7 @@ void main() {
       final spawnFuture = spawner.spawn(
         spawnFn: () => completer.future,
         errorSignal: errorSignal,
-        prompt: 'hi',
+        prompt: [TextPart('hi')],
         isDisposed: () => false,
         onSpawned: (_) => onSpawnedCalled = true,
         onStateTransition: transitions.add,
@@ -168,7 +169,7 @@ void main() {
       final firstSpawn = spawner.spawn(
         spawnFn: () => firstCompleter.future,
         errorSignal: errorSignal,
-        prompt: 'first',
+        prompt: [TextPart('first')],
         isDisposed: () => false,
         onSpawned: (s) => firstReceived = s,
         onStateTransition: transitions.add,
@@ -183,7 +184,7 @@ void main() {
           return secondSession;
         },
         errorSignal: errorSignal,
-        prompt: 'second',
+        prompt: [TextPart('second')],
         isDisposed: () => false,
         onSpawned: (_) => secondOnSpawnedCalled = true,
         onStateTransition: transitions.add,
@@ -218,7 +219,7 @@ void main() {
       unawaited(spawner.spawn(
         spawnFn: () => completer.future,
         errorSignal: Signal<SendError?>(null),
-        prompt: 'hi',
+        prompt: [TextPart('hi')],
         isDisposed: () => false,
         onSpawned: (_) {},
         onStateTransition: (_) {},
@@ -243,7 +244,7 @@ void main() {
       await SessionSpawner(auth: _authInActiveSession()).spawn(
         spawnFn: () => throw StateError('sync boom'),
         errorSignal: errorSignal,
-        prompt: 'hi',
+        prompt: [TextPart('hi')],
         isDisposed: () => false,
         onSpawned: (_) {},
         onStateTransition: transitions.add,
@@ -263,7 +264,7 @@ void main() {
       await spawner.spawn(
         spawnFn: () async => session,
         errorSignal: Signal<SendError?>(null),
-        prompt: 'hi',
+        prompt: [TextPart('hi')],
         isDisposed: () => false,
         onSpawned: (_) {},
         onStateTransition: (_) {},
@@ -281,13 +282,17 @@ void main() {
       final errorSignal = Signal<SendError?>(null);
       final spawner = SessionSpawner(auth: auth);
 
-      String? authExpiredPrompt;
+      final parts = <MessagePart>[
+        const TextPart('hello'),
+        ImagePart(bytes: Uint8List.fromList([0x89]), mimeType: 'image/png'),
+      ];
+      List<MessagePart>? authExpiredPrompt;
       await spawner.spawn(
         spawnFn: () => Future<AgentSession>.error(
           AuthException(statusCode: 401, message: 'JWT validation failed'),
         ),
         errorSignal: errorSignal,
-        prompt: 'hello',
+        prompt: parts,
         isDisposed: () => false,
         onSpawned: (_) => fail('spawn should not have succeeded'),
         onStateTransition: (_) {},
@@ -303,9 +308,9 @@ void main() {
       );
       expect(
         authExpiredPrompt,
-        'hello',
-        reason: 'onAuthExpired receives the prompt so the caller can persist '
-            'the composer before the route guard redirects.',
+        same(parts),
+        reason: 'onAuthExpired receives the whole part list, not a flattened '
+            'string, so the caller decides what its storage can keep.',
       );
     });
 
@@ -325,7 +330,7 @@ void main() {
           AuthException(statusCode: 401, message: 'JWT validation failed'),
         ),
         errorSignal: errorSignal,
-        prompt: 'hello',
+        prompt: [TextPart('hello')],
         isDisposed: () => false,
         onSpawned: (_) => fail('spawn should not have succeeded'),
         onStateTransition: (_) {},
@@ -346,7 +351,7 @@ void main() {
           PermissionDeniedException(statusCode: 403, message: 'Forbidden'),
         ),
         errorSignal: errorSignal,
-        prompt: 'hello',
+        prompt: [TextPart('hello')],
         isDisposed: () => false,
         onSpawned: (_) => fail('spawn should not have succeeded'),
         onStateTransition: (_) {},
@@ -366,7 +371,7 @@ void main() {
       await spawner.spawn(
         spawnFn: () => Future<AgentSession>.error(Exception('network down')),
         errorSignal: errorSignal,
-        prompt: 'hello',
+        prompt: [TextPart('hello')],
         isDisposed: () => false,
         onSpawned: (_) => fail('spawn should not have succeeded'),
         onStateTransition: (_) {},

--- a/test/modules/room/thread_view_state_test.dart
+++ b/test/modules/room/thread_view_state_test.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 import 'dart:convert';
+import 'dart:typed_data';
 
 import 'package:flutter_test/flutter_test.dart';
 import 'package:shared_preferences/shared_preferences.dart';
@@ -70,7 +71,7 @@ class _AuthExceptionThrowingRuntime extends AgentRuntime {
   @override
   Future<AgentSession> spawn({
     required String roomId,
-    required String prompt,
+    required List<MessagePart> prompt,
     String? threadId,
     Duration? timeout,
     bool ephemeral = false,
@@ -489,7 +490,7 @@ void main() {
       // Send a message — spawn will succeed but the run will fail
       // (FakeAgUiStreamClient throws). FailedState may have no
       // conversation, so existing messages should be preserved.
-      await state.sendMessage('Hello', runtime);
+      await state.sendMessage([TextPart('Hello')], runtime);
 
       for (var i = 0; i < 10; i++) {
         await Future<void>.delayed(Duration.zero);
@@ -526,7 +527,7 @@ void main() {
 
       // Dispose the runtime so spawn throws.
       await runtimeManager.dispose();
-      await state.sendMessage('Hello', runtime);
+      await state.sendMessage([TextPart('Hello')], runtime);
 
       // Let the error propagate.
       for (var i = 0; i < 10; i++) {
@@ -564,7 +565,7 @@ void main() {
       await runtimeManager.dispose();
 
       // First send failure.
-      await state.sendMessage('First', runtime);
+      await state.sendMessage([TextPart('First')], runtime);
       for (var i = 0; i < 10; i++) {
         await Future<void>.delayed(Duration.zero);
       }
@@ -572,7 +573,7 @@ void main() {
       expect(state.lastSendError.value!.unsentText, 'First');
 
       // Second send failure without manually clearing the error.
-      await state.sendMessage('Second', runtime);
+      await state.sendMessage([TextPart('Second')], runtime);
       for (var i = 0; i < 10; i++) {
         await Future<void>.delayed(Duration.zero);
       }
@@ -598,7 +599,7 @@ void main() {
       expect(state.messages.value, isA<MessagesLoaded>());
 
       // Start sendMessage but dispose before it completes.
-      final sendFuture = state.sendMessage('Hello', runtime);
+      final sendFuture = state.sendMessage([TextPart('Hello')], runtime);
       state.dispose();
 
       // Let the spawn complete.
@@ -654,7 +655,7 @@ void main() {
       await Future<void>.delayed(Duration.zero);
 
       // Start sendMessage without awaiting — observe intermediate state.
-      final future = state.sendMessage('Hello', runtime);
+      final future = state.sendMessage([TextPart('Hello')], runtime);
       expect(state.sessionState.value, AgentSessionState.spawning);
 
       await future;
@@ -687,7 +688,7 @@ void main() {
       await runtimeManager.dispose();
 
       // sendMessage should bail out before reaching spawn.
-      await state.sendMessage('Hello', runtime);
+      await state.sendMessage([TextPart('Hello')], runtime);
 
       // No error means spawn was never attempted.
       expect(state.lastSendError.value, isNull);
@@ -709,7 +710,7 @@ void main() {
       await Future<void>.delayed(Duration.zero);
 
       // Start sendMessage and immediately cancel.
-      final future = state.sendMessage('Hello', runtime);
+      final future = state.sendMessage([TextPart('Hello')], runtime);
       state.cancelRun();
 
       await future;
@@ -861,7 +862,7 @@ void main() {
 
       await Future<void>.delayed(Duration.zero);
 
-      await state.sendMessage('Hello', runtime);
+      await state.sendMessage([TextPart('Hello')], runtime);
 
       // Wait for terminal state
       for (var i = 0; i < 10; i++) {
@@ -1173,7 +1174,10 @@ void main() {
         await Future<void>.delayed(Duration.zero);
 
         final throwingRuntime = _AuthExceptionThrowingRuntime(connection);
-        await state.sendMessage('half-written question', throwingRuntime);
+        await state.sendMessage([
+          const TextPart('half-written question'),
+          ImagePart(bytes: Uint8List.fromList([0x89]), mimeType: 'image/png'),
+        ], throwingRuntime);
 
         for (var i = 0; i < 10; i++) {
           await Future<void>.delayed(Duration.zero);
@@ -1189,7 +1193,8 @@ void main() {
           'half-written question',
           reason: 'ThreadViewState must wire composer persistence as the '
               "spawner's onAuthExpired hook; without it the user's draft "
-              'is dropped on the floor by the redirect.',
+              'is dropped on the floor by the redirect. Storage holds a '
+              'string, so the text survives and the image does not.',
         );
 
         state.dispose();

--- a/test/modules/room/ui/chat_input_test.dart
+++ b/test/modules/room/ui/chat_input_test.dart
@@ -45,27 +45,30 @@ void main() {
   });
 
   testWidgets('send button dispatches text and clears field', (tester) async {
-    String? sentText;
+    List<MessagePart>? sentParts;
     final sessionState = signal<AgentSessionState?>(null);
 
     await tester.pumpWidget(MaterialApp(
       theme: soliplexLightTheme(),
       home: Scaffold(
         body: ChatInput(
-          onSend: (text) => sentText = text,
+          onSend: (parts) => sentParts = parts,
           onCancel: () {},
           sessionState: sessionState,
         ),
       ),
     ));
 
-    await tester.enterText(find.byType(TextField), 'Hello agent');
+    // Padded on purpose: the composer sends one run of trimmed text, and
+    // nothing downstream trims again.
+    await tester.enterText(find.byType(TextField), '  Hello agent  ');
     await tester.pump();
 
     await tester.tap(find.byIcon(Icons.send));
     await tester.pump();
 
-    expect(sentText, 'Hello agent');
+    expect(sentParts, hasLength(1));
+    expect((sentParts!.single as TextPart).text, 'Hello agent');
     expect(
       tester.widget<TextField>(find.byType(TextField)).controller!.text,
       isEmpty,
@@ -177,7 +180,7 @@ void main() {
       theme: soliplexLightTheme(),
       home: Scaffold(
         body: ChatInput(
-          onSend: (text) => sentText = text,
+          onSend: (parts) => sentText = parts.plainText,
           onCancel: () {},
           sessionState: sessionState,
         ),
@@ -203,7 +206,7 @@ void main() {
       theme: soliplexLightTheme(),
       home: Scaffold(
         body: ChatInput(
-          onSend: (text) => sentText = text,
+          onSend: (parts) => sentText = parts.plainText,
           onCancel: () {},
           sessionState: sessionState,
         ),


### PR DESCRIPTION
PR 2 of 5 for inline image attachments, following #497. Mechanical widening: every
hop from the composer to the optimistic echo now carries an ordered
`List<MessagePart>` instead of a bare `String`. **Nothing in the app can attach an
image yet, so no screen behaves differently and no wire byte changes for any
message sent today** — every existing caller sends one text run, which still
travels as a bare string.

## What's here

- **The send path widens** — `ChatInput.onSend`, `ThreadViewState.sendMessage`,
  `RoomState.sendToNewThread`, `SessionSpawner.spawn`, `AgentRuntime.spawn`,
  `MultiServerRuntime.spawn`, `AgentSession.start`, and the orchestrator's
  `runToCompletion` / `startRun` / `_initializeStream` / `_buildConversation`.
- **`TextMessage.fromParts`** derives `text` by flattening the parts rather than
  taking it as a second argument, and the optimistic echo is built through it, so
  a message's text can no longer disagree with its parts. It holds an
  unmodifiable copy, since the text is derived once.
- **`plainText`** on `List<MessagePart>` — named for what it discards. Four sites
  need a plain string and an image has no text to give.

## Breaking, for library consumers

`AgentRuntime.spawn` / `MultiServerRuntime.spawn` (`prompt`) and
`AgentSession.start` (`userMessage`). Wrap the text in a single part to migrate:

```dart
prompt: 'Hello'  →  prompt: [TextPart('Hello')]
```

The text-only APIs are deliberately unchanged: `spawnChild`, `delegateTask` and
the `AgentApi` platform callback still take a `String`, because a prompt from
those sources is always text. Widening a signature whose callers have no image to
pass buys nothing.

## `parts != null` no longer means "has an image"

Worth flagging because it **supersedes a statement in #497**. Since every send
now builds its echo through `fromParts`, a plain-text message carries
`parts: [TextPart('…')]` rather than null. So the field describes *how a message
was built*, not whether it holds an image — test for an image with
`parts?.whereType<ImagePart>().isNotEmpty`. The field's dartdoc now says this;
the previous wording ("set only when a user message interleaves text with
images") became false with this change.

Two consequences:

- `parts` was dropped from `TextMessage.create` and `copyWith`, which #497 added
  and no call site ever passed. Both were unreleased, so no released consumer
  breaks. `fromParts` is now the only parts-bearing construction path, which is
  what makes the derive-once invariant hold.
- A message replayed from history still carries no `parts` — the receive side is
  PR 3's job (`_extractUserMessageEvents` currently drops list content to `''`).

## `fromParts` rejects a payload with no image and no text

#497 established that an empty `content` array makes the backend discard the
user's turn with no error anywhere. That guard lives in the mapper, but it
converts the empty *array* into an empty *string* — which fails the same
non-empty test on the backend. With `text` now derived from the parts, the
fallback no longer has independent text to fall back to:

| `fromParts(parts:)` | `text` | Wire `content` |
| --- | --- | --- |
| `[]` | `''` | `''` — turn silently discarded |
| `[TextPart('')]` | `''` | `''` — same |

So the factory throws `ArgumentError` instead. It's a throw rather than an
`assert` because asserts are stripped in release, which is exactly where a
vanished turn is unrecoverable. Every widened signature funnels through this one
site, and it surfaces as a visible send error rather than a crash:
`AgentRuntime.spawn` cleans up the session and its ephemeral thread, rethrows,
and `SessionSpawner` turns that into a `SendError`.

Unreachable from the app today — `ChatInput` rejects empty text — but these are
now public APIs taking a `List`, and an external caller passing `[]` would
otherwise get a silently dropped turn.

## Draft persistence carries text only

The part list is threaded to the auth-expiry persistence callbacks, so the caller
decides what its storage can keep. `ReturnToStorage` holds one string, so a draft
round-trips its text and drops any image.

That is a waypoint, not the end state: what a draft should carry across re-auth is
each image's **position and count, never its bytes** — restored as "unavailable"
placeholders so the user knows to re-attach rather than resending a caption whose
images silently vanished. That needs the placeholder-token controller, so it lands
with PR 4; the plan's §4.2 records the design and the reasoning for rejecting byte
persistence.

## Also here

- The catch-all in `SessionSpawner` now logs at SEVERE with its stack trace. Both
  typed branches above it already logged; the branch catching errors nobody
  anticipated bound no stack trace at all, so a `TypeError` from thread
  resolution or a `StateError` from a disposed runtime left nothing but the
  banner's truncated `error.toString()`.
- The auth-expiry and unsent-text tests now carry an `ImagePart`, so the lossy
  boundaries are pinned by assertions that already existed, and `onAuthExpired`
  is asserted to receive the whole list rather than a flattened string.

## Verification

Most of the test diff is type migration (`'x'` → `[TextPart('x')]`). New
behavioural coverage: `plainText` ordering and image-drop, `fromParts`' defensive
copy and its two rejection cases, an image-with-no-text accepted, and the echo
carrying parts in order with `text` derived.

- [x] `dart format --set-exit-if-changed` clean
- [x] `flutter analyze` — no issues
- [x] App suite: 2254 passing
- [x] `soliplex_agent`: 502 passing (`--exclude-tags integration`, as CI runs it)
- [x] `soliplex_client`: 1625 passing (`--exclude-tags integration`)
- [x] `markdownlint-cli2` clean on `CHANGELOG.md`

Wire-shape coverage was verified against the body proven end-to-end in the
passthrough spike (real backend + `qwen2.5vl:3b`): the mapper's assertions match
it field-by-field, including camelCase `mimeType`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
