### PR TITLE
feat(diagnostics): show the app's log records beside the requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,24 @@ Versions follow the `version+build` scheme from `pubspec.yaml`, bumped via
 
 ### Changed
 
+- The Diagnostics screen now shows the app's own log records beside the
+  network requests, and can save both as a single plain-text report. The
+  records are the half of a failure the request list cannot show — why a probe
+  gave up, what the platform error behind a friendly message actually was,
+  whether a name resolves — and reading them used to mean attaching a debugger
+  or launching from a terminal, neither of which is true of an installed app
+  on a device. A `Requests` / `Logs` switch chooses the pane; clearing takes
+  whichever one is showing, while the saved report always carries both,
+  unfiltered, so nothing looks absent that was only filtered out. The report
+  gives every exchange an outcome, including one still in flight, since a
+  request that never came back is usually the reason for saving a report at
+  all, and it times everything in UTC so it can be read beside a server's own
+  logs. The sign-in screen's ⓘ button becomes a ⋮ menu offering Diagnostics
+  and Versions, the same pair the room and lobby menus already offer, so the
+  screen can be reached without a connected server — a user who cannot sign in
+  has no route through the lobby, and that is exactly when the records are
+  worth reading.
+
 - A failed sign-in or connection now leaves a record behind. Until now the app
   logged through `dart:developer`, whose entries only exist while a debugger is
   attached, so nothing survived in the builds where these failures actually get

--- a/docs/diagnostics-known-risks.md
+++ b/docs/diagnostics-known-risks.md
@@ -1,0 +1,89 @@
+# Diagnostics screen: known risks
+
+What the in-app Diagnostics screen and its saved report do *not* guarantee, and
+what has never been executed. Written when the Logs pane and the report landed,
+so the open questions are recorded rather than rediscovered.
+
+## Log records are not redacted
+
+HTTP capture is redacted before any observer sees it: `HttpRedactor` replaces
+the values of `Authorization`, cookies and token-bearing query parameters, and
+also redacts request bodies, SSE content and error strings
+(`ObservableHttpClient`). The names remain, the secrets do not.
+
+**Nothing redacts log records.** `installLogSinks` adds a bare `MemorySink`,
+and `formatLogRecord` applies no redaction. Two consequences:
+
+- Every `attributes:` site in the app today carries deployment detail —
+  `discoveryUrl`, `serverUrl`, `hosts`, `alias`, `expiresAt`, `session`,
+  `platformError`, `elapsedMs`, `returnTo`. None carries a credential.
+  (`accessToken` / `refreshToken` / `idToken` appear in the codebase only as
+  token-storage JSON keys, never as log attributes.)
+- `error:` takes an arbitrary object. An IdP or plugin exception whose
+  `toString()` embeds a raw token response would reach the buffer, the Logs
+  pane, and the saved file.
+
+The screen is in `_publicPaths`, so this is readable and savable without a
+session — deliberately, since a user who cannot sign in is who it is for.
+
+The standard is therefore author discipline plus a comment at the route.
+Nothing fails CI when someone logs a secret. **Open question: whether
+`LogRecord` should get a redaction pass before this is on many devices.**
+
+## The report is built synchronously on the UI thread
+
+`buildDiagnosticsReport` walks up to 1000 grouped exchanges and 2000 log
+records — with stack traces — into one string, then `utf8.encode` doubles it in
+memory, all in one frame. The busiest sessions are exactly the ones worth
+reporting.
+
+The action disables itself while running, so it cannot double-fire, but there
+is no progress affordance and no isolate. **This has never been measured.**
+
+## The save timeout can be wrong about a slow save
+
+`FilePicker.saveFile` is bounded at five minutes, because a platform future
+that never completes would leave the in-flight guard set and the action dead
+with nothing logged (Android's picker has result codes it never resolves).
+
+`Future.timeout` does not cancel the underlying call. A user browsing to a
+network share, or using Android SAF over a cloud provider, can exceed the bound
+with the dialog still open: the screen then says the dialog did not answer, and
+if they finish it the file writes correctly while a stamped notice says
+otherwise. Late completions are logged, so the record is recoverable.
+
+Five minutes is a chosen number, not a measured one.
+
+## Web export has never been executed
+
+`kIsWeb` is a compile-time constant, so no VM test reaches the web branches.
+The behaviour is reasoned from `file_picker`'s web implementation: it dispatches
+an anchor click and returns null unconditionally, with no cancellation concept
+and no way to observe whether the browser delivered the download. The screen
+therefore claims only that a download started.
+
+## iOS may retain a copy of every cancelled save
+
+`file_picker`'s iOS plugin appears to write the bytes into app storage *before*
+presenting the export picker, and returns nil on cancel. If so, each cancelled
+save leaves a complete report — hostnames, discovery URLs, log records — on
+disk under a timestamped name that nothing deletes, outside the reasoning at
+`_publicPaths`.
+
+Unverified: this was read from the plugin's Objective-C, not exercised.
+**Open question: confirm, and clean up on the cancel path if it holds.**
+
+## Smaller, recorded rather than fixed
+
+- The report's `Requests captured: N` counts the groups it renders.
+  `groupHttpEvents` drops orphans — exchanges whose start event the bounded
+  buffer evicted — so a busy streaming session can omit exchanges without
+  saying so.
+- `HttpResponseEvent.reasonPhrase` is captured and never printed, so a server's
+  own status text does not reach the report. `bodySize` is printed.
+- `formatLogRecord` collapses line breaks in the message, attributes and error,
+  but stack-trace frames are split on `\n` only and not sanitised. Every trace
+  today is VM-generated, so no frame contains a stray `\r`.
+- `capturedLogSink` returns the first `MemorySink` when several are installed.
+  This app installs one; a host app that installs two gets the
+  earlier-registered one and no warning.

--- a/lib/src/core/ui/menu_row.dart
+++ b/lib/src/core/ui/menu_row.dart
@@ -1,0 +1,42 @@
+import 'package:flutter/material.dart';
+
+import 'package:soliplex_design/soliplex_design.dart';
+
+/// One icon-and-label row inside a popup menu, so every ⋮ menu in the app is
+/// styled the same and a row added to one does not have to be styled again in
+/// the others.
+class MenuRow extends StatelessWidget {
+  const MenuRow({
+    required this.icon,
+    required this.label,
+    this.destructive = false,
+    super.key,
+  });
+
+  final IconData icon;
+  final String label;
+
+  /// Tints the row with `colorScheme.error` for a destructive action.
+  final bool destructive;
+
+  @override
+  Widget build(BuildContext context) {
+    final color = destructive ? Theme.of(context).colorScheme.error : null;
+    return Row(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        Icon(icon, size: 20, color: color),
+        const SizedBox(width: SoliplexSpacing.s3),
+        // Flexible so a long label can't overflow the menu's width; the menu
+        // widens to fit when there's room.
+        Flexible(
+          child: Text(
+            label,
+            overflow: TextOverflow.ellipsis,
+            style: color == null ? null : TextStyle(color: color),
+          ),
+        ),
+      ],
+    );
+  }
+}

--- a/lib/src/modules/auth/auth_module.dart
+++ b/lib/src/modules/auth/auth_module.dart
@@ -19,6 +19,19 @@ const _publicPaths = {
   AppRoutes.home,
   AppRoutes.authCallback,
   AppRoutes.versions,
+  // A user who cannot sign in is unauthenticated by definition, and this
+  // screen is where the failure is visible. Guarding it would put the
+  // diagnosis out of reach of exactly the session that needs it.
+  //
+  // What that exposes without a session: request metadata, already redacted at
+  // capture (HttpRedactor replaces the values of Authorization, cookies and
+  // token-bearing query parameters), and log records, which are not redacted
+  // by anything.
+  // Those carry server and discovery URLs, hostnames and token expiry times —
+  // deployment detail, not credentials — and the release level floor keeps
+  // them to warnings and above. Nothing enforces that, so a logger that starts
+  // recording a secret makes it readable here.
+  AppRoutes.diagnostics,
 };
 
 class AuthAppModule extends AppModule {

--- a/lib/src/modules/auth/connect_flow.dart
+++ b/lib/src/modules/auth/connect_flow.dart
@@ -379,7 +379,7 @@ class ConnectFlow {
       }
     } on Exception catch (e, st) {
       _logger.error(
-        '_authenticate failed',
+        'Authentication failed',
         error: e,
         stackTrace: st,
       );

--- a/lib/src/modules/auth/ui/home_shell.dart
+++ b/lib/src/modules/auth/ui/home_shell.dart
@@ -5,6 +5,7 @@ import 'package:soliplex_design/soliplex_design.dart';
 import '../../../../version.dart';
 import '../../../core/layout.dart';
 import '../../../core/routes.dart';
+import '../../../core/ui/menu_row.dart';
 
 /// Shared chrome for the unauthenticated onboarding surfaces (home /
 /// connect flow, the OAuth callback, and the server list).
@@ -57,8 +58,8 @@ class HomeShell extends StatelessWidget {
 
 /// The branded top bar shared across the onboarding surfaces (home / connect
 /// flow, the OAuth callback, and the server list) and the versions screens:
-/// logo, app name, library version, and trailing [actions] — followed by an
-/// about/versions button so the bar reads the same everywhere.
+/// logo, app name, library version, and trailing [actions] — followed by the
+/// ⋮ menu of utility destinations so the bar reads the same everywhere.
 class HomeShellHeader extends StatelessWidget {
   const HomeShellHeader({
     super.key,
@@ -66,7 +67,7 @@ class HomeShellHeader extends StatelessWidget {
     this.logo,
     this.leading,
     this.actions,
-    this.showAbout = true,
+    this.showUtilityMenu = true,
   });
 
   final String appName;
@@ -76,13 +77,14 @@ class HomeShellHeader extends StatelessWidget {
   /// pushed sub-pages like the versions screens.
   final Widget? leading;
 
-  /// Trailing actions shown before the about/versions button. Screens like the
-  /// server list slot their navigation here.
+  /// Trailing actions shown before the ⋮ menu. Screens like the server list
+  /// slot their navigation here.
   final List<Widget>? actions;
 
-  /// Whether to show the trailing about/versions button. Off on the versions
-  /// screens themselves, which are already the about destination.
-  final bool showAbout;
+  /// Shows the ⋮ menu of utility destinations. On by default, and off for
+  /// screens that bring their own trailing chrome — the destinations
+  /// themselves, and the room info screen.
+  final bool showUtilityMenu;
 
   static const _logoSize = 24.0;
 
@@ -142,14 +144,47 @@ class HomeShellHeader extends StatelessWidget {
             ),
           ),
           ...?actions,
-          if (showAbout)
-            IconButton(
-              tooltip: 'About & versions',
-              icon: const Icon(Icons.info_outline),
-              onPressed: () => context.push(AppRoutes.versions),
-            ),
+          if (showUtilityMenu) const _UtilityMenu(),
         ],
       ),
+    );
+  }
+}
+
+/// Utility destinations reachable before a server is connected.
+///
+/// The same pair the room rail and lobby sidebar offer in their ⋮ menus, put
+/// where a user who cannot sign in can reach them: the rail and the sidebar
+/// both need a connected server, and a failed sign-in is exactly when the
+/// diagnostics are worth reading.
+enum _UtilityAction { diagnostics, versions }
+
+class _UtilityMenu extends StatelessWidget {
+  const _UtilityMenu();
+
+  @override
+  Widget build(BuildContext context) {
+    return PopupMenuButton<_UtilityAction>(
+      icon: const Icon(Icons.more_vert),
+      tooltip: 'Diagnostics & versions',
+      onSelected: (action) {
+        switch (action) {
+          case _UtilityAction.diagnostics:
+            context.push(AppRoutes.diagnostics);
+          case _UtilityAction.versions:
+            context.push(AppRoutes.versions);
+        }
+      },
+      itemBuilder: (context) => const [
+        PopupMenuItem(
+          value: _UtilityAction.diagnostics,
+          child: MenuRow(icon: Icons.troubleshoot, label: 'Diagnostics'),
+        ),
+        PopupMenuItem(
+          value: _UtilityAction.versions,
+          child: MenuRow(icon: Icons.info_outline, label: 'Versions'),
+        ),
+      ],
     );
   }
 }

--- a/lib/src/modules/diagnostics/log_capture.dart
+++ b/lib/src/modules/diagnostics/log_capture.dart
@@ -1,0 +1,17 @@
+import 'package:soliplex_logging/soliplex_logging.dart';
+
+/// The log records the diagnostics screen shows, alongside the HTTP exchanges
+/// `NetworkInspector` collects.
+///
+/// Null when no [MemorySink] is installed, which is a different thing from a
+/// sink holding no records — a host app embedding this package configures its
+/// own sinks and need not include one, and then there is nothing to show
+/// rather than nothing having happened. Callers are expected to render that
+/// difference, not collapse it.
+///
+/// Returns the first sink when several are installed. [LogManager] permits
+/// that, and this app installs exactly one of these (see `installLogSinks`,
+/// which adds three sinks of which one is a MemorySink), but a host app that
+/// installs two gets the earlier-registered one and no warning.
+MemorySink? capturedLogSink(LogManager manager) =>
+    manager.sinks.whereType<MemorySink>().firstOrNull;

