### PR TITLE
chore(ios): declare one minimum OS version across the build

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ Versions follow the `version+build` scheme from `pubspec.yaml`, bumped via
 
 ## [Unreleased]
 
+### Changed
+
+- The iOS build declares one minimum OS version throughout. The app has
+  required iOS 16 since the platform was configured, but the bundled
+  `App.framework` still announced 13.0, so the two disagreed about the oldest
+  system the build supports. Both now read 16.0. Apple reads only the app's own
+  value, so the version the App Store enforces is unchanged.
+
 ## [0.99.3+82] - 2026-08-19
 
 ### Changed

--- a/ios/Flutter/AppFrameworkInfo.plist
+++ b/ios/Flutter/AppFrameworkInfo.plist
@@ -21,6 +21,6 @@
   <key>CFBundleVersion</key>
   <string>1.0</string>
   <key>MinimumOSVersion</key>
-  <string>13.0</string>
+  <string>16.0</string>
 </dict>
 </plist>


### PR DESCRIPTION
The Runner target has required iOS 16 since the platform was configured, but the
bundled `App.framework` still announced `MinimumOSVersion` 13.0. The two
disagreed about the oldest system the build supports; both now read 16.0.

**No change to what Apple enforces.** App Store Connect reads only the app's own
`Info.plist` value, which was already 16.0 and stays 16.0. Verified by inspecting
a rebuilt IPA:

| | app `Info.plist` | `App.framework` |
| --- | --- | --- |
| before | 16.0 | 13.0 |
| after | 16.0 | **16.0** |

Embedded frameworks are permitted to declare minimums below the app's — this
build still ships `Flutter.framework` at 13.0 and `SDWebImage` at 9.0, and
uploaded clean before this change. The fix is consistency, not compliance.

Context: App Store Connect warns on upload that `MinimumOSVersion` below 15.0
will be rejected starting Spring 2027. This app was never affected; its consumer
was, and is raised to match in a separate PR.

Release build succeeded with zero warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)