### PR TITLE
fix(logging): keep decoded input out of log records

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,9 +15,27 @@ Versions follow the `version+build` scheme from `pubspec.yaml`, bumped via
   `LogSink` interface, the console, stdout and memory sinks, and
   `LoggerFactory` — which carries `LogManager.getLogger`, and without which the
   exported `Logger` could never be obtained.
+- `describeFailure` in the logging API, which renders a caught exception for a
+  log record without echoing the input it was thrown over.
 
 ### Fixed
 
+- Decode failures no longer carry the data they failed on into the log buffer
+  the diagnostics screen displays and can export to a file.
+  `FormatException.toString()` embeds roughly 78 characters of its source, so a
+  corrupt stored session logged its access and refresh tokens and a corrupt
+  composer entry logged the user's unsent draft. Thirteen sites now record the
+  failure's reason and position instead of the exception object, and keep the
+  stack trace.
+- A token refresh that fails for an unexpected reason now records what
+  happened. `unknownError` collapsed five distinct failures and the exception
+  was discarded, so the log could report that a refresh failed but never why —
+  the case behind sessions that could only be recovered by deleting and
+  re-adding the server.
+- A response body that cannot be decoded is now reported by its content type
+  and size instead of by quoting the body, which named a credential when the
+  endpoint returning it was the MCP token, and which surfaced in the on-screen
+  error text as well as the log.
 - Apps embedding this package as a library can now get logging. `LogManager`
   discards every record when no sink is registered, and the function that
   registers them was reachable only through a `src/` path with the logging

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,29 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 Versions follow the `version+build` scheme from `pubspec.yaml`, bumped via
 `dart run tool/bump_version.dart`.
 
+## [Unreleased]
+
+### Added
+
+- Public logging API for apps embedding this package as a library:
+  `installLogSinks()`, `LogManager`, `Logger`, `LogRecord`, `LogLevel`, the
+  `LogSink` interface, the console, stdout and memory sinks, and
+  `LoggerFactory` — which carries `LogManager.getLogger`, and without which the
+  exported `Logger` could never be obtained.
+
+### Fixed
+
+- Apps embedding this package as a library can now get logging. `LogManager`
+  discards every record when no sink is registered, and the function that
+  registers them was reachable only through a `src/` path with the logging
+  package not re-exported, so a host writing its own `main()` had no supported
+  way to turn logging on. Installing sinks stays the host's decision — nothing
+  is registered on its behalf.
+- The file picker's boot-time cache cleanup (Android and iOS) no longer fails
+  silently. The plugin reports a failed delete by resolving with `false`, or
+  `null` when Android has no attached activity, so the result is now checked as
+  well as the throw.
+
 ## [0.100.0+83] - 2026-08-20
 
 ### Changed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -98,6 +98,55 @@ composes the standard one; `standard()` is that flavor, lowered. Modules are
 included/excluded by presence in the flavor — no enum or toggle framework. See
 `docs/authoring-a-flavor.md`.
 
+## Logging
+
+### Hard rule — never log a value the user or the backend supplied
+
+`error:` puts the exception object on the `LogRecord`, and `toString()` renders
+it into the in-memory buffer the diagnostics screen displays and can export to
+a file. Some exceptions carry the input they failed on:
+
+| Thrown by | What travels with it |
+| --------- | -------------------- |
+| `jsonDecode`, `int.parse`, `double.parse`, `Uri.parse`, `base64Decode` | `FormatException.source` — roughly 78 characters of the input around the failure offset |
+| `ArgumentError.value` | the rejected value |
+
+`utf8.decode` is the exception to the rule: its source is a byte list, so
+`toString()` prints no window.
+
+When a `catch` can see one of those — directly, or through a function it calls
+— pass `attributes: {'failure': describeFailure(e)}` (from `soliplex_logging`)
+instead of `error: e`. Keep `stackTrace:`; a stack trace carries frames, not
+values, and it is what says where the failure happened. This applies equally to
+a `.catchError(...)` or `onError:` callback, which is the same forward without
+the `catch` keyword to make it visible.
+
+The same applies to strings: never interpolate a caught exception into a log
+message, or into the `message:` of an exception you throw — the source window
+travels inside it. Interpolating an identifier (`serverId`, `roomId`) or a
+`runtimeType` is fine, and is what makes a record actionable.
+
+`describeFailure` keeps a `TypeError` whole, because the runtime builds it from
+type names alone: a cast failure still says what shape actually arrived, which
+is what names a proxy or portal page answering in the backend's place. An
+`ArgumentError` — and a `RangeError`, which extends it — keeps the name of the
+parameter it rejected, but never the value. Everything else is reduced to a
+type name, `StateError` and `UnsupportedError` included, because their text is
+supplied by whoever threw them.
+
+The rule does not fire when the record already carries the same value
+deliberately. `connection_probe.dart` logs `input`, `inputLength`, `candidates`
+and `hosts` as attributes, because a typed address with a stray character is a
+reported failure mode and the address is not a secret. Forwarding the
+`Uri.parse` failure beside them adds the offset of the offending character and
+no new value, so that site keeps `error:`.
+
+The rule does not reach network failures. A `SocketException` renders as a host
+and an OS error, and this codebase already logs hostnames as attributes
+(`discoveryUrl`). A `catch` that can only see those should keep `error:` —
+routing it through `describeFailure` would drop the failed host lookup that is
+the whole diagnosis.
+
 ## Design system
 
 The design system is the **single source of truth** for color, type, spacing,

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -232,7 +232,7 @@ Five internal packages under `packages/`:
 - `soliplex_client` — Backend HTTP/AG-UI API client, domain models, citation extraction
 - `soliplex_client_native` — Native HTTP client (iOS/macOS via cupertino_http)
 - `soliplex_design` — Core design system: tokens, theme factories, branded component library (button / badge / chip / input / dropdown / date+time picker), `SoliplexGlow`, `SoliplexShimmer` (animated skeleton placeholder), `SoliplexShimmerText` (light-sweep on running labels), shared visual primitives