--- a/lib/src/modules/diagnostics/models/diagnostics_report.dart
+++ b/lib/src/modules/diagnostics/models/diagnostics_report.dart
@@ -1,0 +1,155 @@
+import 'package:soliplex_client/soliplex_client.dart';
+
+import '../../../../version.dart';
+import 'http_event_group.dart';
+
+/// Renders the captured traffic and log records as a plain-text report a user
+/// can send to support.
+///
+/// The HTTP sections are redacted at capture time by `HttpRedactor`, which
+/// replaces the values of `Authorization`, cookies and token-bearing query
+/// parameters with a placeholder — the names still appear, the secrets do not.
+/// So they carry hostnames, paths, status codes, timings and error detail, and
+/// no credentials.
+///
+/// The log section is not redacted by anything. What it carries is whatever
+/// the app logs: server and discovery URLs, hostnames, token expiry times.
+/// That is deployment detail rather than credentials, but nothing enforces it,
+/// so a logger that starts recording a secret puts the secret in this report.
+///
+/// Errors are rendered with the underlying platform exception alongside the
+/// friendly message shown in the UI: on Apple platforms
+/// `NSErrorClientException` appends the domain and numeric code (e.g.
+/// `[domain=NSURLErrorDomain, code=-1003]`), which names a failure far more
+/// precisely than its localized sentence.
+///
+/// Every timestamp this function writes is UTC, and the log lines arrive
+/// already formatted that way by `formatLogRecord`. A report is read beside
+/// server logs on another machine, and a local wall-clock time with no offset
+/// cannot be lined up against them.
+String buildDiagnosticsReport({
+  required String appName,
+  required List<HttpEventGroup> groups,
+  required DateTime generatedAt,
+  required List<ConcurrencyWaitEvent> concurrencyEvents,
+
+  /// One entry per record, already rendered by `formatLogRecord`. An entry
+  /// spans several lines when it carries a stack trace.
+  ///
+  /// Null when nothing is collecting records at all, which is a different
+  /// report from one where nothing was recorded — see the log section below.
+  required List<String>? renderedLogRecords,
+  required String logLevel,
+}) {
+  final out = StringBuffer()
+    ..writeln('$appName diagnostics report')
+    ..writeln('Generated: ${_utc(generatedAt)}')
+    ..writeln('App version: $soliplexVersion')
+    ..writeln('Requests captured: ${groups.length}');
+  // Naming the floor keeps a reader from concluding nothing happened when
+  // records below it were simply never recorded — a release build keeps only
+  // warnings and above.
+  out
+    ..writeln('Log level floor: $logLevel')
+    ..writeln();
+
+  if (groups.isEmpty) {
+    out.writeln('No requests captured.');
+  }
+
+  for (final group in groups) {
+    out
+      ..writeln('--- ${group.methodLabel} ${group.uri}')
+      ..writeln('    requestId: ${group.requestId}')
+      // Reads through the group rather than `group.request`, because a
+      // streamed exchange has no request event at all — the same detail
+      // arrives on its stream-start event instead.
+      ..writeln('    sent: ${_utc(group.timestamp)}');
+    for (final header in group.requestHeaders.entries) {
+      out.writeln('    > ${header.key}: ${header.value}');
+    }
+
+    // Written for every exchange, whatever kind, and whether or not it
+    // finished. An exchange still in flight is the reason a report gets
+    // exported at all — a hanging agent run — and printing nothing for it left
+    // the one entry that mattered indistinguishable from a request that came
+    // back empty. `statusDescription` names the outcome and carries the numeric
+    // code where there is one, so no separate line is needed for the code.
+    out.writeln('    outcome: ${group.statusDescription}');
+
+    if (group.response case final response?) {
+      out
+        ..writeln('    duration: ${response.duration.inMilliseconds}ms')
+        // Printed for the same reason a stream's bytesReceived is: without it
+        // a 200 that returned nothing reads exactly like a 200 that returned
+        // the answer.
+        ..writeln('    bodySize: ${response.bodySize}');
+    }
+
+    // A stream carries its timing, its size and its failure detail on
+    // stream-end rather than on a response or error event, so without this arm
+    // an agent run — the traffic most worth reporting — would be named and
+    // given an outcome with nothing to say how long it ran, how much it
+    // returned, or what the platform error behind a failure was.
+    if (group.streamEnd case final end?) {
+      out
+        ..writeln('    duration: ${end.duration.inMilliseconds}ms')
+        ..writeln('    bytesReceived: ${end.bytesReceived}');
+      if (end.error case final error?) {
+        out
+          ..writeln('    STREAM FAILED: $error')
+          ..writeln('    platform: ${error.originalError ?? '-'}');
+      }
+    }
+
+    if (group.error case final error?) {
+      out
+        ..writeln('    FAILED after ${error.duration.inMilliseconds}ms')
+        ..writeln('    error: ${error.exception}')
+        // The wrapped platform error, when there is one, carries the domain
+        // and numeric code the friendly message drops.
+        ..writeln('    platform: ${error.exception.originalError ?? '-'}');
+    }
+
+    out.writeln();
+  }
+
+  // Written even when empty, and distinguishing empty from absent: "no
+  // records", "records were not collected" and a missing section lead a reader
+  // to three different conclusions.
+  if (renderedLogRecords == null) {
+    out.writeln('--- Log records (not collected)');
+    out.writeln('No log sink is installed in this build, so no records were '
+        'kept. Their absence here says nothing about what happened.');
+  } else {
+    out.writeln('--- Log records (${renderedLogRecords.length})');
+    if (renderedLogRecords.isEmpty) {
+      out.writeln('No log records captured.');
+    } else {
+      out.writeAll(renderedLogRecords.map((line) => '$line\n'));
+    }
+  }
+
+  // Always written, for the same reason as the log section: a reader cannot
+  // tell an omitted section from one with nothing in it.
+  out
+    ..writeln()
+    ..writeln('--- Request pool waits (${concurrencyEvents.length})');
+  if (concurrencyEvents.isEmpty) {
+    out.writeln('No requests waited for a pool slot.');
+  } else {
+    // The request pool caps in-flight requests, so a queued request can look
+    // slow for reasons that have nothing to do with the server it is calling.
+    for (final event in concurrencyEvents) {
+      out.writeln('    ${_utc(event.timestamp)} '
+          'waited ${event.waitDuration.inMilliseconds}ms '
+          '(queue depth ${event.queueDepthAtEnqueue}, '
+          'slots in use ${event.slotsInUseAfterAcquire}) '
+          '${event.uri}');
+    }
+  }
+
+  return out.toString();
+}
+
+String _utc(DateTime at) => at.toUtc().toIso8601String();

--- a/lib/src/modules/diagnostics/models/log_record_format.dart
+++ b/lib/src/modules/diagnostics/models/log_record_format.dart
@@ -1,0 +1,59 @@
+import 'package:soliplex_logging/soliplex_logging.dart';
+
+/// Renders a [LogRecord] as one plain-text line for the diagnostics screen,
+/// and optionally with its stack trace across following lines for the exported
+/// report.
+///
+/// The package's own `formatLogMessage` drops `attributes` and `error`, which
+/// are exactly where diagnostic detail lives — a probe failure carries the
+/// resolved host, the platform error code, and the elapsed time as attributes.
+/// It is not strictly lossier, though: it emits `traceId`/`spanId`, which this
+/// drops in favour of the timestamp, since a report is read as a timeline.
+///
+/// The timestamp is written in UTC so a record lines up against server logs
+/// read on another machine.
+///
+/// Set [includeStackTrace] for the report, where an unexpected error's frames
+/// name where it came from. The screen leaves it off: one record per row keeps
+/// the list scannable.
+String formatLogRecord(LogRecord record, {bool includeStackTrace = false}) {
+  final out = StringBuffer()
+    ..write(record.timestamp.toUtc().toIso8601String())
+    ..write(' [${record.level.label}] ')
+    ..write('${_singleLine(record.loggerName)}: ')
+    // The exported report is one text blob, so a record there is delimited by
+    // starting at column 0 — only the indented stack-trace continuation below
+    // is meant to add lines. An embedded break in the message, an attribute or
+    // the error would forge a record that never happened. (The on-screen list
+    // is not parsed, one row per record, so this only matters for the report.)
+    ..write(_singleLine(record.message));
+
+  if (record.attributes.isNotEmpty) {
+    final pairs = record.attributes.entries
+        .map((e) => '${_singleLine(e.key)}=${_singleLine('${e.value}')}')
+        .join(', ');
+    out.write(' {$pairs}');
+  }
+
+  if (record.error != null) {
+    out.write(' | error: ${_singleLine('${record.error}')}');
+  }
+
+  if (includeStackTrace && record.stackTrace != null) {
+    for (final frame in '${record.stackTrace}'.trimRight().split('\n')) {
+      out.write('\n    $frame');
+    }
+  }
+
+  return out.toString();
+}
+
+/// Collapses the characters a reader, a terminal or a line-splitting parser
+/// would treat as a break: CR and LF, the vertical tab and form feed a
+/// terminal moves down on, NEL, the ASCII separators, and the Unicode line and
+/// paragraph separators.
+///
+/// A bare `\r` is the dangerous one: it leaves the text intact for `grep`
+/// while painting the record's tail over its own timestamp.
+String _singleLine(String value) => value.replaceAll(
+    RegExp(r'[\r\n\v\f\u0085\u001c-\u001e\u2028\u2029]+'), ' ');

--- a/lib/src/modules/diagnostics/ui/diagnostics_screen.dart
+++ b/lib/src/modules/diagnostics/ui/diagnostics_screen.dart
@@ -1,23 +1,74 @@
+import 'dart:async';
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:file_picker/file_picker.dart';
+import 'package:flutter/foundation.dart' show defaultTargetPlatform, kIsWeb;
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
 
 import 'package:soliplex_design/soliplex_design.dart';
+import 'package:soliplex_logging/soliplex_logging.dart';
+
 import '../../../core/routes.dart';
 import '../../auth/ui/home_shell.dart';
-import '../models/http_category.dart';
-import '../models/http_event_group.dart';
+import '../log_capture.dart';
+import '../models/diagnostics_report.dart';
 import '../models/http_event_grouper.dart';
-import '../models/run_event_filter.dart';
+import '../models/log_record_format.dart';
 import '../network_inspector.dart';
-import 'concurrency_summary_panel.dart';
-import 'http_exchange_tile.dart';
+import 'logs_pane.dart';
+import 'requests_pane.dart';
 
-/// Status buckets for the request list's quick filter. `pending`/`streaming`
-/// in-flight exchanges only show under [all].
-enum _StatusFilter { all, success, errors }
+final Logger _logger =
+    LogManager.instance.getLogger('soliplex.diagnostics_screen');
 
