### PR TITLE
fix: ask for the status message afresh on every poll

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,17 @@ Versions follow the `version+build` scheme from `pubspec.yaml`, bumped via
   ends on rather than trailing off into words that repeat what the screen
   already shows.
 
+### Fixed
+
+- A status message that operators withdraw now clears within one poll instead
+  of lingering for hours. The app asked for the same address on every poll, so
+  a browser or system HTTP cache was free to answer from the copy it already
+  held; with the file served without any statement of how long it stays good,
+  those caches fall back to a guess proportional to the file's age, which for a
+  message posted days earlier runs to hours. Each poll now carries a value no
+  earlier poll used, which no cache can have an answer for. Edits to a posted
+  message reach readers on the same schedule.
+
 ## [0.99.2+81] - 2026-08-17
 
 ### Added

--- a/lib/src/status_message/status_message_fetcher.dart
+++ b/lib/src/status_message/status_message_fetcher.dart
@@ -7,13 +7,30 @@ final Logger _logger = LogManager.instance.getLogger('soliplex.status_message');
 
 typedef StatusMessageFetcher = Future<StatusMessage?> Function();
 
+/// Seeded from the wall clock so a relaunch cannot reuse a value a previous
+/// run already spent, then incremented so two polls in the same millisecond
+/// still differ.
+int _cacheBuster = DateTime.now().millisecondsSinceEpoch;
+
+/// Operators cancel a banner by deleting the file, so a cached response keeps
+/// a withdrawn message on screen. The hosting block ships no `Cache-Control`,
+/// which leaves browsers and NSURLSession free to apply heuristic freshness; a
+/// per-fetch parameter makes every poll a distinct cache key. A fixed marker
+/// would not — it is just a different stable key.
+Uri _cacheBusted(Uri uri) => uri.replace(
+      queryParameters: <String, dynamic>{
+        ...uri.queryParametersAll,
+        '_': (_cacheBuster++).toString(),
+      },
+    );
+
 Future<StatusMessage?> fetchStatusMessage({
   required Uri baseUrl,
   required SoliplexHttpClient client,
   required String path,
 }) async {
   final transport = HttpTransport(client: client);
-  final uri = baseUrl.resolve(path);
+  final uri = _cacheBusted(baseUrl.resolve(path));
   try {
     final json = await transport.request<Map<String, dynamic>>('GET', uri);
     final message = StatusMessage.fromJson(json);

--- a/test/status_message/status_message_fetcher_test.dart
+++ b/test/status_message/status_message_fetcher_test.dart
@@ -1,0 +1,53 @@
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:soliplex_client/soliplex_client.dart';
+import 'package:soliplex_frontend/src/status_message/status_message_fetcher.dart';
+
+import '../helpers/fakes.dart';
+
+void main() {
+  late FakeHttpClient client;
+  late List<Uri> requested;
+
+  setUp(() {
+    requested = [];
+    client = FakeHttpClient()
+      ..onRequest = (method, uri) async {
+        requested.add(uri);
+        return HttpResponse(
+          statusCode: 200,
+          bodyBytes: Uint8List.fromList(
+            utf8.encode(jsonEncode({'id': 'm', 'title': 't', 'body': 'b'})),
+          ),
+        );
+      };
+  });
+
+  test('successive fetches request distinct URIs', () async {
+    Future<void> fetch() => fetchStatusMessage(
+          baseUrl: Uri.parse('https://example.test/'),
+          client: client,
+          path: '/messages/status.json',
+        );
+
+    await fetch();
+    await fetch();
+
+    expect(requested, hasLength(2));
+    expect(requested[0], isNot(requested[1]));
+  });
+
+  test('cache busting preserves the path and its query parameters', () async {
+    await fetchStatusMessage(
+      baseUrl: Uri.parse('https://example.test/'),
+      client: client,
+      path: '/messages/status.json?tenant=acme&tenant=beta',
+    );
+
+    final uri = requested.single;
+    expect(uri.path, '/messages/status.json');
+    expect(uri.queryParametersAll['tenant'], ['acme', 'beta']);
+  });
+}


### PR DESCRIPTION
## Problem

Operators withdraw a status banner by deleting `status.json`. The banner stayed
on screen for hours afterwards, and edits to a posted message did not propagate.

The poll built an identical URI on every cycle, so a cache could answer it from
its own copy. The file is served with no `Cache-Control` and no `expires` — only
`Last-Modified` and `ETag` — so caches fall back to heuristic freshness (~10% of
the file's age). A message posted days earlier stays "fresh" for hours after the
file is gone.

Affected clients: web (`BrowserClient`, persistent browser cache) and iOS/macOS
(`CupertinoHttpClient`, in-memory `URLCache`). Android/Linux/Windows use
`dart:io HttpClient`, which does not cache.

## Change

Each fetch appends a query parameter whose value no earlier fetch used, making
every poll a distinct cache key. A *fixed* marker would not work — it is just a
different stable key.

The value is seeded from the wall clock, so a relaunch cannot replay values a
previous run spent, then incremented per fetch. A clock read alone is not enough:
on the web `microsecondsSinceEpoch` is milliseconds x 1000, so it has no
sub-millisecond resolution on the one platform whose cache is most aggressive.
Incrementing also makes the "successive fetches produce distinct URIs" test
deterministic rather than timing-dependent.

Merging happens *after* `Uri.resolve` and spreads `queryParametersAll`, so a
query in the configured path survives intact, repeated keys included.

## Trade-off

The parameter defeats conditional GET, so every poll transfers the body instead
of a 304. A few hundred bytes every five minutes — accepted.

## Scope

Only the `status.json` GET. No other request in the app changes.

The server-side companion — declaring `Cache-Control` on the `/messages/` nginx
block — lives in the deployment repo and is not part of this change. It is the
root-cause fix and covers every consumer; the query parameter is what works
today without a backend deploy, and keeps working against deployments we do not
control.

## Verification

- Both tests confirmed failing before the implementation.
- Each test re-confirmed as load-bearing by breaking its target independently:
  removing the buster fails the first, dropping the `queryParametersAll` spread
  fails the second.
- Deletion path traced end to end: nginx returns a real 404 (the `error_page`
  swaps the body, not the status), so `NotFoundException` -> `fetchStatusMessage`
  returns null -> the controller assigns null -> the banner clears.
- `dart format`, `flutter analyze` (zero warnings), full suite (2365 tests),
  `markdownlint-cli2` — all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)