-- `soliplex_logging` — Structured logging with memory, console, disk, and backend sinks
+- `soliplex_logging` — Structured logging with memory, console, stdout, and backend sinks (the backend sink buffers through a queue, disk-backed on native)
 
 ## CI
 

--- a/docs/authoring-a-flavor.md
+++ b/docs/authoring-a-flavor.md
@@ -60,6 +60,7 @@ Future<Flavor> myFlavor() {
 
 Future<void> main() async {
   WidgetsFlutterBinding.ensureInitialized();
+  installLogSinks();
   final flavor = await myFlavor();
   runSoliplexShell(flavor.build());
 }
@@ -85,9 +86,13 @@ Prefer `standardFlavor` unless you genuinely need a different module graph.
   `ShellConfig.fromModules`) throws without it.
 - Composition is append-only: add your own modules via `extraModules`; do not
   drop standard ones (Room depends on Lobby, and modules share session state).
+- Logging is yours to install, and nothing installs it for you: with no sink
+  attached `LogManager` discards every record. Call `installLogSinks()` before
+  you build your flavor, as the `main()` above does — the storage migration,
+  server restoration and the contrast checks below all log while the flavor is
+  being assembled.
 - Contrast checks only warn, never block. The warnings go through `LogManager`,
-  so attach a log sink in your app's `main()` to see them — with no sink
-  attached they drop silently.
+  so without a sink installed first they drop silently.
 - Disposal is yours: the `ShellConfig` returned by `Flavor.build()` carries a
   `dispose` callback that the shell widget never invokes. Standalone apps can
   rely on OS reclamation; embedders that unmount the shell must retain the

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,14 +1,11 @@
 import 'package:flutter/widgets.dart';
-import 'package:soliplex_logging/soliplex_logging.dart';
-
 import 'package:soliplex_frontend/soliplex_frontend.dart';
