### PR TITLE
feat: restore a user message's images when a thread reloads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,9 +24,27 @@ Versions follow the `version+build` scheme from `pubspec.yaml`, bumped via
   ordered part list, deriving `text` from the parts so a caller of it cannot let
   the two disagree, and a `plainText` getter on `List<MessagePart>` flattens a
   part list to its text alone — runs concatenated in order, images dropped.
-  `fromParts` throws `ArgumentError` for a part list carrying neither an image
-  nor any text, because such a payload reaches the wire as empty content and
-  the backend discards the turn without reporting an error.
+  `fromParts` throws `ArgumentError` for a part list carrying neither an
+  attachment nor any text, because such a payload reaches the wire as empty
+  content and the backend discards the turn without reporting an error.
+- **Library consumers:** `MissingAttachmentPart` is a third `MessagePart`
+  alongside `TextPart` and `ImagePart`, standing in for an attachment a message
+  was sent with whose content cannot be rebuilt, and carrying the declared MIME
+  type and a `MissingAttachmentReason` (`undecodable`, `unsupportedType`,
+  `remoteSource`). It has no wire form and is dropped when a message is
+  converted for sending. A `hasAttachment` getter on `List<MessagePart>`
+  reports whether any part carries something other than text. Code that
+  switches over `MessagePart` exhaustively gains a case.
+- A user message carrying image parts now renders them in its bubble: text runs
+  read as text and each image sits inline where it was placed, so a sentence
+  written around its images still reads as one sentence. Tapping an image opens
+  every image in that message in the zoomable browser, starting at the tapped
+  one, so a photo that arrived sideways can be rotated. An image whose bytes
+  will not decode, and an attachment that could not be rebuilt at all, each show
+  a placeholder in their own slot. Because the glyph looks the same whichever
+  loss produced it, the slot says what is missing — and the kind of file it was
+  — as a tooltip on hover or long-press, and as the screen reader's
+  announcement. A message with no parts renders exactly as before.
 
 ### Changed
 
@@ -43,9 +61,47 @@ Versions follow the `version+build` scheme from `pubspec.yaml`, bumped via
   A draft held across an authentication round trip still restores its text.
   Code reading a conversation does see one difference: the echo of a sent
   message now always carries `parts`, where it previously carried none.
+- **Library consumers:** thread history no longer fabricates
+  `TEXT_MESSAGE_START` / `CONTENT` / `END` events for a user message. The
+  backend never streams the user's own turn, so history now rebuilds that
+  message directly from the run's persisted input and appends it ahead of the
+  run's real events — the same shape the live path already used, where the
+  message is seeded into the conversation before the stream opens. The messages
+  a thread reconstructs to are unchanged, including their order and timestamps.
+  Two consequences for code reading `ThreadHistory.runs`: a run's event list no
+  longer carries those three synthetic events, and for any run whose input
+  carried a user message, the ids of its `DroppedEventMessage`s
+  (`dropped-<runId>-<index>`) shift by three, since the index now refers to the
+  run's actual wire payload.
 
 ### Fixed
 
+- Reloading a thread now restores the images a user message was sent with. A
+  message whose content was an ordered list of parts previously lost all of it,
+  its text included, and came back blank; it now hydrates into the same ordered
+  parts with its text re-derived from them. Content the app has no way to hold —
+  an image given as a URL instead of bytes, audio, video or a document, or bytes
+  that will not decode — becomes a placeholder in the slot it occupied, so the
+  message reports what it was sent with instead of reading as though it never
+  carried an attachment. Such a placeholder has no content to send, so a
+  reloaded message goes back to the model without that attachment.
+- A malformed piece of a user message costs no more than itself. Each element of
+  an ordered payload is read on its own, so one entry this protocol version
+  cannot name leaves its siblings intact — the message's text and its readable
+  images alike — where before a single unreadable element blanked the whole
+  message. Whatever cannot be read is logged with the message, run and thread it
+  belongs to, and no single message or run can fail a thread's history load.
+- A user message whose id is blank on the wire no longer swallows the turns
+  after it. Such an id was taken at face value and keyed every blank-id turn in
+  a thread to the same message, so all but the first lost its bubble and their
+  citations piled onto one turn; a blank id is now treated as absent and the
+  message is keyed to its run instead. A run entry whose own `run_id` is blank
+  is rejected for the same reason, since that id is what a message without one
+  falls back to.
+- A run whose stored events end before any terminal event no longer hands its
+  half-streamed reply to the run after it, where that run's terminal event
+  committed the text under the wrong run and out of order. Streaming state is
+  now scoped to the run it belongs to, since each run is its own stream.
 - Pressing the platform's paste chord in a room — Cmd+V on macOS and iOS, Ctrl+V
   elsewhere — no longer does nothing when the composer is unfocused. One keypress
   now moves focus to the composer and inserts the clipboard's text, over the

