### PR TITLE
fix(cancel): handle errors raised while cancelling a stream

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,27 @@ Versions follow the `version+build` scheme from `pubspec.yaml`, bumped via
 - Errors contained inside the HTTP stack reach the app's log sink from the
   platform clients, and are rendered without echoing the input they were
   thrown over.
+- Pressing Stop always leaves the session in a terminal state.
+  `AgentSession.cancel()` previously let a throw from the orchestrator escape
+  into the widget callback that pressed the button, where Flutter printed it
+  and carried on: the press did nothing, the run kept streaming with no way to
+  reach it again, and the runtime waited on the session's result forever,
+  stalling every queued spawn behind it.
+- A run that throws instead of reaching a terminal state now settles the
+  session rather than stranding it, for the same reason.
+- Cancelling a spawn on a torn-down room or thread view no longer crashes.
+  `RoomState.cancelSpawn` and `ThreadViewState.cancelRun` wrote a signal their
+  own `dispose` had already disposed, which raises rather than being ignored;
+  every other method on both classes already returned early.
+
+### Added
+
+- `installUncaughtErrorLogging()` records errors no `catch` in the app saw —
+  the framework's, via `FlutterError.onError`, and the root zone's unhandled
+  asynchronous ones, via `PlatformDispatcher.onError` — into the same log sinks
+  the diagnostics screen reads. Both are additive: the framework's own console
+  dump and the platform's report of an unhandled error still happen. Host apps
+  embedding this package as a library can call it alongside `installLogSinks()`.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,49 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 Versions follow the `version+build` scheme from `pubspec.yaml`, bumped via
 `dart run tool/bump_version.dart`.
 
+## [Unreleased]
+
+### Fixed
+
+- Tearing down a cancelled SSE subscription now observes the future
+  `StreamSubscription.cancel()` returns, so an error raised while the stream
+  generator unwinds — the transport's injected `CancelledException` among them
+  — no longer reaches the zone unhandled. Applies to the four teardown sites
+  in `RunOrchestrator`; other unguarded callbacks on the cancel path are
+  unchanged.
+- The upload request-body pipe observes that future too, on both the Dart and
+  the Cupertino client, so an error raised while the multipart body unwinds no
+  longer reaches the zone.
+- Cancellation is now observable to client-side tools and session extensions.
+  `AgentSession` owns a cancellation signal for the session's lifetime instead
+  of exposing `RunOrchestrator`'s request-scoped token, which is absent for the
+  whole tool-execution window and at extension-attach time — so a tool polling
+  `ToolExecutionContext.cancelToken` never saw a cancel, and a pending tool
+  approval was not denied when the session was cancelled.
+- Cancelling an upload on iOS and macOS reports the cancellation rather than a
+  network failure. NSURLSession surfaces an aborted upload as a client error,
+  so the cancel arrived as a `NetworkException` and the upload was shown as
+  failed instead of cancelled.
+- Pressing Stop denies a pending tool approval even when the run already
+  failed, instead of leaving the approval unresolved.
+- A session cancelled while its extensions are attaching no longer starts a
+  backend run.
+- The fallback from the native HTTP client to `DartHttpClient` is recorded
+  instead of downgrading silently.
+- Errors contained inside the HTTP stack reach the app's log sink from the
+  platform clients, and are rendered without echoing the input they were
+  thrown over.
+
+### Changed
+
+- **Breaking (library):** `AgentSession.cancelToken` is now scoped to the
+  session rather than the active request: it is one instance for the session's
+  lifetime, cancelled by `cancel()` or `dispose()`. It previously answered a
+  fresh, never-cancelled token whenever no request was in flight.
+- `DartHttpClient`, `CupertinoHttpClient`, `WebXhrHttpClient` and
+  `createPlatformClient` accept an optional `onDiagnostic` handler, defaulting
+  to `dart:developer` as the other clients in the stack already did.
+
 ## [0.101.0+84] - 2026-08-21
 
 ### Added

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -6,6 +6,8 @@ Future<void> main() async {
   // See installLogSinks for where records surface (DevTools Logging vs stdout),
   // what can observe each, and the per-mode level floor.
   installLogSinks();
+  // After the sinks, not before: without one, LogManager discards the record.
+  installUncaughtErrorLogging();
   final callbackParams = CallbackParamsCapture.captureNow();
   clearCallbackUrl();
   runSoliplexShell(await standard(callbackParams: callbackParams));

--- a/lib/soliplex_frontend.dart
+++ b/lib/soliplex_frontend.dart
@@ -49,6 +49,7 @@ export 'src/core/inactivity/inactivity_config.dart' show InactivityConfig;
 export 'src/core/shell.dart' show runSoliplexShell;
 export 'src/core/shell_config.dart' show ShellConfig;
 export 'src/core/status_message_config.dart' show StatusMessageConfig;
+export 'src/core/uncaught_errors.dart' show installUncaughtErrorLogging;
 export 'src/flavors/standard.dart' show standard, standardFlavor;
 export 'src/flavors/standard_kit.dart' show buildStandardKit, StandardKit;
 // The resolver type for `standard(documentBrowserUrl: ...)`; the provider that

--- a/lib/src/core/uncaught_errors.dart
+++ b/lib/src/core/uncaught_errors.dart
@@ -1,0 +1,63 @@
+import 'package:flutter/foundation.dart';
+import 'package:soliplex_logging/soliplex_logging.dart';
+
+/// Records errors no `catch` in this app saw.
+///
+/// Two intakes, because Flutter splits them:
+///
+/// - [FlutterError.onError] takes what the framework catches on the app's
+///   behalf — a throw out of `build`, a layout assertion, a gesture callback.
+///   A throw out of `onPressed` is one of these: the framework prints it and
+///   the app carries on, so without an intake here the press leaves no record.
+/// - [PlatformDispatcher.onError] takes an unhandled error that reached the
+///   root zone: a `Future` nobody awaited, an error delivered to a stream with
+///   no `onError`. It sees the **root zone only**, which is the right intake
+///   here because nothing in this app runs under `runZonedGuarded` — and it is
+///   preferable to wrapping `runApp`, which would put the whole app in a child
+///   zone for no other reason.
+///
+/// This is detection, not repair. Neither intake can unstick whatever the
+/// error left half-done; what they buy is that a broken invariant leaves a
+/// record on the diagnostics screen instead of a line on a console nobody is
+/// attached to.
+///
+/// Both records go through `describeFailure` rather than `error:`. An uncaught
+/// error is thrown over whatever the app happened to be holding — a
+/// `FormatException` off a backend payload renders roughly 78 characters of it
+/// — and these records land in the buffer the diagnostics screen displays and
+/// can export.
+///
+/// Call this after [installLogSinks]; without a sink [LogManager] discards
+/// every record. Calling it twice chains a second framework handler onto the
+/// first and logs each framework error twice.
+void installUncaughtErrorLogging() {
+  final logger = LogManager.instance.getLogger('uncaught');
+
+  // Whatever the app is already running under — `FlutterError.presentError` in
+  // a normal launch, the test binding's collector under `flutter test`.
+  // Logging is a second copy, not a replacement: dropping this delegation
+  // silences the console dump app-wide and still compiles.
+  final priorOnError = FlutterError.onError;
+  FlutterError.onError = (details) {
+    logger.error(
+      'Uncaught framework error',
+      attributes: {'failure': describeFailure(details.exception)},
+      stackTrace: details.stack,
+    );
+    priorOnError?.call(details);
+  };
+
+  PlatformDispatcher.instance.onError = (error, stackTrace) {
+    logger.error(
+      'Uncaught asynchronous error',
+      attributes: {'failure': describeFailure(error)},
+      stackTrace: stackTrace,
+    );
+    // False: the record is a second copy, and returning true would tell the
+    // engine the error is handled and suppress its own report. On a target
+    // where no installed sink has a transport — a packaged release build, or
+    // Android, where stdout reaches nobody — that report is the only place the
+    // error still appears outside the app.
+    return false;
+  };
+}

--- a/lib/src/flavors/standard_kit.dart
+++ b/lib/src/flavors/standard_kit.dart
@@ -1,7 +1,8 @@
 import 'package:flutter/foundation.dart' show kIsWeb, Listenable;
 import 'package:soliplex_agent/soliplex_agent.dart';
 import 'package:soliplex_client_native/soliplex_client_native.dart';
-import 'package:soliplex_logging/soliplex_logging.dart' show LoggerFactory;
+import 'package:soliplex_logging/soliplex_logging.dart'
+    show Logger, LoggerFactory, describeFailure;
 
 import '../core/app_identity.dart';
 import '../core/app_module.dart';
@@ -74,16 +75,15 @@ Future<StandardKit> buildStandardKit({
     Object error,
     StackTrace stackTrace, {
     required String message,
-  }) {
-    httpLogger.error(message, error: error, stackTrace: stackTrace);
-  }
+  }) =>
+      logHttpDiagnostic(httpLogger, error, stackTrace, message: message);
 
   SoliplexHttpClient buildClient({
     String? Function()? getToken,
     TokenRefresher? tokenRefresher,
   }) =>
       createAgentHttpClient(
-        innerClient: createPlatformClient(),
+        innerClient: createPlatformClient(onDiagnostic: onHttpDiagnostic),
         observers: [inspector],
         getToken: getToken,
         tokenRefresher: tokenRefresher,
@@ -206,5 +206,26 @@ Future<StandardKit> buildStandardKit({
       pollInterval: statusMessagePollInterval,
     ),
     serverManager: serverManager,
+  );
+}
+
+/// Writes an HTTP-stack diagnostic to [logger].
+///
+/// Uses `describeFailure` rather than `error:` because this sink carries
+/// exceptions this package did not construct. The request-body pipes forward
+/// whatever a caller-supplied upload stream raises — a `FileSystemException`
+/// renders the path it failed on — and the observer and redaction guards
+/// forward whatever host-app code throws. Either would otherwise render into
+/// the buffer the diagnostics screen displays and can export.
+void logHttpDiagnostic(
+  Logger logger,
+  Object error,
+  StackTrace stackTrace, {
+  required String message,
+}) {
+  logger.error(
+    message,
+    attributes: {'failure': describeFailure(error)},
+    stackTrace: stackTrace,
   );
 }

