### PR TITLE
chore: version 0.99.3+82

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ Versions follow the `version+build` scheme from `pubspec.yaml`, bumped via
 
 ## [Unreleased]
 
+## [0.99.3+82] - 2026-08-19
+
 ### Changed
 
 - Failure messages can now be selected and copied. Until now the transcript was

--- a/lib/version.dart
+++ b/lib/version.dart
@@ -2,4 +2,4 @@
 ///
 /// Generated from pubspec.yaml. Run `dart run tool/update_version.dart` after
 /// changing the version in pubspec.yaml.
-const String soliplexVersion = '0.99.2+81';
+const String soliplexVersion = '0.99.3+82';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,7 +3,7 @@ description: Modular Flutter frontend framework for Soliplex
 publish_to: none
 # To update version, run:
 # dart run tool/bump_version.dart <major|minor|patch|build>
-version: 0.99.2+81
+version: 0.99.3+82
 
 environment:
   sdk: ^3.6.0


### PR DESCRIPTION
Bumps the app to `0.99.3+82` and closes the `[Unreleased]` changelog block as `[0.99.3+82]`.

The released block covers the four commits since `v0.99.2+81`:

- Selectable failure text (with a copy button on the send-failure banner)
- Connect screen no longer swallows the first keystroke when the URL field is unfocused
- Close control on the full-size image/SVG viewer
- Tighter information-level line under the composer
- Withdrawn status messages clear within one poll instead of being served from an HTTP cache

🤖 Generated with [Claude Code](https://claude.com/claude-code)