### PR TITLE
feat(logging): make a failed sign-in diagnosable from a release build

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,18 @@ Versions follow the `version+build` scheme from `pubspec.yaml`, bumped via
 
 ### Changed
 
+- A failed sign-in or connection now leaves a record behind. Until now the app
+  logged through `dart:developer`, whose entries only exist while a debugger is
+  attached, so nothing survived in the builds where these failures actually get
+  reported — the user saw one friendly sentence and there was no way to tell a
+  name that does not resolve from a name that resolves while something above DNS
+  blocks the request, or from a session the app already believed was live. Log
+  records are now retained in the app itself, and a failed connection attempt
+  records every address it tried, the platform error behind the friendly message,
+  how long it took, and whether the name resolves when asked directly. A server
+  restored as connected on credentials that had already expired — which opens the
+  app as if signed in and then fails every call — is called out specifically.
+
 - The developer menu entry that opens the captured HTTP traffic is now
   called Diagnostics, matching the module behind it, and the route it opens
   is `/diagnostics` rather than `/diagnostics/network`. The screen shows the

--- a/lib/src/core/inactivity/inactivity_provider.dart
+++ b/lib/src/core/inactivity/inactivity_provider.dart
@@ -1,12 +1,13 @@
-import 'dart:developer' as dev;
-
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:soliplex_logging/soliplex_logging.dart';
 
 import '../../modules/auth/auth_providers.dart';
 import '../../modules/auth/inactivity_logout_storage.dart';
 import '../../modules/auth/server_manager.dart';
 import 'inactivity_config.dart';
 import 'inactivity_monitor.dart';
+
+final Logger _logger = LogManager.instance.getLogger('soliplex.inactivity');
 
 /// Holds the active [InactivityConfig].
 ///
