### PR TITLE
chore: version 0.100.0+83

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 Versions follow the `version+build` scheme from `pubspec.yaml`, bumped via
 `dart run tool/bump_version.dart`.
 
-## [Unreleased]
+## [0.100.0+83] - 2026-08-20
 
 ### Changed
 

--- a/lib/version.dart
+++ b/lib/version.dart
@@ -2,4 +2,4 @@
 ///
 /// Generated from pubspec.yaml. Run `dart run tool/update_version.dart` after
 /// changing the version in pubspec.yaml.
-const String soliplexVersion = '0.99.3+82';
+const String soliplexVersion = '0.100.0+83';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,7 +3,7 @@ description: Modular Flutter frontend framework for Soliplex
 publish_to: none
 # To update version, run:
 # dart run tool/bump_version.dart <major|minor|patch|build>
-version: 0.99.3+82
+version: 0.100.0+83
 
 environment:
   sdk: ^3.6.0


### PR DESCRIPTION
Cuts release `0.100.0+83` (minor bump from `0.99.3+82`).

- `pubspec.yaml` / `lib/version.dart` — bumped via `dart run tool/bump_version.dart minor`
- `CHANGELOG.md` — the existing `[Unreleased]` block becomes `[0.100.0+83] - 2026-08-20`

No code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)