### PR TITLE
fix(logging): make the log-sink seam usable by host apps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,29 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 Versions follow the `version+build` scheme from `pubspec.yaml`, bumped via
 `dart run tool/bump_version.dart`.
 
+## [Unreleased]
+
+### Added
+
+- Public logging API for apps embedding this package as a library:
+  `installLogSinks()`, `LogManager`, `Logger`, `LogRecord`, `LogLevel`, the
+  `LogSink` interface, the console, stdout and memory sinks, and
+  `LoggerFactory` — which carries `LogManager.getLogger`, and without which the
+  exported `Logger` could never be obtained.
+
+### Fixed
+
+- Apps embedding this package as a library can now get logging. `LogManager`
+  discards every record when no sink is registered, and the function that
+  registers them was reachable only through a `src/` path with the logging
+  package not re-exported, so a host writing its own `main()` had no supported
+  way to turn logging on. Installing sinks stays the host's decision — nothing
+  is registered on its behalf.
+- The file picker's boot-time cache cleanup (Android and iOS) no longer fails
+  silently. The plugin reports a failed delete by resolving with `false`, or
+  `null` when Android has no attached activity, so the result is now checked as
+  well as the throw.
+
 ## [0.100.0+83] - 2026-08-20
 
 ### Changed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -232,7 +232,7 @@ Five internal packages under `packages/`:
 - `soliplex_client` — Backend HTTP/AG-UI API client, domain models, citation extraction
 - `soliplex_client_native` — Native HTTP client (iOS/macOS via cupertino_http)
 - `soliplex_design` — Core design system: tokens, theme factories, branded component library (button / badge / chip / input / dropdown / date+time picker), `SoliplexGlow`, `SoliplexShimmer` (animated skeleton placeholder), `SoliplexShimmerText` (light-sweep on running labels), shared visual primitives
-- `soliplex_logging` — Structured logging with memory, console, disk, and backend sinks
+- `soliplex_logging` — Structured logging with memory, console, stdout, and backend sinks (the backend sink buffers through a queue, disk-backed on native)
 
 ## CI
 

--- a/docs/authoring-a-flavor.md
+++ b/docs/authoring-a-flavor.md
@@ -60,6 +60,7 @@ Future<Flavor> myFlavor() {
 
 Future<void> main() async {
   WidgetsFlutterBinding.ensureInitialized();
+  installLogSinks();
   final flavor = await myFlavor();
   runSoliplexShell(flavor.build());
 }
@@ -85,9 +86,13 @@ Prefer `standardFlavor` unless you genuinely need a different module graph.
   `ShellConfig.fromModules`) throws without it.
 - Composition is append-only: add your own modules via `extraModules`; do not
   drop standard ones (Room depends on Lobby, and modules share session state).
+- Logging is yours to install, and nothing installs it for you: with no sink
+  attached `LogManager` discards every record. Call `installLogSinks()` before
+  you build your flavor, as the `main()` above does — the storage migration,
+  server restoration and the contrast checks below all log while the flavor is
+  being assembled.
 - Contrast checks only warn, never block. The warnings go through `LogManager`,
-  so attach a log sink in your app's `main()` to see them — with no sink
-  attached they drop silently.
+  so without a sink installed first they drop silently.
 - Disposal is yours: the `ShellConfig` returned by `Flavor.build()` carries a
   `dispose` callback that the shell widget never invokes. Standalone apps can
   rely on OS reclamation; embedders that unmount the shell must retain the

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,14 +1,11 @@
 import 'package:flutter/widgets.dart';
-import 'package:soliplex_logging/soliplex_logging.dart';
-
 import 'package:soliplex_frontend/soliplex_frontend.dart';