@@ -37,9 +38,9 @@ final inactivityMonitorProvider = Provider<InactivityMonitor?>((ref) {
     // throw at read time). Returning null keeps the shell bootable for
     // consumers that don't include the auth module; logging leaves a
     // breadcrumb if that assumption ever stops holding.
-    dev.log(
-      'Inactivity monitor disabled: auth providers unavailable ($e).',
-      name: 'soliplex_frontend.inactivity',
+    _logger.warning(
+      'Inactivity monitor disabled: auth providers unavailable',
+      error: e,
     );
     return null;
   }

--- a/lib/src/core/log_sinks.dart
+++ b/lib/src/core/log_sinks.dart
@@ -3,7 +3,7 @@ import 'package:soliplex_logging/soliplex_logging.dart';
 
 /// Registers the app's log sinks and sets the level floor.
 ///
-/// Two sinks, each on its own transport:
+/// Three sinks, each on its own transport:
 ///
 /// - [ConsoleSink] goes through `dart:developer` to the VM-service logging
 ///   stream, so it reaches whatever client is attached — the DevTools
@@ -17,8 +17,16 @@ import 'package:soliplex_logging/soliplex_logging.dart';
 ///   carry the `dart:developer`/OS-logging path, not raw process stdout), and
 ///   on web the sink is a no-op. For a view that doesn't depend on what's
 ///   attached, route to a file (a disk sink, or shell redirection of stdout).
+/// - [MemorySink] retains recent records in a ring buffer, readable in-process
+///   via `LogManager.sinks`. On a *packaged* native release build it is the
+///   only one whose output can be read back at all — the console sink's
+///   `dart:developer` stream has no VM service to reach, and a GUI launch
+///   discards stdout — which is why the in-app diagnostics screen reads it.
+///   Both qualifiers matter: a release binary started from a terminal still
+///   shows the stdout sink, and on web the console sink reaches the browser
+///   console in release too.
 ///
-/// Both register in every build mode; without a sink [LogManager] discards
+/// All three register in every build mode; without a sink [LogManager] discards
 /// every record. Release is held to [LogLevel.warning] so the on-device stream
 /// stays quiet, while debug keeps [LogLevel.info]. Shipping logs *off* the
 /// device (a backend sink) is a separate decision that needs redaction and
@@ -28,5 +36,6 @@ void installLogSinks(LogManager manager) {
   manager.minimumLevel = kReleaseMode ? LogLevel.warning : LogLevel.info;
   manager
     ..addSink(ConsoleSink())
-    ..addSink(StdoutSink());
+    ..addSink(StdoutSink())
+    ..addSink(MemorySink());
 }

--- a/lib/src/modules/auth/auth_session.dart
+++ b/lib/src/modules/auth/auth_session.dart
@@ -1,9 +1,14 @@
-import 'dart:developer' as dev;
-
 import 'package:soliplex_agent/soliplex_agent.dart';
+import 'package:soliplex_logging/soliplex_logging.dart';
 
 import 'access_token_identity.dart';
 import 'auth_tokens.dart';
+
+/// Routed through [LogManager] rather than `dart:developer` so these records
+/// reach the in-memory sink the diagnostics screen reads. A `dart:developer`
+/// entry only exists while a VM service is attached, which never holds for the
+/// release builds where refresh failures actually get reported.
+final Logger _logger = LogManager.instance.getLogger('soliplex.auth_session');
 
 /// Manages auth session and implements TokenRefresher for the HTTP client.
 ///
@@ -69,6 +74,10 @@ class AuthSession implements TokenRefresher {
   void markSessionExpired() {
     switch (_session.value) {
       case ActiveSession(:final provider, :final tokens):
+        _logger.warning(
+          'Session flipped ActiveSession -> ExpiredSession; tokens kept',
+          attributes: {'expiresAt': tokens.expiresAt.toIso8601String()},
+        );
         _session.value = ExpiredSession(provider: provider, tokens: tokens);
       case ExpiredSession():
       case NoSession():
@@ -115,11 +124,11 @@ class AuthSession implements TokenRefresher {
         clientId: provider.clientId,
       );
     } on AuthException catch (e, st) {
-      dev.log(
+      _logger.warning(
         'Token refresh threw AuthException; funneling to markSessionExpired',
         error: e,
         stackTrace: st,
-        level: 900,
+        attributes: {'discoveryUrl': provider.discoveryUrl},
       );
       markSessionExpired();
       return false;
@@ -128,13 +137,13 @@ class AuthSession implements TokenRefresher {
       // the AuthException arm above): an unexpected throw here is a
       // bug or a transient anomaly, not proof the IdP grant is dead.
       // Flipping to ExpiredSession would lock the user out for a
-      // recoverable failure. Log SEVERE and let the next API call
+      // recoverable failure. Log at error level and let the next API call
       // surface the real status via AuthException → funnel.
-      dev.log(
+      _logger.error(
         'Token refresh threw before producing a result',
         error: e,
         stackTrace: st,
-        level: 1000,
+        attributes: {'discoveryUrl': provider.discoveryUrl},
       );
       return false;
     }
@@ -158,9 +167,9 @@ class AuthSession implements TokenRefresher {
         return true;
 
       case TokenRefreshFailure(reason: TokenRefreshFailureReason.invalidGrant):
-        dev.log(
-          'Token refresh rejected (invalid_grant) for ${provider.discoveryUrl}',
-          level: 900,
+        _logger.warning(
+          'Token refresh rejected (invalid_grant)',
+          attributes: {'discoveryUrl': provider.discoveryUrl},
         );
         markSessionExpired();
         return false;
@@ -171,21 +180,25 @@ class AuthSession implements TokenRefresher {
         // A refresh attempt without a refresh token is a frontend
         // invariant violation: the session should never have been
         // marked refreshable in the first place.
-        dev.log(
-          'Token refresh requested without a refresh token '
-          'for ${provider.discoveryUrl}',
-          level: 1000,
+        _logger.error(
+          'Token refresh requested without a refresh token',
+          attributes: {'discoveryUrl': provider.discoveryUrl},
         );
         markSessionExpired();
         return false;
 
       case TokenRefreshFailure(:final reason):
         // networkError is recoverable on retry; unknownError is the
-        // anomaly worth a SEVERE entry.
-        dev.log(
-          'Token refresh failed (${reason.name}) for ${provider.discoveryUrl}',
-          level: reason == TokenRefreshFailureReason.networkError ? 900 : 1000,
-        );
+        // anomaly worth recording at error level.
+        final attributes = {
+          'discoveryUrl': provider.discoveryUrl,
+          'reason': reason.name,
+        };
+        if (reason == TokenRefreshFailureReason.networkError) {
+          _logger.warning('Token refresh failed', attributes: attributes);
+        } else {
+          _logger.error('Token refresh failed', attributes: attributes);
+        }
         return false;
     }
   }

--- a/lib/src/modules/auth/connect_flow.dart
+++ b/lib/src/modules/auth/connect_flow.dart
@@ -138,6 +138,29 @@ class ConnectFlow {
           final resultId = serverIdFromUrl(result.serverUrl);
           final existing = serverManager.servers.value[resultId];
           if (existing != null && existing.isConnected) {
+            // Reporting success straight from local state, without contacting
+            // the IdP. Benign when the session really is live, but it is also
+            // how a stale `isConnected` strands someone: every retry lands
+            // here and no sign-in is ever attempted. Record it either way, and
+            // escalate when the credentials backing that claim have already
+            // expired, so the strand is visible in a field report.
+            final session = existing.auth.session.value;
+            final message = 'Probe succeeded; reporting the existing session '
+                'as connected without re-authenticating';
+            final attributes = {
+              'serverId': resultId,
+              'session': session.runtimeType.toString(),
+              'requiresAuth': existing.requiresAuth,
+            };
+            if (session case ActiveSession(:final tokens)
+                when tokens.expiresAt.isBefore(DateTime.now())) {
+              _logger.warning(message, attributes: {
+                ...attributes,
+                'expiredAt': tokens.expiresAt.toIso8601String(),
+              });
+            } else {
+              _logger.info(message, attributes: attributes);
+            }
             await SelectedServerStorage.save(resultId);
             if (!_isCancelled(gen)) state.value = const Connected();
             return;
@@ -158,7 +181,7 @@ class ConnectFlow {
           );
       }
     } catch (e, st) {
-      _logger.error('ConnectFlow.connect failed', error: e, stackTrace: st);
+      _logger.error('connect failed', error: e, stackTrace: st);
       if (!_isCancelled(gen)) {
         state.value = UrlInput(
           message: ConnectError('Unexpected error connecting to $url: $e'),
@@ -252,7 +275,7 @@ class ConnectFlow {
     try {
       onServerConnected?.call(serverUrl);
     } on Object catch (e, st) {
-      _logger.warning('ConnectFlow: onServerConnected callback failed',
+      _logger.warning('onServerConnected callback failed',
           error: e, stackTrace: st);
     }
   }
@@ -323,7 +346,7 @@ class ConnectFlow {
         await PreAuthStateStorage.clear();
       } catch (e, st) {
         _logger.warning(
-          'ConnectFlow: post-login PreAuthState clear failed',
+          'post-login PreAuthState clear failed',
           error: e,
           stackTrace: st,
         );
@@ -356,7 +379,7 @@ class ConnectFlow {
       }
     } on Exception catch (e, st) {
       _logger.error(
-        'ConnectFlow._authenticate failed',
+        '_authenticate failed',
         error: e,
         stackTrace: st,
       );

--- a/lib/src/modules/auth/connection_probe.dart
+++ b/lib/src/modules/auth/connection_probe.dart
@@ -3,6 +3,8 @@ import 'dart:async';
 import 'package:soliplex_agent/soliplex_agent.dart';
 import 'package:soliplex_logging/soliplex_logging.dart';
 
+import 'platform/host_resolution.dart';
+
 final Logger _logger =
     LogManager.instance.getLogger('soliplex.connection_probe');
 
@@ -81,9 +83,15 @@ Future<ConnectionProbeResult> probeConnection({
   try {
     candidates = _buildCandidateUrls(input);
   } on FormatException catch (e) {
+    _logger.warning(
+      'Probe rejected the address before any request',
+      error: e,
+      attributes: {'input': '"$input"', 'inputLength': input.length},
+    );
     return ConnectionFailure(e);
   }
 
+  final started = DateTime.now();
   NetworkException? lastNetworkError;
   final tried = <Uri>[];
   for (final uri in candidates) {
@@ -116,9 +124,48 @@ Future<ConnectionProbeResult> probeConnection({
         isTimeout: true,
       );
     } on Exception catch (e) {
+      _logger.warning(
+        'Probe failed with a non-network error',
+        error: e,
+        attributes: {
+          'requestedUrl': uri.toString(),
+          'errorType': e.runtimeType.toString(),
+          'elapsedMs': DateTime.now().difference(started).inMilliseconds,
+        },
+      );
       return ConnectionFailure(e, attemptedUrls: List.unmodifiable(tried));
     }
   }
+  // Stopped before the resolver check below, so it measures the probe rather
+  // than the probe plus the diagnostic that follows it. An instant failure
+  // means no resolution was attempted; seconds mean a real attempt that failed.
+  final elapsedMs = DateTime.now().difference(started).inMilliseconds;
+  // Ask the platform resolver directly: a "cannot find host" from the HTTP
+  // stack does not distinguish a real resolver failure from anything else in
+  // that stack preventing the lookup.
+  //
+  // This delays the failure the user is waiting on, which is why the lookup is
+  // held to a short deadline: a resolver that has not answered by then has
+  // already told us what the record needs to say.
+  final hostResolution = await describeHostResolution(tried.last.host);
+  _logger.warning(
+    'Probe exhausted every candidate address',
+    error: lastNetworkError,
+    attributes: {
+      'input': '"$input"',
+      'inputLength': input.length,
+      'candidates': tried.map((u) => u.toString()).toList(),
+      'hosts': tried.map((u) => '"${u.host}"').toList(),
+      'hostResolution': hostResolution,
+      'errorType': lastNetworkError?.runtimeType.toString(),
+      'isTimeout': lastNetworkError?.isTimeout,
+      // The platform error carries the domain and numeric code (e.g.
+      // NSURLErrorDomain -1003), which name the failure far more precisely
+      // than the localized sentence shown to the user.
+      'platformError': lastNetworkError?.originalError?.toString(),
+      'elapsedMs': elapsedMs,
+    },
+  );
   return ConnectionFailure(
     lastNetworkError ?? Exception('No reachable server at: $input'),
     attemptedUrls: List.unmodifiable(tried),

--- a/lib/src/modules/auth/default_backend_url.dart
+++ b/lib/src/modules/auth/default_backend_url.dart
@@ -1,6 +1,8 @@
-import 'dart:developer' as dev;
-
 import 'package:shared_preferences/shared_preferences.dart';
+import 'package:soliplex_logging/soliplex_logging.dart';
+
+final Logger _logger =
+    LogManager.instance.getLogger('soliplex.default_backend_url');
 
 /// Resolves the default backend URL using platform logic.
 ///
@@ -47,11 +49,11 @@ abstract final class DefaultBackendUrlStorage {
       final prefs = await SharedPreferences.getInstance();
       await prefs.setString(_key, url);
     } catch (e, st) {
-      dev.log(
-        'Failed to persist default backend url ($url)',
+      _logger.error(
+        'Failed to persist the default backend url',
         error: e,
         stackTrace: st,
-        level: 1000,
+        attributes: {'url': url},
       );
     }
   }

--- a/lib/src/modules/auth/platform/auth_flow_native.dart
+++ b/lib/src/modules/auth/platform/auth_flow_native.dart
@@ -1,10 +1,12 @@
-import 'dart:developer' as dev;
-
 import 'package:flutter/services.dart';
 import 'package:flutter_appauth/flutter_appauth.dart';
 import 'package:soliplex_agent/soliplex_agent.dart' hide AuthException;
+import 'package:soliplex_logging/soliplex_logging.dart';
 
 import 'auth_flow.dart';
+
+final Logger _logger =
+    LogManager.instance.getLogger('soliplex.auth_flow_native');
 
 /// Creates the native platform implementation of [AuthFlow].
 ///
@@ -56,9 +58,8 @@ class NativeAuthFlow implements AuthFlow {
 
       final accessToken = result.accessToken;
       if (accessToken == null) {
-        dev.log(
-          'NativeAuthFlow: token exchange succeeded but access token was null',
-          level: 1000,
+        _logger.error(
+          'Token exchange succeeded but the access token was null',
         );
         throw const AuthException(
           'IdP returned success but no access token',
@@ -75,22 +76,42 @@ class NativeAuthFlow implements AuthFlow {
     } on AuthException {
       rethrow;
     } on FlutterAppAuthUserCancelledException catch (e, st) {
-      dev.log('NativeAuthFlow: user cancelled', error: e, stackTrace: st);
+      // A deliberate user action, not a fault — so info, which means it is
+      // filtered out of a release build. The flow already renders cancellation
+      // as a distinct notice rather than an error, so a report can tell the
+      // two apart without this record.
+      _logger.info(
+        'User cancelled sign-in',
+        error: e,
+        stackTrace: st,
+      );
       throw const AuthException(
         'User cancelled sign-in',
         kind: AuthFailureKind.cancelled,
       );
     } on FlutterAppAuthPlatformException catch (e, st) {
-      dev.log('NativeAuthFlow: platform exception', error: e, stackTrace: st);
+      _logger.warning(
+        'Sign-in platform exception',
+        error: e,
+        stackTrace: st,
+      );
       throw _classifyAppAuth(e);
     } on PlatformException catch (e, st) {
-      dev.log('NativeAuthFlow: channel exception', error: e, stackTrace: st);
+      _logger.warning(
+        'Sign-in channel exception',
+        error: e,
+        stackTrace: st,
+      );
       throw AuthException(
         'Sign-in channel error: ${e.code}',
         kind: AuthFailureKind.unknown,
       );
     } on Exception catch (e, st) {
-      dev.log('NativeAuthFlow: unexpected', error: e, stackTrace: st);
+      _logger.warning(
+        'Sign-in failed unexpectedly',
+        error: e,
+        stackTrace: st,
+      );
       throw const AuthException(
         'Unexpected sign-in failure',
         kind: AuthFailureKind.unknown,

--- a/lib/src/modules/auth/platform/host_resolution.dart
+++ b/lib/src/modules/auth/platform/host_resolution.dart
@@ -1,0 +1,22 @@
+// Native is the default; web overrides with a stub since it has no resolver
+// API.
+import 'host_resolution_native.dart'
+    if (dart.library.js_interop) 'host_resolution_web.dart' as platform;
+
+/// Describes whether [host] resolves right now, independently of the HTTP
+/// client that just failed to reach it.
+///
+/// This is the discriminator a "cannot find host" error cannot give on its own.
+/// `NSURLErrorCannotFindHost` (-1003) is reported by the URL loading system, so
+/// it conflates a genuine resolver failure with anything inside that stack that
+/// prevents a lookup from completing. Asking the platform resolver directly
+/// separates the two: if the name resolves here while the request failed, the
+/// fault is above DNS; if it fails here too, the name genuinely does not
+/// resolve for this device on this network.
+///
+/// Only called on an already-failed probe, and awaited before that failure is
+/// returned, so its deadline is a delay the user feels. Held short on purpose:
+/// a name that resolves answers in milliseconds, and a resolver that needs
+/// longer has already told the record what it needs to say.
+Future<String> describeHostResolution(String host) =>
+    platform.describeHostResolution(host);

--- a/lib/src/modules/auth/platform/host_resolution_native.dart
+++ b/lib/src/modules/auth/platform/host_resolution_native.dart
@@ -1,0 +1,31 @@
+import 'dart:async' show TimeoutException;
+import 'dart:io' show InternetAddress;
+
+/// How long the lookup may take before the answer stops being worth waiting
+/// for. This runs on the path that returns a connection failure to the user, so
+/// the deadline is a delay they feel; a name that resolves answers well inside
+/// it.
+const _lookupDeadline = Duration(milliseconds: 500);
+
+/// Resolves [host] through the platform resolver, bypassing the HTTP stack.
+///
+/// Deliberately reports the address *count* and families rather than the
+/// addresses themselves: whether the name resolves is the diagnostic signal,
+/// and a report a user sends onward should not carry a deployment's internal
+/// addressing.
+Future<String> describeHostResolution(String host) async {
+  try {
+    final addresses =
+        await InternetAddress.lookup(host).timeout(_lookupDeadline);
+    if (addresses.isEmpty) return 'resolved, but to no addresses';
+    final families = addresses.map((a) => a.type.name).toSet().toList()..sort();
+    return 'resolved to ${addresses.length} address(es) '
+        '(${families.join(', ')})';
+  } on TimeoutException {
+    // Distinct from a refusal: the resolver did not answer either way, which
+    // on its own says the lookup is not simply returning NXDOMAIN.
+    return 'no answer within ${_lookupDeadline.inMilliseconds}ms';
+  } on Object catch (e) {
+    return 'lookup failed: ${e.runtimeType}: $e';
+  }
+}

--- a/lib/src/modules/auth/platform/host_resolution_web.dart
+++ b/lib/src/modules/auth/platform/host_resolution_web.dart
@@ -1,0 +1,4 @@
+/// Web has no resolver API, so the browser's own name resolution cannot be
+/// probed separately from the request that failed.
+Future<String> describeHostResolution(String host) async =>
+    'not available on web';

--- a/lib/src/modules/auth/pre_auth_state.dart
+++ b/lib/src/modules/auth/pre_auth_state.dart
@@ -1,8 +1,10 @@
 import 'dart:convert';
-import 'dart:developer' as dev;
 
 import 'package:flutter/foundation.dart' show immutable;
 import 'package:shared_preferences/shared_preferences.dart';
+import 'package:soliplex_logging/soliplex_logging.dart';
+
+final Logger _logger = LogManager.instance.getLogger('soliplex.pre_auth_state');
 
 /// State saved before OAuth redirect.
 ///
@@ -151,7 +153,13 @@ abstract final class PreAuthStateStorage {
       }
       return state;
     } catch (e, st) {
-      dev.log('Failed to load pre-auth state', error: e, stackTrace: st);
+      // Warning, not info: the state is cleared right after, so a sign-in
+      // already in flight loses its return target.
+      _logger.warning(
+        'Failed to load pre-auth state',
+        error: e,
+        stackTrace: st,
+      );
       await clear();
       return null;
     }

--- a/lib/src/modules/auth/selected_server_storage.dart
+++ b/lib/src/modules/auth/selected_server_storage.dart
@@ -1,6 +1,8 @@
-import 'dart:developer' as dev;
-
 import 'package:shared_preferences/shared_preferences.dart';
+import 'package:soliplex_logging/soliplex_logging.dart';
+
+final Logger _logger =
+    LogManager.instance.getLogger('soliplex.selected_server_storage');
 
 /// Persists the id of the active server so the lobby can restore the
 /// selection across launches.
@@ -35,11 +37,11 @@ abstract final class SelectedServerStorage {
         await prefs.setString(_key, serverId);
       }
     } catch (e, st) {
-      dev.log(
-        'Failed to persist selected server ($serverId)',
+      _logger.error(
+        'Failed to persist the selected server',
         error: e,
         stackTrace: st,
-        level: 1000,
+        attributes: {'serverId': serverId},
       );
     }
   }

--- a/lib/src/modules/auth/server_logout.dart
+++ b/lib/src/modules/auth/server_logout.dart
@@ -1,14 +1,15 @@
-import 'dart:developer' as dev;
-
 import 'package:flutter/foundation.dart' show kIsWeb;
 import 'package:flutter/services.dart' show PlatformException;
 import 'package:soliplex_agent/soliplex_agent.dart'
     show SoliplexHttpClient, fetchOidcDiscoveryDocument;
 import 'package:soliplex_client/soliplex_client.dart' show SoliplexException;
+import 'package:soliplex_logging/soliplex_logging.dart';
 
 import 'auth_tokens.dart';
 import 'platform/auth_flow.dart';
 import 'server_entry.dart';
+
+final Logger _logger = LogManager.instance.getLogger('soliplex.server_logout');
 
 /// Signs [entry] out of its identity provider, clearing the local session.
 ///
@@ -62,10 +63,9 @@ Future<void> logoutServer({
     // specific session and may ignore it, leaving the IdP session alive. Make
     // that degraded outcome observable rather than passing an empty hint
     // silently.
-    dev.log(
-      'Logout: active session has no id_token; RP-initiated logout omits '
-      'id_token_hint and the IdP may not end its session.',
-      level: 900,
+    _logger.warning(
+      'Active session has no id_token; RP-initiated logout omits '
+      'id_token_hint and the IdP may not end its session',
     );
   }
 
@@ -87,10 +87,9 @@ Future<void> logoutServer({
       // logout is impossible — local state is cleared but the IdP's SSO
       // session stays alive. Make that partial logout observable instead of a
       // silent no-op.
-      dev.log(
+      _logger.warning(
         'Web logout: provider has no end_session_endpoint; cleared local '
-        'session only, IdP session not ended.',
-        level: 900,
+        'session only, IdP session not ended',
       );
     }
     await authFlow.endSession(

--- a/lib/src/modules/auth/server_manager.dart
+++ b/lib/src/modules/auth/server_manager.dart
@@ -174,6 +174,17 @@ class ServerManager {
       throw StateError('No server entry for "$serverId"');
     }
 
+    // Deliberate, destructive, and the only in-app action that clears a
+    // server's stored credentials — so it belongs on the timeline of a field
+    // report at a level a release build keeps.
+    _logger.warning(
+      'Removing a server and its stored session',
+      attributes: {
+        'serverId': serverId,
+        'alias': entry.alias,
+        'session': entry.auth.session.value.runtimeType.toString(),
+      },
+    );
     _aliases.remove(entry.alias);
     _subscriptions.remove(serverId)?.call();
 
@@ -247,6 +258,42 @@ class ServerManager {
       }
     } finally {
       _restoring = false;
+    }
+    _logger.info(
+      'Restored ${_servers.value.length} server(s)',
+      attributes: {
+        'entries': [
+          for (final e in _servers.value.values)
+            {
+              'serverId': e.serverId,
+              'alias': e.alias,
+              'serverUrl': e.serverUrl.toString(),
+              'session': e.auth.session.value.runtimeType.toString(),
+              // isConnected is `!requiresAuth || isAuthenticated`, so a
+              // no-auth entry reads as connected whatever its session says.
+              'requiresAuth': e.requiresAuth,
+              'isConnected': e.isConnected,
+            },
+        ],
+      },
+    );
+    // The summary above is informational, so a release build drops it. A
+    // server restored as connected on credentials that already expired is a
+    // different matter: it makes the app open as if signed in and every call
+    // then fails, so it is recorded at a level that survives to a field
+    // report.
+    for (final entry in _servers.value.values) {
+      if (entry.auth.session.value case ActiveSession(:final tokens)
+          when tokens.expiresAt.isBefore(DateTime.now())) {
+        _logger.warning(
+          'Restored a server as connected on already-expired credentials',
+          attributes: {
+            'serverId': entry.serverId,
+            'alias': entry.alias,
+            'expiredAt': tokens.expiresAt.toIso8601String(),
+          },
+        );
+      }
     }
   }
 

--- a/lib/src/modules/auth/server_storage.dart
+++ b/lib/src/modules/auth/server_storage.dart
@@ -1,8 +1,9 @@
-import 'dart:developer' as dev;
-
 import 'package:shared_preferences/shared_preferences.dart';
+import 'package:soliplex_logging/soliplex_logging.dart';
 
 import 'auth_tokens.dart';
+
+final Logger _logger = LogManager.instance.getLogger('soliplex.server_storage');
 
 /// Data persisted per server for session restoration.
 sealed class PersistedServer {
@@ -34,7 +35,10 @@ sealed class PersistedServer {
       );
     }
     if (providerJson != null || tokensJson != null) {
-      dev.log('Partial auth data for $serverUrl — treating as unauthenticated');
+      _logger.warning(
+        'Partial auth data; treating the server as unauthenticated',
+        attributes: {'serverUrl': serverUrl},
+      );
     }
     return KnownServer(
       serverUrl: serverUrl,
@@ -128,8 +132,11 @@ Future<void> clearServersIfFreshInstall(ServerStorage storage) async {
       await storage.delete(serverId);
     }
   } catch (e, st) {
-    dev.log('Failed to clear servers on fresh install',
-        error: e, stackTrace: st);
+    _logger.warning(
+      'Failed to clear servers on fresh install',
+      error: e,
+      stackTrace: st,
+    );
   }
   await prefs.setBool(_freshInstallKey, true);
 }

--- a/lib/src/modules/auth/ui/auth_callback_screen.dart
+++ b/lib/src/modules/auth/ui/auth_callback_screen.dart
@@ -1,8 +1,7 @@
-import 'dart:developer' as dev;
-
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
+import 'package:soliplex_logging/soliplex_logging.dart';
 
 import '../../../core/routes.dart';
 import '../auth_failure_description.dart';
@@ -17,6 +16,9 @@ import '../server_entry.dart';
 import '../server_manager.dart';
 import 'home_shell.dart';
 import 'package:soliplex_design/soliplex_design.dart';
+
+final Logger _logger =
+    LogManager.instance.getLogger('soliplex.auth_callback_screen');
 
 class AuthCallbackScreen extends ConsumerStatefulWidget {
   const AuthCallbackScreen({
@@ -53,7 +55,10 @@ class _AuthCallbackScreenState extends ConsumerState<AuthCallbackScreen> {
           _fail('No callback parameters received.');
           return;
         case WebCallbackError(:final error):
-          dev.log('Auth callback returned OAuth error', error: error);
+          _logger.warning(
+            'Auth callback returned an OAuth error',
+            error: error,
+          );
           _fail(describeAuthFailure(
             kind: AuthFailureKind.idpRejected,
             oauthError: error,
@@ -112,11 +117,10 @@ class _AuthCallbackScreenState extends ConsumerState<AuthCallbackScreen> {
 
       if (mounted) context.go(_safeReturnTo(preAuth.frontendReturnTo));
     } catch (e, st) {
-      dev.log(
+      _logger.error(
         'Auth callback failed',
         error: e,
         stackTrace: st,
-        level: 1000,
       );
       _fail('Something went wrong. Please try again.');
     }
@@ -135,16 +139,16 @@ class _AuthCallbackScreenState extends ConsumerState<AuthCallbackScreen> {
     if (returnTo.startsWith('//') ||
         returnTo.startsWith('http://') ||
         returnTo.startsWith('https://')) {
-      dev.log(
-        'Rejected returnTo (open-redirect target): $returnTo',
-        level: 900,
+      _logger.warning(
+        'Rejected returnTo (open-redirect target)',
+        attributes: {'returnTo': returnTo},
       );
       return AppRoutes.lobby;
     }
     if (!returnTo.startsWith('/')) {
-      dev.log(
-        'Rejected returnTo (not an absolute path): $returnTo',
-        level: 800,
+      _logger.info(
+        'Rejected returnTo (not an absolute path)',
+        attributes: {'returnTo': returnTo},
       );
       return AppRoutes.lobby;
     }

--- a/lib/src/modules/lobby/ui/server_sidebar.dart
+++ b/lib/src/modules/lobby/ui/server_sidebar.dart
@@ -1,9 +1,8 @@
-import 'dart:developer' as dev;
-
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:signals_flutter/signals_flutter.dart';
+import 'package:soliplex_logging/soliplex_logging.dart';
 
 import '../../../../version.dart';
 import '../../../core/app_identity.dart';
@@ -15,6 +14,8 @@ import '../../auth/server_logout.dart';
 import '../../auth/server_manager.dart';
 import '../lobby_state.dart';
 import 'package:soliplex_design/soliplex_design.dart';
+
+final Logger _logger = LogManager.instance.getLogger('soliplex.server_sidebar');
 
 class ServerSidebar extends StatelessWidget {
   const ServerSidebar({
@@ -420,7 +421,11 @@ class _ServerTileMenuState extends ConsumerState<_ServerTileMenu> {
     try {
       await Clipboard.setData(ClipboardData(text: address));
     } on Exception catch (e, st) {
-      dev.log('Clipboard.setData failed', error: e, stackTrace: st);
+      _logger.warning(
+        'Clipboard.setData failed',
+        error: e,
+        stackTrace: st,
+      );
       messenger.showSnackBar(
         const SnackBar(content: Text('Could not copy server address')),
       );
@@ -455,8 +460,11 @@ class _ServerTileMenuState extends ConsumerState<_ServerTileMenu> {
           // The user chose to remove despite a failing sign-out; honour it and
           // drop the entry, logging the swallowed error (the IdP session may
           // outlive the entry — the accepted cost of the escape hatch).
-          dev.log('Logout failed; removing server anyway',
-              error: e, stackTrace: st);
+          _logger.warning(
+            'Logout failed; removing the server anyway',
+            error: e,
+            stackTrace: st,
+          );
           widget.serverManager.removeServer(widget.entry.serverId);
           return;
         case _AfterLogout.keep:
@@ -466,7 +474,7 @@ class _ServerTileMenuState extends ConsumerState<_ServerTileMenu> {
           // and, via [_LogoutFailure.removalWasIntended], in the surfaced
           // message.
           final removalWasIntended = then == _AfterLogout.removeOnSuccess;
-          dev.log(
+          _logger.warning(
             removalWasIntended ? 'Logout failed; server kept' : 'Logout failed',
             error: e,
             stackTrace: st,

--- a/lib/src/modules/room/composer_persistence.dart
+++ b/lib/src/modules/room/composer_persistence.dart
@@ -1,7 +1,10 @@
 import 'dart:async' show unawaited;
-import 'dart:developer' as dev;
+import 'package:soliplex_logging/soliplex_logging.dart';
 
 import '../auth/return_to_storage.dart';
+
+final Logger _logger =
+    LogManager.instance.getLogger('soliplex.composer_persistence');
 
 /// Persists [draft] so it survives the route guard's redirect on auth
 /// expiry. Build it with `encodeComposerDraft`, which keeps every image's
@@ -24,11 +27,10 @@ void persistComposerDraft({
       roomId: roomId,
       unsentText: draft,
     ).catchError((Object e, StackTrace st) {
-      dev.log(
+      _logger.error(
         'Failed to persist composer draft for auth roundtrip',
         error: e,
         stackTrace: st,
-        level: 1000,
       );
     }),
   );

--- a/lib/src/modules/room/room_state.dart
+++ b/lib/src/modules/room/room_state.dart
@@ -1,7 +1,7 @@
 import 'dart:async' show unawaited;
-import 'dart:developer' as dev;
 
 import 'package:soliplex_agent/soliplex_agent.dart';
+import 'package:soliplex_logging/soliplex_logging.dart';
 
 import '../../core/util/debouncer.dart';
 import '../auth/auth_session.dart';
@@ -18,6 +18,8 @@ import 'upload_tracker.dart';
 import 'upload_tracker_registry.dart';
 
 export 'send_error.dart';
+
+final Logger _logger = LogManager.instance.getLogger('soliplex.room_state');
 
 sealed class RoomStatus {}
 
@@ -151,32 +153,26 @@ class RoomState {
     } on PermissionDeniedException catch (error) {
       if (token.isCancelled) return;
       _roomFetchToken = null;
-      dev.log(
+      _logger.warning(
         'getRoom forbidden (403)',
         error: error,
-        name: 'RoomState',
-        level: 900,
       );
       _room.value = RoomFailed(error);
     } on AuthException catch (error) {
       if (token.isCancelled) return;
       _roomFetchToken = null;
-      dev.log(
+      _logger.warning(
         'getRoom hit AuthException; funneling to markSessionExpired',
         error: error,
-        name: 'RoomState',
-        level: 900,
       );
       _auth.markSessionExpired();
     } on Object catch (error, st) {
       if (token.isCancelled) return;
       _roomFetchToken = null;
-      dev.log(
+      _logger.error(
         'getRoom failed',
         error: error,
         stackTrace: st,
-        name: 'RoomState',
-        level: 1000,
       );
       _room.value = RoomFailed(error);
     }
@@ -234,22 +230,18 @@ class RoomState {
       return threadInfo.id;
     } on PermissionDeniedException catch (error) {
       if (_isDisposed) return null;
-      dev.log(
+      _logger.warning(
         'createThread forbidden (403)',
         error: error,
-        name: 'RoomState',
-        level: 900,
       );
       _lastError.value = SendError(error);
       return null;
     } on Object catch (error, st) {
       if (_isDisposed) return null;
-      dev.log(
+      _logger.error(
         'createThread failed',
         error: error,
         stackTrace: st,
-        name: 'RoomState',
-        level: 1000,
       );
       _lastError.value = SendError(error);
       return null;

--- a/lib/src/modules/room/session_spawner.dart
+++ b/lib/src/modules/room/session_spawner.dart
@@ -1,11 +1,14 @@
 import 'dart:async' show unawaited;
-import 'dart:developer' as dev;
 
 import 'package:soliplex_agent/soliplex_agent.dart';
+import 'package:soliplex_logging/soliplex_logging.dart';
 
 import '../auth/auth_session.dart';
 import 'composer_draft.dart';
 import 'send_error.dart';
+
+final Logger _logger =
+    LogManager.instance.getLogger('soliplex.session_spawner');
 
 /// Owns the pending-spawn state machine shared by [ThreadViewState] and
 /// [RoomState].
@@ -82,21 +85,17 @@ class SessionSpawner {
       succeeded = true;
     } on PermissionDeniedException catch (error) {
       if (_cancelled || isDisposed()) return;
-      dev.log(
+      _logger.warning(
         'Spawn forbidden (403)',
         error: error,
-        name: 'SessionSpawner',
-        level: 900,
       );
       errorSignal.value =
           SendError(error, unsentText: encodeComposerDraft(prompt));
     } on AuthException catch (error) {
       if (_cancelled || isDisposed()) return;
-      dev.log(
+      _logger.warning(
         'Spawn hit AuthException; funneling to markSessionExpired',
         error: error,
-        name: 'SessionSpawner',
-        level: 900,
       );
       // The persistence callback runs first so the caller can save
       // state the redirect would otherwise drop, but a throw here must
@@ -104,12 +103,10 @@ class SessionSpawner {
       try {
         onAuthExpired?.call(prompt);
       } catch (callbackError, st) {
-        dev.log(
+        _logger.error(
           'onAuthExpired callback threw; continuing to markSessionExpired',
           error: callbackError,
           stackTrace: st,
-          name: 'SessionSpawner',
-          level: 1000,
         );
       }
       _auth.markSessionExpired();
@@ -117,12 +114,10 @@ class SessionSpawner {
       if (_cancelled || isDisposed()) return;
       // The banner shows only `error.toString()`, so an unanticipated failure
       // leaves no other trace of where it came from.
-      dev.log(
+      _logger.error(
         'Spawn failed',
         error: error,
         stackTrace: st,
-        name: 'SessionSpawner',
-        level: 1000,
       );
       errorSignal.value =
           SendError(error, unsentText: encodeComposerDraft(prompt));
@@ -153,23 +148,19 @@ class SessionSpawner {
           // caller is gone, but the auth state machine is the
           // singleton funnel and still needs the signal — otherwise
           // the next interaction continues with a dead session.
-          dev.log(
+          _logger.warning(
             'Cancelled spawn cleanup hit AuthException; '
             'funneling to markSessionExpired',
             error: e,
             stackTrace: st,
-            name: 'SessionSpawner',
-            level: 900,
           );
           _auth.markSessionExpired();
           return;
         }
-        dev.log(
+        _logger.warning(
           'Cancelled spawn cleanup failed',
           error: e,
           stackTrace: st,
-          name: 'SessionSpawner',
-          level: 900,
         );
       }),
     );

--- a/lib/src/modules/room/thread_view_state.dart
+++ b/lib/src/modules/room/thread_view_state.dart
@@ -1,7 +1,7 @@
 import 'dart:async' show unawaited;
-import 'dart:developer' as dev;
 
 import 'package:soliplex_agent/soliplex_agent.dart';
+import 'package:soliplex_logging/soliplex_logging.dart';
 
 import '../auth/auth_session.dart';
 import '../auth/auth_tokens.dart';
@@ -17,6 +17,9 @@ import 'session_spawner.dart';
 import 'tool_calls_extension.dart';
 
 export 'send_error.dart';
+
+final Logger _logger =
+    LogManager.instance.getLogger('soliplex.thread_view_state');
 
 sealed class ThreadViewStatus {}
 
@@ -197,12 +200,10 @@ class ThreadViewState {
           .submitFeedback(_roomId, threadId, runId, feedback, reason: reason)
           .then((_) {}, onError: (Object e, StackTrace st) {
         if (e is AuthException) {
-          dev.log(
+          _logger.warning(
             'submitFeedback hit AuthException; funneling to markSessionExpired',
             error: e,
             stackTrace: st,
-            name: 'ThreadViewState',
-            level: 900,
           );
           _auth.markSessionExpired();
           return;
@@ -210,12 +211,10 @@ class ThreadViewState {
         // Fire-and-forget UX: surface nothing inline (thumbs-up is
         // ambient), but keep the failure debuggable so 5xx / decode /
         // programmer errors don't vanish.
-        dev.log(
+        _logger.warning(
           'Feedback submission failed',
           error: e,
           stackTrace: st,
-          name: 'ThreadViewState',
-          level: 900,
         );
       }),
     );
@@ -316,11 +315,9 @@ class ThreadViewState {
           // Both reasons surface to the user only as a friendly string.
           // Without this log, the underlying error and stack are
           // unrecoverable for diagnosis.
-          dev.log(
+          _logger.error(
             'Thread run failed: ${reason.name}',
             error: error,
-            name: 'ThreadViewState',
-            level: 1000,
           );
         }
         _lastSendError.value = SendError(_friendlyMessage(reason, error));
@@ -445,13 +442,11 @@ class ThreadViewState {
     } on PermissionDeniedException catch (error) {
       if (token.isCancelled) return;
       _cancelToken = null;
-      dev.log(
+      _logger.warning(
         _messages.value is MessagesLoaded
             ? 'Thread history refresh forbidden (403), keeping stale messages'
             : 'Thread history forbidden (403)',
         error: error,
-        name: 'ThreadViewState',
-        level: 900,
       );
       if (_messages.value is! MessagesLoaded) {
         _messages.value = MessagesFailed(error);
@@ -459,11 +454,9 @@ class ThreadViewState {
     } on AuthException catch (error) {
       if (token.isCancelled) return;
       _cancelToken = null;
-      dev.log(
+      _logger.warning(
         'Thread history hit AuthException; funneling to markSessionExpired',
         error: error,
-        name: 'ThreadViewState',
-        level: 900,
       );
       _auth.markSessionExpired();
     } on Object catch (error) {

--- a/lib/src/modules/room/ui/document_picker.dart
+++ b/lib/src/modules/room/ui/document_picker.dart
@@ -1,12 +1,14 @@
-import 'dart:developer' as developer;
-
 import 'package:flutter/material.dart';
 import 'package:soliplex_client/soliplex_client.dart' hide State;
+import 'package:soliplex_logging/soliplex_logging.dart';
 
 import '../../../shared/document_display.dart';
 import 'document_label.dart';
 import 'document_source.dart';
 import 'package:soliplex_design/soliplex_design.dart';
+
+final Logger _logger =
+    LogManager.instance.getLogger('soliplex.document_picker');
 
 class DocumentPicker extends StatefulWidget {
   const DocumentPicker({
@@ -197,7 +199,7 @@ Future<Set<RagDocument>?> showDocumentPicker({
             );
           } else if (snapshot.hasError) {
             canConfirm = false;
-            developer.log(
+            _logger.warning(
               'Failed to load documents',
               error: snapshot.error,
               stackTrace: snapshot.stackTrace,

--- a/lib/src/modules/room/ui/room_info_screen.dart
+++ b/lib/src/modules/room/ui/room_info_screen.dart
@@ -1,11 +1,11 @@
 import 'dart:async' show unawaited;
-import 'dart:developer' as dev;
 
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
 import 'package:signals_flutter/signals_flutter.dart';
 import 'package:soliplex_agent/soliplex_agent.dart' hide State;
 import 'package:soliplex_client/soliplex_client.dart' hide Room, State;
+import 'package:soliplex_logging/soliplex_logging.dart';
 
 import '../pick_file.dart';
 
@@ -25,6 +25,9 @@ import 'room_info/skill_card.dart';
 import 'room_info/system_prompt_viewer.dart';
 import '../../../shared/selectable_content.dart';
 import 'package:soliplex_design/soliplex_design.dart';
+
+final Logger _logger =
+    LogManager.instance.getLogger('soliplex.room_info_screen');
 
 class RoomInfoScreen extends StatefulWidget {
   const RoomInfoScreen({
@@ -400,12 +403,10 @@ class _UploadedFilesCardState extends State<_UploadedFilesCard> {
       result = await pick();
     } on PickFilePickerException catch (e, st) {
       if (!mounted) return;
-      dev.log(
+      _logger.error(
         'Pick failed',
         error: e.cause,
         stackTrace: st,
-        name: 'RoomInfoScreen',
-        level: 1000,
       );
       _tracker.recordClientError(
         roomId: widget.roomId,
@@ -416,11 +417,10 @@ class _UploadedFilesCardState extends State<_UploadedFilesCard> {
     }
     if (result == null || !mounted) return;
     for (final itemError in result.errors) {
-      dev.log(
-        'Pick failed for ${itemError.filename}',
+      _logger.error(
+        'Pick failed',
         error: itemError.cause,
-        name: 'RoomInfoScreen',
-        level: 1000,
+        attributes: {'filename': itemError.filename},
       );
       _tracker.recordClientError(
         roomId: widget.roomId,

--- a/lib/src/modules/room/upload_tracker.dart
+++ b/lib/src/modules/room/upload_tracker.dart
@@ -1,13 +1,15 @@
 import 'dart:async' show unawaited;
 import 'dart:collection' show Queue;
-import 'dart:developer' as dev;
 import 'dart:io' show FileSystemException, SocketException;
 
 import 'package:signals_flutter/signals_flutter.dart';
 import 'package:soliplex_client/soliplex_client.dart';
+import 'package:soliplex_logging/soliplex_logging.dart';
 
 import '../auth/auth_session.dart';
 import '../auth/auth_tokens.dart';
+
+final Logger _logger = LogManager.instance.getLogger('soliplex.upload_tracker');
 
 /// Sealed status for a single upload scope (a room or a thread).
 ///
@@ -353,21 +355,18 @@ class UploadTracker {
       // no longer the UX channel for an auth failure.
       if (token.isCancelled || _isDisposed) return;
       scope.fetchToken = null;
-      dev.log(
+      _logger.warning(
         'Upload list refresh hit AuthException; funneling to markSessionExpired',
         error: error,
-        name: 'UploadTracker',
-        level: 900,
       );
       _auth.markSessionExpired();
     } on SoliplexException catch (error) {
       if (token.isCancelled || _isDisposed) return;
       scope.fetchToken = null;
       if (scope.signal.value is UploadsLoaded) {
-        dev.log(
+        _logger.warning(
           'Upload list refresh failed, keeping stale list',
           error: error,
-          name: 'UploadTracker',
         );
       } else {
         scope.signal.value = UploadsFailed(error);
@@ -379,12 +378,10 @@ class UploadTracker {
       // fetchToken, wedging future refreshes. Wrap and surface.
       if (token.isCancelled || _isDisposed) return;
       scope.fetchToken = null;
-      dev.log(
+      _logger.error(
         'Unexpected error in upload list refresh',
         error: error,
         stackTrace: stackTrace,
-        name: 'UploadTracker',
-        level: 1000,
       );
       if (scope.signal.value is UploadsLoaded) {
         return;
@@ -635,10 +632,9 @@ class UploadTracker {
           // The next attempt re-invokes openStream() (via runPost) and
           // re-enters the auth-aware HTTP stack, which gets a fresh
           // proactive refresh.
-          dev.log(
+          _logger.warning(
             'Upload hit 401; retrying with a fresh stream',
             error: error,
-            name: 'UploadTracker',
           );
           continue;
         }
@@ -654,12 +650,10 @@ class UploadTracker {
           // Non-Soliplex throw indicates a bug (e.g., TypeError from a
           // mapper, StateError from a plugin). Log loudly; the user
           // still sees a Failed row via uploadErrorMessage's fallback.
-          dev.log(
+          _logger.error(
             'Unexpected error during upload POST',
             error: error,
             stackTrace: stackTrace,
-            name: 'UploadTracker',
-            level: 1000,
           );
         }
         _markFailed(scope, id, error);
@@ -674,11 +668,9 @@ class UploadTracker {
       // The dismiss path shouldn't be reachable (UI dismisses only
       // Failed rows); log loudly if it ever fires so the swallowed
       // exception is investigated.
-      dev.log(
+      _logger.error(
         'Upload completed after its pending record was removed',
         error: error,
-        name: 'UploadTracker',
-        level: 1000,
       );
       return;
     }

--- a/test/core/log_sinks_test.dart
+++ b/test/core/log_sinks_test.dart
@@ -6,7 +6,7 @@ import 'package:soliplex_frontend/src/core/log_sinks.dart';
 void main() {
   tearDown(LogManager.instance.reset);
 
-  test('installLogSinks registers a console sink and a stdout sink', () {
+  test('installLogSinks registers console, stdout, and memory sinks', () {
     installLogSinks(LogManager.instance);
 
     final sinks = LogManager.instance.sinks;
@@ -15,5 +15,10 @@ void main() {
     // of what's attached to the process.
     expect(sinks.whereType<ConsoleSink>(), hasLength(1));
     expect(sinks.whereType<StdoutSink>(), hasLength(1));
+    // The memory sink is the only one that survives a native release build —
+    // the other two ride transports a packaged AOT app does not have — so it
+    // is what the in-app diagnostics screen reads. Losing it silently disables
+    // field diagnosis entirely, which is why it is pinned here.
+    expect(sinks.whereType<MemorySink>(), hasLength(1));
   });
 }

--- a/test/modules/auth/platform/host_resolution_test.dart
+++ b/test/modules/auth/platform/host_resolution_test.dart
@@ -1,0 +1,28 @@
+@TestOn('vm')
+library;
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:soliplex_frontend/src/modules/auth/platform/host_resolution.dart';
+
+void main() {
+  test('a name that does not resolve is reported as a lookup failure',
+      () async {
+    // .invalid is reserved by RFC 2606 precisely so it can never resolve.
+    final description =
+        await describeHostResolution('nonexistent.example.invalid');
+
+    expect(description, startsWith('lookup failed:'));
+  });
+
+  test('a name that resolves reports a count and family, not addresses',
+      () async {
+    // Loopback resolves without leaving the machine, so this does not depend
+    // on the network the suite runs on.
+    final description = await describeHostResolution('localhost');
+
+    expect(description, startsWith('resolved to'));
+    expect(description, contains('address(es)'));
+    // The addresses themselves stay out of the report.
+    expect(description, isNot(contains('127.0.0.1')));
+  });
+}


### PR DESCRIPTION
## What

A user who cannot sign in, or cannot reach a server, saw one friendly sentence and left nothing behind. Everything the app logged went through `dart:developer`, whose entries only exist while a VM service is attached — so in a packaged release build, which is where these failures actually get reported, none of it was readable. This PR fixes the transport and then records the things worth having.

Four commits, each independently green:

1. **`412e8ba9` install a sink a release build can read back** — `MemorySink` joins Console and Stdout. Console needs an attached VM service; Stdout goes to a terminal a packaged GUI launch doesn't have. The memory sink is the only one whose output can be read back in-process. Also fixes the doc, which said "Two sinks" and "Both register in every build mode" with three registered, and listed them out of registration order.
2. **`13a6d22a` route every log record through LogManager** — 17 files, 19 call sites. `dart:developer` is now gone from `lib/` entirely.
3. **`75b4d042` record what a failed connect actually did** — the probe, `ServerManager` restore, and `ConnectFlow`'s stale-session path.
4. **`7aa2ac5b`** — CHANGELOG.

## Why these records

A failed connect had three causes that looked identical from the UI: a name that does not resolve, a name that resolves while something above DNS blocks the request, and a session the app already believes is live.

- **The probe** records every candidate address it tried, the platform error behind the friendly message (`NSURLErrorDomain` plus a numeric code names a failure far more precisely than a localized sentence), and elapsed time. It also asks the platform resolver directly, which is the discriminator `NSURLErrorCannotFindHost` cannot give on its own — that error comes from the URL loading system and conflates a real resolver failure with anything else in that stack preventing a lookup.
- **`ServerManager`** logs what it restored, and escalates a server restored as connected on credentials that had already expired — that opens the app as if signed in and then fails every call.
- **`ConnectFlow`** logs reporting an existing session as connected without contacting the IdP. Benign when the session is live, but it's also how a stale `isConnected` strands someone: every retry succeeds locally and no sign-in is ever attempted.

## Notes for review

**Level mapping.** 900 → `warning`, 1000 → `error`, 800 → `info`, mechanically. Calls that passed *no* level needed a judgement call each, because release is floored at `warning` — `info` records do not exist in the build that matters. I sent failures the user actually hit to `warning` (clipboard failure, logout failure, partial auth data, pre-auth load failure — that one clears state, so a sign-in in flight loses its return target) and left only the benign `returnTo`-not-absolute case at `info`. Worth a second opinion on those.

**The resolver lookup is awaited, deliberately.** I first made it fire-and-forget so it couldn't delay the failure the user is waiting on. That was wrong: it leaves the lookup's timer outliving its caller, which two `home_screen_test` cases correctly catch as a pending timer after the widget tree is disposed. Any "off the return path" variant leaks that timer by construction. The real complaint was the *size* of the delay, so the deadline is 500ms rather than 3s — imperceptible next to a probe that has already spent seconds failing — and a resolver that needs longer gets its own distinct record (`no answer within 500ms`) instead of being reported as a generic lookup failure.

**Placement.** The `host_resolution` trio lives in `auth/platform/` with the other platform splits, named `_native`/`_web` to match `auth_flow_native` and `callback_service_native` in that directory.

**Scope note.** The migration deliberately covers the whole of `lib/`, not just the auth path. Leaving any `dev.log` behind would mean this PR claims a readable transport while the most relevant code — `auth_callback_screen`, 4 call sites on the OAuth callback — still had none.

## Verification

- `flutter analyze --fatal-infos` — clean, and run per-commit in isolation by the pre-commit hook, so the stack is bisectable
- `flutter test` — 2389 passing
- `dart format`, `markdownlint-cli2` — clean

Second of three PRs. #517 (the rename) is merged; the diagnostics screen's Logs pane and exportable report follow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)