### PR TITLE
feat: attach images to a message from the composer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,32 @@ Versions follow the `version+build` scheme from `pubspec.yaml`, bumped via
 
 ### Added
 
+- Images can be attached to a message. An add-image button beside the composer
+  opens the platform's image picker, and each image picked lands at the caret as
+  a chip, so a sentence can be written around its images and reaches the model
+  in the order they sit in. Several can be picked at once; on iOS a multi-pick
+  may arrive in a different order from the one it was chosen in, which the
+  platform does not report. The button is offered in every room: an inline image
+  is a property of the model, not of the room's skills, so it does not depend on
+  the paperclip's sandbox capability. Once picked, bytes are sent untouched —
+  nothing in the app decodes, re-encodes, or scales them, so a PNG cannot be
+  inflated, a photo's EXIF cannot be stripped, and an animated GIF keeps its
+  frames. PNG, JPEG, WebP and GIF are accepted, up to four images and 15 MB a
+  message; an image is typed by what its bytes hold rather than by its name, so
+  one saved under a misleading extension is recognised for what it is. Anything
+  the message cannot carry is left out rather than sent, and said so in a line
+  under the composer that a screen reader announces — by name where the file
+  itself is the problem, as a limit where the message is. On iOS the picker is
+  asked for a compatible representation, so a photo an iPhone shot as HEIC
+  arrives as JPEG — re-encoded by the system before the app sees it — and the
+  copy the picker leaves behind is discarded as soon as the app is done with it,
+  whether or not it could be read.
+- On a composer narrower than a tablet, the document filter and thread upload
+  now share one menu of labelled items — `Filter documents` and `Upload
+  files…`, plus `Upload folder…` wherever folders can be picked — so the text
+  field keeps a usable width with the add-image button beside it. At tablet
+  width and above all three stay separate buttons.
+
 - **Library consumers:** `soliplex_client` exports a `MessagePart` type —
   `TextPart` for a run of text, `ImagePart` for image bytes with their MIME
   type — and an optional `parts` list on `TextMessage`. A user message carrying
@@ -50,13 +76,12 @@ Versions follow the `version+build` scheme from `pubspec.yaml`, bumped via
 
 - The chat composer's controller can carry images inline in its text — one
   code unit each, rendered as a chip and split back out into an ordered part
-  list on send. Groundwork only: nothing can put an image in the composer yet,
-  and a composer holding none delegates its rendering whole to
-  `TextEditingController`, IME composition underline included, so no screen
-  behaves differently.
-- Groundwork, unreachable until images can be attached: a composer draft held
-  across a failed send or an authentication round trip keeps each image's
-  position, as a placeholder the user removes before sending. Bytes are
+  list on send. A composer holding none delegates its rendering whole to
+  `TextEditingController`, IME composition underline included, so a screen
+  without images behaves exactly as before.
+- A composer draft held across a failed send or an authentication round trip
+  keeps each image's position, as a placeholder the user removes before
+  sending. Bytes are
   deliberately not persisted — drafts live in `SharedPreferences`, which
   Android reads whole into memory at first access — and the source images are
   still on the device. Dropping the images silently instead would send a

--- a/lib/src/modules/room/attachable_images.dart
+++ b/lib/src/modules/room/attachable_images.dart
@@ -1,0 +1,193 @@
+import 'package:soliplex_agent/soliplex_agent.dart';
+
+import 'pick_image.dart';
+
+/// The image types a message may carry inline.
+///
+/// HEIC is absent even though an iPhone shoots it by default. Only iOS is asked
+/// for a compatible representation (see [inlineImageCompressionQuality]), so an
+/// iPhone's photo arrives as JPEG; nothing transcodes on any other platform, so
+/// a HEIC picked there arrives as itself and is turned away. Either way the
+/// model most likely cannot read it, and saying so gives the user something to
+/// act on.
+const allowedInlineImageMimeTypes = <String>{
+  'image/png',
+  'image/jpeg',
+  'image/webp',
+  'image/gif',
+};
+
+/// How many images one message may carry.
+///
+/// A backstop against a pathological payload rather than a dial to tune.
+///
+/// Applied when images are added, against the images the composer's text
+/// already holds, so four picks of one image each meet the same ceiling as one
+/// pick of four. It counts the text rather than the bytes the composer is
+/// keeping: an image removed from the text keeps its bytes until a send or a
+/// thread change, so that undoing the removal brings the image back rather
+/// than a broken chip.
+///
+/// A placeholder left by a draft that came back from re-authentication without
+/// its images is not counted. It carries no bytes, and it blocks the send until
+/// it is removed, so charging it against the ceiling would only refuse a pick
+/// the user is still free to make good on.
+///
+/// Nothing re-applies it when the message is sent, so copying an image's
+/// character out of the text and pasting it carries that image twice. Left
+/// that way on purpose — the ceiling is here to stop an accident, and a user
+/// duplicating their own image is spending their own bandwidth.
+const maxInlineImagesPerMessage = 4;
+
+/// How many bytes of image one message may carry, counted before base64
+/// inflates them by 4/3. Same backstop, applied and escapable the same way.
+///
+/// Sized against nothing in particular: the backend application sets no body
+/// limit of its own, but a proxy in front of it may well, and this side cannot
+/// see one.
+const maxInlineImageBytesPerMessage = 15 * 1024 * 1024;
+
+/// Why a picked image will not be attached.
+enum ImageRejection {
+  /// Not a type [allowedInlineImageMimeTypes] carries.
+  unsupportedType,
+
+  /// The message already holds [maxInlineImagesPerMessage].
+  tooManyImages,
+
+  /// Attaching it would put the message over [maxInlineImageBytesPerMessage].
+  messageTooLarge,
+
+  /// Nothing usable came back for it — the picker could not read its bytes, or
+  /// read no bytes at all.
+  unreadable,
+}
+
+/// A picked image that will not be attached, and why: the file's name as the
+/// picker reported it, and the reason it is being turned away.
+typedef RejectedImage = ({String name, ImageRejection reason});
+
+/// What a pick yields once the message's limits are applied: the images to
+/// attach, in selection order, and the ones turned away.
+typedef AttachableImages = ({
+  List<ImagePart> accepted,
+  List<RejectedImage> rejected,
+});
+
+/// Splits [picked] into the images a message may carry and the ones it may not.
+///
+/// The limits are per message, not per pick, so [attached] is what the composer
+/// already holds — four picks of one image each have to meet the same ceiling
+/// as one pick of four. Taking the images rather than a count and a byte total
+/// is what keeps those two from disagreeing with each other, or with the
+/// composer.
+///
+/// Turns away one image at a time rather than the whole pick, so a selection
+/// that runs past a limit still attaches what fits, in the order it was
+/// selected. Never yields [ImageRejection.unreadable] for anything but an
+/// image with no bytes; the picker owns the rest of that reason.
+///
+/// Never decodes an image, and never re-encodes one: an accepted image carries
+/// the bytes the picker returned. Doing otherwise here would inflate a PNG,
+/// strip a photo's EXIF, and flatten an animated GIF to a single frame — none
+/// of it visible from the composer.
+AttachableImages attachableImages(
+  List<PickedImage> picked, {
+  required Iterable<ImagePart> attached,
+}) {
+  final accepted = <ImagePart>[];
+  final rejected = <RejectedImage>[];
+  var count = attached.length;
+  var bytes = attached.fold(0, (total, part) => total + part.bytes.length);
+
+  for (final image in picked) {
+    final reason = _rejectionFor(image, count: count, bytes: bytes);
+    if (reason != null) {
+      rejected.add((name: image.name, reason: reason));
+      continue;
+    }
+    accepted.add(ImagePart(bytes: image.bytes, mimeType: image.mimeType));
+    count++;
+    bytes += image.bytes.length;
+  }
+  return (accepted: accepted, rejected: rejected);
+}
+
+ImageRejection? _rejectionFor(
+  PickedImage image, {
+  required int count,
+  required int bytes,
+}) {
+  // An allowed type over no bytes still reaches the model as an image, and one
+  // it can make nothing of. It also comes back from history as an attachment
+  // that cannot be rebuilt, since a valid encoding of nothing is undecodable.
+  //
+  // Asked before the type, because an empty file has no content to be typed
+  // by: its type is only ever its name's claim, so a zero-byte `photo.png`
+  // would pass the allow-list and be reported as something other than what is
+  // wrong with it.
+  if (image.bytes.isEmpty) return ImageRejection.unreadable;
+  if (!allowedInlineImageMimeTypes.contains(image.mimeType)) {
+    return ImageRejection.unsupportedType;
+  }
+  if (count >= maxInlineImagesPerMessage) return ImageRejection.tooManyImages;
+  if (bytes + image.bytes.length > maxInlineImageBytesPerMessage) {
+    return ImageRejection.messageTooLarge;
+  }
+  return null;
+}
+
+/// Lists the first few names and counts whatever is left, so the sentence a
+/// notice builds from this is the same length however large the pick was.
+///
+/// Naming every file is what this replaces: a pick of a folder of unsupported
+/// images grew the notice, and with it the composer, until the text field and
+/// the send button left the screen — the notice sits above the composer with
+/// nothing to scroll it, so its height comes out of the conversation.
+///
+/// It names [maxInlineImagesPerMessage] of them because a pick that could have
+/// been attached in full is worth naming in full; past that, the files were
+/// never going to fit anyway. That ties this sentence's length to a ceiling
+/// that exists for another reason — raising [maxInlineImagesPerMessage] far
+/// would put the composer back off the screen, and would mean giving this a
+/// bound of its own.
+String _namesAndTheRest(List<String> names) =>
+    names.length <= maxInlineImagesPerMessage
+        ? names.join(', ')
+        : '${names.take(maxInlineImagesPerMessage).join(', ')} '
+            'and ${names.length - maxInlineImagesPerMessage} more';
+
+/// What to tell the user about everything a pick turned away, or null when it
+/// turned away nothing.
+///
+/// Names the files whose type or contents were the problem, since only the user
+/// can pick something else — see [_namesAndTheRest] for how many; states a
+/// limit once however many images ran into it, since naming them adds nothing
+/// to a ceiling.
+String? rejectedImagesNotice(List<RejectedImage> rejected) {
+  if (rejected.isEmpty) return null;
+
+  List<String> namesFor(ImageRejection reason) => rejected
+      .where((image) => image.reason == reason)
+      .map((image) => image.name)
+      .toList();
+
+  final unsupported = namesFor(ImageRejection.unsupportedType);
+  final unreadable = namesFor(ImageRejection.unreadable);
+  final megabytes = maxInlineImageBytesPerMessage ~/ (1024 * 1024);
+
+  return [
+    if (unsupported.isNotEmpty)
+      unsupported.length == 1
+          ? '${unsupported.single} is not a supported image.'
+          : '${_namesAndTheRest(unsupported)} are not supported images.',
+    // No singular form to pick between: unlike "is/are not supported" above,
+    // this sentence reads the same however many files it names.
+    if (unreadable.isNotEmpty)
+      '${_namesAndTheRest(unreadable)} could not be read.',
+    if (rejected.any((image) => image.reason == ImageRejection.tooManyImages))
+      'A message carries at most $maxInlineImagesPerMessage images.',
+    if (rejected.any((image) => image.reason == ImageRejection.messageTooLarge))
+      'Images must total at most $megabytes MB.',
+  ].join(' ');
+}

--- a/lib/src/modules/room/pick_file.dart
+++ b/lib/src/modules/room/pick_file.dart
@@ -1,4 +1,5 @@
-import 'pick_file_impl.dart' if (dart.library.html) 'pick_file_impl_web.dart';
+import 'pick_file_impl.dart'
+    if (dart.library.js_interop) 'pick_file_impl_web.dart';
 
 /// A file selected by the user, with metadata and a re-callable stream
 /// factory over its contents.