--- a/lib/src/modules/room/ui/markdown/log_source.dart
+++ b/lib/src/modules/room/ui/markdown/log_source.dart
@@ -28,8 +28,9 @@ String safeSourceForLog(String src, {int max = 120}) {
 final _loggedSources = <int>{};
 
 /// Logs [message] at warning level the first time [key] is seen, otherwise
-/// silently drops it. Keys are URIs for per-source dedupe, or short tags like
-/// `'scheme:ftp'` for per-category dedupe. Dedupe is best-effort: keyed on
+/// silently drops it. A key names whatever the caller wants deduped: a URI for
+/// per-source dedupe, a short tag like `'scheme:ftp'` for per-category dedupe,
+/// or a message-and-slot tag for one attachment. Dedupe is best-effort: keyed on
 /// [key]'s hash so large payloads are never retained, at the cost that two keys
 /// whose hashes collide are treated as one — an acceptable, rare miss for log
 /// dedupe. Pass [logger] so the call site's logger namespace appears in the

--- a/lib/src/modules/room/ui/paged_zoomable_images.dart
+++ b/lib/src/modules/room/ui/paged_zoomable_images.dart
@@ -5,8 +5,7 @@ import 'package:soliplex_design/soliplex_design.dart';
 import 'pager_dots.dart';
 
 /// A pageable set of zoomable images sharing one page indicator and per-page
-/// rotation that persists across paging. Used by the chunk-visualization page
-/// browser and the citation-figure browser.
+/// rotation that persists across paging.
 ///
 /// Each page is built by [pageBuilder], which receives the page's current
 /// rotation and a rotate callback to wire into a `ZoomableImage`. [footerBuilder]

--- a/lib/src/modules/room/ui/text_message_tile.dart
+++ b/lib/src/modules/room/ui/text_message_tile.dart
@@ -1,6 +1,10 @@
 import 'package:flutter/material.dart';
 import 'package:soliplex_agent/soliplex_agent.dart';
+import 'package:soliplex_logging/soliplex_logging.dart';
 
+import '../../../shared/failed_image.dart';
+import '../../../shared/zoomable_image.dart';
+import '../../../shared/zoomable_view.dart';
 import '../execution_tracker.dart';
 import 'citations_section.dart';
 import 'copy_button.dart';
@@ -10,9 +14,37 @@ import 'execution/static_thinking_block.dart';
 import 'execution/thinking_block.dart';
 import 'feedback_buttons.dart';
 import 'markdown/flutter_markdown_plus_renderer.dart';
+import 'markdown/log_source.dart';
 import 'message_caption.dart';
+import 'paged_zoomable_images.dart';
 import 'workdir_files_section.dart';
 import 'package:soliplex_design/soliplex_design.dart';
+
+final _logger =
+    LogManager.instance.getLogger('soliplex_frontend.text_message_tile');
+
+/// Side of an attached image's inline thumbnail. Sized as a tap target — it is
+/// what opens the full-size browser — so it sits at the 48 px platform minimum.
+/// A component dimension, off the spacing scale.
+const double _inlineImageSize = 48;
+
+/// Long-edge bound on an inline thumbnail's *decode*. `BoxFit.cover` in a 48 px
+/// box fills from the short edge, which needs
+/// `_inlineImageSize * devicePixelRatio` ≈ 144 px at dpr 3; a 640 long edge
+/// clears that for anything narrower than ~40:9. Costs at most ~1.6 MB of RGBA
+/// (a square 640×640), against ~48 MB for an unbounded 12 MP photo — and the
+/// timeline is a scrolling list, so that cost repeats per image on screen.
+const int _inlineDecodeExtent = 640;
+
+/// Long-edge bound on a full-size page's decode in the zoom browser, which
+/// `showZoomableMediaDialog` bounds to a fixed max width and a fraction of the
+/// viewport height. At fit, that is well inside this on most devices; a tall
+/// window at a high pixel ratio can ask for somewhat more, and there the viewer
+/// interpolates slightly — which `ZoomableView`'s max scale would make a 12 MP
+/// original do anyway.
+const int _zoomDecodeExtent = 2560;
+
+const _imageUnavailableLabel = 'Attached image unavailable';
 
 class TextMessageTile extends StatelessWidget {
   const TextMessageTile({
@@ -167,18 +199,249 @@ class _MessageBubble extends StatelessWidget {
         ),
       ),
       child: isUser
-          ? Text(
-              message.text,
-              style: theme.textTheme.bodyMedium?.copyWith(
-                color: theme.colorScheme.onPrimaryContainer,
-              ),
-            )
+          ? _userContent(theme)
           : message.text.isEmpty
               ? const SoliplexShimmer(lineFractions: [1, 1, 0.55])
               : FlutterMarkdownPlusRenderer(
                   data: message.text,
                   selectable: false,
                 ),
+    );
+  }
+
+  Widget _userContent(ThemeData theme) {
+    final style = theme.textTheme.bodyMedium?.copyWith(
+      color: theme.colorScheme.onPrimaryContainer,
+    );
+    final parts = message.parts;
+    if (parts == null) return Text(message.text, style: style);
+    return _InterleavedParts(
+      messageId: message.id,
+      parts: parts,
+      style: style,
+    );
+  }
+}
+
+/// A user message's ordered parts as one flow of rich text: text runs as text,
+/// each image as an inline span at its position in the list.
+///
+/// Inline so an image's place in the sentence survives into the bubble — a
+/// message written around its images still reads as one sentence, and a thread
+/// of them stays scannable. The thumbnail is a tap target rather than a preview;
+/// tapping opens the full-size browser, which is what answers "did I attach the
+/// right one".
+class _InterleavedParts extends StatelessWidget {
+  const _InterleavedParts({
+    required this.messageId,
+    required this.parts,
+    this.style,
+  });
+
+  final String messageId;
+  final List<MessagePart> parts;
+  final TextStyle? style;
+
+  @override
+  Widget build(BuildContext context) {
+    final images = parts.whereType<ImagePart>().toList();
+    final spans = <InlineSpan>[];
+    var imageIndex = 0;
+
+    for (final part in parts) {
+      switch (part) {
+        case TextPart(:final text):
+          // Empty runs are dropped on the way out too, so the bubble does not
+          // render a span the model never received.
+          if (text.isEmpty) continue;
+          spans.add(TextSpan(text: text));
+        case ImagePart():
+          final index = imageIndex++;
+          spans.add(
+            _attachmentSpan(
+              _InlineImage(
+                image: part,
+                label: _imageLabel(index, images.length),
+                logSource: _imageLogSource(index),
+                onTap: () => _openBrowser(context, images, index),
+              ),
+            ),
+          );
+        case MissingAttachmentPart():
+          // Holds the slot rather than closing the gap, so the sentence reads
+          // the way it was written and the loss is where the user put it.
+          spans.add(
+            _attachmentSpan(
+              _InlineImageFailed(label: _missingLabel(part)),
+            ),
+          );
+      }
+    }
+
+    return Text.rich(TextSpan(children: spans), style: style);
+  }
+
+  /// Wraps an attachment's widget as an inline span.
+  ///
+  /// The transcript is wrapped in a SelectionArea. An attachment carries no
+  /// text, so it stays out of a drag-selection rather than contributing a gap
+  /// to what the user copies.
+  InlineSpan _attachmentSpan(Widget child) => WidgetSpan(
+        alignment: PlaceholderAlignment.middle,
+        child: SelectionContainer.disabled(child: child),
+      );
+
+  String _imageLabel(int index, int count) =>
+      'Attached image ${index + 1} of $count';
+
+  /// Names what is missing rather than only that something is, so a screen
+  /// reader distinguishes a broken image from a kind of file this app cannot
+  /// show at all.
+  String _missingLabel(MissingAttachmentPart part) {
+    final type = part.mimeType;
+    final subject = type == null ? 'An attachment' : 'An attachment ($type)';
+    return switch (part.reason) {
+      MissingAttachmentReason.undecodable =>
+        '$subject could not be read and is not shown',
+      MissingAttachmentReason.unsupportedType =>
+        '$subject is a kind this app cannot show',
+      MissingAttachmentReason.remoteSource =>
+        '$subject is stored elsewhere and is not shown',
+    };
+  }
+
+  String _imageLogSource(int index) => '$messageId#$index';
+
+  /// Opens every image in the message, starting at the tapped one, in the
+  /// app's shared zoom browser — so a photo that arrived sideways can be
+  /// rotated and read.
+  void _openBrowser(BuildContext context, List<ImagePart> images, int index) {
+    showZoomableMediaDialog(
+      context,
+      viewer: PagedZoomableImages(
+        itemCount: images.length,
+        initialIndex: index,
+        autofocus: true,
+        pageBuilder: (context, i, rotation) => ZoomableImage.controlledRotation(
+          bytes: images[i].bytes,
+          maxDecodeExtent: _zoomDecodeExtent,
+          semanticLabel: _imageLabel(i, images.length),
+          logSource: _imageLogSource(i),
+          rotationQuarterTurns: rotation.quarterTurns,
+          onRotate: rotation.onRotate,
+          decodeFailureChild: const FailedImage(
+            label: _imageUnavailableLabel,
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+/// Stands in for an attachment that cannot be shown, filling the same 48 px
+/// slot as a thumbnail so the sentence does not reflow.
+///
+/// Serves both losses that reach the bubble: an attachment history could not
+/// rebuild, and an image whose bytes reached the widget but would not decode.
+///
+/// Purpose-built rather than [FailedImage], which is sized for the full-size
+/// browser: a 96 px icon box over a text label is several times wider than this
+/// slot, so fitting it here shrinks the label well past legibility.
+///
+/// The glyph alone says only that something is missing, and it looks the same
+/// whichever loss produced it, so [label] is carried two ways: as the screen
+/// reader's announcement, and as a tooltip for everyone else — on hover on a
+/// pointer, on long-press on a touch screen. There is no room to render it
+/// inline without breaking the sentence the slot sits in.
+class _InlineImageFailed extends StatelessWidget {
+  const _InlineImageFailed({required this.label});
+
+  /// The complete announcement for this slot — what is missing, and which one.
+  final String label;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Semantics(
+      label: label,
+      image: true,
+      child: Tooltip(
+        message: label,
+        // The Semantics above already announces this; a tooltip that also
+        // contributed it would have a screen reader read the slot twice.
+        excludeFromSemantics: true,
+        child: Container(
+          width: _inlineImageSize,
+          height: _inlineImageSize,
+          decoration: BoxDecoration(
+            border: Border.all(color: theme.colorScheme.outline),
+            color: theme.colorScheme.surfaceContainerLow,
+            borderRadius: BorderRadius.circular(context.radii.sm),
+          ),
+          child: Icon(
+            Icons.broken_image,
+            size: 24,
+            color: theme.colorScheme.onSurfaceVariant,
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+/// One attached image, inline in the bubble's text. Tapping opens the full-size
+/// browser; a decode failure shows a broken-image fallback in the same slot.
+class _InlineImage extends StatelessWidget {
+  const _InlineImage({
+    required this.image,
+    required this.label,
+    required this.logSource,
+    required this.onTap,
+  });
+
+  final ImagePart image;
+  final String label;
+  final String logSource;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    // `sm` rather than the default `md`: at 48 px this is a small hit-target
+    // well, where a 12 px radius reads as a lozenge.
+    final radius = BorderRadius.circular(context.radii.sm);
+    return InkWell(
+      onTap: onTap,
+      borderRadius: radius,
+      child: ClipRRect(
+        borderRadius: radius,
+        child: Image(
+          // `ResizeImagePolicy.fit` bounds the *long* edge, unlike `.exact`,
+          // so a tall image is capped too — see `_inlineDecodeExtent`.
+          image: ResizeImage(
+            MemoryImage(image.bytes),
+            width: _inlineDecodeExtent,
+            height: _inlineDecodeExtent,
+            policy: ResizeImagePolicy.fit,
+          ),
+          width: _inlineImageSize,
+          height: _inlineImageSize,
+          fit: BoxFit.cover,
+          semanticLabel: label,
+          errorBuilder: (context, error, stack) {
+            logFailedSourceOnce(
+              _logger,
+              'attached image decode failed: $logSource '
+              '(${image.mimeType}, ${image.bytes.length} bytes)',
+              logSource,
+              error: error,
+              stackTrace: stack,
+            );
+            return _InlineImageFailed(
+              label: '$label — $_imageUnavailableLabel',
+            );
+          },
+        ),
+      ),
     );
   }
 }

--- a/lib/src/shared/zoomable_image.dart
+++ b/lib/src/shared/zoomable_image.dart
@@ -8,6 +8,24 @@ import 'zoomable_view.dart';
 final _logger =
     LogManager.instance.getLogger('soliplex_frontend.zoomable_image');
 
+/// A byte-backed image provider whose *decode* is bounded to [maxDecodeExtent]
+/// on the long edge, aspect ratio preserved and never upscaled.
+///
+/// `Image`'s `width`/`height` only constrain layout — the engine still decodes
+/// the full bitmap, which is ~48 MB of RGBA for a 12 MP photo. Callers handing
+/// over bytes whose size they do not control should bound the decode; a null
+/// [maxDecodeExtent] leaves it unbounded, which is only safe when the caller
+/// knows the bytes are small.
+ImageProvider _boundedMemoryImage(Uint8List bytes, int? maxDecodeExtent) =>
+    maxDecodeExtent == null
+        ? MemoryImage(bytes)
+        : ResizeImage(
+            MemoryImage(bytes),
+            width: maxDecodeExtent,
+            height: maxDecodeExtent,
+            policy: ResizeImagePolicy.fit,
+          );
+
 /// Pan/zoom/rotate viewer for a single image, shared by the app's image-preview
 /// surfaces. Delegates the interaction to [ZoomableView]; owns the load/decode
 /// failure so the fallback is shown *in place of* the viewer — no zoom or rotate
@@ -17,21 +35,26 @@ final _logger =
 /// [ZoomableImage.controlledRotation] to own rotation from the caller so it
 /// persists across paging. When the image fails to load or decode,
 /// [decodeFailureChild] is shown, centered, in place of the viewer.
+///
+/// The byte constructors take an optional `maxDecodeExtent` bounding the decode
+/// on the long edge; pass one when the bytes' size is not under your control,
+/// since `Image`'s own width/height constrain layout only.
 class ZoomableImage extends StatefulWidget {
-  /// Decoded bytes, self-managed rotation, starting unrotated.
+  /// Encoded image bytes, self-managed rotation, starting unrotated.
   ZoomableImage({
     required Uint8List bytes,
     required this.decodeFailureChild,
     this.semanticLabel,
     this.logSource,
+    int? maxDecodeExtent,
     super.key,
-  })  : provider = MemoryImage(bytes),
+  })  : provider = _boundedMemoryImage(bytes, maxDecodeExtent),
         byteLength = bytes.length,
         rotationQuarterTurns = 0,
         onRotate = null;
 
-  /// Decoded bytes with caller-owned rotation so it survives paging (e.g. per
-  /// document page).
+  /// Encoded image bytes with caller-owned rotation so it survives paging
+  /// (e.g. per document page).
   ZoomableImage.controlledRotation({
     required Uint8List bytes,
     required this.decodeFailureChild,
@@ -39,8 +62,9 @@ class ZoomableImage extends StatefulWidget {
     required VoidCallback this.onRotate,
     this.semanticLabel,
     this.logSource,
+    int? maxDecodeExtent,
     super.key,
-  })  : provider = MemoryImage(bytes),
+  })  : provider = _boundedMemoryImage(bytes, maxDecodeExtent),
         byteLength = bytes.length;
 
   /// Any [ImageProvider] (network, asset, file), self-managed rotation. The

--- a/packages/soliplex_client/lib/src/api/agui_message_mapper.dart
+++ b/packages/soliplex_client/lib/src/api/agui_message_mapper.dart
@@ -1,8 +1,13 @@
 import 'dart:convert';
+import 'dart:typed_data';
 
 import 'package:ag_ui/ag_ui.dart';
-
+import 'package:meta/meta.dart';
 import 'package:soliplex_client/src/domain/chat_message.dart';
+import 'package:soliplex_logging/soliplex_logging.dart';
+
+final Logger _logger =
+    LogManager.instance.getLogger('soliplex_client.message_mapper');
 
 /// Converts a list of [ChatMessage]s to AG-UI protocol [Message]s.
 ///
@@ -71,24 +76,36 @@ Message _convertTextMessage(TextMessage message) {
 /// array discards the turn with no error anywhere. Empty text runs are dropped
 /// for the same reason in miniature — the OpenAI paths forward them verbatim
 /// as empty text blocks instead of skipping them.
+///
+/// A [MissingAttachmentPart] is skipped: its content is exactly what this
+/// client does not have, so there is nothing to send. The whole conversation
+/// is re-sent on every run, so a message rebuilt from history goes back to the
+/// model without the attachment it originally carried — unavoidable, and the
+/// reason the bubble shows the user that it happened.
 List<InputContent>? _multimodalParts(List<MessagePart>? parts) {
   if (parts == null) return null;
 
   final content = <InputContent>[];
-  var hasNonTextPart = false;
+  var hasSendablePart = false;
   for (final part in parts) {
     switch (part) {
       case TextPart(:final text):
         if (text.isEmpty) continue;
       case ImagePart():
-        hasNonTextPart = true;
+        hasSendablePart = true;
+      case MissingAttachmentPart():
+        continue;
     }
     content.add(_convertMessagePart(part));
   }
 
-  return hasNonTextPart ? content : null;
+  return hasSendablePart ? content : null;
 }
 
+/// The wire form of [part].
+///
+/// [MissingAttachmentPart] never reaches here — [_multimodalParts] drops it
+/// before the call, because it has no wire form to produce.
 InputContent _convertMessagePart(MessagePart part) {
   switch (part) {
     case TextPart():
@@ -99,6 +116,259 @@ InputContent _convertMessagePart(MessagePart part) {
           value: base64Encode(part.bytes),
           mimeType: part.mimeType,
         ),
+      );
+    case MissingAttachmentPart():
+      throw ArgumentError.value(
+        part,
+        'part',
+        'has no wire form and must be dropped before conversion',
+      );
+  }
+}
+
+/// Reads a user message's wire `content` back into the domain — the inbound
+/// counterpart to [_multimodalParts] and the bare-string arm of
+/// [_convertTextMessage].
+///
+/// AG-UI gives `UserMessage.content` as either a bare string or an ordered list
+/// of typed parts. `text` is the message's text either way: the bare string, or
+/// every text part concatenated in order.
+///
+/// `parts` is non-null **only** when the content is an ordered list carrying at
+/// least one attachment, because that is the only case where the parts say more
+/// than `text` alone. It is null for a bare string and for a list of text
+/// alone, which the bare-string form already carries — mirroring
+/// [_multimodalParts] on the way out.
+///
+/// **One element costs no more than itself.** Every element is decoded on its
+/// own, so a part this version cannot read leaves its siblings — text and
+/// images alike — intact. Content the domain cannot hold becomes a
+/// [MissingAttachmentPart] in the slot it occupied: a URL image source, audio,
+/// video, a document, binary content, or bytes that will not decode. The
+/// message keeps its shape and reports the gap, rather than dropping the
+/// attachments silently and reading as though it never had any.
+///
+/// Content hydrates empty only when it holds no text to recover: absent, an
+/// empty list, or a shape that is neither a string nor a list.
+///
+/// Never throws. A throw escaping here would abort a whole thread's history
+/// load rather than one message, so the body is wrapped as a last resort.
+///
+/// [logContext] names the message being read — every warning below reports
+/// content the user will not get back, and a log that cannot say which message
+/// lost it cannot answer the question it exists to answer.
+///
+/// Public only so `SoliplexApi` can call it from another file in this package;
+/// it is hidden at the barrel and is not part of the supported surface.
+@internal
+({List<MessagePart>? parts, String text}) readUserMessageContent(
+  Object? content, {
+  required String logContext,
+}) {
+  try {
+    return _readContentParts(content, logContext);
+  } on Object catch (error, stackTrace) {
+    // Every failure below is handled where it happens, so reaching here means a
+    // dependency started throwing where it did not before — our fault to fix,
+    // not data to degrade. Logged at error for that reason, and still degraded
+    // so one message cannot cost the thread.
+    _logger.error(
+      'Reading the content of $logContext threw; hydrating the message empty.',
+      error: error,
+      stackTrace: stackTrace,
+    );
+    return (parts: null, text: '');
+  }
+}
+
+({List<MessagePart>? parts, String text}) _readContentParts(
+  Object? content,
+  String logContext,
+) {
+  if (content is String) return (parts: null, text: content);
+  if (content == null) {
+    // A message persisted without content at all. Distinguished from the drift
+    // below because it is the one shape that says nothing went wrong.
+    return (parts: null, text: '');
+  }
+  if (content is! List) {
+    _logger.warning(
+      'The content of $logContext is ${content.runtimeType}, not a string or a '
+      'list of parts; hydrating the message empty.',
+    );
+    return (parts: null, text: '');
+  }
+  if (content.isEmpty) {
+    // The shape `_multimodalParts` refuses to send: pydantic_ai's AG-UI adapter
+    // builds the prompt only from non-empty content, so the model never saw
+    // this turn. Only observable here, on the way back in.
+    _logger.warning(
+      'The content of $logContext is an empty list; the model was given no '
+      'prompt for that turn.',
+    );
+    return (parts: null, text: '');
+  }
+
+  final parts = <MessagePart>[];
+
+  for (var i = 0; i < content.length; i++) {
+    final decoded = _decodeContentPart(content[i], i, logContext);
+    if (decoded == null) {
+      // Undecodable as a part at all, so its kind is unknown too — but it
+      // occupied a slot, and saying so beats leaving a hole in the message.
+      parts.add(
+        const MissingAttachmentPart(
+          reason: MissingAttachmentReason.undecodable,
+        ),
+      );
+      continue;
+    }
+    switch (decoded) {
+      case TextInputContent(:final text):
+        parts.add(TextPart(text));
+      case ImageInputContent(:final source):
+        parts.add(_readImageSource(source, i, logContext));
+      // Explicit arms rather than a default: a new content type upstream should
+      // be a compile error here, not a silently dropped attachment. The media
+      // kinds are grouped because they carry their type the same way; binary
+      // declares one directly.
+      case AudioInputContent(:final source) ||
+            VideoInputContent(:final source) ||
+            DocumentInputContent(:final source):
+        parts.add(
+          _unsupportedAttachment(
+            decoded.type,
+            _sourceMimeType(source),
+            i,
+            logContext,
+          ),
+        );
+      case BinaryInputContent(:final mimeType):
+        parts.add(
+          _unsupportedAttachment(decoded.type, mimeType, i, logContext),
+        );
+    }
+  }
+
+  final text = parts.plainText;
+  // A list of text alone says no more than the bare string does, so it takes
+  // the plain path — matching what `_multimodalParts` would send.
+  if (!parts.hasAttachment) return (parts: null, text: text);
+  return (parts: parts, text: text);
+}
+
+/// The MIME type [source] declared, or null when it named none. Required on a
+/// [DataSource] and optional on a [UrlSource], so only the latter can be null.
+String? _sourceMimeType(InputContentSource source) => switch (source) {
+      DataSource(:final mimeType) => mimeType,
+      UrlSource(:final mimeType) => mimeType,
+    };
+
+/// The placeholder for a part that decoded cleanly but has no domain
+/// equivalent, logged as it is built.
+///
+/// [mimeType] is what the sender declared. It is the only thing the placeholder
+/// can say about what is missing — the glyph is the same for every kind — so it
+/// is carried through wherever the payload names one.
+MissingAttachmentPart _unsupportedAttachment(
+  String type,
+  String? mimeType,
+  int index,
+  String logContext,
+) {
+  _logger.warning(
+    'Content[$index] of $logContext is $type content, which has no domain '
+    'part; showing it as a missing attachment.',
+  );
+  return MissingAttachmentPart(
+    reason: MissingAttachmentReason.unsupportedType,
+    mimeType: mimeType,
+  );
+}
+
+/// The AG-UI content part at [index] of a message's content list, or null when
+/// it cannot be decoded.
+///
+/// Decoded one element at a time rather than through
+/// `UserMessageContent.fromJson`, which is all-or-nothing: a single unknown
+/// part type there discards the whole list, taking the message's text with it.
+InputContent? _decodeContentPart(Object? raw, int index, String logContext) {
+  if (raw is! Map<String, dynamic>) {
+    _logger.warning(
+      'Content[$index] of $logContext is ${raw.runtimeType}, not an object; '
+      'showing it as a missing attachment.',
+    );
+    return null;
+  }
+  try {
+    return InputContent.fromJson(raw);
+  } on AGUIValidationError catch (error) {
+    // Shape drift in someone else's data — an unknown part type, or a known one
+    // missing a required field.
+    _logger.warning(
+      'Content[$index] of $logContext is not a part this protocol version '
+      'describes; showing it as a missing attachment.',
+      error: error,
+    );
+    return null;
+  } on Object catch (error, stackTrace) {
+    _logger.error(
+      'Content[$index] of $logContext threw unexpectedly while decoding; '
+      'showing it as a missing attachment.',
+      error: error,
+      stackTrace: stackTrace,
+    );
+    return null;
+  }
+}
+
+/// The [ImagePart] for the image content [source] at [index], or a
+/// [MissingAttachmentPart] when the source is one the domain cannot hold.
+MessagePart _readImageSource(
+  InputContentSource source,
+  int index,
+  String logContext,
+) {
+  switch (source) {
+    case DataSource(:final value, :final mimeType):
+      final Uint8List bytes;
+      try {
+        bytes = base64Decode(value);
+      } on FormatException catch (error) {
+        _logger.warning(
+          'Content[$index] of $logContext has undecodable base64; showing it '
+          'as a missing attachment.',
+          error: error,
+        );
+        return MissingAttachmentPart(
+          reason: MissingAttachmentReason.undecodable,
+          mimeType: mimeType,
+        );
+      }
+      if (bytes.isEmpty) {
+        // Valid base64 for zero bytes. No decoder can render it, so an
+        // ImagePart here would only fail again at paint time.
+        _logger.warning(
+          'Content[$index] of $logContext carries an empty image payload; '
+          'showing it as a missing attachment.',
+        );
+        return MissingAttachmentPart(
+          reason: MissingAttachmentReason.undecodable,
+          mimeType: mimeType,
+        );
+      }
+      return ImagePart(bytes: bytes, mimeType: mimeType);
+    case UrlSource(:final mimeType):
+      // We only ever send DataSource, so a URL here came from another client.
+      // ImagePart holds bytes and cannot represent one, and fetching it during
+      // hydration is out of scope.
+      _logger.warning(
+        'Content[$index] of $logContext is an image given as a URL, which has '
+        'no domain part; showing it as a missing attachment.',
+      );
+      return MissingAttachmentPart(
+        reason: MissingAttachmentReason.remoteSource,
+        mimeType: mimeType,
       );
   }
 }

--- a/packages/soliplex_client/lib/src/api/api.dart
+++ b/packages/soliplex_client/lib/src/api/api.dart
@@ -1,4 +1,8 @@
-export 'agui_message_mapper.dart';
+// `readUserMessageContent` is public only so `SoliplexApi` can call it from
+// another file in this package, which imports this file's target directly. It
+// is withheld here rather than at the top-level barrel so every path out of the
+// package is covered by the one restriction.
+export 'agui_message_mapper.dart' hide readUserMessageContent;
 export 'fetch_auth_providers.dart';
 export 'fetch_server_info.dart';
 export 'soliplex_api.dart';

--- a/packages/soliplex_client/lib/src/api/soliplex_api.dart
+++ b/packages/soliplex_client/lib/src/api/soliplex_api.dart
@@ -3,6 +3,7 @@ import 'dart:developer' as developer;
 import 'dart:typed_data';
 
 import 'package:ag_ui/ag_ui.dart' hide CancelToken;
+import 'package:soliplex_client/src/api/agui_message_mapper.dart';
 import 'package:soliplex_client/src/api/mappers.dart';
 import 'package:soliplex_client/src/application/agui_event_processor.dart';
 import 'package:soliplex_client/src/application/citation_extractor.dart';
@@ -33,6 +34,59 @@ import 'package:soliplex_client/src/utils/url_builder.dart';
 import 'package:soliplex_logging/soliplex_logging.dart';
 
 final Logger _logger = LogManager.instance.getLogger('soliplex_client.api');
+
+/// The user message that initiated a run, read from its persisted `run_input`
+/// because the backend never echoes the user's own turn as AG-UI events.
+///
+/// `text` is always the message's text. `parts` is set only when the message
+/// carried an attachment — an image, or a placeholder for one that could not be
+/// rebuilt — the only case where the ordered form says more than `text` alone.
+/// So a non-null `parts` always satisfies [TextMessage.fromParts].
+typedef _RunUserMessage = ({
+  String messageId,
+  List<MessagePart>? parts,
+  String text,
+});
+
+/// What a run's GET yielded: the AG-UI events the backend streamed, plus the
+/// user message that initiated the run, which those events never carry.
+///
+/// `events` is `List<Object?>` rather than `List<dynamic>` deliberately. Items
+/// must survive shape drift as *data* — the replay loop mints a drop tile for
+/// any non-Map entry — but `dynamic` would also switch off the static checking
+/// that forces each consumer to narrow before use, which is the one thing
+/// keeping that drift from becoming a runtime throw.
+typedef _RunPayload = ({
+  List<Object?> events,
+  _RunUserMessage? userMessage,
+});
+
+/// A run with nothing to replay. `events` is empty rather than null so the
+/// replay loop reads one shape either way.
+///
+/// Not a sentinel: records compare field-wise, so a run the backend genuinely
+/// returned empty can compare equal to this. What marks a run as missing is its
+/// `fetchError`, never a comparison against this value.
+const _RunPayload _noRunData = (
+  events: <Object?>[],
+  userMessage: null,
+);
+
+/// One run as replay sees it: its payload joined with the identity, fetch
+/// outcome, and server `created` time from the thread listing, in creation
+/// order.
+///
+/// Separate from [_RunPayload] because [_RunPayload] is what the run cache
+/// stores. A fetch outcome or a listing timestamp folded into it would be
+/// served again on the next open of the thread, long after it stopped being
+/// true.
+typedef _ReplayRun = ({
+  String runId,
+  _RunPayload payload,
+  SoliplexException? fetchError,
+  StackTrace? fetchStackTrace,
+  DateTime? created,
+});
 
 /// API client for Soliplex backend CRUD operations.
 ///
@@ -81,16 +135,18 @@ class SoliplexApi {
   /// LRU cache for run events. Completed runs are immutable, so safe to cache.
   /// Uses insertion order - oldest entries are at the front.
   ///
-  /// Cached as `List<dynamic>` so a backend that emits non-Map items
-  /// (shape drift) round-trips through the cache without throwing on
-  /// access; the replay loop in [_replayEventsToHistory] mints a drop
-  /// tile for any non-Map item it encounters.
-  final _runEventsCache = <String, List<dynamic>>{};
+  /// The reconstructed user message rides the same entry rather than a parallel
+  /// map: a cache hit returns before [_fetchRunEvents] ever sees `run_input`
+  /// again, so parts kept anywhere else would be lost the second time a thread
+  /// is opened in one session. That also means an entry retains its message's
+  /// image bytes until it is evicted — past the close of the thread it belongs
+  /// to — and eviction counts entries, not bytes.
+  final _runEventsCache = <String, _RunPayload>{};
 
   String _runCacheKey(String threadId, String runId) => '$threadId:$runId';
 
   /// Adds to cache with LRU eviction.
-  void _cacheRunEvents(String key, List<dynamic> events) {
+  void _cacheRunEvents(String key, _RunPayload run) {
     // Remove if exists (to update position for LRU)
     _runEventsCache.remove(key);
 
@@ -99,16 +155,16 @@ class SoliplexApi {
       _runEventsCache.remove(_runEventsCache.keys.first);
     }
 
-    _runEventsCache[key] = events;
+    _runEventsCache[key] = run;
   }
 
   /// Gets from cache and updates LRU position.
-  List<dynamic>? _getCachedRunEvents(String key) {
-    final events = _runEventsCache.remove(key);
-    if (events != null) {
-      _runEventsCache[key] = events; // Re-add to move to end (most recent)
+  _RunPayload? _getCachedRunEvents(String key) {
+    final run = _runEventsCache.remove(key);
+    if (run != null) {
+      _runEventsCache[key] = run; // Re-add to move to end (most recent)
     }
-    return events;
+    return run;
   }
 
   // ============================================================
@@ -731,13 +787,17 @@ class SoliplexApi {
       }
       if (value['finished'] == null) continue;
       final rawRunId = value['run_id'];
-      if (rawRunId is! String) {
+      // Blank is rejected alongside the wrong type: a run id stands in for a
+      // missing message id below, where two runs sharing one would have the
+      // second's message dropped as a repeat.
+      if (rawRunId is! String || rawRunId.isEmpty) {
+        final got =
+            rawRunId is String ? 'an empty String' : '${rawRunId.runtimeType}';
         preFetchDrops.add(
           (
             runId: entry.key,
             error: MalformedResponseException(
-              message: 'Run entry ${entry.key} missing `run_id` (got '
-                  '${rawRunId.runtimeType})',
+              message: 'Run entry ${entry.key} missing `run_id` (got $got)',
             ),
           ),
         );
@@ -759,16 +819,30 @@ class SoliplexApi {
         cancelToken: cancelToken,
       )
           .then(
-        (events) => (runId: runId, events: events, fetchError: null as Object?),
+        (payload) => (
+          runId: runId,
+          payload: payload,
+          fetchError: null as SoliplexException?,
+          fetchStackTrace: null as StackTrace?,
+        ),
       )
           .catchError(
-        (Object e) {
+        // The stack is taken here because this is the only frame that has it;
+        // the replay loop logs the failure far from where it was thrown.
+        (Object e, StackTrace stackTrace) {
           // Log transient failure but continue with other runs. The
           // fetchError below carries the same exception into the replay
           // loop, which mints a drop tile so the run is visibly missing
           // rather than silently absent.
           _onWarning?.call('Failed to fetch events for run $runId: $e');
-          return (runId: runId, events: <dynamic>[], fetchError: e as Object?);
+          return (
+            runId: runId,
+            payload: _noRunData,
+            // Narrowed by `test` below to the two transient types, both
+            // SoliplexException subtypes.
+            fetchError: e as SoliplexException,
+            fetchStackTrace: stackTrace,
+          );
         },
         // Only catch transient errors - show partial results for batch ops:
         // - NetworkException: network blip, retry might succeed
@@ -785,21 +859,18 @@ class SoliplexApi {
     //    position by walking the original sort once.
     final fetchByRunId = {for (final r in results) r.runId: r};
     final preFetchByRunKey = {for (final d in preFetchDrops) d.runId: d.error};
-    final eventsPerRun = <({
-      String runId,
-      List<dynamic> events,
-      Object? fetchError,
-      DateTime? created,
-    })>[];
+    final runsToReplay = <_ReplayRun>[];
     for (final entry in _sortRunsByCreationTime(runs)) {
       final created = _runCreated(entry.value, entry.key, threadId);
       final preFetchError = preFetchByRunKey[entry.key];
       if (preFetchError != null) {
-        eventsPerRun.add(
+        runsToReplay.add(
           (
             runId: entry.key,
-            events: const <dynamic>[],
+            payload: _noRunData,
             fetchError: preFetchError,
+            // Built here, not thrown, so there is no stack worth carrying.
+            fetchStackTrace: null,
             created: created,
           ),
         );
@@ -812,32 +883,36 @@ class SoliplexApi {
       if (rawRunId is! String) continue;
       final fetched = fetchByRunId[rawRunId];
       if (fetched == null) continue;
-      eventsPerRun.add(
+      runsToReplay.add(
         (
           runId: rawRunId,
-          events: fetched.events,
+          payload: fetched.payload,
           fetchError: fetched.fetchError,
+          fetchStackTrace: fetched.fetchStackTrace,
           created: created,
         ),
       );
     }
 
     // 5. Replay events to reconstruct history (messages + AG-UI state)
-    return _replayEventsToHistory(eventsPerRun, threadId, documentFilter);
+    return _replayEventsToHistory(runsToReplay, threadId, documentFilter);
   }
 
   /// Fetches events for a single run, using cache for completed runs.
   ///
-  /// Returns events including synthetic user message events extracted from
-  /// run_input.messages. The backend stores user input separately from
-  /// streamed events, so we synthesize TEXT_MESSAGE events for them.
+  /// Returns the run's streamed events alongside the user message that
+  /// initiated it, read from `run_input` because the backend stores user input
+  /// separately and never echoes it as AG-UI events.
   ///
-  /// Returns `List<dynamic>` rather than `List<Map<String, dynamic>>`:
+  /// `events` is `List<Object?>` rather than `List<Map<String, dynamic>>`:
   /// shape drift on the wire (a non-Map item slipping into `events`)
   /// must reach [_replayEventsToHistory] as data, not throw at the cast
   /// site. The replay loop type-checks each item and mints a drop tile
   /// for non-Map entries.
-  Future<List<dynamic>> _fetchRunEvents(
+  ///
+  /// `events` not being a list at all is the one drift that cannot become a
+  /// drop tile — there is no item to mint one for — so it is logged instead.
+  Future<_RunPayload> _fetchRunEvents(
     String roomId,
     String threadId,
     String runId, {
@@ -855,40 +930,71 @@ class SoliplexApi {
       cancelToken: cancelToken,
     );
 
-    // Extract user messages from run_input and create synthetic events
-    final userMessageEvents = _extractUserMessageEvents(rawRun);
-
     final rawEvents = rawRun['events'];
-    final events = rawEvents is List ? rawEvents : const <dynamic>[];
-
-    // Combine: user message events first, then actual streamed events
-    final allEvents = <dynamic>[...userMessageEvents, ...events];
-    _cacheRunEvents(cacheKey, allEvents);
-    return allEvents;
+    if (rawEvents is! List && rawEvents != null) {
+      // Absent is normal for a run that streamed nothing; present-but-wrong-
+      // shape erases every reply the run produced, and this is the only place
+      // it is visible.
+      _logger.warning(
+        'replay: run $runId in thread $threadId has `events` as '
+        '${rawEvents.runtimeType}, not a list; the run replays as empty.',
+      );
+    }
+    final run = (
+      events: rawEvents is List ? rawEvents : const <Object?>[],
+      userMessage: _extractUserMessage(rawRun, threadId, runId),
+    );
+    _cacheRunEvents(cacheKey, run);
+    return run;
   }
 
-  /// Extracts the initiating user message from run_input and creates
-  /// synthetic events.
+  /// The user message that initiated the run [runId], read from `run_input`.
   ///
   /// Each run's `run_input.messages` contains the full conversation context,
   /// but only the last user message initiated THIS run. Prior user messages
   /// were already processed in earlier runs.
-  List<Map<String, dynamic>> _extractUserMessageEvents(
+  ///
+  /// Null when the run carries no user message to rebuild. That costs more than
+  /// the message itself — [_replayEventsToHistory] keys the turn's citations
+  /// and message state off its id — so every shape that reaches it by drift
+  /// rather than by absence is logged.
+  _RunUserMessage? _extractUserMessage(
     Map<String, dynamic> rawRun,
+    String threadId,
+    String runId,
   ) {
-    // Type-checked rather than cast: shape drift on `run_input` or
-    // `messages` should silently degrade to "no synthetic user message"
-    // rather than abort the run-level fetch.
+    // Type-checked rather than cast: shape drift here degrades to "no user
+    // message" rather than aborting the run-level fetch.
     final runInput = rawRun['run_input'];
-    if (runInput is! Map<String, dynamic>) return [];
+    if (runInput is! Map<String, dynamic>) {
+      // Absent is normal for a run the backend has not persisted input for;
+      // present-but-wrong-shape is drift only findable here.
+      if (runInput != null) {
+        _logger.warning(
+          'replay: run $runId in thread $threadId has `run_input` as '
+          '${runInput.runtimeType}, not an object; its user message is lost, '
+          'and with it the citations for that turn.',
+        );
+      }
+      return null;
+    }
 
     final rawMessages = runInput['messages'];
-    final messages = rawMessages is List ? rawMessages : const <dynamic>[];
+    if (rawMessages is! List) {
+      if (rawMessages != null) {
+        _logger.warning(
+          'replay: run $runId in thread $threadId has `run_input.messages` as '
+          '${rawMessages.runtimeType}, not a list; its user message is lost, '
+          'and with it the citations for that turn.',
+        );
+      }
+      return null;
+    }
 
     // Find the last user message — the one that initiated this run.
     Map<String, dynamic>? lastUserMessage;
-    for (var i = messages.length - 1; i >= 0; i--) {
-      final raw = messages[i];
+    for (var i = rawMessages.length - 1; i >= 0; i--) {
+      final raw = rawMessages[i];
       if (raw is! Map<String, dynamic>) continue;
       final role = raw['role'];
       if ((role is String ? role : 'user') == 'user') {
@@ -896,26 +1002,76 @@ class SoliplexApi {
         break;
       }
     }
-    if (lastUserMessage == null) return [];
+    if (lastUserMessage == null) {
+      if (rawMessages.isNotEmpty) {
+        _logger.warning(
+          'replay: run $runId in thread $threadId carries '
+          '${rawMessages.length} input message(s) but none from the user; '
+          'the turn has no citations or message state.',
+        );
+      }
+      return null;
+    }
 
-    final runId =
-        rawRun['run_id'] is String ? rawRun['run_id'] as String : 'unknown';
-    final id = lastUserMessage['id'] is String
-        ? lastUserMessage['id'] as String
-        : 'user-$runId';
-    final content = lastUserMessage['content'] is String
-        ? lastUserMessage['content'] as String
-        : '';
+    // A blank id is no more usable than a missing one: the append guard below
+    // reads a repeat as a continuation, so every blank-id turn in a thread
+    // would collapse onto the first. Both fall back to the run's own id, which
+    // the thread listing rejects unless it is a non-empty String — so two runs
+    // cannot collide on it.
+    final rawId = lastUserMessage['id'];
+    if (rawId is! String || rawId.isEmpty) {
+      _logger.warning(
+        'replay: the user message initiating run $runId in thread $threadId '
+        'has no usable id; keying it to the run instead.',
+      );
+    }
+    final id = rawId is String && rawId.isNotEmpty ? rawId : 'user-$runId';
+    final content = readUserMessageContent(
+      lastUserMessage['content'],
+      logContext: 'message $id in run $runId of thread $threadId',
+    );
 
-    return [
-      {'type': 'TEXT_MESSAGE_START', 'messageId': id, 'role': 'user'},
-      {
-        'type': 'TEXT_MESSAGE_CONTENT',
-        'messageId': id,
-        'delta': content,
-      },
-      {'type': 'TEXT_MESSAGE_END', 'messageId': id},
-    ];
+    return (messageId: id, parts: content.parts, text: content.text);
+  }
+
+  /// The domain message for [userMessage], stamped with [createdAt].
+  ///
+  /// A non-null `parts` already satisfies [TextMessage.fromParts], but that
+  /// holds only by the postcondition [readUserMessageContent] documents rather
+  /// than by anything a type enforces, so it is re-checked here. An escaping
+  /// `ArgumentError` would cost the whole thread's history, where the one
+  /// message is what is actually in doubt.
+  ///
+  /// Checked rather than caught: a rejection is a payload this method can
+  /// render around, while anything else that factory throws is a defect, and
+  /// catching would hide it for as long as it lives.
+  TextMessage _hydratedUserMessage(
+    _RunUserMessage userMessage,
+    DateTime? createdAt,
+    String threadId,
+    String runId,
+  ) {
+    final parts = userMessage.parts;
+    if (parts != null) {
+      if (parts.plainText.isNotEmpty || parts.hasAttachment) {
+        return TextMessage.fromParts(
+          id: userMessage.messageId,
+          parts: parts,
+          createdAt: createdAt,
+        );
+      }
+      _logger.error(
+        'replay: the ordered content of message ${userMessage.messageId} in '
+        'run $runId of thread $threadId carries neither an attachment nor any '
+        'text; rendering it as an empty message.',
+      );
+    }
+    return TextMessage.create(
+      id: userMessage.messageId,
+      user: ChatUser.user,
+      text: userMessage.text,
+      createdAt: createdAt,
+    );
   }
 
   /// The `document_filter` from the newest run that carries one in its
@@ -951,23 +1107,15 @@ class SoliplexApi {
   /// messages. Each run's citations are keyed by the user message ID that
   /// initiated that run.
   ThreadHistory _replayEventsToHistory(
-    List<
-            ({
-              String runId,
-              List<dynamic> events,
-              Object? fetchError,
-              DateTime? created,
-            })>
-        eventsPerRun,
+    List<_ReplayRun> runsToReplay,
     String threadId,
     String? documentFilter,
   ) {
-    if (eventsPerRun.isEmpty) {
+    if (runsToReplay.isEmpty) {
       return ThreadHistory(messages: const [], documentFilter: documentFilter);
     }
 
     var conversation = Conversation.empty(threadId: threadId);
-    var streaming = const AwaitingText() as StreamingState;
     final extractor = CitationExtractor();
     final messageStates = <String, MessageState>{};
     // Citations accumulated per turn (keyed by the run's last user message id),
@@ -976,17 +1124,38 @@ class SoliplexApi {
     // later invocation's `searches` clear.
     final turnsByUserMessage = <String, TurnCitations>{};
     final runs = <RunEventBundle>[];
+    // Text of the user messages already appended, keyed by id, so a
+    // continuation run does not add its parent's message a second time. An
+    // index of what this loop appended, rather than a scan of the whole
+    // conversation, so it cannot be confused by an assistant message that
+    // happens to share an id.
+    //
+    // The text is kept because a repeated id has two very different causes: a
+    // continuation run re-stating the turn it continues, or one id assigned to
+    // two different messages. Both drop the second message; only the first is
+    // harmless, and without the text they are indistinguishable.
+    final appendedUserText = <String, String>{};
 
-    for (final (:runId, :events, :fetchError, :created) in eventsPerRun) {
+    for (final (:runId, :payload, :fetchError, :fetchStackTrace, :created)
+        in runsToReplay) {
+      final events = payload.events;
+      final userMessage = payload.userMessage;
+      // Scoped to one run because each run is its own AG-UI stream. A run whose
+      // events lack RUN_FINISHED and RUN_ERROR alike leaves this mid-stream,
+      // and carrying that into the next run would let its terminal event commit
+      // the previous run's half-streamed text under the wrong run.
+      var streaming = const AwaitingText() as StreamingState;
       // Run-level fetch failure (transient HTTP error or pre-fetch
       // shape-drift on the run entry) → mint one drop tile in place so
       // the run is visibly missing from the timeline rather than
-      // silently absent. `events` may still be empty (transient failure)
-      // or non-empty if a future code path attaches partial data.
+      // silently absent. Such a run carries `_noRunData`, so there are no
+      // events to replay after it and no user message to append; the drop
+      // tile stands alone.
       if (fetchError != null) {
         _logger.error(
           'replay: run $runId in thread $threadId could not be fetched.',
           error: fetchError,
+          stackTrace: fetchStackTrace,
         );
         conversation = conversation.withAppendedMessage(
           DroppedEventMessage.create(
@@ -999,22 +1168,8 @@ class SoliplexApi {
         );
       }
 
-      // Find user message ID from LAST TEXT_MESSAGE_START with role=user.
-      // The run_input.messages contains ALL conversation messages, but the
-      // LAST user message is the one that initiated THIS run. Non-Map
-      // items are skipped here; the main loop below mints a drop tile
-      // for each.
-      String? userMessageId;
-      for (final eventJson in events) {
-        if (eventJson is! Map<String, dynamic>) continue;
-        if (eventJson['type'] != 'TEXT_MESSAGE_START') continue;
-        if (eventJson['role'] != 'user') continue;
-        final messageId = eventJson['messageId'];
-        if (messageId is String) {
-          userMessageId = messageId;
-          // Don't break - keep iterating to find the last one
-        }
-      }
+      // Keys this turn's citations and message state below.
+      final userMessageId = userMessage?.messageId;
 
       // The run-start event carries the server time the run began. Messages
       // without a timestamp of their own — chiefly the user message — resolve
@@ -1045,6 +1200,40 @@ class SoliplexApi {
         break;
       }
       final fallbackCreated = runStartedAt ?? created;
+
+      // The user message is appended ahead of the events it triggered, rather
+      // than folded from the stream, because the backend never sends it — the
+      // same shape the live path uses, where the caller seeds the message into
+      // the conversation before the stream opens.
+      //
+      // A run that could not be fetched has no user message to append, so its
+      // drop tile stands alone.
+      //
+      // A repeat id is normally a continuation run, whose `run_input` still
+      // ends with the user message its parent already contributed; the turn
+      // keeps one bubble and later runs fold their events onto it.
+      if (userMessage != null) {
+        final appended = appendedUserText[userMessage.messageId];
+        if (appended == null) {
+          appendedUserText[userMessage.messageId] = userMessage.text;
+          conversation = conversation.withAppendedMessage(
+            _hydratedUserMessage(userMessage, fallbackCreated, threadId, runId),
+          );
+        } else if (appended == userMessage.text) {
+          _logger.info(
+            'replay: run $runId in thread $threadId continues the turn of '
+            'message ${userMessage.messageId}; not appending it twice.',
+          );
+        } else {
+          // Same id, different message: one of the two turns is now missing
+          // from the transcript, and its citations are keyed onto the other.
+          _logger.error(
+            'replay: run $runId in thread $threadId reuses message id '
+            '${userMessage.messageId} for different text; the user message of '
+            'this run is dropped from the transcript.',
+          );
+        }
+      }
 
       // Per-event try/catch so one bad event can't abort replay.
       final decodedEvents = <BaseEvent>[];

--- a/packages/soliplex_client/lib/src/domain/chat_message.dart
+++ b/packages/soliplex_client/lib/src/domain/chat_message.dart
@@ -36,13 +36,57 @@ final class ImagePart extends MessagePart {
   final String mimeType;
 }
 
-/// Flattening of an ordered part list to text alone.
+/// Why an attachment a message was sent with cannot be shown again.
+enum MissingAttachmentReason {
+  /// The payload could not be read — an element this protocol version cannot
+  /// describe, invalid base64, or a valid encoding of nothing.
+  undecodable,
+
+  /// A kind of content this domain has no part for: audio, video, a document,
+  /// or opaque binary.
+  unsupportedType,
+
+  /// Held somewhere else rather than sent inline, as a URL this client does
+  /// not fetch.
+  remoteSource,
+}
+
+/// An attachment that was part of a message but whose content cannot be
+/// reconstructed, holding its place in the ordered content.
+///
+/// Kept as a part rather than dropped so a message reports what it was sent
+/// with. Silently removing it would leave a bubble that reads as complete
+/// while the model was given something else — the stronger false claim of the
+/// two. [mimeType] is the type the sender declared, when the payload named one
+/// at all.
+@immutable
+final class MissingAttachmentPart extends MessagePart {
+  /// Creates a placeholder for an attachment that cannot be reconstructed.
+  const MissingAttachmentPart({required this.reason, this.mimeType});
+
+  /// Why the attachment cannot be shown.
+  final MissingAttachmentReason reason;
+
+  /// The MIME type the sender declared, or null when the payload named none.
+  final String? mimeType;
+}
+
+/// What an ordered part list carries: its text, and whether it holds anything
+/// beyond text.
 extension MessagePartsText on List<MessagePart> {
   /// Every [TextPart]'s text, concatenated in order, with no separator.
   ///
   /// Lossy by nature: an image carries no text and is dropped, so anything
   /// that stores or displays this alone keeps the words and loses the images.
   String get plainText => whereType<TextPart>().map((part) => part.text).join();
+
+  /// Whether any part carries something other than text — an image, or an
+  /// attachment that could not be reconstructed.
+  ///
+  /// This is what makes an ordered list worth keeping: a list of text alone
+  /// says no more than [plainText] does, and travels the wire as a bare
+  /// string.
+  bool get hasAttachment => any((part) => part is! TextPart);
 }
 
 /// User type for messages.
@@ -153,20 +197,26 @@ class TextMessage extends ChatMessage {
   ///
   /// Parts are honoured only for a user message, so the role is fixed.
   ///
-  /// Throws [ArgumentError] when [parts] carries neither an image nor any
+  /// Throws [ArgumentError] when [parts] carries neither an attachment nor any
   /// text. Such a payload reaches the wire as empty content, which makes the
   /// backend discard the turn without reporting an error — a throw here is
   /// the only way the caller learns the message went nowhere.
+  ///
+  /// A [MissingAttachmentPart] satisfies the requirement even though it has no
+  /// wire form: it is the whole reason a message rebuilt from history still has
+  /// something to render. Such a message is still re-sent on the next run, and
+  /// a parts list of placeholders alone contributes nothing — so it reaches the
+  /// backend as empty content, and that turn is discarded there.
   factory TextMessage.fromParts({
     required String id,
     required List<MessagePart> parts,
     DateTime? createdAt,
   }) {
-    if (parts.plainText.isEmpty && parts.whereType<ImagePart>().isEmpty) {
+    if (parts.plainText.isEmpty && !parts.hasAttachment) {
       throw ArgumentError.value(
         parts,
         'parts',
-        'must carry an image or some text',
+        'must carry an attachment or some text',
       );
     }
     return TextMessage(
@@ -182,12 +232,12 @@ class TextMessage extends ChatMessage {
   final String text;
 
   /// Ordered content parts, set on a user message built by
-  /// [TextMessage.fromParts] and null on one rebuilt from history by
-  /// [TextMessage.create]. A list holding nothing but text still travels the
-  /// wire as a bare string, so `parts != null` means "built from a payload",
-  /// not "has an image" — test for an image with
-  /// `parts?.whereType<ImagePart>().isNotEmpty`. Only honoured for user
-  /// messages, ignored elsewhere.
+  /// [TextMessage.fromParts] and null on one built by [TextMessage.create].
+  /// A list holding nothing but text still travels the wire as a bare string,
+  /// so `parts != null` means "built from a payload", not "has an image" —
+  /// test for an image with `parts?.whereType<ImagePart>().isNotEmpty`, and
+  /// for any attachment with `hasAttachment`. Only honoured for user messages,
+  /// ignored elsewhere.
   ///
   /// When set, [text] must hold the flattened text of these parts. The mapper
   /// falls back to [text] for any parts list it cannot send as multimodal, and

--- a/packages/soliplex_client/test/api/agui_message_mapper_test.dart
+++ b/packages/soliplex_client/test/api/agui_message_mapper_test.dart
@@ -164,6 +164,54 @@ void main() {
         expect(userMsg.toJson()['content'], equals('no images here'));
       });
 
+      // The whole conversation is re-sent on every run, so a message rebuilt
+      // from history goes back over the wire. A placeholder has no content to
+      // send, and reaching the converter with one would throw and take the
+      // next run with it.
+      test('drops a missing attachment but keeps the images beside it', () {
+        final bytes = Uint8List.fromList([0x89, 0x50]);
+
+        final aguiMessages = convertToAgui([
+          TextMessage.fromParts(
+            id: 'msg-rehydrated',
+            parts: [
+              const TextPart('compare '),
+              ImagePart(bytes: bytes, mimeType: 'image/png'),
+              const MissingAttachmentPart(
+                reason: MissingAttachmentReason.undecodable,
+              ),
+            ],
+          ),
+        ]);
+
+        final content = (aguiMessages[0] as UserMessage).toJson()['content']
+            as List<Map<String, dynamic>>;
+        expect(content, hasLength(2));
+        expect(content[0], equals({'type': 'text', 'text': 'compare '}));
+        expect(content[1]['type'], equals('image'));
+      });
+
+      // Nothing sendable is left once the placeholder is dropped, so the
+      // multimodal array would be text-only — which buys nothing over the bare
+      // string and must not become an empty array either.
+      test('falls back to plain text when only a missing attachment remains',
+          () {
+        final aguiMessages = convertToAgui([
+          TextMessage.fromParts(
+            id: 'msg-all-missing',
+            parts: const [
+              TextPart('look at this'),
+              MissingAttachmentPart(
+                reason: MissingAttachmentReason.remoteSource,
+              ),
+            ],
+          ),
+        ]);
+
+        final userMsg = aguiMessages[0] as UserMessage;
+        expect(userMsg.toJson()['content'], equals('look at this'));
+      });
+
       // An empty array makes the backend discard the user's turn entirely,
       // with no error anywhere — the one degenerate case that loses data.
       test('never serializes an empty content array', () {

--- a/packages/soliplex_client/test/api/soliplex_api_test.dart
+++ b/packages/soliplex_client/test/api/soliplex_api_test.dart
@@ -5320,6 +5320,458 @@ void main() {
       });
     });
 
+    group('getThreadHistory user message content', () {
+      // Bytes stay a List<int> so `equals` compares them elementwise against
+      // the Uint8List an ImagePart carries.
+      const imageBytes = [0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a];
+
+      Map<String, dynamic> dataImage(String mimeType) => {
+            'type': 'image',
+            'source': {
+              'type': 'data',
+              'value': base64Encode(imageBytes),
+              'mimeType': mimeType,
+            },
+          };
+
+      /// Stubs a thread of one finished run whose `run_input` carries a single
+      /// user message with [content], then hydrates and returns that message.
+      Future<TextMessage> hydrateUserMessage(Object? content) async {
+        when(
+          () => mockTransport.request<Map<String, dynamic>>(
+            'GET',
+            Uri.parse(
+              'https://api.example.com/api/v1/rooms/room-123/agui/thread-456',
+            ),
+            cancelToken: any(named: 'cancelToken'),
+            fromJson: any(named: 'fromJson'),
+            body: any(named: 'body'),
+            headers: any(named: 'headers'),
+            timeout: any(named: 'timeout'),
+          ),
+        ).thenAnswer(
+          (_) async => {
+            'runs': {
+              'run-1': {
+                'run_id': 'run-1',
+                'created': '2026-01-07T01:00:00.000Z',
+                'finished': '2026-01-07T01:01:00.000Z',
+              },
+            },
+          },
+        );
+        when(
+          () => mockTransport.request<Map<String, dynamic>>(
+            'GET',
+            Uri.parse(
+              'https://api.example.com/api/v1/rooms/room-123/agui/thread-456/run-1',
+            ),
+            cancelToken: any(named: 'cancelToken'),
+            fromJson: any(named: 'fromJson'),
+            body: any(named: 'body'),
+            headers: any(named: 'headers'),
+            timeout: any(named: 'timeout'),
+          ),
+        ).thenAnswer(
+          (_) async => {
+            'run_id': 'run-1',
+            'run_input': {
+              'messages': [
+                {'id': 'user-msg-1', 'role': 'user', 'content': content},
+              ],
+            },
+            'events': <dynamic>[],
+          },
+        );
+
+        final history = await api.getThreadHistory('room-123', 'thread-456');
+        return history.messages
+            .whereType<TextMessage>()
+            .firstWhere((m) => m.user == ChatUser.user);
+      }
+
+      // The sequence is text/image/text rather than text/image so ordering is
+      // actually proven: a two-element list would pass even if the parts came
+      // back in a fixed wrong order.
+      test('reconstructs ordered parts from list content', () async {
+        final message = await hydrateUserMessage([
+          {'type': 'text', 'text': 'read the code in '},
+          dataImage('image/png'),
+          {'type': 'text', 'text': ' and reply'},
+        ]);
+
+        expect(message.parts, isNotNull);
+        final parts = message.parts!;
+        expect(parts, hasLength(3));
+        expect((parts[0] as TextPart).text, equals('read the code in '));
+        expect((parts[2] as TextPart).text, equals(' and reply'));
+
+        final image = parts[1] as ImagePart;
+        expect(image.bytes, equals(imageBytes));
+        expect(image.mimeType, equals('image/png'));
+
+        // text stays the flattened form of parts, so the copy button and the
+        // wire fallback cannot disagree with what is rendered.
+        expect(message.text, equals('read the code in  and reply'));
+      });
+
+      test('hydrates bare string content as plain text with no parts',
+          () async {
+        final message = await hydrateUserMessage('just words');
+
+        expect(message.text, equals('just words'));
+        expect(message.parts, isNull);
+      });
+
+      // A text-only list carries nothing the bare string does not, so it takes
+      // the plain path. This gate is also what keeps TextMessage.fromParts from
+      // rejecting the payload; the replay loop checks that precondition anyway,
+      // since it lives in another library.
+      test('leaves parts null for a list with no image', () async {
+        final message = await hydrateUserMessage([
+          {'type': 'text', 'text': 'still just words'},
+        ]);
+
+        expect(message.text, equals('still just words'));
+        expect(message.parts, isNull);
+      });
+
+      // The gate that decides `parts` keys off the image, so it must not
+      // accidentally require text as well — an image sent without a caption
+      // still has to come back as parts.
+      test('reconstructs parts for an image with no text', () async {
+        final message = await hydrateUserMessage([dataImage('image/png')]);
+
+        expect(message.text, isEmpty);
+        final parts = message.parts;
+        expect(parts, hasLength(1));
+        expect((parts![0] as ImagePart).bytes, equals(imageBytes));
+      });
+
+      // An image held somewhere else rather than sent inline. We never send
+      // that form, so it came from another client; the slot is kept so the
+      // message still reports that it carried an attachment.
+      test('marks a url image source as a missing attachment', () async {
+        final message = await hydrateUserMessage([
+          {'type': 'text', 'text': 'look at this'},
+          {
+            'type': 'image',
+            'source': {
+              'type': 'url',
+              'value': 'https://example.com/cat.png',
+              'mimeType': 'image/png',
+            },
+          },
+        ]);
+
+        expect(message.text, equals('look at this'));
+        final missing = message.parts![1] as MissingAttachmentPart;
+        expect(missing.reason, equals(MissingAttachmentReason.remoteSource));
+        // The placeholder's glyph is the same whichever loss produced it, so
+        // the declared type is the only thing that can name what is missing.
+        expect(missing.mimeType, equals('image/png'));
+      });
+
+      // base64Decode throws FormatException, and _fetchRunEvents is awaited
+      // inside a Future.wait that only catches network errors — so an escaping
+      // throw would take out the whole thread's history, not just this run.
+      test('marks undecodable base64 as a missing attachment', () async {
+        final message = await hydrateUserMessage([
+          {'type': 'text', 'text': 'look at this'},
+          {
+            'type': 'image',
+            'source': {
+              'type': 'data',
+              'value': 'not!valid!base64',
+              'mimeType': 'image/png',
+            },
+          },
+        ]);
+
+        expect(message.text, equals('look at this'));
+        final missing = message.parts![1] as MissingAttachmentPart;
+        expect(missing.reason, equals(MissingAttachmentReason.undecodable));
+        // The declared type survives even though the bytes did not, so the
+        // placeholder can say what kind of thing is missing.
+        expect(missing.mimeType, equals('image/png'));
+      });
+
+      test('hydrates an empty content list as empty text', () async {
+        final message = await hydrateUserMessage(<dynamic>[]);
+
+        expect(message.text, isEmpty);
+        expect(message.parts, isNull);
+      });
+
+      // ag_ui's own list decoder is all-or-nothing, so decoding per element is
+      // what keeps both the question and the readable image from disappearing
+      // along with the part this version cannot name. An image on each side of
+      // the bad part, so the assertion holds in both directions.
+      test('one unknown part costs only its own slot', () async {
+        final message = await hydrateUserMessage([
+          {'type': 'text', 'text': 'what is this'},
+          dataImage('image/png'),
+          {'type': 'sticker', 'id': 'nope'},
+          dataImage('image/png'),
+        ]);
+
+        expect(message.text, equals('what is this'));
+        final parts = message.parts!;
+        expect(parts, hasLength(4));
+        expect((parts[1] as ImagePart).bytes, equals(imageBytes));
+        expect(parts[2], isA<MissingAttachmentPart>());
+        expect((parts[3] as ImagePart).bytes, equals(imageBytes));
+      });
+
+      // A document is a live payload in this product, and it takes a different
+      // branch from the unknown type above: ag_ui decodes it fine, so it
+      // reaches the content switch rather than failing validation.
+      test('marks a document as a missing attachment of unsupported type',
+          () async {
+        final message = await hydrateUserMessage([
+          {'type': 'text', 'text': 'summarise '},
+          {
+            'type': 'document',
+            'source': {
+              'type': 'data',
+              'value': base64Encode(imageBytes),
+              'mimeType': 'application/pdf',
+            },
+          },
+        ]);
+
+        expect(message.text, equals('summarise '));
+        final missing = message.parts![1] as MissingAttachmentPart;
+        expect(missing.reason, equals(MissingAttachmentReason.unsupportedType));
+        expect(missing.mimeType, equals('application/pdf'));
+      });
+
+      // Valid base64 for zero bytes: no decoder can render it, so an ImagePart
+      // here would only fail again at paint time.
+      test('marks an empty image payload as a missing attachment', () async {
+        final message = await hydrateUserMessage([
+          {'type': 'text', 'text': 'look at this'},
+          {
+            'type': 'image',
+            'source': {'type': 'data', 'value': '', 'mimeType': 'image/png'},
+          },
+        ]);
+
+        expect(message.text, equals('look at this'));
+        final missing = message.parts![1] as MissingAttachmentPart;
+        expect(missing.reason, equals(MissingAttachmentReason.undecodable));
+      });
+
+      // The parts ride the run cache as their own field rather than inside the
+      // cached event list, so their survival across a second open of a thread
+      // is a property of the cache entry's shape and has to be asserted.
+      test('serves the parts from cache on a second load', () async {
+        await hydrateUserMessage([
+          {'type': 'text', 'text': 'read this '},
+          dataImage('image/png'),
+        ]);
+
+        final again = await api.getThreadHistory('room-123', 'thread-456');
+        final message = again.messages
+            .whereType<TextMessage>()
+            .firstWhere((m) => m.user == ChatUser.user);
+
+        final parts = message.parts;
+        expect(parts, hasLength(2));
+        expect((parts![1] as ImagePart).bytes, equals(imageBytes));
+
+        // Served from cache: the run endpoint was not asked a second time.
+        verify(
+          () => mockTransport.request<Map<String, dynamic>>(
+            'GET',
+            Uri.parse(
+              'https://api.example.com/api/v1/rooms/room-123/agui/thread-456/run-1',
+            ),
+            cancelToken: any(named: 'cancelToken'),
+            fromJson: any(named: 'fromJson'),
+            body: any(named: 'body'),
+            headers: any(named: 'headers'),
+            timeout: any(named: 'timeout'),
+          ),
+        ).called(1);
+      });
+    });
+
+    group('getThreadHistory run isolation', () {
+      /// Stubs a thread of [runs] keyed by run id, in the order given, each
+      /// already finished, then hydrates it.
+      Future<ThreadHistory> hydrate(
+        Map<String, Map<String, dynamic>> runs,
+      ) async {
+        var minute = 0;
+        when(
+          () => mockTransport.request<Map<String, dynamic>>(
+            'GET',
+            Uri.parse(
+              'https://api.example.com/api/v1/rooms/room-123/agui/thread-456',
+            ),
+            cancelToken: any(named: 'cancelToken'),
+            fromJson: any(named: 'fromJson'),
+            body: any(named: 'body'),
+            headers: any(named: 'headers'),
+            timeout: any(named: 'timeout'),
+          ),
+        ).thenAnswer(
+          (_) async => {
+            'runs': {
+              for (final runId in runs.keys)
+                runId: {
+                  'run_id': runId,
+                  'created': '2026-01-07T01:0$minute:00.000Z',
+                  'finished': '2026-01-07T01:0${minute++}:30.000Z',
+                },
+            },
+          },
+        );
+        for (final entry in runs.entries) {
+          when(
+            () => mockTransport.request<Map<String, dynamic>>(
+              'GET',
+              Uri.parse(
+                'https://api.example.com/api/v1/rooms/room-123/agui/thread-456/${entry.key}',
+              ),
+              cancelToken: any(named: 'cancelToken'),
+              fromJson: any(named: 'fromJson'),
+              body: any(named: 'body'),
+              headers: any(named: 'headers'),
+              timeout: any(named: 'timeout'),
+            ),
+          ).thenAnswer((_) async => {'run_id': entry.key, ...entry.value});
+        }
+        return api.getThreadHistory('room-123', 'thread-456');
+      }
+
+      Map<String, dynamic> userInput(String id, String text) => {
+            'run_input': {
+              'messages': [
+                {'id': id, 'role': 'user', 'content': text},
+              ],
+            },
+          };
+
+      // An id the wire supplies as empty is not an id. Taking it at face value
+      // keys every such turn to the same empty string, where the append guard
+      // reads the second one as a continuation of the first and drops its
+      // bubble — so two unrelated questions collapse into one.
+      test('runs whose user message has a blank id keep separate bubbles',
+          () async {
+        final history = await hydrate({
+          'run-1': {
+            ...userInput('', 'first question'),
+            'events': [
+              {'type': 'RUN_STARTED', 'threadId': 't', 'runId': 'run-1'},
+              {'type': 'RUN_FINISHED', 'threadId': 't', 'runId': 'run-1'},
+            ],
+          },
+          'run-2': {
+            ...userInput('', 'second question'),
+            'events': [
+              {'type': 'RUN_STARTED', 'threadId': 't', 'runId': 'run-2'},
+              {'type': 'RUN_FINISHED', 'threadId': 't', 'runId': 'run-2'},
+            ],
+          },
+        });
+
+        final texts = history.messages
+            .whereType<TextMessage>()
+            .where((m) => m.user == ChatUser.user)
+            .map((m) => m.text);
+        expect(texts, containsAll(['first question', 'second question']));
+      });
+
+      // A continuation run adds no user turn, so its `run_input` still ends
+      // with the message its parent contributed. Appending is blind, so the
+      // guard is the only thing keeping the turn to one bubble.
+      test('a continuation run does not repeat its parent user message',
+          () async {
+        final history = await hydrate({
+          'run-1': {
+            ...userInput('user-1', 'do the thing'),
+            'events': [
+              {'type': 'RUN_STARTED', 'threadId': 't', 'runId': 'run-1'},
+              {'type': 'RUN_FINISHED', 'threadId': 't', 'runId': 'run-1'},
+            ],
+          },
+          // Same last user message; the tool loop opened a second run for it.
+          'run-2': {
+            'run_input': {
+              'messages': [
+                {'id': 'user-1', 'role': 'user', 'content': 'do the thing'},
+                {'id': 'a-1', 'role': 'assistant', 'content': 'calling a tool'},
+              ],
+            },
+            'events': [
+              {'type': 'RUN_STARTED', 'threadId': 't', 'runId': 'run-2'},
+              {'type': 'RUN_FINISHED', 'threadId': 't', 'runId': 'run-2'},
+            ],
+          },
+        });
+
+        expect(
+          history.messages.where((m) => m.id == 'user-1'),
+          hasLength(1),
+          reason: 'the turn keeps one user bubble across its runs',
+        );
+        // Both runs key their state to the one message; the later run wins.
+        expect(history.messageStates['user-1']?.runId, equals('run-2'));
+      });
+
+      // Streaming state is scoped to a run, so a run whose events were
+      // truncated before any terminal event cannot hand its half-streamed
+      // reply to the next run, where that run's terminal event would commit it
+      // under the wrong run and out of order.
+      test('a truncated run does not leak partial text into the next run',
+          () async {
+        final history = await hydrate({
+          'run-1': {
+            ...userInput('user-1', 'first'),
+            'events': [
+              {'type': 'RUN_STARTED', 'threadId': 't', 'runId': 'run-1'},
+              {
+                'type': 'TEXT_MESSAGE_START',
+                'messageId': 'a-1',
+                'role': 'assistant',
+              },
+              {
+                'type': 'TEXT_MESSAGE_CONTENT',
+                'messageId': 'a-1',
+                'delta': 'half a rep',
+              },
+              // Truncated: no TEXT_MESSAGE_END, no RUN_FINISHED.
+            ],
+          },
+          // Reaches a terminal event without starting a message of its own.
+          // That is what makes the leak observable: a run that starts its own
+          // text replaces the dangling stream before any terminal event can
+          // commit it, so only this shape discriminates.
+          'run-2': {
+            ...userInput('user-2', 'second'),
+            'events': [
+              {'type': 'RUN_STARTED', 'threadId': 't', 'runId': 'run-2'},
+              {'type': 'RUN_FINISHED', 'threadId': 't', 'runId': 'run-2'},
+            ],
+          },
+        });
+
+        final texts =
+            history.messages.whereType<TextMessage>().map((m) => m.text);
+        expect(texts, contains('first'));
+        expect(texts, contains('second'));
+        // An assertion about attribution, not about retention: that a truncated
+        // run's buffered text is discarded outright is settled elsewhere.
+        expect(
+          texts.where((t) => t.contains('half a rep')),
+          isEmpty,
+          reason: "run-1's partial reply must not be committed under run-2",
+        );
+      });
+    });
+
     group('getRun', () {
       test('returns run by ID', () async {
         when(

--- a/packages/soliplex_client/test/domain/chat_message_test.dart
+++ b/packages/soliplex_client/test/domain/chat_message_test.dart
@@ -499,10 +499,10 @@ void main() {
       expect(message.parts, hasLength(1));
     });
 
-    // A payload with no image and no text reaches the wire as empty content,
-    // which the backend discards without reporting an error. Rejecting it at
-    // construction is the only point where the caller can still be told.
-    test('a message with neither text nor an image is rejected', () {
+    // A payload with no attachment and no text reaches the wire as empty
+    // content, which the backend discards without reporting an error. Rejecting
+    // it at construction is the only point where the caller can still be told.
+    test('a message with neither text nor an attachment is rejected', () {
       expect(
         () => TextMessage.fromParts(id: 'm-1', parts: const []),
         throwsArgumentError,
@@ -511,6 +511,23 @@ void main() {
         () => TextMessage.fromParts(id: 'm-1', parts: const [TextPart('')]),
         throwsArgumentError,
       );
+    });
+
+    // A message rebuilt from history whose only attachment could not be
+    // rebuilt: it has nothing to send, but the placeholder is the whole reason
+    // it still has something to render. Tightening the guard back to requiring
+    // an image would throw here, and the throw escapes into replay where it
+    // costs the whole thread's history rather than the one message.
+    test('a placeholder with no text is accepted', () {
+      final message = TextMessage.fromParts(
+        id: 'm-1',
+        parts: const [
+          MissingAttachmentPart(reason: MissingAttachmentReason.remoteSource),
+        ],
+      );
+
+      expect(message.text, isEmpty);
+      expect(message.parts, hasLength(1));
     });
 
     // An image alone is a complete message: it carries no text, so `text` is

--- a/test/modules/room/ui/text_message_tile_test.dart
+++ b/test/modules/room/ui/text_message_tile_test.dart
@@ -1,3 +1,6 @@
+import 'dart:convert';
+import 'dart:typed_data';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -10,7 +13,9 @@ import 'package:soliplex_frontend/src/modules/room/ui/copy_button.dart';
 import 'package:soliplex_frontend/src/modules/room/ui/feedback_buttons.dart';
 import 'package:soliplex_frontend/src/modules/room/ui/markdown/flutter_markdown_plus_renderer.dart';
 import 'package:soliplex_frontend/src/modules/room/ui/message_caption.dart';
+import 'package:soliplex_frontend/src/modules/room/ui/paged_zoomable_images.dart';
 import 'package:soliplex_frontend/src/modules/room/ui/text_message_tile.dart';
+import 'package:soliplex_frontend/src/shared/zoomable_image.dart';
 
 Widget _wrap(Widget child, {MessageExpansions? store}) => ProviderScope(
       overrides: [
@@ -21,6 +26,16 @@ Widget _wrap(Widget child, {MessageExpansions? store}) => ProviderScope(
     );
 
 void main() {
+  setUp(() {
+    // Decode results outlive the test that produced them: the binding's image
+    // cache is not reset between tests in a file, so a failed decode in one
+    // test makes a later test's sound image fail too. Cleared so no test's
+    // result depends on the ones that ran before it.
+    imageCache
+      ..clear()
+      ..clearLiveImages();
+  });
+
   testWidgets('user message shows copy button but no feedback buttons',
       (tester) async {
     await tester.pumpWidget(_wrap(
@@ -252,5 +267,199 @@ void main() {
     ));
 
     expect(find.byType(SoliplexShimmer), findsOneWidget);
+  });
+
+  group('a user message carrying image parts', () {
+    // A real 1x1 PNG rather than arbitrary bytes, so these tests exercise the
+    // decoding path instead of the failure placeholder.
+    final pngBytes = base64Decode(
+      'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8'
+      '//8/AwAI/AL+XJ/PIAAAAABJRU5ErkJggg==',
+    );
+
+    ImagePart image() => ImagePart(bytes: pngBytes, mimeType: 'image/png');
+
+    Widget tile(List<MessagePart> parts) => _wrap(
+          TextMessageTile(
+            roomId: 'r',
+            message: TextMessage.fromParts(
+              id: 'parts-1',
+              parts: parts,
+              createdAt: DateTime(2026),
+            ),
+          ),
+        );
+
+    /// The bubble's rich text — the only `Text.rich` in the tile.
+    TextSpan bubbleSpan(WidgetTester tester) {
+      final rich = tester
+          .widgetList<Text>(find.byType(Text))
+          .singleWhere((t) => t.textSpan != null);
+      return rich.textSpan! as TextSpan;
+    }
+
+    testWidgets('renders text and images interleaved in order', (tester) async {
+      await tester.pumpWidget(tile([
+        const TextPart('read the code in '),
+        image(),
+        const TextPart(' and reply'),
+      ]));
+
+      final children = bubbleSpan(tester).children!;
+      expect(children, hasLength(3));
+      expect((children[0] as TextSpan).text, equals('read the code in '));
+      expect(children[1], isA<WidgetSpan>());
+      expect((children[2] as TextSpan).text, equals(' and reply'));
+      expect(find.byType(Image), findsOneWidget);
+    });
+
+    // One slot per ImagePart, each laid out at the tap target rather than at
+    // the image's intrinsic size, so a bubble of photos stays a sentence.
+    testWidgets('gives every image its own tap-target slot', (tester) async {
+      await tester.pumpWidget(tile([
+        const TextPart('rank these '),
+        image(),
+        image(),
+        image(),
+        image(),
+        const TextPart(' by sharpness please'),
+      ]));
+
+      expect(find.byType(Image), findsNWidgets(4));
+      expect(tester.getSize(find.byType(Image).first), const Size(48, 48));
+    });
+
+    // The pager pages over the images alone, so its index counts images while
+    // the bubble counts parts. A placeholder between the two makes those
+    // diverge — index 1 against slot 3 — so an off-by-one that opened the wrong
+    // photo cannot pass here.
+    testWidgets('tapping the second image opens the pager at that image',
+        (tester) async {
+      await tester.pumpWidget(tile([
+        const TextPart('compare '),
+        image(),
+        const MissingAttachmentPart(
+          reason: MissingAttachmentReason.remoteSource,
+        ),
+        const TextPart(' with '),
+        image(),
+      ]));
+
+      expect(find.byType(ZoomableImage), findsNothing);
+
+      await tester.tap(find.byType(Image).last);
+      await tester.pumpAndSettle();
+
+      // The starting page is read off the pager itself. Asserting on which
+      // ZoomableImage happens to be built would instead rest on how many
+      // neighbours PageView keeps alive, which is not our decision to pin.
+      final pager =
+          tester.widget<PagedZoomableImages>(find.byType(PagedZoomableImages));
+      expect(pager.initialIndex, equals(1));
+      expect(pager.itemCount, equals(2));
+    });
+
+    // Bytes that are not a decodable image at all. The slot keeps its size so
+    // the sentence does not reflow, and the surrounding text still reads.
+    testWidgets('an image whose bytes will not decode shows a placeholder',
+        (tester) async {
+      await tester.pumpWidget(tile([
+        const TextPart('look at '),
+        ImagePart(
+          bytes: Uint8List.fromList(const [1, 2, 3, 4]),
+          mimeType: 'image/png',
+        ),
+      ]));
+      await tester.pump(const Duration(milliseconds: 100));
+
+      expect(find.byIcon(Icons.broken_image), findsOneWidget);
+      expect(bubbleSpan(tester).children, hasLength(2));
+      // The failed slot keeps the same footprint as a decoded one, so the
+      // sentence does not reflow when an image turns out to be unreadable.
+      expect(
+        tester.getSize(
+          find
+              .ancestor(
+                of: find.byIcon(Icons.broken_image),
+                matching: find.byType(Container),
+              )
+              .first,
+        ),
+        const Size(48, 48),
+      );
+    });
+
+    // An attachment history could not rebuild keeps its place in the sentence
+    // instead of vanishing, so the bubble reports what it was sent with rather
+    // than reading as though it never carried anything.
+    testWidgets('a missing attachment holds its slot beside a readable image',
+        (tester) async {
+      await tester.pumpWidget(tile([
+        const TextPart('compare '),
+        image(),
+        const MissingAttachmentPart(
+          reason: MissingAttachmentReason.unsupportedType,
+          mimeType: 'audio/mpeg',
+        ),
+        const TextPart(' please'),
+      ]));
+
+      final children = bubbleSpan(tester).children!;
+      expect(children, hasLength(4));
+      expect(children[1], isA<WidgetSpan>());
+      expect(children[2], isA<WidgetSpan>());
+      // The readable image still renders; only the unreadable slot degrades.
+      expect(find.byType(Image), findsOneWidget);
+      expect(find.byIcon(Icons.broken_image), findsOneWidget);
+    });
+
+    // The glyph carries the meaning visually, so the announcement is all a
+    // screen reader user gets — it has to say what kind of thing is missing,
+    // not merely that something is. Asserting the type reaches the label, not
+    // the wording around it.
+    testWidgets('a missing attachment names its kind for a screen reader',
+        (tester) async {
+      await tester.pumpWidget(tile([
+        const TextPart('listen to '),
+        const MissingAttachmentPart(
+          reason: MissingAttachmentReason.unsupportedType,
+          mimeType: 'audio/mpeg',
+        ),
+      ]));
+
+      final semantics = tester.getSemantics(
+        find
+            .ancestor(
+              of: find.byIcon(Icons.broken_image),
+              matching: find.byType(Semantics),
+            )
+            .first,
+      );
+      expect(semantics.label, contains('audio/mpeg'));
+    });
+  });
+
+  testWidgets('a user message without parts renders as plain text',
+      (tester) async {
+    await tester.pumpWidget(_wrap(
+      TextMessageTile(
+        roomId: 'r',
+        message: TextMessage(
+          id: 'plain-1',
+          user: ChatUser.user,
+          createdAt: DateTime(2026),
+          text: 'just words',
+        ),
+      ),
+    ));
+
+    expect(find.text('just words'), findsOneWidget);
+    expect(find.byType(Image), findsNothing);
+    expect(
+      tester
+          .widgetList<Text>(find.byType(Text))
+          .where((t) => t.textSpan != null),
+      isEmpty,
+    );
   });
 }


### PR DESCRIPTION
# Summary

Thread history rebuilt a user message by fabricating `TEXT_MESSAGE_START` /
`CONTENT` / `END` events from the run's persisted input, reading `content` only
when it was a bare string. A message sent as an ordered list of parts came back
blank — its text lost along with its images. This reads that content back into
the domain and appends the message directly ahead of the run's real events,
which is the shape the live path already uses.

Third of the inline image attachments series: PR 1 added the part types, PR 2
widened the send path, this restores the round trip and renders it. The picker
that lets a user actually attach an image is PR 4 — until then nothing in the
app can produce an image-bearing message, so this is not manually reachable.

## Changes

- Read a user message's wire `content` back into ordered `MessagePart`s.
  Content the domain cannot hold becomes a `MissingAttachmentPart` in the slot
  it occupied — a URL image source, audio, video, a document, opaque binary, or
  bytes that will not decode — carrying the declared MIME type and a reason,
  since the placeholder looks the same whichever loss produced it.
- Decode each element on its own rather than through ag_ui's list decoder,
  which is all-or-nothing: one unnameable part would otherwise discard the whole
  list and take the message's text with it. Nothing on this path throws, and
  everything unreadable is logged with its message, run and thread.
- Render a user message's parts in the bubble: text as text, each image inline
  at its position as a 48 px tap target that opens the message's images in the
  shared zoom browser. An unshowable slot keeps the same footprint so the
  sentence does not reflow, and names what is missing to a screen reader and as
  a tooltip. A message with no parts renders as before.
- `ZoomableImage`'s byte constructors take an optional `maxDecodeExtent`.
  `Image`'s width and height bound layout only; the engine still decodes the
  full bitmap, ~48 MB of RGBA for a 12 MP photo, repeated per image on screen.
- Scope streaming state to its own run, so a run truncated before any terminal
  event cannot hand its half-streamed reply to the next run.
- Treat a blank message id as absent and key it to the run. Taken at face value
  it keyed every blank-id turn to the same message, so all but the first lost
  its bubble and their citations piled onto one turn. A blank `run_id` is
  rejected for the same reason, since that id is the fallback.
- Keep one bubble per turn across a continuation run, whose input still ends
  with the message its parent contributed.

## Notes for reviewers

Two consequences for code reading `ThreadHistory.runs`: a run's event list no
longer carries the three synthetic events, and for any run whose input carried a
user message the ids of its `DroppedEventMessage`s shift by three, since the
index now refers to the run's actual wire payload.

Three behaviours are deliberate rather than oversights, and each is described by
the code where it lives:

- A message whose only attachment could not be rebuilt and which had no caption
  re-sends as empty content, so that turn gives the model no prompt. There is
  genuinely nothing to send; it is strictly better than the previous blank
  hydration, but the loss is silent.
- If the backend ever reuses a message id across runs with different text, the
  second turn is dropped with an error log and no drop tile.
- The run cache now retains image bytes past a thread's close and evicts on
  entry count, not bytes. Tracked separately.

## Test Plan

- [x] Tests pass locally — 2261 frontend, 1642 `soliplex_client`
- [x] `flutter analyze` clean, `dart format` clean, markdownlint clean
- [ ] Manual testing — **not possible on this branch.** `ChatInput` emits
      `[TextPart(text)]` only, so no image-bearing message can exist yet. The
      wire round trip is covered by mocked transport only; whether the backend
      returns multimodal `content` in the shape this decoder expects is
      unverified against a real server until PR 4 lands.

## Related Issues

N/A
