### PR TITLE
chore: version 0.99.2+81

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ Versions follow the `version+build` scheme from `pubspec.yaml`, bumped via
 
 ## [Unreleased]
 
+## [0.99.2+81] - 2026-08-17
+
 ### Added
 
 - The room's confidentiality marking is shown inside the chat, where until now
@@ -49,6 +51,11 @@ Versions follow the `version+build` scheme from `pubspec.yaml`, bumped via
   fitting and the address loses its descenders. The toolbar now sizes itself to
   the title it has to carry. It reproduces only with the OS text size raised, so
   a stock emulator does not show it.
+- The app bar no longer takes on a blue cast once content scrolls beneath it.
+  Material tints a scrolled-under bar toward the brand's own accent color, so on
+  mobile the bar shifted away from the surfaces around it the moment the
+  conversation moved under it. The bar now stays flat on every platform and at
+  every scroll position, with its bottom border as the only separator.
 
 ## [0.99.1+80] - 2026-08-06
 

--- a/lib/version.dart
+++ b/lib/version.dart
@@ -2,4 +2,4 @@
 ///
 /// Generated from pubspec.yaml. Run `dart run tool/update_version.dart` after
 /// changing the version in pubspec.yaml.
-const String soliplexVersion = '0.99.1+80';
+const String soliplexVersion = '0.99.2+81';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,7 +3,7 @@ description: Modular Flutter frontend framework for Soliplex
 publish_to: none
 # To update version, run:
 # dart run tool/bump_version.dart <major|minor|patch|build>
-version: 0.99.1+80
+version: 0.99.2+81
 
 environment:
   sdk: ^3.6.0


### PR DESCRIPTION
Patch release cut of `soliplex_frontend`: `0.99.1+80` → `0.99.2+81`.

- `pubspec.yaml` and `lib/version.dart` bumped via `dart run tool/bump_version.dart patch`.
- `CHANGELOG.md`: the `[Unreleased]` block moved under `[0.99.2+81]`, and a Fixed entry added for the app bar surface-tint change, which had landed on `main` without one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)