### PR TITLE
feat: hold images inline in the composer's text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,22 @@ Versions follow the `version+build` scheme from `pubspec.yaml`, bumped via
 
 ### Changed
 
+- The chat composer's controller can carry images inline in its text — one
+  code unit each, rendered as a chip and split back out into an ordered part
+  list on send. Groundwork only: nothing can put an image in the composer yet,
+  and a composer holding none delegates its rendering whole to
+  `TextEditingController`, IME composition underline included, so no screen
+  behaves differently.
+- Groundwork, unreachable until images can be attached: a composer draft held
+  across a failed send or an authentication round trip keeps each image's
+  position, as a placeholder the user removes before sending. Bytes are
+  deliberately not persisted — drafts live in `SharedPreferences`, which
+  Android reads whole into memory at first access — and the source images are
+  still on the device. Dropping the images silently instead would send a
+  sentence written around pictures that are no longer in it. A draft of images
+  and no caption is kept too, where an image-only payload previously flattened
+  to an empty string and left an older draft in the slot to be restored in its
+  place.
 - **Breaking (library consumers):** the send path carries an ordered
   `List<MessagePart>` where it previously carried a `String`. This affects
   `AgentRuntime.spawn` and `MultiServerRuntime.spawn` (`prompt`), and

--- a/lib/src/modules/room/composer_draft.dart
+++ b/lib/src/modules/room/composer_draft.dart
@@ -1,0 +1,44 @@
+import 'package:soliplex_agent/soliplex_agent.dart';
+
+/// Stands for one image in a persisted draft.
+///
+/// The same marker serves every image, unlike the per-image code units the
+/// live composer uses: a draft carries no bytes, so at restore time every
+/// image is unavailable and there is no identity for two markers to confuse.
+///
+/// It is a non-whitespace character, which is what lets a draft of images and
+/// no caption reach storage at all: `persistComposerDraft` returns early on a
+/// whitespace-only draft, leaving an older draft in the slot to be restored
+/// later in its place.
+const composerDraftImageMarker = '￼';
+
+/// Serializes [parts] to the single string a composer draft is stored as:
+/// text runs verbatim, one [composerDraftImageMarker] per image, in order.
+///
+/// **A draft carries each image's position and none of its bytes.** Drafts
+/// live in `SharedPreferences`, which on Android is an XML file read whole
+/// into memory at first access, and base64 inflates by 4/3 — so persisted
+/// images would be paid for at every launch. The source images are still on
+/// the device, where re-picking one is a few taps; retyping a paragraph is
+/// not.
+///
+/// The inverse is `InlineImageComposerController.restoreDraft`, which turns
+/// each marker back into a placeholder the user must remove before sending, so
+/// nothing is dropped from the message without them seeing it go.
+String encodeComposerDraft(List<MessagePart> parts) {
+  final draft = StringBuffer();
+  for (final part in parts) {
+    switch (part) {
+      case TextPart(:final text):
+        // The marker has to mean one thing. A copy out of a PDF can carry the
+        // same character, and restoring that as an image would tell the user
+        // an image they never attached went missing; it stands for an object
+        // that is not there, so dropping it costs nothing visible.
+        draft.write(text.replaceAll(composerDraftImageMarker, ''));
+      case ImagePart():
+      case MissingAttachmentPart():
+        draft.write(composerDraftImageMarker);
+    }
+  }
+  return draft.toString();
+}

--- a/lib/src/modules/room/composer_persistence.dart
+++ b/lib/src/modules/room/composer_persistence.dart
@@ -3,25 +3,26 @@ import 'dart:developer' as dev;
 
 import '../auth/return_to_storage.dart';
 
-/// Persists [prompt] so it survives the route guard's redirect on auth
-/// expiry.
+/// Persists [draft] so it survives the route guard's redirect on auth
+/// expiry. Build it with `encodeComposerDraft`, which keeps every image's
+/// position and none of its bytes.
 ///