-import 'package:soliplex_frontend/src/core/log_sinks.dart';
 
 Future<void> main() async {
   WidgetsFlutterBinding.ensureInitialized();
   // See installLogSinks for where records surface (DevTools Logging vs stdout),
   // what can observe each, and the per-mode level floor.
-  installLogSinks(LogManager.instance);
+  installLogSinks();
   final callbackParams = CallbackParamsCapture.captureNow();
   clearCallbackUrl();
   runSoliplexShell(await standard(callbackParams: callbackParams));

--- a/lib/soliplex_frontend.dart
+++ b/lib/soliplex_frontend.dart
@@ -26,9 +26,25 @@ export 'package:soliplex_design/soliplex_design.dart'
         lightSoliplexColors,
         lowerBrandTheme,
         soliplexTextTheme;
+// Logging primitives, re-exported so a host app needs no `soliplex_logging`
+// dependency of its own. `LoggerFactory` carries `LogManager.getLogger`;
+// without it `Logger` would be a name a host can write but never obtain, since
+// its only constructor is private.
+export 'package:soliplex_logging/soliplex_logging.dart'
+    show
+        ConsoleSink,
+        LogLevel,
+        LogManager,
+        LogRecord,
+        LogSink,
+        Logger,
+        LoggerFactory,
+        MemorySink,
+        StdoutSink;
 export 'src/core/app_module.dart' show AppModule, ModuleRoutes;
 export 'src/core/app_identity.dart' show AppIdentity, BrandLogo;
 export 'src/core/flavor.dart' show Flavor, FlavorTheme;
+export 'src/core/log_sinks.dart' show installLogSinks;
 export 'src/core/inactivity/inactivity_config.dart' show InactivityConfig;
 export 'src/core/shell.dart' show runSoliplexShell;
 export 'src/core/shell_config.dart' show ShellConfig;

--- a/lib/src/core/log_sinks.dart
+++ b/lib/src/core/log_sinks.dart
@@ -7,16 +7,19 @@ import 'package:soliplex_logging/soliplex_logging.dart';
 ///
 /// - [ConsoleSink] goes through `dart:developer` to the VM-service logging
 ///   stream, so it reaches whatever client is attached — the DevTools
-///   "Logging" view or an IDE debugger. On a native release build it is
-///   effectively inert (AOT runs no VM service); on web it also writes the
-///   browser console, which is present even in a release build.
+///   "Logging" view or an IDE debugger, and *not* logcat or the `flutter run`
+///   console. On a native release build it is effectively inert (AOT runs no
+///   VM service); on web it also writes the browser console, which is present
+///   even in a release build.
 /// - [StdoutSink] writes raw stdout via `dart:io`, which goes to whoever owns
-///   the process: a terminal under `flutter run` or the launching tool under
-///   `flutter run --machine`. A packaged GUI app has no attached terminal, so
-///   its stdout is typically discarded (it is not Console.app / logcat — those
-///   carry the `dart:developer`/OS-logging path, not raw process stdout), and
-///   on web the sink is a no-op. For a view that doesn't depend on what's
-///   attached, route to a file (a disk sink, or shell redirection of stdout).
+///   the process. On a desktop target that is the terminal running the app, or
+///   the launching tool under `flutter run --machine`. On Android it is nobody:
+///   a record emitted through this sink reaches neither the `flutter run`
+///   console nor logcat — measured on a device, since the process's stdout
+///   belongs to the device rather than the host. A packaged GUI app likewise
+///   has no attached terminal, and on web the sink is a no-op. For a view that
+///   doesn't depend on what's attached, route to a file (a disk sink, or shell
+///   redirection of stdout).
 /// - [MemorySink] retains recent records in a ring buffer, readable in-process
 ///   via `LogManager.sinks`. On a *packaged* native release build it is the
 ///   only one whose output can be read back at all — the console sink's
@@ -28,13 +31,23 @@ import 'package:soliplex_logging/soliplex_logging.dart';
 ///
 /// All three register in every build mode; without a sink [LogManager] discards
 /// every record. Release is held to [LogLevel.warning] so the on-device stream
-/// stays quiet, while debug keeps [LogLevel.info]. Shipping logs *off* the
-/// device (a backend sink) is a separate decision that needs redaction and
-/// consent handling, since records can carry server URLs and error details.
-/// Host apps that embed this package as a library configure their own sinks.
-void installLogSinks(LogManager manager) {
-  manager.minimumLevel = kReleaseMode ? LogLevel.warning : LogLevel.info;
-  manager
+/// stays quiet, while every other mode — debug and profile — keeps
+/// [LogLevel.info]. Shipping logs *off* the device (a backend sink) is a
+/// separate decision that needs redaction and consent handling, since records
+/// can carry server URLs and error details.
+///
+/// Host apps that embed this package as a library configure their own sinks,
+/// and nothing installs any on their behalf: a host that calls neither this nor
+/// [LogManager.addSink] gets no logging, which is the default this package
+/// leaves alone. Call this once, before building your flavor — it sets the
+/// level floor unconditionally, and calling it twice registers a second set.
+///
+/// [LogManager.reset] is a test hook and [LogManager.close] is a shutdown
+/// path. Nothing re-installs sinks after either, so a host that calls one at
+/// runtime is back to discarding every record.
+void installLogSinks() {
+  LogManager.instance
+    ..minimumLevel = kReleaseMode ? LogLevel.warning : LogLevel.info
     ..addSink(ConsoleSink())
     ..addSink(StdoutSink())
     ..addSink(MemorySink());

--- a/lib/src/core/shell.dart
+++ b/lib/src/core/shell.dart
@@ -7,6 +7,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
+import 'package:soliplex_logging/soliplex_logging.dart';
 
 import 'inactivity/inactivity_dialog_host.dart';
 import 'inactivity/inactivity_monitor.dart';
@@ -35,12 +36,35 @@ void runSoliplexShell(ShellConfig config) {
 /// `UnimplementedError`. The `kIsWeb` short-circuit is necessary
 /// because `Platform.isAndroid` itself throws on web.
 ///
-/// Fire-and-forget: errors during cleanup never block app startup.
+/// Fire-and-forget: a failed cleanup never blocks app startup, but it is
+/// recorded, because the symptom — last session's picked files staying on disk
+/// — is otherwise invisible.
+///
+/// Both outcomes need handling. The plugin reports a failed delete by
+/// *resolving* with `false`, and with `null` when Android has no attached
+/// activity; only a channel-level fault (`MissingPluginException`, a
+/// `PlatformException`) arrives as a throw. On a device cold start the call
+/// resolved `true`, so the `null` case is handled rather than expected.
 void _clearFilePickerTempCacheOnMobile() {
   if (kIsWeb) return;
   if (!(Platform.isAndroid || Platform.isIOS)) return;
+  final logger = LogManager.instance.getLogger('soliplex.shell');
   unawaited(
-    FilePicker.clearTemporaryFiles().catchError((Object _) => false),
+    FilePicker.clearTemporaryFiles().then((cleared) {
+      if (cleared != true) {
+        logger.warning(
+          'The file picker temp cache was not cleared (result: $cleared)',
+        );
+      }
+    }).catchError((Object error, StackTrace stack) {
+      // With the trace: for a MissingPluginException or a TypeError out of the
+      // plugin path it is the only thing naming where the throw came from.
+      logger.warning(
+        'Failed to clear the file picker temp cache',
+        error: error,
+        stackTrace: stack,
+      );
+    }),
   );
 }
 

--- a/test/core/log_sinks_test.dart
+++ b/test/core/log_sinks_test.dart
@@ -1,18 +1,26 @@
 import 'package:flutter_test/flutter_test.dart';
-import 'package:soliplex_logging/soliplex_logging.dart';
 
-import 'package:soliplex_frontend/src/core/log_sinks.dart';
+// The barrel, not `src/`: it is the only supported path for a host app, so
+// importing `src/` here would let the export be dropped without a test
+// failing.
+import 'package:soliplex_frontend/soliplex_frontend.dart';
 
 void main() {
   tearDown(LogManager.instance.reset);
 
   test('installLogSinks registers console, stdout, and memory sinks', () {
-    installLogSinks(LogManager.instance);
+    // Not the value `reset` restores, so the floor assignment is observable.
+    LogManager.instance.minimumLevel = LogLevel.error;
 
+    installLogSinks();
+
+    // Debug and profile only: `kReleaseMode` is a compile-time constant, so
+    // the release floor cannot be reached from a test.
+    expect(LogManager.instance.minimumLevel, LogLevel.info);
     final sinks = LogManager.instance.sinks;
     // Console sink → DevTools/IDE logging view (via dart:developer); stdout
-    // sink → terminal / platform console. Both, so logs are visible regardless
-    // of what's attached to the process.
+    // sink → a terminal, on the platforms that hand the process one. Two
+    // transports, so a record does not depend on a single one being attached.
     expect(sinks.whereType<ConsoleSink>(), hasLength(1));
     expect(sinks.whereType<StdoutSink>(), hasLength(1));
     // The memory sink is the only one that survives a native release build —
@@ -21,4 +29,35 @@ void main() {
     // field diagnosis entirely, which is why it is pinned here.
     expect(sinks.whereType<MemorySink>(), hasLength(1));
   });
+
+  test('a host can compose a sink and name a logger through the barrel alone',
+      () {
+    final sink = _RecordingSink();
+    LogManager.instance.addSink(sink);
+
+    // `Logger`'s only constructor is private, so `LoggerFactory` — the
+    // extension carrying `getLogger` — has to be exported too or the exported
+    // `Logger` type is unobtainable. Dart `show` clauses gate extensions by
+    // name, so dropping it from the barrel breaks this line.
+    final Logger logger = LogManager.instance.getLogger('host.app');
+    logger.warning('from the host');
+
+    final LogRecord record = sink.records.single;
+    expect(record.message, 'from the host');
+  });
+}
+
+/// The whole point of exporting [LogSink]: a host implements its own sink
+/// against the barrel, with no `soliplex_logging` dependency of its own.
+class _RecordingSink implements LogSink {
+  final records = <LogRecord>[];
+
+  @override
+  void write(LogRecord record) => records.add(record);
+
+  @override
+  Future<void> flush() async {}
+
+  @override
+  Future<void> close() async {}
 }


### PR DESCRIPTION
## Problem

`LogManager.emit` iterates its sink list, so with no sink registered **every log record in the app is discarded at the source** — no console, no diagnostics pane, nothing.

The function that registers them, `installLogSinks`, was not exported from the barrel, and `soliplex_logging` was not re-exported either. A host app writing its own `main()` therefore had no supported way to turn logging on: the only routes were importing a `src/` path (which the `implementation_imports` lint flags) or declaring `soliplex_logging` itself, which couples the host to the exact commit this package resolved to.

The failure was silent. The single symptom was one note in the diagnostics screen, which nobody opens until something has already gone wrong — by which point there is nothing to read.

Note why CI could never have caught this: `implementation_imports` does not fire for same-package imports, so this repo's own clean `flutter analyze` was consistent with the export being absent.

## What this changes

- **Export `installLogSinks`** from the barrel, with a curated `show` list of the logging types (`LogManager`, `Logger`, `LogRecord`, `LogLevel`, `LogSink`, and the console/stdout/memory sinks). `LoggerFactory` is included because it carries `LogManager.getLogger`; without it the exported `Logger` is a name a host can write but never obtain, since its only constructor is private.
- **Drop the `LogManager` parameter.** That constructor is private and `instance` is the only obtainable value, so the only argument any caller could pass was the singleton the function already used.
- **Installing sinks stays the host's decision.** Nothing registers any on its behalf: a host that wants no logging keeps getting none by doing nothing, and one that wants the standard three calls `installLogSinks()` before building its flavor — early enough to catch the storage migration, server restoration and contrast checks that log during assembly.
- **Handle both failure paths of the file picker's boot cache cleanup.** The plugin reports a failed delete by *resolving* with `false`, and with `null` when Android has no attached activity; only a channel-level fault throws. The error was previously bound to `_` and discarded, so the realistic failure was invisible.
- **Correct the sink transport notes,** measured on an Android device: raw stdout reaches neither the `flutter run` console nor logcat there, and `dart:developer` reaches the VM-service stream rather than logcat.

## Verification

- `dart format` clean, `flutter analyze` zero issues, **2413 tests pass**, `markdownlint` clean.
- Coverage **90.6%** measured as CI does (after `lcov --remove 'packages/*'`), against the 80% gate.
- `flutter build web --release` succeeds.
- **Mutation-tested, 11/11 caught.** Every one of the ten public names was deleted from the `show` clause in turn and confirmed to break the build, and the level floor was both deleted and flipped to an unconditional `warning`. The test imports *only* the barrel, and every export clause carries a `show` list, so a dropped export is a compile failure rather than a silent regression.
- **Checked on hardware** (Galaxy S22, Android 16): `clearTemporaryFiles()` resolves `true` on a cold start, so the `null` branch is handled rather than expected; and a record emitted through all three sinks appears in neither the `flutter run` console nor `adb logcat`, which is what the corrected transport notes now say.

## Deliberately not included

- **Buffering pre-sink records.** `LogManager.emit` could retain a bounded buffer while the sink list is empty and replay it on the first `addSink`, which would make the position of the `installLogSinks()` call irrelevant. It changes a second package and wants its own review.
- **`@visibleForTesting` on `LogManager.reset()`.** Exporting `LogManager` makes that test hook host-reachable; the current guard is a dartdoc paragraph. Also a second-package change.
- **A shell-side fallback that installs sinks when a host registered none.** Considered and dropped: it changed the default behaviour of logging, and a consumer that wanted the old default — no sinks, no records — would have had to work around it by registering a no-op `LogSink`.

## Review note

Over half the added lines are comments and docs, and that prose has no automated check behind it. The riskiest claims (the sink transports, the plugin's failure contract) are now backed by device measurements and plugin sources rather than reasoning, but a careful read of `lib/src/core/shell.dart`'s cleanup dartdoc and the `installLogSinks` transport bullets would be worth more here than a re-read of the code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)