### PR TITLE
fix(room): gate attachments per scope on the room capability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,17 @@ Versions follow the `version+build` scheme from `pubspec.yaml`, bumped via
 
 ### Fixed
 
+- The file-attach button no longer disappears from a thread once that thread
+  has a finished run. Attachment support was read from a `bubble-sandbox`
+  namespace in the thread's replayed AG-UI state, which the backend no longer
+  writes, so any thread whose state carried another namespace resolved to a
+  hard "unsupported". Both scopes now read the room's capability, which is what
+  the server actually gates uploads on.
+- An upload refused for lack of permission now says so. The 403 branch tested
+  `AuthException`, but the transport raises `PermissionDeniedException` for
+  403, so the branch never ran and the server's own wording was shown instead.
+- An upload to a scope the server has no upload path configured for (405) now
+  reports that, rather than passing the backend's internal wording through.
 - Tearing down a cancelled SSE subscription now observes the future
   `StreamSubscription.cancel()` returns, so an error raised while the stream
   generator unwinds — the transport's injected `CancelledException` among them
@@ -62,6 +73,17 @@ Versions follow the `version+build` scheme from `pubspec.yaml`, bumped via
 
 ### Changed
 
+- **Breaking (library):** `Room.supportsAttachments` is replaced by
+  `Room.supportsRoomAttachments` and `Room.supportsThreadAttachments`. The
+  server gates room and thread uploads on separate installation settings, so an
+  unqualified name had to silently pick one. Both currently answer the same
+  room-level condition.
+- **Breaking (library):** `ThreadHistory.supportsAttachments` is removed.
+  Nothing produces the state it read, and it has no replacement — attachment
+  support is a property of the room, not of one of its threads.
+- Room Information reports attachments per scope, as `Room attachments` and
+  `Thread attachments`, instead of a single row that could not show a
+  deployment configured for one scope but not the other.
 - **Breaking (library):** `AgentSession.cancelToken` is now scoped to the
   session rather than the active request: it is one instance for the session's
   lifetime, cancelled by `cancel()` or `dispose()`. It previously answered a