--- a/lib/src/modules/room/room_state.dart
+++ b/lib/src/modules/room/room_state.dart
@@ -280,6 +280,7 @@ class RoomState {
 
   /// Cancels a pending new-thread spawn. No-op if nothing is in progress.
   void cancelSpawn() {
+    if (_isDisposed) return;
     if (_spawner.cancel()) _sessionState.value = null;
   }
 

--- a/lib/src/modules/room/thread_view_state.dart
+++ b/lib/src/modules/room/thread_view_state.dart
@@ -261,6 +261,7 @@ class ThreadViewState {
   }
 
   void cancelRun() {
+    if (_isDisposed) return;
     if (_spawner.cancel()) {
       _sessionState.value = null;
       return;

--- a/packages/soliplex_agent/lib/src/http/create_agent_http_client.dart
+++ b/packages/soliplex_agent/lib/src/http/create_agent_http_client.dart
@@ -15,6 +15,11 @@ import 'package:soliplex_client/soliplex_client.dart';
 /// platform client. 6 sits under the backend's per-client 10-connection
 /// cap with headroom. Raise it when moving to an HTTP/2 backend.
 ///
+/// [onDiagnostic] receives internal errors the stack contained without
+/// failing the request. It reaches the concurrency limiter and, when
+/// [observers] is non-empty, the observable decorator. Pass [innerClient]
+/// and it is that client's own handler that applies.
+///
 /// See `package:soliplex_client/CLAUDE.md` for the decorator stack
 /// rationale.
 SoliplexHttpClient createAgentHttpClient({
@@ -30,7 +35,7 @@ SoliplexHttpClient createAgentHttpClient({
     'tokenRefresher requires getToken to inject refreshed tokens',
   );
 
-  var client = innerClient ?? DartHttpClient();
+  var client = innerClient ?? DartHttpClient(onDiagnostic: onDiagnostic);
 
   if (observers != null && observers.isNotEmpty) {
     client = ObservableHttpClient(

--- a/packages/soliplex_agent/lib/src/orchestration/run_orchestrator.dart
+++ b/packages/soliplex_agent/lib/src/orchestration/run_orchestrator.dart
@@ -159,14 +159,6 @@ class RunOrchestrator {
   /// conversation state.
   Stream<BaseEvent> get baseEvents => _baseEventController.stream;
 
-  /// The current cancellation token for the active run.
-  ///
-  /// Returns a fresh (uncancelled) token if no run is active.
-  CancelToken get cancelToken {
-    _guardNotDisposed();
-    return _cancelToken ?? CancelToken();
-  }
-
   /// Runs a complete agent interaction including all tool yield/resume cycles.
   ///
   /// State emissions continue on [stateChanges] for UI observers.
@@ -420,7 +412,7 @@ class RunOrchestrator {
     _cancelToken = null;
     _completeTerminalOnDispose();
     if (!_receivedTerminalEvent) {
-      unawaited(_subscription?.cancel());
+      _absorbTeardown(_subscription?.cancel(), 'dispose');
     }
     _subscription = null;
     if (!_controller.isClosed) {
@@ -462,11 +454,11 @@ class RunOrchestrator {
     // overwrite the user's cancel intent. Both paths drain and bail
     // before _subscribeToStream.
     if (_disposed) {
-      _drainUnownedStream(handle.events, 'Initialize drain failed');
+      _drainUnownedStream(handle.events, 'initialize drain (disposed)');
       return;
     }
     if (_cancelToken?.isCancelled ?? false) {
-      _drainUnownedStream(handle.events, 'Initialize drain failed');
+      _drainUnownedStream(handle.events, 'initialize drain (cancelled)');
       throw CancelledException(reason: _cancelToken?.reason);
     }
     _subscribeToStream(
@@ -481,20 +473,15 @@ class RunOrchestrator {
   }
 
   /// Drains an SSE stream we no longer own (cancel/dispose during a
-  /// post-`startRun` await). Listening with no `onData` and immediately
-  /// cancelling releases the underlying socket. `onError` routes through
-  /// `Logger.error` so a future bug landing here from a non-cancel path
-  /// leaves a Sentry-grade breadcrumb instead of an unhandled future.
-  void _drainUnownedStream(Stream<DecodeOutcome> events, String errorMessage) {
-    unawaited(
-      events
-          .listen(
-            null,
-            onError: (Object e, StackTrace st) =>
-                _logger.error(errorMessage, error: e, stackTrace: st),
-          )
-          .cancel(),
-    );
+  /// post-`startRun` await), releasing the underlying socket.
+  ///
+  /// The listen and the cancel happen in one turn, and every provider in
+  /// this package returns a cold `async*`, so no event can be delivered
+  /// first and an `onData`/`onError` pair would never fire. Whatever the generator raises as it unwinds arrives on the cancel
+  /// future instead, which is what [_absorbTeardown] reads; [site] labels the
+  /// record so each drain is distinguishable in the log.
+  void _drainUnownedStream(Stream<DecodeOutcome> events, String site) {
+    _absorbTeardown(events.listen(null).cancel(), site);
   }
 
   /// Drives the tool yield/resume loop for [runToCompletion].
@@ -572,7 +559,7 @@ class RunOrchestrator {
           '(state=${_currentState.runtimeType})',
         );
       }
-      _drainUnownedStream(handle.events, 'Resume drain failed');
+      _drainUnownedStream(handle.events, 'resume drain');
       _terminalCompleter = Completer<RunState>()..complete(_currentState);
       return;
     }
@@ -900,7 +887,7 @@ class RunOrchestrator {
     // which can fire after the new subscription replaces the old one.
     // `onData`/`onError` cease firing on the cancelled subscription, so
     // they need no epoch guard.
-    unawaited(_subscription?.cancel());
+    _absorbTeardown(_subscription?.cancel(), 'stale subscription');
     _subscription = null;
     _cancelToken ??= CancelToken();
     _receivedTerminalEvent = false;
@@ -1285,7 +1272,7 @@ class RunOrchestrator {
       // user-visible result mirrors mid-stream cancel handling —
       // not a `FailedState(reason: internalError)`. Accepts both
       // `CancelledException` (from our `CancelToken`) and
-      // `CancellationError` (Dart core / ag_ui interop).
+      // `CancellationError` (ag_ui's, for interop with its client).
       _setState(CancelledState.preRun(threadKey: key));
       return;
     }
@@ -1310,8 +1297,38 @@ class RunOrchestrator {
     }
   }
 
+  /// Absorbs whatever the teardown of an SSE subscription surfaces, where
+  /// [pending] is the future returned by [StreamSubscription.cancel] and
+  /// [site] names the teardown on the log record.
+  ///
+  /// Cancelling that subscription unwinds the provider's `async*` generator.
+  /// An error raised while it unwinds is delivered here rather than to the
+  /// subscription's `onError`, so discarding this future lets it reach the
+  /// zone as an unhandled error.
+  ///
+  /// The expected one is the cancellation the transport injects when the
+  /// run's token fires, scheduled by the token's completer and so still
+  /// undelivered when the caller's cancel runs. Every caller has its own
+  /// route to the outcome — a terminal state it publishes, or an exception
+  /// it throws — so this second copy carries nothing its recipient does not
+  /// already have: deliberate silence. Anything else is a real teardown
+  /// failure and is logged.
+  void _absorbTeardown(Future<void>? pending, String site) {
+    if (pending == null) return;
+    unawaited(
+      pending.catchError((Object e, StackTrace st) {
+        if (e is CancelledException || e is CancellationError) return;
+        _logger.warning(
+          'SSE subscription teardown failed: $site',
+          attributes: {'failure': describeFailure(e)},
+          stackTrace: st,
+        );
+      }),
+    );
+  }
+
   void _cleanup() {
-    unawaited(_subscription?.cancel());
+    _absorbTeardown(_subscription?.cancel(), 'cleanup');
     _subscription = null;
     _cancelToken = null;
   }

--- a/packages/soliplex_agent/lib/src/runtime/agent_session.dart
+++ b/packages/soliplex_agent/lib/src/runtime/agent_session.dart
@@ -351,24 +351,49 @@ class AgentSession implements ToolExecutionContext {
   ///
   /// The cancellation signal always fires; the child cascade and the
   /// orchestrator cancel are skipped once the session is terminal.
+  ///
+  /// Cannot throw. The callers that press Stop are widget callbacks, where
+  /// Flutter prints a throw and carries on — so an error escaping here is a
+  /// press that silently did nothing while the run kept streaming. And since
+  /// `AgentRuntime` waits on [result] before disposing this session and
+  /// draining the spawn queue, a cancel that leaves no terminal state stalls
+  /// every spawn queued behind it, which is why the catch settles the session
+  /// itself rather than only recording the fault.
   void cancel() {
     // Ahead of the terminal check: a run that already failed is terminal, and
     // a tool parked on an approval is still waiting on this token.
     _cancelToken.cancel('session cancelled');
     if (_isTerminal) return;
-    for (final child in _children.toList()) {
-      try {
+    try {
+      // No per-child guard: the cascade calls this same method, and it does
+      // not throw.
+      for (final child in _children.toList()) {
         child.cancel();
-      } on Object catch (e, st) {
-        _logger.error(
-          'Child AgentSession cancel threw (parent=$id, '
-          'thread=${threadKey.threadId}, child=${child.id})',
-          error: e,
-          stackTrace: st,
+      }
+      _orchestrator.cancelRun();
+    } on Object catch (e, st) {
+      // The stack trace is what locates this one: `describeFailure` reduces a
+      // `StateError` to its type name, and the guard that threw it is a frame.
+      _logger.error(
+        'AgentSession cancel threw (session=$id, '
+        'thread=${threadKey.threadId})',
+        attributes: {'failure': describeFailure(e)},
+        stackTrace: st,
+      );
+      // Only here. Every other path out of `cancelRun` publishes a terminal
+      // `RunState`, or leaves one already published, and `_onStateChange`
+      // settles the session from it; a throw is the one exit that publishes
+      // nothing, so this is the one exit that has to settle it.
+      if (!_isTerminal && !_disposed) {
+        _completeWith(
+          AgentFailure(
+            threadKey: threadKey,
+            reason: FailureReason.cancelled,
+            error: 'Session cancelled',
+          ),
         );
       }
     }
-    _orchestrator.cancelRun();
   }
 
   /// Starts the orchestrator run and subscribes to state changes.
@@ -406,17 +431,45 @@ class AgentSession implements ToolExecutionContext {
     }
     _subscription = _orchestrator.stateChanges.listen(_onStateChange);
     _baseEventSubscription = _orchestrator.baseEvents.listen(_bridgeBaseEvent);
+    // Fire and forget, but not unobserved: `AgentRuntime` waits on this
+    // session's result before disposing it and draining the spawn queue, so a
+    // throw escaping here would leave the run with no terminal state, the
+    // session never torn down, and later spawns queued behind it. Every
+    // expected outcome — including a cancel — comes back as a terminal
+    // `RunState`, so reaching this handler means a bug, not a failed run.
     unawaited(
-      _orchestrator.runToCompletion(
-        key: threadKey,
-        userMessage: userMessage,
-        toolExecutor: _executeAll,
-        existingRunId: existingRunId,
-        cachedHistory: cachedHistory,
-        stateOverlay: stateOverlay,
-        onReconnectStatus: _onReconnectStatus,
-      ),
+      _orchestrator
+          .runToCompletion(
+            key: threadKey,
+            userMessage: userMessage,
+            toolExecutor: _executeAll,
+            existingRunId: existingRunId,
+            cachedHistory: cachedHistory,
+            stateOverlay: stateOverlay,
+            onReconnectStatus: _onReconnectStatus,
+          )
+          .catchError(_settleFailedRun),
     );
+  }
+
+  /// Settles the session when `runToCompletion` throws instead of returning a
+  /// terminal state, so the runtime's wait on [result] cannot hang.
+  RunState _settleFailedRun(Object error, StackTrace stackTrace) {
+    _logger.error(
+      'runToCompletion threw (session=$id, thread=${threadKey.threadId})',
+      attributes: {'failure': describeFailure(error)},
+      stackTrace: stackTrace,
+    );
+    if (!_disposed) {
+      _completeWith(
+        AgentFailure(
+          threadKey: threadKey,
+          reason: FailureReason.internalError,
+          error: 'Run did not reach a terminal state',
+        ),
+      );
+    }
+    return _orchestrator.currentState;
   }
 
   /// Bridges reconnect-lifecycle callbacks from `RunOrchestrator` /

--- a/packages/soliplex_agent/lib/src/runtime/agent_session.dart
+++ b/packages/soliplex_agent/lib/src/runtime/agent_session.dart
@@ -84,6 +84,21 @@ class AgentSession implements ToolExecutionContext {
   static const _toolTimeout = Duration(seconds: 60);
 
   final List<AgentSession> _children = [];
+
+  /// Cancellation signal for the session as a whole. Never replaced, and
+  /// cancelled at most once — [CancelToken.cancel] is idempotent — by
+  /// [cancel] or by [dispose].
+  ///
+  /// Deliberately not the token `RunOrchestrator` passes to the transport.
+  /// That one is scoped to a single HTTP request: it is re-minted for every
+  /// resume segment and cleared whenever no request is in flight, including
+  /// for the whole of the tool-execution window. Readers that need to know
+  /// whether *the session* was cancelled — tools polling
+  /// [ToolExecutionContext.cancelToken], and extensions that subscribe in
+  /// `onAttach`, which runs before the first request exists — need a token
+  /// whose lifetime is the session's.
+  final CancelToken _cancelToken = CancelToken();
+
   final Completer<AgentResult> _resultCompleter = Completer<AgentResult>();
   StreamSubscription<RunState>? _subscription;
   StreamSubscription<BaseEvent>? _baseEventSubscription;
@@ -196,16 +211,14 @@ class AgentSession implements ToolExecutionContext {
   // ToolExecutionContext implementation
   // ---------------------------------------------------------------------------
 
-  /// CancelToken from the underlying orchestrator, or a pre-cancelled token
-  /// once the session has been disposed.
+  /// The session's cancellation signal. Stable for the session's lifetime,
+  /// so a listener registered in `onAttach` still sees a later [cancel].
   ///
-  /// Late tool callers (a microtask resuming after [dispose]) read a
-  /// cancelled token rather than triggering the orchestrator's
-  /// disposed-getter guard, so dispose-race short-circuits return cleanly
-  /// instead of surfacing as opaque "tool failed" errors.
+  /// [dispose] cancels it, so a late tool caller (a microtask resuming after
+  /// teardown) reads a cancelled token and short-circuits cleanly instead of
+  /// surfacing an opaque "tool failed" error.
   @override
-  CancelToken get cancelToken =>
-      _disposed ? (CancelToken()..cancel()) : _orchestrator.cancelToken;
+  CancelToken get cancelToken => _cancelToken;
 
   @override
   Future<AgentSession> spawnChild({
@@ -334,11 +347,26 @@ class AgentSession implements ToolExecutionContext {
     _children.remove(child);
   }
 
-  /// Cancels the session and all children. No-op if already terminal.
+  /// Cancels the session and all children.
+  ///
+  /// The cancellation signal always fires; the child cascade and the
+  /// orchestrator cancel are skipped once the session is terminal.
   void cancel() {
+    // Ahead of the terminal check: a run that already failed is terminal, and
+    // a tool parked on an approval is still waiting on this token.
+    _cancelToken.cancel('session cancelled');
     if (_isTerminal) return;
     for (final child in _children.toList()) {
-      child.cancel();
+      try {
+        child.cancel();
+      } on Object catch (e, st) {
+        _logger.error(
+          'Child AgentSession cancel threw (parent=$id, '
+          'thread=${threadKey.threadId}, child=${child.id})',
+          error: e,
+          stackTrace: st,
+        );
+      }
     }
     _orchestrator.cancelRun();
   }
@@ -355,6 +383,27 @@ class AgentSession implements ToolExecutionContext {
     Map<String, dynamic>? stateOverlay,
   }) async {
     await _attachExtensions();
+    // `AgentRuntime.spawn` registers this session with its parent before
+    // awaiting `start`, so a parent cancel can land during the attach above.
+    // Starting anyway would create a backend run the user already stopped.
+    //
+    // Settle the result rather than just returning: `AgentRuntime` awaits it
+    // before draining the spawn queue, and before disposing the session when
+    // it owns the lifecycle, so leaving it pending would strand both.
+    if (_cancelToken.isCancelled) {
+      // [dispose] cancels the token too, and settles the result itself
+      // through `_completeIfPending` before disposing the signals that
+      // `_completeWith` writes.
+      if (_disposed) return;
+      _completeWith(
+        AgentFailure(
+          threadKey: threadKey,
+          reason: FailureReason.cancelled,
+          error: 'Cancelled before the run started',
+        ),
+      );
+      return;
+    }
     _subscription = _orchestrator.stateChanges.listen(_onStateChange);
     _baseEventSubscription = _orchestrator.baseEvents.listen(_bridgeBaseEvent);
     unawaited(
@@ -384,6 +433,7 @@ class AgentSession implements ToolExecutionContext {
   void dispose() {
     if (_disposed) return;
     _disposed = true;
+    _cancelToken.cancel('session disposed');
     for (final child in _children.toList()) {
       try {
         child.dispose();

--- a/packages/soliplex_agent/lib/src/tools/tool_execution_context.dart
+++ b/packages/soliplex_agent/lib/src/tools/tool_execution_context.dart
@@ -15,7 +15,10 @@ import 'package:soliplex_client/soliplex_client.dart';
 /// - Use streaming/chunked processing for large data
 /// - Check [cancelToken] at natural yield points
 abstract interface class ToolExecutionContext {
-  /// Cancellation token for the current run.
+  /// Cancellation signal for the session, cancelled when the session is
+  /// cancelled or torn down. Stable for the session's lifetime, so it
+  /// keeps reporting the session's state across a tool-yield boundary,
+  /// where no request is in flight.
   CancelToken get cancelToken;
 
   /// Spawn a child agent session linked to the current session.

--- a/packages/soliplex_agent/test/orchestration/cancel_teardown_test.dart
+++ b/packages/soliplex_agent/test/orchestration/cancel_teardown_test.dart
@@ -1,0 +1,442 @@
+import 'dart:async';
+import 'dart:convert';
+
+import 'package:mocktail/mocktail.dart';
+import 'package:soliplex_agent/soliplex_agent.dart';
+import 'package:soliplex_agent/src/orchestration/run_orchestrator.dart';
+import 'package:soliplex_client/soliplex_client.dart';
+import 'package:test/test.dart';
+
+class MockSoliplexHttpClient extends Mock implements SoliplexHttpClient {}
+
+class MockSoliplexApi extends Mock implements SoliplexApi {}
+
+class MockLogger extends Mock implements Logger {}
+
+/// A provider whose event stream is an `async*` generator parked inside
+/// `await for` — the shape `AgUiStreamClient.runAgent` has, and the one that
+/// reports an unwinding error through `StreamSubscription.cancel()`.
+class _ParkedProvider implements AgentLlmProvider {
+  _ParkedProvider(this.inner, {this.startGate});
+
+  final StreamController<DecodeOutcome> inner;
+
+  /// Holds `startRun` open so a cancel can land while the orchestrator is
+  /// awaiting it, which is the window `_initializeStream` drains from.
+  final Future<void>? startGate;
+
+  @override
+  Future<LlmRunHandle> startRun({
+    required ThreadKey key,
+    required SimpleRunAgentInput input,
+    String? existingRunId,
+    CancelToken? cancelToken,
+    void Function(ReconnectStatus)? onReconnectStatus,
+  }) async {
+    if (startGate != null) await startGate;
+    return LlmRunHandle(runId: 'run-1', events: _events());
+  }
+
+  Stream<DecodeOutcome> _events() async* {
+    await for (final outcome in inner.stream) {
+      yield outcome;
+    }
+  }
+}
+
+const ThreadKey _key = (
+  serverId: 'srv-1',
+  roomId: 'room-1',
+  threadId: 'thread-1',
+);
+
+String _sse(Map<String, dynamic> event) => 'data: ${jsonEncode(event)}\n\n';
+
+void main() {
+  setUpAll(() {
+    registerFallbackValue(Uri.parse('https://example.com'));
+  });
+
+  test(
+    'cancelling a streaming run does not leak the injected cancel as an '
+    'unhandled error',
+    () async {
+      final httpClient = MockSoliplexHttpClient();
+      final api = MockSoliplexApi();
+      final logger = MockLogger();
+      final body = StreamController<List<int>>();
+      addTearDown(body.close);
+
+      for (final stub in [
+        () => logger.warning(
+              any(),
+              error: any(named: 'error'),
+              stackTrace: any(named: 'stackTrace'),
+              attributes: any(named: 'attributes'),
+            ),
+        () => logger.info(
+              any(),
+              error: any(named: 'error'),
+              stackTrace: any(named: 'stackTrace'),
+              attributes: any(named: 'attributes'),
+            ),
+        () => logger.error(
+              any(),
+              error: any(named: 'error'),
+              stackTrace: any(named: 'stackTrace'),
+              attributes: any(named: 'attributes'),
+            ),
+        () => logger.debug(
+              any(),
+              error: any(named: 'error'),
+              stackTrace: any(named: 'stackTrace'),
+              attributes: any(named: 'attributes'),
+            ),
+      ]) {
+        when(stub).thenReturn(null);
+      }
+
+      when(() => api.createRun(any(), any())).thenAnswer(
+        (_) async => RunInfo(
+          id: 'run-1',
+          threadId: _key.threadId,
+          createdAt: DateTime(2026),
+        ),
+      );
+      when(
+        () => httpClient.requestStream(
+          any(),
+          any(),
+          headers: any(named: 'headers'),
+          body: any(named: 'body'),
+          cancelToken: any(named: 'cancelToken'),
+        ),
+      ).thenAnswer(
+        (_) async => StreamedHttpResponse(
+          statusCode: 200,
+          headers: const {'content-type': 'text/event-stream'},
+          body: body.stream,
+        ),
+      );
+
+      final orchestrator = RunOrchestrator(
+        llmProvider: AgUiLlmProvider(
+          api: api,
+          agUiStreamClient: AgUiStreamClient(
+            httpTransport: HttpTransport(client: httpClient),
+            urlBuilder: UrlBuilder('https://example.com'),
+          ),
+        ),
+        toolRegistry: const ToolRegistry(),
+        logger: logger,
+      );
+      addTearDown(orchestrator.dispose);
+
+      final unhandled = <Object>[];
+      await runZonedGuarded(
+        () async {
+          final run = orchestrator.runToCompletion(
+            key: _key,
+            userMessage: [const TextPart('hi')],
+            toolExecutor: (_) async => [],
+          );
+
+          // Park the AG-UI generator mid-stream so its teardown has to
+          // unwind an `await for`.
+          await Future<void>.delayed(const Duration(milliseconds: 30));
+          body.add(
+            utf8.encode(
+              _sse({
+                'type': 'RUN_STARTED',
+                'threadId': _key.threadId,
+                'runId': 'run-1',
+              }),
+            ),
+          );
+          await Future<void>.delayed(const Duration(milliseconds: 30));
+          expect(orchestrator.currentState, isA<RunningState>());
+
+          orchestrator.cancelRun();
+
+          expect(await run, isA<CancelledState>());
+          await Future<void>.delayed(const Duration(milliseconds: 150));
+        },
+        (error, _) => unhandled.add(error),
+      );
+
+      expect(
+        unhandled,
+        isEmpty,
+        reason: 'the transport injects CancelledException into the body '
+            'stream as the run is cancelled; tearing down the subscription '
+            'must absorb it rather than let it reach the zone',
+      );
+      // Absorbed, not recorded: the cancellation tells no one anything the
+      // caller who initiated it does not already know.
+      verifyNever(
+        () => logger.warning(
+          any(),
+          error: any(named: 'error'),
+          stackTrace: any(named: 'stackTrace'),
+          attributes: any(named: 'attributes'),
+        ),
+      );
+    },
+  );
+
+  test(
+    'a non-cancel teardown failure is recorded rather than absorbed',
+    () async {
+      final logger = MockLogger();
+      when(
+        () => logger.warning(
+          any(),
+          error: any(named: 'error'),
+          stackTrace: any(named: 'stackTrace'),
+          attributes: any(named: 'attributes'),
+        ),
+      ).thenReturn(null);
+
+      final inner = StreamController<DecodeOutcome>();
+      addTearDown(inner.close);
+      final orchestrator = RunOrchestrator(
+        llmProvider: _ParkedProvider(inner),
+        toolRegistry: const ToolRegistry(),
+        logger: logger,
+      );
+      addTearDown(orchestrator.dispose);
+
+      final unhandled = <Object>[];
+      await runZonedGuarded(
+        () async {
+          final run = orchestrator.runToCompletion(
+            key: _key,
+            userMessage: [const TextPart('hi')],
+            toolExecutor: (_) async => [],
+          );
+          await Future<void>.delayed(Duration.zero);
+          inner.add(
+            DecodedEvent(
+              RunStartedEvent(threadId: _key.threadId, runId: 'run-1'),
+              const {},
+            ),
+          );
+          await Future<void>.delayed(Duration.zero);
+          expect(orchestrator.currentState, isA<RunningState>());
+
+          // Scheduled before the cancel, so it is still undelivered when the
+          // subscription is torn down and surfaces on the cancel future.
+          inner.addError(StateError('teardown blew up'));
+          orchestrator.cancelRun();
+
+          expect(await run, isA<CancelledState>());
+          await Future<void>.delayed(const Duration(milliseconds: 50));
+        },
+        (error, _) => unhandled.add(error),
+      );
+
+      expect(unhandled, isEmpty);
+
+      // The record is the only trace this branch leaves, and it must carry a
+      // description rather than the exception object.
+      final logged = verify(
+        () => logger.warning(
+          captureAny(),
+          error: any(named: 'error'),
+          stackTrace: any(named: 'stackTrace'),
+          attributes: captureAny(named: 'attributes'),
+        ),
+      ).captured;
+      expect(logged[0], 'SSE subscription teardown failed: cleanup');
+      expect(logged[1], {'failure': 'StateError'});
+    },
+  );
+
+  test(
+    'disposing mid-run does not leak the teardown error either',
+    () async {
+      // `dispose()` reaches the same absorption as `cancelRun()`, through
+      // `AgentSession.dispose()`.
+      final logger = MockLogger();
+      when(
+        () => logger.warning(
+          any(),
+          error: any(named: 'error'),
+          stackTrace: any(named: 'stackTrace'),
+          attributes: any(named: 'attributes'),
+        ),
+      ).thenReturn(null);
+
+      final inner = StreamController<DecodeOutcome>();
+      addTearDown(inner.close);
+      final orchestrator = RunOrchestrator(
+        llmProvider: _ParkedProvider(inner),
+        toolRegistry: const ToolRegistry(),
+        logger: logger,
+      );
+
+      final unhandled = <Object>[];
+      await runZonedGuarded(
+        () async {
+          final run = orchestrator.runToCompletion(
+            key: _key,
+            userMessage: [const TextPart('hi')],
+            toolExecutor: (_) async => [],
+          );
+          await Future<void>.delayed(Duration.zero);
+          inner.add(
+            DecodedEvent(
+              RunStartedEvent(threadId: _key.threadId, runId: 'run-1'),
+              const {},
+            ),
+          );
+          await Future<void>.delayed(Duration.zero);
+          expect(orchestrator.currentState, isA<RunningState>());
+
+          inner.addError(StateError('teardown blew up'));
+          orchestrator.dispose();
+
+          expect(await run, isA<CancelledState>());
+          await Future<void>.delayed(const Duration(milliseconds: 50));
+        },
+        (error, _) => unhandled.add(error),
+      );
+
+      expect(unhandled, isEmpty);
+      final logged = verify(
+        () => logger.warning(
+          captureAny(),
+          error: any(named: 'error'),
+          stackTrace: any(named: 'stackTrace'),
+          attributes: captureAny(named: 'attributes'),
+        ),
+      ).captured;
+      expect(logged[0], 'SSE subscription teardown failed: dispose');
+      expect(logged[1], {'failure': 'StateError'});
+    },
+  );
+
+  test(
+    'draining a stream we never owned records its teardown failure',
+    () async {
+      // Cancel landing between `startRun` returning and `_subscribeToStream`:
+      // the orchestrator owns an event stream it will never subscribe to, and
+      // drains it to release the socket.
+      final logger = MockLogger();
+      when(
+        () => logger.warning(
+          any(),
+          error: any(named: 'error'),
+          stackTrace: any(named: 'stackTrace'),
+          attributes: any(named: 'attributes'),
+        ),
+      ).thenReturn(null);
+
+      final gate = Completer<void>();
+      final inner = StreamController<DecodeOutcome>();
+      addTearDown(inner.close);
+      final orchestrator = RunOrchestrator(
+        llmProvider: _ParkedProvider(inner, startGate: gate.future),
+        toolRegistry: const ToolRegistry(),
+        logger: logger,
+      );
+      addTearDown(orchestrator.dispose);
+
+      final unhandled = <Object>[];
+      await runZonedGuarded(
+        () async {
+          final run = orchestrator.runToCompletion(
+            key: _key,
+            userMessage: [const TextPart('hi')],
+            toolExecutor: (_) async => [],
+          );
+          await Future<void>.delayed(Duration.zero);
+
+          orchestrator.cancelRun();
+          inner.addError(StateError('drain blew up'));
+          gate.complete();
+
+          expect(await run, isA<CancelledState>());
+          await Future<void>.delayed(const Duration(milliseconds: 50));
+        },
+        (error, _) => unhandled.add(error),
+      );
+
+      expect(unhandled, isEmpty);
+      final logged = verify(
+        () => logger.warning(
+          captureAny(),
+          error: any(named: 'error'),
+          stackTrace: any(named: 'stackTrace'),
+          attributes: captureAny(named: 'attributes'),
+        ),
+      ).captured;
+      expect(
+        logged[0],
+        'SSE subscription teardown failed: initialize drain (cancelled)',
+      );
+      expect(logged[1], {'failure': 'StateError'});
+    },
+  );
+
+  test(
+    'disposing during startRun drains the stream it never owned',
+    () async {
+      // The sibling of the cancelled drain: dispose lands in the same
+      // post-`startRun` window and takes the other branch.
+      final logger = MockLogger();
+      when(
+        () => logger.warning(
+          any(),
+          error: any(named: 'error'),
+          stackTrace: any(named: 'stackTrace'),
+          attributes: any(named: 'attributes'),
+        ),
+      ).thenReturn(null);
+
+      final gate = Completer<void>();
+      final inner = StreamController<DecodeOutcome>();
+      addTearDown(inner.close);
+      final orchestrator = RunOrchestrator(
+        llmProvider: _ParkedProvider(inner, startGate: gate.future),
+        toolRegistry: const ToolRegistry(),
+        logger: logger,
+      );
+
+      final unhandled = <Object>[];
+      await runZonedGuarded(
+        () async {
+          final run = orchestrator.runToCompletion(
+            key: _key,
+            userMessage: [const TextPart('hi')],
+            toolExecutor: (_) async => [],
+          );
+          await Future<void>.delayed(Duration.zero);
+
+          orchestrator.dispose();
+          inner.addError(StateError('drain blew up'));
+          gate.complete();
+
+          expect(await run, isA<CancelledState>());
+          await Future<void>.delayed(const Duration(milliseconds: 50));
+        },
+        (error, _) => unhandled.add(error),
+      );
+
+      expect(unhandled, isEmpty);
+      final logged = verify(
+        () => logger.warning(
+          captureAny(),
+          error: any(named: 'error'),
+          stackTrace: any(named: 'stackTrace'),
+          attributes: captureAny(named: 'attributes'),
+        ),
+      ).captured;
+      expect(
+        logged[0],
+        'SSE subscription teardown failed: initialize drain (disposed)',
+      );
+      expect(logged[1], {'failure': 'StateError'});
+    },
+  );
+}

--- a/packages/soliplex_agent/test/orchestration/run_to_completion_test.dart
+++ b/packages/soliplex_agent/test/orchestration/run_to_completion_test.dart
@@ -702,8 +702,8 @@ void main() {
     });
   });
 
-  group('runToCompletion cancelToken', () {
-    test('cancelToken getter returns active token during run', () async {
+  group('runToCompletion cancellation', () {
+    test('cancelRun cancels the token handed to the provider', () async {
       orchestrator = RunOrchestrator(
         llmProvider: AgUiLlmProvider(
           api: api,
@@ -713,23 +713,42 @@ void main() {
         logger: logger,
       );
       stubCreateRun();
-      stubRunAgent(stream: Stream.fromIterable(_toolCallEvents()));
 
-      CancelToken? captured;
-      final result = await orchestrator.runToCompletion(
+      final controller = StreamController<BaseEvent>();
+      addTearDown(controller.close);
+      CancelToken? sentToProvider;
+      when(
+        () => agUiStreamClient.runAgent(
+          any(),
+          any(),
+          cancelToken: any(named: 'cancelToken'),
+          resumePolicy: any(named: 'resumePolicy'),
+          onReconnectStatus: any(named: 'onReconnectStatus'),
+        ),
+      ).thenAnswer((invocation) {
+        sentToProvider =
+            invocation.namedArguments[#cancelToken] as CancelToken?;
+        return controller.stream
+            .map<DecodeOutcome>((e) => DecodedEvent(e, const {}));
+      });
+
+      final run = orchestrator.runToCompletion(
         key: _key,
         userMessage: [const TextPart('Weather?')],
-        toolExecutor: (pending) async {
-          captured = orchestrator.cancelToken;
-          return _defaultToolExecutor(pending);
-        },
+        toolExecutor: _defaultToolExecutor,
       );
+      controller.add(RunStartedEvent(threadId: 'thread-1', runId: _runId));
+      await Future<void>.delayed(Duration.zero);
+      expect(orchestrator.currentState, isA<RunningState>());
+      expect(sentToProvider, isNotNull);
+      expect(sentToProvider!.isCancelled, isFalse);
 
-      // Tool executor captured a non-cancelled token.
-      expect(captured, isNotNull);
-      expect(captured!.isCancelled, isFalse);
-      // After completion, ignore the result type — just ensure no crash.
-      expect(result, isA<RunState>());
+      orchestrator.cancelRun();
+
+      // The transport learns of the cancel through this token; without it
+      // the socket is only torn down by the subscription cancel.
+      expect(sentToProvider!.isCancelled, isTrue);
+      expect(await run, isA<CancelledState>());
     });
   });
 }

--- a/packages/soliplex_agent/test/runtime/agent_session_approval_test.dart
+++ b/packages/soliplex_agent/test/runtime/agent_session_approval_test.dart
@@ -149,12 +149,11 @@ void main() {
       expect(result, isFalse);
     });
 
-    // The cancelToken.isCancelled short-circuit at AgentSession.requestApproval
-    // is only reachable mid-run (the orchestrator creates the token lazily in
-    // _subscribeToStream). Exercising it requires a real run; the disposed-
-    // session test below covers the equivalent deny-without-extension-call
-    // semantics through the _disposed guard, which is the path actually taken
-    // when AgentRuntime tears the session down.
+    // The cancelToken.isCancelled short-circuit at
+    // AgentSession.requestApproval is covered against a cancelled session in
+    // `cancel_during_tool_window_test.dart`. The disposed-session test below
+    // covers the sibling deny-without-extension-call path through the
+    // _disposed guard, which is what AgentRuntime's teardown takes.
 
     test(
       'session disposed → resolves false without touching extension',

--- a/packages/soliplex_agent/test/runtime/agent_session_test.dart
+++ b/packages/soliplex_agent/test/runtime/agent_session_test.dart
@@ -142,13 +142,16 @@ AgentSession createSession({
   ToolRegistry? toolRegistry,
   List<SessionExtension> extensions = const [],
   bool ephemeral = false,
+  RunOrchestrator? orchestrator,
 }) {
   final registry = toolRegistry ?? const ToolRegistry();
-  final orchestrator = RunOrchestrator(
-    llmProvider: AgUiLlmProvider(api: api, agUiStreamClient: agUiStreamClient),
-    toolRegistry: registry,
-    logger: logger,
-  );
+  final effectiveOrchestrator = orchestrator ??
+      RunOrchestrator(
+        llmProvider:
+            AgUiLlmProvider(api: api, agUiStreamClient: agUiStreamClient),
+        toolRegistry: registry,
+        logger: logger,
+      );
   final effectiveRuntime = runtime ?? MockAgentRuntime();
   // Stub ensureThreadState — `AgentSession.bus` resolves through it,
   // and `_onStateChange` calls `bus.setAgentState(...)` on every
@@ -166,7 +169,7 @@ AgentSession createSession({
     ephemeral: ephemeral,
     depth: 0,
     runtime: effectiveRuntime,
-    orchestrator: orchestrator,
+    orchestrator: effectiveOrchestrator,
     toolRegistry: registry,
     coordinator: SessionCoordinator(extensions, logger: logger),
     logger: logger,
@@ -422,6 +425,46 @@ void main() {
       expect(session.state, equals(AgentSessionState.completed));
       session.cancel(); // should not throw
       expect(session.state, equals(AgentSessionState.completed));
+    });
+
+    test('cancel settles the session when the orchestrator cancel throws',
+        () async {
+      // `cancelRun` guards on the orchestrator being live and throws a
+      // `StateError` when it is not. That throw lands in the widget callback
+      // that pressed Stop, where Flutter prints it and moves on: the press
+      // does nothing, the session never reaches a terminal state, and the
+      // runtime — which waits on `result` before disposing the session and
+      // draining the spawn queue — waits forever.
+      //
+      // Disposing the orchestrator alone is what reaches the guard. Disposing
+      // the session would dispose the orchestrator too, but it also forces the
+      // session terminal, so `cancel` returns before it ever gets there.
+      final orchestrator = RunOrchestrator(
+        llmProvider:
+            AgUiLlmProvider(api: api, agUiStreamClient: agUiStreamClient),
+        toolRegistry: const ToolRegistry(),
+        logger: logger,
+      );
+      final session = createSession(
+        api: api,
+        agUiStreamClient: agUiStreamClient,
+        logger: logger,
+        orchestrator: orchestrator,
+      );
+      addTearDown(session.dispose);
+      orchestrator.dispose();
+
+      session.cancel();
+
+      expect(
+        await session.result.timeout(const Duration(seconds: 2)),
+        isA<AgentFailure>().having(
+          (f) => f.reason,
+          'reason',
+          FailureReason.cancelled,
+        ),
+      );
+      expect(session.state, AgentSessionState.cancelled);
     });
   });
 
@@ -929,6 +972,48 @@ void main() {
       expect(completed, hasLength(1));
       expect(completed.first.status, equals(ToolCallStatus.failed));
       expect(completed.first.result, contains('timed out after'));
+    });
+
+    test('a throw from runToCompletion settles the session', () async {
+      // `runToCompletion` returns a terminal state on every expected path,
+      // cancellation included, so a throw is a bug — but the runtime waits on
+      // `result` before disposing the session and draining the spawn queue,
+      // and a stranded completer stalls both. A second `start` trips the
+      // orchestrator's already-active guard, which throws outside its own
+      // try/finally.
+      stubCreateRun();
+      final controller = StreamController<BaseEvent>();
+      addTearDown(controller.close);
+      stubRunAgent(stream: controller.stream);
+
+      final session = createSession(
+        api: api,
+        agUiStreamClient: agUiStreamClient,
+        logger: logger,
+      );
+      addTearDown(session.dispose);
+
+      final unhandled = <Object>[];
+      await runZonedGuarded(
+        () async {
+          // The first run never terminates, so nothing else can settle the
+          // session.
+          await session.start(userMessage: [const TextPart('Hi')]);
+          await session.start(userMessage: [const TextPart('Hi again')]);
+          await Future<void>.delayed(Duration.zero);
+        },
+        (error, _) => unhandled.add(error),
+      );
+
+      expect(unhandled, isEmpty);
+      expect(
+        await session.result.timeout(const Duration(seconds: 2)),
+        isA<AgentFailure>().having(
+          (f) => f.reason,
+          'reason',
+          FailureReason.internalError,
+        ),
+      );
     });
 
     test('cancel after the session went terminal still cancels the token',

--- a/packages/soliplex_agent/test/runtime/agent_session_test.dart
+++ b/packages/soliplex_agent/test/runtime/agent_session_test.dart
@@ -931,7 +931,13 @@ void main() {
       expect(completed.first.result, contains('timed out after'));
     });
 
-    test('cancelToken delegates to orchestrator', () {
+    test('cancel after the session went terminal still cancels the token',
+        () async {
+      // A run that failed or completed is terminal, but a tool parked on
+      // `requestApproval` is still waiting on this token: skipping the
+      // cancel leaves it hanging until the 60s tool timeout.
+      stubCreateRun();
+      stubRunAgent(stream: Stream.fromIterable(_happyPathEvents()));
       final session = createSession(
         api: api,
         agUiStreamClient: agUiStreamClient,
@@ -939,9 +945,34 @@ void main() {
       );
       addTearDown(session.dispose);
 
-      // cancelToken returns a fresh token when no run is active.
+      await session.start(userMessage: [const TextPart('Hi')]);
+      expect(await session.result, isA<AgentSuccess>());
+      expect(session.cancelToken.isCancelled, isFalse);
+
+      session.cancel();
+
+      expect(session.cancelToken.isCancelled, isTrue);
+    });
+
+    test('cancelToken is one instance for the session, cancelled by dispose',
+        () {
+      final session = createSession(
+        api: api,
+        agUiStreamClient: agUiStreamClient,
+        logger: logger,
+      );
+      addTearDown(session.dispose);
+
+      // Every reader must get the same token, or a listener registered by an
+      // extension in onAttach cannot observe a later cancel.
       final token = session.cancelToken;
-      expect(token, isA<CancelToken>());
+      expect(session.cancelToken, same(token));
+      expect(token.isCancelled, isFalse);
+
+      session.dispose();
+
+      expect(session.cancelToken, same(token));
+      expect(token.isCancelled, isTrue);
     });
 
     test('ActivitySnapshotEvent bridges to ActivitySnapshot', () async {

--- a/packages/soliplex_agent/test/runtime/cancel_during_tool_window_test.dart
+++ b/packages/soliplex_agent/test/runtime/cancel_during_tool_window_test.dart
@@ -1,0 +1,356 @@
+import 'dart:async';
+
+import 'package:mocktail/mocktail.dart';
+import 'package:soliplex_agent/soliplex_agent.dart';
+import 'package:soliplex_agent/src/orchestration/run_orchestrator.dart';
+import 'package:soliplex_client/soliplex_client.dart'
+    show AgUiStreamClient, SoliplexApi;
+import 'package:test/test.dart';
+
+// Guards the session cancellation signal against the lifetime it must not
+// be given. `RunOrchestrator`'s token is scoped to one HTTP request and is
+// absent for the whole tool-execution window (`_handleRunFinished` clears it
+// before emitting `ToolYieldingState`) and at `onAttach` time. Sourcing
+// `AgentSession.cancelToken` from it leaves tools and extensions holding a
+// token that a later cancel never reaches.
+
+class _MockSoliplexApi extends Mock implements SoliplexApi {}
+
+class _MockAgUiStreamClient extends Mock implements AgUiStreamClient {}
+
+class _MockLogger extends Mock implements Logger {}
+
+class _MockAgentRuntime extends Mock implements AgentRuntime {}
+
+class _FakeSimpleRunAgentInput extends Fake implements SimpleRunAgentInput {}
+
+class _FakeCancelToken extends Fake implements CancelToken {}
+
+/// Records whether the extension was asked, so a test can assert that a
+/// cancelled session never surfaces an approval at all.
+class _RecordingApprovalExtension extends ToolApprovalExtension {
+  int requestCount = 0;
+
+  @override
+  Future<void> onAttach(AgentSession session) async {}
+
+  @override
+  List<ClientTool> get tools => const [];
+
+  @override
+  void onDispose() {}
+
+  @override
+  Future<bool> requestApproval({
+    required String toolCallId,
+    required String toolName,
+    required Map<String, dynamic> arguments,
+    required String rationale,
+  }) async {
+    requestCount++;
+    return true;
+  }
+}
+
+/// Holds `attachAll` open so a cancel can land mid-attach.
+class _GatedExtension extends SessionExtension {
+  _GatedExtension(this.gate);
+
+  final Future<void> gate;
+
+  @override
+  String get namespace => 'gated';
+
+  @override
+  Future<void> onAttach(AgentSession session) => gate;
+
+  @override
+  List<ClientTool> get tools => const [];
+
+  @override
+  void onDispose() {}
+}
+
+/// The same shape as `HumanApprovalExtension`: one `whenCancelled`
+/// subscription taken at attach time, a completer per request, and a deny on
+/// either cancel or dispose. It omits the parts that do not bear on cancel —
+/// denying a superseded request, and the state signal.
+class _PendingApprovalExtension extends ToolApprovalExtension {
+  Completer<bool>? _pending;
+  bool get isPending => !(_pending?.isCompleted ?? true);
+
+  @override
+  Future<void> onAttach(AgentSession session) async {
+    unawaited(
+      session.cancelToken.whenCancelled.then((_) => _deny()),
+    );
+  }
+
+  @override
+  List<ClientTool> get tools => const [];
+
+  @override
+  void onDispose() => _deny();
+
+  @override
+  Future<bool> requestApproval({
+    required String toolCallId,
+    required String toolName,
+    required Map<String, dynamic> arguments,
+    required String rationale,
+  }) {
+    final completer = Completer<bool>();
+    _pending = completer;
+    return completer.future;
+  }
+
+  void _deny() {
+    final pending = _pending;
+    if (pending != null && !pending.isCompleted) pending.complete(false);
+  }
+}
+
+const ThreadKey _key = (
+  serverId: 'srv-1',
+  roomId: 'room-1',
+  threadId: 'thread-1',
+);
+
+const _runId = 'run-abc';
+
+RunInfo _runInfo() =>
+    RunInfo(id: _runId, threadId: _key.threadId, createdAt: DateTime(2026));
+
+/// A run that ends on a pending tool call, which is what parks the
+/// orchestrator in `ToolYieldingState` and runs the tool executor.
+List<BaseEvent> _toolCallEvents() => [
+      RunStartedEvent(threadId: _key.threadId, runId: _runId),
+      const ToolCallStartEvent(toolCallId: 'tc-1', toolCallName: 'weather'),
+      const ToolCallArgsEvent(toolCallId: 'tc-1', delta: '{"city":"NYC"}'),
+      const ToolCallEndEvent(toolCallId: 'tc-1'),
+      RunFinishedEvent(threadId: _key.threadId, runId: _runId),
+    ];
+
+/// Marks every pending call executed so the orchestrator resumes rather
+/// than failing the resume on an unfinished tool call.
+List<ToolCallInfo> _completed(List<ToolCallInfo> pending) => pending
+    .map(
+      (tc) => tc.copyWith(status: ToolCallStatus.completed, result: 'sunny'),
+    )
+    .toList();
+
+/// The resume segment: plain text, no pending tool call, so the run ends.
+List<BaseEvent> _replyEvents() => [
+      RunStartedEvent(threadId: _key.threadId, runId: _runId),
+      const TextMessageStartEvent(messageId: 'msg-1'),
+      const TextMessageContentEvent(messageId: 'msg-1', delta: 'Sunny'),
+      const TextMessageEndEvent(messageId: 'msg-1'),
+      RunFinishedEvent(threadId: _key.threadId, runId: _runId),
+    ];
+
+ToolRegistry _registry() => const ToolRegistry().register(
+      ClientTool(
+        definition: const Tool(name: 'weather', description: 'A test tool'),
+        executor: (_, __) async => 'result',
+      ),
+    );
+
+void main() {
+  setUpAll(() {
+    registerFallbackValue(_FakeSimpleRunAgentInput());
+    registerFallbackValue(_FakeCancelToken());
+  });
+
+  late _MockSoliplexApi api;
+  late _MockAgUiStreamClient agUiStreamClient;
+  late _MockLogger logger;
+  late RunOrchestrator orchestrator;
+  late int segment;
+
+  setUp(() {
+    segment = 0;
+    api = _MockSoliplexApi();
+    agUiStreamClient = _MockAgUiStreamClient();
+    logger = _MockLogger();
+    orchestrator = RunOrchestrator(
+      llmProvider:
+          AgUiLlmProvider(api: api, agUiStreamClient: agUiStreamClient),
+      toolRegistry: _registry(),
+      logger: logger,
+    );
+    when(() => api.createRun(any(), any())).thenAnswer((_) async => _runInfo());
+    when(
+      () => agUiStreamClient.runAgent(
+        any(),
+        any(),
+        cancelToken: any(named: 'cancelToken'),
+        resumePolicy: any(named: 'resumePolicy'),
+        onReconnectStatus: any(named: 'onReconnectStatus'),
+      ),
+    ).thenAnswer((_) {
+      // First segment yields a pending tool call (which opens the tool
+      // window); the resume segment answers with text so the run reaches
+      // CompletedState instead of looping to the depth limit.
+      final events = segment++ == 0 ? _toolCallEvents() : _replyEvents();
+      return Stream.fromIterable(events)
+          .map<DecodeOutcome>((e) => DecodedEvent(e, const {}));
+    });
+  });
+
+  tearDown(() {
+    orchestrator.dispose();
+  });
+
+  /// Mirrors `AgentSession.start()`'s ordering: extensions are attached
+  /// before the run begins, which is the window the defect lives in.
+  Future<AgentSession> buildSession(List<SessionExtension> extensions) async {
+    final coordinator = SessionCoordinator(extensions, logger: logger);
+    final session = AgentSession(
+      threadKey: _key,
+      ephemeral: false,
+      depth: 0,
+      runtime: _MockAgentRuntime(),
+      orchestrator: orchestrator,
+      toolRegistry: _registry(),
+      coordinator: coordinator,
+      logger: logger,
+    );
+    await coordinator.attachAll(session);
+    return session;
+  }
+
+  test(
+    'a cancelled session does not surface an approval request',
+    () async {
+      final ext = _RecordingApprovalExtension();
+      final session = await buildSession([ext]);
+      addTearDown(session.dispose);
+
+      final result = await orchestrator.runToCompletion(
+        key: _key,
+        userMessage: [const TextPart('Weather?')],
+        toolExecutor: (pending) async {
+          session.cancel();
+          // A tool that reaches its approval point after the user pressed
+          // Stop. `AgentSession.requestApproval`'s cancel short-circuit
+          // exists precisely to deny this without showing a dialog.
+          await session.requestApproval(
+            toolCallId: 'tc-1',
+            toolName: 'weather',
+            arguments: const {},
+            rationale: 'r',
+          );
+          return pending;
+        },
+      );
+
+      expect(result, isA<CancelledState>());
+      expect(
+        ext.requestCount,
+        0,
+        reason: 'a cancelled session must not raise an approval dialog',
+      );
+    },
+  );
+
+  test(
+    'cancelling lets the run finish while an approval is pending',
+    () async {
+      final ext = _PendingApprovalExtension();
+      final session = await buildSession([ext]);
+      // Registered rather than called inline: disposing before the check
+      // would resolve the approval and mask a hang.
+      addTearDown(session.dispose);
+
+      final run = orchestrator.runToCompletion(
+        key: _key,
+        userMessage: [const TextPart('Weather?')],
+        toolExecutor: (pending) async {
+          final approval = session.requestApproval(
+            toolCallId: 'tc-1',
+            toolName: 'weather',
+            arguments: const {},
+            rationale: 'r',
+          );
+          session.cancel();
+          await approval;
+          return _completed(pending);
+        },
+      );
+
+      // Completing at all is the assertion: a cancelled run must not park
+      // forever on an approval that only its cancel listener can resolve.
+      // `completes` surfaces a real throw instead of reporting it as a hang.
+      await expectLater(run.timeout(const Duration(seconds: 2)), completes);
+    },
+  );
+
+  test(
+    'a session cancelled while attaching never starts a run',
+    () async {
+      // `AgentRuntime.spawn` registers a child with its parent before
+      // awaiting `start`, so a parent cancel can land inside `onAttach`.
+      final attaching = Completer<void>();
+      final ext = _GatedExtension(attaching.future);
+      final session = AgentSession(
+        threadKey: _key,
+        ephemeral: false,
+        depth: 0,
+        runtime: _MockAgentRuntime(),
+        orchestrator: orchestrator,
+        toolRegistry: _registry(),
+        coordinator: SessionCoordinator([ext], logger: logger),
+        logger: logger,
+      );
+      addTearDown(session.dispose);
+
+      final started = session.start(userMessage: [const TextPart('hi')]);
+      session.cancel();
+      attaching.complete();
+      await started;
+      await Future<void>.delayed(Duration.zero);
+
+      expect(orchestrator.currentState, isA<IdleState>());
+      verifyNever(() => api.createRun(any(), any()));
+      // The runtime awaits this before disposing the session and draining
+      // the spawn queue, so it has to settle.
+      expect(
+        await session.result.timeout(const Duration(seconds: 2)),
+        isA<AgentFailure>().having(
+          (f) => f.reason,
+          'reason',
+          FailureReason.cancelled,
+        ),
+      );
+    },
+  );
+
+  test(
+    'a session disposed while attaching settles without throwing',
+    () async {
+      // `dispose()` cancels the token as well, and disposes the signals
+      // `_completeWith` writes — so the cancelled-during-attach path has to
+      // recognise that dispose already settled the result.
+      final attaching = Completer<void>();
+      final ext = _GatedExtension(attaching.future);
+      final session = AgentSession(
+        threadKey: _key,
+        ephemeral: false,
+        depth: 0,
+        runtime: _MockAgentRuntime(),
+        orchestrator: orchestrator,
+        toolRegistry: _registry(),
+        coordinator: SessionCoordinator([ext], logger: logger),
+        logger: logger,
+      );
+
+      final started = session.start(userMessage: [const TextPart('hi')]);
+      session.dispose();
+      attaching.complete();
+
+      await expectLater(started, completes);
+      verifyNever(() => api.createRun(any(), any()));
+      expect(await session.result, isA<AgentFailure>());
+    },
+  );
+}

--- a/packages/soliplex_client/lib/src/http/concurrency_limiting_http_client.dart
+++ b/packages/soliplex_client/lib/src/http/concurrency_limiting_http_client.dart
@@ -338,9 +338,10 @@ class ConcurrencyLimitingHttpClient implements SoliplexHttpClient {
   Duration _nonNegative(Duration duration) {
     if (!duration.isNegative) return duration;
     _onDiagnostic(
-      StateError('Negative waitDuration from clock skew: $duration'),
+      StateError('Negative waitDuration from clock skew'),
       StackTrace.current,
-      message: 'Clock went backward during request; clamping waitDuration',
+      message: 'Clock went backward during request; clamping waitDuration '
+          'from $duration',
     );
     return Duration.zero;
   }

--- a/packages/soliplex_client/lib/src/http/dart_http_client.dart
+++ b/packages/soliplex_client/lib/src/http/dart_http_client.dart
@@ -4,6 +4,7 @@ import 'dart:typed_data';
 
 import 'package:http/http.dart' as http;
 import 'package:soliplex_client/src/errors/exceptions.dart';
+import 'package:soliplex_client/src/http/http_diagnostic.dart';
 import 'package:soliplex_client/src/http/http_response.dart';
 import 'package:soliplex_client/src/http/soliplex_http_client.dart';
 import 'package:soliplex_client/src/utils/cancel_token.dart';
@@ -37,12 +38,19 @@ class DartHttpClient implements SoliplexHttpClient {
   /// - [client]: Optional [http.Client] to use. Creates a new one if not
   ///   provided.
   /// - [defaultTimeout]: Default timeout for requests.
+  /// - [onDiagnostic]: Sink for internal errors the client contained
+  ///   without failing the request. Defaults to `dart:developer`.
   DartHttpClient({
     http.Client? client,
     this.defaultTimeout = defaultHttpTimeout,
-  }) : _client = client ?? http.Client();
+    HttpDiagnosticHandler? onDiagnostic,
+  })  : _client = client ?? http.Client(),
+        _onDiagnostic = safeDiagnosticHandler(
+          onDiagnostic ?? defaultHttpDiagnosticHandler,
+        );
 
   final http.Client _client;
+  final HttpDiagnosticHandler _onDiagnostic;
 
   /// Default timeout for requests when not specified per-request.
   final Duration defaultTimeout;
@@ -296,7 +304,27 @@ class DartHttpClient implements SoliplexHttpClient {
         if (closed) return;
         sink.addError(CancelledException(reason: cancelToken.reason));
         closeSink();
-        subscription.cancel();
+        // A body stream that is an `async*` generator can raise while it
+        // unwinds, and Dart reports that through the future returned by
+        // `cancel()` rather than through `onError`. Discarding the future
+        // lets it reach the zone as an unhandled error.
+        //
+        // A [CancelledException] here is the body reacting to the same
+        // token, a second route for an event the caller already has: the
+        // sink error above makes their request future complete with one.
+        // Deliberate silence. Anything else is a real body failure — a file
+        // read that broke as the socket closed — and this is its only
+        // record, because that future carries the cancellation instead.
+        unawaited(
+          subscription.cancel().catchError((Object e, StackTrace st) {
+            if (e is CancelledException) return;
+            _onDiagnostic(
+              e,
+              st,
+              message: 'Request body teardown failed after cancel',
+            );
+          }),
+        );
       });
     }
   }

--- a/packages/soliplex_client/test/http/upload_cancel_teardown_test.dart
+++ b/packages/soliplex_client/test/http/upload_cancel_teardown_test.dart
@@ -1,0 +1,207 @@
+import 'dart:async';
+
+import 'package:http/http.dart' as http;
+import 'package:mocktail/mocktail.dart';
+import 'package:soliplex_client/soliplex_client.dart' hide CancelToken;
+import 'package:soliplex_client/src/utils/cancel_token.dart';
+import 'package:test/test.dart';
+
+class _MockHttpClient extends Mock implements http.Client {}
+
+class _FakeBaseRequest extends Fake implements http.BaseRequest {}
+
+/// The `openStream` factory `UploadTracker` hands to
+/// `encodeMultipartStream` (`UploadTracker`'s `wrappedOpenStream`): an
+/// `async*` generator that forwards the file stream through `await for` so
+/// it can count bytes for progress. That shape is why cancelling matters: an
+/// error the file stream surfaces while this generator unwinds is reported
+/// on the future returned by `StreamSubscription.cancel()` rather than to
+/// `onError`.
+Stream<List<int>> progressCountingOpenStream(
+  Stream<List<int>> file,
+  void Function(int sent) emitProgress,
+) async* {
+  var sent = 0;
+  await for (final chunk in file) {
+    yield chunk;
+    sent += chunk.length;
+    emitProgress(sent);
+  }
+}
+
+void main() {
+  setUpAll(() {
+    registerFallbackValue(_FakeBaseRequest());
+  });
+
+  test(
+    'cancelling a streaming upload does not leak the body teardown error',
+    () async {
+      final mockClient = _MockHttpClient();
+      final diagnostics = <String>[];
+      final client = DartHttpClient(
+        client: mockClient,
+        onDiagnostic: (error, _, {required message}) =>
+            diagnostics.add('$message: $error'),
+      );
+      addTearDown(client.close);
+
+      when(() => mockClient.send(any())).thenAnswer((invocation) async {
+        final request = invocation.positionalArguments[0] as http.BaseRequest;
+        // A real client reads the request body and fails the send when that
+        // body errors, which is how the caller learns of the cancel.
+        await request.finalize().toBytes();
+        return http.StreamedResponse(const Stream<List<int>>.empty(), 200);
+      });
+
+      final fileChunks = StreamController<List<int>>();
+      final token = CancelToken();
+      // Witness placed between the controller and the generator: it proves
+      // the injected error really reached the body, without putting a
+      // `finally` on the unwind path being tested.
+      var reachedBody = false;
+      final source = fileChunks.stream.handleError((Object e, StackTrace st) {
+        reachedBody = true;
+        Error.throwWithStackTrace(e, st);
+      });
+
+      // The file read failing as the socket goes down. Registered before
+      // the client's own cancel listener so the error is in flight at the
+      // moment the pipe cancels its source — the losing interleaving.
+      unawaited(
+        token.whenCancelled.then((_) {
+          fileChunks.addError(StateError('file read failed'));
+        }),
+      );
+
+      final encoded = encodeMultipartStream(
+        fieldName: 'upload_file',
+        filename: 'a.pdf',
+        openStream: () => progressCountingOpenStream(source, (_) {}),
+        contentLength: 3,
+      );
+
+      final unhandled = <Object>[];
+      await runZonedGuarded(
+        () async {
+          final pending = client.request(
+            'POST',
+            Uri.parse('https://example.com/upload'),
+            body: encoded.bodyStream,
+            headers: {'content-type': encoded.contentType},
+            cancelToken: token,
+          );
+          // Park the counting generator inside `await for`.
+          await Future<void>.delayed(const Duration(milliseconds: 30));
+          fileChunks.add(const [1, 2, 3]);
+          await Future<void>.delayed(const Duration(milliseconds: 30));
+
+          token.cancel('user');
+
+          // The caller's own contract on cancel, and the positive control
+          // that the cancel machinery ran end to end.
+          await expectLater(pending, throwsA(isA<CancelledException>()));
+          await Future<void>.delayed(const Duration(milliseconds: 150));
+        },
+        (error, _) => unhandled.add(error),
+      );
+
+      expect(
+        unhandled,
+        isEmpty,
+        reason: 'an error raised while the counting generator unwinds must '
+            'be absorbed by the pipe, not reach the zone',
+      );
+      // The read failure is not the cancellation the caller already has, so
+      // it must leave a record rather than vanish.
+      const expected = 'Request body teardown failed after cancel: '
+          'Bad state: file read failed';
+      expect(diagnostics, [expected]);
+      expect(reachedBody, isTrue);
+    },
+  );
+
+  test(
+    'a cancellation surfacing from the body is not recorded',
+    () async {
+      final mockClient = _MockHttpClient();
+      final diagnostics = <String>[];
+      final client = DartHttpClient(
+        client: mockClient,
+        onDiagnostic: (error, _, {required message}) =>
+            diagnostics.add('$message: $error'),
+      );
+      addTearDown(client.close);
+
+      when(() => mockClient.send(any())).thenAnswer((invocation) async {
+        final request = invocation.positionalArguments[0] as http.BaseRequest;
+        // A real client reads the request body and fails the send when that
+        // body errors, which is how the caller learns of the cancel.
+        await request.finalize().toBytes();
+        return http.StreamedResponse(const Stream<List<int>>.empty(), 200);
+      });
+
+      final fileChunks = StreamController<List<int>>();
+      final token = CancelToken();
+      // Witness placed between the controller and the generator: it proves
+      // the injected error really reached the body, without putting a
+      // `finally` on the unwind path being tested.
+      var reachedBody = false;
+      final source = fileChunks.stream.handleError((Object e, StackTrace st) {
+        reachedBody = true;
+        Error.throwWithStackTrace(e, st);
+      });
+
+      // A cancel-aware body reacting to the same token, in flight at the
+      // moment the pipe cancels its source.
+      unawaited(
+        token.whenCancelled.then((_) {
+          fileChunks.addError(const CancelledException(reason: 'user'));
+        }),
+      );
+
+      final encoded = encodeMultipartStream(
+        fieldName: 'upload_file',
+        filename: 'a.pdf',
+        openStream: () => progressCountingOpenStream(source, (_) {}),
+        contentLength: 3,
+      );
+
+      final unhandled = <Object>[];
+      await runZonedGuarded(
+        () async {
+          final pending = client.request(
+            'POST',
+            Uri.parse('https://example.com/upload'),
+            body: encoded.bodyStream,
+            headers: {'content-type': encoded.contentType},
+            cancelToken: token,
+          );
+          // Park the counting generator inside `await for`.
+          await Future<void>.delayed(const Duration(milliseconds: 30));
+          fileChunks.add(const [1, 2, 3]);
+          await Future<void>.delayed(const Duration(milliseconds: 30));
+
+          token.cancel('user');
+
+          // The caller's own contract on cancel, and the positive control
+          // that the cancel machinery ran end to end.
+          await expectLater(pending, throwsA(isA<CancelledException>()));
+          await Future<void>.delayed(const Duration(milliseconds: 150));
+        },
+        (error, _) => unhandled.add(error),
+      );
+
+      expect(
+        unhandled,
+        isEmpty,
+        reason: 'an error raised while the counting generator unwinds must '
+            'be absorbed by the pipe, not reach the zone',
+      );
+      // The caller already has this cancellation on their request future,
+      // so a second copy of it must leave no record.
+      expect(diagnostics, isEmpty);
+      expect(reachedBody, isTrue);
+    },
+  );
+}

--- a/packages/soliplex_client_native/lib/src/clients/cupertino_http_client.dart
+++ b/packages/soliplex_client_native/lib/src/clients/cupertino_http_client.dart
@@ -38,11 +38,17 @@ class CupertinoHttpClient implements SoliplexHttpClient {
   ///   to timeoutIntervalForRequest. When providing your own configuration,
   ///   you are responsible for its timeout settings.
   /// - [defaultTimeout]: Default timeout for requests.
+  /// - [onDiagnostic]: Sink for internal errors the client contained
+  ///   without failing the request. Defaults to `dart:developer`.
   CupertinoHttpClient({
     URLSessionConfiguration? configuration,
     this.defaultTimeout = defaultHttpTimeout,
-  }) : _client = CupertinoClient.fromSessionConfiguration(
+    HttpDiagnosticHandler? onDiagnostic,
+  })  : _client = CupertinoClient.fromSessionConfiguration(
           configuration ?? _createConfiguration(defaultTimeout),
+        ),
+        _onDiagnostic = safeDiagnosticHandler(
+          onDiagnostic ?? defaultHttpDiagnosticHandler,
         );
 
   /// Creates a Cupertino HTTP client with a custom client for testing.
@@ -52,7 +58,11 @@ class CupertinoHttpClient implements SoliplexHttpClient {
   CupertinoHttpClient.forTesting({
     required http.Client client,
     this.defaultTimeout = defaultHttpTimeout,
-  }) : _client = client;
+    HttpDiagnosticHandler? onDiagnostic,
+  })  : _client = client,
+        _onDiagnostic = safeDiagnosticHandler(
+          onDiagnostic ?? defaultHttpDiagnosticHandler,
+        );
 
   /// Creates a URLSessionConfiguration with the given timeout.
   static URLSessionConfiguration _createConfiguration(Duration timeout) {
@@ -61,6 +71,7 @@ class CupertinoHttpClient implements SoliplexHttpClient {
   }
 
   final http.Client _client;
+  final HttpDiagnosticHandler _onDiagnostic;
 
   /// Default timeout for requests when not specified per-request.
   final Duration defaultTimeout;
@@ -123,6 +134,25 @@ class CupertinoHttpClient implements SoliplexHttpClient {
         stackTrace: stackTrace,
       );
     } on http.ClientException catch (e, stackTrace) {
+      // Only a streamed body is wired to the token: `_pipeStreamToSink`
+      // injects the cancellation into the request sink, and it crosses the
+      // `NSInputStream` bridge as an `NSError`, so the [CancelledException]
+      // identity is gone by the time it lands here. Reporting a network
+      // failure for an upload the caller cancelled is what makes
+      // `UploadTracker` show a cancelled row as failed.
+      //
+      // Buffered bodies are never wired, so a client error there is a real
+      // failure even when some other request sharing the token was
+      // cancelled; those keep reporting as network failures.
+      if (body is Stream<List<int>> && (cancelToken?.isCancelled ?? false)) {
+        _onDiagnostic(
+          e,
+          stackTrace,
+          message: 'Client error on a cancelled streamed upload; '
+              'reporting the cancellation instead',
+        );
+        cancelToken!.throwIfCancelled();
+      }
       throw NetworkException(
         message: 'Client error: ${e.message}',
         originalError: e,
@@ -180,6 +210,25 @@ class CupertinoHttpClient implements SoliplexHttpClient {
     } on CancelledException {
       rethrow;
     } on http.ClientException catch (e, stackTrace) {
+      // Only a streamed body is wired to the token: `_pipeStreamToSink`
+      // injects the cancellation into the request sink, and it crosses the
+      // `NSInputStream` bridge as an `NSError`, so the [CancelledException]
+      // identity is gone by the time it lands here. Reporting a network
+      // failure for an upload the caller cancelled is what makes
+      // `UploadTracker` show a cancelled row as failed.
+      //
+      // Buffered bodies are never wired, so a client error there is a real
+      // failure even when some other request sharing the token was
+      // cancelled; those keep reporting as network failures.
+      if (body is Stream<List<int>> && (cancelToken?.isCancelled ?? false)) {
+        _onDiagnostic(
+          e,
+          stackTrace,
+          message: 'Client error on a cancelled streamed upload; '
+              'reporting the cancellation instead',
+        );
+        cancelToken!.throwIfCancelled();
+      }
       throw NetworkException(
         message: 'Client error: ${e.message}',
         originalError: e,
@@ -314,7 +363,27 @@ class CupertinoHttpClient implements SoliplexHttpClient {
         if (closed) return;
         sink.addError(CancelledException(reason: cancelToken.reason));
         closeSink();
-        subscription.cancel();
+        // A body stream that is an `async*` generator can raise while it
+        // unwinds, and Dart reports that through the future returned by
+        // `cancel()` rather than through `onError`. Discarding the future
+        // lets it reach the zone as an unhandled error.
+        //
+        // A [CancelledException] here is the body reacting to the same
+        // token, a second route for an event the caller already has: the
+        // sink error above makes their request future complete with one.
+        // Deliberate silence. Anything else is a real body failure — a file
+        // read that broke as the socket closed — and this is its only
+        // record, because that future carries the cancellation instead.
+        unawaited(
+          subscription.cancel().catchError((Object e, StackTrace st) {
+            if (e is CancelledException) return;
+            _onDiagnostic(
+              e,
+              st,
+              message: 'Request body teardown failed after cancel',
+            );
+          }),
+        );
       });
     }
   }

--- a/packages/soliplex_client_native/lib/src/clients/web_xhr_http_client.dart
+++ b/packages/soliplex_client_native/lib/src/clients/web_xhr_http_client.dart
@@ -18,9 +18,17 @@ import 'package:web/web.dart' as web;
 /// behaves identically to today.
 class WebXhrHttpClient implements SoliplexHttpClient {
   /// Wraps an inner [DartHttpClient] for non-upload paths.
-  WebXhrHttpClient({Duration defaultTimeout = defaultHttpTimeout})
-      : _defaultTimeout = defaultTimeout,
-        _inner = DartHttpClient(defaultTimeout: defaultTimeout);
+  ///
+  /// [onDiagnostic] is forwarded to that inner client, which is where
+  /// this client's contained internal errors arise.
+  WebXhrHttpClient({
+    Duration defaultTimeout = defaultHttpTimeout,
+    HttpDiagnosticHandler? onDiagnostic,
+  })  : _defaultTimeout = defaultTimeout,
+        _inner = DartHttpClient(
+          defaultTimeout: defaultTimeout,
+          onDiagnostic: onDiagnostic,
+        );
 
   final Duration _defaultTimeout;
   final DartHttpClient _inner;

--- a/packages/soliplex_client_native/lib/src/platform/create_platform_client.dart
+++ b/packages/soliplex_client_native/lib/src/platform/create_platform_client.dart
@@ -9,6 +9,8 @@ import 'package:soliplex_client_native/src/platform/create_platform_client_stub.
 /// - `DartHttpClient` on all other platforms (Android, Windows, Linux, Web)
 ///
 /// The [defaultTimeout] parameter sets the default request timeout.
+/// [onDiagnostic] receives internal errors the client contained without
+/// failing the request; it defaults to `dart:developer`.
 ///
 /// Example:
 /// ```dart
@@ -23,6 +25,10 @@ import 'package:soliplex_client_native/src/platform/create_platform_client_stub.
 /// ```
 SoliplexHttpClient createPlatformClient({
   Duration defaultTimeout = defaultHttpTimeout,
+  HttpDiagnosticHandler? onDiagnostic,
 }) {
-  return createPlatformClientImpl(defaultTimeout: defaultTimeout);
+  return createPlatformClientImpl(
+    defaultTimeout: defaultTimeout,
+    onDiagnostic: onDiagnostic,
+  );
 }

--- a/packages/soliplex_client_native/lib/src/platform/create_platform_client_io.dart
+++ b/packages/soliplex_client_native/lib/src/platform/create_platform_client_io.dart
@@ -12,16 +12,34 @@ import 'package:soliplex_client_native/src/clients/cupertino_http_client.dart';
 /// (e.g., in Flutter test environment).
 SoliplexHttpClient createPlatformClientImpl({
   Duration defaultTimeout = defaultHttpTimeout,
+  HttpDiagnosticHandler? onDiagnostic,
 }) {
+  final handler = onDiagnostic ?? defaultHttpDiagnosticHandler;
   if (Platform.isMacOS || Platform.isIOS) {
     try {
-      return CupertinoHttpClient(defaultTimeout: defaultTimeout);
-    } catch (e) {
+      return CupertinoHttpClient(
+        defaultTimeout: defaultTimeout,
+        onDiagnostic: handler,
+      );
+    } on Object catch (error, stackTrace) {
       // Fallback to DartHttpClient if native bindings unavailable
-      // (e.g., in Flutter test environment)
-      return DartHttpClient(defaultTimeout: defaultTimeout);
+      // (e.g., in Flutter test environment). Silently downgrading would
+      // hide the loss of NSURLSession's proxy, trust and HTTP/2 handling
+      // behind whatever the request fails with later, so record it.
+      safeDiagnosticHandler(handler)(
+        error,
+        stackTrace,
+        message: 'Native HTTP client unavailable; using DartHttpClient',
+      );
+      return DartHttpClient(
+        defaultTimeout: defaultTimeout,
+        onDiagnostic: handler,
+      );
     }
   }
   // Fallback to DartHttpClient for Android, Windows, Linux
-  return DartHttpClient(defaultTimeout: defaultTimeout);
+  return DartHttpClient(
+    defaultTimeout: defaultTimeout,
+    onDiagnostic: handler,
+  );
 }

--- a/packages/soliplex_client_native/lib/src/platform/create_platform_client_stub.dart
+++ b/packages/soliplex_client_native/lib/src/platform/create_platform_client_stub.dart
@@ -10,6 +10,10 @@ import 'package:soliplex_client_native/src/clients/web_xhr_http_client.dart';
 /// the file's disk-backed Blob — file bytes never enter the JS heap.
 SoliplexHttpClient createPlatformClientImpl({
   Duration defaultTimeout = defaultHttpTimeout,
+  HttpDiagnosticHandler? onDiagnostic,
 }) {
-  return WebXhrHttpClient(defaultTimeout: defaultTimeout);
+  return WebXhrHttpClient(
+    defaultTimeout: defaultTimeout,
+    onDiagnostic: onDiagnostic,
+  );
 }

--- a/packages/soliplex_client_native/test/clients/cupertino_upload_cancel_teardown_test.dart
+++ b/packages/soliplex_client_native/test/clients/cupertino_upload_cancel_teardown_test.dart
@@ -1,0 +1,322 @@
+@TestOn('vm')
+library;
+
+import 'dart:async';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
+import 'package:mocktail/mocktail.dart';
+import 'package:soliplex_client/cancel_token.dart';
+import 'package:soliplex_client/soliplex_client.dart' hide CancelToken;
+// Import implementation directly since package uses conditional exports
+import 'package:soliplex_client_native/src/clients/cupertino_http_client.dart';
+
+class _MockHttpClient extends Mock implements http.Client {}
+
+class _FakeBaseRequest extends Fake implements http.BaseRequest {}
+
+/// The `openStream` factory `UploadTracker` hands to
+/// `encodeMultipartStream` (`UploadTracker`'s `wrappedOpenStream`): an
+/// `async*` generator forwarding the file stream through `await for` so it
+/// can count bytes for progress. Cancelling the upload tears this down,
+/// and an error the file stream raises while it unwinds is reported on the
+/// future returned by `StreamSubscription.cancel()` rather than to
+/// `onError`.
+Stream<List<int>> progressCountingOpenStream(
+  Stream<List<int>> file,
+  void Function(int sent) emitProgress,
+) async* {
+  var sent = 0;
+  await for (final chunk in file) {
+    yield chunk;
+    sent += chunk.length;
+    emitProgress(sent);
+  }
+}
+
+void main() {
+  setUpAll(() {
+    registerFallbackValue(_FakeBaseRequest());
+  });
+
+  test(
+    'cancelling a streaming upload does not leak the body teardown error',
+    () async {
+      final mockClient = _MockHttpClient();
+      final diagnostics = <String>[];
+      final client = CupertinoHttpClient.forTesting(
+        client: mockClient,
+        onDiagnostic: (error, _, {required message}) =>
+            diagnostics.add('$message: $error'),
+      );
+      addTearDown(client.close);
+
+      when(() => mockClient.send(any())).thenAnswer((invocation) async {
+        final request = invocation.positionalArguments[0] as http.BaseRequest;
+        // A real client reads the request body and fails the send when that
+        // body errors, which is how the caller learns of the cancel.
+        await request.finalize().toBytes();
+        return http.StreamedResponse(const Stream<List<int>>.empty(), 200);
+      });
+
+      final fileChunks = StreamController<List<int>>();
+      final token = CancelToken();
+      // Witness placed between the controller and the generator: it proves
+      // the injected error really reached the body, without putting a
+      // `finally` on the unwind path being tested.
+      var reachedBody = false;
+      final source = fileChunks.stream.handleError((Object e, StackTrace st) {
+        reachedBody = true;
+        Error.throwWithStackTrace(e, st);
+      });
+
+      // The file read failing as the socket goes down. Registered before the
+      // client's own cancel listener so the error is in flight at the moment
+      // the pipe cancels its source — the losing interleaving.
+      unawaited(
+        token.whenCancelled.then((_) {
+          fileChunks.addError(StateError('file read failed'));
+        }),
+      );
+
+      final encoded = encodeMultipartStream(
+        fieldName: 'upload_file',
+        filename: 'a.pdf',
+        openStream: () => progressCountingOpenStream(source, (_) {}),
+        contentLength: 3,
+      );
+
+      final unhandled = <Object>[];
+      await runZonedGuarded(
+        () async {
+          final pending = client.request(
+            'POST',
+            Uri.parse('https://example.com/upload'),
+            body: encoded.bodyStream,
+            headers: {'content-type': encoded.contentType},
+            cancelToken: token,
+          );
+          // Park the counting generator inside `await for`.
+          await Future<void>.delayed(const Duration(milliseconds: 30));
+          fileChunks.add(const [1, 2, 3]);
+          await Future<void>.delayed(const Duration(milliseconds: 30));
+
+          token.cancel('user');
+
+          // The caller's own contract on cancel, and the positive control
+          // that the cancel machinery ran end to end.
+          await expectLater(pending, throwsA(isA<CancelledException>()));
+          await Future<void>.delayed(const Duration(milliseconds: 150));
+        },
+        (error, _) => unhandled.add(error),
+      );
+
+      expect(
+        unhandled,
+        isEmpty,
+        reason: 'an error raised while the counting generator unwinds must '
+            'be absorbed by the pipe, not reach the zone',
+      );
+      // The read failure is not the cancellation the caller already has, so
+      // it must leave a record rather than vanish.
+      const expected = 'Request body teardown failed after cancel: '
+          'Bad state: file read failed';
+      expect(diagnostics, [expected]);
+      expect(reachedBody, isTrue);
+    },
+  );
+
+  test(
+    'a cancellation surfacing from the body is not recorded',
+    () async {
+      final mockClient = _MockHttpClient();
+      final diagnostics = <String>[];
+      final client = CupertinoHttpClient.forTesting(
+        client: mockClient,
+        onDiagnostic: (error, _, {required message}) =>
+            diagnostics.add('$message: $error'),
+      );
+      addTearDown(client.close);
+
+      when(() => mockClient.send(any())).thenAnswer((invocation) async {
+        final request = invocation.positionalArguments[0] as http.BaseRequest;
+        // A real client reads the request body and fails the send when that
+        // body errors, which is how the caller learns of the cancel.
+        await request.finalize().toBytes();
+        return http.StreamedResponse(const Stream<List<int>>.empty(), 200);
+      });
+
+      final fileChunks = StreamController<List<int>>();
+      final token = CancelToken();
+      // Witness placed between the controller and the generator: it proves
+      // the injected error really reached the body, without putting a
+      // `finally` on the unwind path being tested.
+      var reachedBody = false;
+      final source = fileChunks.stream.handleError((Object e, StackTrace st) {
+        reachedBody = true;
+        Error.throwWithStackTrace(e, st);
+      });
+
+      // A cancel-aware body reacting to the same token, in flight at the
+      // moment the pipe cancels its source.
+      unawaited(
+        token.whenCancelled.then((_) {
+          fileChunks.addError(const CancelledException(reason: 'user'));
+        }),
+      );
+
+      final encoded = encodeMultipartStream(
+        fieldName: 'upload_file',
+        filename: 'a.pdf',
+        openStream: () => progressCountingOpenStream(source, (_) {}),
+        contentLength: 3,
+      );
+
+      final unhandled = <Object>[];
+      await runZonedGuarded(
+        () async {
+          final pending = client.request(
+            'POST',
+            Uri.parse('https://example.com/upload'),
+            body: encoded.bodyStream,
+            headers: {'content-type': encoded.contentType},
+            cancelToken: token,
+          );
+          // Park the counting generator inside `await for`.
+          await Future<void>.delayed(const Duration(milliseconds: 30));
+          fileChunks.add(const [1, 2, 3]);
+          await Future<void>.delayed(const Duration(milliseconds: 30));
+
+          token.cancel('user');
+
+          // The caller's own contract on cancel, and the positive control
+          // that the cancel machinery ran end to end.
+          await expectLater(pending, throwsA(isA<CancelledException>()));
+          await Future<void>.delayed(const Duration(milliseconds: 150));
+        },
+        (error, _) => unhandled.add(error),
+      );
+
+      expect(
+        unhandled,
+        isEmpty,
+        reason: 'an error raised while the counting generator unwinds must '
+            'be absorbed by the pipe, not reach the zone',
+      );
+      // The caller already has this cancellation on their request future,
+      // so a second copy of it must leave no record.
+      expect(diagnostics, isEmpty);
+      expect(reachedBody, isTrue);
+    },
+  );
+
+  test(
+    'an abort reported as a client error surfaces as a cancellation',
+    () async {
+      // NSURLSession does not hand back the [CancelledException] the sink
+      // carried: it crosses the `NSInputStream` bridge as an `NSError` and
+      // arrives as `NSErrorClientException extends ClientException`. Without
+      // the token check in that catch arm the caller sees a network failure
+      // for a request they cancelled, and `UploadTracker`'s
+      // `on CancelledException` arm never matches.
+      final mockClient = _MockHttpClient();
+      final diagnostics = <String>[];
+      final client = CupertinoHttpClient.forTesting(
+        client: mockClient,
+        onDiagnostic: (error, _, {required message}) =>
+            diagnostics.add('$message: $error'),
+      );
+      addTearDown(client.close);
+
+      final gate = Completer<void>();
+      when(() => mockClient.send(any())).thenAnswer((_) async {
+        await gate.future;
+        throw http.ClientException('NSError: cancelled');
+      });
+
+      final token = CancelToken();
+      final pending = client.request(
+        'POST',
+        Uri.parse('https://example.com/upload'),
+        // A streamed body is the only one wired to the token.
+        body: Stream<List<int>>.fromIterable(const [
+          [1, 2, 3],
+        ]),
+        headers: const {'content-type': 'application/octet-stream'},
+        cancelToken: token,
+      );
+      // Cancel after dispatch, so the pre-flight check has already passed.
+      token.cancel('user');
+      gate.complete();
+
+      await expectLater(pending, throwsA(isA<CancelledException>()));
+      // The client error is discarded in favour of the cancellation, so this
+      // record is the only trace the request died for another reason.
+      const record = 'Client error on a cancelled streamed upload; '
+          'reporting the cancellation instead: '
+          'ClientException: NSError: cancelled';
+      expect(diagnostics, [record]);
+    },
+  );
+
+  test(
+    'a client error on a buffered body stays a network failure',
+    () async {
+      // A buffered body is never wired to the token, so a cancel meant for
+      // some other request sharing it must not relabel this failure.
+      // `RoomInfoScreen` shares one token across two concurrent GETs.
+      final mockClient = _MockHttpClient();
+      final client = CupertinoHttpClient.forTesting(client: mockClient);
+      addTearDown(client.close);
+
+      final gate = Completer<void>();
+      when(() => mockClient.send(any())).thenAnswer((_) async {
+        await gate.future;
+        throw http.ClientException('Connection reset by peer');
+      });
+
+      final token = CancelToken();
+      final pending = client.request(
+        'GET',
+        Uri.parse('https://example.com/room'),
+        cancelToken: token,
+      );
+      token.cancel('retry');
+      gate.complete();
+
+      await expectLater(pending, throwsA(isA<NetworkException>()));
+    },
+  );
+
+  test(
+    'requestStream maps an aborted streamed body to a cancellation too',
+    () async {
+      // The same guard arm, byte-identical, on the SSE entry point: a fix
+      // landing in only one of the two is the risk this pins.
+      final mockClient = _MockHttpClient();
+      final client = CupertinoHttpClient.forTesting(client: mockClient);
+      addTearDown(client.close);
+
+      final gate = Completer<void>();
+      when(() => mockClient.send(any())).thenAnswer((_) async {
+        await gate.future;
+        throw http.ClientException('NSError: cancelled');
+      });
+
+      final token = CancelToken();
+      final pending = client.requestStream(
+        'POST',
+        Uri.parse('https://example.com/stream'),
+        body: Stream<List<int>>.fromIterable(const [
+          [1, 2, 3],
+        ]),
+        headers: const {'content-type': 'application/octet-stream'},
+        cancelToken: token,
+      );
+      token.cancel('user');
+      gate.complete();
+
+      await expectLater(pending, throwsA(isA<CancelledException>()));
+    },
+  );
+}

--- a/test/core/uncaught_errors_test.dart
+++ b/test/core/uncaught_errors_test.dart
@@ -1,0 +1,103 @@
+import 'dart:convert';
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+// The barrel, not `src/`: it is the only supported path for a host app, so
+// importing `src/` here would let the export be dropped without a test
+// failing.
+import 'package:soliplex_frontend/soliplex_frontend.dart';
+
+/// A `FormatException` carrying the input it failed on, which is the shape
+/// the rule against `error:` exists for: `toString()` renders roughly 78
+/// characters of that input, and an uncaught error can be thrown over
+/// anything the backend or the user supplied.
+Object _failureCarryingItsInput() {
+  try {
+    jsonDecode('{"token":"SECRET_PROJECT_VALUE","x":}');
+    fail('expected a FormatException');
+  } on FormatException catch (e) {
+    return e;
+  }
+}
+
+void main() {
+  late MemorySink sink;
+
+  setUp(() {
+    sink = MemorySink();
+    LogManager.instance.addSink(sink);
+  });
+
+  tearDown(LogManager.instance.reset);
+
+  group('installUncaughtErrorLogging', () {
+    // Both are process-global and the test binding owns them: restore through
+    // `addTearDown` so a failing expectation cannot skip it.
+    void installOverRestorableGlobals() {
+      final priorFlutterOnError = FlutterError.onError;
+      final priorPlatformOnError = PlatformDispatcher.instance.onError;
+      addTearDown(() {
+        FlutterError.onError = priorFlutterOnError;
+        PlatformDispatcher.instance.onError = priorPlatformOnError;
+      });
+      installUncaughtErrorLogging();
+    }
+
+    test('a framework error is recorded without the data it carries', () {
+      final delegatedTo = <FlutterErrorDetails>[];
+      // Stand in for `FlutterError.presentError`, which the app is running
+      // under at install time — and keep the dump out of the test output.
+      FlutterError.onError = delegatedTo.add;
+      installOverRestorableGlobals();
+
+      final details = FlutterErrorDetails(
+        exception: _failureCarryingItsInput(),
+        stack: StackTrace.current,
+        library: 'widgets library',
+      );
+      FlutterError.reportError(details);
+
+      final record = sink.records.single;
+      expect(record.level, LogLevel.error);
+      // The offset survives; the ~78-character window of the decoded input
+      // that `FormatException.toString()` would print does not.
+      expect(
+        record.attributes['failure'],
+        'FormatException: Unexpected character (offset 36)',
+      );
+      // The whole record is what the diagnostics screen renders and exports.
+      expect(record.toString(), isNot(contains('SECRET_PROJECT_VALUE')));
+      expect(record.error, isNull);
+      expect(record.stackTrace, isNotNull);
+      // Logging is additive. Taking over `FlutterError.onError` without
+      // passing the details on would silence the console dump app-wide, and
+      // nothing about dropping the delegation fails to compile.
+      expect(delegatedTo, [details]);
+    });
+
+    test('an uncaught async error is recorded without the data it carries', () {
+      installOverRestorableGlobals();
+
+      final handled = PlatformDispatcher.instance.onError!(
+        _failureCarryingItsInput(),
+        StackTrace.current,
+      );
+
+      // False, not true: the record is a second copy, so the platform's own
+      // report of an unhandled error has to stay. On a target where no sink
+      // has a transport — a packaged app, or Android, where stdout reaches
+      // nobody — claiming the error was handled is what makes it disappear.
+      expect(handled, isFalse);
+      final record = sink.records.single;
+      expect(record.level, LogLevel.error);
+      expect(
+        record.attributes['failure'],
+        'FormatException: Unexpected character (offset 36)',
+      );
+      expect(record.toString(), isNot(contains('SECRET_PROJECT_VALUE')));
+      expect(record.error, isNull);
+      expect(record.stackTrace, isNotNull);
+    });
+  });
+}

--- a/test/flavors/http_diagnostic_logging_test.dart
+++ b/test/flavors/http_diagnostic_logging_test.dart
@@ -1,0 +1,51 @@
+import 'dart:convert';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:soliplex_frontend/src/flavors/standard_kit.dart';
+import 'package:soliplex_logging/soliplex_logging.dart';
+
+void main() {
+  group('logHttpDiagnostic', () {
+    late MemorySink sink;
+
+    setUp(() {
+      sink = MemorySink();
+      LogManager.instance.addSink(sink);
+    });
+
+    tearDown(LogManager.instance.reset);
+
+    test('records a description, never the data the failure carries', () {
+      // The shape the request-body pipes and the observer guards forward:
+      // an exception this package did not construct, carrying data it was
+      // thrown over.
+      final Object failure;
+      try {
+        jsonDecode('{"token":"SECRET_PROJECT_VALUE","x":}');
+        fail('expected a FormatException');
+      } on FormatException catch (e) {
+        failure = e;
+      }
+
+      logHttpDiagnostic(
+        LogManager.instance.getLogger('http_stack'),
+        failure,
+        StackTrace.current,
+        message: 'Response body redaction failed unexpectedly',
+      );
+
+      final record = sink.records.single;
+      expect(record.message, 'Response body redaction failed unexpectedly');
+      // The offset survives; the ~78-character window of the body that
+      // `FormatException.toString()` would print does not.
+      expect(
+        record.attributes['failure'],
+        'FormatException: Unexpected character (offset 36)',
+      );
+      // The whole record is what the diagnostics screen renders and exports.
+      expect(record.toString(), isNot(contains('SECRET_PROJECT_VALUE')));
+      expect(record.error, isNull);
+      expect(record.stackTrace, isNotNull);
+    });
+  });
+}

--- a/test/modules/room/room_state_test.dart
+++ b/test/modules/room/room_state_test.dart
@@ -237,6 +237,36 @@ void main() {
     state.dispose();
   });
 
+  test('cancelSpawn after dispose does not throw', () async {
+    // The same shape as `ThreadViewState.cancelRun`, one file away: every
+    // other method here opens with the disposed guard, this one writes
+    // `_sessionState` without it, and signals raise on a write after disposal.
+    api.nextRoom = Room(id: 'room-1', name: 'Test');
+    api.nextThreads = [];
+
+    final state = RoomState(
+      serverEntry: serverEntry,
+      roomId: 'room-1',
+      runtimeManager: runtimeManager,
+      registry: registry,
+      uploadRegistry: uploadRegistry,
+    );
+
+    await Future<void>.delayed(Duration.zero);
+
+    // Left pending, so `_spawner.cancel()` reports a spawn to cancel and
+    // `cancelSpawn` reaches the write.
+    final future = state.sendToNewThread([const TextPart('Hello')]);
+    state.dispose();
+
+    state.cancelSpawn();
+
+    await future;
+    for (var i = 0; i < 10; i++) {
+      await Future<void>.delayed(Duration.zero);
+    }
+  });
+
   test('sendToNewThread adds thread to list locally', () async {
     final createdThread = ThreadInfo(
       id: 'spawned-thread',

--- a/test/modules/room/thread_view_state_test.dart
+++ b/test/modules/room/thread_view_state_test.dart
@@ -697,6 +697,36 @@ void main() {
       state.dispose();
     });
 
+    test('cancelRun after dispose does not throw', () async {
+      // Every other method on this class opens with the disposed guard —
+      // `_onAuthChanged` three lines away from `cancelRun` does. Without it
+      // the spawn-cancel arm writes `_sessionState`, which `dispose` has
+      // already disposed, and signals raise on a write after disposal rather
+      // than ignoring it. The throw lands in the Stop button's `onPressed`.
+      api.nextThreadHistory = ThreadHistory(messages: const []);
+
+      final state = ThreadViewState(
+        connection: connection,
+        auth: auth,
+        roomId: 'room-1',
+        threadId: 'thread-1',
+        registry: registry,
+      );
+
+      await Future<void>.delayed(Duration.zero);
+
+      // Left pending, so the spawn-cancel arm is the one that runs.
+      final future = state.sendMessage([TextPart('Hello')], runtime);
+      state.dispose();
+
+      state.cancelRun();
+
+      await future;
+      for (var i = 0; i < 10; i++) {
+        await Future<void>.delayed(Duration.zero);
+      }
+    });
+
     test('cancelRun during spawn prevents session from attaching', () async {
       api.nextThreadHistory = ThreadHistory(messages: const []);
 


### PR DESCRIPTION
# Summary

Pressing Stop could leave the app **crashed, stuck, or silently ignoring the
press**. Two commits: the first fixes the mechanism, the second makes every
cancel path reach a terminal state and adds the backstop that would have
surfaced the original defect years earlier.

The root of the first half is a non-obvious Dart semantic: **an error raised
while an `async*` generator unwinds is delivered to the future returned by
`StreamSubscription.cancel()`, not to the subscription's `onError`** — so
`unawaited(sub.cancel())` drops it.

## Changes — `898d234b`

**The discarded teardown future**

- `RunOrchestrator` routes its four SSE teardown sites through
  `_absorbTeardown`: a cancellation is deliberate silence, anything else is
  recorded (labelled by site) through `describeFailure`.
- `_pipeStreamToSink` does the same for the upload request body in both the
  Dart and Cupertino clients. Its multipart generator forwards the file stream
  through `await for`, which is the shape that leaks.
- `_drainUnownedStream`'s `onError` is removed: the listen and the cancel happen
  in one turn on a cold generator, so it could never fire.

**Cancellation the session could not observe**

- `AgentSession` owns a cancellation signal for its own lifetime instead of
  exposing `RunOrchestrator`'s request-scoped token. That token is absent for
  the entire tool-execution window and at extension-attach time, and the getter
  fabricated a fresh, never-cancelled token to cover the gap. So a tool polling
  `ToolExecutionContext.cancelToken` never saw a cancel, and a pending tool
  approval was not denied on cancel.
- `cancel()` records the cancel before the terminal check; `start()` settles the
  result as cancelled rather than creating a run when the session was cancelled
  while its extensions were attaching.

**Cancellation reported as something else**

- A streamed upload is the only body wired to the token, and NSURLSession
  reports its abort as a client error — the cancellation identity is lost
  crossing the `NSInputStream` bridge, and `UploadTracker` showed a row the user
  cancelled as **failed**. Narrowed to `body is Stream<List<int>>`; buffered
  bodies stay a network failure, since a token can be shared across concurrent
  requests.

## Changes — `611ddfe5`

**Every cancel path reaches a terminal state**

- `AgentSession.cancel()` let a throw from `RunOrchestrator.cancelRun()` escape
  into the widget callback that pressed the button, where Flutter prints it and
  carries on: the press did nothing, the run kept streaming with no way to reach
  it again, and the runtime — which waits on the session's result before
  disposing it and draining the spawn queue — waited forever.
- The fire-and-forget `runToCompletion` future gets the same treatment. Every
  expected outcome, cancellation included, returns a terminal `RunState`, so a
  throw there is a bug — but an unobserved one stranded the run and stalled
  every spawn queued behind it.

The settle lives in the `catch`, deliberately **not** a `finally`. A throw is
the only exit from `cancelRun()` that publishes no terminal `RunState`, so it is
the only exit that must settle the result directly; every other exit leaves the
state stream to do it. Duplicating that in a `finally` would give the completer
two writers racing for it — and since `stateChanges` is an *async* broadcast
controller, the `finally` would fire on **every** cancel, not just the failure
path, and could settle an already-completed run as cancelled. The per-child
guard on the cascade came out for the same reason: it calls `cancel()`, which by
this construction cannot throw.

**Two crashes on the Stop button itself**

`ThreadViewState.cancelRun` and `RoomState.cancelSpawn` — the two methods the
Stop button is wired to (`room_screen.dart:2480`) — wrote a signal their own
`dispose()` had already disposed. Signals **raise** on a write after disposal
rather than ignoring it, so a press landing on a torn-down room or thread view
threw `SignalsWriteAfterDisposeError`. Every other method on both classes
already opened with the disposed guard; these two did not. Neither was in the
original analysis; both surfaced from enumerating all five cancel entry points.

**The visibility backstop**

`installUncaughtErrorLogging()` routes errors no `catch` in the app saw into the
log sinks the diagnostics screen reads — the framework's via
`FlutterError.onError`, the root zone's unhandled asynchronous ones via
`PlatformDispatcher.onError`. Both are additive: the framework's console dump
and the platform's own report still happen. `PlatformDispatcher.onError` returns
**false**, not the idiomatic `true`, because on a target where no sink has a
transport (a packaged release build, or Android, where stdout reaches nobody)
the platform's report is the only place the error still appears. Both render
through `describeFailure` — an uncaught error is thrown over whatever the app
was holding. Chosen over `runZonedGuarded`, which would put the whole app in a
child zone for no other reason.

## Three premises that did not survive checking

Worth flagging for review, since each changed the diff:

1. `cancelRun()` was believed to make the session terminal **synchronously**. It
   does not — `stateChanges` is an async broadcast controller. This is why the
   settle is in the `catch` rather than a `finally`.
2. A throwing `whenCancelled` listener in `HumanApprovalExtension` was believed
   to escape and strand the approval dialog. It cannot: `_denyPending()` reads a
   field behind a null check, completes a plain (async) `Completer`, and writes
   through `StatefulSessionExtension.state`, whose setter already returns early
   once disposed. **No change was needed.**
3. Cancellations were believed to be miscategorised as failures in the UI, via
   `MessagesFailed(CancelledException)`. Two things are wrong with that. Every
   failure-state sink already returns early on a cancelled token
   (`thread_view_state.dart:443`/`:463`, `lobby_state.dart:691`,
   `room_screen.dart:403`/`:413`) — and more fundamentally, **Stop cannot reach
   those sinks at all.** They sit behind data-fetch tokens (thread history,
   lobby rooms), cancelled by supersession, navigation, disconnect, auth expiry
   or dispose. `cancelRun()` cancels the *session's* token, a different
   `CancelToken` entirely. **No change was needed.**

## Breaking (library consumers)

`AgentSession.cancelToken` is now scoped to the session rather than the active
request: one instance for the session's lifetime, cancelled by `cancel()` or
`dispose()`. It previously answered a fresh, never-cancelled token whenever no
request was in flight. `RunOrchestrator.cancelToken` is removed — it was never
exported from the barrel.

## Test Plan

- [x] Tests pass locally — agent 514, client 1655, native 52 (+6 platform
      skips), logging 245, design 218, app 2420
- [x] App suite also passes under **randomized ordering** (seed `3155980315`) —
      the uncaught-error tests mutate process globals, so the restoration is
      order-sensitive by nature
- [x] Coverage **90.7%** measured the way CI does (after
      `lcov --remove 'packages/*'`), against an 80% gate;
      `uncaught_errors.dart` at 100%
- [x] `dart format --set-exit-if-changed` and `dart analyze --fatal-infos` clean
      repo-wide; markdownlint clean
- [x] `flutter build web` succeeds — some changed files compile only for web, so
      local analyze never covers them
- [x] Manual testing completed

26 tests added across the two commits. Every one was mutation-checked: it fails
when its production fix is reverted, and each has a verified **unique** kill, so
no test duplicates another's coverage. For the second commit that twice meant
deleting: a test covering the `finally`, once the `finally` was proven
unnecessary, and a pair of asserts that turned out to guard a cancellation the
Stop button cannot reach. Notable pins: the deliberate-silence guards (deleting one
previously passed the whole suite), each teardown call site by its label, the
streamed-vs-buffered split on the Cupertino arm, both Stop-button crashes
(reproduced as real failures first), and that neither uncaught-error handler
echoes the input its exception was thrown over.

Known gaps, stated rather than assumed: the native-client fallback branch is
Apple-only and CI is `ubuntu-latest`, so any test for it skips where it matters.

## Related Issues

Fixes #

🤖 Generated with [Claude Code](https://claude.com/claude-code)
