### PR TITLE
fix(ui): selectable failure text, a close control for the zoom dialog, and a tighter level notice

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ Versions follow the `version+build` scheme from `pubspec.yaml`, bumped via
 
 ## [Unreleased]
 
+### Changed
+
+- The information level under the composer now reads "Information level is:
+  LEVEL" and sits tighter to the composer, so the level itself is what the line
+  ends on rather than trailing off into words that repeat what the screen
+  already shows.
+
 ## [0.99.2+81] - 2026-08-17
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,25 @@ Versions follow the `version+build` scheme from `pubspec.yaml`, bumped via
 
 ### Changed
 
+- Failure messages can now be selected and copied. Until now the transcript was
+  the only place text could be selected, which left the strings worth reporting
+  — the exception behind a failed load or send, the reason a connection or
+  sign-in was refused, an upload's error, the detail behind a failed sign-out —
+  readable but impossible to get out of the app except by retyping. The
+  send-failure banner also gains a copy button, because it shows at most two
+  lines and a drag can only take the text that was painted. Server maintenance
+  and outage notices are selectable for the same reason: they are written to be
+  acted on elsewhere. Attached filenames can be selected alongside the upload
+  errors beside them. A room's details are selectable throughout — the model
+  name, provider, tool kinds and skill fields a user would quote when asking
+  about a room's setup.
+- Typing on the connect screen while the URL field has lost focus no longer
+  swallows the first character. The field only takes focus after the keystroke
+  has been dispatched, so until now that character went nowhere; it is now
+  entered along with the focus. A keystroke only counts as typing, so a shortcut
+  chord keeps its meaning and leaves any selection alone, control keys enter
+  nothing, and a keystroke aimed at a dialog over the screen no longer reaches
+  the field behind it.
 - The full-size image and SVG viewer now has a close button in its top-right
   corner. Tapping the backdrop already dismissed it, but nothing said so: on a
   full-bleed image there is no visible backdrop to aim at, and a screen reader

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ Versions follow the `version+build` scheme from `pubspec.yaml`, bumped via
 
 ### Changed
 
+- The full-size image and SVG viewer now has a close button in its top-right
+  corner. Tapping the backdrop already dismissed it, but nothing said so: on a
+  full-bleed image there is no visible backdrop to aim at, and a screen reader
+  user had nothing to land on at all. The viewer's own rotate and reset controls
+  move to the opposite corner to keep both reachable.
 - The information level under the composer now reads "Information level is:
   LEVEL" and sits tighter to the composer, so the level itself is what the line
   ends on rather than trailing off into words that repeat what the screen