--- a/lib/src/modules/room/ui/room_info/features_card.dart
+++ b/lib/src/modules/room/ui/room_info/features_card.dart
@@ -29,8 +29,12 @@ class FeaturesCard extends StatelessWidget {
       title: 'FEATURES',
       children: [
         InfoRow(
-          label: 'Attachments',
-          value: room.supportsAttachments ? 'Enabled' : 'Disabled',
+          label: 'Room attachments',
+          value: room.supportsRoomAttachments ? 'Enabled' : 'Disabled',
+        ),
+        InfoRow(
+          label: 'Thread attachments',
+          value: room.supportsThreadAttachments ? 'Enabled' : 'Disabled',
         ),
         InfoRow(
           label: 'Allow MCP',

--- a/lib/src/modules/room/ui/room_info_screen.dart
+++ b/lib/src/modules/room/ui/room_info_screen.dart
@@ -244,7 +244,7 @@ class _RoomInfoBody extends StatelessWidget {
               contentOf: (e) => _buildToolsetContent(e.value),
             ),
             ClientToolsCard(clientToolsFuture: clientToolsFuture),
-            if (room.supportsAttachments)
+            if (room.supportsRoomAttachments)
               _UploadedFilesCard(
                 uploadRegistry: uploadRegistry,
                 serverEntry: serverEntry,

--- a/lib/src/modules/room/ui/room_screen.dart
+++ b/lib/src/modules/room/ui/room_screen.dart
@@ -324,14 +324,6 @@ class _RoomScreenState extends State<RoomScreen> {
 
   late DocumentFilterHydrator _filterHydrator;
 
-  /// Per-thread attachment support resolved from thread history (the sandbox
-  /// namespace in the thread's AG-UI state). A missing entry means it could not
-  /// be resolved — history has not loaded, was bypassed for a registry-restored
-  /// / just-spawned thread, or the thread has no finished run yet (the backend
-  /// omits `run_input` for unfinished runs, so history alone cannot tell).
-  /// Callers fall back to the room's current capability in that case.
-  final Map<String, bool> _threadAttachmentSupport = <String, bool>{};
-
   /// Show the filter button only when filtering is enabled and there is
   /// something to filter (or we failed to find out).
   bool get _showDocumentFilter =>
@@ -878,34 +870,13 @@ class _RoomScreenState extends State<RoomScreen> {
     }
   }
 
-  /// Records thread-level attachment support and feeds the thread's last-run
-  /// filter to the hydrator on history load.
+  /// Feeds the thread's last-run filter to the hydrator on history load.
   void _onThreadHistoryLoaded(String threadId, ThreadHistory history) {
     if (!mounted) return;
     if (threadId != widget.threadId) return; // stale fetch for another thread
-    // Only record a resolved value. When history couldn't resolve state (null,
-    // e.g. an unfinished-only thread), leave the entry unset so the attach gate
-    // falls back to the room capability instead of a false negative.
-    final resolved = history.supportsAttachments;
-    if (resolved != null && _threadAttachmentSupport[threadId] != resolved) {
-      setState(() {
-        _threadAttachmentSupport[threadId] = resolved;
-      });
-    }
     if (!_filterEnabled) return;
     _filterHydrator.setFilter(threadId, history.documentFilter);
   }
-
-  /// Whether attachments are enabled for [threadId] within [room].
-  ///
-  /// Prefers the thread's resolved capability; when it could not be resolved
-  /// (no entry — see [_threadAttachmentSupport]), falls back to the room-level
-  /// capability. An undetermined thread must not collapse to `false` here, as
-  /// that would hide attachments on a thread whose state simply hasn't
-  /// resolved yet.
-  bool _attachEnabledForThread(String threadId, Room? room) =>
-      _threadAttachmentSupport[threadId] ??
-      (room?.supportsAttachments ?? false);
 
   /// Seeds the resolved selection — but only if the thread is still active and
   /// the user hasn't already made a selection for it during the async load
@@ -1825,7 +1796,7 @@ class _RoomScreenState extends State<RoomScreen> {
     required bool showHeader,
   }) {
     final threadView = _state.activeThreadView;
-    final roomAttachEnabled = room?.supportsAttachments ?? false;
+    final roomAttachEnabled = room?.supportsRoomAttachments ?? false;
     final messagesStatus = threadView?.messages.watch(context);
 
     final UploadsStatus roomStatus = roomAttachEnabled
@@ -1833,7 +1804,7 @@ class _RoomScreenState extends State<RoomScreen> {
         : const UploadsLoaded(<DisplayUpload>[]);
     final threadId = threadView?.threadId;
     final threadAttachEnabled =
-        threadId != null && _attachEnabledForThread(threadId, room);
+        threadId != null && (room?.supportsThreadAttachments ?? false);
     final UploadsStatus threadStatus = threadAttachEnabled
         ? _state.uploadTracker
             .threadUploads(widget.roomId, threadId)
@@ -2310,7 +2281,7 @@ class _RoomScreenState extends State<RoomScreen> {
             error: roomError,
             onDismiss: _state.clearError,
           ),
-        if (room?.supportsAttachments ?? false)
+        if (room?.supportsRoomAttachments ?? false)
           UploadEventBanner(
             tracker: _state.uploadTracker,
             roomId: widget.roomId,
@@ -2328,7 +2299,7 @@ class _RoomScreenState extends State<RoomScreen> {
     final streaming = threadView.streamingState.watch(context);
     final sendError = threadView.lastSendError.watch(context);
     final reconnectStatus = threadView.reconnectStatus.watch(context);
-    final attachEnabled = _attachEnabledForThread(threadView.threadId, room);
+    final attachEnabled = room?.supportsThreadAttachments ?? false;
 
     _restoreUnsentText(sendError?.unsentText);
 
@@ -2445,10 +2416,7 @@ class _RoomScreenState extends State<RoomScreen> {
     Room? room,
     ThreadViewStatus? status,
   ) {
-    final threadId = threadView?.threadId;
-    final attachEnabled = threadId != null
-        ? _attachEnabledForThread(threadId, room)
-        : (room?.supportsAttachments ?? false);
+    final attachEnabled = room?.supportsThreadAttachments ?? false;
     VoidCallback? attachCallback(Future<PickFilesResult?> Function() pick) {
       if (!attachEnabled) return null;
       return threadView != null

--- a/lib/src/modules/room/upload_tracker.dart
+++ b/lib/src/modules/room/upload_tracker.dart
@@ -91,6 +91,11 @@ String uploadErrorMessage(Object error) {
     // of whether the body said anything useful.
     if (error.statusCode == 413) return 'File is too large to upload.';
     if (error.statusCode == 415) return "This file type isn't supported.";
+    // The server accepts uploads for this scope only when the installation
+    // configures a path for it. Nothing the user can act on.
+    if (error.statusCode == 405) {
+      return "File uploads aren't configured on this server.";
+    }
     if (error.statusCode >= 500) {
       return 'Server is temporarily unavailable. '
           'Try uploading again in a moment.';
@@ -115,13 +120,12 @@ String uploadErrorMessage(Object error) {
     }
   }
 
-  if (error is AuthException) {
-    if (error.statusCode == 401) {
-      return 'Session expired. Please sign in again.';
-    }
-    if (error.statusCode == 403) {
-      return "You don't have permission to upload here.";
-    }
+  if (error is AuthException && error.statusCode == 401) {
+    return 'Session expired. Please sign in again.';
+  }
+
+  if (error is PermissionDeniedException) {
+    return "You don't have permission to upload here.";
   }
 
   if (error is SoliplexException) return error.message;

--- a/packages/soliplex_client/lib/src/application/rag_snapshot.dart
+++ b/packages/soliplex_client/lib/src/application/rag_snapshot.dart
@@ -271,9 +271,9 @@ class RagSnapshot {
       raw is Map<String, dynamic> && raw[_citationIndexKey] is Map;
 
   /// Every citation-bearing namespace block in a full agent-state map,
-  /// identified by a [`_citationIndexKey`] map. Non-citation namespaces
-  /// (e.g. `bubble-sandbox`) and non-Map or mistyped blocks are skipped,
-  /// so this is the single place that knows how a citation block is shaped.
+  /// identified by a [`_citationIndexKey`] map. Namespaces without one, and
+  /// non-Map or mistyped blocks, are skipped, so this is the single place that
+  /// knows how a citation block is shaped.
   ///
   /// When [namespaces] is given, only blocks under those keys are considered;
   /// otherwise every namespace in [state] is.

--- a/packages/soliplex_client/lib/src/domain/attachments.dart
+++ b/packages/soliplex_client/lib/src/domain/attachments.dart
@@ -1,6 +1,5 @@
-/// Name of the skill whose presence enables file attachments.
+/// Name of the sandbox skill, whose presence in a room is the room-level
+/// condition for file uploads.
 ///
-/// The backend uses this same string as the AG-UI state namespace it seeds
-/// into every thread created in a room that has the skill, so it identifies
-/// attachment capability at both the room and thread level.
+/// The rooms API keys a room's `skills` map by this name.
 const sandboxSkillName = 'bubble-sandbox';

--- a/packages/soliplex_client/lib/src/domain/room.dart
+++ b/packages/soliplex_client/lib/src/domain/room.dart
@@ -94,9 +94,21 @@ class Room {
   /// Whether the room has any AG-UI feature names.
   bool get hasAguiFeatures => aguiFeatureNames.isNotEmpty;
 
-  /// Whether this room is configured for file attachments (it carries the
-  /// [sandboxSkillName] skill).
-  bool get supportsAttachments => skills.containsKey(sandboxSkillName);
+  /// Whether this room can accept uploads scoped to the room itself.
+  ///
+  /// Covers only the room-level condition — the room carries the
+  /// [sandboxSkillName] skill. The server also requires a configured room
+  /// upload path and an administrator caller, neither of which the rooms API
+  /// reports, so `true` means "not ruled out by anything readable here".
+  bool get supportsRoomAttachments => skills.containsKey(sandboxSkillName);
+
+  /// Whether this room can accept uploads scoped to one of its threads.
+  ///
+  /// Covers only the room-level condition — the room carries the
+  /// [sandboxSkillName] skill. The server also requires a configured thread
+  /// upload path, which the rooms API does not report, so `true` means "not
+  /// ruled out by anything readable here".
+  bool get supportsThreadAttachments => skills.containsKey(sandboxSkillName);
 
   /// Creates a copy of this room with the given fields replaced.
   Room copyWith({

--- a/packages/soliplex_client/lib/src/domain/thread_history.dart
+++ b/packages/soliplex_client/lib/src/domain/thread_history.dart
@@ -1,7 +1,6 @@
 import 'package:ag_ui/ag_ui.dart';
 import 'package:meta/meta.dart';
 
-import 'package:soliplex_client/src/domain/attachments.dart';
 import 'package:soliplex_client/src/domain/chat_message.dart';
 import 'package:soliplex_client/src/domain/message_state.dart';
 
@@ -51,18 +50,6 @@ class ThreadHistory {
   /// when no run carries one. The backend keeps no merged filter state, so this
   /// (not any state event) is the only record of the thread's active filter.
   final String? documentFilter;
-
-  /// Whether this thread's resolved AG-UI state carries the [sandboxSkillName]
-  /// namespace, i.e. attachments are available for this thread.
-  ///
-  /// `null` when history carried no AG-UI state to resolve (empty state) —
-  /// chiefly a freshly created thread whose only run is unfinished: it has no
-  /// replayable events, and the backend omits `run_input` for unfinished runs
-  /// on the history endpoint, so history alone cannot tell. Callers must fall
-  /// back to the room-level capability rather than treating this as a
-  /// definitive `false`.
-  bool? get supportsAttachments =>
-      aguiState.isEmpty ? null : aguiState.containsKey(sandboxSkillName);
 }
 
 /// Decoded AG-UI events for a single run, in arrival order.

--- a/packages/soliplex_client/test/api/soliplex_api_test.dart
+++ b/packages/soliplex_client/test/api/soliplex_api_test.dart
@@ -142,13 +142,13 @@ void main() {
 
     group('getThreadHistory', () {
       test(
-        'reports undetermined attachment support for a freshly created thread '
-        '(unfinished run, no run_input on GET)',
+        'replays a run whose run_input is null without throwing '
+        '(unfinished run on GET)',
         () async {
           // Real backend shape: the GET history endpoint omits `run_input`
-          // for an unfinished run, so there is no state to judge from. The
-          // capability is undetermined (null) and the caller falls back to
-          // the room-level capability rather than reporting a false negative.
+          // for an unfinished run. Everything read from it — the document
+          // filter above all — must tolerate its absence rather than fail
+          // the whole history load.
           when(
             () => mockTransport.request<Map<String, dynamic>>(
               'GET',
@@ -178,7 +178,7 @@ void main() {
 
           final history = await api.getThreadHistory('room-123', 'thread-456');
 
-          expect(history.supportsAttachments, isNull);
+          expect(history.documentFilter, isNull);
           expect(history.messages, isEmpty);
         },
       );

--- a/packages/soliplex_client/test/domain/room_test.dart
+++ b/packages/soliplex_client/test/domain/room_test.dart
@@ -184,8 +184,10 @@ void main() {
       expect(str, contains('Test Room'));
     });
 
-    group('supportsAttachments', () {
-      test('is true when the sandbox skill is present', () {
+    // Both scopes read the same room-level condition, so every case asserts
+    // both. That is what makes a later divergence between them deliberate.
+    group('attachment scopes', () {
+      test('both are true when the sandbox skill is present', () {
         const room = Room(
           id: 'r1',
           name: 'Test',
@@ -196,15 +198,17 @@ void main() {
             ),
           },
         );
-        expect(room.supportsAttachments, isTrue);
+        expect(room.supportsRoomAttachments, isTrue);
+        expect(room.supportsThreadAttachments, isTrue);
       });
 
-      test('is false when the sandbox skill is absent', () {
+      test('both are false when the sandbox skill is absent', () {
         const room = Room(id: 'r1', name: 'Test');
-        expect(room.supportsAttachments, isFalse);
+        expect(room.supportsRoomAttachments, isFalse);
+        expect(room.supportsThreadAttachments, isFalse);
       });
 
-      test('is false when only a different skill is present', () {
+      test('both are false when only a different skill is present', () {
         const room = Room(
           id: 'r1',
           name: 'Test',
@@ -212,7 +216,8 @@ void main() {
             'other-skill': RoomSkill(name: 'other-skill', description: 'Other'),
           },
         );
-        expect(room.supportsAttachments, isFalse);
+        expect(room.supportsRoomAttachments, isFalse);
+        expect(room.supportsThreadAttachments, isFalse);
       });
     });
   });

--- a/packages/soliplex_client/test/domain/thread_history_test.dart
+++ b/packages/soliplex_client/test/domain/thread_history_test.dart
@@ -138,32 +138,6 @@ void main() {
         equals("id = 'x'"),
       );
     });
-
-    group('supportsAttachments', () {
-      test('is true when aguiState carries the sandbox namespace', () {
-        final history = ThreadHistory(
-          messages: const [],
-          aguiState: const {sandboxSkillName: <String, dynamic>{}},
-        );
-        expect(history.supportsAttachments, isTrue);
-      });
-
-      test('is false when state is known but lacks the sandbox namespace', () {
-        final history = ThreadHistory(
-          messages: const [],
-          aguiState: const {'rag': <String, dynamic>{}},
-        );
-        expect(history.supportsAttachments, isFalse);
-      });
-
-      test('is null (undetermined) when no AG-UI state was resolved', () {
-        // A freshly created thread whose only run is unfinished carries no
-        // replayable state; the backend omits run_input on GET, so history
-        // alone cannot tell — callers fall back to the room capability.
-        final history = ThreadHistory(messages: const []);
-        expect(history.supportsAttachments, isNull);
-      });
-    });
   });
 
   group('RunEventBundle', () {

--- a/test/modules/room/ui/room_info/features_card_test.dart
+++ b/test/modules/room/ui/room_info/features_card_test.dart
@@ -27,7 +27,7 @@ void main() {
   const baseRoom = Room(id: 'r1', name: 'Test Room');
 
   group('FeaturesCard', () {
-    testWidgets('shows attachments status row', (tester) async {
+    testWidgets('shows a status row per attachment scope', (tester) async {
       final api = FakeSoliplexApi();
       await tester.pumpWidget(wrap(
         FeaturesCard(
@@ -45,8 +45,9 @@ void main() {
       ));
       await tester.pump();
 
-      expect(find.text('Attachments'), findsOneWidget);
-      expect(find.text('Enabled'), findsOneWidget);
+      expect(find.text('Room attachments'), findsOneWidget);
+      expect(find.text('Thread attachments'), findsOneWidget);
+      expect(find.text('Enabled'), findsNWidgets(2));
     });
 
     testWidgets('shows attachments disabled', (tester) async {
@@ -60,7 +61,9 @@ void main() {
       ));
       await tester.pump();
 
-      expect(find.text('Disabled'), findsOneWidget);
+      expect(find.text('Room attachments'), findsOneWidget);
+      expect(find.text('Thread attachments'), findsOneWidget);
+      expect(find.text('Disabled'), findsNWidgets(2));
     });
 
     testWidgets('shows MCP row when allowMcp is true', (tester) async {

--- a/test/modules/room/ui/room_info_screen_test.dart
+++ b/test/modules/room/ui/room_info_screen_test.dart
@@ -142,7 +142,8 @@ void main() {
       await tester.pumpAndSettle();
 
       expect(find.text('FEATURES'), findsOneWidget);
-      expect(find.text('Enabled'), findsOneWidget); // attachments
+      // One attachments row per scope.
+      expect(find.text('Enabled'), findsNWidgets(2));
     });
 
     testWidgets('shows tools section', (tester) async {

--- a/test/modules/room/ui/room_screen_test.dart
+++ b/test/modules/room/ui/room_screen_test.dart
@@ -1366,113 +1366,50 @@ void main() {
       expect(find.byTooltip('Add image'), findsOneWidget);
     });
 
-    testWidgets(
-        'active thread shows attach from thread AG-UI state, not room '
-        'skill', (tester) async {
-      tester.view.physicalSize = const Size(1200, 800);
-      tester.view.devicePixelRatio = 1.0;
-      addTearDown(tester.view.resetPhysicalSize);
+    // A thread's replayed AG-UI state does not decide attachment support; the
+    // room capability does. Both fixtures were shipped bugs: `{}` is the
+    // freshly created thread whose only run is unfinished, and `{'rag': ...}`
+    // is what a real sandbox+RAG room replays.
+    for (final (label, aguiState) in const <(String, Map<String, dynamic>)>[
+      ('empty', {}),
+      ('rag-only', {'rag': <String, dynamic>{}}),
+    ]) {
+      testWidgets(
+          'active thread with $label AG-UI state shows attach when the room '
+          'has the skill', (tester) async {
+        tester.view.physicalSize = const Size(1200, 800);
+        tester.view.devicePixelRatio = 1.0;
+        addTearDown(tester.view.resetPhysicalSize);
 
-      // Room WITHOUT the skill; thread state WITH the namespace. Attach must
-      // still appear, proving the active thread reads thread state.
-      api.nextRoom = const Room(id: 'room-1', name: 'Plain');
-      api.nextThreads = const [];
-      api.nextThreadHistory = ThreadHistory(
-        messages: const [],
-        aguiState: const {sandboxSkillName: <String, dynamic>{}},
-      );
+        api.nextRoom = const Room(
+          id: 'room-1',
+          name: 'Attachable',
+          skills: {sandboxSkillName: _sandboxSkill},
+        );
+        api.nextThreads = const [];
+        api.nextThreadHistory = ThreadHistory(
+          messages: const [],
+          aguiState: aguiState,
+        );
 
-      await tester.pumpWidget(MaterialApp(
-        home: RoomScreen(
-          serverEntry: entry,
-          roomId: 'room-1',
-          threadId: 'thread-1',
-          runtimeManager: runtimeManager,
-          registry: registry,
-          uploadRegistry: uploadRegistry,
-          documentSelections: DocumentSelections(),
-        ),
-      ));
-      await tester.pumpAndSettle();
+        await tester.pumpWidget(MaterialApp(
+          home: RoomScreen(
+            serverEntry: entry,
+            roomId: 'room-1',
+            threadId: 'thread-1',
+            runtimeManager: runtimeManager,
+            registry: registry,
+            uploadRegistry: uploadRegistry,
+            documentSelections: DocumentSelections(),
+          ),
+        ));
+        await tester.pumpAndSettle();
 
-      expect(find.byIcon(Icons.attach_file), findsOneWidget);
-    });
+        expect(find.byIcon(Icons.attach_file), findsOneWidget);
+      });
+    }
 
-    testWidgets(
-        'active thread with room skill shows attach when thread history is '
-        'undetermined (falls back to room capability)', (tester) async {
-      tester.view.physicalSize = const Size(1200, 800);
-      tester.view.devicePixelRatio = 1.0;
-      addTearDown(tester.view.resetPhysicalSize);
-
-      // Empty history = undetermined thread state: a freshly created thread
-      // whose only run is unfinished carries no replayable state, and the
-      // backend omits run_input for unfinished runs on GET. The composer must
-      // fall back to the room capability rather than reporting a false
-      // negative and hiding attach.
-      api.nextRoom = const Room(
-        id: 'room-1',
-        name: 'Attachable',
-        skills: {sandboxSkillName: _sandboxSkill},
-      );
-      api.nextThreads = const [];
-      api.nextThreadHistory = ThreadHistory(messages: const []);
-
-      await tester.pumpWidget(MaterialApp(
-        home: RoomScreen(
-          serverEntry: entry,
-          roomId: 'room-1',
-          threadId: 'thread-1',
-          runtimeManager: runtimeManager,
-          registry: registry,
-          uploadRegistry: uploadRegistry,
-          documentSelections: DocumentSelections(),
-        ),
-      ));
-      await tester.pumpAndSettle();
-
-      expect(find.byIcon(Icons.attach_file), findsOneWidget);
-    });
-
-    testWidgets(
-        'active thread with resolved state lacking the namespace hides attach '
-        'even when the room has the skill', (tester) async {
-      tester.view.physicalSize = const Size(1200, 800);
-      tester.view.devicePixelRatio = 1.0;
-      addTearDown(tester.view.resetPhysicalSize);
-
-      // Resolved (non-empty) thread state that lacks the sandbox namespace is
-      // authoritative: it hides attach even though the room advertises the
-      // skill. Contrast the empty/undetermined case above, which falls back to
-      // the room capability.
-      api.nextRoom = const Room(
-        id: 'room-1',
-        name: 'Attachable',
-        skills: {sandboxSkillName: _sandboxSkill},
-      );
-      api.nextThreads = const [];
-      api.nextThreadHistory = ThreadHistory(
-        messages: const [],
-        aguiState: const {'rag': <String, dynamic>{}},
-      );
-
-      await tester.pumpWidget(MaterialApp(
-        home: RoomScreen(
-          serverEntry: entry,
-          roomId: 'room-1',
-          threadId: 'thread-1',
-          runtimeManager: runtimeManager,
-          registry: registry,
-          uploadRegistry: uploadRegistry,
-          documentSelections: DocumentSelections(),
-        ),
-      ));
-      await tester.pumpAndSettle();
-
-      expect(find.byIcon(Icons.attach_file), findsNothing);
-    });
-
-    testWidgets('registry-restored thread falls back to room skill for attach',
+    testWidgets('registry-restored thread shows attach from the room skill',
         (tester) async {
       tester.view.physicalSize = const Size(1200, 800);
       tester.view.devicePixelRatio = 1.0;
@@ -1480,8 +1417,8 @@ void main() {
 
       // Room has the skill; a live session is pre-registered so ThreadViewState
       // restores from the registry and never fetches history (the sendToNewThread
-      // / return-to-running-thread path). The Map has no entry → the composer
-      // must fall back to room capability and still show attach.
+      // / return-to-running-thread path). The gate depends entirely on the room
+      // having loaded, so attach must still show.
       api.nextRoom = const Room(
         id: 'room-1',
         name: 'Attachable',

--- a/test/modules/room/upload_tracker_test.dart
+++ b/test/modules/room/upload_tracker_test.dart
@@ -1454,6 +1454,16 @@ void main() {
       expect(message, "This file type isn't supported.");
     });
 
+    test('405 ApiException surfaces as uploads-not-configured message', () {
+      final message = uploadErrorMessage(
+        const ApiException(
+          statusCode: 405,
+          message: 'Room uploads not configured',
+        ),
+      );
+      expect(message, "File uploads aren't configured on this server.");
+    });
+
     test('5xx ApiException surfaces as temporarily-unavailable message', () {
       for (final statusCode in [500, 502, 503, 504]) {
         final message = uploadErrorMessage(
@@ -1500,10 +1510,14 @@ void main() {
       expect(message, 'Session expired. Please sign in again.');
     });
 
-    test('AuthException(statusCode: 403) surfaces as no-permission message',
-        () {
+    // 403 arrives as PermissionDeniedException — HttpTransport reserves
+    // AuthException for 401 — so this is the type production feeds.
+    test('PermissionDeniedException surfaces as no-permission message', () {
       final message = uploadErrorMessage(
-        const AuthException(statusCode: 403, message: 'forbidden'),
+        const PermissionDeniedException(
+          statusCode: 403,
+          message: 'Admin access required',
+        ),
       );
       expect(message, "You don't have permission to upload here.");
     });


### PR DESCRIPTION
## The bug

In a room with the sandbox skill, the attach button worked on a fresh thread and then disappeared once the thread's history was replayed — after a reload, or after leaving and re-entering the room.

The thread-level gate asked whether the thread's replayed AG-UI state carried the `bubble-sandbox` namespace. Backend `68c219ef` (soliplex#1161) stopped writing that namespace, so the check can only answer "no". A thread carrying any *other* namespace — `rag`, which every RAG room produces — has non-empty state, so the getter returned a hard `false` rather than the `null` that triggers the room fallback. This is the inversion of the fresh-thread bug fixed in `fadb6af2`: that one made the *undetermined* case fall back, and could not anticipate the *resolved* case losing its source too.

## The fix

The backend has no per-thread notion of attachment capability at all — thread uploads gate on `_room_config.has_sandbox`, a room-level property. So the per-thread signal is deleted, not repaired.

What is real is the per-**scope** distinction: the server gates room and thread uploads on independent installation settings (`rooms_upload_path` vs `threads_upload_path`), so `Room.supportsAttachments` becomes `supportsRoomAttachments` and `supportsThreadAttachments`. Both answer the same room-level condition today; each call site now names the scope it means instead of leaving it inferable from what it feeds. `ThreadHistory.supportsAttachments` is removed — nothing produces the state it read.

Room Information reports both scopes, since a deployment configured for one and not the other is exactly what a single row hid.

## Also fixed, in the function this already opens

`uploadErrorMessage`'s 403 branch sat inside `if (error is AuthException)`, but `HttpTransport` raises `PermissionDeniedException` for 403 and reserves `AuthException` for 401 — so `"You don't have permission to upload here."` had never rendered. Its test passed the whole time by constructing an `AuthException` with a 403, a type production does not produce. 405 had no branch. Both fell through to the backend's `detail` string, which is chosen for audit records rather than for users.

## Breaking (library)

`Room` and `ThreadHistory` are exported from the `soliplex_client` barrel:

- `Room.supportsAttachments` → `supportsRoomAttachments` / `supportsThreadAttachments`
- `ThreadHistory.supportsAttachments` removed, no replacement

## Test plan

- New regression test drives the two fixtures that were each a shipped bug — `{}` (fresh thread, unfinished run) and `{'rag': {}}` (the #1161 case) — and asserts attach shows from the room skill. Confirmed failing on the `rag` fixture before the fix, with exactly the reported symptom.
- Three tests deleted: two whose premise (a thread-state signal) no longer exists, and one that asserted the bug.
- `soliplex_api_test`'s `run_input: null` case retargeted to what it uniquely pins — that replay tolerates the unfinished-run shape — rather than left asserting only `messages, isEmpty` under a name about attachments.
- `dart format --set-exit-if-changed` clean, `flutter analyze` zero issues, root suite +2420, `soliplex_client` +1652.
- **Not automated:** widget tests drive a fake API. Live verification is create a thread → send a message → reload → attach button still present.

## Follow-ups, not in this PR

soliplex#1303 publishes `has_room_uploads` / `has_thread_uploads` on `models.Room`. When it merges and ships, the two getters gain a nullable field and a `??` — two bodies, zero call sites — with `null` read as "older backend", never as `false`. That is deliberately not written against an unmerged PR's field names.

🤖 Generated with [Claude Code](https://claude.com/claude-code)