-/// Category buckets, mapped onto [HttpCategory] (with an `all` passthrough).
-enum _CategoryFilter { all, llm, auth, system }
+/// Outcome of the last export, shown inline on the action rather than through
+/// a transient message, and reverted on a timer — the same shape the shared
+/// copy button uses.
+enum _ExportFeedback {
+  idle,
+  savedToFile,
+
+  /// Web has no save dialog and no way to observe the download it dispatched,
+  /// so this claims only that one was started.
+  downloadStarted,
+  failed,
+}
+
+/// Which of the three ways an export can fail happened. They leave different
+/// things behind, and telling the user the wrong one sends them looking for a
+/// file that does not exist — or fails to warn them about one that does.
+enum _ExportFailure {
+  /// The report was never built, so nothing was offered to a dialog.
+  reportNotBuilt,
+
+  /// The dialog closed and the save then failed. On a desktop platform the
+  /// bytes are written after it closes, so a truncated file may exist.
+  saveFailed,
+
+  /// The dialog never answered. Nothing has been written, and the user may
+  /// still finish it — in which case the file appears normally.
+  saveNeverAnswered,
+}
+
+/// [fileName] is the name the app *offered* the dialog, not necessarily the
+/// file that exists: the dialog lets the user rename, and it returns the path
+/// it actually used only on success.
+///
+/// [at] stamps the attempt, because the notice deliberately outlives the
+/// attempt that raised it: without a time a standing notice reads as the
+/// verdict on whatever the user did last.
+typedef _ExportProblem = ({DateTime at, _ExportFailure kind, String? fileName});
+
+/// Which capture the screen is showing. The two are bounded separately — the
+/// inspector drops the oldest HTTP event past its cap, the sink overwrites the
+/// oldest record past its own — and HTTP events churn far faster under
+/// streaming traffic than records are written, so a failure recorded in the
+/// log routinely outlives the request that caused it. (A host app that
+/// configures its own MemorySink can change its capacity, which would change
+/// that; the inspector's cap is fixed by the flavor.)
+enum _View { requests, logs }
 
 class DiagnosticsScreen extends StatefulWidget {
   const DiagnosticsScreen({
@@ -32,8 +83,8 @@ class DiagnosticsScreen extends StatefulWidget {
   final Widget? logo;
   final NetworkInspector inspector;
 
-  /// When set (via the per-message deep link), the list opens scoped to this
-  /// agent run, shown as a removable chip. Null for the plain inspector.
+  /// When set (via the per-message deep link), the request list opens scoped to
+  /// this agent run, shown as a removable chip.
   final String? initialRunId;
 
   @override
@@ -41,82 +92,67 @@ class DiagnosticsScreen extends StatefulWidget {
 }
 
 class _DiagnosticsScreenState extends State<DiagnosticsScreen> {
-  final _searchController = TextEditingController();
-  String _searchQuery = '';
-  _StatusFilter _statusFilter = _StatusFilter.all;
-  _CategoryFilter _categoryFilter = _CategoryFilter.all;
+  _ExportFeedback _exportFeedback = _ExportFeedback.idle;
+  Timer? _exportRevertTimer;
+  _View _view = _View.requests;
+
+  /// Guards against a second export starting while one is in flight, which on
+  /// desktop would open two save dialogs over each other.
+  bool _exporting = false;
+
+  /// Set when a save failed, and kept until the next attempt that produces an
+  /// outcome — a dismissed dialog leaves it standing on purpose, since it names
+  /// a file the user may still have to go and inspect. Unlike the success
+  /// glyphs it does not time out: it is the only account the user gets of an
+  /// action that produced nothing, and a tooltip cannot be read on a touch
+  /// screen.
+  _ExportProblem? _exportProblem;
+
+  /// Held here, not in [RequestsPane], because switching panes disposes that
+  /// pane: a run filter the user dismissed would come back seeded from the
+  /// deep link, silently re-hiding traffic.
   String? _runId;
+
+  /// Resolved once. Re-reading [LogManager] on every build would leave the
+  /// screen able to disagree with itself about which sink it is showing.
+  late final MemorySink? _logSink;
+
+  /// Whether the log capture holds anything. Drives the export and clear
+  /// actions in the header; [LogsPane] owns rendering the records themselves,
+  /// and the export reads them from [_logSink] when it runs.
+  bool _hasLogRecords = false;
+  final List<StreamSubscription<void>> _logSubscriptions = [];
 
   @override
   void initState() {
     super.initState();
     _runId = widget.initialRunId;
+    _logSink = capturedLogSink(LogManager.instance);
+    final sink = _logSink;
+    if (sink != null) {
+      _hasLogRecords = sink.length > 0;
+      // Only the empty/non-empty transition matters here, so a busy debug
+      // session does not rebuild the screen once per record. The pane
+      // subscribes separately for the rows.
+      _logSubscriptions.addAll([
+        sink.onRecord.listen((_) => _setHasLogRecords(true)),
+        sink.onClear.listen((_) => _setHasLogRecords(false)),
+      ]);
+    }
   }
 
   @override
   void dispose() {
-    _searchController.dispose();
+    _exportRevertTimer?.cancel();
+    for (final subscription in _logSubscriptions) {
+      subscription.cancel();
+    }
     super.dispose();
   }
 
-  bool get _filterActive =>
-      _searchQuery.isNotEmpty ||
-      _statusFilter != _StatusFilter.all ||
-      _categoryFilter != _CategoryFilter.all ||
-      _runId != null;
-
-  List<HttpEventGroup> _applyFilters(List<HttpEventGroup> groups) {
-    final query = _searchQuery.trim().toLowerCase();
-    final runId = _runId;
-    return groups.where((g) {
-      if (runId != null && !groupMatchesRun(g, runId)) return false;
-      if (!_statusMatches(g)) return false;
-      if (!_categoryMatches(g)) return false;
-      if (query.isNotEmpty &&
-          !g.methodLabel.toLowerCase().contains(query) &&
-          !g.pathWithQuery.toLowerCase().contains(query)) {
-        return false;
-      }
-      return true;
-    }).toList();
-  }
-
-  bool _statusMatches(HttpEventGroup g) {
-    switch (_statusFilter) {
-      case _StatusFilter.all:
-        return true;
-      case _StatusFilter.success:
-        return g.status == HttpEventStatus.success ||
-            g.status == HttpEventStatus.streamComplete;
-      case _StatusFilter.errors:
-        return g.status == HttpEventStatus.networkError ||
-            g.status == HttpEventStatus.serverError ||
-            g.status == HttpEventStatus.clientError ||
-            g.status == HttpEventStatus.streamError;
-    }
-  }
-
-  bool _categoryMatches(HttpEventGroup g) {
-    switch (_categoryFilter) {
-      case _CategoryFilter.all:
-        return true;
-      case _CategoryFilter.llm:
-        return categoryOf(g) == HttpCategory.llm;
-      case _CategoryFilter.auth:
-        return categoryOf(g) == HttpCategory.auth;
-      case _CategoryFilter.system:
-        return categoryOf(g) == HttpCategory.system;
-    }
-  }
-
-  void _clearFilters() {
-    setState(() {
-      _searchController.clear();
-      _searchQuery = '';
-      _statusFilter = _StatusFilter.all;
-      _categoryFilter = _CategoryFilter.all;
-      _runId = null;
-    });
+  void _setHasLogRecords(bool value) {
+    if (!mounted || _hasLogRecords == value) return;
+    setState(() => _hasLogRecords = value);
   }
 
   @override
@@ -124,9 +160,7 @@ class _DiagnosticsScreenState extends State<DiagnosticsScreen> {
     return ListenableBuilder(
       listenable: widget.inspector,
       builder: (context, _) {
-        final allGroups =
-            groupHttpEvents(widget.inspector.events).reversed.toList();
-        final groups = _applyFilters(allGroups);
+        final hasRequests = widget.inspector.events.isNotEmpty;
 
         return Scaffold(
           body: SafeArea(
@@ -135,7 +169,7 @@ class _DiagnosticsScreenState extends State<DiagnosticsScreen> {
                 HomeShellHeader(
                   appName: widget.appName,
                   logo: widget.logo,
-                  showAbout: false,
+                  showUtilityMenu: false,
                   leading: IconButton(
                     icon: Icon(Icons.adaptive.arrow_back),
                     tooltip: 'Back',
@@ -145,26 +179,58 @@ class _DiagnosticsScreenState extends State<DiagnosticsScreen> {
                   ),
                   actions: [
                     IconButton(
+                      icon: Icon(
+                        _exportAffordance.icon,
+                        color: _exportAffordance.color,
+                      ),
+                      // Disabled while one is in flight, so the control stops
+                      // claiming to be available during a save that can take
+                      // as long as the user takes to pick a folder.
+                      onPressed: (hasRequests || _hasLogRecords) && !_exporting
+                          ? _export
+                          : null,
+                      tooltip: _exportAffordance.tooltip,
+                    ),
+                    IconButton(
                       icon: const Icon(Icons.delete_sweep_outlined),
-                      onPressed: widget.inspector.events.isEmpty &&
-                              widget.inspector.concurrencyEvents.isEmpty
-                          ? null
-                          : widget.inspector.clear,
-                      tooltip: 'Clear all requests',
+                      onPressed: _clearAction(),
+                      tooltip: _view == _View.requests
+                          ? 'Clear all requests'
+                          : 'Clear all log records',
                     ),
                   ],
                 ),
-                ConcurrencySummaryPanel(
-                  events: widget.inspector.concurrencyEvents,
+                if (_exportProblem case final problem?)
+                  _ExportProblemNotice(
+                      problem: problem, hasLogSink: _logSink != null),
+                Padding(
+                  padding: const EdgeInsets.symmetric(
+                    horizontal: SoliplexSpacing.s4,
+                    vertical: SoliplexSpacing.s2,
+                  ),
+                  child: SegmentedButton<_View>(
+                    showSelectedIcon: false,
+                    segments: const [
+                      ButtonSegment(
+                        value: _View.requests,
+                        label: Text('Requests'),
+                      ),
+                      ButtonSegment(value: _View.logs, label: Text('Logs')),
+                    ],
+                    selected: {_view},
+                    onSelectionChanged: (selection) =>
+                        setState(() => _view = selection.first),
+                  ),
                 ),
-                if (allGroups.isNotEmpty)
-                  _buildToolbar(context, allGroups.length, groups.length),
                 Expanded(
-                  child: allGroups.isEmpty
-                      ? _buildEmptyState(context)
-                      : groups.isEmpty
-                          ? _buildNoMatchState(context)
-                          : _buildList(context, groups),
+                  child: switch (_view) {
+                    _View.requests => RequestsPane(
+                        inspector: widget.inspector,
+                        runId: _runId,
+                        onRunFilterCleared: () => setState(() => _runId = null),
+                      ),
+                    _View.logs => LogsPane(sink: _logSink),
+                  },
                 ),
               ],
             ),
@@ -174,178 +240,334 @@ class _DiagnosticsScreenState extends State<DiagnosticsScreen> {
     );
   }
 
-  Widget _buildToolbar(BuildContext context, int total, int visible) {
+  /// Clears whichever capture is on screen, so the action never looks live
+  /// while doing nothing to the visible list. Null disables it when there is
+  /// nothing to clear.
+  VoidCallback? _clearAction() {
+    if (_view == _View.logs) {
+      final sink = _logSink;
+      if (sink == null || !_hasLogRecords) return null;
+      return sink.clear;
+    }
+    if (widget.inspector.events.isEmpty &&
+        widget.inspector.concurrencyEvents.isEmpty) {
+      return null;
+    }
+    return widget.inspector.clear;
+  }
+
+  /// How long to wait on the save dialog before giving up on it.
+  ///
+  /// Generous, because the user may be browsing folders — but bounded, because
+  /// a platform future that never completes would leave the in-flight guard
+  /// set and the action permanently, invisibly dead. Android's picker has
+  /// result codes it never resolves.
+  static const _saveTimeout = Duration(minutes: 5);
+
+  /// How long a success glyph stays before reverting. The notice has no
+  /// equivalent: it is the lasting account of a failure.
+  static const _feedbackRevert = Duration(seconds: 2);
+
+  /// Writes the captured traffic and log records to a file the user chooses.
+  ///
+  /// Guards against a second run while one is in flight, and catches the
+  /// report building as well as the save: an error while building would
+  /// otherwise escape into a future nobody awaits, and this app installs no
+  /// zone handler, so it would reach no sink and no surface at all.
+  Future<void> _export() async {
+    if (_exporting) {
+      // Reachable while a non-modal dialog is open, and the button is disabled
+      // for exactly that window, so a tap that lands here is worth a trace.
+      _logger.info('An export is already in flight; ignoring the request');
+      return;
+    }
+    setState(() => _exporting = true);
+    // The glyph resets now; the notice does not. It is the only account of the
+    // previous failure, and an attempt that ends in a dismissed dialog would
+    // otherwise erase the name of a file the user still has to go look at.
+    _exportRevertTimer?.cancel();
+    if (_exportFeedback != _ExportFeedback.idle) {
+      setState(() => _exportFeedback = _ExportFeedback.idle);
+    }
+    try {
+      await _writeReport();
+    } on Object catch (e, st) {
+      _logger.error(
+        'Building the report failed; nothing was written',
+        error: e,
+        stackTrace: st,
+      );
+      _showExportFeedback(_ExportFeedback.failed);
+      _setExportProblem(kind: _ExportFailure.reportNotBuilt);
+    } finally {
+      if (mounted) {
+        setState(() => _exporting = false);
+      } else {
+        _exporting = false;
+      }
+    }
+  }
+
+  /// Builds the report and offers it to the platform's save dialog.
+  ///
+  /// A failure is reported and nothing else happens. There is deliberately no
+  /// clipboard fallback: the user asked for a file, and silently overwriting
+  /// whatever they had copied is not that. Nothing is stranded either way —
+  /// the records stay readable in the Logs pane.
+  Future<void> _writeReport() async {
+    final sink = _logSink;
+    final startedAt = DateTime.now();
+    final stamp = startedAt
+        .toUtc()
+        .toIso8601String()
+        .replaceAll(RegExp(r'[:.]'), '-')
+        .split('T')
+        .join('_');
+    final fileName = 'diagnostics_$stamp.txt';
+
+    // Both captures and no filters, whichever pane is showing: a report is
+    // read as the whole session, and a reader cannot tell that something was
+    // filtered out rather than never recorded.
+    final report = buildDiagnosticsReport(
+      appName: widget.appName,
+      // Chronological, unlike the on-screen list: a report is read top to
+      // bottom as a timeline, alongside log records that are already in that
+      // order.
+      groups: groupHttpEvents(widget.inspector.events),
+      generatedAt: startedAt,
+      // Null when nothing is collecting, which the report states rather than
+      // reporting as an empty capture. Copied because the sink's view is live
+      // over its ring buffer.
+      renderedLogRecords: sink == null
+          ? null
+          : List.of(sink.records)
+              .map((r) => formatLogRecord(r, includeStackTrace: true))
+              .toList(),
+      concurrencyEvents: widget.inspector.concurrencyEvents,
+      logLevel: LogManager.instance.minimumLevel.label,
+    );
+
+    var timedOut = false;
+    final save = FilePicker.saveFile(
+      dialogTitle: 'Save diagnostics report',
+      fileName: fileName,
+      bytes: Uint8List.fromList(utf8.encode(report)),
+    );
+    // Attached before the wait is bounded. Once `timeout` fires, the original
+    // future's own callbacks stop running, so a failure arriving late would be
+    // consumed and reported nowhere at all.
+    unawaited(save.then(
+      (path) {
+        if (timedOut) {
+          _logger.info(
+            'The save dialog answered after the export gave up waiting',
+            attributes: {'fileName': fileName, 'chosePath': path != null},
+          );
+        }
+      },
+      onError: (Object e, StackTrace st) {
+        if (timedOut) {
+          _logger.error(
+            'The save dialog failed after the export gave up waiting',
+            error: e,
+            stackTrace: st,
+            attributes: {'fileName': fileName},
+          );
+        }
+      },
+    ));
+
+    try {
+      final path = await save.timeout(_saveTimeout, onTimeout: () {
+        timedOut = true;
+        throw TimeoutException('the save dialog did not answer', _saveTimeout);
+      });
+
+      // Web has no dialog and no cancellation: the download is dispatched and
+      // null comes back either way. Whether the browser actually delivered it
+      // cannot be observed from here, so the claim stops at "started" — saying
+      // "saved" would leave a user who was silently blocked believing they
+      // have a report they never got.
+      if (kIsWeb) {
+        _showExportFeedback(_ExportFeedback.downloadStarted);
+        _clearExportProblem();
+        return;
+      }
+      if (path != null) {
+        _showExportFeedback(_ExportFeedback.savedToFile);
+        _clearExportProblem();
+        return;
+      }
+      // Null with no throw. A dismissed dialog on macOS, Android and iOS — but
+      // Linux returns null for a failed portal request and Windows for any
+      // CommDlgExtendedError, and neither is distinguishable from a cancel
+      // here. Left silent on screen, since a cancel is by far the likely case
+      // and the user asked for nothing; recorded so that the other case is at
+      // least in the log and in the next report.
+      _logger.warning(
+        'The save dialog returned no path; the report was not written',
+        attributes: {
+          'fileName': fileName,
+          'platform': kIsWeb ? 'web' : defaultTargetPlatform.name,
+        },
+      );
+      return;
+      // A timeout is neither a decline nor a failure: the dialog is still open
+      // and still the user's to finish, so this reports that it gave up
+      // waiting rather than claiming the save failed.
+    } on TimeoutException catch (e, st) {
+      _logger.error(
+        'The save dialog did not answer in time; the export was abandoned '
+        'while it was still open',
+        error: e,
+        stackTrace: st,
+        attributes: {'fileName': fileName},
+      );
+      _showExportFeedback(_ExportFeedback.failed);
+      _setExportProblem(
+        kind: _ExportFailure.saveNeverAnswered,
+        fileName: fileName,
+      );
+      return;
+      // `on Object`, not `on Exception`: file_picker throws ArgumentError and
+      // UnimplementedError from its platform legs, and an Error escaping here
+      // would leave the button doing nothing at all, forever, with no record
+      // of why. Matches pick_file_impl.dart.
+    } on Object catch (e, st) {
+      // A desktop save writes the bytes after the dialog closes, so the file
+      // it chose may exist and be truncated. Deleting it would not undo that —
+      // an overwrite already discarded whatever was there — so the only useful
+      // thing is to name it.
+      _logger.error(
+        'Saving the report to a file failed; on a desktop platform a file of '
+        'this name may exist and be incomplete',
+        error: e,
+        stackTrace: st,
+        attributes: {'fileName': fileName},
+      );
+      _showExportFeedback(_ExportFeedback.failed);
+      _setExportProblem(kind: _ExportFailure.saveFailed, fileName: fileName);
+    }
+  }
+
+  void _setExportProblem({required _ExportFailure kind, String? fileName}) {
+    if (!mounted) return;
+    setState(() =>
+        _exportProblem = (at: DateTime.now(), kind: kind, fileName: fileName));
+  }
+
+  void _clearExportProblem() {
+    if (mounted && _exportProblem != null) {
+      setState(() => _exportProblem = null);
+    }
+  }
+
+  /// Reverts to the idle glyph after a beat so the action does not read as
+  /// permanently "done". The notice, unlike the glyph, stays put.
+  void _showExportFeedback(_ExportFeedback value) {
+    if (!mounted) return;
+    setState(() => _exportFeedback = value);
+    _exportRevertTimer?.cancel();
+    _exportRevertTimer = Timer(_feedbackRevert, () {
+      if (mounted) setState(() => _exportFeedback = _ExportFeedback.idle);
+    });
+  }
+
+  ({IconData icon, Color? color, String tooltip}) get _exportAffordance =>
+      switch (_exportFeedback) {
+        _ExportFeedback.idle => (
+            // Saves a file; it does not open a share sheet.
+            icon: Icons.save_alt,
+            color: null,
+            tooltip: 'Save report (all requests and log records)',
+          ),
+        _ExportFeedback.savedToFile => (
+            icon: Icons.check,
+            color: null,
+            tooltip: 'Report saved'
+          ),
+        _ExportFeedback.downloadStarted => (
+            icon: Icons.check,
+            color: null,
+            tooltip: 'Download started — check your browser downloads',
+          ),
+        _ExportFeedback.failed => (
+            icon: Icons.error_outline,
+            color: Theme.of(context).colorScheme.error,
+            tooltip: 'Could not save the report',
+          ),
+      };
+}
+
+/// Says what a failed save left behind, and stays until the next attempt that
+/// produces an outcome — a dismissed dialog deliberately leaves it standing.
+///
+/// The failure needs words, not a glyph: on a desktop platform the save writes
+/// after the dialog closes, so a file may exist and be truncated. It is stamped
+/// because it outlives its attempt, and without a time a standing notice reads
+/// as the verdict on whatever the user did last. Selectable because the
+/// filename is the part a user has to quote.
+class _ExportProblemNotice extends StatelessWidget {
+  const _ExportProblemNotice({required this.problem, required this.hasLogSink});
+
+  final _ExportProblem problem;
+
+  /// Whether pointing the user at the Logs pane would lead anywhere.
+  final bool hasLogSink;
+
+  @override
+  Widget build(BuildContext context) {
     final theme = Theme.of(context);
-    final runId = _runId;
-    return Padding(
-      padding: const EdgeInsets.fromLTRB(
-        SoliplexSpacing.s4,
-        SoliplexSpacing.s4,
-        SoliplexSpacing.s4,
-        SoliplexSpacing.s2,
+    final fileName = problem.fileName;
+    final what = switch (problem.kind) {
+      _ExportFailure.reportNotBuilt => 'Nothing was written.',
+      _ExportFailure.saveNeverAnswered =>
+        'The save dialog did not answer, so nothing has been saved. If you '
+            'finish it, the file will still be written.',
+      // No file is ever written on web — the download is dispatched from
+      // memory — so naming one to go and distrust would send the user hunting
+      // for something that cannot exist.
+      _ExportFailure.saveFailed when kIsWeb => 'Could not download the report.',
+      // Deliberately hedged: the dialog lets the user rename, and it returns
+      // the path it used only on success, so this is the name that was
+      // offered, not necessarily the name of the file now on disk.
+      _ExportFailure.saveFailed =>
+        'Could not finish saving the report. A partly-written file may have '
+            'been left where you chose, probably named $fileName.',
+    };
+    final pointer = hasLogSink ? ' Details are in the Logs pane.' : '';
+    final at = '${problem.at.toUtc().toIso8601String()}: ';
+
+    return Container(
+      width: double.infinity,
+      margin: const EdgeInsets.symmetric(
+        horizontal: SoliplexSpacing.s4,
+        vertical: SoliplexSpacing.s2,
       ),
-      child: Column(
-        mainAxisSize: MainAxisSize.min,
+      padding: const EdgeInsets.all(SoliplexSpacing.s3),
+      decoration: BoxDecoration(
+        color: theme.colorScheme.errorContainer,
+        borderRadius: BorderRadius.circular(context.radii.md),
+      ),
+      child: Row(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
-          Text(
-            _filterActive
-                ? 'Requests ($visible / $total)'
-                : 'Requests ($total)',
-            style: theme.textTheme.titleMedium,
-          ),
-          const SizedBox(height: SoliplexSpacing.s2),
-          SoliplexInput(
-            controller: _searchController,
-            hintText: 'Filter by method or path…',
-            leadingIcon: const Icon(Icons.search),
-            trailingIcon: _searchQuery.isNotEmpty
-                ? IconButton(
-                    icon: const Icon(Icons.clear),
-                    tooltip: 'Clear search',
-                    onPressed: () => setState(() {
-                      _searchController.clear();
-                      _searchQuery = '';
-                    }),
-                  )
-                : null,
-            onChanged: (value) => setState(() => _searchQuery = value),
-          ),
-          const SizedBox(height: SoliplexSpacing.s2),
-          Wrap(
-            spacing: SoliplexSpacing.s4,
-            runSpacing: SoliplexSpacing.s2,
-            children: [
-              SegmentedButton<_StatusFilter>(
-                showSelectedIcon: false,
-                segments: const [
-                  ButtonSegment(value: _StatusFilter.all, label: Text('All')),
-                  ButtonSegment(
-                      value: _StatusFilter.success, label: Text('Success')),
-                  ButtonSegment(
-                      value: _StatusFilter.errors, label: Text('Errors')),
-                ],
-                selected: {_statusFilter},
-                onSelectionChanged: (selection) =>
-                    setState(() => _statusFilter = selection.first),
-              ),
-              SegmentedButton<_CategoryFilter>(
-                showSelectedIcon: false,
-                segments: const [
-                  ButtonSegment(value: _CategoryFilter.all, label: Text('All')),
-                  ButtonSegment(value: _CategoryFilter.llm, label: Text('LLM')),
-                  ButtonSegment(
-                      value: _CategoryFilter.auth, label: Text('Auth')),
-                  ButtonSegment(
-                      value: _CategoryFilter.system, label: Text('System')),
-                ],
-                selected: {_categoryFilter},
-                onSelectionChanged: (selection) =>
-                    setState(() => _categoryFilter = selection.first),
-              ),
-            ],
-          ),
-          if (runId != null) ...[
-            const SizedBox(height: SoliplexSpacing.s2),
-            Row(
-              mainAxisSize: MainAxisSize.min,
-              children: [
-                Icon(Icons.tag, size: 16, color: theme.colorScheme.primary),
-                const SizedBox(width: SoliplexSpacing.s1),
-                Text(
-                  'Run · ${_shortRun(runId)}',
-                  style: theme.textTheme.labelMedium,
-                ),
-                IconButton(
-                  icon: const Icon(Icons.close, size: 16),
-                  tooltip: 'Clear run filter',
-                  visualDensity: VisualDensity.compact,
-                  onPressed: () => setState(() => _runId = null),
-                ),
-              ],
-            ),
-          ],
-        ],
-      ),
-    );
-  }
-
-  Widget _buildList(BuildContext context, List<HttpEventGroup> groups) {
-    return LayoutBuilder(
-      builder: (context, constraints) {
-        final tabular = constraints.maxWidth >= SoliplexBreakpoints.tablet;
-        return ListView.separated(
-          padding: const EdgeInsets.symmetric(vertical: SoliplexSpacing.s2),
-          itemCount: groups.length,
-          separatorBuilder: (_, __) => const Divider(height: 1),
-          itemBuilder: (context, index) => HttpExchangeTile(
-            key: ValueKey(groups[index].requestId),
-            group: groups[index],
-            tabular: tabular,
-          ),
-        );
-      },
-    );
-  }
-
-  Widget _buildEmptyState(BuildContext context) {
-    final theme = Theme.of(context);
-    return Center(
-      child: Column(
-        mainAxisSize: MainAxisSize.min,
-        children: [
           Icon(
-            Icons.http,
-            size: 64,
-            color: theme.colorScheme.onSurfaceVariant.withValues(alpha: 0.5),
+            Icons.error_outline,
+            size: 20,
+            color: theme.colorScheme.onErrorContainer,
           ),
-          const SizedBox(height: SoliplexSpacing.s4),
-          Text(
-            'No HTTP requests yet',
-            style: theme.textTheme.titleMedium?.copyWith(
-              color: theme.colorScheme.onSurfaceVariant,
-            ),
-          ),
-          const SizedBox(height: SoliplexSpacing.s2),
-          Text(
-            'Requests will appear here as you use the app',
-            style: theme.textTheme.bodyMedium?.copyWith(
-              color: theme.colorScheme.onSurfaceVariant,
+          const SizedBox(width: SoliplexSpacing.s3),
+          Expanded(
+            child: SelectableText(
+              '$at$what$pointer',
+              style: theme.textTheme.bodyMedium?.copyWith(
+                color: theme.colorScheme.onErrorContainer,
+              ),
             ),
           ),
         ],
       ),
     );
   }
-
-  Widget _buildNoMatchState(BuildContext context) {
-    final theme = Theme.of(context);
-    return Center(
-      child: Column(
-        mainAxisSize: MainAxisSize.min,
-        children: [
-          Icon(
-            Icons.filter_alt_off_outlined,
-            size: 64,
-            color: theme.colorScheme.onSurfaceVariant.withValues(alpha: 0.5),
-          ),
-          const SizedBox(height: SoliplexSpacing.s4),
-          Text(
-            'No requests match these filters',
-            style: theme.textTheme.titleMedium?.copyWith(
-              color: theme.colorScheme.onSurfaceVariant,
-            ),
-          ),
-          const SizedBox(height: SoliplexSpacing.s2),
-          SoliplexButton.text(
-            onPressed: _clearFilters,
-            child: const Text('Clear filters'),
-          ),
-        ],
-      ),
-    );
-  }
-
-  static String _shortRun(String runId) =>
-      runId.length <= 10 ? runId : '${runId.substring(0, 8)}…';
 }

--- a/lib/src/modules/diagnostics/ui/logs_pane.dart
+++ b/lib/src/modules/diagnostics/ui/logs_pane.dart
@@ -1,0 +1,153 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+
+import 'package:soliplex_design/soliplex_design.dart';
+import 'package:soliplex_logging/soliplex_logging.dart';
+
+import '../models/log_record_format.dart';
+
+/// The captured log records, newest first.
+///
+/// Stateful, and owning its own subscription, so that a record arriving while
+/// the request list is on screen does not rebuild this pane: only the selected
+/// pane is mounted, so there is nothing here to tell about it. (The screen
+/// stays subscribed for its own header actions.)
+class LogsPane extends StatefulWidget {
+  const LogsPane({required this.sink, super.key});
+
+  /// Null when no memory sink is installed, which this pane reports
+  /// differently from a sink with no records: nothing is being collected,
+  /// rather than nothing having happened.
+  final MemorySink? sink;
+
+  @override
+  State<LogsPane> createState() => _LogsPaneState();
+}
+
+class _LogsPaneState extends State<LogsPane> {
+  final List<StreamSubscription<void>> _subscriptions = [];
+
+  @override
+  void initState() {
+    super.initState();
+    _subscribe();
+  }
+
+  @override
+  void dispose() {
+    _cancel();
+    super.dispose();
+  }
+
+  void _subscribe() {
+    final sink = widget.sink;
+    if (sink == null) return;
+    // Both streams matter: without `onClear` the list keeps painting records
+    // the sink has already dropped. Neither needs an `onError`: MemorySink
+    // only ever calls `add`, never `addError`.
+    _subscriptions.addAll([
+      sink.onRecord.listen((_) => _rebuild()),
+      sink.onClear.listen((_) => _rebuild()),
+    ]);
+  }
+
+  void _cancel() {
+    for (final subscription in _subscriptions) {
+      subscription.cancel();
+    }
+    _subscriptions.clear();
+  }
+
+  void _rebuild() {
+    if (mounted) setState(() {});
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final sink = widget.sink;
+
+    // Said plainly rather than shown as an empty list: a reader who sees "no
+    // records" concludes the code logged nothing and looks elsewhere, when in
+    // fact nothing was ever collected to look at.
+    if (sink == null) {
+      return _Message(
+        'No log sink is installed in this build, so no records are being '
+        'kept. Their absence here says nothing about what happened.',
+      );
+    }
+
+    // A snapshot, not the sink's live view. `MemorySink.records` recomputes
+    // `length` on every read, and once the buffer is full it also recomputes
+    // every index from the current head — so a record written between
+    // `ListView.builder` capturing `itemCount` and running `itemBuilder` would
+    // shift the rows under it, and a `clear` in that window would throw.
+    final records = List.of(sink.records);
+
+    if (records.isEmpty) {
+      return _Message('No log records captured.');
+    }
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        // Named and counted like the request list, so switching panes doesn't
+        // lose track of how much was captured.
+        Padding(
+          padding: const EdgeInsets.fromLTRB(
+            SoliplexSpacing.s4,
+            SoliplexSpacing.s4,
+            SoliplexSpacing.s4,
+            SoliplexSpacing.s2,
+          ),
+          child: Text(
+            'Log records (${records.length})',
+            style: theme.textTheme.titleMedium,
+          ),
+        ),
+        Expanded(
+          // Newest first, matching the request list's ordering.
+          child: ListView.builder(
+            padding: const EdgeInsets.symmetric(horizontal: SoliplexSpacing.s4),
+            itemCount: records.length,
+            itemBuilder: (context, index) {
+              final record = records[records.length - 1 - index];
+              return Padding(
+                padding:
+                    const EdgeInsets.symmetric(vertical: SoliplexSpacing.s1),
+                child: SelectableText(
+                  formatLogRecord(record),
+                  style: context.monospaceOn(theme.textTheme.bodySmall),
+                ),
+              );
+            },
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+class _Message extends StatelessWidget {
+  const _Message(this.text);
+
+  final String text;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Center(
+      child: Padding(
+        padding: const EdgeInsets.all(SoliplexSpacing.s4),
+        child: Text(
+          text,
+          textAlign: TextAlign.center,
+          style: theme.textTheme.bodyMedium?.copyWith(
+            color: theme.colorScheme.onSurfaceVariant,
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/src/modules/diagnostics/ui/requests_pane.dart
+++ b/lib/src/modules/diagnostics/ui/requests_pane.dart
@@ -1,0 +1,323 @@
+import 'package:flutter/material.dart';
+
+import 'package:soliplex_design/soliplex_design.dart';
+
+import '../models/http_category.dart';
+import '../models/http_event_group.dart';
+import '../models/http_event_grouper.dart';
+import '../models/run_event_filter.dart';
+import '../network_inspector.dart';
+import 'concurrency_summary_panel.dart';
+import 'http_exchange_tile.dart';
+
+/// Status buckets for the request list's quick filter. `pending`/`streaming`
+/// in-flight exchanges only show under [all].
+enum _StatusFilter { all, success, errors }
+
+/// Category buckets, mapped onto [HttpCategory] (with an `all` passthrough).
+enum _CategoryFilter { all, llm, auth, system }
+
+/// The captured HTTP exchanges, newest first, with the filters that narrow
+/// them.
+///
+/// Stateful because the search and bucket filters are the pane's own concern:
+/// changing one rebuilds the list without disturbing the screen's chrome. They
+/// reset when the pane is swapped out, which the run filter deliberately does
+/// not — see [runId].
+///
+/// Reads [inspector] in `build` without listening to it: the screen wraps this
+/// pane in a `ListenableBuilder`, so a new instance arrives on every captured
+/// event. Mounting it anywhere without that wrapper would leave it stale.
+class RequestsPane extends StatefulWidget {
+  const RequestsPane({
+    required this.inspector,
+    required this.onRunFilterCleared,
+    this.runId,
+    super.key,
+  });
+
+  final NetworkInspector inspector;
+
+  /// When set (via the per-message deep link), the list is scoped to this agent
+  /// run and shows a removable chip. Owned by the screen, because dismissing it
+  /// has to survive a switch to the Logs pane and back.
+  final String? runId;
+
+  /// Called when the user dismisses the run chip. Required even though [runId]
+  /// is nullable: a scoped list with no way to unscope it is a dead end, with
+  /// a disabled chip and a "Clear filters" button that cannot clear.
+  final VoidCallback onRunFilterCleared;
+
+  @override
+  State<RequestsPane> createState() => _RequestsPaneState();
+}
+
+class _RequestsPaneState extends State<RequestsPane> {
+  final _searchController = TextEditingController();
+  String _searchQuery = '';
+  _StatusFilter _statusFilter = _StatusFilter.all;
+  _CategoryFilter _categoryFilter = _CategoryFilter.all;
+
+  @override
+  void dispose() {
+    _searchController.dispose();
+    super.dispose();
+  }
+
+  bool get _filterActive =>
+      _searchQuery.isNotEmpty ||
+      _statusFilter != _StatusFilter.all ||
+      _categoryFilter != _CategoryFilter.all ||
+      widget.runId != null;
+
+  List<HttpEventGroup> _applyFilters(List<HttpEventGroup> groups) {
+    final query = _searchQuery.trim().toLowerCase();
+    final runId = widget.runId;
+    return groups.where((g) {
+      if (runId != null && !groupMatchesRun(g, runId)) return false;
+      if (!_statusMatches(g)) return false;
+      if (!_categoryMatches(g)) return false;
+      if (query.isNotEmpty &&
+          !g.methodLabel.toLowerCase().contains(query) &&
+          !g.pathWithQuery.toLowerCase().contains(query)) {
+        return false;
+      }
+      return true;
+    }).toList();
+  }
+
+  bool _statusMatches(HttpEventGroup g) {
+    switch (_statusFilter) {
+      case _StatusFilter.all:
+        return true;
+      case _StatusFilter.success:
+        return g.status == HttpEventStatus.success ||
+            g.status == HttpEventStatus.streamComplete;
+      case _StatusFilter.errors:
+        return g.status == HttpEventStatus.networkError ||
+            g.status == HttpEventStatus.serverError ||
+            g.status == HttpEventStatus.clientError ||
+            g.status == HttpEventStatus.streamError;
+    }
+  }
+
+  bool _categoryMatches(HttpEventGroup g) {
+    switch (_categoryFilter) {
+      case _CategoryFilter.all:
+        return true;
+      case _CategoryFilter.llm:
+        return categoryOf(g) == HttpCategory.llm;
+      case _CategoryFilter.auth:
+        return categoryOf(g) == HttpCategory.auth;
+      case _CategoryFilter.system:
+        return categoryOf(g) == HttpCategory.system;
+    }
+  }
+
+  void _clearFilters() {
+    setState(() {
+      _searchController.clear();
+      _searchQuery = '';
+      _statusFilter = _StatusFilter.all;
+      _categoryFilter = _CategoryFilter.all;
+    });
+    widget.onRunFilterCleared();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final allGroups =
+        groupHttpEvents(widget.inspector.events).reversed.toList();
+    final groups = _applyFilters(allGroups);
+
+    return Column(
+      children: [
+        ConcurrencySummaryPanel(events: widget.inspector.concurrencyEvents),
+        if (allGroups.isNotEmpty)
+          _buildToolbar(context, allGroups.length, groups.length),
+        Expanded(
+          child: allGroups.isEmpty
+              ? _buildEmptyState(context)
+              : groups.isEmpty
+                  ? _buildNoMatchState(context)
+                  : _buildList(context, groups),
+        ),
+      ],
+    );
+  }
+
+  Widget _buildToolbar(BuildContext context, int total, int visible) {
+    final theme = Theme.of(context);
+    final runId = widget.runId;
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(
+        SoliplexSpacing.s4,
+        SoliplexSpacing.s4,
+        SoliplexSpacing.s4,
+        SoliplexSpacing.s2,
+      ),
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            _filterActive
+                ? 'Requests ($visible / $total)'
+                : 'Requests ($total)',
+            style: theme.textTheme.titleMedium,
+          ),
+          const SizedBox(height: SoliplexSpacing.s2),
+          SoliplexInput(
+            controller: _searchController,
+            hintText: 'Filter by method or path…',
+            leadingIcon: const Icon(Icons.search),
+            trailingIcon: _searchQuery.isNotEmpty
+                ? IconButton(
+                    icon: const Icon(Icons.clear),
+                    tooltip: 'Clear search',
+                    onPressed: () => setState(() {
+                      _searchController.clear();
+                      _searchQuery = '';
+                    }),
+                  )
+                : null,
+            onChanged: (value) => setState(() => _searchQuery = value),
+          ),
+          const SizedBox(height: SoliplexSpacing.s2),
+          Wrap(
+            spacing: SoliplexSpacing.s4,
+            runSpacing: SoliplexSpacing.s2,
+            children: [
+              SegmentedButton<_StatusFilter>(
+                showSelectedIcon: false,
+                segments: const [
+                  ButtonSegment(value: _StatusFilter.all, label: Text('All')),
+                  ButtonSegment(
+                      value: _StatusFilter.success, label: Text('Success')),
+                  ButtonSegment(
+                      value: _StatusFilter.errors, label: Text('Errors')),
+                ],
+                selected: {_statusFilter},
+                onSelectionChanged: (selection) =>
+                    setState(() => _statusFilter = selection.first),
+              ),
+              SegmentedButton<_CategoryFilter>(
+                showSelectedIcon: false,
+                segments: const [
+                  ButtonSegment(value: _CategoryFilter.all, label: Text('All')),
+                  ButtonSegment(value: _CategoryFilter.llm, label: Text('LLM')),
+                  ButtonSegment(
+                      value: _CategoryFilter.auth, label: Text('Auth')),
+                  ButtonSegment(
+                      value: _CategoryFilter.system, label: Text('System')),
+                ],
+                selected: {_categoryFilter},
+                onSelectionChanged: (selection) =>
+                    setState(() => _categoryFilter = selection.first),
+              ),
+            ],
+          ),
+          if (runId != null) ...[
+            const SizedBox(height: SoliplexSpacing.s2),
+            Row(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                Icon(Icons.tag, size: 16, color: theme.colorScheme.primary),
+                const SizedBox(width: SoliplexSpacing.s1),
+                Text(
+                  'Run · ${_shortRun(runId)}',
+                  style: theme.textTheme.labelMedium,
+                ),
+                IconButton(
+                  icon: const Icon(Icons.close, size: 16),
+                  tooltip: 'Clear run filter',
+                  visualDensity: VisualDensity.compact,
+                  onPressed: widget.onRunFilterCleared,
+                ),
+              ],
+            ),
+          ],
+        ],
+      ),
+    );
+  }
+
+  Widget _buildList(BuildContext context, List<HttpEventGroup> groups) {
+    return LayoutBuilder(
+      builder: (context, constraints) {
+        final tabular = constraints.maxWidth >= SoliplexBreakpoints.tablet;
+        return ListView.separated(
+          padding: const EdgeInsets.symmetric(vertical: SoliplexSpacing.s2),
+          itemCount: groups.length,
+          separatorBuilder: (_, __) => const Divider(height: 1),
+          itemBuilder: (context, index) => HttpExchangeTile(
+            key: ValueKey(groups[index].requestId),
+            group: groups[index],
+            tabular: tabular,
+          ),
+        );
+      },
+    );
+  }
+
+  Widget _buildEmptyState(BuildContext context) {
+    final theme = Theme.of(context);
+    return Center(
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Icon(
+            Icons.http,
+            size: 64,
+            color: theme.colorScheme.onSurfaceVariant.withValues(alpha: 0.5),
+          ),
+          const SizedBox(height: SoliplexSpacing.s4),
+          Text(
+            'No HTTP requests yet',
+            style: theme.textTheme.titleMedium?.copyWith(
+              color: theme.colorScheme.onSurfaceVariant,
+            ),
+          ),
+          const SizedBox(height: SoliplexSpacing.s2),
+          Text(
+            'Requests will appear here as you use the app',
+            style: theme.textTheme.bodyMedium?.copyWith(
+              color: theme.colorScheme.onSurfaceVariant,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildNoMatchState(BuildContext context) {
+    final theme = Theme.of(context);
+    return Center(
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Icon(
+            Icons.filter_alt_off_outlined,
+            size: 64,
+            color: theme.colorScheme.onSurfaceVariant.withValues(alpha: 0.5),
+          ),
+          const SizedBox(height: SoliplexSpacing.s4),
+          Text(
+            'No requests match these filters',
+            style: theme.textTheme.titleMedium?.copyWith(
+              color: theme.colorScheme.onSurfaceVariant,
+            ),
+          ),
+          const SizedBox(height: SoliplexSpacing.s2),
+          SoliplexButton.text(
+            onPressed: _clearFilters,
+            child: const Text('Clear filters'),
+          ),
+        ],
+      ),
+    );
+  }
+
+  static String _shortRun(String runId) =>
+      runId.length <= 10 ? runId : '${runId.substring(0, 8)}…';
+}

--- a/lib/src/modules/lobby/ui/server_sidebar.dart
+++ b/lib/src/modules/lobby/ui/server_sidebar.dart
@@ -7,6 +7,7 @@ import 'package:soliplex_logging/soliplex_logging.dart';
 import '../../../../version.dart';
 import '../../../core/app_identity.dart';
 import '../../../core/ui/confirm_dialog.dart';
+import '../../../core/ui/menu_row.dart';
 import '../../auth/auth_providers.dart';
 import '../../auth/auth_tokens.dart';
 import '../../auth/server_entry.dart';
@@ -524,30 +525,30 @@ class _ServerTileMenuState extends ConsumerState<_ServerTileMenu> {
         if (!connected)
           const PopupMenuItem(
             value: _ServerTileAction.signIn,
-            child: _MenuRow(icon: Icons.login, label: 'Sign in'),
+            child: MenuRow(icon: Icons.login, label: 'Sign in'),
           ),
         if (connected && entry.requiresAuth)
           const PopupMenuItem(
             value: _ServerTileAction.logOut,
-            child: _MenuRow(icon: Icons.logout, label: 'Log out'),
+            child: MenuRow(icon: Icons.logout, label: 'Log out'),
           ),
         const PopupMenuItem(
           value: _ServerTileAction.markAllRead,
-          child: _MenuRow(
+          child: MenuRow(
             icon: Icons.mark_chat_read_outlined,
             label: 'Mark all as read',
           ),
         ),
         const PopupMenuItem(
           value: _ServerTileAction.copyAddress,
-          child: _MenuRow(
+          child: MenuRow(
             icon: Icons.content_copy,
             label: 'Copy server address',
           ),
         ),
         PopupMenuItem(
           value: _ServerTileAction.remove,
-          child: _MenuRow(
+          child: MenuRow(
             icon: Icons.delete_outline,
             label: 'Remove',
             destructive: true,
@@ -615,15 +616,15 @@ class _LogoutErrorButton extends StatelessWidget {
       itemBuilder: (context) => const [
         PopupMenuItem(
           value: _ErrorAction.retry,
-          child: _MenuRow(icon: Icons.refresh, label: 'Try again'),
+          child: MenuRow(icon: Icons.refresh, label: 'Try again'),
         ),
         PopupMenuItem(
           value: _ErrorAction.showDetail,
-          child: _MenuRow(icon: Icons.info_outline, label: 'Show error detail'),
+          child: MenuRow(icon: Icons.info_outline, label: 'Show error detail'),
         ),
         PopupMenuItem(
           value: _ErrorAction.remove,
-          child: _MenuRow(
+          child: MenuRow(
             icon: Icons.delete_outline,
             label: 'Remove server',
             destructive: true,
@@ -700,51 +701,16 @@ class _AccountBar extends StatelessWidget {
             itemBuilder: (context) => const [
               PopupMenuItem(
                 value: _SidebarAction.diagnostics,
-                child: _MenuRow(icon: Icons.lan_outlined, label: 'Diagnostics'),
+                child: MenuRow(icon: Icons.lan_outlined, label: 'Diagnostics'),
               ),
               PopupMenuItem(
                 value: _SidebarAction.versions,
-                child: _MenuRow(icon: Icons.info_outline, label: 'Versions'),
+                child: MenuRow(icon: Icons.info_outline, label: 'Versions'),
               ),
             ],
           ),
         ],
       ),
-    );
-  }
-}
-
-class _MenuRow extends StatelessWidget {
-  const _MenuRow({
-    required this.icon,
-    required this.label,
-    this.destructive = false,
-  });
-
-  final IconData icon;
-  final String label;
-
-  /// Tints the row with `colorScheme.error` for a destructive action (Remove).
-  final bool destructive;
-
-  @override
-  Widget build(BuildContext context) {
-    final color = destructive ? Theme.of(context).colorScheme.error : null;
-    return Row(
-      mainAxisSize: MainAxisSize.min,
-      children: [
-        Icon(icon, size: 20, color: color),
-        const SizedBox(width: SoliplexSpacing.s3),
-        // Flexible so a long label can't overflow the menu's width; the menu
-        // widens to fit when there's room.
-        Flexible(
-          child: Text(
-            label,
-            overflow: TextOverflow.ellipsis,
-            style: color == null ? null : TextStyle(color: color),
-          ),
-        ),
-      ],
     );
   }
 }

--- a/lib/src/modules/lobby/ui/server_sidebar.dart
+++ b/lib/src/modules/lobby/ui/server_sidebar.dart
@@ -701,7 +701,7 @@ class _AccountBar extends StatelessWidget {
             itemBuilder: (context) => const [
               PopupMenuItem(
                 value: _SidebarAction.diagnostics,
-                child: MenuRow(icon: Icons.lan_outlined, label: 'Diagnostics'),
+                child: MenuRow(icon: Icons.troubleshoot, label: 'Diagnostics'),
               ),
               PopupMenuItem(
                 value: _SidebarAction.versions,

--- a/lib/src/modules/room/ui/room_info_screen.dart
+++ b/lib/src/modules/room/ui/room_info_screen.dart
@@ -95,7 +95,7 @@ class _RoomInfoScreenState extends State<RoomInfoScreen> {
             HomeShellHeader(
               appName: widget.appName,
               logo: widget.logo,
-              showAbout: false,
+              showUtilityMenu: false,
               leading: IconButton(
                 icon: Icon(Icons.adaptive.arrow_back),
                 tooltip: 'Back to room',

--- a/lib/src/modules/room/ui/room_rail.dart
+++ b/lib/src/modules/room/ui/room_rail.dart
@@ -341,7 +341,7 @@ class _RailAccountMenu extends StatelessWidget {
           PopupMenuItem(
             onTap: onDiagnostics,
             child:
-                const MenuRow(icon: Icons.lan_outlined, label: 'Diagnostics'),
+                const MenuRow(icon: Icons.troubleshoot, label: 'Diagnostics'),
           ),
           PopupMenuItem(
             onTap: onVersions,

--- a/lib/src/modules/room/ui/room_rail.dart
+++ b/lib/src/modules/room/ui/room_rail.dart
@@ -4,6 +4,7 @@ import 'package:soliplex_client/soliplex_client.dart'
     show PermissionDeniedException, Room;
 import 'package:soliplex_design/soliplex_design.dart';
 
+import '../../../core/ui/menu_row.dart';
 import '../../../shared/mark_read_context_menu.dart';
 import '../../auth/auth_tokens.dart';
 import '../../auth/server_entry.dart';
@@ -340,11 +341,11 @@ class _RailAccountMenu extends StatelessWidget {
           PopupMenuItem(
             onTap: onDiagnostics,
             child:
-                const _MenuRow(icon: Icons.lan_outlined, label: 'Diagnostics'),
+                const MenuRow(icon: Icons.lan_outlined, label: 'Diagnostics'),
           ),
           PopupMenuItem(
             onTap: onVersions,
-            child: const _MenuRow(icon: Icons.info_outline, label: 'Versions'),
+            child: const MenuRow(icon: Icons.info_outline, label: 'Versions'),
           ),
         ],
       );
@@ -415,26 +416,6 @@ class _AccountHeader extends StatelessWidget {
             ],
           ),
         ),
-      ],
-    );
-  }
-}
-
-/// An icon + label row for a ⋮ menu item.
-class _MenuRow extends StatelessWidget {
-  const _MenuRow({required this.icon, required this.label});
-
-  final IconData icon;
-  final String label;
-
-  @override
-  Widget build(BuildContext context) {
-    return Row(
-      mainAxisSize: MainAxisSize.min,
-      children: [
-        Icon(icon, size: 20),
-        const SizedBox(width: SoliplexSpacing.s3),
-        Flexible(child: Text(label, overflow: TextOverflow.ellipsis)),
       ],
     );
   }

--- a/lib/src/modules/versions/server_versions_screen.dart
+++ b/lib/src/modules/versions/server_versions_screen.dart
@@ -70,7 +70,7 @@ class _ServerVersionsScreenState extends State<ServerVersionsScreen> {
             HomeShellHeader(
               appName: widget.appName,
               logo: widget.logo,
-              showAbout: false,
+              showUtilityMenu: false,
               leading: IconButton(
                 icon: Icon(Icons.adaptive.arrow_back),
                 tooltip: 'Back to versions',

--- a/lib/src/modules/versions/versions_screen.dart
+++ b/lib/src/modules/versions/versions_screen.dart
@@ -68,7 +68,7 @@ class _VersionsScreenState extends State<VersionsScreen> {
             HomeShellHeader(
               appName: widget.appName,
               logo: widget.logo,
-              showAbout: false,
+              showUtilityMenu: false,
               leading: IconButton(
                 icon: Icon(Icons.adaptive.arrow_back),
                 tooltip: 'Back',

--- a/test/modules/auth/auth_module_test.dart
+++ b/test/modules/auth/auth_module_test.dart
@@ -87,6 +87,36 @@ void main() {
       expect(find.text('Soliplex'), findsOneWidget);
     });
 
+    testWidgets('allows the diagnostics screen when unauthenticated',
+        (tester) async {
+      // A user stranded on the sign-in screen is by definition unauthenticated,
+      // and the inspector is the only place the failing request is visible.
+      final contribution = module.build();
+      router = GoRouter(
+        initialLocation: '/',
+        routes: [
+          ...contribution.routes,
+          GoRoute(
+            path: AppRoutes.diagnostics,
+            builder: (_, __) => const Text('Inspector'),
+          ),
+        ],
+        redirect: contribution.redirect,
+      );
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: contribution.overrides,
+          child: MaterialApp.router(routerConfig: router),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      router.go(AppRoutes.diagnostics);
+      await tester.pumpAndSettle();
+
+      expect(find.text('Inspector'), findsOneWidget);
+    });
+
     testWidgets('redirects /chat to / when unauthenticated', (tester) async {
       await tester.pumpWidget(buildApp());
       await tester.pumpAndSettle();

--- a/test/modules/auth/ui/home_shell_test.dart
+++ b/test/modules/auth/ui/home_shell_test.dart
@@ -1,6 +1,8 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
 import 'package:soliplex_design/soliplex_design.dart';
+import 'package:soliplex_frontend/src/core/routes.dart';
 import 'package:soliplex_frontend/src/modules/auth/ui/home_shell.dart';
 
 void main() {
@@ -42,6 +44,74 @@ void main() {
       final nameText = tester.widget<Text>(find.text('Soliplex'));
       // No brand font: style comes from textTheme.titleSmall unmodified.
       expect(nameText.style?.fontFamily, isNot('Squada One'));
+    });
+  });
+
+  group('HomeShellHeader utility menu', () {
+    /// The header under a router, so the menu's destinations can be observed by
+    /// where they navigate to.
+    Future<GoRouter> pumpHeader(WidgetTester tester) async {
+      final router = GoRouter(
+        initialLocation: '/',
+        routes: [
+          GoRoute(
+            path: '/',
+            builder: (_, __) => const Scaffold(
+              body: HomeShellHeader(appName: 'Soliplex'),
+            ),
+          ),
+          GoRoute(
+            path: AppRoutes.diagnostics,
+            builder: (_, __) => const Text('diagnostics screen'),
+          ),
+          GoRoute(
+            path: AppRoutes.versions,
+            builder: (_, __) => const Text('versions screen'),
+          ),
+        ],
+      );
+      await tester.pumpWidget(MaterialApp.router(routerConfig: router));
+      await tester.pumpAndSettle();
+      return router;
+    }
+
+    testWidgets('reaches diagnostics, which needs no connected server',
+        (tester) async {
+      // The rail and sidebar menus both sit behind a connected server, so this
+      // is the only route to the diagnostics screen for a user who cannot sign
+      // in — which is when it is worth reading.
+      await pumpHeader(tester);
+
+      await tester.tap(find.byTooltip('Diagnostics & versions'));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('Diagnostics'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('diagnostics screen'), findsOneWidget);
+    });
+
+    testWidgets('reaches versions from the same menu', (tester) async {
+      await pumpHeader(tester);
+
+      await tester.tap(find.byTooltip('Diagnostics & versions'));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('Versions'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('versions screen'), findsOneWidget);
+    });
+
+    testWidgets('is hidden on screens that are themselves destinations',
+        (tester) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Scaffold(
+            body: HomeShellHeader(appName: 'Soliplex', showUtilityMenu: false),
+          ),
+        ),
+      );
+
+      expect(find.byTooltip('Diagnostics & versions'), findsNothing);
     });
   });
 }

--- a/test/modules/diagnostics/log_capture_test.dart
+++ b/test/modules/diagnostics/log_capture_test.dart
@@ -1,0 +1,30 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:soliplex_frontend/src/modules/diagnostics/log_capture.dart';
+import 'package:soliplex_logging/soliplex_logging.dart';
+
+void main() {
+  tearDown(LogManager.instance.reset);
+
+  test('reports no capture when no memory sink is installed', () {
+    // The screen renders this as "nothing is being collected", which is a
+    // different message from "nothing was recorded" — so null has to survive
+    // the lookup rather than arriving as an empty list.
+    LogManager.instance.addSink(ConsoleSink());
+
+    expect(capturedLogSink(LogManager.instance), isNull);
+  });
+
+  test('picks the first installed sink when a host installs several', () {
+    // LogManager permits several, and the screen, its clear action and the
+    // export all have to agree on which one they mean. Registration order is
+    // the documented tie-break; a change here silently shows one buffer while
+    // clearing another.
+    final first = MemorySink();
+    final second = MemorySink();
+    LogManager.instance
+      ..addSink(first)
+      ..addSink(second);
+
+    expect(capturedLogSink(LogManager.instance), same(first));
+  });
+}

--- a/test/modules/diagnostics/models/diagnostics_report_test.dart
+++ b/test/modules/diagnostics/models/diagnostics_report_test.dart
@@ -1,0 +1,169 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:soliplex_agent/soliplex_agent.dart';
+import 'package:soliplex_frontend/src/modules/diagnostics/models/diagnostics_report.dart';
+import 'package:soliplex_frontend/src/modules/diagnostics/models/http_event_group.dart';
+
+void main() {
+  final at = DateTime.utc(2026, 8, 18, 7, 51);
+
+  String report({
+    List<HttpEventGroup> groups = const [],
+    List<String>? renderedLogRecords = const [],
+    List<ConcurrencyWaitEvent> concurrencyEvents = const [],
+    String logLevel = 'WARNING',
+    DateTime? generatedAt,
+  }) =>
+      buildDiagnosticsReport(
+        appName: 'Test',
+        groups: groups,
+        generatedAt: generatedAt ?? at,
+        renderedLogRecords: renderedLogRecords,
+        concurrencyEvents: concurrencyEvents,
+        logLevel: logLevel,
+      );
+
+  test('a failed request reports the platform error, not just the message', () {
+    // The banner shows only the localized sentence; the domain and numeric
+    // code are what actually name the failure.
+    final group = HttpEventGroup(
+      requestId: 'r1',
+      error: HttpErrorEvent(
+        requestId: 'r1',
+        timestamp: at,
+        method: 'GET',
+        uri: Uri.parse('https://ai.example.mil/api/login'),
+        exception: NetworkException(
+          message: 'Client error: A server with the specified hostname could '
+              'not be found.',
+          originalError: 'NSErrorClientException: A server with the specified '
+              'hostname could not be found. '
+              '[domain=NSURLErrorDomain, code=-1003]',
+        ),
+        duration: const Duration(milliseconds: 32),
+      ),
+    );
+
+    final out = report(groups: [group]);
+
+    expect(out, contains('https://ai.example.mil/api/login'));
+    expect(out, contains('code=-1003'));
+    expect(out, contains('FAILED after 32ms'));
+  });
+
+  test('a failed stream reports its outcome, not a bare URL', () {
+    // A streamed exchange emits no request, response or error event, only
+    // stream start/end, so reading only those three renders every agent run —
+    // the traffic most worth reporting — as a URL and nothing else.
+    final group = HttpEventGroup(
+      requestId: 'r2',
+      streamStart: HttpStreamStartEvent(
+        requestId: 'r2',
+        timestamp: at,
+        method: 'POST',
+        uri: Uri.parse('https://ai.example.mil/api/v1/rooms/r1/agui/t1/run-1'),
+        headers: const {'accept': 'text/event-stream'},
+      ),
+      streamEnd: HttpStreamEndEvent(
+        requestId: 'r2',
+        timestamp: at.add(const Duration(seconds: 4)),
+        bytesReceived: 2048,
+        duration: const Duration(seconds: 4),
+        error: const NetworkException(
+          message: 'Connection closed',
+          originalError: '[domain=NSURLErrorDomain, code=-1005]',
+        ),
+      ),
+    );
+
+    final out = report(groups: [group]);
+
+    expect(out, contains('/api/v1/rooms/r1/agui/t1/run-1'));
+    // The request half survives even though there is no request event.
+    expect(out, contains('sent: 2026-08-18T07:51:00.000Z'));
+    expect(out, contains('accept: text/event-stream'));
+    // And the outcome.
+    expect(out, contains('outcome: stream error'));
+    expect(out, contains('duration: 4000ms'));
+    expect(out, contains('bytesReceived: 2048'));
+    expect(out, contains('STREAM FAILED'));
+    expect(out, contains('code=-1005'));
+  });
+
+  test('timestamps are UTC so a report lines up against server logs', () {
+    // Fed a LOCAL DateTime on purpose. `toIso8601String` emits the trailing Z
+    // only when `isUtc`, so this fails if the conversion is dropped — which a
+    // UTC input could not detect, and CI runs in UTC.
+    final out = report(generatedAt: DateTime(2026, 8, 18, 7, 51));
+
+    expect(out, contains('Generated: '));
+    expect(
+      RegExp(r'Generated: \S+Z$', multiLine: true).hasMatch(out),
+      isTrue,
+      reason: 'the generated-at line must carry a UTC offset',
+    );
+  });
+
+  test('an exchange still in flight reports that, not silence', () {
+    // The reason a report gets exported at all is often a run that is hanging,
+    // so the one entry that matters has no response, no stream end and no
+    // error. Printing nothing for it made it look like a request that came
+    // back empty.
+    final group = HttpEventGroup(
+      requestId: 'r3',
+      streamStart: HttpStreamStartEvent(
+        requestId: 'r3',
+        timestamp: at,
+        method: 'POST',
+        uri: Uri.parse('https://ai.example.mil/api/v1/rooms/r1/agui/t1/run-9'),
+      ),
+    );
+
+    final out = report(groups: [group]);
+
+    expect(out, contains('/api/v1/rooms/r1/agui/t1/run-9'));
+    expect(out, contains('outcome: streaming'));
+  });
+
+  test('an empty log section is stated rather than omitted', () {
+    // "No records" and "records were never collected" lead a reader to
+    // different conclusions; a missing section cannot distinguish them.
+    final out = report();
+
+    expect(out, contains('Log level floor: WARNING'));
+    expect(out, contains('Log records (0)'));
+    expect(out, contains('No log records captured.'));
+  });
+
+  test('an uncollected log section says so instead of claiming none', () {
+    // The case a host app hits when it installs no memory sink. Reporting it
+    // as an empty capture would tell the reader the code logged nothing.
+    final out = report(renderedLogRecords: null);
+
+    expect(out, contains('Log records (not collected)'));
+    expect(out, contains('No log sink is installed'));
+    expect(out, isNot(contains('No log records captured.')));
+  });
+
+  test('request pool waits are reported, and their absence is too', () {
+    // A request queued behind the pool's cap looks slow for reasons unrelated
+    // to the server it is calling, so the wait has to be visible — and the
+    // section is written either way, for the same reason the log section is.
+    final waited = report(
+      concurrencyEvents: [
+        ConcurrencyWaitEvent(
+          acquisitionId: 'a1',
+          timestamp: at,
+          uri: Uri.parse('https://ai.example.mil/api/login'),
+          waitDuration: const Duration(milliseconds: 1400),
+          queueDepthAtEnqueue: 3,
+          slotsInUseAfterAcquire: 6,
+        ),
+      ],
+    );
+
+    expect(waited, contains('Request pool waits (1)'));
+    expect(waited, contains('waited 1400ms'));
+
+    expect(report(), contains('No requests waited for a pool slot.'));
+  });
+}

--- a/test/modules/diagnostics/models/log_record_format_test.dart
+++ b/test/modules/diagnostics/models/log_record_format_test.dart
@@ -1,0 +1,90 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:soliplex_frontend/src/modules/diagnostics/models/log_record_format.dart';
+import 'package:soliplex_logging/soliplex_logging.dart';
+
+void main() {
+  test('a record renders its attributes and error, not just the message', () {
+    // Attributes are where the diagnostic detail lives: the resolved host, the
+    // platform error code, the elapsed time.
+    final record = LogRecord(
+      level: LogLevel.warning,
+      message: 'Probe exhausted every candidate address',
+      timestamp: DateTime.utc(2026, 8, 18, 7, 51),
+      loggerName: 'soliplex.connection_probe',
+      error: 'NetworkException: Client error',
+      attributes: {
+        'hosts': ['"ai.example.mil"'],
+        'platformError': '[domain=NSURLErrorDomain, code=-1003]',
+        'elapsedMs': 32,
+      },
+    );
+
+    final line = formatLogRecord(record);
+
+    expect(line, contains('soliplex.connection_probe'));
+    expect(line, contains('"ai.example.mil"'));
+    expect(line, contains('code=-1003'));
+    expect(line, contains('elapsedMs=32'));
+    expect(line, contains('error: NetworkException: Client error'));
+  });
+
+  test('a line break inside a record cannot forge a new record', () {
+    // Records are told apart by starting at column 0, in the list and in the
+    // exported report. A bare \r is the worst case: it leaves the text intact
+    // for grep while painting the record's tail over its own timestamp.
+    final record = LogRecord(
+      level: LogLevel.warning,
+      message: 'upstream said:\r\nHTTP/1.1 500',
+      timestamp: DateTime.utc(2026, 8, 18, 7, 51),
+      loggerName: 'soliplex.probe',
+      attributes: const {'body': 'line one\nline two'},
+    );
+
+    final line = formatLogRecord(record);
+
+    expect(line.contains('\n'), isFalse);
+    expect(line.contains('\r'), isFalse);
+    expect(line, contains('HTTP/1.1 500'));
+    expect(line, contains('line two'));
+  });
+
+  test('the report mode keeps the stack trace, the list mode does not', () {
+    // The frames name where an unexpected error came from, which is the whole
+    // reason the exported report carries them; the on-screen list keeps one
+    // row per record instead.
+    final record = LogRecord(
+      level: LogLevel.error,
+      message: 'Authentication failed',
+      timestamp: DateTime.utc(2026, 8, 18, 7, 51),
+      loggerName: 'soliplex.connect_flow',
+      error: 'Bad state',
+      stackTrace: StackTrace.fromString('#0 frameOne\n#1 frameTwo'),
+    );
+
+    expect(formatLogRecord(record).contains('frameOne'), isFalse);
+
+    final withTrace = formatLogRecord(record, includeStackTrace: true);
+    expect(withTrace, contains('frameOne'));
+    expect(withTrace, contains('frameTwo'));
+    // Continuation lines are indented so they cannot be read as new records.
+    expect(withTrace, contains('\n    #0 frameOne'));
+  });
+
+  test('the timestamp is UTC, so a record lines up against server logs', () {
+    // Fed a LOCAL DateTime on purpose, which is what the logging package
+    // produces: `Logger` stamps every record with `DateTime.now()`. Asserting
+    // the trailing Z is what fails if the conversion is dropped — an already
+    // UTC input could not detect that, and CI runs in UTC.
+    final record = LogRecord(
+      level: LogLevel.warning,
+      message: 'probe failed',
+      timestamp: DateTime(2026, 8, 18, 7, 51),
+      loggerName: 'soliplex.probe',
+    );
+
+    final line = formatLogRecord(record);
+
+    expect(RegExp(r'^\S+Z ').hasMatch(line), isTrue,
+        reason: 'the record must open with a UTC timestamp');
+  });
+}

--- a/test/modules/diagnostics/ui/diagnostics_screen_test.dart
+++ b/test/modules/diagnostics/ui/diagnostics_screen_test.dart
@@ -1,9 +1,62 @@
+import 'dart:async';
+
+import 'package:file_picker/file_picker.dart';
+// ignore: implementation_imports
+import 'package:file_picker/src/platform/file_picker_platform_interface.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:soliplex_frontend/src/modules/diagnostics/network_inspector.dart';
+import 'package:soliplex_logging/soliplex_logging.dart';
 import 'package:soliplex_frontend/src/modules/diagnostics/ui/diagnostics_screen.dart';
 
 import '../../../helpers/http_event_factories.dart';
+
+/// Stands in for the platform save dialog. `saveFile` has three outcomes the
+/// export branches on: a path (saved), null (a dismissed dialog — but also a
+/// failed portal on Linux and any CommDlgExtendedError on Windows), and a
+/// throw.
+class _FakeSavePicker extends FilePickerPlatform {
+  _FakeSavePicker.returns(this._path) : _thrown = null;
+  _FakeSavePicker.throwing(Object this._thrown) : _path = null;
+
+  final String? _path;
+  final Object? _thrown;
+
+  @override
+  Future<String?> saveFile({
+    String? dialogTitle,
+    String? fileName,
+    String? initialDirectory,
+    FileType type = FileType.any,
+    List<String>? allowedExtensions,
+    Uint8List? bytes,
+    bool lockParentWindow = false,
+  }) async {
+    if (_thrown != null) throw _thrown;
+    return _path;
+  }
+}
+
+/// A save dialog that does not answer, standing in for the Android result
+/// codes the plugin never resolves.
+class _HangingSavePicker extends FilePickerPlatform {
+  _HangingSavePicker(this._never);
+
+  final Future<String?> _never;
+
+  @override
+  Future<String?> saveFile({
+    String? dialogTitle,
+    String? fileName,
+    String? initialDirectory,
+    FileType type = FileType.any,
+    List<String>? allowedExtensions,
+    Uint8List? bytes,
+    bool lockParentWindow = false,
+  }) =>
+      _never;
+}
 
 void main() {
   group('DiagnosticsScreen', () {
@@ -36,7 +89,7 @@ void main() {
 
       // Branded app name in the bar; the about/versions button is dropped.
       expect(find.text('Acme'), findsOneWidget);
-      expect(find.byTooltip('About & versions'), findsNothing);
+      expect(find.byTooltip('Diagnostics & versions'), findsNothing);
       expect(find.byTooltip('Back'), findsOneWidget);
       // The request-count heading stays hidden while the list is empty so it
       // doesn't compete with the empty state.
@@ -50,7 +103,7 @@ void main() {
 
       tester.view.physicalSize = const Size(400, 800);
       tester.view.devicePixelRatio = 1.0;
-      addTearDown(tester.view.resetPhysicalSize);
+      addTearDown(tester.view.reset);
 
       await tester.pumpWidget(
         MaterialApp(
@@ -74,7 +127,7 @@ void main() {
       // Use a narrow viewport so the list layout (not master-detail) is used
       tester.view.physicalSize = const Size(400, 800);
       tester.view.devicePixelRatio = 1.0;
-      addTearDown(tester.view.resetPhysicalSize);
+      addTearDown(tester.view.reset);
 
       await tester.pumpWidget(
         MaterialApp(
@@ -96,7 +149,7 @@ void main() {
 
       tester.view.physicalSize = const Size(400, 800);
       tester.view.devicePixelRatio = 1.0;
-      addTearDown(tester.view.resetPhysicalSize);
+      addTearDown(tester.view.reset);
 
       await tester.pumpWidget(
         MaterialApp(
@@ -142,7 +195,7 @@ void main() {
 
       tester.view.physicalSize = const Size(400, 800);
       tester.view.devicePixelRatio = 1.0;
-      addTearDown(tester.view.resetPhysicalSize);
+      addTearDown(tester.view.reset);
 
       await tester.pumpWidget(
         MaterialApp(
@@ -226,7 +279,7 @@ void main() {
     Future<void> pumpWide(WidgetTester tester, {String? initialRunId}) async {
       tester.view.physicalSize = const Size(900, 800);
       tester.view.devicePixelRatio = 1.0;
-      addTearDown(tester.view.resetPhysicalSize);
+      addTearDown(tester.view.reset);
       await tester.pumpWidget(
         MaterialApp(
           home: DiagnosticsScreen(
@@ -313,6 +366,45 @@ void main() {
       expect(find.text('/api/v1/threads'), findsOneWidget);
     });
 
+    testWidgets('Clear filters drops the run scope too, not just the search',
+        (tester) async {
+      // The run filter is the one filter the pane does not own, so clearing it
+      // goes through a callback to the screen. Without that call the button
+      // reports the filters cleared while the list stays scoped.
+      inspector
+        ..onRequest(createRequestEvent(
+            requestId: 'req-1',
+            uri: Uri.parse('http://localhost/api/v1/rooms/r1/agui/t1/run-1')))
+        ..onResponse(createResponseEvent(requestId: 'req-1'))
+        ..onRequest(createRequestEvent(
+            requestId: 'req-2', uri: Uri.parse('http://localhost/api/other')))
+        ..onResponse(createResponseEvent(requestId: 'req-2'));
+      tester.view.physicalSize = const Size(900, 1200);
+      tester.view.devicePixelRatio = 1.0;
+      addTearDown(tester.view.reset);
+      await tester.pumpWidget(
+        MaterialApp(
+          home: DiagnosticsScreen(
+            appName: 'Acme',
+            inspector: inspector,
+            initialRunId: 'run-1',
+          ),
+        ),
+      );
+
+      // Scoped to the run, then narrowed to nothing so the empty state's
+      // "Clear filters" is the only way out.
+      await tester.enterText(find.byType(TextField), 'nomatch');
+      await tester.pumpAndSettle();
+      expect(find.text('No requests match these filters'), findsOneWidget);
+
+      await tester.tap(find.text('Clear filters'));
+      await tester.pumpAndSettle();
+
+      expect(find.textContaining('Run · '), findsNothing);
+      expect(find.text('/api/other'), findsOneWidget);
+    });
+
     testWidgets('the category filter narrows to LLM (AG-UI) traffic',
         (tester) async {
       inspector
@@ -333,6 +425,349 @@ void main() {
 
       expect(find.text('/api/v1/rooms/r1/agui/t1/run-1'), findsOneWidget);
       expect(find.text('/api/v1/rooms'), findsNothing);
+    });
+  });
+
+  group('DiagnosticsScreen log capture', () {
+    late NetworkInspector inspector;
+    late MemorySink sink;
+
+    setUp(() {
+      inspector = NetworkInspector();
+      sink = MemorySink();
+      LogManager.instance.addSink(sink);
+    });
+
+    tearDown(() {
+      inspector.dispose();
+      LogManager.instance.reset();
+    });
+
+    Future<void> pumpScreen(WidgetTester tester) async {
+      tester.view.physicalSize = const Size(900, 1200);
+      tester.view.devicePixelRatio = 1.0;
+      addTearDown(tester.view.reset);
+      await tester.pumpWidget(
+        MaterialApp(
+          home: DiagnosticsScreen(appName: 'Acme', inspector: inspector),
+        ),
+      );
+    }
+
+    testWidgets('the Logs segment shows captured records and their count',
+        (tester) async {
+      LogManager.instance.getLogger('soliplex.probe').warning('probe failed');
+      await pumpScreen(tester);
+
+      // The request list is the landing pane, so the record is not on screen
+      // until the segment is chosen.
+      expect(find.textContaining('probe failed'), findsNothing);
+
+      await tester.tap(find.text('Logs'));
+      await tester.pumpAndSettle();
+
+      expect(find.textContaining('probe failed'), findsOneWidget);
+      expect(find.text('Log records (1)'), findsOneWidget);
+    });
+
+    testWidgets('a record arriving while the Logs pane is up is rendered',
+        (tester) async {
+      await pumpScreen(tester);
+      await tester.tap(find.text('Logs'));
+      await tester.pumpAndSettle();
+      expect(find.text('No log records captured.'), findsOneWidget);
+
+      LogManager.instance.getLogger('soliplex.probe').warning('arrived late');
+      await tester.pumpAndSettle();
+
+      expect(find.textContaining('arrived late'), findsOneWidget);
+    });
+
+    testWidgets('clear empties the capture the visible pane is showing',
+        (tester) async {
+      inspector.onRequest(createRequestEvent(requestId: 'req-1'));
+      inspector.onResponse(createResponseEvent(requestId: 'req-1'));
+      LogManager.instance.getLogger('soliplex.probe').warning('kept');
+      await pumpScreen(tester);
+
+      // Logs first, deliberately: clearing requests first would let a
+      // logs-pane trash-can wired to the inspector pass this test, and losing
+      // the HTTP capture is the loss that matters.
+      await tester.tap(find.text('Logs'));
+      await tester.pumpAndSettle();
+      await tester.tap(find.byTooltip('Clear all log records'));
+      await tester.pumpAndSettle();
+      expect(find.text('No log records captured.'), findsOneWidget);
+
+      await tester.tap(find.text('Requests'));
+      await tester.pumpAndSettle();
+      expect(find.text('/api/v1/rooms'), findsOneWidget);
+
+      await tester.tap(find.byTooltip('Clear all requests'));
+      await tester.pumpAndSettle();
+      expect(find.text('No HTTP requests yet'), findsOneWidget);
+    });
+
+    testWidgets('the report can be saved when only log records were captured',
+        (tester) async {
+      await pumpScreen(tester);
+
+      // Nothing captured at all: there is no report worth writing.
+      final action = find.widgetWithIcon(IconButton, Icons.save_alt);
+      expect(tester.widget<IconButton>(action).onPressed, isNull);
+
+      // A record with no HTTP exchange is the case the probe hits when it
+      // rejects an address before any request is made. The action lives in the
+      // header, above both panes, so it has to notice from either one.
+      LogManager.instance
+          .getLogger('soliplex.probe')
+          .warning('no request made');
+      await tester.pumpAndSettle();
+
+      expect(tester.widget<IconButton>(action).onPressed, isNotNull);
+    });
+  });
+
+  group('DiagnosticsScreen export outcomes', () {
+    late NetworkInspector inspector;
+    late MemorySink sink;
+    late FilePickerPlatform originalPicker;
+    setUp(() {
+      inspector = NetworkInspector();
+      sink = MemorySink();
+      LogManager.instance.addSink(sink);
+      originalPicker = FilePickerPlatform.instance;
+    });
+
+    tearDown(() {
+      FilePickerPlatform.instance = originalPicker;
+      // Reset regardless: a throw from dispose would otherwise leak the sink
+      // into every later test.
+      try {
+        inspector.dispose();
+      } finally {
+        LogManager.instance.reset();
+      }
+    });
+
+    Future<void> pumpAndSave(WidgetTester tester) async {
+      tester.view.physicalSize = const Size(900, 1200);
+      tester.view.devicePixelRatio = 1.0;
+      addTearDown(tester.view.reset);
+      LogManager.instance.getLogger('soliplex.probe').warning('something');
+      await tester.pumpWidget(
+        MaterialApp(
+          home: DiagnosticsScreen(appName: 'Acme', inspector: inspector),
+        ),
+      );
+      await tester.tap(find.widgetWithIcon(IconButton, Icons.save_alt));
+      await tester.pumpAndSettle();
+    }
+
+    testWidgets('a dismissed dialog says nothing on screen', (tester) async {
+      // A cancel is the user's decision; the screen stays quiet about it.
+      FilePickerPlatform.instance = _FakeSavePicker.returns(null);
+      await pumpAndSave(tester);
+
+      expect(find.textContaining('Could not finish saving'), findsNothing);
+      // Recorded even so: Linux and Windows return null for real failures too,
+      // and this is the only trace either leaves.
+      expect(
+        sink.records.map((r) => r.message),
+        contains('The save dialog returned no path; the report was not '
+            'written'),
+      );
+    });
+
+    testWidgets('a saved file reports success', (tester) async {
+      FilePickerPlatform.instance =
+          _FakeSavePicker.returns('/tmp/diagnostics.txt');
+      await pumpAndSave(tester);
+
+      expect(find.byTooltip('Report saved'), findsOneWidget);
+      expect(find.textContaining('Could not finish saving'), findsNothing);
+    });
+
+    testWidgets('a failing picker names the file that may be incomplete',
+        (tester) async {
+      // A desktop save writes after the dialog closes, so the user needs to
+      // know which file to go and distrust.
+      FilePickerPlatform.instance =
+          _FakeSavePicker.throwing(ArgumentError('no plugin'));
+      await pumpAndSave(tester);
+
+      expect(find.textContaining('Could not finish saving'), findsOneWidget);
+      expect(find.textContaining('diagnostics_'), findsOneWidget);
+    });
+
+    testWidgets('the notice outlives the glyph, which reverts', (tester) async {
+      // The glyph is a two-second flash; the notice is the only lasting
+      // account of a failure, and it names the file that may be truncated.
+      FilePickerPlatform.instance =
+          _FakeSavePicker.throwing(ArgumentError('no plugin'));
+      await pumpAndSave(tester);
+
+      await tester.pump(const Duration(seconds: 3));
+      await tester.pumpAndSettle();
+
+      expect(find.textContaining('Could not finish saving'), findsOneWidget);
+      expect(find.byTooltip('Report saved'), findsNothing);
+    });
+  });
+
+  group('DiagnosticsScreen filters across panes', () {
+    late NetworkInspector inspector;
+
+    setUp(() => inspector = NetworkInspector());
+    tearDown(() => inspector.dispose());
+
+    testWidgets('a dismissed run filter stays dismissed across a pane switch',
+        (tester) async {
+      // The whole reason the run filter lives on the screen: the pane is
+      // disposed on a switch, and re-seeding from the deep link would silently
+      // re-hide traffic the user had chosen to see.
+      inspector
+        ..onRequest(createRequestEvent(
+            requestId: 'req-1',
+            uri: Uri.parse('http://localhost/api/v1/rooms/r1/agui/t1/run-1')))
+        ..onResponse(createResponseEvent(requestId: 'req-1'))
+        ..onRequest(createRequestEvent(
+            requestId: 'req-2', uri: Uri.parse('http://localhost/api/other')))
+        ..onResponse(createResponseEvent(requestId: 'req-2'));
+
+      tester.view.physicalSize = const Size(900, 1200);
+      tester.view.devicePixelRatio = 1.0;
+      addTearDown(tester.view.reset);
+      await tester.pumpWidget(
+        MaterialApp(
+          home: DiagnosticsScreen(
+            appName: 'Acme',
+            inspector: inspector,
+            initialRunId: 'run-1',
+          ),
+        ),
+      );
+
+      expect(find.text('/api/other'), findsNothing);
+
+      await tester.tap(find.byTooltip('Clear run filter'));
+      await tester.pumpAndSettle();
+      expect(find.text('/api/other'), findsOneWidget);
+
+      await tester.tap(find.text('Logs'));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('Requests'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('/api/other'), findsOneWidget);
+      expect(find.textContaining('Run · '), findsNothing);
+    });
+  });
+
+  group('DiagnosticsScreen save that never answers', () {
+    late NetworkInspector inspector;
+    late FilePickerPlatform originalPicker;
+
+    setUp(() {
+      inspector = NetworkInspector();
+      originalPicker = FilePickerPlatform.instance;
+    });
+
+    tearDown(() {
+      FilePickerPlatform.instance = originalPicker;
+      inspector.dispose();
+    });
+
+    testWidgets('gives up and says so, without claiming the save failed',
+        (tester) async {
+      // A dialog that has not answered is still open and still the user's to
+      // finish, so the report must not say a file may have been left behind.
+      final never = Completer<String?>();
+      addTearDown(() => never.complete(null));
+      FilePickerPlatform.instance = _HangingSavePicker(never.future);
+
+      inspector.onRequest(createRequestEvent(requestId: 'req-1'));
+      inspector.onResponse(createResponseEvent(requestId: 'req-1'));
+      tester.view.physicalSize = const Size(900, 1200);
+      tester.view.devicePixelRatio = 1.0;
+      addTearDown(tester.view.reset);
+      await tester.pumpWidget(
+        MaterialApp(
+          home: DiagnosticsScreen(appName: 'Acme', inspector: inspector),
+        ),
+      );
+
+      await tester.tap(find.widgetWithIcon(IconButton, Icons.save_alt));
+      await tester.pump();
+      // The action stops claiming to be available while it waits.
+      expect(
+        tester
+            .widget<IconButton>(
+              find.widgetWithIcon(IconButton, Icons.save_alt),
+            )
+            .onPressed,
+        isNull,
+      );
+
+      await tester.pump(const Duration(minutes: 6));
+      await tester.pumpAndSettle();
+
+      // Not the "a partly-written file may exist" wording: the dialog never
+      // wrote anything, and the user can still complete it.
+      expect(find.textContaining('Could not finish saving'), findsNothing);
+      expect(find.textContaining('did not answer'), findsOneWidget);
+      expect(find.textContaining('the file will still be written'),
+          findsOneWidget);
+      // And the action is offered again, rather than staying dead.
+      expect(
+        tester
+            .widget<IconButton>(
+              find.widgetWithIcon(IconButton, Icons.save_alt),
+            )
+            .onPressed,
+        isNotNull,
+      );
+    });
+  });
+
+  group('DiagnosticsScreen with no log capture installed', () {
+    late NetworkInspector inspector;
+
+    setUp(() {
+      inspector = NetworkInspector();
+      // Deliberately no MemorySink: the state a host app lands in when it
+      // configures its own sinks.
+      LogManager.instance.reset();
+    });
+    tearDown(() => inspector.dispose());
+
+    testWidgets('says nothing is being collected, not that nothing happened',
+        (tester) async {
+      // Reporting an empty capture here would tell the reader the code logged
+      // nothing, which is the opposite of what is true.
+      tester.view.physicalSize = const Size(900, 1200);
+      tester.view.devicePixelRatio = 1.0;
+      addTearDown(tester.view.reset);
+      await tester.pumpWidget(
+        MaterialApp(
+          home: DiagnosticsScreen(appName: 'Acme', inspector: inspector),
+        ),
+      );
+
+      await tester.tap(find.text('Logs'));
+      await tester.pumpAndSettle();
+
+      expect(find.textContaining('No log sink is installed'), findsOneWidget);
+      expect(find.text('No log records captured.'), findsNothing);
+      // And the clear action does not offer to empty a capture that is absent.
+      expect(
+        tester
+            .widget<IconButton>(
+              find.widgetWithIcon(IconButton, Icons.delete_sweep_outlined),
+            )
+            .onPressed,
+        isNull,
+      );
     });
   });
 }

--- a/test/modules/versions/server_versions_screen_test.dart
+++ b/test/modules/versions/server_versions_screen_test.dart
@@ -32,7 +32,7 @@ void main() {
       // Branded app name in the bar; the about/versions button is dropped
       // because this screen is itself part of the about destination.
       expect(find.text('Acme'), findsOneWidget);
-      expect(find.byTooltip('About & versions'), findsNothing);
+      expect(find.byTooltip('Diagnostics & versions'), findsNothing);
       // Back affordance and the server URL surfaced in the body.
       expect(find.byTooltip('Back to versions'), findsOneWidget);
       expect(find.text('http://test-server:8000'), findsOneWidget);

--- a/test/modules/versions/versions_screen_test.dart
+++ b/test/modules/versions/versions_screen_test.dart
@@ -32,7 +32,7 @@ void main() {
       // Branded app name shows in the bar; the about/versions button is
       // dropped because we are already on the versions destination.
       expect(find.text('Acme'), findsOneWidget);
-      expect(find.byTooltip('About & versions'), findsNothing);
+      expect(find.byTooltip('Diagnostics & versions'), findsNothing);
       expect(find.byTooltip('Back'), findsOneWidget);
     });
 


### PR DESCRIPTION
Third and last of three PRs. #517 renamed the screen, #518 routed logging through `LogManager` so records reach a sink a release build can read. This makes them readable, and saves both captures as one report.

## What

A `Requests` / `Logs` switch on the diagnostics screen. The log half is what the request list cannot show — why a probe gave up, what the platform error behind a friendly message was, whether a name resolves — and reading it used to mean attaching a debugger or launching from a terminal, neither of which is true of an installed app.

Either pane can save a plain-text report carrying **both** captures, unfiltered, because a reader cannot tell that something was filtered out rather than never recorded. Clearing takes whichever pane is showing.

The screen splits along the same seam: `diagnostics_screen.dart` (chrome, pane switch, export), `requests_pane.dart` (filters and list), `logs_pane.dart` (owns its own sink subscription). The 577-line screen became 3 files.

## Please look at these two

**1. The route joins `_publicPaths`.** A user stranded on the sign-in screen is unauthenticated by definition, so the guard put the one screen that explains why out of reach. The sign-in header's ⓘ button becomes a ⋮ menu with Diagnostics and Versions — the same pair the room rail and lobby sidebar already offer, both of which need a connected server.

**2. What that exposes.** HTTP capture is redacted (`HttpRedactor` replaces the values of `Authorization`, cookies and token-bearing query parameters, plus bodies, SSE content and error strings). **Log records are redacted by nothing.** Every `attributes:` site in the app today carries deployment detail — `discoveryUrl`, `serverUrl`, `hosts`, `expiresAt`, `platformError` — and no credential. But `error:` takes an arbitrary object, and an exception embedding a raw token response would reach the buffer and the saved file. The standard is author discipline plus a comment at the route; nothing fails CI.

That, and three other things never measured or never executed, are written down in `docs/diagnostics-known-risks.md` rather than left to be rediscovered. The redaction question and a possible iOS temp-file leak are flagged there as decisions this PR does not make.

## Report content worth knowing about

- **Every exchange gets an outcome, finished or not.** The reason to export a report is usually a run that is hanging — and a hanging run has no response, no stream end and no error, so it used to print a URL and stop. That was the one entry that mattered.
- **Streamed exchanges are read from their stream events**, since `onStreamStart`/`onStreamEnd` is a separate path from `onRequest`/`onResponse`/`onError` and a stream emits none of the latter.
- **Timestamps are UTC**, since the artifact exists to be read beside server logs on another machine.
- **An absent log sink is reported as such**, not as an empty capture — a host app configuring its own sinks would otherwise be told the code logged nothing.

## Saving states what happened rather than implying it

There is deliberately **no clipboard fallback**. The user asked for a file; silently overwriting whatever they had copied is not that.

- A dismissed dialog stays silent on screen but is recorded — Linux returns no path for a failed portal request and Windows for any dialog error, and neither is distinguishable from a cancel.
- Web claims only that a download *started*; whether the browser delivered it cannot be observed from Dart.
- A save that never answers says so, and leaves the file to the dialog the user still has open.
- A save that fails after the dialog closed names the file it *offered* — hedged, because the dialog lets the user rename and returns the name it used only on success.
- The wait is bounded, because a platform future that never completes would leave the action dead with nothing logged.

## Verification

- `flutter analyze --fatal-infos` clean, run per-commit in isolation by the pre-commit hook, so the stack bisects
- `flutter test` — 2412 passing
- Coverage measured as CI does (`packages/*` removed): **90.7%** against the 80% gate. New files: `logs_pane`, `diagnostics_report`, `log_record_format`, `log_capture`, `menu_row`, `home_shell` at 100%; `requests_pane` 93%; `diagnostics_screen` 90%
- `dart format`, `markdownlint-cli2` clean

Reviewed in three rounds by the pr-review-toolkit agents; the findings that survived verification are fixed, and the declines are recorded in the risk doc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)