--- a/lib/src/modules/room/pick_image.dart
+++ b/lib/src/modules/room/pick_image.dart
@@ -1,0 +1,100 @@
+import 'dart:typed_data';
+
+import 'package:mime/mime.dart';
+
+import 'pick_file.dart' show PickFileItemError, PickFilePickerException;
+import 'pick_image_impl.dart'
+    if (dart.library.js_interop) 'pick_image_impl_web.dart';
+
+/// An image the user picked, with its bytes in hand.
+///
+/// Held whole where a picked *file* streams: an upload re-reads its source on a
+/// retry, while an inline image becomes part of the message the composer is
+/// building and is drawn as a thumbnail while it sits there.
+class PickedImage {
+  /// Creates a picked image of a known type.
+  const PickedImage({
+    required this.name,
+    required this.mimeType,
+    required this.bytes,
+  });
+
+  /// Creates a picked image, typing it by what [bytes] hold and falling back to
+  /// [name]'s extension.
+  ///
+  /// Content first because the name can lie, and one way it lies matters here:
+  /// iOS is asked to hand back a JPEG in place of an iPhone's HEIC, and a HEIC
+  /// delivered under a `.jpeg` name would otherwise be typed as JPEG and sent
+  /// to the model as one. Reading the type from the bytes makes that a
+  /// rejection the user can see instead.
+  ///
+  /// It catches the HEIF brands `mime` carries a magic number for — `heic`,
+  /// `heix`, `mif1` — and no others. One boxed as `msf1` or `hevc` has nothing
+  /// to match against, so it falls through to the extension and is typed by
+  /// the name after all.
+  factory PickedImage.fromBytes({
+    required String name,
+    required Uint8List bytes,
+  }) =>
+      PickedImage(
+        name: name,
+        mimeType: lookupMimeType(name, headerBytes: bytes) ??
+            'application/octet-stream',
+        bytes: bytes,
+      );
+
+  /// Display name (basename), as the picker reported it. Names the file in
+  /// feedback about one that could not be attached — though iOS's photo picker
+  /// substitutes a name of its own, so there it identifies the file to us
+  /// rather than to the user.
+  final String name;
+
+  /// The type of [bytes]: what they hold, or what [name]'s extension claims
+  /// when nothing recognises them. `application/octet-stream` when neither
+  /// answers, which no allow-list carries — so an image that cannot be typed is
+  /// turned away rather than sent as opaque bytes.
+  final String mimeType;
+
+  /// The encoded image file bytes, exactly as picked.
+  final Uint8List bytes;
+}
+
+/// Successful batch from [pickImages]: zero or more images the composer can
+/// consider, plus zero or more per-file failures for it to report.
+typedef PickImagesResult = ({
+  List<PickedImage> images,
+  List<PickFileItemError> errors,
+});
+
+/// What to pass the picker as `compressionQuality`, which means two unrelated
+/// things depending on the platform.
+///
+/// On iOS the number is read only as a boolean: any non-zero value flips
+/// `PHPicker` to Compatible mode, which hands us JPEG in place of the HEIC an
+/// iPhone shoots by default — `1` and `100` are identical there. On Android the
+/// same number is a real re-encode quality handed to `Bitmap.compress`, so
+/// anything above zero silently recompresses every image the user picks, which
+/// is the one thing this path exists to avoid. So one value cannot serve both:
+/// `90` would destroy Android's originals and `1` would keep iOS's transcode
+/// while destroying them anyway.
+int inlineImageCompressionQuality({required bool isIOS}) => isIOS ? 100 : 0;
+
+/// Opens the platform image picker with multi-select enabled, and reads the
+/// bytes of everything it returns.
+///
+/// Returns `null` only when the user cancels. Throws [PickFilePickerException]
+/// when the picker itself fails. A file this reads nothing usable from does not
+/// abort the batch — it lands in [PickImagesResult.errors], so the composer can
+/// attach the user's other images and still say which one it could not.
+///
+/// A batch holding neither images nor errors is a third outcome, and not a
+/// cancel: Android answers a pick it could not copy a single item out of with
+/// an empty list, having dropped the names on its side. Handing that back as a
+/// cancel would leave the user looking at a button that did nothing, so it
+/// comes back as the empty batch it is and the composer speaks for it.
+///
+/// The per-file guarantee stops at what the plugin reports. iOS's photo picker
+/// handles a per-item failure by logging it natively and returning the items
+/// that did work, so a pick of four photos can arrive as three with nothing to
+/// say the fourth existed. Nothing on this side can see the difference.
+Future<PickImagesResult?> pickImages() => pickImagesImpl();

--- a/lib/src/modules/room/pick_image_impl.dart
+++ b/lib/src/modules/room/pick_image_impl.dart
@@ -1,0 +1,118 @@
+import 'dart:io' show File, IOException;
+
+import 'package:file_picker/file_picker.dart';
+import 'package:flutter/foundation.dart'
+    show TargetPlatform, defaultTargetPlatform;
+import 'package:soliplex_logging/soliplex_logging.dart';
+
+import 'pick_file.dart';
+import 'pick_image.dart';
+
+final _logger = LogManager.instance.getLogger('soliplex_frontend.pick_image');
+
+/// Native implementation of [pickImages].
+///
+/// `type: FileType.image` is what narrows the chooser to images, and it is why
+/// `compressionQuality` matters here — see [inlineImageCompressionQuality]. On
+/// iOS it opens the photo library; Android resolves it through the system
+/// chooser, which usually offers the files app alongside photos.
+///
+/// Bytes come from the returned path everywhere rather than through `withData`.
+/// Both mobile platforms leave behind a copy that has to be deleted once its
+/// bytes are held — see [_discardPickerCopy] — so the path is needed on those
+/// regardless, and reading it directly keeps one path for every native
+/// platform. Every native platform populates it; the `path == null` branch
+/// below is belt and braces, since the plugin's own type allows it.
+///
+/// Selection order does not survive iOS, where the web implementation's
+/// `readSequential` has no counterpart. The plugin starts a load for every
+/// picked asset and appends to its result from inside each completion handler,
+/// so a large photo picked first can land behind a small one picked second.
+/// The paths it hands back are minted names carrying a UUID and a timestamp,
+/// with nothing of the order in them, so this cannot put them back.
+Future<PickImagesResult?> pickImagesImpl() async {
+  final FilePickerResult? result;
+  try {
+    result = await FilePicker.pickFiles(
+      type: FileType.image,
+      allowMultiple: true,
+      withData: false,
+      withReadStream: false,
+      compressionQuality: inlineImageCompressionQuality(
+        isIOS: defaultTargetPlatform == TargetPlatform.iOS,
+      ),
+    );
+  } on Object catch (error) {
+    throw PickFilePickerException(cause: error);
+  }
+  if (result == null) return null;
+
+  final images = <PickedImage>[];
+  final errors = <PickFileItemError>[];
+  for (final file in result.files) {
+    final path = file.path;
+    if (path == null) {
+      errors.add(
+        PickFileItemError(
+          filename: file.name,
+          cause: StateError('picker returned no path for ${file.name}'),
+        ),
+      );
+      continue;
+    }
+    try {
+      images.add(
+        PickedImage.fromBytes(
+          name: file.name,
+          bytes: await File(path).readAsBytes(),
+        ),
+      );
+    } on IOException catch (error) {
+      // Only the file's own problems are the file's to report. Anything else
+      // is ours, and reporting it as the user's image being unreadable would
+      // hide it behind a message they can do nothing with.
+      errors.add(PickFileItemError(filename: file.name, cause: error));
+    } finally {
+      // Also on the failing path. The read most likely to fail is of the
+      // largest image, which is the copy worth least leaving behind.
+      await _discardPickerCopy(path);
+    }
+  }
+  return (images: images, errors: errors);
+}
+
+/// Deletes the copy the picker made of an image, now that its bytes are held.
+///
+/// Only where the path *is* a copy. Both mobile platforms write the pick into
+/// app storage, while on desktop the path is the user's own file and deleting
+/// it would destroy their picture.
+///
+/// The stakes differ by platform. Android's copy goes to the cache directory,
+/// which the OS reclaims under pressure and which the shell's boot-time
+/// `FilePicker.clearTemporaryFiles()` sweeps; deleting here just keeps a long
+/// session from accumulating copies it is already done with. iOS writes to the
+/// Documents directory, which nothing reclaims — not the system, and not that
+/// boot-time sweep, which only covers the temporary directory — and which a
+/// backup carries. There, an undeleted copy costs its size for the life of the
+/// install.
+///
+/// Best effort: the bytes are already in hand, so failing to tidy up costs
+/// nothing this call needs. It is logged all the same, because on iOS a delete
+/// that always failed would grow the install forever with nothing to show for
+/// it.
+Future<void> _discardPickerCopy(String path) async {
+  if (defaultTargetPlatform != TargetPlatform.iOS &&
+      defaultTargetPlatform != TargetPlatform.android) {
+    return;
+  }
+  try {
+    await File(path).delete();
+  } on Object catch (error, stackTrace) {
+    _logger.warning(
+      'could not discard the picker copy of an image',
+      error: error,
+      stackTrace: stackTrace,
+      attributes: {'platform': defaultTargetPlatform.name},
+    );
+  }
+}

--- a/lib/src/modules/room/pick_image_impl_web.dart
+++ b/lib/src/modules/room/pick_image_impl_web.dart
@@ -1,0 +1,70 @@
+import 'package:file_picker/file_picker.dart';
+import 'package:web/web.dart' as web;
+
+import 'pick_file.dart';
+import 'pick_image.dart';
+
+/// Web implementation of [pickImages].
+///
+/// Uses `file_picker` where [pickFiles] hand-rolls an `<input>`. That bypass
+/// exists so an upload can re-stream a large file from its blob instead of
+/// buffering it, which an inline image cannot use: it is held whole for as long
+/// as it sits in the composer, and drawn from those bytes. So the requirement
+/// the bypass serves is absent here, and asking `file_picker` for the bytes
+/// costs no interop of our own.
+///
+/// It does cost one thing that has to be undone. For every file it read bytes
+/// from — before any of it is validated — the plugin copies those bytes into a
+/// `Blob` and mints an object URL it never revokes, which would hold that copy
+/// for the life of the page in proportion to what the user picked rather than to
+/// what the message keeps. Revoking the URL releases the copy; the bytes we were
+/// handed are unaffected.
+///
+/// `readSequential` is what holds the pick in the order the user made it. The
+/// plugin otherwise starts a `FileReader` per file at once and appends each one
+/// as it finishes, so a large image chosen first can land behind a small one
+/// chosen second — and the order images sit in is the whole point of carrying
+/// them inline.
+///
+/// The plugin ignores `compressionQuality`, so nothing is re-encoded here.
+Future<PickImagesResult?> pickImagesImpl() async {
+  final FilePickerResult? result;
+  try {
+    result = await FilePicker.pickFiles(
+      type: FileType.image,
+      allowMultiple: true,
+      withData: true,
+      readSequential: true,
+    );
+  } on Object catch (error) {
+    throw PickFilePickerException(cause: error);
+  }
+  if (result == null) return null;
+
+  // Discharged for the whole batch before a byte of it is looked at, so that
+  // nothing going wrong with one file can strand another file's copy.
+  for (final file in result.files) {
+    // The plugin puts the object URL it minted where a native path would go.
+    final blobUrl = file.path;
+    if (blobUrl != null && blobUrl.startsWith('blob:')) {
+      web.URL.revokeObjectURL(blobUrl);
+    }
+  }
+
+  final images = <PickedImage>[];
+  final errors = <PickFileItemError>[];
+  for (final file in result.files) {
+    final bytes = file.bytes;
+    if (bytes == null) {
+      errors.add(
+        PickFileItemError(
+          filename: file.name,
+          cause: StateError('browser returned no bytes for ${file.name}'),
+        ),
+      );
+      continue;
+    }
+    images.add(PickedImage.fromBytes(name: file.name, bytes: bytes));
+  }
+  return (images: images, errors: errors);
+}

--- a/lib/src/modules/room/ui/chat_input.dart
+++ b/lib/src/modules/room/ui/chat_input.dart
@@ -1,12 +1,19 @@
+import 'package:flutter/foundation.dart' show defaultTargetPlatform;
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:signals_flutter/signals_flutter.dart';
 import 'package:soliplex_agent/soliplex_agent.dart' hide State;
+import 'package:soliplex_logging/soliplex_logging.dart';
 
 import '../../../shared/document_display.dart';
+import '../attachable_images.dart';
+import '../pick_file.dart' show PickFileException;
+import '../pick_image.dart';
 import 'document_label.dart';
 import 'inline_image_composer_controller.dart';
 import 'package:soliplex_design/soliplex_design.dart';
+
+final _logger = LogManager.instance.getLogger('soliplex_frontend.chat_input');
 
 /// Shown while the composer holds an image it cannot send, which is only ever
 /// a draft that came back from re-authentication without its images. Removing
@@ -20,10 +27,14 @@ const unrestoredImageNotice =
 /// text routed in during either state could not be edited or removed until the
 /// composer came back.
 ///