--- a/lib/src/modules/auth/ui/auth_callback_screen.dart
+++ b/lib/src/modules/auth/ui/auth_callback_screen.dart
@@ -183,7 +183,7 @@ class _AuthCallbackScreenState extends ConsumerState<AuthCallbackScreen> {
         children: [
           Icon(Icons.error_outline, size: 48, color: theme.colorScheme.error),
           const SizedBox(height: SoliplexSpacing.s4),
-          Text(
+          SelectableText(
             _error ?? 'An error occurred',
             textAlign: TextAlign.center,
             style: theme.textTheme.bodyMedium,

--- a/lib/src/modules/auth/ui/home_screen.dart
+++ b/lib/src/modules/auth/ui/home_screen.dart
@@ -16,6 +16,8 @@ import '../server_entry.dart';
 import '../server_manager.dart';
 import 'connect_flow_rail.dart';
 import 'home_shell.dart';
+import '../../../shared/selectable_content.dart';
+import '../../../shared/type_to_focus.dart';
 import 'package:soliplex_design/soliplex_design.dart';
 
 class HomeScreen extends ConsumerStatefulWidget {
@@ -179,9 +181,31 @@ class _HomeScreenState extends ConsumerState<HomeScreen> {
   bool _handleKey(KeyEvent event) {
     if (_flow.state.value is! UrlInput) return false;
     if (_urlFocusNode.hasFocus) return false;
-    if (event is! KeyDownEvent) return false;
+    // A dialog over this screen owns the keyboard; the field behind it is not
+    // what the user is typing into. The flow state stays UrlInput throughout.
+    if (ModalRoute.of(context)?.isCurrent == false) return false;
+    final keyboard = HardwareKeyboard.instance;
+    if (!shouldFocusInputOnKey(
+      event,
+      isMetaPressed: keyboard.isMetaPressed,
+      isControlPressed: keyboard.isControlPressed,
+      isAltPressed: keyboard.isAltPressed,
+    )) {
+      return false;
+    }
     _urlFocusNode.requestFocus();
-    return false;
+
+    // Focus only lands after this event has been dispatched, so the field has
+    // no input connection to receive it and the character would be dropped —
+    // from a keystroke the user plainly meant for the field. Type it here.
+    if (!isTypedText(event.character)) return false;
+
+    final text = _urlController.text + event.character!;
+    _urlController.value = TextEditingValue(
+      text: text,
+      selection: TextSelection.collapsed(offset: text.length),
+    );
+    return true;
   }
 
   // -- Shared layout --
@@ -280,11 +304,13 @@ class _HomeScreenState extends ConsumerState<HomeScreen> {
                 Icon(Icons.public, size: 16, color: colors.onSurfaceVariant),
                 const SizedBox(width: SoliplexSpacing.s2),
                 Expanded(
-                  child: Text(
-                    _urlController.text,
-                    maxLines: 1,
-                    overflow: TextOverflow.ellipsis,
-                    style: context.monospaceOn(theme.textTheme.bodySmall),
+                  child: SelectableContent(
+                    child: Text(
+                      _urlController.text,
+                      maxLines: 1,
+                      overflow: TextOverflow.ellipsis,
+                      style: context.monospaceOn(theme.textTheme.bodySmall),
+                    ),
                   ),
                 ),
               ],
@@ -368,7 +394,7 @@ class _HomeScreenState extends ConsumerState<HomeScreen> {
                 borderRadius: BorderRadius.circular(context.radii.sm),
                 border: Border.all(color: colors.outlineVariant),
               ),
-              child: Text(
+              child: SelectableText(
                 probeResult.serverUrl.toString(),
                 style: context.monospaceOn(theme.textTheme.bodySmall),
               ),
@@ -702,7 +728,7 @@ class UrlMessageBanner extends StatelessWidget {
               ),
               const SizedBox(width: SoliplexSpacing.s2),
               Expanded(
-                child: Text(
+                child: SelectableText(
                   text,
                   style: theme.textTheme.bodyMedium?.copyWith(
                     color: theme.colorScheme.onErrorContainer,
@@ -712,7 +738,7 @@ class UrlMessageBanner extends StatelessWidget {
             ],
           ),
         ),
-      ConnectNotice(:final text) => Text(
+      ConnectNotice(:final text) => SelectableText(
           text,
           style: theme.textTheme.bodyMedium?.copyWith(
             color: theme.colorScheme.onSurfaceVariant,

--- a/lib/src/modules/lobby/ui/lobby_screen.dart
+++ b/lib/src/modules/lobby/ui/lobby_screen.dart
@@ -856,7 +856,7 @@ class _ServerSection extends StatelessWidget {
           RoomsFailed(:final error) => Padding(
               padding:
                   const EdgeInsets.symmetric(horizontal: SoliplexSpacing.s4),
-              child: Text(switch (error) {
+              child: SelectableText(switch (error) {
                 PermissionDeniedException() =>
                   "You don't have permission to view rooms on this server.",
                 _ => 'Failed to load rooms: $error',

--- a/lib/src/modules/lobby/ui/server_sidebar.dart
+++ b/lib/src/modules/lobby/ui/server_sidebar.dart
@@ -634,7 +634,7 @@ class _LogoutErrorButton extends StatelessWidget {
               ? 'Server kept — sign-out failed'
               : 'Log out failed',
         ),
-        content: Text(failure.message),
+        content: SelectableText(failure.message),
         actions: [
           SoliplexButton.text(
             onPressed: () => Navigator.pop(context),

--- a/lib/src/modules/room/ui/async_action_dialog.dart
+++ b/lib/src/modules/room/ui/async_action_dialog.dart
@@ -89,7 +89,7 @@ class _AsyncActionDialogState extends State<AsyncActionDialog> {
           if (_error != null)
             Padding(
               padding: const EdgeInsets.only(top: SoliplexSpacing.s2),
-              child: Text(
+              child: SelectableText(
                 _error!,
                 style: theme.textTheme.bodySmall?.copyWith(
                   color: theme.colorScheme.error,

--- a/lib/src/modules/room/ui/chat_classification.dart
+++ b/lib/src/modules/room/ui/chat_classification.dart
@@ -102,10 +102,9 @@ class ChatClassificationNotice extends StatelessWidget {
       padding: const EdgeInsets.only(
         left: SoliplexSpacing.s4,
         right: SoliplexSpacing.s4,
-        bottom: SoliplexSpacing.s2,
       ),
       child: Text(
-        'Information level is ${level.label} for this room',
+        'Information level is: ${level.label}',
         textAlign: TextAlign.center,
         style: theme.textTheme.bodySmall
             ?.copyWith(color: theme.colorScheme.onSurfaceVariant),

--- a/lib/src/modules/room/ui/error_retry_panel.dart
+++ b/lib/src/modules/room/ui/error_retry_panel.dart
@@ -30,7 +30,8 @@ class ErrorRetryPanel extends StatelessWidget {
         children: [
           Text(title, style: theme.textTheme.bodyMedium),
           const SizedBox(height: SoliplexSpacing.s1),
-          Text(
+          // Outside the transcript's SelectionArea — this panel replaces it.
+          SelectableText(
             error.toString(),
             style: theme.textTheme.bodySmall?.copyWith(
               color: theme.colorScheme.error,

--- a/lib/src/modules/room/ui/room_info_screen.dart
+++ b/lib/src/modules/room/ui/room_info_screen.dart
@@ -23,6 +23,7 @@ import 'room_info/quizzes_card.dart';
 import 'room_info/room_info_widgets.dart';
 import 'room_info/skill_card.dart';
 import 'room_info/system_prompt_viewer.dart';
+import '../../../shared/selectable_content.dart';
 import 'package:soliplex_design/soliplex_design.dart';
 
 class RoomInfoScreen extends StatefulWidget {
@@ -170,87 +171,89 @@ class _RoomInfoBody extends StatelessWidget {
   Widget build(BuildContext context) {
     return SingleChildScrollView(
       padding: const EdgeInsets.all(SoliplexSpacing.s4),
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.stretch,
-        children: [
-          SectionCard(
-            title: 'SERVER',
-            children: [
-              Text(
-                formatServerUrl(serverUrl),
-                style: Theme.of(context).textTheme.bodyMedium?.copyWith(
-                      color: Theme.of(context).colorScheme.onSurfaceVariant,
-                    ),
+      child: SelectableContent(
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            SectionCard(
+              title: 'SERVER',
+              children: [
+                Text(
+                  formatServerUrl(serverUrl),
+                  style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                        color: Theme.of(context).colorScheme.onSurfaceVariant,
+                      ),
+                ),
+              ],
+            ),
+            SectionCard(
+              title: 'ROOM',
+              children: [
+                Text(
+                  room.name,
+                  style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                        color: Theme.of(context).colorScheme.onSurfaceVariant,
+                      ),
+                ),
+              ],
+            ),
+            if (room.hasDescription)
+              Padding(
+                padding: const EdgeInsets.only(bottom: SoliplexSpacing.s4),
+                child: Text(
+                  room.description,
+                  style: Theme.of(context).textTheme.bodyLarge,
+                ),
               ),
-            ],
-          ),
-          SectionCard(
-            title: 'ROOM',
-            children: [
-              Text(
-                room.name,
-                style: Theme.of(context).textTheme.bodyMedium?.copyWith(
-                      color: Theme.of(context).colorScheme.onSurfaceVariant,
-                    ),
-              ),
-            ],
-          ),
-          if (room.hasDescription)
-            Padding(
-              padding: const EdgeInsets.only(bottom: SoliplexSpacing.s4),
-              child: Text(
-                room.description,
-                style: Theme.of(context).textTheme.bodyLarge,
+            _AgentCard(agent: room.agent),
+            FeaturesCard(room: room, api: api, roomId: roomId),
+            QuizzesCard(
+              quizzes: room.quizzes,
+              onQuizTapped: (quizId) => context.go(
+                AppRoutes.quiz(
+                  serverAlias,
+                  roomId,
+                  quizId,
+                  from: AppRoutes.roomInfo(serverAlias, roomId),
+                ),
               ),
             ),
-          _AgentCard(agent: room.agent),
-          FeaturesCard(room: room, api: api, roomId: roomId),
-          QuizzesCard(
-            quizzes: room.quizzes,
-            onQuizTapped: (quizId) => context.go(
-              AppRoutes.quiz(
-                serverAlias,
-                roomId,
-                quizId,
-                from: AppRoutes.roomInfo(serverAlias, roomId),
+            ExpandableListCard<MapEntry<String, RoomSkill>>(
+              key: const ValueKey('skills'),
+              title: 'SKILLS',
+              items: room.skills.entries.toList(),
+              nameOf: (e) => e.key,
+              contentOf: (e) => buildSkillContent(e.value),
+            ),
+            ExpandableListCard<MapEntry<String, RoomTool>>(
+              key: const ValueKey('tools'),
+              title: 'TOOLS',
+              items: room.tools.entries.toList(),
+              nameOf: (e) => e.key,
+              contentOf: (e) => _buildToolContent(e.value),
+            ),
+            ExpandableListCard<MapEntry<String, McpClientToolset>>(
+              key: const ValueKey('mcp-toolsets'),
+              title: 'MCP CLIENT TOOLSETS',
+              emptyLabel: 'MCP client toolsets',
+              items: room.mcpClientToolsets.entries.toList(),
+              nameOf: (e) => e.key,
+              contentOf: (e) => _buildToolsetContent(e.value),
+            ),
+            ClientToolsCard(clientToolsFuture: clientToolsFuture),
+            if (room.supportsAttachments)
+              _UploadedFilesCard(
+                uploadRegistry: uploadRegistry,
+                serverEntry: serverEntry,
+                roomId: roomId,
               ),
+            DocumentsCard(
+              documentsFuture: documentsFuture,
+              onRetry: onRetryDocuments,
             ),
-          ),
-          ExpandableListCard<MapEntry<String, RoomSkill>>(
-            key: const ValueKey('skills'),
-            title: 'SKILLS',
-            items: room.skills.entries.toList(),
-            nameOf: (e) => e.key,
-            contentOf: (e) => buildSkillContent(e.value),
-          ),
-          ExpandableListCard<MapEntry<String, RoomTool>>(
-            key: const ValueKey('tools'),
-            title: 'TOOLS',
-            items: room.tools.entries.toList(),
-            nameOf: (e) => e.key,
-            contentOf: (e) => _buildToolContent(e.value),
-          ),
-          ExpandableListCard<MapEntry<String, McpClientToolset>>(
-            key: const ValueKey('mcp-toolsets'),
-            title: 'MCP CLIENT TOOLSETS',
-            emptyLabel: 'MCP client toolsets',
-            items: room.mcpClientToolsets.entries.toList(),
-            nameOf: (e) => e.key,
-            contentOf: (e) => _buildToolsetContent(e.value),
-          ),
-          ClientToolsCard(clientToolsFuture: clientToolsFuture),
-          if (room.supportsAttachments)
-            _UploadedFilesCard(
-              uploadRegistry: uploadRegistry,
-              serverEntry: serverEntry,
-              roomId: roomId,
-            ),
-          DocumentsCard(
-            documentsFuture: documentsFuture,
-            onRetry: onRetryDocuments,
-          ),
-          ChunkLookupCard(api: api, roomId: roomId),
-        ],
+            ChunkLookupCard(api: api, roomId: roomId),
+          ],
+        ),
       ),
     );
   }

--- a/lib/src/modules/room/ui/room_screen.dart
+++ b/lib/src/modules/room/ui/room_screen.dart
@@ -55,6 +55,7 @@ import 'approval_handler.dart';
 import 'chat_classification.dart';
 import 'chat_input.dart';
 import 'chunk_visualization_page.dart';
+import 'copy_button.dart';
 import 'document_picker.dart';
 import 'error_retry_panel.dart';
 import 'inline_image_composer_controller.dart';
@@ -67,50 +68,12 @@ import '../../auth/auth_tokens.dart';
 import 'upload_event_banner.dart';
 import '../upload_tracker.dart';
 import '../upload_tracker_registry.dart';
+import '../../../shared/selectable_content.dart';
+import '../../../shared/type_to_focus.dart';
 import 'package:soliplex_design/soliplex_design.dart';
 
 final Logger _logger =
     LogManager.instance.getLogger('soliplex_frontend.room_screen');
-
-final _modifierKeys = <LogicalKeyboardKey>{
-  LogicalKeyboardKey.meta,
-  LogicalKeyboardKey.metaLeft,
-  LogicalKeyboardKey.metaRight,
-  LogicalKeyboardKey.control,
-  LogicalKeyboardKey.controlLeft,
-  LogicalKeyboardKey.controlRight,
-  LogicalKeyboardKey.alt,
-  LogicalKeyboardKey.altLeft,
-  LogicalKeyboardKey.altRight,
-  LogicalKeyboardKey.shift,
-  LogicalKeyboardKey.shiftLeft,
-  LogicalKeyboardKey.shiftRight,
-};
-
-/// Whether a key press should pull focus into the chat composer
-/// ("type to focus"). Only real typing does — never a bare modifier, and never
-/// while a shortcut modifier is held, so shortcuts like copy and select-all
-/// leave the transcript's [SelectionArea] selection intact instead of clearing
-/// it by moving focus.
-///
-/// Control *combined with* alt is treated as typing, not a shortcut: Windows
-/// synthesizes AltGr as Ctrl+Alt to compose special characters (`@`, `€`, `{`,
-/// …), so those keystrokes must still focus-and-type. Plain Alt/Option is
-/// likewise typing. A genuine Ctrl+Alt shortcut therefore focuses the composer
-/// too, which is harmless: callers move focus and leave the keystroke to run its
-/// normal course, so the shortcut still fires.
-bool shouldFocusChatInputOnKey(
-  KeyEvent event, {
-  required bool isMetaPressed,
-  required bool isControlPressed,
-  required bool isAltPressed,
-}) {
-  if (event is! KeyDownEvent) return false;
-  if (_modifierKeys.contains(event.logicalKey)) return false;
-  final shortcutModifierActive =
-      isMetaPressed || (isControlPressed && !isAltPressed);
-  return !shortcutModifierActive;
-}
 
 /// Whether a key press is [platform]'s paste chord: `V` under the command
 /// modifier that platform pastes with — meta on Apple, control elsewhere — and
@@ -1352,7 +1315,7 @@ class _RoomScreenState extends State<RoomScreen> {
       // stops the browser adding a copy of its own.
       return true;
     }
-    if (!shouldFocusChatInputOnKey(
+    if (!shouldFocusInputOnKey(
       event,
       isMetaPressed: keyboard.isMetaPressed,
       isControlPressed: keyboard.isControlPressed,
@@ -2131,29 +2094,34 @@ class _RoomScreenState extends State<RoomScreen> {
           // dismiss) on file rows.
           child: SingleChildScrollView(
             padding: const EdgeInsets.only(right: SoliplexSpacing.s3),
-            child: Column(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              mainAxisSize: MainAxisSize.min,
-              children: [
-                if (bothEmpty)
-                  Text(
-                    'No files attached.',
-                    style: theme.textTheme.bodySmall?.copyWith(
-                      color: theme.colorScheme.outline,
-                    ),
-                  )
-                else ...[
-                  _buildScopeSection('Room', roomStatus, theme),
-                  // The divider sits between two visible sections. A
-                  // scope is "visible" when it's Loading or Failed
-                  // (those render a section row), or Loaded with at
-                  // least one file.
-                  if (_scopeRendersContent(roomStatus) &&
-                      _scopeRendersContent(threadStatus))
-                    const Divider(height: 12),
-                  _buildScopeSection('Thread', threadStatus, theme),
+            // One area over the panel covers the filenames and each row's
+            // upload error; sitting above the rows' own handlers leaves their
+            // taps intact.
+            child: SelectableContent(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  if (bothEmpty)
+                    Text(
+                      'No files attached.',
+                      style: theme.textTheme.bodySmall?.copyWith(
+                        color: theme.colorScheme.outline,
+                      ),
+                    )
+                  else ...[
+                    _buildScopeSection('Room', roomStatus, theme),
+                    // The divider sits between two visible sections. A
+                    // scope is "visible" when it's Loading or Failed
+                    // (those render a section row), or Loaded with at
+                    // least one file.
+                    if (_scopeRendersContent(roomStatus) &&
+                        _scopeRendersContent(threadStatus))
+                      const Divider(height: 12),
+                    _buildScopeSection('Thread', threadStatus, theme),
+                  ],
                 ],
-              ],
+              ),
             ),
           ),
         ),
@@ -2556,6 +2524,7 @@ class _SendErrorBanner extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
+    final errorText = error.error.toString();
     return Container(
       width: double.infinity,
       padding: const EdgeInsets.symmetric(
@@ -2566,14 +2535,23 @@ class _SendErrorBanner extends StatelessWidget {
           Icon(Icons.error_outline, size: 16, color: theme.colorScheme.error),
           const SizedBox(width: SoliplexSpacing.s2),
           Expanded(
-            child: Text(
-              error.error.toString(),
-              style: theme.textTheme.bodySmall?.copyWith(
-                color: theme.colorScheme.onErrorContainer,
+            child: SelectableContent(
+              child: Text(
+                errorText,
+                style: theme.textTheme.bodySmall?.copyWith(
+                  color: theme.colorScheme.onErrorContainer,
+                ),
+                maxLines: 2,
+                overflow: TextOverflow.ellipsis,
               ),
-              maxLines: 2,
-              overflow: TextOverflow.ellipsis,
             ),
+          ),
+          // Two lines rarely hold a whole exception, and a drag can only select
+          // the glyphs that were painted. This copies the untruncated text.
+          CopyButton(
+            text: errorText,
+            tooltip: 'Copy error',
+            iconSize: 16,
           ),
           IconButton(
             icon: const Icon(Icons.close, size: 16),

--- a/lib/src/shared/selectable_content.dart
+++ b/lib/src/shared/selectable_content.dart
@@ -1,0 +1,34 @@
+import 'package:flutter/material.dart';
+
+/// Makes the text inside [child] selectable with a drag.
+///
+/// Place this *above* any tap handler in [child]. A selection widget wins the
+/// gesture arena, so one sitting under a handler leaves that region dead to
+/// taps; from above, a tap still reaches the handler and a drag selects.
+class SelectableContent extends StatefulWidget {
+  const SelectableContent({required this.child, super.key});
+
+  final Widget child;
+
+  @override
+  State<SelectableContent> createState() => _SelectableContentState();
+}
+
+class _SelectableContentState extends State<SelectableContent> {
+  // A bare SelectionArea takes a focusable node that paints nothing, so
+  // keyboard traversal stops on an invisible target between the real controls.
+  final FocusNode _focusNode = FocusNode(
+    skipTraversal: true,
+    debugLabel: 'SelectableContent',
+  );
+
+  @override
+  void dispose() {
+    _focusNode.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) =>
+      SelectionArea(focusNode: _focusNode, child: widget.child);
+}

--- a/lib/src/shared/type_to_focus.dart
+++ b/lib/src/shared/type_to_focus.dart
@@ -1,0 +1,54 @@
+import 'package:flutter/services.dart';
+
+final _modifierKeys = <LogicalKeyboardKey>{
+  LogicalKeyboardKey.meta,
+  LogicalKeyboardKey.metaLeft,
+  LogicalKeyboardKey.metaRight,
+  LogicalKeyboardKey.control,
+  LogicalKeyboardKey.controlLeft,
+  LogicalKeyboardKey.controlRight,
+  LogicalKeyboardKey.alt,
+  LogicalKeyboardKey.altLeft,
+  LogicalKeyboardKey.altRight,
+  LogicalKeyboardKey.shift,
+  LogicalKeyboardKey.shiftLeft,
+  LogicalKeyboardKey.shiftRight,
+};
+
+/// Whether a key press should pull focus into a text field ("type to focus").
+/// Only real typing does - never a bare modifier, and never while a shortcut
+/// modifier is held, so shortcuts like copy and select-all leave the surrounding
+/// selection intact instead of clearing it by moving focus.
+///
+/// Control *combined with* alt is treated as typing, not a shortcut: Windows
+/// synthesizes AltGr as Ctrl+Alt to compose special characters (`@`, `\u20ac`,
+/// `{`), so those keystrokes must still focus-and-type. Plain Alt/Option is
+/// likewise typing. A genuine Ctrl+Alt shortcut therefore focuses the field too,
+/// which is harmless: callers move focus and leave the keystroke to run its
+/// normal course, so the shortcut still fires.
+bool shouldFocusInputOnKey(
+  KeyEvent event, {
+  required bool isMetaPressed,
+  required bool isControlPressed,
+  required bool isAltPressed,
+}) {
+  if (event is! KeyDownEvent) return false;
+  if (_modifierKeys.contains(event.logicalKey)) return false;
+  final shortcutModifierActive =
+      isMetaPressed || (isControlPressed && !isAltPressed);
+  return !shortcutModifierActive;
+}
+
+/// Whether [character] is text a field should receive, as opposed to a control
+/// code that a key happens to report.
+///
+/// Platforms disagree. The Windows engine filters non-printables out of
+/// [KeyEvent.character], but the macOS and Linux engines pass them through, so
+/// Enter arrives as a carriage return, Tab as a tab, and Escape as U+001B.
+/// Inserting those corrupts a field silently: `String.trim()` strips the first
+/// two but not an escape.
+bool isTypedText(String? character) {
+  if (character == null || character.isEmpty) return false;
+  final code = character.codeUnitAt(0);
+  return code >= 0x20 && code != 0x7F;
+}

--- a/lib/src/shared/zoomable_view.dart
+++ b/lib/src/shared/zoomable_view.dart
@@ -12,6 +12,10 @@ import 'package:soliplex_design/soliplex_design.dart';
 /// which Flutter would otherwise route to a (clamped, invisible) pan.
 ///
 /// A reset control appears while zoomed. A rotate control is always shown.
+/// Both sit in the top-left, leaving the opposite corner free for whatever
+/// affordance the host puts there. The view carries no dismissal of its own:
+/// every host that embeds it already provides one.
+///
 /// Rotation is self-managed by default; use [ZoomableView.controlledRotation]
 /// to own rotation from the caller so it can persist across paging (e.g. per
 /// document page).
@@ -104,25 +108,27 @@ class _ZoomableViewState extends State<ZoomableView> {
             ),
           ),
         ),
-        // A quick way back to fit without scrolling all the way out. Shown only
-        // while zoomed.
-        if (_zoomed)
-          Positioned(
-            left: SoliplexSpacing.s2,
-            top: SoliplexSpacing.s2,
-            child: IconButton.filledTonal(
-              onPressed: _reset,
-              icon: const Icon(Icons.zoom_out_map),
-              tooltip: 'Reset zoom',
-            ),
-          ),
+        // Rotate is anchored at the edge so it keeps its position when reset
+        // appears beside it.
         Positioned(
-          right: SoliplexSpacing.s2,
+          left: SoliplexSpacing.s2,
           top: SoliplexSpacing.s2,
-          child: IconButton.filledTonal(
-            onPressed: _rotate,
-            icon: const Icon(Icons.rotate_right),
-            tooltip: 'Rotate',
+          child: Row(
+            spacing: SoliplexSpacing.s2,
+            children: [
+              IconButton.filledTonal(
+                onPressed: _rotate,
+                icon: const Icon(Icons.rotate_right),
+                tooltip: 'Rotate',
+              ),
+              // A quick way back to fit without scrolling all the way out.
+              if (_zoomed)
+                IconButton.filledTonal(
+                  onPressed: _reset,
+                  icon: const Icon(Icons.zoom_out_map),
+                  tooltip: 'Reset zoom',
+                ),
+            ],
           ),
         ),
       ],
@@ -132,7 +138,8 @@ class _ZoomableViewState extends State<ZoomableView> {
 
 /// Opens [viewer] full-size in a centered dialog, with an optional [caption]
 /// row beneath it, so the image and SVG zoom paths frame the viewer
-/// identically.
+/// identically. The dialog frame owns the close control, which is why
+/// [ZoomableView] has none.
 Future<void> showZoomableMediaDialog(
   BuildContext context, {
   required Widget viewer,
@@ -147,11 +154,28 @@ Future<void> showZoomableMediaDialog(
           maxWidth: 800,
           maxHeight: MediaQuery.sizeOf(context).height * 0.85,
         ),
-        child: Column(
-          mainAxisSize: MainAxisSize.min,
+        child: Stack(
           children: [
-            Expanded(child: viewer),
-            if (caption != null) caption,
+            Column(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                Expanded(child: viewer),
+                if (caption != null) caption,
+              ],
+            ),
+            // The barrier dismisses too, but not discoverably: this is the way
+            // out a pointer or screen reader user can find. Kept in the corner
+            // the viewer leaves free, so it never covers the viewer's own
+            // controls.
+            Positioned(
+              right: SoliplexSpacing.s2,
+              top: SoliplexSpacing.s2,
+              child: IconButton.filledTonal(
+                onPressed: () => Navigator.of(context).pop(),
+                icon: const Icon(Icons.close),
+                tooltip: 'Close',
+              ),
+            ),
           ],
         ),
       ),

--- a/lib/src/status_message/ui/status_message_banner.dart
+++ b/lib/src/status_message/ui/status_message_banner.dart
@@ -6,6 +6,7 @@ import 'package:signals_flutter/signals_flutter.dart';
 import 'package:soliplex_agent/soliplex_agent.dart' show SoliplexHttpClient;
 import 'package:soliplex_design/soliplex_design.dart';
 
+import '../../shared/selectable_content.dart';
 import '../../core/status_message_config.dart';
 import '../status_message.dart';
 import '../status_message_controller.dart';
@@ -196,10 +197,14 @@ class _StatusMessageBannerState extends ConsumerState<StatusMessageBanner> {
                 child: Icon(_icon(message.category), color: fg),
               ),
               const SizedBox(width: SoliplexSpacing.s3),
+              // Operators write these to be acted on elsewhere — a maintenance
+              // window or an outage detail gets pasted into a ticket.
               Expanded(
-                child: _expanded
-                    ? _expandedContent(context, message, pill, window, fg)
-                    : _collapsedContent(context, message, pill, fg),
+                child: SelectableContent(
+                  child: _expanded
+                      ? _expandedContent(context, message, pill, window, fg)
+                      : _collapsedContent(context, message, pill, fg),
+                ),
               ),
               IconButton(
                 icon: const Icon(Icons.close),

--- a/test/modules/auth/ui/home_screen_test.dart
+++ b/test/modules/auth/ui/home_screen_test.dart
@@ -818,6 +818,128 @@ void main() {
       expect(focusNode.hasFocus, isTrue);
     });
 
+    testWidgets('a keystroke that restores focus is not swallowed',
+        (tester) async {
+      final serverManager = _createServerManager();
+      await tester.pumpWidget(_buildApp(serverManager: serverManager));
+      await tester.pumpAndSettle();
+
+      final editableText = tester.widget<EditableText>(
+        find.descendant(
+          of: find.byType(TextFormField),
+          matching: find.byType(EditableText),
+        ),
+      );
+      editableText.focusNode.unfocus();
+      await tester.pumpAndSettle();
+
+      // Focus lands on the field only after this event is dispatched, so the
+      // field holds no input connection and the character would be lost.
+      await tester.sendKeyEvent(LogicalKeyboardKey.keyH);
+      await tester.pumpAndSettle();
+
+      expect(editableText.controller.text, 'h');
+    });
+
+    testWidgets('a shortcut chord leaves focus and selection alone',
+        (tester) async {
+      final serverManager = _createServerManager();
+      await tester.pumpWidget(_buildApp(serverManager: serverManager));
+      await tester.pumpAndSettle();
+
+      final editableText = tester.widget<EditableText>(
+        find.descendant(
+          of: find.byType(TextFormField),
+          matching: find.byType(EditableText),
+        ),
+      );
+      editableText.focusNode.unfocus();
+      await tester.pumpAndSettle();
+
+      // Copying selected text on this screen starts with a bare modifier. If
+      // that pulled focus to the URL field, the field would select-all and the
+      // copy would take the URL instead of what the user highlighted.
+      await tester.sendKeyDownEvent(LogicalKeyboardKey.meta);
+      await tester.pumpAndSettle();
+
+      expect(editableText.focusNode.hasFocus, isFalse);
+      await tester.sendKeyUpEvent(LogicalKeyboardKey.meta);
+    });
+
+    testWidgets('a keystroke behind a dialog does not reach the URL field',
+        (tester) async {
+      final serverManager = _createServerManager();
+      serverManager.addServer(
+        serverId: 'test',
+        serverUrl: Uri.parse('https://api.example.com'),
+      );
+      await tester.pumpWidget(_buildApp(serverManager: serverManager));
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.byIcon(Icons.delete_outline));
+      await tester.pumpAndSettle();
+      expect(find.text('Remove server?'), findsOneWidget);
+
+      final editableText = tester.widget<EditableText>(
+        find.descendant(
+          of: find.byType(TextFormField),
+          matching: find.byType(EditableText),
+        ),
+      );
+      final before = editableText.controller.text;
+
+      await tester.sendKeyEvent(LogicalKeyboardKey.keyY);
+      await tester.pumpAndSettle();
+
+      expect(editableText.controller.text, before);
+    });
+
+    testWidgets('a restored keystroke appends rather than replacing',
+        (tester) async {
+      final serverManager = _createServerManager();
+      await tester.pumpWidget(_buildApp(
+        serverManager: serverManager,
+        defaultBackendUrl: 'https://api.example.com',
+      ));
+      await tester.pumpAndSettle();
+
+      final editableText = tester.widget<EditableText>(
+        find.descendant(
+          of: find.byType(TextFormField),
+          matching: find.byType(EditableText),
+        ),
+      );
+      editableText.focusNode.unfocus();
+      await tester.pumpAndSettle();
+
+      await tester.sendKeyEvent(LogicalKeyboardKey.keyX);
+      await tester.pumpAndSettle();
+
+      expect(editableText.controller.text, 'https://api.example.comx');
+    });
+
+    testWidgets('a control key restores focus without typing anything',
+        (tester) async {
+      final serverManager = _createServerManager();
+      await tester.pumpWidget(_buildApp(serverManager: serverManager));
+      await tester.pumpAndSettle();
+
+      final editableText = tester.widget<EditableText>(
+        find.descendant(
+          of: find.byType(TextFormField),
+          matching: find.byType(EditableText),
+        ),
+      );
+      editableText.focusNode.unfocus();
+      await tester.pumpAndSettle();
+
+      await tester.sendKeyEvent(LogicalKeyboardKey.arrowLeft);
+      await tester.pumpAndSettle();
+
+      expect(editableText.focusNode.hasFocus, isTrue);
+      expect(editableText.controller.text, isEmpty);
+    });
+
     testWidgets('no server section when no servers exist', (tester) async {
       final serverManager = _createServerManager();
       await tester.pumpWidget(_buildApp(serverManager: serverManager));

--- a/test/modules/auth/ui/url_message_banner_test.dart
+++ b/test/modules/auth/ui/url_message_banner_test.dart
@@ -32,6 +32,27 @@ void main() {
       expect(decoration.color, equals(theme.colorScheme.errorContainer));
     });
 
+    testWidgets('connect failure text can be selected for copying',
+        (tester) async {
+      await tester.pumpWidget(
+        _wrap(
+          UrlMessageBanner(
+            message: const ConnectError(
+              'Cannot reach https://example.invalid. (503)',
+            ),
+          ),
+        ),
+      );
+
+      expect(
+        find.widgetWithText(
+          SelectableText,
+          'Cannot reach https://example.invalid. (503)',
+        ),
+        findsOneWidget,
+      );
+    });
+
     testWidgets('ConnectNotice shows text, no icon, no error container',
         (tester) async {
       await tester.pumpWidget(

--- a/test/modules/room/ui/chat_classification_test.dart
+++ b/test/modules/room/ui/chat_classification_test.dart
@@ -151,7 +151,7 @@ void main() {
     testWidgets('names the level the room carries', (tester) async {
       await tester.pumpWidget(_wrap(const ChatClassificationNotice()));
       expect(
-        find.text('Information level is RESTRICTED for this room'),
+        find.text('Information level is: RESTRICTED'),
         findsOneWidget,
       );
     });

--- a/test/modules/room/ui/error_retry_panel_test.dart
+++ b/test/modules/room/ui/error_retry_panel_test.dart
@@ -53,6 +53,28 @@ void main() {
       expect(retried, 1);
     });
 
+    testWidgets('the error detail can be selected for copying', (tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: ErrorRetryPanel(
+              title: 'Failed to load messages',
+              error: Exception('connection closed before full header'),
+              onRetry: () {},
+            ),
+          ),
+        ),
+      );
+
+      expect(
+        find.widgetWithText(
+          SelectableText,
+          'Exception: connection closed before full header',
+        ),
+        findsOneWidget,
+      );
+    });
+
     testWidgets('auth error without onReauthenticate falls back to Retry',
         (tester) async {
       await tester.pumpWidget(

--- a/test/modules/room/ui/room_info/expandable_list_card_test.dart
+++ b/test/modules/room/ui/room_info/expandable_list_card_test.dart
@@ -1,0 +1,35 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:soliplex_frontend/src/modules/room/ui/room_info/expandable_list_card.dart';
+import 'package:soliplex_frontend/src/modules/room/ui/room_info/room_info_widgets.dart';
+
+void main() {
+  testWidgets('an expanded tile collapses when its content is tapped',
+      (tester) async {
+    // The whole tile is the toggle, so a tap anywhere over an InfoRow has to
+    // reach it. A selection-aware widget in the value column silently wins the
+    // gesture arena and leaves most of the row dead to taps.
+    var toggles = 0;
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: ExpandableTile(
+            name: 'search_documents',
+            expanded: true,
+            onToggle: () => toggles++,
+            content: const InfoRow(label: 'Allow MCP', value: 'Yes'),
+          ),
+        ),
+      ),
+    );
+
+    final value = tester.getRect(find.text('Yes'));
+    // Far from any glyph: `Expanded` stretches the value column across the
+    // tile, so this lands in empty space that still belongs to the row.
+    await tester.tapAt(Offset(value.right - 8, value.center.dy));
+    await tester.pump();
+
+    expect(toggles, 1);
+  });
+}

--- a/test/modules/room/ui/room_info_screen_test.dart
+++ b/test/modules/room/ui/room_info_screen_test.dart
@@ -5,6 +5,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:soliplex_agent/soliplex_agent.dart';
 
 import 'package:soliplex_frontend/src/modules/auth/server_entry.dart';
+import 'package:soliplex_frontend/src/shared/selectable_content.dart';
 import 'package:soliplex_frontend/src/modules/room/ui/room_info_screen.dart';
 import 'package:soliplex_frontend/src/modules/room/upload_tracker_registry.dart';
 
@@ -117,6 +118,23 @@ void main() {
       expect(find.text('AGENT'), findsOneWidget);
       expect(find.text('gpt-4o'), findsOneWidget);
       expect(find.text('openai'), findsOneWidget);
+    });
+
+    testWidgets('the identifiers on this screen can be selected',
+        (tester) async {
+      await tester.pumpWidget(_buildScreen());
+      await tester.pumpAndSettle();
+
+      // One region above every card, rather than a selectable widget per row:
+      // a selection widget wins the gesture arena, so one placed inside a card
+      // would leave its tap-to-expand rows dead to taps.
+      expect(
+        find.ancestor(
+          of: find.text('gpt-4o'),
+          matching: find.byType(SelectableContent),
+        ),
+        findsOneWidget,
+      );
     });
 
     testWidgets('shows features card', (tester) async {

--- a/test/modules/room/ui/room_screen_test.dart
+++ b/test/modules/room/ui/room_screen_test.dart
@@ -737,7 +737,7 @@ void main() {
         );
         expect(find.text('RESTRICTED'), findsOneWidget);
         expect(
-          find.text('Information level is RESTRICTED for this room'),
+          find.text('Information level is: RESTRICTED'),
           findsOneWidget,
         );
         expect(tester.takeException(), isNull);
@@ -753,7 +753,7 @@ void main() {
         expect(find.byType(AppBar), findsNothing);
         expect(find.text('RESTRICTED'), findsOneWidget);
         expect(
-          find.text('Information level is RESTRICTED for this room'),
+          find.text('Information level is: RESTRICTED'),
           findsOneWidget,
         );
         expect(tester.takeException(), isNull);

--- a/test/modules/room/ui/room_screen_test.dart
+++ b/test/modules/room/ui/room_screen_test.dart
@@ -23,6 +23,7 @@ import 'package:soliplex_frontend/src/modules/room/thread_read_markers.dart';
 import 'package:soliplex_frontend/src/modules/room/ui/chat_classification.dart';
 import 'package:soliplex_frontend/src/modules/room/ui/chat_input.dart';
 import 'package:soliplex_frontend/src/modules/room/ui/room_rail.dart';
+import 'package:soliplex_frontend/src/shared/type_to_focus.dart';
 import 'package:soliplex_frontend/src/modules/room/ui/room_screen.dart';
 import 'package:soliplex_frontend/src/modules/room/ui/thread_sidebar.dart';
 import 'package:soliplex_frontend/src/modules/room/ui/thread_tile.dart';
@@ -132,7 +133,7 @@ Widget _buildRouted({
 }
 
 void main() {
-  group('shouldFocusChatInputOnKey', () {
+  group('shouldFocusInputOnKey', () {
     KeyDownEvent down(LogicalKeyboardKey key) => KeyDownEvent(
           physicalKey: PhysicalKeyboardKey.keyA,
           logicalKey: key,
@@ -145,7 +146,7 @@ void main() {
       bool control = false,
       bool alt = false,
     }) =>
-        shouldFocusChatInputOnKey(
+        shouldFocusInputOnKey(
           event,
           isMetaPressed: meta,
           isControlPressed: control,

--- a/test/shared/selectable_content_test.dart
+++ b/test/shared/selectable_content_test.dart
@@ -1,0 +1,67 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:soliplex_frontend/src/shared/selectable_content.dart';
+
+void main() {
+  testWidgets('keyboard traversal skips the selectable region', (tester) async {
+    final first = FocusNode(debugLabel: 'first');
+    final second = FocusNode(debugLabel: 'second');
+    addTearDown(first.dispose);
+    addTearDown(second.dispose);
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: Column(
+            children: [
+              TextButton(
+                  focusNode: first, onPressed: () {}, child: const Text('one')),
+              const SelectableContent(child: Text('an error worth copying')),
+              TextButton(
+                focusNode: second,
+                onPressed: () {},
+                child: const Text('two'),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+
+    first.requestFocus();
+    await tester.pump();
+    expect(primaryFocus, first);
+
+    // The region paints no focus ring, so a stop on it would look like the
+    // keyboard had vanished. Tab has to reach the next real control.
+    await tester.sendKeyEvent(LogicalKeyboardKey.tab);
+    await tester.pump();
+
+    expect(primaryFocus, second);
+  });
+
+  testWidgets('a tap inside still reaches a handler underneath',
+      (tester) async {
+    var taps = 0;
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: SelectableContent(
+            child: GestureDetector(
+              onTap: () => taps++,
+              behavior: HitTestBehavior.opaque,
+              child: const Text('tap me'),
+            ),
+          ),
+        ),
+      ),
+    );
+
+    await tester.tap(find.text('tap me'));
+    await tester.pump();
+
+    expect(taps, 1);
+  });
+}

--- a/test/shared/type_to_focus_test.dart
+++ b/test/shared/type_to_focus_test.dart
@@ -1,0 +1,28 @@
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:soliplex_frontend/src/shared/type_to_focus.dart';
+
+void main() {
+  group('isTypedText', () {
+    test('accepts printable characters, including space', () {
+      expect(isTypedText('h'), isTrue);
+      expect(isTypedText(' '), isTrue);
+      expect(isTypedText('\u00e9'), isTrue);
+    });
+
+    test('rejects the control codes macOS and Linux report for control keys',
+        () {
+      // The Windows engine filters these; macOS and Linux pass them through, so
+      // Enter, Tab, Escape and Delete would otherwise be typed into the field.
+      expect(isTypedText('\r'), isFalse, reason: 'Enter');
+      expect(isTypedText('\t'), isFalse, reason: 'Tab');
+      expect(isTypedText('\u001b'), isFalse, reason: 'Escape');
+      expect(isTypedText('\u007f'), isFalse, reason: 'Delete');
+    });
+
+    test('rejects absent or empty text', () {
+      expect(isTypedText(null), isFalse);
+      expect(isTypedText(''), isFalse);
+    });
+  });
+}

--- a/test/shared/zoomable_view_test.dart
+++ b/test/shared/zoomable_view_test.dart
@@ -14,6 +14,32 @@ Widget _wrap(Widget child) => MaterialApp(
 InteractiveViewer _viewer(WidgetTester tester) =>
     tester.widget<InteractiveViewer>(find.byType(InteractiveViewer));
 
+int _quarterTurns(WidgetTester tester) =>
+    tester.widget<RotatedBox>(find.byType(RotatedBox)).quarterTurns;
+
+/// Pumps a host that opens the media dialog on tap, then opens it.
+Future<void> _openMediaDialog(WidgetTester tester, {Widget? caption}) async {
+  await tester.pumpWidget(
+    MaterialApp(
+      home: Scaffold(
+        body: Builder(
+          builder: (context) => TextButton(
+            onPressed: () => showZoomableMediaDialog(
+              context,
+              viewer: const ZoomableView(child: SizedBox()),
+              caption: caption,
+            ),
+            child: const Text('open'),
+          ),
+        ),
+      ),
+    ),
+  );
+
+  await tester.tap(find.text('open'));
+  await tester.pumpAndSettle();
+}
+
 void main() {
   testWidgets('enables trackpad-scroll zoom (Mac web support)', (tester) async {
     // On Mac web, Flutter routes trackpad two-finger scroll to a pan; with the
@@ -63,12 +89,12 @@ void main() {
     await tester.pumpWidget(_wrap(const ZoomableView(child: SizedBox())));
 
     expect(find.byTooltip('Rotate'), findsOneWidget);
-    expect(tester.widget<RotatedBox>(find.byType(RotatedBox)).quarterTurns, 0);
+    expect(_quarterTurns(tester), 0);
 
     await tester.tap(find.byTooltip('Rotate'));
     await tester.pump();
 
-    expect(tester.widget<RotatedBox>(find.byType(RotatedBox)).quarterTurns, 1);
+    expect(_quarterTurns(tester), 1);
   });
 
   testWidgets('rotate delegates to onRotate when provided (no self-rotation)',
@@ -83,7 +109,7 @@ void main() {
     ));
 
     // The caller-supplied rotation is applied to the content.
-    expect(tester.widget<RotatedBox>(find.byType(RotatedBox)).quarterTurns, 3);
+    expect(_quarterTurns(tester), 3);
 
     await tester.tap(find.byTooltip('Rotate'));
     await tester.pump();
@@ -91,6 +117,35 @@ void main() {
     expect(rotations, 1);
     // Caller owns rotation; the view does not rotate itself — it stays at the
     // caller's value until the caller updates it.
-    expect(tester.widget<RotatedBox>(find.byType(RotatedBox)).quarterTurns, 3);
+    expect(_quarterTurns(tester), 3);
+  });
+
+  testWidgets('media dialog close control dismisses without shadowing rotate',
+      (tester) async {
+    await _openMediaDialog(tester);
+    expect(find.byType(Dialog), findsOneWidget);
+
+    // The dialog's close control sits over the viewer, so it can swallow taps
+    // meant for the viewer's own controls. Rotating has to still rotate, and
+    // must not dismiss.
+    await tester.tap(find.byTooltip('Rotate'));
+    await tester.pumpAndSettle();
+
+    expect(find.byType(Dialog), findsOneWidget);
+    expect(_quarterTurns(tester), 1);
+
+    // The barrier dismisses as well; the button is the affordance a pointer or
+    // screen reader user can find.
+    await tester.tap(find.byTooltip('Close'));
+    await tester.pumpAndSettle();
+
+    expect(find.byType(Dialog), findsNothing);
+  });
+
+  testWidgets('media dialog shows the caption beneath the viewer',
+      (tester) async {
+    await _openMediaDialog(tester, caption: const Text('figure 1'));
+
+    expect(find.text('figure 1'), findsOneWidget);
   });
 }


### PR DESCRIPTION
Three UI fixes. Each commit stands alone.

## `599fc33f` — tighten the information level notice

The standing line under the composer read *"Information level is RESTRICTED for
this room"*. It now reads *"Information level is: RESTRICTED"*, so the line ends
on the level itself rather than trailing off into words the screen already
shows, and it sits tighter to the composer.

## `5a6223f3` — give the zoom dialog a close control

The full-size image/SVG viewer could only be dismissed by the backdrop or Esc.
On a full-bleed image there is no visible backdrop to aim at, and a screen
reader user had nothing to land on. A close button now sits top-right; the
viewer's own rotate and reset controls move to the opposite corner so a tap
meant for one never hits the other.

Rotate is anchored at the edge so it keeps its position when reset appears
beside it.

## `198a888` — let failure text be selected

Only the transcript and rendered prose carried a `SelectionArea`, so every
string outside them was unselectable — including the ones worth reporting: the
exception behind a failed load or send, the reason a connection or sign-in was
refused, an upload's error, the detail behind a failed sign-out. They were
readable but could only leave the app by being retyped.

- Single strings become `SelectableText`, matching how the diagnostics, versions
  and room-info screens already expose one value.
- Where the text truncates, `SelectableText` cannot express `overflow`, so those
  regions keep a selection region around the `Text` and hold their ellipsis.
- The send-failure banner also gains a copy button: it shows at most two lines,
  and a drag can only take the glyphs that were painted.
- A room's details are selectable throughout — model name, provider, tool kinds,
  skill fields.

Also fixes a pre-existing bug it surfaced: typing on the connect screen while
the URL field had lost focus dropped the first character, because focus only
lands after the event has been dispatched and the field holds no input
connection to receive it.

### The gesture-arena rule, which shaped the whole commit

Both a `SelectableText` and a `SelectionArea` win the gesture arena for taps, so
a selection-aware widget **under** a tap handler leaves that region dead to
taps. Measured:

| Configuration | ancestor `onTap` fires |
| ------------- | ---------------------- |
| plain `Text` | yes |
| `SelectableText` inside the handler | **no** |
| `SelectionArea` inside the handler | **no** |
| `SelectionArea` **above** the handler | yes |
| area above, but leaf is `SelectableText` | **no** |

An earlier revision of this branch made `InfoRow` selectable and silently broke
tap-to-collapse on seven room-info tool/toolset rows. That is reverted; the
identifiers are now covered by one region **above** every tap handler, which
also covers more text than the original attempt. Guarded by
`test/modules/room/ui/room_info/expandable_list_card_test.dart`.

`lib/src/shared/selectable_content.dart` is the region to use rather than a bare
`SelectionArea` — it carries a `skipTraversal` focus node, because
`SelectableRegion` otherwise installs a focusable node that paints nothing and
reads as an empty Tab stop between the real controls.

## Verification

- `flutter test --exclude-tags golden` — **2373 passing**. The app's own `test/`
  tree has no goldens (no `matchesGoldenFile`, no `.png` baselines), so that
  excludes nothing; goldens live only under `packages/soliplex_design/`, which
  this branch does not touch.
- `flutter analyze` clean, `dart format --set-exit-if-changed` clean,
  markdownlint clean. All pre-commit hooks pass on each commit independently.
- New regression guards were each confirmed to **fail** against the broken code
  before being kept: the rotate-reachability guard, the room-info tap guard, the
  selectable-region guard, and the dropped-keystroke test.

## Not in this PR

Four pre-existing sites log a full error and then show a bare sentence, so
selectability does not help them — and none handles `AuthException` or
`PermissionDeniedException` while all four offer a Retry that cannot succeed.
That is a pre-existing defect, deliberately punted, and specced in an untracked
local plan doc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)