### PR TITLE
chore: version 0.99.0+79

### DIFF
--- a/lib/version.dart
+++ b/lib/version.dart
@@ -2,4 +2,4 @@
 ///
 /// Generated from pubspec.yaml. Run `dart run tool/update_version.dart` after
 /// changing the version in pubspec.yaml.
-const String soliplexVersion = '0.98.2+78';
+const String soliplexVersion = '0.99.0+79';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,7 +3,7 @@ description: Modular Flutter frontend framework for Soliplex
 publish_to: none
 # To update version, run:
 # dart run tool/bump_version.dart <major|minor|patch|build>
-version: 0.98.2+78
+version: 0.99.0+79
 
 environment:
   sdk: ^3.6.0


### PR DESCRIPTION
Bumps `soliplex_frontend` to `0.99.0+79`.

A minor bump: this release completes v1 of inline image attachments, which adds
new public surface to `soliplex_client` (`MessagePart`, `TextPart`, `ImagePart`,
`MissingAttachmentPart`, `TextMessage.parts` / `fromParts`) and widens the send
path — so code that switches over `MessagePart` exhaustively gains a case.

Version files only; see `CHANGELOG.md` `[Unreleased]` for what ships.

🤖 Generated with [Claude Code](https://claude.com/claude-code)