-/// [ChatInput] gates its text field, send button, document filter, attach
-/// control, and chip removal on this. The Stop button sits outside it by
-/// necessity: it renders only while a run holds the composer, which is one of the
-/// states this refuses.
+/// [ChatInput] gates its text field, send button, add-image button, document
+/// filter, upload control, and document chip removal on this. Two things sit
+/// outside it. The Stop button, by necessity: it renders only while a run holds
+/// the composer, which is one of the states this refuses. And an inline image's
+/// placeholder chip, whose tap target is a gesture inside the field that
+/// `readOnly` does not reach — so a restored draft's unavailable images can
+/// still be cleared while a run is in flight, which costs nothing, since they
+/// block the send until they are gone either way.
 bool composerAcceptsText({
   required bool enabled,
   required AgentSessionState? sessionState,
@@ -48,6 +59,8 @@ class ChatInput extends StatefulWidget {
     this.onDocumentRemoved,
     this.onAttachFile,
     this.onAttachFolder,
+    this.openImagePicker,
+    this.composerScope,
   });
 
   final void Function(List<MessagePart> parts) onSend;
@@ -69,10 +82,28 @@ class ChatInput extends StatefulWidget {
   /// Optional folder-pick callback. When both [onAttachFile] and
   /// [onAttachFolder] are non-null, the attach control becomes a popup
   /// menu with "Files…" and "Folder…" choices. When only [onAttachFile]
-  /// is provided, the attach control stays a single-action icon. Web
-  /// callers leave this `null` because the file_picker plugin can't
-  /// pick folders on web.
+  /// is provided, the attach control stays a single-action icon. Below
+  /// [SoliplexBreakpoints.tablet] with a document filter also present, the two
+  /// are not a control of their own at all: they fold into the shared actions
+  /// menu as "Upload files…" and "Upload folder…".
   final VoidCallback? onAttachFolder;
+
+  /// Opens the image picker behind the add-image button. Defaults to the
+  /// platform picker; a test supplies its own so the add-image path can be
+  /// exercised without a plugin behind it.
+  final Future<PickImagesResult?> Function()? openImagePicker;
+
+  /// What the composer is composing for. Changing it drops the notice about
+  /// the last pick, which describes a pick made into the conversation being
+  /// left and would otherwise sit above the one being entered.
+  ///
+  /// Deliberately a plain field and not a [Key] on this widget. Keying it
+  /// would re-inflate the composer, and re-inflating it closes the platform
+  /// text input connection: the [FocusNode] belongs to the caller and outlives
+  /// the rebuild, so nothing reports a focus change and `EditableText` never
+  /// reopens the connection. The caret stays on screen while the soft keyboard
+  /// drops and typing goes nowhere until the field is tapped again.
+  final Object? composerScope;
 
   @override
   State<ChatInput> createState() => _ChatInputState();
@@ -80,12 +111,25 @@ class ChatInput extends StatefulWidget {
 
 enum _AttachChoice { files, folder }
 
+/// The optional room actions, which collapse into one menu on a narrow
+/// composer.
+enum _RoomActionChoice { filter, uploadFiles, uploadFolder }
+
 class _ChatInputState extends State<ChatInput> {
   late InlineImageComposerController _controller;
   late FocusNode _focusNode;
   bool _ownsController = false;
   bool _ownsFocusNode = false;
   bool _chipsExpanded = true;
+
+  /// Why the last attempt to add images did not do all the user asked, held
+  /// until a send, a change of conversation, or a pick that comes back with
+  /// something to say replaces it. A cancel is none of those and leaves it
+  /// standing, since the user may still need to read it.
+  String? _attachNotice;
+
+  /// Whether a pick is open, which closes the add-image button behind it.
+  bool _picking = false;
 
   @override
   void initState() {
@@ -100,6 +144,9 @@ class _ChatInputState extends State<ChatInput> {
     if (widget.controller != oldWidget.controller) {
       if (_ownsController) _controller.dispose();
       _initController();
+    }
+    if (widget.composerScope != oldWidget.composerScope) {
+      _attachNotice = null;
     }
     if (widget.focusNode != oldWidget.focusNode) {
       if (_ownsFocusNode) _focusNode.dispose();
@@ -145,31 +192,286 @@ class _ChatInputState extends State<ChatInput> {
     if (parts == null) return;
     widget.onSend(parts);
     _controller.clear();
+    setState(() => _attachNotice = null);
     _focusNode.requestFocus();
   }
 
-  Widget _placeholderNotice(BuildContext context) {
+  /// Runs one pick, and owns everything that can go wrong with it.
+  ///
+  /// Holds the button closed for the duration: a second pick over an open one
+  /// is refused outright by the Android plugin, which would report a failure
+  /// over a pick that is still working.
+  ///
+  /// The catch-all is not defensive padding. Nothing in the app installs a
+  /// global async error handler, and this runs from a [VoidCallback], so any
+  /// throw it does not model — from a picker the caller supplied, or from a
+  /// platform this does not know about — would be dropped by the root zone.
+  /// The user would be left tapping a button that does nothing, with no log
+  /// line for anyone to work back from.
+  Future<void> _addImages() async {
+    if (_picking) return;
+    setState(() => _picking = true);
+    try {
+      await _attachPickedImages();
+    } on PickFileException catch (error, stackTrace) {
+      _logger.error(
+        'image picker failed',
+        error: error.cause,
+        stackTrace: stackTrace,
+      );
+      if (mounted) {
+        // Not the upload path's "could not open file picker": on web the bytes
+        // are read inside the picker call, so a failure here is as likely to
+        // have come after the chooser closed — which the user just watched
+        // work.
+        setState(
+          () => _attachNotice = error.cause is RangeError
+              ? 'The images are too large to load in the browser.'
+              : 'Could not add the images.',
+        );
+      }
+    } on Object catch (error, stackTrace) {
+      _logger.error(
+        'could not add images',
+        error: error,
+        stackTrace: stackTrace,
+      );
+      if (mounted) {
+        setState(() => _attachNotice = 'Could not add the images.');
+      }
+    } finally {
+      if (mounted) setState(() => _picking = false);
+    }
+  }
+
+  /// Picks images and inserts the ones this message may carry at the caret,
+  /// reporting whatever it could not take.
+  ///
+  /// The composer's own images are what the limits are measured against, and
+  /// they are read after the picker closes rather than before it opens: on web
+  /// the page stays interactive while the chooser is up, so the composer can
+  /// change under it.
+  Future<void> _attachPickedImages() async {
+    // A pick belongs to the conversation it was made into. The composer
+    // deliberately survives a thread change — see [ChatInput.composerScope] —
+    // so nothing else here would notice: it comes back mounted, enabled, and
+    // holding someone else's draft.
+    final scope = widget.composerScope;
+    final result = await (widget.openImagePicker ?? pickImages)();
+    if (result == null) return;
+
+    // Logged before anything below can return early. A pick that comes back to
+    // a composer that has gone away, that has moved to another conversation, or
+    // that a run has taken, still has to leave a record of the files it could
+    // not read — it is the only account of them, and those paths have nowhere
+    // to show one.
+    for (final error in result.errors) {
+      _logger.error(
+        'could not read a picked image',
+        error: error.cause,
+        attributes: {'filename': error.filename},
+      );
+    }
+
+    // A batch with nothing in it is not a cancel, which comes back as null.
+    // Android answers a pick it could not copy a single item out of this way,
+    // having dropped the names on its side — so there is nothing to name, and
+    // this line is the only record the pick happened at all.
+    final pickedNothing = result.images.isEmpty && result.errors.isEmpty;
+    if (pickedNothing) {
+      _logger.error(
+        'the image picker returned an empty batch',
+        // The platform is the whole of what a reader has to go on here: the
+        // batch names nothing, and which platform produced it is what says
+        // whether this is the known Android case or something new.
+        attributes: {'platform': defaultTargetPlatform.name},
+      );
+    }
+
+    // Dropped without a word on a scope change: `didUpdateWidget` has already
+    // cleared the notice slot, and a message about a pick made in the last
+    // conversation is exactly what must not appear over this one.
+    if (!mounted || widget.composerScope != scope) return;
+
+    // The same window that lets the composer change can hand it to a run, which
+    // renders it read-only. An image put there could not be removed until the
+    // run ended — a chip showing its picture has no other way out — and would
+    // then be sent with whatever the user typed next.
+    if (!composerAcceptsText(
+      enabled: widget.enabled,
+      sessionState: widget.sessionState?.peek(),
+    )) {
+      setState(
+        () => _attachNotice = 'The composer was busy. Add the images again.',
+      );
+      return;
+    }
+
+    if (pickedNothing) {
+      setState(
+        () => _attachNotice = 'Could not read the images you picked.',
+      );
+      return;
+    }
+
+    final selection = attachableImages(
+      result.images,
+      attached: _controller.contents
+          .whereType<ComposerImageSlot>()
+          .map((slot) => slot.image)
+          .whereType<InlineImage>()
+          .map((image) => image.part),
+    );
+
+    _controller.insertImagesAtCaret(selection.accepted);
+    setState(
+      () => _attachNotice = rejectedImagesNotice([
+        for (final error in result.errors)
+          (name: error.filename, reason: ImageRejection.unreadable),
+        ...selection.rejected,
+      ]),
+    );
+    _focusNode.requestFocus();
+  }
+
+  Widget _notice(
+    BuildContext context, {
+    required IconData icon,
+    required String message,
+    required Color color,
+  }) {
     final theme = Theme.of(context);
     return Padding(
       padding: const EdgeInsets.only(bottom: SoliplexSpacing.s1),
-      child: Row(
-        children: [
-          Icon(
-            Icons.image_not_supported_outlined,
-            size: 16,
-            color: theme.colorScheme.onSurfaceVariant,
-          ),
-          const SizedBox(width: SoliplexSpacing.s1),
-          Flexible(
-            child: Text(
-              unrestoredImageNotice,
-              style: theme.textTheme.bodySmall
-                  ?.copyWith(color: theme.colorScheme.onSurfaceVariant),
+      // A notice appears without taking focus, and is the only account of what
+      // happened — the house style has no transient banner that would announce
+      // itself.
+      child: Semantics(
+        liveRegion: true,
+        child: Row(
+          children: [
+            Icon(icon, size: 16, color: color),
+            const SizedBox(width: SoliplexSpacing.s1),
+            Flexible(
+              child: Text(
+                message,
+                style: theme.textTheme.bodySmall?.copyWith(color: color),
+              ),
             ),
-          ),
-        ],
+          ],
+        ),
       ),
     );
+  }
+
+  /// The composer's leading controls, at most two of them below
+  /// [SoliplexBreakpoints.tablet].
+  ///
+  /// Add-image is always a button of its own. It is the only way to attach an
+  /// image, and the only one of the three controls every room offers, so behind
+  /// a menu it would cost a tap and buy nothing. The *optional* pair collapses
+  /// instead, and only where the composer is too narrow to carry three: three
+  /// 48 px buttons, the gap and the send button leave a 320 px composer a
+  /// 104 px text field.
+  ///
+  /// Collapsing the pair holds the row at two slots whenever either optional
+  /// action is already present, so the field does not resize under the user when
+  /// the room's document load lands and reveals the filter mid-typing. A room
+  /// with no upload affordance still shifts once, the first time the filter
+  /// appears. Only below [SoliplexBreakpoints.tablet]: above it the row carries
+  /// all three, so the filter arriving still widens it by a slot.
+  List<Widget> _leadingControls(
+    BuildContext context,
+    BoxConstraints constraints, {
+    required bool disabled,
+  }) {
+    final hasFilter = widget.onFilterTap != null;
+    final hasUpload = widget.onAttachFile != null;
+    final collapse = constraints.maxWidth < SoliplexBreakpoints.tablet &&
+        hasFilter &&
+        hasUpload;
+
+    return [
+      IconButton(
+        icon: const Icon(Icons.add_photo_alternate_outlined),
+        // Carries the semantics label, so a screen reader names the button.
+        tooltip: 'Add image',
+        // Never gated on the room's sandbox capability: that governs uploads to
+        // the thread, while an inline image is a property of the model.
+        onPressed: disabled || _picking ? null : _addImages,
+      ),
+      if (collapse)
+        // Flattened rather than nested: upload is a menu of its own, and
+        // Material handles a menu inside a menu poorly. Labelled items are a
+        // gain of their own on touch, where a bare icon's tooltip never shows.
+        PopupMenuButton<_RoomActionChoice>(
+          // Not a second plus beside the add-image button: these are the rest
+          // of the room's actions, which is what an overflow glyph says.
+          icon: const Icon(Icons.more_horiz),
+          tooltip: 'More actions',
+          enabled: !disabled,
+          itemBuilder: (_) => [
+            const PopupMenuItem(
+              value: _RoomActionChoice.filter,
+              child: Text('Filter documents'),
+            ),
+            const PopupMenuItem(
+              value: _RoomActionChoice.uploadFiles,
+              child: Text('Upload files…'),
+            ),
+            if (widget.onAttachFolder != null)
+              const PopupMenuItem(
+                value: _RoomActionChoice.uploadFolder,
+                child: Text('Upload folder…'),
+              ),
+          ],
+          onSelected: (choice) => switch (choice) {
+            _RoomActionChoice.filter => widget.onFilterTap!(),
+            _RoomActionChoice.uploadFiles => widget.onAttachFile!(),
+            _RoomActionChoice.uploadFolder => widget.onAttachFolder!(),
+          },
+        )
+      else ...[
+        if (hasFilter)
+          IconButton(
+            icon: Icon(
+              Icons.filter_alt,
+              color: widget.selectedDocuments.isNotEmpty && !disabled
+                  ? Theme.of(context).colorScheme.primary
+                  : null,
+            ),
+            tooltip: 'Filter documents',
+            onPressed: disabled ? null : widget.onFilterTap,
+          ),
+        if (hasUpload)
+          if (widget.onAttachFolder != null)
+            PopupMenuButton<_AttachChoice>(
+              icon: const Icon(Icons.attach_file),
+              tooltip: 'Upload to thread',
+              enabled: !disabled,
+              itemBuilder: (_) => const [
+                PopupMenuItem(
+                  value: _AttachChoice.files,
+                  child: Text('Files…'),
+                ),
+                PopupMenuItem(
+                  value: _AttachChoice.folder,
+                  child: Text('Folder…'),
+                ),
+              ],
+              onSelected: (choice) => switch (choice) {
+                _AttachChoice.files => widget.onAttachFile!(),
+                _AttachChoice.folder => widget.onAttachFolder!(),
+              },
+            )
+          else
+            IconButton(
+              icon: const Icon(Icons.attach_file),
+              tooltip: 'Upload file to thread',
+              onPressed: disabled ? null : widget.onAttachFile,
+            ),
+      ],
+    ];
   }
 
   @override
@@ -180,193 +482,177 @@ class _ChatInputState extends State<ChatInput> {
         !composerAcceptsText(enabled: widget.enabled, sessionState: state);
     final cancelEnabled = widget.cancelEnabled?.watch(context) ?? true;
 
-    return Padding(
-      padding: const EdgeInsets.all(SoliplexSpacing.s2),
-      child: Column(
-        mainAxisSize: MainAxisSize.min,
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          if (widget.selectedDocuments.isNotEmpty)
-            Container(
-              margin: const EdgeInsets.only(bottom: SoliplexSpacing.s1),
-              padding: const EdgeInsets.all(SoliplexSpacing.s2),
-              decoration: BoxDecoration(
-                color: Theme.of(context).colorScheme.surfaceContainerLow,
-                borderRadius: BorderRadius.circular(context.radii.md),
-              ),
-              width: double.infinity,
-              child: _chipsExpanded
-                  ? Column(
-                      mainAxisSize: MainAxisSize.min,
-                      crossAxisAlignment: CrossAxisAlignment.stretch,
-                      children: [
-                        GestureDetector(
-                          behavior: HitTestBehavior.opaque,
-                          onTap: () => setState(() => _chipsExpanded = false),
-                          child: Row(
-                            children: [
-                              const Spacer(),
-                              Text(
-                                'Hide',
-                                style: Theme.of(context)
-                                    .textTheme
-                                    .bodySmall
-                                    ?.copyWith(
-                                      color:
-                                          Theme.of(context).colorScheme.primary,
-                                    ),
-                              ),
-                              Icon(
-                                Icons.expand_more,
-                                size: 16,
-                                color: Theme.of(context).colorScheme.primary,
-                              ),
-                            ],
-                          ),
-                        ),
-                        ConstrainedBox(
-                          constraints: const BoxConstraints(maxHeight: 160),
-                          child: SingleChildScrollView(
-                            child: Wrap(
-                              spacing: SoliplexSpacing.s1,
-                              runSpacing: SoliplexSpacing.s1,
+    // Measures the composer, not the row inside its padding, so the threshold
+    // the leading controls collapse at does not move with that padding.
+    return LayoutBuilder(
+      builder: (context, constraints) => Padding(
+        padding: const EdgeInsets.all(SoliplexSpacing.s2),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            if (widget.selectedDocuments.isNotEmpty)
+              Container(
+                margin: const EdgeInsets.only(bottom: SoliplexSpacing.s1),
+                padding: const EdgeInsets.all(SoliplexSpacing.s2),
+                decoration: BoxDecoration(
+                  color: Theme.of(context).colorScheme.surfaceContainerLow,
+                  borderRadius: BorderRadius.circular(context.radii.md),
+                ),
+                width: double.infinity,
+                child: _chipsExpanded
+                    ? Column(
+                        mainAxisSize: MainAxisSize.min,
+                        crossAxisAlignment: CrossAxisAlignment.stretch,
+                        children: [
+                          GestureDetector(
+                            behavior: HitTestBehavior.opaque,
+                            onTap: () => setState(() => _chipsExpanded = false),
+                            child: Row(
                               children: [
-                                for (final display in widget.selectedDocuments
-                                    .map(DocumentDisplay.new))
-                                  // A chip has room for a name and nothing
-                                  // else, so two files embedded in different
-                                  // documents under the same name read alike
-                                  // here, having been told apart everywhere the
-                                  // user chose them.
-                                  Tooltip(
-                                    message: documentProvenanceSentence(
-                                      display.name,
-                                      display.ancestorNames,
-                                    ),
-                                    waitDuration:
-                                        const Duration(milliseconds: 500),
-                                    child: SoliplexChip(
-                                      icon: Icon(
-                                        display.icon,
+                                const Spacer(),
+                                Text(
+                                  'Hide',
+                                  style: Theme.of(context)
+                                      .textTheme
+                                      .bodySmall
+                                      ?.copyWith(
+                                        color: Theme.of(context)
+                                            .colorScheme
+                                            .primary,
                                       ),
-                                      label: Text(display.name),
-                                      onDeleted:
-                                          widget.onDocumentRemoved == null ||
-                                                  disabled
-                                              ? null
-                                              : () => widget.onDocumentRemoved!(
-                                                    display.document,
-                                                  ),
-                                    ),
-                                  ),
+                                ),
+                                Icon(
+                                  Icons.expand_more,
+                                  size: 16,
+                                  color: Theme.of(context).colorScheme.primary,
+                                ),
                               ],
                             ),
                           ),
-                        ),
-                      ],
-                    )
-                  : GestureDetector(
-                      behavior: HitTestBehavior.opaque,
-                      onTap: () => setState(() => _chipsExpanded = true),
-                      child: Row(
-                        children: [
-                          Text(
-                            '${widget.selectedDocuments.length} documents selected',
-                            style: Theme.of(context)
-                                .textTheme
-                                .bodySmall
-                                ?.copyWith(
-                                  color: Theme.of(context).colorScheme.primary,
-                                ),
-                          ),
-                          const Spacer(),
-                          Icon(
-                            Icons.expand_less,
-                            size: 16,
-                            color: Theme.of(context).colorScheme.primary,
+                          ConstrainedBox(
+                            constraints: const BoxConstraints(maxHeight: 160),
+                            child: SingleChildScrollView(
+                              child: Wrap(
+                                spacing: SoliplexSpacing.s1,
+                                runSpacing: SoliplexSpacing.s1,
+                                children: [
+                                  for (final display in widget.selectedDocuments
+                                      .map(DocumentDisplay.new))
+                                    // A chip has room for a name and nothing
+                                    // else, so two files embedded in different
+                                    // documents under the same name read alike
+                                    // here, having been told apart everywhere the
+                                    // user chose them.
+                                    Tooltip(
+                                      message: documentProvenanceSentence(
+                                        display.name,
+                                        display.ancestorNames,
+                                      ),
+                                      waitDuration:
+                                          const Duration(milliseconds: 500),
+                                      child: SoliplexChip(
+                                        icon: Icon(
+                                          display.icon,
+                                        ),
+                                        label: Text(display.name),
+                                        onDeleted: widget.onDocumentRemoved ==
+                                                    null ||
+                                                disabled
+                                            ? null
+                                            : () => widget.onDocumentRemoved!(
+                                                  display.document,
+                                                ),
+                                      ),
+                                    ),
+                                ],
+                              ),
+                            ),
                           ),
                         ],
+                      )
+                    : GestureDetector(
+                        behavior: HitTestBehavior.opaque,
+                        onTap: () => setState(() => _chipsExpanded = true),
+                        child: Row(
+                          children: [
+                            Text(
+                              '${widget.selectedDocuments.length} documents selected',
+                              style: Theme.of(context)
+                                  .textTheme
+                                  .bodySmall
+                                  ?.copyWith(
+                                    color:
+                                        Theme.of(context).colorScheme.primary,
+                                  ),
+                            ),
+                            const Spacer(),
+                            Icon(
+                              Icons.expand_less,
+                              size: 16,
+                              color: Theme.of(context).colorScheme.primary,
+                            ),
+                          ],
+                        ),
                       ),
-                    ),
-            ),
-          ValueListenableBuilder<TextEditingValue>(
-            valueListenable: _controller,
-            builder: (context, value, child) => _controller.hasPlaceholderImage
-                ? _placeholderNotice(context)
-                : const SizedBox.shrink(),
-          ),
-          Row(
-            children: [
-              if (widget.onFilterTap != null)
-                IconButton(
-                  icon: Icon(
-                    Icons.filter_alt,
-                    color: widget.selectedDocuments.isNotEmpty && !disabled
-                        ? Theme.of(context).colorScheme.primary
-                        : null,
-                  ),
-                  tooltip: 'Filter documents',
-                  onPressed: disabled ? null : widget.onFilterTap,
-                ),
-              if (widget.onAttachFile != null && widget.onAttachFolder != null)
-                PopupMenuButton<_AttachChoice>(
-                  icon: const Icon(Icons.attach_file),
-                  tooltip: 'Upload to thread',
-                  enabled: !disabled,
-                  itemBuilder: (_) => const [
-                    PopupMenuItem(
-                      value: _AttachChoice.files,
-                      child: Text('Files…'),
-                    ),
-                    PopupMenuItem(
-                      value: _AttachChoice.folder,
-                      child: Text('Folder…'),
-                    ),
-                  ],
-                  onSelected: (choice) => switch (choice) {
-                    _AttachChoice.files => widget.onAttachFile!(),
-                    _AttachChoice.folder => widget.onAttachFolder!(),
-                  },
-                )
-              else if (widget.onAttachFile != null)
-                IconButton(
-                  icon: const Icon(Icons.attach_file),
-                  tooltip: 'Upload file to thread',
-                  onPressed: disabled ? null : widget.onAttachFile,
-                ),
-              Expanded(
-                child: CallbackShortcuts(
-                  bindings: {
-                    const SingleActivator(LogicalKeyboardKey.enter): _send,
-                  },
-                  child: SoliplexInput(
-                    controller: _controller,
-                    focusNode: _focusNode,
-                    readOnly: disabled,
-                    minLines: 1,
-                    maxLines: 5,
-                    textInputAction: TextInputAction.newline,
-                    hintText: 'Type a message...',
-                  ),
-                ),
               ),
-              const SizedBox(width: SoliplexSpacing.s2),
-              if (active)
-                IconButton(
-                  icon: const Icon(Icons.stop),
-                  onPressed: cancelEnabled ? widget.onCancel : null,
-                )
-              else
-                ValueListenableBuilder<TextEditingValue>(
-                  valueListenable: _controller,
-                  builder: (context, value, child) => IconButton(
-                    icon: const Icon(Icons.send),
-                    onPressed: disabled || !_controller.canSend ? null : _send,
+            ValueListenableBuilder<TextEditingValue>(
+              valueListenable: _controller,
+              builder: (context, value, child) =>
+                  _controller.hasPlaceholderImage
+                      ? _notice(
+                          context,
+                          icon: Icons.image_not_supported_outlined,
+                          message: unrestoredImageNotice,
+                          color: Theme.of(context).colorScheme.onSurfaceVariant,
+                        )
+                      : const SizedBox.shrink(),
+            ),
+            if (_attachNotice case final notice?)
+              _notice(
+                context,
+                icon: Icons.error_outline,
+                message: notice,
+                color: Theme.of(context).colorScheme.error,
+              ),
+            Row(
+              children: [
+                ..._leadingControls(context, constraints, disabled: disabled),
+                Expanded(
+                  child: CallbackShortcuts(
+                    bindings: {
+                      const SingleActivator(LogicalKeyboardKey.enter): _send,
+                    },
+                    child: SoliplexInput(
+                      controller: _controller,
+                      focusNode: _focusNode,
+                      readOnly: disabled,
+                      minLines: 1,
+                      maxLines: 5,
+                      textInputAction: TextInputAction.newline,
+                      hintText: 'Type a message...',
+                    ),
                   ),
                 ),
-            ],
-          ),
-        ],
+                const SizedBox(width: SoliplexSpacing.s2),
+                if (active)
+                  IconButton(
+                    icon: const Icon(Icons.stop),
+                    onPressed: cancelEnabled ? widget.onCancel : null,
+                  )
+                else
+                  ValueListenableBuilder<TextEditingValue>(
+                    valueListenable: _controller,
+                    builder: (context, value, child) => IconButton(
+                      icon: const Icon(Icons.send),
+                      onPressed:
+                          disabled || !_controller.canSend ? null : _send,
+                    ),
+                  ),
+              ],
+            ),
+          ],
+        ),
       ),
     );
   }

--- a/lib/src/modules/room/ui/room_screen.dart
+++ b/lib/src/modules/room/ui/room_screen.dart
@@ -2408,6 +2408,10 @@ class _RoomScreenState extends State<RoomScreen> {
   /// callbacks based on whether a [threadView] is active. Using one widget for
   /// both states keeps the [EditableText] element stable across the
   /// welcome → thread transition; see issue #212.
+  ///
+  /// Nothing here may carry a per-thread [Key]: that stability is the point,
+  /// and a key that changes with the thread throws it away. State that has to
+  /// be dropped on a thread change travels as a value instead.
   Widget _buildChatInput(
     ThreadViewState? threadView,
     Room? room,
@@ -2425,6 +2429,15 @@ class _RoomScreenState extends State<RoomScreen> {
     }
 
     return ChatInput(
+      // The composer's transient state belongs to the thread it is composing
+      // for, and what the composer is saying about that state is held in widget
+      // state, so a notice about a pick made into one thread would otherwise
+      // sit above another. The controller is cleared when a thread is entered
+      // but not when one is left for the welcome composer, so in that direction
+      // the draft and its images outlive the notice explaining them. Passed as
+      // a value rather than as a `key` so the composer is not re-inflated — see
+      // [ChatInput.composerScope] for what that would cost.
+      composerScope: (_serverId, widget.roomId, threadView?.threadId),
       onSend: (parts) {
         if (threadView != null) {
           threadView.sendMessage(

--- a/test/modules/room/attachable_images_test.dart
+++ b/test/modules/room/attachable_images_test.dart
@@ -1,0 +1,280 @@
+import 'dart:typed_data';
+import 'dart:ui' as ui;
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:soliplex_agent/soliplex_agent.dart';
+import 'package:soliplex_frontend/src/modules/room/attachable_images.dart';
+import 'package:soliplex_frontend/src/modules/room/pick_image.dart';
+
+import 'image_fixtures.dart';
+
+PickedImage _picked(
+  String name,
+  String mimeType, {
+  int bytes = 8,
+  Uint8List? content,
+}) =>
+    PickedImage(
+      name: name,
+      mimeType: mimeType,
+      bytes: content ?? Uint8List(bytes),
+    );
+
+/// An image the composer already holds, standing in for prior state.
+ImagePart _attached({int bytes = 8}) =>
+    ImagePart(bytes: Uint8List(bytes), mimeType: 'image/png');
+
+AttachableImages _attach(
+  List<PickedImage> picked, {
+  Iterable<ImagePart> attached = const [],
+}) =>
+    attachableImages(picked, attached: attached);
+
+void main() {
+  group('attachableImages', () {
+    test('turns away a type the allow-list does not carry', () {
+      final result = _attach([
+        _picked('shot.png', 'image/png'),
+        _picked('scan.tiff', 'image/tiff'),
+        _picked('photo.HEIC', 'image/heic'),
+        _picked('README', 'application/octet-stream'),
+      ]);
+
+      expect(result.accepted, hasLength(1));
+      expect(
+        result.rejected,
+        const [
+          (name: 'scan.tiff', reason: ImageRejection.unsupportedType),
+          (name: 'photo.HEIC', reason: ImageRejection.unsupportedType),
+          (name: 'README', reason: ImageRejection.unsupportedType),
+        ],
+      );
+    });
+
+    test('counts against what the composer already holds, not just this pick',
+        () {
+      // Four picks of one image each must run into the same ceiling as one
+      // pick of four.
+      final result = _attach(
+        [_picked('a.png', 'image/png'), _picked('b.png', 'image/png')],
+        attached: [
+          for (var i = 0; i < maxInlineImagesPerMessage - 1; i++) _attached(),
+        ],
+      );
+
+      expect(result.accepted, hasLength(1));
+      expect(result.rejected.single.name, 'b.png');
+      expect(result.rejected.single.reason, ImageRejection.tooManyImages);
+    });
+
+    test('attaches what fits and turns away only the overflow', () {
+      final result = _attach([
+        for (var i = 0; i < maxInlineImagesPerMessage + 2; i++)
+          _picked('image$i.png', 'image/png'),
+      ]);
+
+      expect(
+        result.accepted,
+        hasLength(maxInlineImagesPerMessage),
+        reason: 'a selection past the limit still attaches what fits',
+      );
+      expect(result.rejected.map((r) => r.name), [
+        'image$maxInlineImagesPerMessage.png',
+        'image${maxInlineImagesPerMessage + 1}.png',
+      ]);
+    });
+
+    test('spends no part of the message on an image it turned away', () {
+      // An image that is refused must leave the ceiling where it found it, or
+      // a pick with one bad file in it silently costs the user a good one.
+      final result = _attach([
+        _picked('scan.tiff', 'image/tiff'),
+        _picked('empty.png', 'image/png', bytes: 0),
+        for (var i = 0; i < maxInlineImagesPerMessage; i++)
+          _picked('image$i.png', 'image/png'),
+      ]);
+
+      expect(result.accepted, hasLength(maxInlineImagesPerMessage));
+      expect(
+        result.rejected.map((r) => r.name),
+        ['scan.tiff', 'empty.png'],
+      );
+    });
+
+    test('turns away an image that would put the message over the byte cap',
+        () {
+      final result = _attach([
+        _picked('big.png', 'image/png', bytes: maxInlineImageBytesPerMessage),
+        _picked('one-too-many.png', 'image/png', bytes: 1),
+      ]);
+
+      expect(result.accepted, hasLength(1));
+      expect(result.rejected.single.reason, ImageRejection.messageTooLarge);
+    });
+
+    test('counts bytes the composer already holds toward the cap', () {
+      final result = _attach(
+        [_picked('small.png', 'image/png', bytes: 2)],
+        attached: [_attached(bytes: maxInlineImageBytesPerMessage - 1)],
+      );
+
+      expect(result.accepted, isEmpty);
+      expect(result.rejected.single.reason, ImageRejection.messageTooLarge);
+    });
+
+    test('accepts a pick that lands exactly on the byte cap', () {
+      final result = _attach([
+        _picked('exact.png', 'image/png', bytes: maxInlineImageBytesPerMessage),
+      ]);
+
+      expect(result.accepted, hasLength(1));
+      expect(result.rejected, isEmpty);
+    });
+
+    test('keeps selection order', () {
+      final result = _attach([
+        _picked('1.gif', 'image/gif'),
+        _picked('2.png', 'image/png'),
+        _picked('3.webp', 'image/webp'),
+      ]);
+
+      expect(
+        result.accepted.map((p) => p.mimeType),
+        ['image/gif', 'image/png', 'image/webp'],
+      );
+    });
+
+    // Keeps the passthrough test below honest about its own coverage: an
+    // allowed type with no fixture is a format it silently never exercises.
+    test('has a fixture for every type the allow-list carries', () {
+      expect(onePixelImages.keys.toSet(), allowedInlineImageMimeTypes);
+    });
+
+    // The passthrough assertion below is only worth its name while the
+    // fixtures decode: a transform that fell back to the original on a decode
+    // failure would leave it green over bytes no encoder could have touched.
+    // Deleting this test means deleting that claim from `image_fixtures.dart`
+    // too — it is the only thing enforcing it.
+    test('every fixture is an image an encoder could act on', () async {
+      for (final MapEntry(key: mimeType, value: bytes)
+          in onePixelImages.entries) {
+        final codec = await ui.instantiateImageCodec(bytes);
+        final frame = await codec.getNextFrame();
+        expect(frame.image.width, 1, reason: mimeType);
+        expect(frame.image.height, 1, reason: mimeType);
+      }
+    });
+
+    // Validates and never transforms: no decode, no re-encode, no scaling. A
+    // transform added here instead of behind the encoder would inflate a PNG,
+    // strip a photo's EXIF, or flatten an animated GIF to one frame, none of it
+    // visible from the composer.
+    test('passes every allowed format through byte-identical', () {
+      for (final MapEntry(key: mimeType, value: bytes)
+          in onePixelImages.entries) {
+        final picked = _picked('x', mimeType, content: bytes);
+        final result = _attach([picked]);
+
+        expect(result.accepted, hasLength(1), reason: mimeType);
+        final part = result.accepted.single;
+        expect(part.mimeType, mimeType);
+        expect(part.bytes, equals(bytes), reason: mimeType);
+      }
+    });
+
+    test('turns away an image with no bytes', () {
+      // An allowed type over nothing still reaches the model as an image, and
+      // comes back from history as an attachment that cannot be rebuilt.
+      final result = _attach([_picked('empty.png', 'image/png', bytes: 0)]);
+
+      expect(result.accepted, isEmpty);
+      expect(result.rejected.single.reason, ImageRejection.unreadable);
+    });
+  });
+
+  group('rejectedImagesNotice', () {
+    test('says nothing when nothing was turned away', () {
+      expect(rejectedImagesNotice(const []), isNull);
+    });
+
+    test('names the files whose type is not supported', () {
+      expect(
+        rejectedImagesNotice(const [
+          (name: 'scan.tiff', reason: ImageRejection.unsupportedType),
+        ]),
+        'scan.tiff is not a supported image.',
+      );
+      expect(
+        rejectedImagesNotice(const [
+          (name: 'scan.tiff', reason: ImageRejection.unsupportedType),
+          (name: 'a.heic', reason: ImageRejection.unsupportedType),
+        ]),
+        'scan.tiff, a.heic are not supported images.',
+      );
+    });
+
+    test('states each limit once however many images ran into it', () {
+      expect(
+        rejectedImagesNotice(const [
+          (name: 'a.png', reason: ImageRejection.tooManyImages),
+          (name: 'b.png', reason: ImageRejection.tooManyImages),
+        ]),
+        'A message carries at most $maxInlineImagesPerMessage images.',
+      );
+      expect(
+        rejectedImagesNotice(const [
+          (name: 'a.png', reason: ImageRejection.messageTooLarge),
+        ]),
+        'Images must total at most 15 MB.',
+      );
+    });
+
+    test('carries every reason a pick was turned away for', () {
+      expect(
+        rejectedImagesNotice(const [
+          (name: 'a.tiff', reason: ImageRejection.unsupportedType),
+          (name: 'b.png', reason: ImageRejection.unreadable),
+          (name: 'c.png', reason: ImageRejection.tooManyImages),
+        ]),
+        'a.tiff is not a supported image. '
+        'b.png could not be read. '
+        'A message carries at most $maxInlineImagesPerMessage images.',
+      );
+    });
+
+    test('counts the files past the first few rather than naming them all', () {
+      // The notice sits above the composer with nothing to scroll it, so a
+      // pick of a folder of unsupported files would otherwise grow the
+      // composer until the text field and send button left the screen.
+      expect(
+        rejectedImagesNotice([
+          for (var i = 0; i < 30; i++)
+            (name: 'IMG_$i.tiff', reason: ImageRejection.unsupportedType),
+        ]),
+        'IMG_0.tiff, IMG_1.tiff, IMG_2.tiff, IMG_3.tiff and 26 more '
+        'are not supported images.',
+      );
+      expect(
+        rejectedImagesNotice([
+          for (var i = 0; i < 6; i++)
+            (name: 'IMG_$i.png', reason: ImageRejection.unreadable),
+        ]),
+        'IMG_0.png, IMG_1.png, IMG_2.png, IMG_3.png and 2 more '
+        'could not be read.',
+      );
+    });
+
+    test('names a pick that could have been attached in full', () {
+      // At the ceiling there is nothing to elide: "and 1 more" would cost the
+      // room the fourth name would have.
+      expect(
+        rejectedImagesNotice([
+          for (var i = 0; i < maxInlineImagesPerMessage; i++)
+            (name: 'IMG_$i.tiff', reason: ImageRejection.unsupportedType),
+        ]),
+        'IMG_0.tiff, IMG_1.tiff, IMG_2.tiff, IMG_3.tiff '
+        'are not supported images.',
+      );
+    });
+  });
+}

--- a/test/modules/room/image_fixtures.dart
+++ b/test/modules/room/image_fixtures.dart
@@ -1,0 +1,61 @@
+import 'dart:convert';
+import 'dart:typed_data';
+
+/// A real 1×1 image in each type a message may carry.
+///
+/// Decodable on purpose. A composer thumbnail renders these, so bytes that would
+/// not decode leave a test swallowing a decode failure — and, more to the point,
+/// a transform written the way transforms get written, falling back to the
+/// original on a decode failure, would pass over undecodable bytes untouched and
+/// leave the passthrough assertions green while re-encoding every real photo.
+///
+/// `attachable_images_test.dart` is what holds them to it, in 'every fixture is
+/// an image an encoder could act on'. That test and this paragraph go together:
+/// neither is worth keeping without the other.
+final onePixelPng = base64Decode(
+  'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAAAAAA6fptVAAAACklEQVR42mNgAAAAAgAB'
+  '5Sfe/AAAAABJRU5ErkJggg==',
+);
+
+final onePixelGif = base64Decode(
+  'R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7',
+);
+
+final onePixelWebp = base64Decode(
+  'UklGRhwAAABXRUJQVlA4TA8AAAAvAAAAAAcQ/Y/+ByKi/wEA',
+);
+
+final onePixelJpeg = base64Decode(
+  '/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAMCAgMCAgMDAwMEAwMEBQgFBQQEBQoHBwYIDAoM'
+  'DAsKCwsNDhIQDQ4RDgsLEBYQERMUFRUVDA8XGBYUGBIUFRT/2wBDAQMEBAUEBQkFBQkUDQsN'
+  'FBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBT/wAAR'
+  'CAABAAEDASIAAhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAA'
+  'AgEDAwIEAwUFBAQAAAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkK'
+  'FhcYGRolJicoKSo0NTY3ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWG'
+  'h4iJipKTlJWWl5iZmqKjpKWmp6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl'
+  '5ufo6erx8vP09fb3+Pn6/8QAHwEAAwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREA'
+  'AgECBAQDBAcFBAQAAQJ3AAECAxEEBSExBhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYk'
+  'NOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElKU1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOE'
+  'hYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk'
+  '5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD50ooor8MP9Uz/2Q==',
+);
+
+/// The header an iPhone's HEIC opens with: a `ftyp` box declaring the `heic`
+/// brand.
+///
+/// Only a header, where the others are whole images, because that is all a type
+/// sniffer reads and no allow-list carries HEIC — nothing decodes these bytes.
+final heicHeader = Uint8List.fromList([
+  0x00, 0x00, 0x00, 0x18, // ftyp box length
+  0x66, 0x74, 0x79, 0x70, // 'ftyp'
+  0x68, 0x65, 0x69, 0x63, // 'heic' brand
+  0x00, 0x00, 0x00, 0x00,
+]);
+
+/// Every type the allow-list carries, paired with real bytes of that type.
+final Map<String, Uint8List> onePixelImages = {
+  'image/png': onePixelPng,
+  'image/jpeg': onePixelJpeg,
+  'image/webp': onePixelWebp,
+  'image/gif': onePixelGif,
+};

--- a/test/modules/room/pick_image_impl_test.dart
+++ b/test/modules/room/pick_image_impl_test.dart
@@ -1,0 +1,236 @@
+import 'dart:io';
+
+import 'package:file_picker/file_picker.dart';
+// ignore: implementation_imports
+import 'package:file_picker/src/platform/file_picker_platform_interface.dart';
+import 'package:flutter/foundation.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:soliplex_frontend/src/modules/room/pick_file.dart';
+import 'package:soliplex_frontend/src/modules/room/pick_image.dart';
+
+import 'image_fixtures.dart';
+
+/// Records what the picker was asked for, so the arguments that decide whether
+/// an image is re-encoded can be asserted without a device.
+class _RecordingPicker extends FilePickerPlatform {
+  _RecordingPicker(this._files);
+
+  /// The batch to answer with, or null to stand in for a cancel.
+  final List<PlatformFile>? _files;
+
+  FileType? type;
+  int? compressionQuality;
+  bool? allowMultiple;
+
+  @override
+  Future<FilePickerResult?> pickFiles({
+    String? dialogTitle,
+    String? initialDirectory,
+    FileType type = FileType.any,
+    List<String>? allowedExtensions,
+    Function(FilePickerStatus)? onFileLoading,
+    int compressionQuality = 0,
+    bool allowMultiple = false,
+    bool withData = false,
+    bool withReadStream = false,
+    bool lockParentWindow = false,
+    bool readSequential = false,
+    bool cancelUploadOnWindowBlur = true,
+  }) async {
+    this.type = type;
+    this.compressionQuality = compressionQuality;
+    this.allowMultiple = allowMultiple;
+    final files = _files;
+    return files == null ? null : FilePickerResult(files);
+  }
+}
+
+void main() {
+  late FilePickerPlatform originalPlatform;
+  late Directory tempDir;
+
+  setUp(() {
+    originalPlatform = FilePickerPlatform.instance;
+    tempDir = Directory.systemTemp.createTempSync('pick_image_test');
+  });
+
+  tearDown(() {
+    FilePickerPlatform.instance = originalPlatform;
+    debugDefaultTargetPlatformOverride = null;
+    if (tempDir.existsSync()) tempDir.deleteSync(recursive: true);
+  });
+
+  File writeImage(String name) =>
+      File('${tempDir.path}/$name')..writeAsBytesSync(onePixelPng);
+
+  PlatformFile platformFile(File file) => PlatformFile(
+        name: file.uri.pathSegments.last,
+        path: file.path,
+        size: file.lengthSync(),
+      );
+
+  _RecordingPicker install(List<PlatformFile>? files) {
+    final picker = _RecordingPicker(files);
+    FilePickerPlatform.instance = picker;
+    return picker;
+  }
+
+  // Two outcomes the composer has to tell apart, and only one of them says
+  // nothing to the user. Android answers a pick it could not copy a single
+  // item out of with an empty list, having dropped the names on its side —
+  // read as a cancel, that leaves the user looking at a button that did
+  // nothing, with no record the pick ever happened.
+  test('answers a cancel with nothing at all', () async {
+    install(null);
+
+    expect(await pickImages(), isNull);
+  });
+
+  test('answers a pick it lost every item out of with an empty batch',
+      () async {
+    install([]);
+
+    final result = await pickImages();
+
+    expect(result, isNotNull);
+    expect(result!.images, isEmpty);
+    expect(result.errors, isEmpty);
+  });
+
+  // The picker reads one number two unrelated ways: on iOS any non-zero value
+  // asks for a compatible representation, which is what turns an iPhone's HEIC
+  // into a JPEG; on Android the same number is a real re-encode quality handed
+  // to the platform encoder. `compressionQuality` and `type` both have silent
+  // defaults, so dropping either changes what the user's image is — or which
+  // chooser opens — without failing to compile.
+  test('asks iOS for a compatible representation', () async {
+    debugDefaultTargetPlatformOverride = TargetPlatform.iOS;
+    final picker = install([platformFile(writeImage('a.png'))]);
+
+    await pickImages();
+
+    expect(picker.compressionQuality, greaterThan(0));
+    expect(picker.type, FileType.image);
+    expect(picker.allowMultiple, isTrue);
+  });
+
+  test('leaves every other platform re-encoding nothing', () async {
+    debugDefaultTargetPlatformOverride = TargetPlatform.android;
+    final picker = install([platformFile(writeImage('a.png'))]);
+
+    await pickImages();
+
+    expect(picker.compressionQuality, 0);
+  });
+
+  test('reads the picked bytes and types them', () async {
+    debugDefaultTargetPlatformOverride = TargetPlatform.macOS;
+    install([platformFile(writeImage('a.png'))]);
+
+    final result = await pickImages();
+
+    expect(result!.images.single.bytes, onePixelPng);
+    expect(result.images.single.mimeType, 'image/png');
+    expect(result.errors, isEmpty);
+  });
+
+  for (final platform in [TargetPlatform.iOS, TargetPlatform.android]) {
+    test('discards the copy the ${platform.name} picker made', () async {
+      // On iOS that copy lands in the Documents directory, which the system
+      // never reclaims and a backup carries.
+      debugDefaultTargetPlatformOverride = platform;
+      final file = writeImage('a.png');
+      install([platformFile(file)]);
+
+      await pickImages();
+
+      expect(file.existsSync(), isFalse);
+    });
+  }
+
+  test('discards the copy even when it cannot be read', () async {
+    // The read most likely to fail is of the largest image, so leaving the
+    // copy behind on that path would leak the worst case — and on iOS, leak it
+    // permanently.
+    debugDefaultTargetPlatformOverride = TargetPlatform.iOS;
+    final file = writeImage('a.png');
+    // Unreadable but still deletable: deleting answers to the directory's
+    // permissions, not the file's.
+    Process.runSync('chmod', ['000', file.path]);
+    install([platformFile(file)]);
+
+    final result = await pickImages();
+
+    expect(result!.errors.single.filename, 'a.png');
+    expect(
+      file.existsSync(),
+      isFalse,
+      reason: 'the picker copy should be discarded even after a failed read',
+    );
+  },
+      skip: Platform.isWindows || Process.runSync('id', ['-u']).stdout == '0\n'
+          ? 'needs POSIX permissions and a non-root user to make a read fail'
+          : null);
+
+  test('leaves the picked file alone where it is the user\'s own', () async {
+    // On desktop the path is the file the user chose, not a copy of it.
+    debugDefaultTargetPlatformOverride = TargetPlatform.macOS;
+    final file = writeImage('a.png');
+    install([platformFile(file)]);
+
+    await pickImages();
+
+    expect(file.existsSync(), isTrue);
+  });
+
+  test('reports a file it cannot read and keeps the rest of the batch',
+      () async {
+    debugDefaultTargetPlatformOverride = TargetPlatform.macOS;
+    final readable = writeImage('good.png');
+    install([
+      PlatformFile(name: 'gone.png', path: '${tempDir.path}/gone.png', size: 1),
+      platformFile(readable),
+    ]);
+
+    final result = await pickImages();
+
+    expect(result!.images.single.bytes, onePixelPng);
+    expect(result.errors.single.filename, 'gone.png');
+    expect(result.errors.single.cause, isA<FileSystemException>());
+  });
+
+  test('reports a file the picker gave no path for', () async {
+    debugDefaultTargetPlatformOverride = TargetPlatform.macOS;
+    install([PlatformFile(name: 'nopath.png', size: 1)]);
+
+    final result = await pickImages();
+
+    expect(result!.images, isEmpty);
+    expect(result.errors.single.filename, 'nopath.png');
+  });
+
+  test('wraps a whole-picker failure', () async {
+    FilePickerPlatform.instance = _ThrowingPicker();
+
+    expect(pickImages(), throwsA(isA<PickFilePickerException>()));
+  });
+}
+
+class _ThrowingPicker extends FilePickerPlatform {
+  @override
+  Future<FilePickerResult?> pickFiles({
+    String? dialogTitle,
+    String? initialDirectory,
+    FileType type = FileType.any,
+    List<String>? allowedExtensions,
+    Function(FilePickerStatus)? onFileLoading,
+    int compressionQuality = 0,
+    bool allowMultiple = false,
+    bool withData = false,
+    bool withReadStream = false,
+    bool lockParentWindow = false,
+    bool readSequential = false,
+    bool cancelUploadOnWindowBlur = true,
+  }) async =>
+      throw StateError('plugin missing');
+}

--- a/test/modules/room/pick_image_test.dart
+++ b/test/modules/room/pick_image_test.dart
@@ -1,0 +1,39 @@
+import 'dart:typed_data';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:soliplex_frontend/src/modules/room/attachable_images.dart';
+import 'package:soliplex_frontend/src/modules/room/pick_image.dart';
+
+import 'image_fixtures.dart';
+
+void main() {
+  group('PickedImage.fromBytes', () {
+    test('types an iPhone photo as HEIC however it is named', () {
+      // The case the content-first rule exists for, end to end: a HEIC that
+      // reached us under a .jpeg name must not be sent to the model as JPEG.
+      // Passing the bytes to the sniffer is the decision under test — drop
+      // them and this types by the name — and it rests on the sniffer carrying
+      // HEIC magic, which is a property of a dependency and can be lost in a
+      // bump. The other orderings this resolves are the sniffer's own
+      // guarantees, and are its tests to keep.
+      final image = PickedImage.fromBytes(
+        name: 'IMG_0001.jpeg',
+        bytes: heicHeader,
+      );
+
+      expect(image.mimeType, 'image/heic');
+      expect(allowedInlineImageMimeTypes, isNot(contains(image.mimeType)));
+    });
+
+    test('leaves an image nothing can type as opaque bytes', () {
+      // No allow-list carries this, so such a file is turned away rather than
+      // sent as an image.
+      final image = PickedImage.fromBytes(
+        name: 'notes',
+        bytes: Uint8List.fromList([1, 2, 3, 4]),
+      );
+
+      expect(image.mimeType, 'application/octet-stream');
+    });
+  });
+}

--- a/test/modules/room/ui/chat_input_test.dart
+++ b/test/modules/room/ui/chat_input_test.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -5,9 +7,15 @@ import 'package:signals_flutter/signals_flutter.dart';
 import 'package:soliplex_agent/soliplex_agent.dart' hide State;
 import 'package:soliplex_design/soliplex_design.dart';
 
+import 'package:soliplex_frontend/src/modules/room/attachable_images.dart';
 import 'package:soliplex_frontend/src/modules/room/composer_draft.dart';
+import 'package:soliplex_frontend/src/modules/room/pick_file.dart';
+import 'package:soliplex_frontend/src/modules/room/pick_image.dart';
 import 'package:soliplex_frontend/src/modules/room/ui/chat_input.dart';
 import 'package:soliplex_frontend/src/modules/room/ui/inline_image_composer_controller.dart';
+import 'package:soliplex_logging/soliplex_logging.dart';
+
+import '../image_fixtures.dart';
 
 void main() {
   group('composerAcceptsText', () {
@@ -573,5 +581,701 @@ void main() {
         expect(folderTaps, 1);
       },
     );
+  });
+
+  group('add image button', () {
+    PickedImage pickedImage(
+      String name,
+      String mimeType, {
+      Uint8List? bytes,
+    }) =>
+        PickedImage(
+          name: name,
+          mimeType: mimeType,
+          bytes: bytes ?? onePixelPng,
+        );
+
+    PickImagesResult picks(
+      List<PickedImage> images, {
+      List<PickFileItemError> errors = const [],
+    }) =>
+        (images: images, errors: errors);
+
+    Future<InlineImageComposerController> pumpComposer(
+      WidgetTester tester, {
+      Future<PickImagesResult?> Function()? openImagePicker,
+      ReadonlySignal<AgentSessionState?>? sessionState,
+    }) async {
+      final controller = InlineImageComposerController();
+      addTearDown(controller.dispose);
+      await tester.pumpWidget(
+        MaterialApp(
+          theme: soliplexLightTheme(),
+          home: Scaffold(
+            body: ChatInput(
+              onSend: (_) {},
+              onCancel: () {},
+              controller: controller,
+              sessionState: sessionState,
+              openImagePicker: openImagePicker,
+            ),
+          ),
+        ),
+      );
+      return controller;
+    }
+
+    testWidgets('inserts each image at the caret, in selection order',
+        (tester) async {
+      final controller = await pumpComposer(
+        tester,
+        openImagePicker: () async => picks([
+          pickedImage('a.png', 'image/png'),
+          pickedImage('b.gif', 'image/gif', bytes: onePixelGif),
+        ]),
+      );
+
+      await tester.enterText(find.byType(TextField), 'look at this');
+      // Mid-text, so the images cannot arrive merely appended.
+      controller.selection = const TextSelection.collapsed(offset: 7);
+      await tester.tap(find.byTooltip('Add image'));
+      await tester.pumpAndSettle();
+
+      final parts = controller.sendableParts();
+      expect(
+        parts?.map(
+          (part) => switch (part) {
+            TextPart(:final text) => text,
+            ImagePart(:final mimeType) => mimeType,
+            _ => 'unexpected',
+          },
+        ),
+        ['look at', 'image/png', 'image/gif', ' this'],
+      );
+      // Nothing between the picker and the composer may alter the bytes: a
+      // transform belongs behind the encoder, where it can be measured.
+      expect(
+        parts?.whereType<ImagePart>().map((part) => part.bytes),
+        [onePixelPng, onePixelGif],
+      );
+    });
+
+    testWidgets('says so when the picker itself fails', (tester) async {
+      await pumpComposer(
+        tester,
+        openImagePicker: () async =>
+            throw const PickFilePickerException(cause: 'no plugin'),
+      );
+
+      await tester.tap(find.byTooltip('Add image'));
+      await tester.pumpAndSettle();
+
+      // Not the upload path's "could not open file picker": on web the bytes
+      // are read inside the picker call, so this failure is as likely to have
+      // come after the chooser closed, which the user just watched work.
+      expect(find.text('Could not add the images.'), findsOneWidget);
+    });
+
+    testWidgets('tells the user a browser pick was too large to load',
+        (tester) async {
+      // The web picker buffers every image whole, so this is the failure this
+      // path is likeliest to hit, and 'try again' is advice that cannot work.
+      await pumpComposer(
+        tester,
+        openImagePicker: () async =>
+            throw PickFilePickerException(cause: RangeError('out of memory')),
+      );
+
+      await tester.tap(find.byTooltip('Add image'));
+      await tester.pumpAndSettle();
+
+      expect(
+        find.text('The images are too large to load in the browser.'),
+        findsOneWidget,
+      );
+    });
+
+    testWidgets('names a file it could not read', (tester) async {
+      final controller = await pumpComposer(
+        tester,
+        openImagePicker: () async => picks(
+          [],
+          errors: const [
+            PickFileItemError(filename: 'holiday.png', cause: 'gone'),
+          ],
+        ),
+      );
+
+      await tester.tap(find.byTooltip('Add image'));
+      await tester.pumpAndSettle();
+
+      expect(controller.sendableParts(), isNull);
+      expect(find.text('holiday.png could not be read.'), findsOneWidget);
+    });
+
+    testWidgets('reports what it could not attach and inserts none of it',
+        (tester) async {
+      final controller = await pumpComposer(
+        tester,
+        openImagePicker: () async => picks([
+          pickedImage('scan.tiff', 'image/tiff'),
+        ]),
+      );
+
+      await tester.tap(find.byTooltip('Add image'));
+      await tester.pumpAndSettle();
+
+      expect(controller.sendableParts(), isNull);
+      expect(find.text('scan.tiff is not a supported image.'), findsOneWidget);
+    });
+
+    testWidgets('counts the images already in the composer toward the limit',
+        (tester) async {
+      final controller = await pumpComposer(
+        tester,
+        openImagePicker: () async => picks([
+          for (var i = 0; i < maxInlineImagesPerMessage; i++)
+            pickedImage('image$i.png', 'image/png'),
+        ]),
+      );
+
+      await tester.tap(find.byTooltip('Add image'));
+      await tester.pumpAndSettle();
+      expect(controller.sendableParts(), hasLength(maxInlineImagesPerMessage));
+
+      // The limit is per message, not per pick: a second pick of the same size
+      // must not double what the message carries.
+      await tester.tap(find.byTooltip('Add image'));
+      await tester.pumpAndSettle();
+
+      expect(controller.sendableParts(), hasLength(maxInlineImagesPerMessage));
+      expect(
+        find.text(
+          'A message carries at most $maxInlineImagesPerMessage images.',
+        ),
+        findsOneWidget,
+      );
+    });
+
+    testWidgets('drops a notice on a new conversation, still taking typing',
+        (tester) async {
+      // The notice describes a pick made into the conversation being left, so
+      // it must not follow the user into the next one. It travels as a value
+      // and not as a Key: re-inflating the composer would close the platform
+      // text input connection while the caller-owned FocusNode survived, so
+      // nothing would report a focus change, EditableText would never reopen
+      // the connection, and typing would go nowhere.
+      final controller = InlineImageComposerController();
+      addTearDown(controller.dispose);
+      final focusNode = FocusNode();
+      addTearDown(focusNode.dispose);
+
+      Widget app(Object scope) => MaterialApp(
+            theme: soliplexLightTheme(),
+            home: Scaffold(
+              body: ChatInput(
+                onSend: (_) {},
+                onCancel: () {},
+                controller: controller,
+                focusNode: focusNode,
+                composerScope: scope,
+                openImagePicker: () async =>
+                    picks([pickedImage('scan.tiff', 'image/tiff')]),
+              ),
+            ),
+          );
+
+      await tester.pumpWidget(app('thread-1'));
+      await tester.tap(find.byTooltip('Add image'));
+      await tester.pumpAndSettle();
+      expect(find.text('scan.tiff is not a supported image.'), findsOneWidget);
+
+      await tester.tap(find.byType(TextField));
+      await tester.pump();
+      expect(tester.testTextInput.hasAnyClients, isTrue);
+
+      await tester.pumpWidget(app('thread-2'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('scan.tiff is not a supported image.'), findsNothing);
+      expect(tester.testTextInput.hasAnyClients, isTrue,
+          reason: 'the composer must keep the platform input connection');
+      tester.testTextInput.enterText('still typing');
+      await tester.pump();
+      expect(controller.text, 'still typing');
+    });
+
+    testWidgets('leaves a cancelled pick to say nothing at all',
+        (tester) async {
+      // Backing out of the picker is the commonest thing that happens to it.
+      // It is not a failure and has nothing to report, so it must not clear a
+      // notice the user still needs to read.
+      var cancel = false;
+      final controller = await pumpComposer(
+        tester,
+        openImagePicker: () async =>
+            cancel ? null : picks([pickedImage('scan.tiff', 'image/tiff')]),
+      );
+
+      await tester.tap(find.byTooltip('Add image'));
+      await tester.pumpAndSettle();
+      expect(find.text('scan.tiff is not a supported image.'), findsOneWidget);
+
+      cancel = true;
+      await tester.tap(find.byTooltip('Add image'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('scan.tiff is not a supported image.'), findsOneWidget);
+      expect(controller.sendableParts(), isNull);
+      // And the button has to come back, or a cancel costs the user the
+      // feature for the rest of the message.
+      expect(
+        tester
+            .widget<IconButton>(
+              find.widgetWithIcon(
+                IconButton,
+                Icons.add_photo_alternate_outlined,
+              ),
+            )
+            .onPressed,
+        isNotNull,
+      );
+    });
+
+    testWidgets('speaks for a pick the platform lost entirely', (tester) async {
+      // Android answers a pick it could not copy a single item out of with an
+      // empty batch, having dropped the names on its side. Read as a cancel it
+      // would leave the user tapping a button that does nothing.
+      await pumpComposer(tester, openImagePicker: () async => picks([]));
+
+      await tester.tap(find.byTooltip('Add image'));
+      await tester.pumpAndSettle();
+
+      expect(
+        find.text('Could not read the images you picked.'),
+        findsOneWidget,
+      );
+    });
+
+    testWidgets('leaves a pick behind in the conversation it was made into',
+        (tester) async {
+      // The composer outlives the conversation by design — it travels as a
+      // value so the platform text input connection survives — so a pick that
+      // was still open when the user moved on comes back to a composer that is
+      // mounted, enabled, and now someone else's. Without a scope check the
+      // images land in the wrong thread, and the next send carries them
+      // somewhere the user never chose.
+      final controller = InlineImageComposerController();
+      addTearDown(controller.dispose);
+      final gate = Completer<PickImagesResult?>();
+
+      // Nothing on screen may speak for this pick, so the log has to. It is
+      // the only account left of a file the picker could not read.
+      final sink = MemorySink();
+      LogManager.instance.addSink(sink);
+      addTearDown(() => LogManager.instance.removeSink(sink));
+
+      Widget app(Object scope) => MaterialApp(
+            theme: soliplexLightTheme(),
+            home: Scaffold(
+              body: ChatInput(
+                onSend: (_) {},
+                onCancel: () {},
+                controller: controller,
+                composerScope: scope,
+                openImagePicker: () => gate.future,
+              ),
+            ),
+          );
+
+      await tester.pumpWidget(app('thread-1'));
+      await tester.tap(find.byTooltip('Add image'));
+      await tester.pump();
+
+      // What RoomScreen does on a thread change: same controller, cleared.
+      controller.clear();
+      await tester.pumpWidget(app('thread-2'));
+      await tester.pump();
+
+      gate.complete(
+        picks(
+          [pickedImage('a.png', 'image/png')],
+          errors: const [
+            PickFileItemError(filename: 'holiday.tiff', cause: 'gone'),
+          ],
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(controller.sendableParts(), isNull,
+          reason: 'the images belong to the conversation that was left');
+      expect(find.text('holiday.tiff could not be read.'), findsNothing,
+          reason: 'nor does what that pick had to say about itself');
+      expect(
+        sink.records.where((r) => r.attributes['filename'] == 'holiday.tiff'),
+        isNotEmpty,
+        reason: 'the log is the only place that file is still accounted for',
+      );
+    });
+
+    testWidgets('drops a notice once a later pick has nothing to report',
+        (tester) async {
+      var reject = true;
+      final controller = await pumpComposer(
+        tester,
+        openImagePicker: () async => reject
+            ? picks([pickedImage('scan.tiff', 'image/tiff')])
+            : picks([pickedImage('a.png', 'image/png')]),
+      );
+
+      await tester.tap(find.byTooltip('Add image'));
+      await tester.pumpAndSettle();
+      expect(find.text('scan.tiff is not a supported image.'), findsOneWidget);
+
+      reject = false;
+      await tester.tap(find.byTooltip('Add image'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('scan.tiff is not a supported image.'), findsNothing);
+      expect(controller.sendableParts(), hasLength(1));
+    });
+
+    testWidgets('refuses to add images to a composer a run has taken',
+        (tester) async {
+      // The picker can outlive the composer's availability, and an image put
+      // into a read-only composer cannot be taken back out of it — the chip
+      // showing a picture has no remove affordance — so it would be sent with
+      // whatever the user typed next.
+      final sessionState = signal<AgentSessionState?>(null);
+      addTearDown(sessionState.dispose);
+      final controller = await pumpComposer(
+        tester,
+        sessionState: sessionState,
+        openImagePicker: () async {
+          sessionState.value = AgentSessionState.running;
+          return picks([pickedImage('a.png', 'image/png')]);
+        },
+      );
+
+      await tester.tap(find.byTooltip('Add image'));
+      await tester.pumpAndSettle();
+
+      expect(controller.sendableParts(), isNull);
+      expect(
+        find.text('The composer was busy. Add the images again.'),
+        findsOneWidget,
+      );
+    });
+
+    testWidgets('is disabled while a run holds the composer', (tester) async {
+      final sessionState = signal<AgentSessionState?>(
+        AgentSessionState.running,
+      );
+      addTearDown(sessionState.dispose);
+      await pumpComposer(tester, sessionState: sessionState);
+
+      expect(
+        tester
+            .widget<IconButton>(
+              find.widgetWithIcon(
+                IconButton,
+                Icons.add_photo_alternate_outlined,
+              ),
+            )
+            .onPressed,
+        isNull,
+      );
+    });
+
+    testWidgets('drops a notice once the message it sat above is sent',
+        (tester) async {
+      // The notice describes a pick into a message that has now gone; leaving
+      // it would strand an error above an empty composer with nothing to
+      // explain it.
+      await pumpComposer(
+        tester,
+        openImagePicker: () async =>
+            picks([pickedImage('scan.tiff', 'image/tiff')]),
+      );
+
+      await tester.tap(find.byTooltip('Add image'));
+      await tester.pumpAndSettle();
+      expect(find.text('scan.tiff is not a supported image.'), findsOneWidget);
+
+      await tester.enterText(find.byType(TextField), 'never mind');
+      await tester.pump();
+      await tester.tap(find.byIcon(Icons.send));
+      await tester.pumpAndSettle();
+
+      expect(find.text('scan.tiff is not a supported image.'), findsNothing);
+    });
+
+    testWidgets('says so when the picker fails in a way it cannot name',
+        (tester) async {
+      // Nothing in the app installs a global async error handler, so a throw
+      // this does not catch would leave the button looking dead: no images, no
+      // notice, and no log line for anyone to work back from.
+      await pumpComposer(
+        tester,
+        openImagePicker: () async => throw StateError('plugin blew up'),
+      );
+
+      await tester.tap(find.byTooltip('Add image'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Could not add the images.'), findsOneWidget);
+      expect(tester.takeException(), isNull);
+    });
+
+    testWidgets('opens one picker however often the button is tapped',
+        (tester) async {
+      // A second pick while the first is open is answered by the Android
+      // plugin with an "already active" error, which would report a failure
+      // over a pick that is still working.
+      var opens = 0;
+      final gate = Completer<PickImagesResult?>();
+      await pumpComposer(
+        tester,
+        openImagePicker: () {
+          opens++;
+          return gate.future;
+        },
+      );
+
+      await tester.tap(find.byTooltip('Add image'));
+      await tester.pump();
+      await tester.tap(find.byTooltip('Add image'), warnIfMissed: false);
+      await tester.pump();
+
+      expect(opens, 1);
+
+      gate.complete(picks([pickedImage('a.png', 'image/png')]));
+      await tester.pumpAndSettle();
+
+      // The button comes back once the pick is done.
+      await tester.tap(find.byTooltip('Add image'));
+      await tester.pump();
+      expect(opens, 2);
+    });
+  });
+
+  group('leading controls', () {
+    Widget composer({
+      required double width,
+      required InlineImageComposerController controller,
+      bool filter = false,
+      bool upload = false,
+      bool folder = true,
+      VoidCallback? onFilter,
+      VoidCallback? onFiles,
+      VoidCallback? onFolder,
+      ReadonlySignal<AgentSessionState?>? sessionState,
+    }) =>
+        MaterialApp(
+          theme: soliplexLightTheme(),
+          home: Scaffold(
+            body: Align(
+              alignment: Alignment.topLeft,
+              child: SizedBox(
+                width: width,
+                child: ChatInput(
+                  onSend: (_) {},
+                  onCancel: () {},
+                  controller: controller,
+                  sessionState: sessionState,
+                  onFilterTap: filter ? (onFilter ?? () {}) : null,
+                  onAttachFile: upload ? (onFiles ?? () {}) : null,
+                  onAttachFolder: upload && folder ? (onFolder ?? () {}) : null,
+                ),
+              ),
+            ),
+          ),
+        );
+
+    InlineImageComposerController newController() {
+      final controller = InlineImageComposerController();
+      addTearDown(controller.dispose);
+      return controller;
+    }
+
+    testWidgets('a narrow composer shows the filter alone directly',
+        (tester) async {
+      await tester.pumpWidget(
+        composer(
+          width: SoliplexBreakpoints.mobile,
+          controller: newController(),
+          filter: true,
+        ),
+      );
+
+      expect(find.byTooltip('Filter documents'), findsOneWidget);
+      expect(find.byIcon(Icons.more_horiz), findsNothing);
+    });
+
+    testWidgets('a narrow composer shows upload alone directly',
+        (tester) async {
+      await tester.pumpWidget(
+        composer(
+          width: SoliplexBreakpoints.mobile,
+          controller: newController(),
+          upload: true,
+        ),
+      );
+
+      expect(find.byIcon(Icons.attach_file), findsOneWidget);
+      expect(find.byIcon(Icons.more_horiz), findsNothing);
+    });
+
+    testWidgets(
+        'a narrow composer collapses the filter and upload pair into one menu',
+        (tester) async {
+      await tester.pumpWidget(
+        composer(
+          width: SoliplexBreakpoints.mobile,
+          controller: newController(),
+          filter: true,
+          upload: true,
+        ),
+      );
+
+      // Three leading buttons, the gap and send leave a 320 px composer a
+      // 104 px text field, so the optional pair shares a slot.
+      expect(find.byTooltip('Add image'), findsOneWidget);
+      expect(find.byIcon(Icons.more_horiz), findsOneWidget);
+      expect(find.byIcon(Icons.filter_alt), findsNothing);
+      expect(find.byIcon(Icons.attach_file), findsNothing);
+
+      await tester.tap(find.byIcon(Icons.more_horiz));
+      await tester.pumpAndSettle();
+
+      // Flattened, not nested: upload is a menu of its own, and Material
+      // handles a menu inside a menu poorly.
+      expect(find.text('Filter documents'), findsOneWidget);
+      expect(find.text('Upload files…'), findsOneWidget);
+      expect(find.text('Upload folder…'), findsOneWidget);
+    });
+
+    testWidgets('each collapsed item runs the action it names', (tester) async {
+      // The items lose their icons on the way into the menu, so nothing but
+      // this says a label still reaches the action it was written for.
+      final ran = <String>[];
+      Future<void> choose(String label) async {
+        await tester.pumpWidget(
+          composer(
+            width: SoliplexBreakpoints.mobile,
+            controller: newController(),
+            filter: true,
+            upload: true,
+            onFilter: () => ran.add('filter'),
+            onFiles: () => ran.add('files'),
+            onFolder: () => ran.add('folder'),
+          ),
+        );
+        await tester.tap(find.byIcon(Icons.more_horiz));
+        await tester.pumpAndSettle();
+        await tester.tap(find.text(label));
+        await tester.pumpAndSettle();
+      }
+
+      await choose('Filter documents');
+      await choose('Upload files…');
+      await choose('Upload folder…');
+
+      expect(ran, ['filter', 'files', 'folder']);
+    });
+
+    testWidgets('a composer with no folder picker collapses to two items',
+        (tester) async {
+      // A caller that offers file upload but no folder pick: the pair still
+      // collapses, and the menu carries one upload item.
+      await tester.pumpWidget(
+        composer(
+          width: SoliplexBreakpoints.mobile,
+          controller: newController(),
+          filter: true,
+          upload: true,
+          folder: false,
+        ),
+      );
+
+      await tester.tap(find.byIcon(Icons.more_horiz));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Filter documents'), findsOneWidget);
+      expect(find.text('Upload files…'), findsOneWidget);
+      expect(find.text('Upload folder…'), findsNothing);
+    });
+
+    testWidgets('a run holding the composer disables the collapsed menu',
+        (tester) async {
+      // The buttons this menu stands in for are gated during a run; hiding
+      // them behind a menu must not be the way around that.
+      final sessionState =
+          signal<AgentSessionState?>(AgentSessionState.running);
+      addTearDown(sessionState.dispose);
+
+      await tester.pumpWidget(
+        composer(
+          width: SoliplexBreakpoints.mobile,
+          controller: newController(),
+          filter: true,
+          upload: true,
+          sessionState: sessionState,
+        ),
+      );
+
+      await tester.tap(find.byIcon(Icons.more_horiz));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Filter documents'), findsNothing);
+      expect(find.text('Upload files…'), findsNothing);
+    });
+
+    testWidgets('a tablet-width composer shows all three individually',
+        (tester) async {
+      await tester.pumpWidget(
+        composer(
+          width: SoliplexBreakpoints.tablet,
+          controller: newController(),
+          filter: true,
+          upload: true,
+        ),
+      );
+
+      expect(find.byTooltip('Add image'), findsOneWidget);
+      expect(find.byIcon(Icons.filter_alt), findsOneWidget);
+      expect(find.byIcon(Icons.attach_file), findsOneWidget);
+      expect(find.byIcon(Icons.more_horiz), findsNothing);
+    });
+
+    testWidgets('the field keeps its width when the document filter appears',
+        (tester) async {
+      // The room reveals the filter once its document load lands, which can
+      // happen while the user is typing. Collapsing the optional pair is what
+      // holds the row at two leading slots across that change. Upload is
+      // present because that is the case the row holds steady: with no upload
+      // affordance the filter's arrival still takes the row from one slot to
+      // two.
+      final controller = newController();
+      await tester.pumpWidget(
+        composer(
+          width: SoliplexBreakpoints.mobile,
+          controller: controller,
+          upload: true,
+        ),
+      );
+      final before = tester.getSize(find.byType(TextField)).width;
+
+      await tester.pumpWidget(
+        composer(
+          width: SoliplexBreakpoints.mobile,
+          controller: controller,
+          upload: true,
+          filter: true,
+        ),
+      );
+
+      expect(tester.getSize(find.byType(TextField)).width, before);
+    });
   });
 }

--- a/test/modules/room/ui/room_screen_test.dart
+++ b/test/modules/room/ui/room_screen_test.dart
@@ -19,6 +19,7 @@ import 'package:soliplex_frontend/src/modules/room/document_selections.dart';
 import 'package:soliplex_frontend/src/modules/room/run_registry.dart';
 import 'package:soliplex_frontend/src/modules/room/thread_anchor_storage.dart';
 import 'package:soliplex_frontend/src/modules/room/thread_read_markers.dart';
+import 'package:soliplex_frontend/src/modules/room/ui/chat_input.dart';
 import 'package:soliplex_frontend/src/modules/room/ui/room_rail.dart';
 import 'package:soliplex_frontend/src/modules/room/ui/room_screen.dart';
 import 'package:soliplex_frontend/src/modules/room/ui/thread_sidebar.dart';
@@ -1130,6 +1131,73 @@ void main() {
       await tester.pumpAndSettle();
 
       expect(find.byIcon(Icons.attach_file), findsNothing);
+    });
+
+    testWidgets('gives the composer a scope that changes with the thread',
+        (tester) async {
+      // ChatInput drops a pick that comes back after the conversation moved on
+      // by comparing this value across the picker's await, and the composer
+      // deliberately survives a thread change, so nothing else would catch it.
+      // Supplying a constant here — or dropping the argument — puts one
+      // thread's images into another with every test still green.
+      tester.view.physicalSize = const Size(1200, 800);
+      tester.view.devicePixelRatio = 1.0;
+      addTearDown(tester.view.resetPhysicalSize);
+
+      api.nextRoom = const Room(id: 'room-1', name: 'Plain');
+      api.nextThreads = const [];
+
+      Future<Object?> scopeFor(String? threadId) async {
+        await tester.pumpWidget(MaterialApp(
+          home: RoomScreen(
+            serverEntry: entry,
+            roomId: 'room-1',
+            threadId: threadId,
+            runtimeManager: runtimeManager,
+            registry: registry,
+            uploadRegistry: uploadRegistry,
+            documentSelections: DocumentSelections(),
+          ),
+        ));
+        await tester.pumpAndSettle();
+        return tester.widget<ChatInput>(find.byType(ChatInput)).composerScope;
+      }
+
+      final welcome = await scopeFor(null);
+      final first = await scopeFor('thread-1');
+      final second = await scopeFor('thread-2');
+
+      expect(first, isNotNull, reason: 'a null scope never changes');
+      expect(first, isNot(second));
+      expect(first, isNot(welcome));
+    });
+
+    testWidgets('a room without the sandbox skill can still add an image',
+        (tester) async {
+      // An inline image is a property of the model, not of the room's skills,
+      // so the affordance this room has no paperclip for must still be here.
+      tester.view.physicalSize = const Size(1200, 800);
+      tester.view.devicePixelRatio = 1.0;
+      addTearDown(tester.view.resetPhysicalSize);
+
+      api.nextRoom = const Room(id: 'room-1', name: 'Plain');
+      api.nextThreads = const [];
+
+      await tester.pumpWidget(MaterialApp(
+        home: RoomScreen(
+          serverEntry: entry,
+          roomId: 'room-1',
+          threadId: null,
+          runtimeManager: runtimeManager,
+          registry: registry,
+          uploadRegistry: uploadRegistry,
+          documentSelections: DocumentSelections(),
+        ),
+      ));
+      await tester.pumpAndSettle();
+
+      expect(find.byIcon(Icons.attach_file), findsNothing);
+      expect(find.byTooltip('Add image'), findsOneWidget);
     });
 
     testWidgets(


### PR DESCRIPTION
## What

An add-image button beside the composer opens the platform image picker and
inserts each picked image at the caret, so a message reaches the model carrying
its images in the order they were written around. The button appears in every
room — an inline image is a property of the model, not of the room's skills, so
it does not depend on the paperclip's sandbox capability.

## Behaviour

- Picked bytes are sent untouched: nothing decodes, re-encodes or scales them,
  so a PNG cannot be inflated, a photo's EXIF cannot be stripped, and an
  animated GIF keeps its frames.
- PNG, JPEG, WebP and GIF, up to 4 images and 15 MB a message, counted against
  what the composer already holds rather than per pick.
- An image is typed by what its bytes hold before its name, so one saved under
  a misleading extension is turned away rather than reaching the model mistyped.
- Anything the message cannot carry is left out and reported in a line under
  the composer that a screen reader announces — by name where the file itself
  is the problem, stated once as a limit where the message is. The notice names
  at most as many files as a message could have carried and counts the rest, so
  a pick of a whole folder cannot grow the composer off the screen.
- Below tablet width the document filter and thread upload collapse into one
  menu of labelled items, keeping the text field usable beside the add-image
  button.

## Platform notes

- **iOS** is asked for a compatible representation, so an iPhone's HEIC arrives
  as JPEG. The same `compressionQuality` argument is a real re-encode quality on
  **Android**, so it is passed as zero there — one value cannot serve both.
- Both mobile platforms leave a copy of the pick behind, discarded once its
  bytes are held. iOS writes to Documents, which nothing reclaims.
- **Web** reads sequentially so pick order survives, and revokes the object URLs
  `file_picker` mints in their own pass over the batch, so a failure reading one
  file cannot strand another file's copy.
- Both pickers select their web implementation on `dart.library.js_interop`.
  `dart.library.html` is false under dart2wasm while `dart:io` stays an
  importable stub, which would otherwise compile the native picker into a wasm
  build and break image attachment and file upload at runtime.

### Known limitation

Selection order does not survive an iOS multi-pick: the plugin appends each
asset from its own completion handler and the paths it returns carry nothing of
the order, so it cannot be restored on our side. Documented in
`pick_image_impl.dart` and called out in the CHANGELOG.

## Conversation scoping

The composer deliberately survives a thread change — its scope travels as a
value rather than a `Key`, because keying `ChatInput` re-inflates it and closes
the platform text input connection while the screen-owned `FocusNode` survives,
leaving a composer that looks focused but takes no typing. A pick still open
when the user moved on therefore came back to a composer that was mounted,
enabled, and holding another conversation's draft. The scope is now compared
across the picker's await and such a pick is dropped, after logging the files it
could not read, since that path has nowhere to show them.

## Testing

- Full suite **2337 passing**; `flutter analyze` clean; `dart format` clean;
  markdownlint clean.
- Three regression tests were each verified by mutation — the guard was removed
  and the test confirmed to fail: the conversation-scoping fix, the
  empty-batch-vs-cancel distinction in `pickImagesImpl`, and the unreadable-file
  log that the code calls the only account of those files.
- The notice-length fix was measured rather than assumed: the composer stays
  flat at 206 px of an 844 px viewport for 6, 30 and 200 rejected files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
