### PR TITLE
fix(design): flat app bar — drop the M3 scrolled-under surface tint

### DIFF
--- a/packages/soliplex_design/lib/src/theme/theme.dart
+++ b/packages/soliplex_design/lib/src/theme/theme.dart
@@ -101,6 +101,13 @@ ThemeData buildSoliplexThemeData({
       backgroundColor: colors.background,
       foregroundColor: colors.foreground,
       elevation: 0,
+      // Keep the bar flat when content scrolls under it. Material 3 otherwise
+      // paints a `surfaceTint` (our brand `primary`) overlay at a default
+      // scrolled-under elevation of 3, which reads as a blue-shifted bar on the
+      // white page (issue #449). The bottom `shape` border below is the only
+      // separator we want.
+      surfaceTintColor: Colors.transparent,
+      scrolledUnderElevation: 0,
       // Left-align titles on every platform. Left is already the default on
       // non-Apple platforms; iOS/macOS otherwise center the title when the
       // bar has fewer than two actions (on web this follows the browser's host

--- a/packages/soliplex_design/test/theme/theme_test.dart
+++ b/packages/soliplex_design/test/theme/theme_test.dart
@@ -166,6 +166,9 @@ void main() {
 
       expect(theme.appBarTheme.elevation, 0);
       expect(theme.appBarTheme.centerTitle, isFalse);
+      // Flat bar: no scrolled-under surface tint or elevation (issue #449).
+      expect(theme.appBarTheme.surfaceTintColor, Colors.transparent);
+      expect(theme.appBarTheme.scrolledUnderElevation, 0);
       expect(theme.dividerTheme.thickness, 1);
       expect(theme.cardTheme.elevation, 0);
     });


### PR DESCRIPTION
## What

The room app bar on mobile picked up a blue-shifted surface (`#ECF5FF`) once timeline content scrolled beneath it. Cause: Material 3 tints the bar toward `colorScheme.surfaceTint` (our brand `primary`) at a default `scrolledUnderElevation` of 3. Our `AppBarTheme` set `backgroundColor` + `elevation: 0` but never pinned the surface tint or scrolled-under elevation, so the M3 defaults leaked through — desktop/iPad only read flat white because their bars don't scroll content underneath.

This pins `surfaceTintColor: Colors.transparent` and `scrolledUnderElevation: 0` on the shared `AppBarTheme`, so the bar stays flat on every platform and scroll state. The existing bottom `shape` border remains the sole separator.

## Scope

This is **item 4 of 4** from #449. The others are handled separately:
- **#1** (rainbow avatars → brand swatch token) — declined, see the triage comment
- **#2** (default `success` token) and **#3** (thinking-step icon) — pending @vaporboy's design call

So this PR is intentionally non-closing.

## Test

Added two assertions to the existing `configures component themes` test in `packages/soliplex_design/test/theme/theme_test.dart` locking in the flat behavior. No golden baselines affected — `AppBar` is a raw Material widget, not a Soliplex component.

Addresses #449

🤖 Generated with [Claude Code](https://claude.com/claude-code)