-/// Empty / whitespace-only [prompt] is a no-op. Storage failures are
+/// Empty / whitespace-only [draft] is a no-op. Storage failures are
 /// logged at SEVERE and swallowed; the user's draft is lost but the
 /// redirect still proceeds.
 void persistComposerDraft({
   required String serverId,
   required String? userId,
   required String roomId,
-  required String prompt,
+  required String draft,
 }) {
-  if (prompt.trim().isEmpty) return;
+  if (draft.trim().isEmpty) return;
   unawaited(
     ReturnToStorage.saveComposer(
       serverId: serverId,
       userId: userId,
       roomId: roomId,
-      unsentText: prompt,
+      unsentText: draft,
     ).catchError((Object e, StackTrace st) {
       dev.log(
         'Failed to persist composer draft for auth roundtrip',

--- a/lib/src/modules/room/room_state.dart
+++ b/lib/src/modules/room/room_state.dart
@@ -7,6 +7,7 @@ import '../../core/util/debouncer.dart';
 import '../auth/auth_session.dart';
 import '../auth/server_entry.dart';
 import 'agent_runtime_manager.dart';
+import 'composer_draft.dart';
 import 'composer_persistence.dart';
 import 'room_run_activity.dart';
 import 'run_registry.dart';
@@ -311,7 +312,7 @@ class RoomState {
           serverId: _connection.serverId,
           userId: _auth.currentUserId.value,
           roomId: _roomId,
-          prompt: parts.plainText,
+          draft: encodeComposerDraft(parts),
         ),
         onSpawned: (session) {
           // Clear room-level spawn state — the thread view takes over.

--- a/lib/src/modules/room/send_error.dart
+++ b/lib/src/modules/room/send_error.dart
@@ -1,5 +1,10 @@
 class SendError {
   const SendError(this.error, {this.unsentText});
   final Object error;
+
+  /// The message that never went out, encoded as a composer draft — text with
+  /// a marker holding each image's place. Restore it through the composer's
+  /// `restoreDraft` rather than assigning it as text, or every image the user
+  /// attached vanishes without them seeing it go.
   final String? unsentText;
 }

--- a/lib/src/modules/room/session_spawner.dart
+++ b/lib/src/modules/room/session_spawner.dart
@@ -4,6 +4,7 @@ import 'dart:developer' as dev;
 import 'package:soliplex_agent/soliplex_agent.dart';
 
 import '../auth/auth_session.dart';
+import 'composer_draft.dart';
 import 'send_error.dart';
 
 /// Owns the pending-spawn state machine shared by [ThreadViewState] and
@@ -87,7 +88,8 @@ class SessionSpawner {
         name: 'SessionSpawner',
         level: 900,
       );
-      errorSignal.value = SendError(error, unsentText: prompt.plainText);
+      errorSignal.value =
+          SendError(error, unsentText: encodeComposerDraft(prompt));
     } on AuthException catch (error) {
       if (_cancelled || isDisposed()) return;
       dev.log(
@@ -122,7 +124,8 @@ class SessionSpawner {
         name: 'SessionSpawner',
         level: 1000,
       );
-      errorSignal.value = SendError(error, unsentText: prompt.plainText);
+      errorSignal.value =
+          SendError(error, unsentText: encodeComposerDraft(prompt));
     } finally {
       _pendingSpawn = null;
       if (!_cancelled && !succeeded) {

--- a/lib/src/modules/room/thread_view_state.dart
+++ b/lib/src/modules/room/thread_view_state.dart
@@ -5,6 +5,7 @@ import 'package:soliplex_agent/soliplex_agent.dart';
 
 import '../auth/auth_session.dart';
 import '../auth/auth_tokens.dart';
+import 'composer_draft.dart';
 import 'composer_persistence.dart';
 import 'execution_tracker.dart';
 import 'execution_tracker_extension.dart';
@@ -507,9 +508,7 @@ class ThreadViewState {
       serverId: _connection.serverId,
       userId: _auth.currentUserId.value,
       roomId: _roomId,
-      // Storage holds a plain string, so a draft round-trips its text and
-      // drops any image.
-      prompt: prompt.plainText,
+      draft: encodeComposerDraft(prompt),
     );
   }
 }

--- a/lib/src/modules/room/ui/chat_input.dart
+++ b/lib/src/modules/room/ui/chat_input.dart
@@ -5,7 +5,15 @@ import 'package:soliplex_agent/soliplex_agent.dart' hide State;
 
 import '../../../shared/document_display.dart';
 import 'document_label.dart';
+import 'inline_image_composer_controller.dart';
 import 'package:soliplex_design/soliplex_design.dart';
+
+/// Shown while the composer holds an image it cannot send, which is only ever
+/// a draft that came back from re-authentication without its images. Removing
+/// each one is the way past, so the message that goes out is the one on
+/// screen.
+const unrestoredImageNotice =
+    'Remove the images that could not be restored to send this message.';
 
 /// Whether the composer takes text right now. It refuses while the screen has
 /// it disabled and while a run is in flight, because both render it read-only —
@@ -50,7 +58,7 @@ class ChatInput extends StatefulWidget {
   /// `false` (it still renders, since [sessionState] is `spawning` or
   /// `running`). Defaults to `true`.
   final ReadonlySignal<bool>? cancelEnabled;
-  final TextEditingController? controller;
+  final InlineImageComposerController? controller;
   final FocusNode? focusNode;
   final bool enabled;
   final Set<RagDocument> selectedDocuments;
@@ -73,7 +81,7 @@ class ChatInput extends StatefulWidget {
 enum _AttachChoice { files, folder }
 
 class _ChatInputState extends State<ChatInput> {
-  late TextEditingController _controller;
+  late InlineImageComposerController _controller;
   late FocusNode _focusNode;
   bool _ownsController = false;
   bool _ownsFocusNode = false;
@@ -104,7 +112,7 @@ class _ChatInputState extends State<ChatInput> {
       _controller = widget.controller!;
       _ownsController = false;
     } else {
-      _controller = TextEditingController();
+      _controller = InlineImageComposerController();
       _ownsController = true;
     }
   }
@@ -127,17 +135,41 @@ class _ChatInputState extends State<ChatInput> {
   }
 
   void _send() {
-    final text = _controller.text.trim();
-    if (text.isEmpty ||
-        !composerAcceptsText(
-          enabled: widget.enabled,
-          sessionState: widget.sessionState?.peek(),
-        )) {
+    if (!composerAcceptsText(
+      enabled: widget.enabled,
+      sessionState: widget.sessionState?.peek(),
+    )) {
       return;
     }
-    widget.onSend([TextPart(text)]);
+    final parts = _controller.sendableParts();
+    if (parts == null) return;
+    widget.onSend(parts);
     _controller.clear();
     _focusNode.requestFocus();
+  }
+
+  Widget _placeholderNotice(BuildContext context) {
+    final theme = Theme.of(context);
+    return Padding(
+      padding: const EdgeInsets.only(bottom: SoliplexSpacing.s1),
+      child: Row(
+        children: [
+          Icon(
+            Icons.image_not_supported_outlined,
+            size: 16,
+            color: theme.colorScheme.onSurfaceVariant,
+          ),
+          const SizedBox(width: SoliplexSpacing.s1),
+          Flexible(
+            child: Text(
+              unrestoredImageNotice,
+              style: theme.textTheme.bodySmall
+                  ?.copyWith(color: theme.colorScheme.onSurfaceVariant),
+            ),
+          ),
+        ],
+      ),
+    );
   }
 
   @override
@@ -257,6 +289,12 @@ class _ChatInputState extends State<ChatInput> {
                       ),
                     ),
             ),
+          ValueListenableBuilder<TextEditingValue>(
+            valueListenable: _controller,
+            builder: (context, value, child) => _controller.hasPlaceholderImage
+                ? _placeholderNotice(context)
+                : const SizedBox.shrink(),
+          ),
           Row(
             children: [
               if (widget.onFilterTap != null)
@@ -321,10 +359,9 @@ class _ChatInputState extends State<ChatInput> {
               else
                 ValueListenableBuilder<TextEditingValue>(
                   valueListenable: _controller,
-                  builder: (context, value, _) => IconButton(
+                  builder: (context, value, child) => IconButton(
                     icon: const Icon(Icons.send),
-                    onPressed:
-                        value.text.trim().isEmpty || disabled ? null : _send,
+                    onPressed: disabled || !_controller.canSend ? null : _send,
                   ),
                 ),
             ],

--- a/lib/src/modules/room/ui/inline_image_composer_controller.dart
+++ b/lib/src/modules/room/ui/inline_image_composer_controller.dart
@@ -1,0 +1,455 @@
+import 'package:flutter/material.dart';
+import 'package:soliplex_agent/soliplex_agent.dart' hide State;
+import 'package:soliplex_design/soliplex_design.dart';
+import 'package:soliplex_logging/soliplex_logging.dart';
+
+import '../composer_draft.dart';
+import 'markdown/log_source.dart';
+
+final _logger = LogManager.instance
+    .getLogger('soliplex_frontend.inline_image_composer_controller');
+
+/// Where image tokens are allocated from: the Private Use Area, which carries
+/// no meaning of its own.
+///
+/// A single UTF-16 code unit is what makes an image atomic to edit: backspace
+/// removes the whole thing and the caret cannot land inside it, with no key
+/// handling of our own. Giving each image its own unit is what makes it
+/// identifiable: the character names the image, so no edit to the text can
+/// desynchronise it from the images the composer holds.
+const int _firstImageToken = 0xE000;
+
+/// The draft marker, as the code unit a restore walk reads.
+final int _draftMarkerToken = composerDraftImageMarker.codeUnitAt(0);
+
+/// Edge length of an image's chip in the composer.
+const double _thumbnailSize = SoliplexSpacing.s6;
+
+/// Long-edge bound on a chip thumbnail's *decode*. `Image`'s width and height
+/// bound layout only — the engine decodes the full bitmap otherwise, ~48 MB of
+/// RGBA for a 12 MP photo, for each image in the composer. Nothing downscales
+/// what the user picked, so the composer holds originals.
+const int _thumbnailDecodeExtent = 256;
+
+/// What an image token in the composer's text names.
+sealed class ComposerImage {
+  /// Creates a composer image.
+  const ComposerImage();
+}
+
+/// An image the composer holds the bytes of, ready to send.
+final class InlineImage extends ComposerImage {
+  /// Creates an inline image carrying [part].
+  const InlineImage(this.part);
+
+  /// The image, as a send would carry it.
+  final ImagePart part;
+}
+
+/// An image a restored draft knows the position of but not the content of.
+///
+/// A draft persists positions and no bytes, so this is the expected outcome of
+/// coming back from re-authentication — not a fault. It reads as informational
+/// rather than as an error, and blocks the send until the user removes it.
+final class UnavailableImage extends ComposerImage {
+  /// Creates a placeholder for an image a draft could not bring back.
+  const UnavailableImage();
+}
+
+/// One element of the composer's ordered content, read from its text.
+sealed class ComposerContent {
+  /// Creates a content element.
+  const ComposerContent();
+}
+
+/// A run of text between images.
+final class ComposerTextRun extends ComposerContent {
+  /// Creates a text run carrying [text].
+  const ComposerTextRun(this.text);
+
+  /// The text. Never empty.
+  final String text;
+}
+
+/// The place one image occupies in the text.
+final class ComposerImageSlot extends ComposerContent {
+  /// Creates a slot for the image [token] names.
+  const ComposerImageSlot({required this.token, required this.image});
+
+  /// The code unit naming this image in the composer's text.
+  final int token;
+
+  /// The image, or null when the token's image has been released while the
+  /// character survived — an edit undone after a send, or a defect of ours.
+  /// Either way the composer is showing an image it cannot produce, so it
+  /// renders as an error and blocks the send.
+  final ComposerImage? image;
+}
+
+/// A composer whose text carries images inline, so what the user writes around
+/// them survives editing and reaches the model in the order they wrote it.
+///
+/// Each image is one code unit in [text] paired with a chip rendered from
+/// [buildTextSpan]; the images themselves are held beside the text, keyed by
+/// that code unit. Order and membership are read from the text on every pass,
+/// so an edit can neither reorder the images nor leave one naming the wrong
+/// bytes. Only a code unit this controller minted counts — a character the
+/// user typed is text, whatever block it comes from.
+///
+/// Images are released when the content is replaced wholesale — [clear] on
+/// send or on a room or thread change, and [restoreDraft] — rather than the
+/// moment their code unit leaves the text. Identity follows the character, so
+/// a token that comes back must still name its own image: cutting one and
+/// pasting it elsewhere reorders that image, and an undone deletion brings it
+/// back intact. Releasing on the edit would strand both.
+///
+/// While the text holds no image, rendering is delegated whole to
+/// [TextEditingController], IME composition underline included. Once it holds
+/// one, the composing region is no longer underlined: a composing range is
+/// expressed in offsets over the whole text, and splitting the runs to style
+/// it is not worth its cost against the images it would sit between.
+///
+/// One constraint the chips depend on: `EditableText` renders spell-check
+/// results itself and never calls this class when it has any, so enabling
+/// spell check on the composer's field would replace every chip with a raw
+/// placeholder character.
+class InlineImageComposerController extends TextEditingController {
+  final Map<int, ComposerImage> _images = <int, ComposerImage>{};
+
+  /// Every code unit this controller has minted, outliving the images
+  /// themselves so that a token whose image was released still reads as one.
+  ///
+  /// Membership here, rather than a code-unit range, is what makes a character
+  /// a token: the Private Use Area is full of characters users legitimately
+  /// type and paste — the Apple logo, a terminal's Nerd Font glyphs — and
+  /// reading those as images would put a chip over the user's own text.
+  final Set<int> _mintedTokens = <int>{};
+
+  int _nextToken = _firstImageToken;
+
+  bool _isImageToken(int unit) => _mintedTokens.contains(unit);
+
+  /// Allocates a code unit for one image, skipping any the text it is about to
+  /// join already carries — minting one of those would put a second chip over
+  /// a character the user typed.
+  ///
+  /// Never reuses a unit: a reused one would let an undo resurrect a token
+  /// that now names a different image, the ambiguity the per-image unit exists
+  /// to remove.
+  int _mintToken(Set<int> inUse) {
+    while (inUse.contains(_nextToken)) {
+      _nextToken++;
+    }
+    final token = _nextToken++;
+    _mintedTokens.add(token);
+    return token;
+  }
+
+  /// Empties the composer, releasing every image it holds.
+  @override
+  void clear() {
+    _images.clear();
+    super.clear();
+  }
+
+  /// Inserts [images] at the caret in order, replacing the selection.
+  ///
+  /// Takes images that are already allowed: what may be attached, how many,
+  /// and how large is the picker's business, not a text controller's.
+  void insertImagesAtCaret(List<ImagePart> images) {
+    if (images.isEmpty) return;
+    final inUse = text.codeUnits.toSet();
+    final tokens = StringBuffer();
+    for (final image in images) {
+      final token = _mintToken(inUse);
+      _images[token] = InlineImage(image);
+      tokens.writeCharCode(token);
+    }
+    _replaceSelection(tokens.toString());
+  }
+
+  /// Replaces the composer's content with a draft persisted across an
+  /// auth-expiry redirect.
+  ///
+  /// A draft carries every image's position and none of its bytes, so each
+  /// marker becomes a token of its own with an [UnavailableImage] behind it —
+  /// leaving a restored composer structurally identical to a live one.
+  void restoreDraft(String draft) {
+    _images.clear();
+    // A token equal to a character the draft already carries would put a
+    // second chip over that character.
+    final inUse = draft.codeUnits.toSet();
+    final restored = StringBuffer();
+    for (final unit in draft.codeUnits) {
+      if (unit == _draftMarkerToken) {
+        final token = _mintToken(inUse);
+        _images[token] = const UnavailableImage();
+        restored.writeCharCode(token);
+      } else {
+        restored.writeCharCode(unit);
+      }
+    }
+    final text = restored.toString();
+    value = TextEditingValue(
+      text: text,
+      selection: TextSelection.collapsed(offset: text.length),
+    );
+  }
+
+  /// The composer's ordered content, as the text spells it out.
+  List<ComposerContent> get contents => _contentsOf(text);
+
+  /// The ordered parts a send would carry, or null when the composer has
+  /// nothing to send.
+  ///
+  /// Refuses two payloads rather than sending them:
+  /// - one carrying neither an image nor any text, which reaches the backend
+  ///   as empty content and is discarded there without an error;
+  /// - one where an image is only a placeholder, since dropping it would send
+  ///   a different message from the one the composer is showing.
+  List<MessagePart>? sendableParts() {
+    final parts = <MessagePart>[];
+    for (final content in _contentsOf(text.trim())) {
+      switch (content) {
+        case ComposerTextRun(:final text):
+          parts.add(TextPart(text));
+        case ComposerImageSlot(image: InlineImage(:final part)):
+          parts.add(part);
+        case ComposerImageSlot():
+          return null;
+      }
+    }
+    if (parts.plainText.isEmpty && !parts.hasAttachment) return null;
+    return parts;
+  }
+
+  /// Whether the composer holds something it can send.
+  bool get canSend => sendableParts() != null;
+
+  /// Whether any image is a placeholder — restored from a draft, or a token
+  /// whose image has been released.
+  bool get hasPlaceholderImage => contents.any(
+        (content) =>
+            content is ComposerImageSlot && content.image is! InlineImage,
+      );
+
+  /// How many images the composer holds bytes for. Between edits this exceeds
+  /// the number of image tokens in [text] by design — a deleted image is kept
+  /// so undoing the deletion brings it back — but it must reach zero once the
+  /// content is replaced.
+  @visibleForTesting
+  int get heldImageCount => _images.values.whereType<InlineImage>().length;
+
+  @override
+  TextSpan buildTextSpan({
+    required BuildContext context,
+    TextStyle? style,
+    required bool withComposing,
+  }) {
+    if (!text.codeUnits.any(_isImageToken)) {
+      return super.buildTextSpan(
+        context: context,
+        style: style,
+        withComposing: withComposing,
+      );
+    }
+    return TextSpan(
+      style: style,
+      children: [
+        for (final content in contents)
+          switch (content) {
+            ComposerTextRun(:final text) => TextSpan(text: text),
+            ComposerImageSlot(:final token, :final image) => WidgetSpan(
+                alignment: PlaceholderAlignment.middle,
+                child: _ImageChip(
+                  token: token,
+                  image: image,
+                  onRemove: () => _removeImage(token),
+                ),
+              ),
+          },
+      ],
+    );
+  }
+
+  List<ComposerContent> _contentsOf(String source) {
+    final contents = <ComposerContent>[];
+    final run = StringBuffer();
+
+    void flushText() {
+      if (run.isEmpty) return;
+      contents.add(ComposerTextRun(run.toString()));
+      run.clear();
+    }
+
+    for (final unit in source.codeUnits) {
+      if (_isImageToken(unit)) {
+        flushText();
+        contents.add(ComposerImageSlot(token: unit, image: _images[unit]));
+      } else {
+        run.writeCharCode(unit);
+      }
+    }
+    flushText();
+    return contents;
+  }
+
+  void _replaceSelection(String insertion) {
+    // A selection the text cannot accommodate — never placed, or left behind
+    // by an edit while the picker was open — appends rather than throwing out
+    // of `replaceRange`. Matches `insertPastedText`, which takes the same care
+    // with the same value.
+    final fits = selection.isValid && selection.end <= text.length;
+    final start = fits ? selection.start : text.length;
+    final end = fits ? selection.end : text.length;
+    value = TextEditingValue(
+      text: text.replaceRange(start, end, insertion),
+      selection: TextSelection.collapsed(offset: start + insertion.length),
+    );
+  }
+
+  /// Takes [token] out of the text, wherever the user carried it to.
+  void _removeImage(int token) {
+    final at = text.codeUnits.indexOf(token);
+    if (at < 0) return;
+    value = TextEditingValue(
+      text: String.fromCharCodes(
+        text.codeUnits.where((unit) => unit != token),
+      ),
+      selection: TextSelection.collapsed(offset: at),
+    );
+  }
+}
+
+/// One image, inline in the composer's text.
+///
+/// Renders three states, which mean three different things: the image itself;
+/// a placeholder for one a draft could not bring back, which is expected and
+/// reads as such; and an error-coloured `missing` for a token whose image has
+/// been released. Both placeholders are tappable, because they block the send
+/// and removing them is the only way past. A fourth is possible inside the
+/// first: bytes that will not decode paint a broken glyph in the thumbnail's
+/// place, which does not block the send — this app failing to decode an image
+/// does not mean the model will.
+class _ImageChip extends StatelessWidget {
+  const _ImageChip({
+    required this.token,
+    required this.image,
+    required this.onRemove,
+  });
+
+  /// Identifies the image in the decode-failure log, so a chip that will not
+  /// render can be told from its neighbour.
+  final int token;
+  final ComposerImage? image;
+  final VoidCallback onRemove;
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = Theme.of(context).colorScheme;
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: SoliplexSpacing.s1),
+      child: switch (image) {
+        InlineImage(:final part) => _thumbnail(context, part),
+        UnavailableImage() => _placeholder(
+            context,
+            icon: Icons.image_not_supported_outlined,
+            label: 'unavailable',
+            description: 'This image was not kept across sign-in. '
+                'Tap to remove it.',
+            background: colors.secondaryContainer,
+            foreground: colors.onSecondaryContainer,
+          ),
+        null => _placeholder(
+            context,
+            icon: Icons.broken_image_outlined,
+            label: 'missing',
+            description: 'This image is no longer available. Tap to remove it.',
+            background: colors.errorContainer,
+            foreground: colors.onErrorContainer,
+          ),
+      },
+    );
+  }
+
+  Widget _thumbnail(BuildContext context, ImagePart part) {
+    final radius = BorderRadius.circular(context.radii.sm);
+    return ClipRRect(
+      borderRadius: radius,
+      child: Image(
+        // `.fit` scales the long edge into the box and keeps the aspect ratio,
+        // where `.exact` would decode to a squashed 256×256.
+        image: ResizeImage(
+          MemoryImage(part.bytes),
+          width: _thumbnailDecodeExtent,
+          height: _thumbnailDecodeExtent,
+          policy: ResizeImagePolicy.fit,
+        ),
+        width: _thumbnailSize,
+        height: _thumbnailSize,
+        fit: BoxFit.cover,
+        semanticLabel: 'Attached image',
+        errorBuilder: (context, error, stack) {
+          logFailedSourceOnce(
+            _logger,
+            'composer image decode failed '
+                '(${part.mimeType}, ${part.bytes.length} bytes)',
+            'composer:$token',
+            error: error,
+            stackTrace: stack,
+          );
+          return Icon(
+            Icons.broken_image_outlined,
+            size: _thumbnailSize,
+            color: Theme.of(context).colorScheme.onSurfaceVariant,
+          );
+        },
+      ),
+    );
+  }
+
+  Widget _placeholder(
+    BuildContext context, {
+    required IconData icon,
+    required String label,
+    required String description,
+    required Color background,
+    required Color foreground,
+  }) =>
+      Semantics(
+        button: true,
+        label: description,
+        child: Tooltip(
+          message: description,
+          // Announced by the Semantics above; a tooltip that contributed it
+          // too would have a screen reader read the chip twice.
+          excludeFromSemantics: true,
+          child: GestureDetector(
+            behavior: HitTestBehavior.opaque,
+            onTap: onRemove,
+            child: Container(
+              padding:
+                  const EdgeInsets.symmetric(horizontal: SoliplexSpacing.s1),
+              decoration: BoxDecoration(
+                color: background,
+                borderRadius: BorderRadius.circular(context.radii.sm),
+              ),
+              child: Row(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  Icon(icon, size: 16, color: foreground),
+                  const SizedBox(width: SoliplexSpacing.s1),
+                  Text(
+                    label,
+                    style: Theme.of(context)
+                        .textTheme
+                        .labelSmall
+                        ?.copyWith(color: foreground),
+                  ),
+                ],
+              ),
+            ),
+          ),
+        ),
+      );
+}

--- a/lib/src/modules/room/ui/room_screen.dart
+++ b/lib/src/modules/room/ui/room_screen.dart
@@ -56,6 +56,7 @@ import 'chat_input.dart';
 import 'chunk_visualization_page.dart';
 import 'document_picker.dart';
 import 'error_retry_panel.dart';
+import 'inline_image_composer_controller.dart';
 import 'message_timeline.dart';
 import 'async_action_dialog.dart';
 import 'room_rail.dart';
@@ -259,7 +260,7 @@ class _RoomScreenState extends State<RoomScreen> {
   late RoomState _state;
   late WorkdirController _workdirs;
   void Function()? _autoSelectUnsub;
-  final _chatController = TextEditingController();
+  final _chatController = InlineImageComposerController();
   final _chatFocusNode = FocusNode();
   bool _filesExpanded = false;
 
@@ -1035,9 +1036,7 @@ class _RoomScreenState extends State<RoomScreen> {
       );
       if (!mounted || text == null) return;
       if (_chatController.text.isNotEmpty) return;
-      _chatController.text = text;
-      _chatController.selection =
-          TextSelection.collapsed(offset: _chatController.text.length);
+      _chatController.restoreDraft(text);
       // One-shot: clear once restored so subsequent mounts of the same
       // room don't re-pre-fill the box with stale content.
       await ReturnToStorage.clearComposer(
@@ -1845,9 +1844,7 @@ class _RoomScreenState extends State<RoomScreen> {
     if (unsentText == null || _chatController.text.isNotEmpty) return;
     WidgetsBinding.instance.addPostFrameCallback((_) {
       if (!mounted) return;
-      _chatController.text = unsentText;
-      _chatController.selection =
-          TextSelection.collapsed(offset: _chatController.text.length);
+      _chatController.restoreDraft(unsentText);
     });
   }
 

--- a/test/modules/room/room_state_test.dart
+++ b/test/modules/room/room_state_test.dart
@@ -10,6 +10,7 @@ import 'package:soliplex_frontend/src/modules/auth/auth_tokens.dart';
 import 'package:soliplex_frontend/src/modules/auth/return_to_storage.dart';
 import 'package:soliplex_frontend/src/modules/auth/server_entry.dart';
 import 'package:soliplex_frontend/src/modules/room/agent_runtime_manager.dart';
+import 'package:soliplex_frontend/src/modules/room/composer_draft.dart';
 import 'package:soliplex_frontend/src/modules/room/room_state.dart';
 import 'package:soliplex_frontend/src/modules/room/run_registry.dart';
 import 'package:soliplex_frontend/src/modules/room/thread_list_state.dart';
@@ -227,9 +228,10 @@ void main() {
     expect(state.lastError.value, isNotNull);
     expect(
       state.lastError.value!.unsentText,
-      'Hello',
-      reason: 'SendError carries a string, so the retry banner restores the '
-          'text and cannot restore the image.',
+      'Hello$composerDraftImageMarker',
+      reason: 'SendError carries a string, so a failed send restores the text '
+          "with a marker holding the image's place rather than dropping it "
+          'where the user cannot see it go.',
     );
 
     state.dispose();
@@ -953,11 +955,12 @@ void main() {
       );
       expect(
         restored,
-        'half-written question',
+        'half-written question$composerDraftImageMarker',
         reason: 'RoomState.sendToNewThread must wire composer persistence '
             "as the spawner's onAuthExpired hook; without it the user's "
             'draft is dropped on the floor by the redirect. Storage holds a '
-            'string, so the text survives and the image does not.',
+            "string, so the draft keeps the image's position and not its "
+            'bytes.',
       );
 
       state.dispose();

--- a/test/modules/room/thread_view_state_test.dart
+++ b/test/modules/room/thread_view_state_test.dart
@@ -10,6 +10,7 @@ import 'package:soliplex_frontend/src/modules/auth/auth_session.dart';
 import 'package:soliplex_frontend/src/modules/auth/auth_tokens.dart';
 import 'package:soliplex_frontend/src/modules/auth/return_to_storage.dart';
 import 'package:soliplex_frontend/src/modules/room/agent_runtime_manager.dart';
+import 'package:soliplex_frontend/src/modules/room/composer_draft.dart';
 import 'package:soliplex_frontend/src/modules/room/execution_tracker_extension.dart';
 import 'package:soliplex_frontend/src/modules/room/human_approval_extension.dart';
 import 'package:soliplex_frontend/src/modules/room/run_registry.dart';
@@ -1190,11 +1191,12 @@ void main() {
         );
         expect(
           restored,
-          'half-written question',
+          'half-written question$composerDraftImageMarker',
           reason: 'ThreadViewState must wire composer persistence as the '
               "spawner's onAuthExpired hook; without it the user's draft "
               'is dropped on the floor by the redirect. Storage holds a '
-              'string, so the text survives and the image does not.',
+              "string, so the draft keeps the image's position and not its "
+              'bytes.',
         );
 
         state.dispose();

--- a/test/modules/room/ui/chat_input_test.dart
+++ b/test/modules/room/ui/chat_input_test.dart
@@ -5,7 +5,9 @@ import 'package:signals_flutter/signals_flutter.dart';
 import 'package:soliplex_agent/soliplex_agent.dart' hide State;
 import 'package:soliplex_design/soliplex_design.dart';
 
+import 'package:soliplex_frontend/src/modules/room/composer_draft.dart';
 import 'package:soliplex_frontend/src/modules/room/ui/chat_input.dart';
+import 'package:soliplex_frontend/src/modules/room/ui/inline_image_composer_controller.dart';
 
 void main() {
   group('composerAcceptsText', () {
@@ -82,7 +84,7 @@ void main() {
     // Mirrors the room layout: the chat input is a non-flex child of a
     // bounded Column alongside an Expanded body. An uncapped field grows
     // to its content height and overflows the Column.
-    final controller = TextEditingController(text: 'line\n' * 500);
+    final controller = InlineImageComposerController()..text = 'line\n' * 500;
     addTearDown(controller.dispose);
 
     await tester.pumpWidget(MaterialApp(
@@ -125,6 +127,34 @@ void main() {
     expect(sendButton.onPressed, isNull);
 
     sessionState.dispose();
+  });
+
+  testWidgets('refuses to send while an image could not be restored',
+      (tester) async {
+    // Sending would drop the placeholder and deliver a different message from
+    // the one on screen, so the composer says why instead.
+    final controller = InlineImageComposerController()
+      ..restoreDraft('look at $composerDraftImageMarker');
+    addTearDown(controller.dispose);
+
+    await tester.pumpWidget(MaterialApp(
+      theme: soliplexLightTheme(),
+      home: Scaffold(
+        body: ChatInput(
+          controller: controller,
+          onSend: (_) {},
+          onCancel: () {},
+        ),
+      ),
+    ));
+
+    expect(
+      tester
+          .widget<IconButton>(find.widgetWithIcon(IconButton, Icons.send))
+          .onPressed,
+      isNull,
+    );
+    expect(find.text(unrestoredImageNotice), findsOneWidget);
   });
 
   testWidgets('shows cancel button when session is running', (tester) async {

--- a/test/modules/room/ui/inline_image_composer_controller_test.dart
+++ b/test/modules/room/ui/inline_image_composer_controller_test.dart
@@ -1,0 +1,292 @@
+import 'dart:typed_data';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:soliplex_agent/soliplex_agent.dart' hide State;
+import 'package:soliplex_design/soliplex_design.dart';
+
+import 'package:soliplex_frontend/src/modules/room/composer_draft.dart';
+import 'package:soliplex_frontend/src/modules/room/ui/inline_image_composer_controller.dart';
+
+/// An image whose first byte identifies it, so a test can say which image
+/// survived an edit.
+ImagePart _image(int id) =>
+    ImagePart(bytes: Uint8List.fromList([id]), mimeType: 'image/png');
+
+/// The identifying byte of every image the composer would send, in order.
+List<int> _sentImageIds(InlineImageComposerController controller) =>
+    (controller.sendableParts() ?? const <MessagePart>[])
+        .whereType<ImagePart>()
+        .map((part) => part.bytes.first)
+        .toList();
+
+/// Types [text] over the current selection, as the platform would.
+void _type(TextEditingController controller, String text) {
+  final selection = controller.selection;
+  final start = selection.isValid ? selection.start : controller.text.length;
+  final end = selection.isValid ? selection.end : controller.text.length;
+  controller.value = TextEditingValue(
+    text: controller.text.replaceRange(start, end, text),
+    selection: TextSelection.collapsed(offset: start + text.length),
+  );
+}
+
+/// Deletes `[start, end)`, as a selection delete or a backspace would.
+void _delete(TextEditingController controller, int start, int end) {
+  controller.value = TextEditingValue(
+    text: controller.text.replaceRange(start, end, ''),
+    selection: TextSelection.collapsed(offset: start),
+  );
+}
+
+void _caret(TextEditingController controller, int offset) =>
+    controller.value = controller.value
+        .copyWith(selection: TextSelection.collapsed(offset: offset));
+
+InlineImageComposerController _controller() {
+  final controller = InlineImageComposerController();
+  addTearDown(controller.dispose);
+  return controller;
+}
+
+Widget _composer(InlineImageComposerController controller) => MaterialApp(
+      theme: soliplexLightTheme(),
+      home: Scaffold(
+        body: TextField(controller: controller, maxLines: 5),
+      ),
+    );
+
+void main() {
+  group('send split', () {
+    test('splits the text at each image into ordered parts', () {
+      final controller = _controller();
+      _type(controller, 'look at ');
+      controller.insertImagesAtCaret([_image(1)]);
+      _type(controller, ' and tell me');
+
+      final parts = controller.sendableParts();
+
+      expect(parts, hasLength(3));
+      expect((parts![0] as TextPart).text, 'look at ');
+      expect((parts[1] as ImagePart).bytes.first, 1);
+      expect((parts[2] as TextPart).text, ' and tell me');
+    });
+
+    test('emits no text part between adjacent images', () {
+      final controller = _controller();
+      controller.insertImagesAtCaret([_image(1), _image(2)]);
+
+      final parts = controller.sendableParts();
+
+      expect(parts, hasLength(2));
+      expect(parts!.whereType<TextPart>(), isEmpty);
+      expect(_sentImageIds(controller), [1, 2]);
+    });
+
+    test('clearing the composer releases every image it held', () {
+      final controller = _controller();
+      controller.insertImagesAtCaret([_image(1), _image(2)]);
+
+      controller.clear();
+
+      expect(
+        controller.heldImageCount,
+        isZero,
+        reason: 'a sent or abandoned composer must not retain photo bytes',
+      );
+    });
+
+    test('refuses to send a composer holding only whitespace', () {
+      final controller = _controller();
+      expect(controller.sendableParts(), isNull);
+
+      _type(controller, '   ');
+
+      expect(controller.sendableParts(), isNull);
+      expect(controller.canSend, isFalse);
+    });
+
+    test('appends when the selection reaches past the end of the text', () {
+      // A picker runs for seconds; the caret it was opened with can be stale
+      // by the time bytes come back, and replaceRange throws on that.
+      final controller = _controller();
+      controller.value = const TextEditingValue(
+        text: 'abc',
+        selection: TextSelection(baseOffset: 0, extentOffset: 99),
+      );
+
+      controller.insertImagesAtCaret([_image(1)]);
+
+      expect(_sentImageIds(controller), [1]);
+      expect(controller.sendableParts(), hasLength(2));
+    });
+
+    test('sends an image with no text at all', () {
+      final controller = _controller();
+      controller.insertImagesAtCaret([_image(1)]);
+
+      // TextMessage.fromParts throws on a payload carrying neither, so this is
+      // the boundary the empty-composer guard must not overreach into.
+      expect(controller.sendableParts(), hasLength(1));
+      expect(controller.canSend, isTrue);
+    });
+  });
+
+  group('characters the composer did not mint', () {
+    test('a Private Use Area character the user typed is text', () {
+      // U+F8FF is the Apple logo, and a terminal's Nerd Font glyphs sit beside
+      // it. Reading one as an image puts an error chip over the user's own
+      // character and disables the send with no way to comply.
+      final controller = _controller();
+
+      _type(controller, 'made on a  laptop');
+
+      expect(controller.hasPlaceholderImage, isFalse);
+      expect(controller.canSend, isTrue);
+      expect(controller.sendableParts(), hasLength(1));
+    });
+
+    test('an image still reads as one beside a character like it', () {
+      final controller = _controller();
+
+      _type(controller, ' next to ');
+      controller.insertImagesAtCaret([_image(1)]);
+
+      expect(_sentImageIds(controller), [1]);
+      expect(controller.contents.whereType<ComposerImageSlot>(), hasLength(1));
+    });
+  });
+
+  group('image identity survives editing', () {
+    test('deleting the first of two adjacent images keeps the second', () {
+      final controller = _controller();
+      controller.insertImagesAtCaret([_image(1), _image(2)]);
+
+      _delete(controller, 0, 1);
+
+      expect(_sentImageIds(controller), [2]);
+    });
+
+    test('deleting the second of two adjacent images keeps the first', () {
+      final controller = _controller();
+      controller.insertImagesAtCaret([_image(1), _image(2)]);
+
+      _delete(controller, 1, 2);
+
+      expect(_sentImageIds(controller), [1]);
+    });
+
+    test('cutting an image and pasting it elsewhere moves that image', () {
+      final controller = _controller();
+      _type(controller, 'a');
+      controller.insertImagesAtCaret([_image(1), _image(2)]);
+
+      final cut = controller.text[1];
+      _delete(controller, 1, 2);
+      _caret(controller, controller.text.length);
+      _type(controller, cut);
+
+      expect(_sentImageIds(controller), [2, 1]);
+    });
+  });
+
+  group('draft across re-auth', () {
+    const draftText = 'look at ';
+    const draftTail = ' and tell me';
+
+    String draftOf(List<MessagePart> parts) => encodeComposerDraft(parts);
+
+    test('a draft carries each image position and none of its bytes', () {
+      final draft = draftOf([
+        const TextPart(draftText),
+        _image(1),
+        const TextPart(draftTail),
+      ]);
+
+      expect(draft, '$draftText$composerDraftImageMarker$draftTail');
+      // persistComposerDraft drops a whitespace-only draft without writing,
+      // leaving an older one in the slot to be restored later, so an image
+      // with no caption has to survive that check on the marker alone.
+      expect(draftOf([_image(1)]).trim(), isNotEmpty);
+    });
+
+    test("a marker in the user's own text is not restored as an image", () {
+      // A copy out of a PDF carries U+FFFC. Restoring it as a placeholder
+      // would report an image the user never attached, and block the send.
+      final controller = _controller();
+
+      controller.restoreDraft(
+        draftOf([TextPart('see ${composerDraftImageMarker}below')]),
+      );
+
+      expect(controller.hasPlaceholderImage, isFalse);
+      expect(controller.canSend, isTrue);
+    });
+
+    test('restoring puts an unavailable placeholder where each image was', () {
+      final controller = _controller();
+
+      controller.restoreDraft(
+        draftOf([
+          const TextPart(draftText),
+          _image(1),
+          const TextPart(draftTail),
+        ]),
+      );
+
+      expect(controller.contents, [
+        isA<ComposerTextRun>().having((run) => run.text, 'text', draftText),
+        isA<ComposerImageSlot>()
+            .having((slot) => slot.image, 'image', isA<UnavailableImage>()),
+        isA<ComposerTextRun>().having((run) => run.text, 'text', draftTail),
+      ]);
+    });
+
+    test('refuses to send until the unavailable image is removed', () {
+      final controller = _controller();
+      controller.restoreDraft(
+        draftOf([const TextPart(draftText), _image(1)]),
+      );
+
+      // Sending would drop the placeholder and alter what the user wrote.
+      expect(controller.sendableParts(), isNull);
+      expect(controller.hasPlaceholderImage, isTrue);
+
+      _delete(controller, draftText.length, draftText.length + 1);
+
+      expect(controller.sendableParts(), hasLength(1));
+    });
+  });
+
+  group('placeholder chips', () {
+    testWidgets('a token whose image was released renders as missing',
+        (tester) async {
+      // What an undo after a send leaves: the character comes back, the bytes
+      // were let go with the sent message.
+      final controller = _controller();
+      controller.insertImagesAtCaret([_image(1)]);
+      final token = controller.text;
+      controller.clear();
+      controller.text = 'a${token}b';
+
+      await tester.pumpWidget(_composer(controller));
+
+      expect(find.text('missing'), findsOneWidget);
+      expect(controller.canSend, isFalse);
+      expect(tester.takeException(), isNull);
+    });
+
+    testWidgets('tapping an unavailable image removes it', (tester) async {
+      final controller = _controller();
+      controller.restoreDraft('a${composerDraftImageMarker}b');
+
+      await tester.pumpWidget(_composer(controller));
+      await tester.tap(find.byIcon(Icons.image_not_supported_outlined));
+      await tester.pump();
+
+      expect(controller.text, 'ab');
+      expect(controller.hasPlaceholderImage, isFalse);
+      expect(controller.canSend, isTrue);
+    });
+  });
+}


### PR DESCRIPTION
PR 4a of inline image attachments: the token mechanism. **Invisible to users** — it builds the machinery that lets the composer hold images but adds no way to put one there. That is the point of the split: no entry point can ship ahead of its guardrails, and everything here is unit-testable by inserting images programmatically.

## The mechanism

One code unit per image in the composer's text, paired with a `WidgetSpan` chip from `buildTextSpan`, images held beside the text keyed by that code unit.

- **One code unit buys atomicity** — backspace takes the whole image and the caret cannot land inside it, with no key handling of our own.
- **A distinct unit per image buys identity** — the character names the image, so no edit can desynchronise the two. A shared placeholder was tried and rejected: two identical characters are indistinguishable to a diff, so deleting the first of two adjacent images left the survivor rendering its neighbour's picture.

Consequently the controller needs no change diffing at all — no `value` override, no prefix/suffix comparison, no position bookkeeping. `buildTextSpan` and the send split are each one pass over `text.codeUnits`, sharing a single walk.

Units come from the Private Use Area, but **only a unit this controller minted counts as an image**. That block is full of characters people legitimately type and paste — the Apple logo is U+F8FF, a terminal's Nerd Font glyphs sit beside it — and reading those as images would put an error chip over the user's own text and refuse to send it.

## The seam that keeps policy out

    void insertImagesAtCaret(List<ImagePart> images)

Takes already-valid parts. It knows nothing about MIME types, count limits, or byte budgets — a text controller has no business holding attachment policy. PR 4b owns everything upstream of this call.

## Send split

The text splits at each image into an ordered `List<MessagePart>`, feeding `ChatInput.onSend`, which already takes that type. Two structural guards, both returning null rather than sending:

- a payload carrying neither an image nor any text, which reaches the backend as empty content and is discarded there without an error (`TextMessage.fromParts` throws on it);
- a payload where an image is only a placeholder, since dropping it would send a different message from the one the composer is showing.

## Draft restore

A draft held across a failed send or an authentication round trip keeps each image's **position and none of its bytes** — text runs verbatim plus one shared marker per image, still a single string in `unsentText`, no storage schema change. Bytes are deliberately not persisted: drafts live in `SharedPreferences`, which Android reads whole into memory at first access, and base64 inflates 4/3. The source images are still on the device, where re-picking is a few taps.

Restoring re-keys each marker to its own code unit with an `Unavailable` placeholder, so a restored composer is structurally identical to a live one and `buildTextSpan` needs no special case. The placeholder reads as informational and is tapped away; the error-coloured `missing` chip is reserved for a token whose image was released while its character survived.

A draft of images and no caption is non-whitespace and so is kept, where an image-only payload previously flattened to an empty string and left an older draft in the slot to be restored in its place.

## Memory

v1 does not downscale, so the composer holds originals. Thumbnail decodes are bounded on the long edge — `Image`'s width and height bound layout only, and the engine otherwise decodes the full bitmap, ~48 MB of RGBA for a 12 MP photo, per image on screen.

## Review notes

Two judgment calls worth a second opinion:

1. **Images are released when the content is replaced wholesale** (`clear()` on send or a room/thread change, and `restoreDraft`), not the moment a code unit leaves the text. Releasing on the edit is what the plan suggested, but it breaks identity for a token that comes back: cutting an image and pasting it elsewhere, or undoing a deletion, would strand it. The cost is that bytes for a deleted image are held until the composer is cleared.
2. **The chip is a token-styled container, not `SoliplexChip`.** A Material `Chip`'s 32 px minimum height plus tap-target padding inflates the composer's line height badly for an element that has to sit inside a line of text. All colours, spacing, radii, and text styles come from design-system tokens; both themes were checked.

## Testing

`flutter analyze` zero issues, 2279 tests pass, format and markdownlint clean.

**Two device gates remain open** and need a physical phone — I have neither an iPhone nor an Android device attached, and the simulator's software keyboard cannot be driven from a shell:

- iOS IME composition. Add a Korean or Japanese keyboard and compose jamo immediately before a chip, immediately after one, and between an adjacent pair. Assert what the Android trace already satisfied: composing width equals the composed string's code-unit length, the range never spans a chip, chip count unchanged. iOS autocorrect uses no composing region, so English typing cannot substitute.
- Backspace over a chip with the on-screen keyboard, on both iOS and Android.

Verified on the iOS simulator: chips render inline at line height and wrap across lines without overflow, and the placeholder states, notice, and disabled send all behave. Both palettes checked.

One constraint the chips depend on, recorded in the class doc: `EditableText` renders spell-check results itself and never calls the controller when it has any, so enabling spell check on this field would replace every chip with a raw placeholder character. Nothing enables it today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)