-import 'package:soliplex_frontend/src/core/log_sinks.dart';
 
 Future<void> main() async {
   WidgetsFlutterBinding.ensureInitialized();
   // See installLogSinks for where records surface (DevTools Logging vs stdout),
   // what can observe each, and the per-mode level floor.
-  installLogSinks(LogManager.instance);
+  installLogSinks();
   final callbackParams = CallbackParamsCapture.captureNow();
   clearCallbackUrl();
   runSoliplexShell(await standard(callbackParams: callbackParams));

--- a/lib/soliplex_frontend.dart
+++ b/lib/soliplex_frontend.dart
@@ -26,9 +26,25 @@ export 'package:soliplex_design/soliplex_design.dart'
         lightSoliplexColors,
         lowerBrandTheme,
         soliplexTextTheme;
+// Logging primitives, re-exported so a host app needs no `soliplex_logging`
+// dependency of its own. `LoggerFactory` carries `LogManager.getLogger`;
+// without it `Logger` would be a name a host can write but never obtain, since
+// its only constructor is private.
+export 'package:soliplex_logging/soliplex_logging.dart'
+    show
+        ConsoleSink,
+        LogLevel,
+        LogManager,
+        LogRecord,
+        LogSink,
+        Logger,
+        LoggerFactory,
+        MemorySink,
+        StdoutSink;
 export 'src/core/app_module.dart' show AppModule, ModuleRoutes;
 export 'src/core/app_identity.dart' show AppIdentity, BrandLogo;
 export 'src/core/flavor.dart' show Flavor, FlavorTheme;
+export 'src/core/log_sinks.dart' show installLogSinks;
 export 'src/core/inactivity/inactivity_config.dart' show InactivityConfig;
 export 'src/core/shell.dart' show runSoliplexShell;
 export 'src/core/shell_config.dart' show ShellConfig;

--- a/lib/src/core/log_sinks.dart
+++ b/lib/src/core/log_sinks.dart
@@ -7,16 +7,19 @@ import 'package:soliplex_logging/soliplex_logging.dart';
 ///
 /// - [ConsoleSink] goes through `dart:developer` to the VM-service logging
 ///   stream, so it reaches whatever client is attached — the DevTools
-///   "Logging" view or an IDE debugger. On a native release build it is
-///   effectively inert (AOT runs no VM service); on web it also writes the
-///   browser console, which is present even in a release build.
+///   "Logging" view or an IDE debugger, and *not* logcat or the `flutter run`
+///   console. On a native release build it is effectively inert (AOT runs no
+///   VM service); on web it also writes the browser console, which is present
+///   even in a release build.
 /// - [StdoutSink] writes raw stdout via `dart:io`, which goes to whoever owns
-///   the process: a terminal under `flutter run` or the launching tool under
-///   `flutter run --machine`. A packaged GUI app has no attached terminal, so
-///   its stdout is typically discarded (it is not Console.app / logcat — those
-///   carry the `dart:developer`/OS-logging path, not raw process stdout), and
-///   on web the sink is a no-op. For a view that doesn't depend on what's
-///   attached, route to a file (a disk sink, or shell redirection of stdout).
+///   the process. On a desktop target that is the terminal running the app, or
+///   the launching tool under `flutter run --machine`. On Android it is nobody:
+///   a record emitted through this sink reaches neither the `flutter run`
+///   console nor logcat — measured on a device, since the process's stdout
+///   belongs to the device rather than the host. A packaged GUI app likewise
+///   has no attached terminal, and on web the sink is a no-op. For a view that
+///   doesn't depend on what's attached, route to a file (a disk sink, or shell
+///   redirection of stdout).
 /// - [MemorySink] retains recent records in a ring buffer, readable in-process
 ///   via `LogManager.sinks`. On a *packaged* native release build it is the
 ///   only one whose output can be read back at all — the console sink's
@@ -28,13 +31,23 @@ import 'package:soliplex_logging/soliplex_logging.dart';
 ///
 /// All three register in every build mode; without a sink [LogManager] discards
 /// every record. Release is held to [LogLevel.warning] so the on-device stream
-/// stays quiet, while debug keeps [LogLevel.info]. Shipping logs *off* the
-/// device (a backend sink) is a separate decision that needs redaction and
-/// consent handling, since records can carry server URLs and error details.
-/// Host apps that embed this package as a library configure their own sinks.
-void installLogSinks(LogManager manager) {
-  manager.minimumLevel = kReleaseMode ? LogLevel.warning : LogLevel.info;
-  manager
+/// stays quiet, while every other mode — debug and profile — keeps
+/// [LogLevel.info]. Shipping logs *off* the device (a backend sink) is a
+/// separate decision that needs redaction and consent handling, since records
+/// can carry server URLs and error details.
+///
+/// Host apps that embed this package as a library configure their own sinks,
+/// and nothing installs any on their behalf: a host that calls neither this nor
+/// [LogManager.addSink] gets no logging, which is the default this package
+/// leaves alone. Call this once, before building your flavor — it sets the
+/// level floor unconditionally, and calling it twice registers a second set.
+///
+/// [LogManager.reset] is a test hook and [LogManager.close] is a shutdown
+/// path. Nothing re-installs sinks after either, so a host that calls one at
+/// runtime is back to discarding every record.
+void installLogSinks() {
+  LogManager.instance
+    ..minimumLevel = kReleaseMode ? LogLevel.warning : LogLevel.info
     ..addSink(ConsoleSink())
     ..addSink(StdoutSink())
     ..addSink(MemorySink());

--- a/lib/src/core/shell.dart
+++ b/lib/src/core/shell.dart
@@ -7,6 +7,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
+import 'package:soliplex_logging/soliplex_logging.dart';
 
 import 'inactivity/inactivity_dialog_host.dart';
 import 'inactivity/inactivity_monitor.dart';
@@ -35,12 +36,35 @@ void runSoliplexShell(ShellConfig config) {
 /// `UnimplementedError`. The `kIsWeb` short-circuit is necessary
 /// because `Platform.isAndroid` itself throws on web.
 ///
-/// Fire-and-forget: errors during cleanup never block app startup.
+/// Fire-and-forget: a failed cleanup never blocks app startup, but it is
+/// recorded, because the symptom — last session's picked files staying on disk
+/// — is otherwise invisible.
+///
+/// Both outcomes need handling. The plugin reports a failed delete by
+/// *resolving* with `false`, and with `null` when Android has no attached
+/// activity; only a channel-level fault (`MissingPluginException`, a
+/// `PlatformException`) arrives as a throw. On a device cold start the call
+/// resolved `true`, so the `null` case is handled rather than expected.
 void _clearFilePickerTempCacheOnMobile() {
   if (kIsWeb) return;
   if (!(Platform.isAndroid || Platform.isIOS)) return;
+  final logger = LogManager.instance.getLogger('soliplex.shell');
   unawaited(
-    FilePicker.clearTemporaryFiles().catchError((Object _) => false),
+    FilePicker.clearTemporaryFiles().then((cleared) {
+      if (cleared != true) {
+        logger.warning(
+          'The file picker temp cache was not cleared (result: $cleared)',
+        );
+      }
+    }).catchError((Object error, StackTrace stack) {
+      // With the trace: for a MissingPluginException or a TypeError out of the
+      // plugin path it is the only thing naming where the throw came from.
+      logger.warning(
+        'Failed to clear the file picker temp cache',
+        error: error,
+        stackTrace: stack,
+      );
+    }),
   );
 }
 

--- a/lib/src/modules/auth/auth_session.dart
+++ b/lib/src/modules/auth/auth_session.dart
@@ -187,12 +187,13 @@ class AuthSession implements TokenRefresher {
         markSessionExpired();
         return false;
 
-      case TokenRefreshFailure(:final reason):
+      case TokenRefreshFailure(:final reason, :final cause):
         // networkError is recoverable on retry; unknownError is the
         // anomaly worth recording at error level.
         final attributes = {
           'discoveryUrl': provider.discoveryUrl,
           'reason': reason.name,
+          if (cause != null) 'cause': cause,
         };
         if (reason == TokenRefreshFailureReason.networkError) {
           _logger.warning('Token refresh failed', attributes: attributes);

--- a/lib/src/modules/auth/pre_auth_state.dart
+++ b/lib/src/modules/auth/pre_auth_state.dart
@@ -157,7 +157,7 @@ abstract final class PreAuthStateStorage {
       // already in flight loses its return target.
       _logger.warning(
         'Failed to load pre-auth state',
-        error: e,
+        attributes: {'failure': describeFailure(e)},
         stackTrace: st,
       );
       await clear();

--- a/lib/src/modules/auth/return_to_storage.dart
+++ b/lib/src/modules/auth/return_to_storage.dart
@@ -80,7 +80,7 @@ abstract final class ReturnToStorage {
     } catch (e, st) {
       _logger.warning(
         'Corrupted composer entry; clearing',
-        error: e,
+        attributes: {'failure': describeFailure(e)},
         stackTrace: st,
       );
       await clearComposer(serverId: serverId, userId: userId, roomId: roomId);

--- a/lib/src/modules/auth/secure_server_storage.dart
+++ b/lib/src/modules/auth/secure_server_storage.dart
@@ -58,7 +58,7 @@ Map<String, PersistedServer> deserializeStorageEntries(
     } catch (e, st) {
       _logger.warning(
         'Failed to load stored session ${entry.key}',
-        error: e,
+        attributes: {'failure': describeFailure(e)},
         stackTrace: st,
       );
     }

--- a/lib/src/modules/lobby/lobby_read_markers.dart
+++ b/lib/src/modules/lobby/lobby_read_markers.dart
@@ -150,9 +150,13 @@ abstract final class LobbyReadMarkerStorage {
         // skip isn't silent, matching the other corruption sites in this class.
         _logger.warning(
           'Skipped corrupt room read marker blob while clearing a room',
-          error: error,
           stackTrace: st,
-          attributes: {'serverId': serverId, 'roomId': roomId, 'key': k},
+          attributes: {
+            'failure': describeFailure(error),
+            'serverId': serverId,
+            'roomId': roomId,
+            'key': k,
+          },
         );
         continue;
       }

--- a/lib/src/modules/room/thread_anchor_storage.dart
+++ b/lib/src/modules/room/thread_anchor_storage.dart
@@ -122,9 +122,9 @@ abstract final class ThreadAnchorStorage {
         // this skip isn't silent, matching the corruption sites elsewhere.
         _logger.warning(
           'Skipped corrupt thread anchor blob while clearing a thread',
-          error: error,
           stackTrace: st,
           attributes: {
+            'failure': describeFailure(error),
             'serverId': serverId,
             'roomId': roomId,
             'threadId': threadId,

--- a/lib/src/modules/room/thread_read_markers.dart
+++ b/lib/src/modules/room/thread_read_markers.dart
@@ -138,9 +138,9 @@ abstract final class ThreadReadMarkerStorage {
         // this skip isn't silent, matching the corruption sites elsewhere.
         _logger.warning(
           'Skipped corrupt thread read marker blob while clearing a thread',
-          error: error,
           stackTrace: st,
           attributes: {
+            'failure': describeFailure(error),
             'serverId': serverId,
             'roomId': roomId,
             'threadId': threadId,

--- a/lib/src/modules/room/ui/chunk_visualization_page.dart
+++ b/lib/src/modules/room/ui/chunk_visualization_page.dart
@@ -182,7 +182,7 @@ class _ChunkVisualizationPageState extends State<ChunkVisualizationPage> {
     } on FormatException catch (error, stack) {
       _logger.warning(
         'chunk image base64 decode failed',
-        error: error,
+        attributes: {'failure': describeFailure(error)},
         stackTrace: stack,
       );
       return PageImageBroken(reason: error.message);

--- a/packages/soliplex_client/lib/src/api/agui_message_mapper.dart
+++ b/packages/soliplex_client/lib/src/api/agui_message_mapper.dart
@@ -261,7 +261,7 @@ void _dropLabelFor(
     // so one message cannot cost the thread.
     _logger.error(
       'Reading the content of $logContext threw; hydrating the message empty.',
-      error: error,
+      attributes: {'failure': describeFailure(error)},
       stackTrace: stackTrace,
     );
     return (parts: null, text: '');
@@ -434,7 +434,7 @@ MessagePart _readImageSource(
         _logger.warning(
           'Content[$index] of $logContext has undecodable base64; showing it '
           'as a missing attachment.',
-          error: error,
+          attributes: {'failure': describeFailure(error)},
         );
         return MissingAttachmentPart(
           reason: MissingAttachmentReason.undecodable,

--- a/packages/soliplex_client/lib/src/api/soliplex_api.dart
+++ b/packages/soliplex_client/lib/src/api/soliplex_api.dart
@@ -352,7 +352,8 @@ class SoliplexApi {
       rethrow;
     } on Object catch (error, stackTrace) {
       throw MalformedResponseException(
-        message: 'getThreads: malformed thread entry: $error',
+        message: 'getThreads: malformed thread entry: '
+            '${describeFailure(error)}',
         originalError: error,
         stackTrace: stackTrace,
       );

--- a/packages/soliplex_client/lib/src/application/rag_snapshot.dart
+++ b/packages/soliplex_client/lib/src/application/rag_snapshot.dart
@@ -150,7 +150,7 @@ class CitedFigures {
       _logger.warning(
         'RagSnapshot: picture ref "$ref" for document "$documentId" has '
         'undecodable base64; dropped.',
-        error: error,
+        attributes: {'failure': describeFailure(error)},
       );
       return null;
     }

--- a/packages/soliplex_client/lib/src/auth/token_refresh_service.dart
+++ b/packages/soliplex_client/lib/src/auth/token_refresh_service.dart
@@ -4,6 +4,7 @@ import 'package:soliplex_client/src/auth/oidc_discovery.dart';
 import 'package:soliplex_client/src/errors/exceptions.dart';
 import 'package:soliplex_client/src/http/http_response.dart';
 import 'package:soliplex_client/src/http/soliplex_http_client.dart';
+import 'package:soliplex_logging/soliplex_logging.dart';
 
 /// Result of a token refresh operation.
 sealed class TokenRefreshResult {
@@ -45,11 +46,35 @@ class TokenRefreshSuccess extends TokenRefreshResult {
 /// Failed token refresh.
 class TokenRefreshFailure extends TokenRefreshResult {
   /// Creates a failed token refresh result.
-  const TokenRefreshFailure(this.reason);
+  const TokenRefreshFailure(this.reason, {this.cause});
 
   /// The reason for failure.
   final TokenRefreshFailureReason reason;
+
+  /// Log-safe phrase naming what produced [reason].
+  ///
+  /// [TokenRefreshFailureReason.unknownError] is a bucket — a malformed
+  /// response, a rejected discovery document and an IdP error code all land
+  /// in it — so without this the log can say a refresh failed but not why.
+  /// Never holds response text: failures are rendered by [describeFailure]
+  /// and the IdP's error code is reported only when it is one of
+  /// [_oidcErrorCodes]. `null` where [reason] already says everything.
+  final String? cause;
 }
+
+/// The error codes RFC 6749 §5.2 defines for a token endpoint.
+///
+/// A code outside this set is reported as `unrecognized` rather than echoed:
+/// the token response is the most credential-dense payload the app handles,
+/// and a non-conforming IdP could put anything in the field.
+const _oidcErrorCodes = {
+  'invalid_request',
+  'invalid_client',
+  'invalid_grant',
+  'unauthorized_client',
+  'unsupported_grant_type',
+  'invalid_scope',
+};
 
 /// Reason for token refresh failure.
 enum TokenRefreshFailureReason {
@@ -141,10 +166,16 @@ class TokenRefreshService {
     } on NetworkException {
       return const TokenRefreshFailure(TokenRefreshFailureReason.networkError);
     } on FormatException catch (e) {
-      _onDiagnostic('TokenRefreshService: $e');
-      return const TokenRefreshFailure(TokenRefreshFailureReason.unknownError);
-    } catch (_) {
-      return const TokenRefreshFailure(TokenRefreshFailureReason.unknownError);
+      _onDiagnostic('TokenRefreshService: ${describeFailure(e)}');
+      return TokenRefreshFailure(
+        TokenRefreshFailureReason.unknownError,
+        cause: describeFailure(e),
+      );
+    } catch (e) {
+      return TokenRefreshFailure(
+        TokenRefreshFailureReason.unknownError,
+        cause: describeFailure(e),
+      );
     }
   }
 
@@ -184,8 +215,11 @@ class TokenRefreshService {
     final Map<String, dynamic> tokenData;
     try {
       tokenData = jsonDecode(response.body) as Map<String, dynamic>;
-    } on FormatException {
-      return const TokenRefreshFailure(TokenRefreshFailureReason.unknownError);
+    } on FormatException catch (e) {
+      return TokenRefreshFailure(
+        TokenRefreshFailureReason.unknownError,
+        cause: 'token response was not JSON: ${describeFailure(e)}',
+      );
     }
 
     // Handle error responses
@@ -196,13 +230,20 @@ class TokenRefreshService {
           TokenRefreshFailureReason.invalidGrant,
         );
       }
-      return const TokenRefreshFailure(TokenRefreshFailureReason.unknownError);
+      final code = _oidcErrorCodes.contains(error) ? error : 'unrecognized';
+      return TokenRefreshFailure(
+        TokenRefreshFailureReason.unknownError,
+        cause: 'token endpoint returned ${response.statusCode} ($code)',
+      );
     }
 
     // Parse successful response
     final accessToken = tokenData['access_token'] as String?;
     if (accessToken == null) {
-      return const TokenRefreshFailure(TokenRefreshFailureReason.unknownError);
+      return const TokenRefreshFailure(
+        TokenRefreshFailureReason.unknownError,
+        cause: 'token response had no access_token',
+      );
     }
 
     DateTime expiresAt;

--- a/packages/soliplex_client/lib/src/http/http_transport.dart
+++ b/packages/soliplex_client/lib/src/http/http_transport.dart
@@ -6,6 +6,7 @@ import 'package:soliplex_client/src/errors/exceptions.dart';
 import 'package:soliplex_client/src/http/http_response.dart';
 import 'package:soliplex_client/src/http/soliplex_http_client.dart';
 import 'package:soliplex_client/src/utils/cancel_token.dart';
+import 'package:soliplex_logging/soliplex_logging.dart';
 
 /// HTTP transport layer with JSON serialization and exception mapping.
 ///
@@ -431,8 +432,15 @@ class HttpTransport {
     } on SoliplexException {
       rethrow;
     } on Object catch (error, stackTrace) {
+      // `bodyBytes.length`, not `body.length`: `body` decodes UTF-8 and
+      // throws, and a throw here would replace the exception being built.
+      // The content type names a proxy or portal page answering in the
+      // backend's place, which the failure alone cannot.
       throw MalformedResponseException(
-        message: 'Could not decode the response body as $T: $error',
+        message: 'Could not decode the response body as $T '
+            '(content-type ${response.contentType ?? 'none'}, '
+            '${response.bodyBytes.length} bytes): '
+            '${describeFailure(error)}',
         originalError: error,
         stackTrace: stackTrace,
       );

--- a/packages/soliplex_client/test/auth/token_refresh_service_test.dart
+++ b/packages/soliplex_client/test/auth/token_refresh_service_test.dart
@@ -253,6 +253,98 @@ void main() {
     });
 
     group('discovery validation', () {
+      test(
+          'names the cause when the token response is not JSON, without '
+          'echoing the body', () async {
+        setupDiscoverySuccess();
+        // A proxy or portal answering in the IdP's place, truncated mid-write:
+        // the body a real token endpoint returns is the most credential-dense
+        // payload in the app.
+        when(
+          () => mockClient.request(
+            'POST',
+            Uri.parse('https://idp.example.com/oauth2/token'),
+            headers: any(named: 'headers'),
+            body: any(named: 'body'),
+            timeout: any(named: 'timeout'),
+          ),
+        ).thenAnswer(
+          (_) async => HttpResponse(
+            statusCode: 200,
+            bodyBytes: Uint8List.fromList(
+              utf8.encode('{"access_token":"at_SECRET_VALUE",'
+                  '"refresh_token":"rt_SECRET_VALUE" TRUNCATED'),
+            ),
+          ),
+        );
+
+        final result = await service.refresh(
+          discoveryUrl: discoveryUrl,
+          refreshToken: refreshToken,
+          clientId: clientId,
+        );
+
+        final failure = result as TokenRefreshFailure;
+        expect(failure.reason, TokenRefreshFailureReason.unknownError);
+        expect(failure.cause, isNotNull);
+        expect(failure.cause, contains('FormatException'));
+        expect(failure.cause, isNot(contains('SECRET')));
+      });
+
+      test('reports an unrecognized OIDC error code as unrecognized', () async {
+        setupDiscoverySuccess();
+        when(
+          () => mockClient.request(
+            'POST',
+            Uri.parse('https://idp.example.com/oauth2/token'),
+            headers: any(named: 'headers'),
+            body: any(named: 'body'),
+            timeout: any(named: 'timeout'),
+          ),
+        ).thenAnswer(
+          (_) async => jsonResponse(
+            {'error': 'at_SECRET_VALUE_masquerading_as_a_code'},
+            statusCode: 400,
+          ),
+        );
+
+        final result = await service.refresh(
+          discoveryUrl: discoveryUrl,
+          refreshToken: refreshToken,
+          clientId: clientId,
+        );
+
+        final failure = result as TokenRefreshFailure;
+        expect(failure.reason, TokenRefreshFailureReason.unknownError);
+        expect(failure.cause, isNot(contains('SECRET')));
+      });
+
+      test('names a recognized OIDC error code', () async {
+        setupDiscoverySuccess();
+        when(
+          () => mockClient.request(
+            'POST',
+            Uri.parse('https://idp.example.com/oauth2/token'),
+            headers: any(named: 'headers'),
+            body: any(named: 'body'),
+            timeout: any(named: 'timeout'),
+          ),
+        ).thenAnswer(
+          (_) async =>
+              jsonResponse({'error': 'invalid_client'}, statusCode: 400),
+        );
+
+        final result = await service.refresh(
+          discoveryUrl: discoveryUrl,
+          refreshToken: refreshToken,
+          clientId: clientId,
+        );
+
+        final failure = result as TokenRefreshFailure;
+        expect(failure.reason, TokenRefreshFailureReason.unknownError);
+        expect(failure.cause, contains('invalid_client'));
+      });
+
       test('returns unknownError when discovery returns non-200', () async {
         when(
           () => mockClient.request(

--- a/packages/soliplex_logging/lib/soliplex_logging.dart
+++ b/packages/soliplex_logging/lib/soliplex_logging.dart
@@ -1,6 +1,7 @@
 /// Central logging package for Soliplex applications.
 library;
 
+export 'src/failure_description.dart';
 export 'src/log_level.dart';
 export 'src/log_manager.dart';
 export 'src/log_record.dart';

--- a/packages/soliplex_logging/lib/src/failure_description.dart
+++ b/packages/soliplex_logging/lib/src/failure_description.dart
@@ -1,0 +1,37 @@
+/// Renders [failure] for a log record without echoing the input it was
+/// thrown over.
+///
+/// `FormatException.toString()` embeds roughly 78 characters of
+/// `FormatException.source` around the failure offset. Where the source is a
+/// persisted blob or a response body, that window is the payload itself, so
+/// it must not reach a sink. The offset is a number, and the SDK parsers
+/// these callers use (`jsonDecode`, `DateTime.parse`) draw the reason from a
+/// fixed vocabulary, so neither carries input. A hand-thrown
+/// `FormatException` is free to interpolate one into its message; none of
+/// the callers produce those.
+///
+/// A [TypeError] is kept whole. The runtime builds it from type names alone,
+/// so it carries no value, and it is what says a response arrived as a string
+/// where an object was expected.
+///
+/// An [ArgumentError] — including a [RangeError], which extends it — keeps
+/// the name of the parameter it rejected. That is the diagnosis: which field
+/// was refused. Its `invalidValue` is the data, and its message is written by
+/// whoever threw it, so neither is kept.
+///
+/// Any other failure is reduced to its type: an exception is free to put a
+/// value in its message, and the concrete type isn't known at a catch-all
+/// call site.
+String describeFailure(Object failure) {
+  if (failure is TypeError) return 'TypeError: $failure';
+  if (failure is ArgumentError) {
+    final name = failure.name;
+    return name == null
+        ? failure.runtimeType.toString()
+        : '${failure.runtimeType}: $name';
+  }
+  if (failure is! FormatException) return failure.runtimeType.toString();
+  final offset = failure.offset;
+  final where = offset == null ? '' : ' (offset $offset)';
+  return 'FormatException: ${failure.message}$where';
+}

--- a/packages/soliplex_logging/test/failure_description_test.dart
+++ b/packages/soliplex_logging/test/failure_description_test.dart
@@ -1,0 +1,105 @@
+import 'dart:convert';
+
+import 'package:soliplex_logging/soliplex_logging.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('describeFailure', () {
+    test('keeps the reason and offset of a decode failure, not the source', () {
+      // The blob a truncated storage write produces: the token values sit
+      // inside the window FormatException.toString() would echo.
+      const blob = '{"serverUrl":"https://example.com",'
+          '"tokens":{"accessToken":"eyJhbGciOiJIUzI1NiJ9.SECRET_PAYLOAD",'
+          '"refreshToken":"rt_ABCDEF"} TRUNCATED';
+
+      String described;
+      try {
+        jsonDecode(blob);
+        fail('expected a FormatException');
+      } on FormatException catch (e) {
+        described = describeFailure(e);
+      }
+
+      expect(described, contains('Unexpected character'));
+      expect(described, contains('offset'));
+      expect(described, isNot(contains('SECRET_PAYLOAD')));
+      expect(described, isNot(contains('rt_ABCDEF')));
+    });
+
+    test('omits the offset when the failure has none', () {
+      String described;
+      try {
+        DateTime.parse('SECRET-not-a-date');
+        fail('expected a FormatException');
+      } on FormatException catch (e) {
+        described = describeFailure(e);
+      }
+
+      expect(described, contains('Invalid date format'));
+      expect(described, isNot(contains('offset')));
+      expect(described, isNot(contains('SECRET')));
+    });
+
+    test('keeps a type error in full: it renders types, never values', () {
+      const body = '<html>SECRET</html>';
+      Object? caught;
+      try {
+        // The shape a non-JSON response body produces: the cast fails, and
+        // the type names are what say the body arrived as a string.
+        caught = (body as dynamic) as Map<String, dynamic>;
+      } on Object catch (e) {
+        caught = e;
+      }
+
+      expect(caught, isA<TypeError>());
+      final described = describeFailure(caught);
+
+      expect(described, contains("type 'String' is not a subtype"));
+      expect(described, contains('Map<String, dynamic>'));
+      expect(described, isNot(contains('SECRET')));
+    });
+
+    test('names the rejected parameter of an argument error, not its value',
+        () {
+      // The shape a rejected open-redirect return path produces: which field
+      // was refused is the diagnosis; the value and the prose are not.
+      final described = describeFailure(
+        ArgumentError.value(
+          'https://evil.example.com/SECRET',
+          'frontendReturnTo',
+          'must be an in-app path starting with "/"',
+        ),
+      );
+
+      expect(described, 'ArgumentError: frontendReturnTo');
+      expect(described, isNot(contains('SECRET')));
+      expect(described, isNot(contains('in-app path')));
+    });
+
+    test('drops the bounds of a range error, keeping the parameter', () {
+      // RangeError extends ArgumentError and embeds its value, so it must
+      // route through the same arm rather than falling through.
+      final described =
+          describeFailure(RangeError.value(4815162342, 'pageIndex'));
+
+      expect(described, 'RangeError: pageIndex');
+      expect(described, isNot(contains('4815162342')));
+    });
+
+    test('falls back to the type when an argument error names no parameter',
+        () {
+      final described = describeFailure(ArgumentError('SECRET_DETAIL'));
+
+      expect(described, 'ArgumentError');
+    });
+
+    test('reduces any other failure to its type', () {
+      // The message is written by whoever threw; none of it is safe to keep.
+      final described =
+          describeFailure(UnsupportedError('Cannot modify SECRET_LIST'));
+
+      expect(described, 'UnsupportedError');
+      expect(described, isNot(contains('SECRET')));
+    });
+  });
+}

--- a/test/core/log_sinks_test.dart
+++ b/test/core/log_sinks_test.dart
@@ -1,18 +1,26 @@
 import 'package:flutter_test/flutter_test.dart';
-import 'package:soliplex_logging/soliplex_logging.dart';
 
-import 'package:soliplex_frontend/src/core/log_sinks.dart';
+// The barrel, not `src/`: it is the only supported path for a host app, so
+// importing `src/` here would let the export be dropped without a test
+// failing.
+import 'package:soliplex_frontend/soliplex_frontend.dart';
 
 void main() {
   tearDown(LogManager.instance.reset);
 
   test('installLogSinks registers console, stdout, and memory sinks', () {
-    installLogSinks(LogManager.instance);
+    // Not the value `reset` restores, so the floor assignment is observable.
+    LogManager.instance.minimumLevel = LogLevel.error;
 
+    installLogSinks();
+
+    // Debug and profile only: `kReleaseMode` is a compile-time constant, so
+    // the release floor cannot be reached from a test.
+    expect(LogManager.instance.minimumLevel, LogLevel.info);
     final sinks = LogManager.instance.sinks;
     // Console sink → DevTools/IDE logging view (via dart:developer); stdout
-    // sink → terminal / platform console. Both, so logs are visible regardless
-    // of what's attached to the process.
+    // sink → a terminal, on the platforms that hand the process one. Two
+    // transports, so a record does not depend on a single one being attached.
     expect(sinks.whereType<ConsoleSink>(), hasLength(1));
     expect(sinks.whereType<StdoutSink>(), hasLength(1));
     // The memory sink is the only one that survives a native release build —
@@ -21,4 +29,35 @@ void main() {
     // field diagnosis entirely, which is why it is pinned here.
     expect(sinks.whereType<MemorySink>(), hasLength(1));
   });
+
+  test('a host can compose a sink and name a logger through the barrel alone',
+      () {
+    final sink = _RecordingSink();
+    LogManager.instance.addSink(sink);
+
+    // `Logger`'s only constructor is private, so `LoggerFactory` — the
+    // extension carrying `getLogger` — has to be exported too or the exported
+    // `Logger` type is unobtainable. Dart `show` clauses gate extensions by
+    // name, so dropping it from the barrel breaks this line.
+    final Logger logger = LogManager.instance.getLogger('host.app');
+    logger.warning('from the host');
+
+    final LogRecord record = sink.records.single;
+    expect(record.message, 'from the host');
+  });
+}
+
+/// The whole point of exporting [LogSink]: a host implements its own sink
+/// against the barrel, with no `soliplex_logging` dependency of its own.
+class _RecordingSink implements LogSink {
+  final records = <LogRecord>[];
+
+  @override
+  void write(LogRecord record) => records.add(record);
+
+  @override
+  Future<void> flush() async {}
+
+  @override
+  Future<void> close() async {}
 }

--- a/test/modules/auth/return_to_storage_test.dart
+++ b/test/modules/auth/return_to_storage_test.dart
@@ -2,6 +2,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:soliplex_frontend/src/core/keyed_storage.dart';
 import 'package:soliplex_frontend/src/modules/auth/return_to_storage.dart';
+import 'package:soliplex_logging/soliplex_logging.dart';
 
 final _baseTime = DateTime.utc(2026, 5, 20, 12);
 
@@ -9,9 +10,21 @@ void main() {
   group('ReturnToStorage composer', () {
     const u = 'iss#user';
 
+    late MemorySink sink;
+
     setUp(() {
       SharedPreferences.setMockInitialValues({});
+      sink = MemorySink();
+      LogManager.instance.addSink(sink);
     });
+
+    tearDown(LogManager.instance.reset);
+
+    /// An entry truncated mid-write: the shape production actually hands to
+    /// [jsonDecode], with the draft text a failure would sit next to.
+    const truncatedDraftEntry =
+        '{"unsentText":"my private draft about SECRET_PROJECT",'
+        '"createdAt":"2026-05-20T12:00:00.000Z" TRUNCATED';
 
     test('save and load round-trip', () async {
       await ReturnToStorage.saveComposer(
@@ -144,7 +157,7 @@ void main() {
       final prefs = await SharedPreferences.getInstance();
       await prefs.setString(
         encodeKey('soliplex_return_to:composer', ['a', u, 'r']),
-        '{not valid json',
+        truncatedDraftEntry,
       );
 
       final loaded = await ReturnToStorage.loadComposer(
@@ -154,6 +167,30 @@ void main() {
       );
       expect(loaded, isNull);
       expect(prefs.getKeys(), isEmpty);
+    });
+
+    test('logs the corrupted entry without its draft text', () async {
+      final prefs = await SharedPreferences.getInstance();
+      await prefs.setString(
+        encodeKey('soliplex_return_to:composer', ['a', u, 'r']),
+        truncatedDraftEntry,
+      );
+
+      await ReturnToStorage.loadComposer(
+        serverId: 'a',
+        userId: u,
+        roomId: 'r',
+      );
+
+      final record = sink.records.single;
+      expect(record.toString(), isNot(contains('SECRET_PROJECT')));
+      expect(record.toString(), isNot(contains('private draft')));
+      expect(record.error, isNull);
+      expect(record.message, 'Corrupted composer entry; clearing');
+      expect(
+        record.attributes['failure'],
+        'FormatException: Unexpected character (offset 93)',
+      );
     });
 
     test('clearComposer removes a stored entry', () async {

--- a/test/modules/auth/secure_server_storage_test.dart
+++ b/test/modules/auth/secure_server_storage_test.dart
@@ -3,10 +3,28 @@ import 'dart:convert';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:soliplex_frontend/src/modules/auth/secure_server_storage.dart';
 import 'package:soliplex_frontend/src/modules/auth/server_storage.dart';
+import 'package:soliplex_logging/soliplex_logging.dart';
 
 void main() {
   group('deserializeStorageEntries', () {
     const prefix = 'soliplex_server_';
+
+    late MemorySink sink;
+
+    setUp(() {
+      sink = MemorySink();
+      LogManager.instance.addSink(sink);
+    });
+
+    tearDown(LogManager.instance.reset);
+
+    /// A persisted blob truncated mid-write: the shape production actually
+    /// hands to [jsonDecode], with the token values a failure would sit next
+    /// to.
+    const truncatedTokenBlob =
+        '{"serverUrl":"https://example.com","requiresAuth":true,'
+        '"tokens":{"accessToken":"eyJhbGciOiJIUzI1NiJ9.SECRET_PAYLOAD_HERE",'
+        '"refreshToken":"rt_ABCDEF"} TRUNCATED';
 
     String encode(Map<String, dynamic> json) => jsonEncode(json);
 
@@ -88,12 +106,28 @@ void main() {
     test('silently skips malformed JSON', () {
       final raw = {
         '${prefix}good': encode(knownServerJson()),
-        '${prefix}bad': 'not valid json {{{',
+        '${prefix}bad': truncatedTokenBlob,
       };
 
       final result = deserializeStorageEntries(raw, prefix: prefix);
       expect(result, hasLength(1));
       expect(result.containsKey('good'), isTrue);
+    });
+
+    test('logs the skipped entry without its token material', () {
+      final raw = {'${prefix}bad': truncatedTokenBlob};
+
+      deserializeStorageEntries(raw, prefix: prefix);
+
+      final record = sink.records.single;
+      expect(record.toString(), isNot(contains('SECRET_PAYLOAD_HERE')));
+      expect(record.toString(), isNot(contains('rt_ABCDEF')));
+      expect(record.error, isNull);
+      expect(record.message, contains('${prefix}bad'));
+      expect(
+        record.attributes['failure'],
+        'FormatException: Unexpected character (offset 150)',
+      );
     });
 
     test('silently skips entries where fromJson throws', () {


### PR DESCRIPTION
## Why

`FormatException.toString()` embeds roughly 78 characters of its source around
the failure offset. Where that source is a persisted blob or a response body,
the window *is* the payload. Two `catch` blocks passed such an exception to a
logger, so a corrupt stored session put its access and refresh tokens into the
in-memory buffer the diagnostics screen displays and can export to a file, and a
corrupt composer entry put the user's unsent draft there.

Real `dart` output, not a sketch:

```text
FormatException: Unexpected character (at character 103)
...bGciOiJIUzI1NiJ9.SECRET_PAYLOAD_HERE","refreshToken":"rt_ABCDEF"} TRUNCATED
                                                                     ^
```

## What

`describeFailure` builds a description from the fields that **cannot** hold
input, rather than trimming the ones that can — so there is no cut point to get
wrong, and it holds however the data changes:

| Failure | Kept | Dropped |
| --- | --- | --- |
| `FormatException` | reason, offset | `source` — the input |
| `TypeError` | whole; the runtime builds it from type names | — |
| `ArgumentError` / `RangeError` | the rejected parameter's name | the value, the caller's message |
| anything else | the type name | the message, written by whoever threw it |

Thirteen sites now route through it, spanning stored sessions, composer drafts,
read markers, document images, message content and response bodies. Stack traces
stay: they carry frames, not values.

Two changes go the other way, restoring diagnosis the reduction would otherwise
cost:

- A malformed response names its **content type and size**, which tells a proxy
  or portal page apart from a truncated payload without quoting either. This
  also surfaced in the on-screen error text, so it was a leak into screenshots
  as well as logs.
- `TokenRefreshFailure` carries a **cause**. `unknownError` collapsed five
  distinct failures and `catch (_)` discarded the exception, so a refresh could
  fail without the log ever saying why — the case behind sessions recoverable
  only by deleting and re-adding a server. The token endpoint's own error code
  is reported only when it is one of those RFC 6749 §5.2 defines, since a
  non-conforming IdP could put anything in that field.

Network failures are **deliberately untouched**. A `SocketException` renders the
failed host lookup, which is the diagnosis itself, and a hostname grants no
authority — routing those through `describeFailure` would destroy the DNS
diagnostic. `CLAUDE.md` records that scoping, along with the rule and its
exemptions.

## Verification

Every claim about what an exception carries was measured by running it. That
mattered twice: `utf8.decode` turns out **not** to leak (its source is a byte
list, so no window is printed), and `RangeError` extends `ArgumentError`, so it
needed the same arm rather than falling through.

Both adversarial tests were written first and observed failing against the real
logging path before the fix.

- `dart format` clean, `flutter analyze` zero issues, markdownlint clean
- 2415 app + 1653 client + 245 logging tests pass
- `flutter build web --release` succeeds; the wasm dry run also passes.
  `describeFailure` has no imports at all, and no `SocketException` / `OSError`
  arm was added precisely because those are `dart:io`

## Known limits

- No machine enforcement — the rule is prose in `CLAUDE.md`; nothing fails if
  someone writes `error: e` over a fresh `jsonDecode`
- 124 of 131 `catch` sites were classified by caught type, not read individually
- At the converted sites, an exception outside the three arms now logs only its
  type name. That is the deliberate cost of not trusting a message we did not
  write

🤖 Generated with [Claude Code](https://claude.com/claude-code)