### PR TITLE
feat(room): gate attachments on the server's per-scope upload capability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -86,27 +86,33 @@ Versions follow the `version+build` scheme from `pubspec.yaml`, bumped via
   per-scope upload capability, each folding in the sandbox skill and the
   installation's upload path for that scope. They replace inferring the answer
   from the room's skill list, which could not see the upload path at all.
-- Uploading to a room is offered only to administrators. The server has always
-  required one, and the refusal used to arrive after the user had chosen a file.
-  Members still see the room's uploaded files — the agent cites them — and the
-  controls are replaced in place by a line naming who adds them, so a room that
-  already has files explains the absence as readily as an empty one. The answer
-  is asked once per signed-in
-  session and dropped both when that session ends and when the signed-in
-  identity changes — signing in from an expired session never passes through a
-  signed-out state, so neither trigger covers the other. The controls render in
-  their loading state until the answer arrives, for at most three seconds — the
-  request queues behind every other one to that server, so waiting on it
-  without a bound would leave an administrator unable to press a control they
-  are entitled to. A request that cannot be answered, or that outruns that
-  bound, reads as permission rather than withdrawing the controls, and an
-  answer that lands afterwards still withdraws them. A request the server
-  *refuses* is different: a refusal is an answer, so it withholds the controls
-  — the gate must not loosen as the installation tightens — but it is not kept
-  for the session the way a refusal delivered over 200 is: that one is the
-  installation's, while a 403 may be a gateway's, so the next screen asks
-  again rather than locking out an administrator it was never about. Failures
-  are recorded.
+- Uploading to a room is offered only to administrators, and only once the server
+  has said so. The server has always required one, and the refusal used to
+  arrive after the user had chosen a file. Members still see the room's
+  uploaded files — the agent cites them — and the controls are replaced in
+  place by a line naming who adds them, so a room that already has files
+  explains the absence as readily as an empty one. The answer is asked once per
+  signed-in session and dropped both when that session ends and when the
+  signed-in identity changes — signing in from an expired session never passes
+  through a signed-out state, so neither trigger covers the other.
+
+  A check that cannot answer withholds the controls and says only that. The
+  upload authorizes through the same installation-side administrator check this
+  answer comes from, so a check that cannot answer cannot authorize either, and
+  offering the controls would offer an action whose every use fails — a folder
+  of N files sent in full to be refused N times. It does not borrow the
+  refusal's wording, which names who does add the files and so asserts
+  something about the user that nothing established; a retry sits beside it
+  instead. The controls render in their loading state for at most three
+  seconds, because the request queues behind every other one to that server —
+  but the bound does not end the request, and an answer arriving later still
+  replaces what the bound wrote, in either direction. A refusal the server
+  delivers over 403 is an answer and withholds the controls, but unlike one
+  delivered over 200 it is not kept for the session: that one is the
+  installation's, while a 403 may be a gateway's, so the next screen asks again
+  rather than locking out an administrator it was never about. Failures are
+  recorded.
+
 - A server that reports no upload capability is recorded once, rather than
   silently withholding every attach control. Both the room listing and a
   single-room fetch report it, so a deep link into a room is covered too, and a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,24 @@ Versions follow the `version+build` scheme from `pubspec.yaml`, bumped via
 
 ### Fixed
 
+- The attached-files panel no longer strands open, and no longer reopens by
+  itself. The control that opens it is the only one that closes it, and it is
+  withdrawn once neither upload scope has anything left to show — so dismissing
+  the last row left the panel holding up to 40% of the viewport for the rest of
+  the visit with nothing able to collapse it. The request to open it is now
+  withdrawn with the control, so a later upload no longer springs the panel back
+  open over the conversation with no tap behind it.
+- A room's uploaded-file list no longer shows a permanent error row when the
+  installation configures no upload path for that scope. The server reports
+  that by having no list to give, which read as a failure to reach one. The same
+  bare 404 also answers an unknown room and one the caller may no longer read,
+  so a list already on screen is kept and the refusal recorded instead of being
+  silently emptied.
+- A file picked in the welcome composer, before the thread it was destined for
+  exists, no longer fails silently. Such a pick is recorded against the room
+  scope, there being no thread yet to route it to, and that scope's surfaces
+  were shown only for rooms that accept room uploads — so in a room that
+  accepts only thread uploads the failure had nowhere to render.
 - The file-attach button no longer disappears from a thread once that thread
   has a finished run. Attachment support was read from a `bubble-sandbox`
   namespace in the thread's replayed AG-UI state, which the backend no longer
@@ -64,6 +82,36 @@ Versions follow the `version+build` scheme from `pubspec.yaml`, bumped via
 
 ### Added
 
+- `Room.acceptsRoomUploads` and `Room.acceptsThreadUploads` carry the server's
+  per-scope upload capability, each folding in the sandbox skill and the
+  installation's upload path for that scope. They replace inferring the answer
+  from the room's skill list, which could not see the upload path at all.
+- Uploading to a room is offered only to administrators. The server has always
+  required one, and the refusal used to arrive after the user had chosen a file.
+  Members still see the room's uploaded files — the agent cites them — and the
+  controls are replaced in place by a line naming who adds them, so a room that
+  already has files explains the absence as readily as an empty one. The answer
+  is asked once per signed-in
+  session and dropped both when that session ends and when the signed-in
+  identity changes — signing in from an expired session never passes through a
+  signed-out state, so neither trigger covers the other. The controls render in
+  their loading state until the answer arrives, for at most three seconds — the
+  request queues behind every other one to that server, so waiting on it
+  without a bound would leave an administrator unable to press a control they
+  are entitled to. A request that cannot be answered, or that outruns that
+  bound, reads as permission rather than withdrawing the controls, and an
+  answer that lands afterwards still withdraws them. A request the server
+  *refuses* is different: a refusal is an answer, so it withholds the controls
+  — the gate must not loosen as the installation tightens — but it is not kept
+  for the session the way a refusal delivered over 200 is: that one is the
+  installation's, while a 403 may be a gateway's, so the next screen asks
+  again rather than locking out an administrator it was never about. Failures
+  are recorded.
+- A server that reports no upload capability is recorded once, rather than
+  silently withholding every attach control. Both the room listing and a
+  single-room fetch report it, so a deep link into a room is covered too, and a
+  field of the wrong type costs its own value instead of dropping the whole
+  room from the lobby.
 - `installUncaughtErrorLogging()` records errors no `catch` in the app saw —
   the framework's, via `FlutterError.onError`, and the root zone's unhandled
   asynchronous ones, via `PlatformDispatcher.onError` — into the same log sinks
@@ -74,10 +122,13 @@ Versions follow the `version+build` scheme from `pubspec.yaml`, bumped via
 ### Changed
 
 - **Breaking (library):** `Room.supportsAttachments` is replaced by
-  `Room.supportsRoomAttachments` and `Room.supportsThreadAttachments`. The
-  server gates room and thread uploads on separate installation settings, so an
-  unqualified name had to silently pick one. Both currently answer the same
-  room-level condition.
+  `Room.acceptsRoomUploads` and `Room.acceptsThreadUploads`. The server gates
+  room and thread uploads on separate installation settings, so an unqualified
+  name had to silently pick one.
+- **Breaking (library):** `sandboxSkillName` is removed. Nothing infers upload
+  capability from the skill list any more, so it named a wire key no decision
+  reads. This requires a backend that publishes `has_room_uploads` and
+  `has_thread_uploads`.
 - **Breaking (library):** `ThreadHistory.supportsAttachments` is removed.
   Nothing produces the state it read, and it has no replacement — attachment
   support is a property of the room, not of one of its threads.

--- a/lib/src/modules/auth/admin_status.dart
+++ b/lib/src/modules/auth/admin_status.dart
@@ -1,0 +1,129 @@
+import 'package:soliplex_client/soliplex_client.dart';
+import 'package:soliplex_logging/soliplex_logging.dart';
+
+final Logger _logger = LogManager.instance.getLogger('soliplex.admin_status');
+
+/// Whether the signed-in user administers one server.
+///
+/// The question takes no room, so one answer serves every room on that server.
+/// Answering it writes an `admin_access_allowed` or `admin_access_denied`
+/// audit record server-side, which is why an answer is kept rather than asked
+/// per screen.
+///
+/// A verdict the installation delivered is kept until [clear]. A request that
+/// could not be answered at all is not kept, so a blip does not pin "unknown"
+/// for the rest of the session; neither is a refusal, which answers but cannot
+/// be attributed to the installation — [_fetch] says why at that arm.
+///
+/// Two things clear it, and neither covers the other: signing out, and the
+/// signed-in identity changing. `ServerManager` and `UserSwitchTeardown` each
+/// say why at their call site.
+final class AdminStatus {
+  /// Reads through [api], which must be the api for [serverId].
+  AdminStatus({required SoliplexApi api, required String serverId})
+      : _api = api,
+        _serverId = serverId;
+
+  final SoliplexApi _api;
+  final String _serverId;
+
+  Future<bool?>? _pending;
+
+  /// Which signed-in identity the answers belong to. A request carries the
+  /// epoch it was issued under, so one that outlives a [clear] can tell it has
+  /// been retired.
+  ///
+  /// Bumped by [clear] rather than by [read], so nothing depends on `??=`
+  /// leaving its right-hand side unevaluated on a cache hit: a bump there
+  /// would retire the in-flight request that a concurrent reader is waiting
+  /// on, and pin the `null` it returns for the rest of the session.
+  ///
+  /// At most one live request matches this at a time, which is what makes the
+  /// comparison mean "still installed". That rests on a failing request
+  /// clearing [_pending] and returning with nothing suspending in between: an
+  /// `await` anywhere in that tail would leave it live while the slot is free,
+  /// so the next [read] would install a sibling on the same epoch and both
+  /// would pass the test.
+  int _generation = 0;
+
+  /// Whether the signed-in user is an administrator, or `null` when the
+  /// question could not be answered.
+  ///
+  /// Never completes with an error, so callers need no guard: the final `catch`
+  /// in [_fetch] is bare rather than `on Exception`, so an `Error` is reported
+  /// as unanswered rather than thrown, and logging cannot throw past it because
+  /// `LogManager` guards every sink write. `null` is not "no" — callers decide
+  /// what to do without an answer. A refusal is a "no" and arrives as `false`,
+  /// so no caller has to read a denial out of an absence.
+  Future<bool?> read() => _pending ??= _fetch(_generation);
+
+  Future<bool?> _fetch(int generation) async {
+    try {
+      final isAdmin = await _api.getIsAdminUser();
+      // A [clear] while this was in flight retired it: the answer describes
+      // whoever was signed in when it was asked, so it is dropped rather than
+      // handed to a caller who by now means someone else.
+      return generation == _generation ? isAdmin : null;
+    } on PermissionDeniedException catch (e) {
+      // A refusal is the server answering, not failing to answer. Folding it
+      // into `null` would hand the caller a grant, so the gate would loosen
+      // exactly as the installation tightened.
+      //
+      // Answered, but not kept, unlike a `false` that arrives over 200. That
+      // one is attributable — the installation said it. A refusal is not: this
+      // endpoint is contracted to answer, so a 403 is either a policy this
+      // client does not model or a gateway refusing on the installation's
+      // behalf, and the second locks out an administrator who is one. Releasing
+      // the slot costs an ask per screen that opens the card and buys the
+      // recourse of leaving and coming back.
+      //
+      // At `warning` because the release log floor drops anything lower, and
+      // because both readings above are worth a record. The message is the
+      // backend's own text, so only the status is kept.
+      _logger.warning(
+        'The administrator check was refused; treating the caller as not one',
+        attributes: {'serverId': _serverId, 'statusCode': e.statusCode},
+      );
+      if (generation == _generation) _pending = null;
+      return generation == _generation ? false : null;
+    } catch (e, st) {
+      // Releasing the slot lets the next read ask again; the generation test
+      // keeps a request already retired by [clear] from dropping the newer one
+      // that replaced it.
+      if (generation == _generation) _pending = null;
+      // This request carries no user input — a fixed path, no body — so
+      // nothing it could put in a [NetworkException]'s message is a value the
+      // user or the backend supplied, and the host and OS error left there are
+      // the whole diagnosis, so it is forwarded whole. The reasoning is about
+      // this request, not about the type: `DartHttpClient` interpolates the
+      // underlying exception into that message, so a request carrying a body
+      // would need the same treatment as below. Anything else can carry
+      // the response it failed on, so only its shape is kept. That shape is a
+      // bare type name for an [ApiException], which would leave a proxy's 502
+      // and the installation's own 500 indistinguishable, so the status code
+      // rides alongside — it is a protocol constant, not a value the server
+      // chose to put in the response.
+      _logger.warning(
+        'Could not check whether the user is an administrator',
+        error: e is NetworkException ? e : null,
+        attributes: {
+          'serverId': _serverId,
+          if (e is ApiException) 'statusCode': e.statusCode,
+          if (e is! NetworkException) 'failure': describeFailure(e),
+        },
+        stackTrace: st,
+      );
+      return null;
+    }
+  }
+
+  /// Forgets the answer and retires any request in flight, so the next [read]
+  /// asks again.
+  void clear() {
+    // Retiring is what the bump does: [_fetch] compares against this, so a
+    // request still in flight can neither deliver its answer nor clear a slot
+    // a later [read] installs.
+    _generation++;
+    _pending = null;
+  }
+}

--- a/lib/src/modules/auth/server_entry.dart
+++ b/lib/src/modules/auth/server_entry.dart
@@ -1,5 +1,6 @@
 import 'package:soliplex_agent/soliplex_agent.dart';
 
+import 'admin_status.dart';
 import 'auth_session.dart';
 
 /// Canonical server identity: scheme + host + port (default ports omitted).
@@ -36,6 +37,7 @@ class ServerEntry {
     required this.auth,
     required this.httpClient,
     required this.connection,
+    required this.adminStatus,
     this.requiresAuth = true,
     this.name,
     this.description,
@@ -47,6 +49,12 @@ class ServerEntry {
   final AuthSession auth;
   final SoliplexHttpClient httpClient;
   final ServerConnection connection;
+
+  /// Asks whether the signed-in user administers this server, on demand, and
+  /// keeps a verdict the installation delivered. See [AdminStatus] for which
+  /// answers are kept and what clears them.
+  final AdminStatus adminStatus;
+
   final bool requiresAuth;
 
   /// Human-readable server name (e.g., "Demo Server"), or `null` when the

--- a/lib/src/modules/auth/server_manager.dart
+++ b/lib/src/modules/auth/server_manager.dart
@@ -4,6 +4,7 @@ import 'package:soliplex_agent/soliplex_agent.dart';
 import 'package:soliplex_logging/soliplex_logging.dart';
 
 import '../../interfaces/auth_state.dart';
+import 'admin_status.dart';
 import 'auth_session.dart';
 import 'auth_tokens.dart';
 import 'server_entry.dart';
@@ -136,6 +137,7 @@ class ServerManager {
       auth: auth,
       httpClient: httpClient,
       connection: connection,
+      adminStatus: AdminStatus(api: connection.api, serverId: serverId),
       requiresAuth: requiresAuth,
       name: name,
       description: description,
@@ -309,6 +311,13 @@ class ServerManager {
   }
 
   void _onSessionChanged(String serverId, ServerEntry entry) {
+    // A refresh and an expiry keep the same user, so neither invalidates the
+    // answer. Signing out does not tear this entry down, so without this the
+    // next user on this device would read the previous one's answer. This is
+    // half the guard: signing in from an expired session never reaches a
+    // signed-out state, and `UserSwitchTeardown` catches that wherever the
+    // token carries an identity to compare.
+    if (entry.auth.session.value is NoSession) entry.adminStatus.clear();
     if (_restoring) return;
     Future<void> persist() async {
       switch (entry.auth.session.value) {

--- a/lib/src/modules/room/ui/chat_input.dart
+++ b/lib/src/modules/room/ui/chat_input.dart
@@ -181,11 +181,21 @@ class _ChatInputState extends State<ChatInput> {
     super.dispose();
   }
 
+  /// Whether the composer takes input at this moment.
+  ///
+  /// The deferred callers need that rather than the answer from the build that
+  /// produced the control, because they outlive it: a pick outlives the tap
+  /// that started it, and a menu route outlives the items it was filled with.
+  /// [build] reads it too, where `peek` and the watched value are the same —
+  /// the `watch` there is what keeps the composer subscribed, so this getter
+  /// must not become its only reader.
+  bool get _acceptsInput => composerAcceptsText(
+        enabled: widget.enabled,
+        sessionState: widget.sessionState?.peek(),
+      );
+
   void _send() {
-    if (!composerAcceptsText(
-      enabled: widget.enabled,
-      sessionState: widget.sessionState?.peek(),
-    )) {
+    if (!_acceptsInput) {
       return;
     }
     final parts = _controller.sendableParts();
@@ -297,10 +307,7 @@ class _ChatInputState extends State<ChatInput> {
     // renders it read-only. An image put there could not be removed until the
     // run ended — a chip showing its picture has no other way out — and would
     // then be sent with whatever the user typed next.
-    if (!composerAcceptsText(
-      enabled: widget.enabled,
-      sessionState: widget.sessionState?.peek(),
-    )) {
+    if (!_acceptsInput) {
       setState(
         () => _attachNotice = 'The composer was busy. Add the images again.',
       );
@@ -364,6 +371,38 @@ class _ChatInputState extends State<ChatInput> {
     );
   }
 
+  /// Runs a choice from the collapsed actions menu.
+  ///
+  /// Everything the choice needs is read here rather than when the menu was
+  /// filled, because the open route outlives that build: the callback may have
+  /// gone (the filter arrives with the room's document load, and either upload
+  /// callback goes with the room's capability) and the composer may since have
+  /// been handed to a run. Refusing does nothing and says nothing: the buttons
+  /// this menu stands in for are greyed before the tap, which a menu item
+  /// cannot be once its route is open, so the tap is absorbed instead.
+  void _onRoomAction(_RoomActionChoice choice) {
+    if (!_acceptsInput) return;
+    switch (choice) {
+      case _RoomActionChoice.filter:
+        widget.onFilterTap?.call();
+      case _RoomActionChoice.uploadFiles:
+        widget.onAttachFile?.call();
+      case _RoomActionChoice.uploadFolder:
+        widget.onAttachFolder?.call();
+    }
+  }
+
+  /// Runs a choice from the attach menu, on the same terms as [_onRoomAction].
+  void _onAttachChoice(_AttachChoice choice) {
+    if (!_acceptsInput) return;
+    switch (choice) {
+      case _AttachChoice.files:
+        widget.onAttachFile?.call();
+      case _AttachChoice.folder:
+        widget.onAttachFolder?.call();
+    }
+  }
+
   /// The composer's leading controls, at most two of them below
   /// [SoliplexBreakpoints.tablet].
   ///
@@ -396,8 +435,8 @@ class _ChatInputState extends State<ChatInput> {
         icon: const Icon(Icons.add_photo_alternate_outlined),
         // Carries the semantics label, so a screen reader names the button.
         tooltip: 'Add image',
-        // Never gated on the room's sandbox capability: that governs uploads to
-        // the thread, while an inline image is a property of the model.
+        // Never gated on the room's upload capability: that governs files sent
+        // to the thread, while an inline image travels in the message.
         onPressed: disabled || _picking ? null : _addImages,
       ),
       if (collapse)
@@ -425,11 +464,7 @@ class _ChatInputState extends State<ChatInput> {
                 child: Text('Upload folder…'),
               ),
           ],
-          onSelected: (choice) => switch (choice) {
-            _RoomActionChoice.filter => widget.onFilterTap!(),
-            _RoomActionChoice.uploadFiles => widget.onAttachFile!(),
-            _RoomActionChoice.uploadFolder => widget.onAttachFolder!(),
-          },
+          onSelected: _onRoomAction,
         )
       else ...[
         if (hasFilter)
@@ -459,10 +494,7 @@ class _ChatInputState extends State<ChatInput> {
                   child: Text('Folder…'),
                 ),
               ],
-              onSelected: (choice) => switch (choice) {
-                _AttachChoice.files => widget.onAttachFile!(),
-                _AttachChoice.folder => widget.onAttachFolder!(),
-              },
+              onSelected: _onAttachChoice,
             )
           else
             IconButton(
@@ -478,8 +510,7 @@ class _ChatInputState extends State<ChatInput> {
   Widget build(BuildContext context) {
     final state = widget.sessionState?.watch(context);
     final active = _isRunActive(state);
-    final disabled =
-        !composerAcceptsText(enabled: widget.enabled, sessionState: state);
+    final disabled = !_acceptsInput;
     final cancelEnabled = widget.cancelEnabled?.watch(context) ?? true;
 
     // Measures the composer, not the row inside its padding, so the threshold

--- a/lib/src/modules/room/ui/room_info/features_card.dart
+++ b/lib/src/modules/room/ui/room_info/features_card.dart
@@ -30,11 +30,11 @@ class FeaturesCard extends StatelessWidget {
       children: [
         InfoRow(
           label: 'Room attachments',
-          value: room.supportsRoomAttachments ? 'Enabled' : 'Disabled',
+          value: room.acceptsRoomUploads ? 'Enabled' : 'Disabled',
         ),
         InfoRow(
           label: 'Thread attachments',
-          value: room.supportsThreadAttachments ? 'Enabled' : 'Disabled',
+          value: room.acceptsThreadUploads ? 'Enabled' : 'Disabled',
         ),
         InfoRow(
           label: 'Allow MCP',

--- a/lib/src/modules/room/ui/room_info_screen.dart
+++ b/lib/src/modules/room/ui/room_info_screen.dart
@@ -244,7 +244,7 @@ class _RoomInfoBody extends StatelessWidget {
               contentOf: (e) => _buildToolsetContent(e.value),
             ),
             ClientToolsCard(clientToolsFuture: clientToolsFuture),
-            if (room.supportsRoomAttachments)
+            if (room.acceptsRoomUploads)
               _UploadedFilesCard(
                 uploadRegistry: uploadRegistry,
                 serverEntry: serverEntry,
@@ -378,6 +378,21 @@ class _UploadedFilesCard extends StatefulWidget {
 class _UploadedFilesCardState extends State<_UploadedFilesCard> {
   late final UploadTracker _tracker;
 
+  /// Whether the signed-in user may upload to this room: `null` while the
+  /// answer is outstanding, and `false` only once the server has answered that
+  /// they are not an administrator.
+  ///
+  /// Each state renders: `null` the controls in their loading state, so a
+  /// slow answer shows a control on its way rather than no control at all;
+  /// `true` the controls; `false` a line naming who adds the files, in the
+  /// slot the controls would have taken, whether or not the list is empty.
+  /// A question that could not be answered reads as permission —
+  /// withholding the controls on a failed request would strip an
+  /// administrator of a capability they have, and the server still refuses
+  /// anyone else. [_permissionWait] bounds how long `null` can last, so that
+  /// reading is reached in bounded time rather than only on a failed request.
+  bool? _mayUpload;
+
   @override
   void initState() {
     super.initState();
@@ -385,6 +400,7 @@ class _UploadedFilesCardState extends State<_UploadedFilesCard> {
       entry: widget.serverEntry,
       roomId: widget.roomId,
     );
+    unawaited(_resolveUploadPermission());
     // Refresh only if no other screen has populated the shared tracker
     // yet. When `RoomState` is already mounted it has refreshed on room
     // entry, so navigating Room → Info skips a redundant GET.
@@ -394,6 +410,61 @@ class _UploadedFilesCardState extends State<_UploadedFilesCard> {
   }
 
   // Not disposed here — the registry owns the tracker's lifecycle.
+
+  /// How long the controls may stay in their loading state before the answer
+  /// is treated as one that did not arrive.
+  ///
+  /// The request's own timeout does not bound this: it starts only once the
+  /// request holds one of the six connection slots shared with every other
+  /// request to this server, and an upload already running can hold one for
+  /// the whole 600 seconds the transport allows it. Loading renders as
+  /// disabled, so an unbounded wait would withhold from an administrator a
+  /// capability they have — the outcome the `null` reading exists to avoid.
+  static const Duration _permissionWait = Duration(seconds: 3);
+
+  /// Uploading to a room needs an administrator, which is a fact about the
+  /// user rather than the room, so it arrives separately from the room itself.
+  ///
+  /// `AdminStatus.read` never completes with an error, so nothing here needs a
+  /// guard beyond [mounted].
+  Future<void> _resolveUploadPermission() async {
+    final answer = widget.serverEntry.adminStatus.read();
+    final bounded = await answer.timeout(
+      _permissionWait,
+      onTimeout: () => null,
+    );
+    if (!mounted) return;
+    // Answered within the bound. [answer] completes once, so awaiting it again
+    // below could only yield this same value; returning here is what says so.
+    if (bounded != null) {
+      setState(() => _mayUpload = bounded);
+      return;
+    }
+
+    // Records the decision, not its cause: a request that failed is already
+    // described by `AdminStatus`, but one still queued at the bound says
+    // nothing, and that is the branch reachable under load. Granting the
+    // capability on a guess is worth a line either way — paired with the cause
+    // when there is one, and the only trace when there is not. After the
+    // [mounted] check, so the record is written only where the controls it
+    // describes are actually rendered.
+    _logger.warning(
+      'Showing the room upload controls without an answer on whether the user '
+      'administers this room',
+      attributes: {'roomId': widget.roomId},
+    );
+    setState(() => _mayUpload = true);
+
+    // The request outlives the bound, and only a definite refusal corrects the
+    // guess it produced: leaving that guess to stand for the life of the
+    // screen would hand someone two controls whose every use the server
+    // refuses. An answer that never came leaves it exactly as it is — reading
+    // that as permission would grant on the strength of a request `clear`
+    // retired precisely because it describes a different user.
+    final settled = await answer;
+    if (!mounted || settled != false) return;
+    setState(() => _mayUpload = false);
+  }
 
   Future<void> _pickAndUpload(
     Future<PickFilesResult?> Function() pick,
@@ -416,6 +487,21 @@ class _UploadedFilesCardState extends State<_UploadedFilesCard> {
       return;
     }
     if (result == null || !mounted) return;
+    // The pick outlives the tap that opened it. That tap cannot have happened
+    // while the answer was outstanding — loading renders the controls
+    // unpressable — but it can have happened on the grant [_permissionWait]
+    // hands out when the answer has not arrived, with the definite refusal
+    // landing since. The controls are already gone by now. Sending anyway
+    // would upload every file in full to have each one refused in turn, so the
+    // refusal is recorded once here instead of once per file by the server.
+    if (_mayUpload == false) {
+      _tracker.recordClientError(
+        roomId: widget.roomId,
+        filename: '(unknown)',
+        message: "You don't have permission to upload here.",
+      );
+      return;
+    }
     for (final itemError in result.errors) {
       _logger.error(
         'Pick failed',
@@ -454,26 +540,41 @@ class _UploadedFilesCardState extends State<_UploadedFilesCard> {
       title: title,
       children: [
         _buildBody(status, theme),
+        // The controls and the sentence that stands in for them share this
+        // slot, so whichever the answer withholds, the other is in its place.
+        // Present but loading while the answer is outstanding, because an
+        // absent control would read as a refusal. [_permissionWait] is what
+        // keeps that state from outlasting the user's patience.
         const SizedBox(height: SoliplexSpacing.s2),
-        Align(
-          alignment: Alignment.centerLeft,
-          child: Wrap(
-            spacing: SoliplexSpacing.s2,
-            runSpacing: SoliplexSpacing.s2,
-            children: [
-              SoliplexButton.filled(
-                onPressed: () => _pickAndUpload(pickFiles),
-                icon: const Icon(Icons.upload_file, size: 18),
-                child: const Text('Upload files to room'),
-              ),
-              SoliplexButton.filled(
-                onPressed: () => _pickAndUpload(pickFolder),
-                icon: const Icon(Icons.drive_folder_upload, size: 18),
-                child: const Text('Upload folder to room'),
-              ),
-            ],
+        if (_mayUpload == false)
+          Text(
+            'An administrator adds files to this room.',
+            style: theme.textTheme.bodyMedium?.copyWith(
+              color: theme.colorScheme.onSurfaceVariant,
+            ),
+          )
+        else
+          Align(
+            alignment: Alignment.centerLeft,
+            child: Wrap(
+              spacing: SoliplexSpacing.s2,
+              runSpacing: SoliplexSpacing.s2,
+              children: [
+                SoliplexButton.filled(
+                  onPressed: () => _pickAndUpload(pickFiles),
+                  isLoading: _mayUpload == null,
+                  icon: const Icon(Icons.upload_file, size: 18),
+                  child: const Text('Upload files to room'),
+                ),
+                SoliplexButton.filled(
+                  onPressed: () => _pickAndUpload(pickFolder),
+                  isLoading: _mayUpload == null,
+                  icon: const Icon(Icons.drive_folder_upload, size: 18),
+                  child: const Text('Upload folder to room'),
+                ),
+              ],
+            ),
           ),
-        ),
       ],
     );
   }

--- a/lib/src/modules/room/ui/room_info_screen.dart
+++ b/lib/src/modules/room/ui/room_info_screen.dart
@@ -375,23 +375,40 @@ class _UploadedFilesCard extends StatefulWidget {
   State<_UploadedFilesCard> createState() => _UploadedFilesCardState();
 }
 
+/// What is known about whether the signed-in user may upload to this room.
+///
+/// Four states rather than a `bool?`, because a question that was *not
+/// answered* is not the same as one answered "no", and the two must not render
+/// alike: the refusal names who does add the files, which is a claim about the
+/// user this client is in no position to make when it never got an answer.
+enum _UploadPermission {
+  /// The answer is outstanding and still within [_UploadedFilesCardState
+  /// ._permissionWait].
+  checking,
+
+  /// The installation said the user is an administrator.
+  permitted,
+
+  /// The installation said the user is not one.
+  refused,
+
+  /// The question could not be answered — the request failed, or was still
+  /// queued at the bound. Not a verdict, and never rendered as one.
+  unknown,
+}
+
 class _UploadedFilesCardState extends State<_UploadedFilesCard> {
   late final UploadTracker _tracker;
 
-  /// Whether the signed-in user may upload to this room: `null` while the
-  /// answer is outstanding, and `false` only once the server has answered that
-  /// they are not an administrator.
+  /// What is known about the caller's permission to upload here.
   ///
-  /// Each state renders: `null` the controls in their loading state, so a
-  /// slow answer shows a control on its way rather than no control at all;
-  /// `true` the controls; `false` a line naming who adds the files, in the
-  /// slot the controls would have taken, whether or not the list is empty.
-  /// A question that could not be answered reads as permission —
-  /// withholding the controls on a failed request would strip an
-  /// administrator of a capability they have, and the server still refuses
-  /// anyone else. [_permissionWait] bounds how long `null` can last, so that
-  /// reading is reached in bounded time rather than only on a failed request.
-  bool? _mayUpload;
+  /// The controls are offered only under [_UploadPermission.permitted]. An
+  /// unanswered check withholds them and says so, because the upload `POST`
+  /// authorizes through the same installation-side administrator check this
+  /// answer comes from: when that check cannot answer, it cannot authorize
+  /// either, so offering the controls would offer an action whose every use
+  /// fails — a folder of N files uploaded in full to be refused N times.
+  _UploadPermission _permission = _UploadPermission.checking;
 
   @override
   void initState() {
@@ -411,15 +428,16 @@ class _UploadedFilesCardState extends State<_UploadedFilesCard> {
 
   // Not disposed here — the registry owns the tracker's lifecycle.
 
-  /// How long the controls may stay in their loading state before the answer
-  /// is treated as one that did not arrive.
+  /// How long the controls may stay in their loading state before the check is
+  /// reported as one that has not answered.
   ///
   /// The request's own timeout does not bound this: it starts only once the
   /// request holds one of the six connection slots shared with every other
   /// request to this server, and an upload already running can hold one for
   /// the whole 600 seconds the transport allows it. Loading renders as
-  /// disabled, so an unbounded wait would withhold from an administrator a
-  /// capability they have — the outcome the `null` reading exists to avoid.
+  /// disabled, so without a bound the controls would sit unpressable and
+  /// unexplained for as long as that queue lasts. The bound does not end the
+  /// request — an answer arriving later still replaces what the bound wrote.
   static const Duration _permissionWait = Duration(seconds: 3);
 
   /// Uploading to a room needs an administrator, which is a fact about the
@@ -427,43 +445,76 @@ class _UploadedFilesCardState extends State<_UploadedFilesCard> {
   ///
   /// `AdminStatus.read` never completes with an error, so nothing here needs a
   /// guard beyond [mounted].
+  ///
+  /// Safe to re-enter, which is what the retry control does. A reader that has
+  /// been overtaken either returns without writing — `settled == null` is the
+  /// only state it could write, and it declines to — or resolves the same
+  /// definite answer as the reader that overtook it, because
+  /// [AdminStatus.read] hands both the same request while one is in flight.
   Future<void> _resolveUploadPermission() async {
     final answer = widget.serverEntry.adminStatus.read();
+    var timedOut = false;
     final bounded = await answer.timeout(
       _permissionWait,
-      onTimeout: () => null,
+      onTimeout: () {
+        timedOut = true;
+        return null;
+      },
     );
     if (!mounted) return;
-    // Answered within the bound. [answer] completes once, so awaiting it again
-    // below could only yield this same value; returning here is what says so.
     if (bounded != null) {
-      setState(() => _mayUpload = bounded);
+      _settle(bounded);
       return;
     }
 
-    // Records the decision, not its cause: a request that failed is already
-    // described by `AdminStatus`, but one still queued at the bound says
-    // nothing, and that is the branch reachable under load. Granting the
-    // capability on a guess is worth a line either way — paired with the cause
-    // when there is one, and the only trace when there is not. After the
-    // [mounted] check, so the record is written only where the controls it
-    // describes are actually rendered.
+    // Every arrival at [_UploadPermission.unknown] is recorded, because the
+    // state is indistinguishable on screen from an installation that simply
+    // has no answer to give, and because the two ways of reaching it warrant
+    // different action: `queued` says the server is slow or the client's
+    // connection pool is saturated, `unanswered` says the request failed and
+    // `AdminStatus` has already described how. At `warning` because the
+    // release log floor drops anything lower, and this is the state a user
+    // reports. After the [mounted] check, so the record describes a state that
+    // was actually rendered.
+    //
+    // A request that outruns the bound and *then* fails is recorded twice —
+    // correctly: the wait and the failure are separate events, and only the
+    // first is about this screen.
     _logger.warning(
-      'Showing the room upload controls without an answer on whether the user '
-      'administers this room',
-      attributes: {'roomId': widget.roomId},
+      'Could not confirm whether the user administers this room; withholding '
+      'the room upload controls',
+      attributes: {
+        'roomId': widget.roomId,
+        'reason': timedOut ? 'queued' : 'unanswered',
+      },
     );
-    setState(() => _mayUpload = true);
+    setState(() => _permission = _UploadPermission.unknown);
 
-    // The request outlives the bound, and only a definite refusal corrects the
-    // guess it produced: leaving that guess to stand for the life of the
-    // screen would hand someone two controls whose every use the server
-    // refuses. An answer that never came leaves it exactly as it is — reading
-    // that as permission would grant on the strength of a request `clear`
-    // retired precisely because it describes a different user.
+    // The request outlives the bound, so a definite answer of either polarity
+    // still replaces what the bound wrote. A `null` leaves it alone: that is
+    // either the failure this state already describes, or an answer `clear`
+    // retired because it describes a different user.
     final settled = await answer;
-    if (!mounted || settled != false) return;
-    setState(() => _mayUpload = false);
+    if (!mounted || settled == null) return;
+    _settle(settled);
+  }
+
+  /// Records and applies a verdict the installation delivered.
+  ///
+  /// Recorded at `info`, below the release log floor, because neither outcome
+  /// is a fault — but which one it was is the first question asked of a user
+  /// who says the controls are missing, or present when they should not be.
+  /// Without it a diagnostics export cannot tell "the server said yes" from
+  /// "the gate never ran".
+  void _settle(bool isAdmin) {
+    _logger.info(
+      'The installation answered on whether the user administers this room',
+      attributes: {'roomId': widget.roomId, 'isAdmin': isAdmin},
+    );
+    setState(
+      () => _permission =
+          isAdmin ? _UploadPermission.permitted : _UploadPermission.refused,
+    );
   }
 
   Future<void> _pickAndUpload(
@@ -487,21 +538,12 @@ class _UploadedFilesCardState extends State<_UploadedFilesCard> {
       return;
     }
     if (result == null || !mounted) return;
-    // The pick outlives the tap that opened it. That tap cannot have happened
-    // while the answer was outstanding — loading renders the controls
-    // unpressable — but it can have happened on the grant [_permissionWait]
-    // hands out when the answer has not arrived, with the definite refusal
-    // landing since. The controls are already gone by now. Sending anyway
-    // would upload every file in full to have each one refused in turn, so the
-    // refusal is recorded once here instead of once per file by the server.
-    if (_mayUpload == false) {
-      _tracker.recordClientError(
-        roomId: widget.roomId,
-        filename: '(unknown)',
-        message: "You don't have permission to upload here.",
-      );
-      return;
-    }
+    // No permission recheck here. The pick outlives the tap that opened it,
+    // but the controls are pressable only under [_UploadPermission.permitted],
+    // which is written from a definite answer and nothing then moves it. A
+    // grant revoked server-side while the picker was open is left to the
+    // tracker, which renders the `PermissionDeniedException` the POST comes
+    // back with.
     for (final itemError in result.errors) {
       _logger.error(
         'Pick failed',
@@ -540,41 +582,97 @@ class _UploadedFilesCardState extends State<_UploadedFilesCard> {
       title: title,
       children: [
         _buildBody(status, theme),
-        // The controls and the sentence that stands in for them share this
-        // slot, so whichever the answer withholds, the other is in its place.
-        // Present but loading while the answer is outstanding, because an
-        // absent control would read as a refusal. [_permissionWait] is what
-        // keeps that state from outlasting the user's patience.
+        // One slot, one occupant per state, so whatever the check withholds
+        // leaves something in its place. Never empty: an absent control would
+        // read as a refusal the client has not been told.
         const SizedBox(height: SoliplexSpacing.s2),
-        if (_mayUpload == false)
-          Text(
-            'An administrator adds files to this room.',
-            style: theme.textTheme.bodyMedium?.copyWith(
-              color: theme.colorScheme.onSurfaceVariant,
+        switch (_permission) {
+          // Present but unpressable, because a control on its way says more
+          // than no control at all. [_permissionWait] bounds how long this
+          // lasts.
+          _UploadPermission.checking ||
+          _UploadPermission.permitted =>
+            _buildUploadControls(
+              isLoading: _permission == _UploadPermission.checking,
             ),
-          )
-        else
-          Align(
-            alignment: Alignment.centerLeft,
-            child: Wrap(
-              spacing: SoliplexSpacing.s2,
-              runSpacing: SoliplexSpacing.s2,
-              children: [
-                SoliplexButton.filled(
-                  onPressed: () => _pickAndUpload(pickFiles),
-                  isLoading: _mayUpload == null,
-                  icon: const Icon(Icons.upload_file, size: 18),
-                  child: const Text('Upload files to room'),
-                ),
-                SoliplexButton.filled(
-                  onPressed: () => _pickAndUpload(pickFolder),
-                  isLoading: _mayUpload == null,
-                  icon: const Icon(Icons.drive_folder_upload, size: 18),
-                  child: const Text('Upload folder to room'),
-                ),
-              ],
+          // The installation answered, so the client may say who does add
+          // them. Stands whether or not the list is empty.
+          _UploadPermission.refused => Text(
+              'An administrator adds files to this room.',
+              style: theme.textTheme.bodyMedium?.copyWith(
+                color: theme.colorScheme.onSurfaceVariant,
+              ),
             ),
+          // Says only what is true: the check did not answer. Naming an
+          // administrator here would assert something about the user that
+          // nothing established, to someone who may well be one.
+          _UploadPermission.unknown => _buildPermissionUnknown(theme),
+        },
+      ],
+    );
+  }
+
+  /// The two upload controls, greyed while the check is outstanding.
+  Widget _buildUploadControls({required bool isLoading}) {
+    return Align(
+      alignment: Alignment.centerLeft,
+      child: Wrap(
+        spacing: SoliplexSpacing.s2,
+        runSpacing: SoliplexSpacing.s2,
+        children: [
+          SoliplexButton.filled(
+            onPressed: () => _pickAndUpload(pickFiles),
+            isLoading: isLoading,
+            icon: const Icon(Icons.upload_file, size: 18),
+            child: const Text('Upload files to room'),
           ),
+          SoliplexButton.filled(
+            onPressed: () => _pickAndUpload(pickFolder),
+            isLoading: isLoading,
+            icon: const Icon(Icons.drive_folder_upload, size: 18),
+            child: const Text('Upload folder to room'),
+          ),
+        ],
+      ),
+    );
+  }
+
+  /// What stands in the controls' slot when the check did not answer.
+  ///
+  /// Carries its own retry because the alternative recourse — leaving the
+  /// screen and returning — is not discoverable from a sentence that does not
+  /// mention it. A retry costs one request: an unanswered check is never kept,
+  /// so [AdminStatus.read] asks again rather than replaying the non-answer.
+  /// While one is still in flight it joins that request instead of issuing a
+  /// second, which is why pressing this repeatedly cannot stack them up.
+  Widget _buildPermissionUnknown(ThemeData theme) {
+    // The failed-row shape `DocumentsCard` uses, so the two cards on this
+    // screen that can fail read alike. It also carries its weight: the refusal
+    // this slot otherwise holds is an ordinary state in ordinary type, and
+    // rendering a failure the same way would leave "you may not add files"
+    // and "nobody could find out" indistinguishable at a glance.
+    return Row(
+      children: [
+        Icon(
+          Icons.error_outline,
+          size: 18,
+          color: theme.colorScheme.error,
+        ),
+        const SizedBox(width: SoliplexSpacing.s2),
+        Expanded(
+          child: Text(
+            "Couldn't check whether you can add files here.",
+            style: theme.textTheme.bodyMedium
+                ?.copyWith(color: theme.colorScheme.error),
+          ),
+        ),
+        SoliplexButton.filled(
+          onPressed: () {
+            setState(() => _permission = _UploadPermission.checking);
+            unawaited(_resolveUploadPermission());
+          },
+          child: const Text('Retry'),
+        ),
       ],
     );
   }

--- a/lib/src/modules/room/ui/room_screen.dart
+++ b/lib/src/modules/room/ui/room_screen.dart
@@ -143,6 +143,14 @@ const double _sidebarWidth = 300;
 /// edge. Below this width the content fills the available space.
 const double _maxContentWidth = SoliplexBreakpoints.desktop;
 
+/// Identifies the attached-files panel.
+///
+/// The panel renders nothing of its own when both scopes are empty, so whether
+/// it is on screen is otherwise unobservable — and it being on screen with
+/// nothing in it, and no control left to close it, is the defect this names.
+@visibleForTesting
+const Key filePanelKey = Key('room-attached-files-panel');
+
 /// Builds the label for the file indicator chip in the room header.
 ///
 /// Shows separate counts for room and thread uploads. At least one
@@ -996,6 +1004,12 @@ class _RoomScreenState extends State<RoomScreen> {
     final roomChanged = widget.roomId != oldWidget.roomId || serverChanged;
     if (roomChanged || widget.threadId != oldWidget.threadId) {
       _markPreviousThreadRead(oldWidget);
+      // The panel belongs to the conversation it was opened over. Left set, it
+      // would reopen uninvited on arrival: a scope fetched for the first time
+      // reads as content while it loads, so an expanded flag outliving its
+      // rows pops a spinner over the incoming thread and closes again when the
+      // fetch lands.
+      _filesExpanded = false;
     }
     if (roomChanged) {
       // Mark the room being left read (under its own coordinates) before its
@@ -1796,20 +1810,32 @@ class _RoomScreenState extends State<RoomScreen> {
     required bool showHeader,
   }) {
     final threadView = _state.activeThreadView;
-    final roomAttachEnabled = room?.supportsRoomAttachments ?? false;
+    final roomScopeRenders = _roomScopeRenders(room);
     final messagesStatus = threadView?.messages.watch(context);
 
-    final UploadsStatus roomStatus = roomAttachEnabled
+    final UploadsStatus roomStatus = roomScopeRenders
         ? _state.uploadTracker.roomUploads(widget.roomId).watch(context)
         : const UploadsLoaded(<DisplayUpload>[]);
     final threadId = threadView?.threadId;
     final threadAttachEnabled =
-        threadId != null && (room?.supportsThreadAttachments ?? false);
+        threadId != null && (room?.acceptsThreadUploads ?? false);
     final UploadsStatus threadStatus = threadAttachEnabled
         ? _state.uploadTracker
             .threadUploads(widget.roomId, threadId)
             .watch(context)
         : const UploadsLoaded(<DisplayUpload>[]);
+
+    // The flag records that the user asked for the panel. With neither scope
+    // able to show anything the control that would take the ask back is gone
+    // too, so the ask lapses here rather than reopening the panel over whatever
+    // arrives next — dismissing the last row is the ordinary way to get here,
+    // and it reads as "done", not as "hold this open".
+    //
+    // Assigned rather than `setState`: with no content the flag cannot reach
+    // this frame's output, since the panel below is gated on it and the control
+    // that renders it selected is withheld by the same test. Nothing to
+    // rebuild, so nothing to schedule.
+    if (!_panelHasContent(roomStatus, threadStatus)) _filesExpanded = false;
 
     final body = threadView == null || messagesStatus == null
         ? _buildNoThreadBody(room)
@@ -1988,10 +2014,7 @@ class _RoomScreenState extends State<RoomScreen> {
     final anyFailed =
         roomStatus is UploadsFailed || threadStatus is UploadsFailed;
 
-    if (!_scopeRendersContent(roomStatus) &&
-        !_scopeRendersContent(threadStatus)) {
-      return null;
-    }
+    if (!_panelHasContent(roomStatus, threadStatus)) return null;
 
     final all = [...?roomFiles, ...?threadFiles];
     final anyPending = all.any((e) => e is PendingUpload);
@@ -2025,25 +2048,49 @@ class _RoomScreenState extends State<RoomScreen> {
   List<DisplayUpload>? _uploadsOrNull(UploadsStatus s) =>
       s is UploadsLoaded ? s.uploads : null;
 
+  /// Whether the attached-files panel has anything to show.
+  ///
+  /// Withholds the control that toggles the panel, and retires the ask that
+  /// opens it, so the panel cannot outlive either. That control is the only way
+  /// to close the panel, so a panel surviving it would hold the viewport for
+  /// the rest of the visit with nothing able to collapse it; and an ask
+  /// surviving it would reopen the panel unbidden the next time either scope
+  /// had something to say. Dismissing the last row reaches both.
+  bool _panelHasContent(UploadsStatus roomStatus, UploadsStatus threadStatus) =>
+      _scopeRendersContent(roomStatus) || _scopeRendersContent(threadStatus);
+
   bool _scopeRendersContent(UploadsStatus s) => switch (s) {
         UploadsLoading() => true,
         UploadsLoaded(uploads: final u) => u.isNotEmpty,
         UploadsFailed() => true,
       };
 
+  /// Whether the room scope's list is watched — the attached-files control and
+  /// the panel it opens.
+  ///
+  /// Wider than the room's own upload capability, because the room scope is
+  /// also where a pick made before a thread exists is recorded — the welcome
+  /// composer's attach runs on the *thread* capability and has no thread to
+  /// route a failure to, so [_pickWithErrorSurfacing] files it here. Reading
+  /// the room capability alone would leave that failure with nowhere to
+  /// render, which is silence rather than a refusal.
+  ///
+  /// Not the welcome view's event banner, which watches this scope alone and
+  /// reports only transitions of uploads it saw start, so it has nothing to say
+  /// about a record that arrives already failed. The thread view's banner does
+  /// read this predicate — see the call site for why the two differ.
+  bool _roomScopeRenders(Room? room) =>
+      (room?.acceptsRoomUploads ?? false) ||
+      (room?.acceptsThreadUploads ?? false);
+
   Widget _buildFilePanel(
     UploadsStatus roomStatus,
     UploadsStatus threadStatus,
   ) {
     final theme = Theme.of(context);
-    final roomFiles = _uploadsOrNull(roomStatus);
-    final threadFiles = _uploadsOrNull(threadStatus);
-    final bothEmpty = (roomFiles?.isEmpty ?? true) &&
-        (threadFiles?.isEmpty ?? true) &&
-        roomStatus is UploadsLoaded &&
-        threadStatus is UploadsLoaded;
 
     return Padding(
+      key: filePanelKey,
       padding: const EdgeInsets.symmetric(horizontal: SoliplexSpacing.s2),
       child: Container(
         width: double.infinity,
@@ -2073,24 +2120,15 @@ class _RoomScreenState extends State<RoomScreen> {
                 crossAxisAlignment: CrossAxisAlignment.start,
                 mainAxisSize: MainAxisSize.min,
                 children: [
-                  if (bothEmpty)
-                    Text(
-                      'No files attached.',
-                      style: theme.textTheme.bodySmall?.copyWith(
-                        color: theme.colorScheme.outline,
-                      ),
-                    )
-                  else ...[
-                    _buildScopeSection('Room', roomStatus, theme),
-                    // The divider sits between two visible sections. A
-                    // scope is "visible" when it's Loading or Failed
-                    // (those render a section row), or Loaded with at
-                    // least one file.
-                    if (_scopeRendersContent(roomStatus) &&
-                        _scopeRendersContent(threadStatus))
-                      const Divider(height: 12),
-                    _buildScopeSection('Thread', threadStatus, theme),
-                  ],
+                  _buildScopeSection('Room', roomStatus, theme),
+                  // The divider sits between two visible sections. A
+                  // scope is "visible" when it's Loading or Failed
+                  // (those render a section row), or Loaded with at
+                  // least one file.
+                  if (_scopeRendersContent(roomStatus) &&
+                      _scopeRendersContent(threadStatus))
+                    const Divider(height: 12),
+                  _buildScopeSection('Thread', threadStatus, theme),
                 ],
               ),
             ),
@@ -2281,7 +2319,10 @@ class _RoomScreenState extends State<RoomScreen> {
             error: roomError,
             onDismiss: _state.clearError,
           ),
-        if (room?.supportsRoomAttachments ?? false)
+        // Its own capability, not [_roomScopeRenders]: this banner reports
+        // transitions of uploads it saw start, so a scope with no upload path
+        // can never give it anything to say.
+        if (room?.acceptsRoomUploads ?? false)
           UploadEventBanner(
             tracker: _state.uploadTracker,
             roomId: widget.roomId,
@@ -2299,8 +2340,6 @@ class _RoomScreenState extends State<RoomScreen> {
     final streaming = threadView.streamingState.watch(context);
     final sendError = threadView.lastSendError.watch(context);
     final reconnectStatus = threadView.reconnectStatus.watch(context);
-    final attachEnabled = room?.supportsThreadAttachments ?? false;
-
     _restoreUnsentText(sendError?.unsentText);
 
     return Stack(
@@ -2391,7 +2430,11 @@ class _RoomScreenState extends State<RoomScreen> {
                 error: sendError,
                 onDismiss: () => threadView.clearSendError(),
               ),
-            if (attachEnabled)
+            // Both scopes, unlike the welcome view's banner: every banner
+            // watches the room scope, and this one carries a thread id, which
+            // adds the thread scope. So it has something to say whenever
+            // either can produce a transition.
+            if (_roomScopeRenders(room))
               UploadEventBanner(
                 tracker: _state.uploadTracker,
                 roomId: widget.roomId,
@@ -2416,7 +2459,7 @@ class _RoomScreenState extends State<RoomScreen> {
     Room? room,
     ThreadViewStatus? status,
   ) {
-    final attachEnabled = room?.supportsThreadAttachments ?? false;
+    final attachEnabled = room?.acceptsThreadUploads ?? false;
     VoidCallback? attachCallback(Future<PickFilesResult?> Function() pick) {
       if (!attachEnabled) return null;
       return threadView != null

--- a/lib/src/modules/room/upload_tracker.dart
+++ b/lib/src/modules/room/upload_tracker.dart
@@ -364,6 +364,34 @@ class UploadTracker {
         error: error,
       );
       _auth.markSessionExpired();
+    } on NotFoundException {
+      // Must precede the SoliplexException arm. A scope the installation
+      // configures no upload path for has no list to give, and the server says
+      // so with a 404 — an empty shelf rather than a failure to reach one.
+      // Rendering that as a failure put a permanent error row on every visit to
+      // a room not set up for uploads to this scope.
+      //
+      // Only where nothing has loaded yet, which is that room on every refresh.
+      // The same bare 404 also answers an unknown room and one this user may no
+      // longer read, because the membership check runs ahead of the path check,
+      // and a list already on screen must not be retracted on either. Those
+      // keep the list, on the same terms as any other refresh failure.
+      //
+      // The empty shelf is deliberately unrecorded: for such a room it is the
+      // answer every time, so a record would be one line per room entry
+      // describing a configuration working as intended. A 404 arriving after a
+      // load cannot be that configuration, so that one is recorded. Neither
+      // touches `pending`, so a pick failure already filed here survives.
+      if (token.isCancelled || _isDisposed) return;
+      scope.fetchToken = null;
+      if (scope.persisted == null) {
+        scope.persisted = const [];
+        _emit(scope);
+        return;
+      }
+      // The exception carries the server's own text and the path it was built
+      // from, and neither adds to what this line already says.
+      _logger.warning('Upload list refresh 404d after a load; keeping it');
     } on SoliplexException catch (error) {
       if (token.isCancelled || _isDisposed) return;
       scope.fetchToken = null;

--- a/lib/src/modules/room/user_switch_teardown.dart
+++ b/lib/src/modules/room/user_switch_teardown.dart
@@ -20,10 +20,14 @@ final Logger _logger =
 /// [UploadTrackerRegistry] key by the stable `serverId`; and [DocumentSelections]
 /// holds document filters in a single shared map that is not partitioned by
 /// user. Without this the next user would reattach to the prior user's runtime,
-/// runs, uploads, and document filters. `MessageExpansions` is a fifth
-/// module-owned cache left untouched on purpose: its per-message expand/collapse
-/// state is cosmetic, and a cross-user collision would need a shared
-/// server-assigned `messageId`.
+/// runs, uploads, and document filters. A fifth, `AdminStatus`, hangs off the
+/// `ServerEntry` and holds an authorization answer, so it is evicted here too;
+/// `ServerManager` additionally clears it when a session ends, which reaches
+/// the sign-out path on the opaque-token servers this class cannot see. Their
+/// expiry path is the known gap below, for `AdminStatus` as for the rest.
+/// `MessageExpansions` is a module-owned cache left untouched on purpose: its
+/// per-message expand/collapse state is cosmetic, and a cross-user collision
+/// would need a shared server-assigned `messageId`.
 ///
 /// Detection keys off each server's `AuthSession.currentUserId` rather than the
 /// sign-in call sites: that signal is stable across a token refresh (no
@@ -65,7 +69,7 @@ class UserSwitchTeardown {
         final previous = _lastSeen[serverId];
         _lastSeen[serverId] = identity;
         if (previous != null && previous != identity) {
-          _evict(serverId);
+          _evict(serverId, entry);
         }
       }
     });
@@ -82,7 +86,7 @@ class UserSwitchTeardown {
   final Map<String, String> _lastSeen = {};
   late final void Function() _dispose;
 
-  void _evict(String serverId) {
+  void _evict(String serverId, ServerEntry entry) {
     _logger.info(
       'Different user signed in on $serverId; '
       'tearing down the prior in-memory session',
@@ -94,6 +98,7 @@ class UserSwitchTeardown {
     _step(() => _registry.evictServer(serverId), 'runs', serverId);
     _step(() => _uploadRegistry.evictServer(serverId), 'uploads', serverId);
     _step(() => _documentSelections.clearServer(serverId), 'filters', serverId);
+    _step(() => entry.adminStatus.clear(), 'admin status', serverId);
   }
 
   void _step(void Function() evict, String what, String serverId) {

--- a/packages/soliplex_client/lib/src/api/mappers.dart
+++ b/packages/soliplex_client/lib/src/api/mappers.dart
@@ -140,7 +140,7 @@ RoomTool roomToolFromJson(String name, Map<String, dynamic> json) {
     description: (json['tool_description'] as String?) ?? '',
     kind: (json['kind'] as String?) ?? '',
     toolRequires: (json['tool_requires'] as String?) ?? '',
-    allowMcp: json['allow_mcp'] as bool? ?? false,
+    allowMcp: boolOrNull(json['allow_mcp'], 'allow_mcp') ?? false,
     extraParameters:
         (json['extra_parameters'] as Map<String, dynamic>?) ?? const {},
     aguiFeatureNames:
@@ -337,7 +337,7 @@ Room roomFromJson(Map<String, dynamic> json) {
     quizzes: quizzes,
     suggestions: suggestions,
     welcomeMessage: (json['welcome_message'] as String?) ?? '',
-    allowMcp: json['allow_mcp'] as bool? ?? false,
+    allowMcp: boolOrNull(json['allow_mcp'], 'allow_mcp') ?? false,
     agent: agent,
     skills: skills,
     tools: tools,
@@ -345,14 +345,40 @@ Room roomFromJson(Map<String, dynamic> json) {
     toolDefinitions: toolDefinitions,
     aguiFeatureNames:
         stringList(json['agui_feature_names'], 'agui_feature_names'),
+    // Absent — or wrongly typed — reads as no capability, which withholds
+    // every upload control. That is a default, not a deduction: a server too
+    // old to publish these can still have upload paths configured, and
+    // nothing readable here distinguishes it from a server that has none.
+    // [roomOmitsUploadCapability] is what lets a caller record the difference.
+    acceptsRoomUploads:
+        boolOrNull(json[_roomUploadsKey], _roomUploadsKey) ?? false,
+    acceptsThreadUploads:
+        boolOrNull(json[_threadUploadsKey], _threadUploadsKey) ?? false,
   );
 }
 
+/// The rooms API's per-scope upload capability keys.
+///
+/// Named once so the reader below cannot drift from the parser above.
+const _roomUploadsKey = 'has_room_uploads';
+const _threadUploadsKey = 'has_thread_uploads';
+
+/// Whether a room payload reported neither upload scope.
+///
+/// Absent and explicitly null read alike, because both mean the server did not
+/// say and both withhold every upload control. A present-but-wrongly-typed
+/// value is not an omission and is left to [boolOrNull], which records it
+/// against the field it arrived in.
+bool roomOmitsUploadCapability(Map<String, dynamic> json) =>
+    json[_roomUploadsKey] == null && json[_threadUploadsKey] == null;
+
 /// Converts a [Room] to JSON.
 ///
-/// This is a partial serialization — fields like [Room.agent],
-/// [Room.mcpClientToolsets], [Room.allowMcp], and [Room.suggestions]
-/// are not yet serialized. Add them here when round-trip fidelity is needed.
+/// This is a partial serialization — [Room.agent], [Room.mcpClientToolsets],
+/// [Room.allowMcp], [Room.suggestions], [Room.quizzes], [Room.tools],
+/// [Room.acceptsRoomUploads] and [Room.acceptsThreadUploads] are not
+/// serialized. Add them here when round-trip fidelity is needed; until then a
+/// round trip reports a room as accepting no uploads.
 Map<String, dynamic> roomToJson(Room room) {
   return {
     'id': room.id,

--- a/packages/soliplex_client/lib/src/api/soliplex_api.dart
+++ b/packages/soliplex_client/lib/src/api/soliplex_api.dart
@@ -194,12 +194,16 @@ class SoliplexApi {
     final rooms = <Room>[];
     for (final entry in response.entries) {
       try {
-        rooms.add(roomFromJson(entry.value as Map<String, dynamic>));
-      } catch (e) {
-        developer.log(
-          'Malformed room ignored (${entry.key}): $e',
-          name: 'soliplex_client.api',
-          level: 900,
+        final json = entry.value as Map<String, dynamic>;
+        rooms.add(roomFromJson(json));
+        _noteUploadCapability(entry.key, json);
+      } catch (e, st) {
+        // The room id names the entry; the failure carries the payload that
+        // produced it, so only its shape is kept.
+        _logger.warning(
+          'Malformed room ignored',
+          attributes: {'roomId': entry.key, 'failure': describeFailure(e)},
+          stackTrace: st,
         );
       }
     }
@@ -227,7 +231,40 @@ class SoliplexApi {
       'GET',
       _urlBuilder.build(pathSegments: ['rooms', roomId]),
       cancelToken: cancelToken,
-      fromJson: roomFromJson,
+      // Mapped inside the transport so a malformed payload still surfaces as
+      // [MalformedResponseException] rather than the mapper's own failure.
+      fromJson: (json) {
+        final room = roomFromJson(json);
+        _noteUploadCapability(roomId, json);
+        return room;
+      },
+    );
+  }
+
+  /// Whether [_noteUploadCapability] has already recorded an omission.
+  bool _reportedUploadCapabilityOmission = false;
+
+  /// Records that the server did not report upload capability for [roomId].
+  ///
+  /// Absence withholds every upload control, which is otherwise
+  /// indistinguishable from a room the installation has no upload path for,
+  /// so this record is where that difference survives. It is written once per
+  /// server: the omission belongs to the release the server runs, not to one
+  /// room, and every room in a session comes from one release. Both the
+  /// listing and the single-room fetch report, because a deep link reaches a
+  /// room without ever listing one.
+  ///
+  /// Only a payload that reports neither scope counts, per
+  /// [roomOmitsUploadCapability]. A release that publishes one key and not the
+  /// other withholds that scope's control with nothing recorded here — the two
+  /// keys ship together, so nothing is expected to produce it.
+  void _noteUploadCapability(String roomId, Map<String, dynamic> json) {
+    if (_reportedUploadCapabilityOmission) return;
+    if (!roomOmitsUploadCapability(json)) return;
+    _reportedUploadCapabilityOmission = true;
+    _logger.warning(
+      'Server did not report upload capability; attach controls withheld',
+      attributes: {'roomId': roomId, 'baseUrl': _urlBuilder.baseUrl},
     );
   }
 
@@ -1692,6 +1729,47 @@ class SoliplexApi {
     );
 
     return backendVersionInfoFromJson(response);
+  }
+
+  /// How long to wait for the installation's answer about the caller.
+  ///
+  /// Deliberately far below the 600-second transport default, which is sized
+  /// for the streamed upload bodies that rely on it: this is a small question
+  /// whose answer gates an affordance. It bounds the request only once it
+  /// holds a concurrency slot, so a caller that must render before the answer
+  /// arrives still needs its own in-flight state.
+  static const Duration _authzTimeout = Duration(seconds: 15);
+
+  /// Whether the signed-in user is an administrator of this installation.
+  ///
+  /// Installation-wide, not per room. Each call is audited server-side, so
+  /// this is worth keeping for a session rather than asking per screen.
+  ///
+  /// Throws:
+  /// - [NetworkException] if connection fails, including on [_authzTimeout]
+  /// - [AuthException] if not authenticated (401)
+  /// - [NotFoundException] if the server has no such endpoint (404)
+  /// - [PermissionDeniedException] if the caller may not ask (403)
+  /// - [ApiException] for other server errors
+  /// - [MalformedResponseException] if the body is not a JSON object — a
+  ///   portal or proxy answering 200 with a page is the reachable case — or if
+  ///   `is_admin_user` is missing or not a bool
+  /// - [CancelledException] if cancelled via [cancelToken]
+  Future<bool> getIsAdminUser({CancelToken? cancelToken}) async {
+    final response = await _transport.request<Map<String, dynamic>>(
+      'GET',
+      _urlBuilder.build(pathSegments: ['user', 'authz']),
+      cancelToken: cancelToken,
+      timeout: _authzTimeout,
+    );
+
+    final isAdmin = response['is_admin_user'];
+    if (isAdmin is! bool) {
+      throw const MalformedResponseException(
+        message: 'user authz response has no boolean "is_admin_user"',
+      );
+    }
+    return isAdmin;
   }
 
   /// Gets Monty-compatible Python schema validators from the backend.

--- a/packages/soliplex_client/lib/src/domain/attachments.dart
+++ b/packages/soliplex_client/lib/src/domain/attachments.dart
@@ -1,5 +1,0 @@
-/// Name of the sandbox skill, whose presence in a room is the room-level
-/// condition for file uploads.
-///
-/// The rooms API keys a room's `skills` map by this name.
-const sandboxSkillName = 'bubble-sandbox';

--- a/packages/soliplex_client/lib/src/domain/domain.dart
+++ b/packages/soliplex_client/lib/src/domain/domain.dart
@@ -1,5 +1,4 @@
 export 'activity_record.dart';
-export 'attachments.dart';
 export 'auth_provider_config.dart';
 export 'backend_version_info.dart';
 export 'chat_message.dart';

--- a/packages/soliplex_client/lib/src/domain/room.dart
+++ b/packages/soliplex_client/lib/src/domain/room.dart
@@ -1,6 +1,5 @@
 import 'package:meta/meta.dart';
 
-import 'package:soliplex_client/src/domain/attachments.dart';
 import 'package:soliplex_client/src/domain/mcp_client_toolset.dart';
 import 'package:soliplex_client/src/domain/room_agent.dart';
 import 'package:soliplex_client/src/domain/room_skill.dart';
@@ -25,6 +24,8 @@ class Room {
     this.mcpClientToolsets = const {},
     this.toolDefinitions = const [],
     this.aguiFeatureNames = const [],
+    this.acceptsRoomUploads = false,
+    this.acceptsThreadUploads = false,
   });
 
   /// Unique identifier for the room.
@@ -73,6 +74,21 @@ class Room {
   /// AG-UI feature names enabled for this room.
   final List<String> aguiFeatureNames;
 
+  /// Whether the server accepts uploads scoped to this room, as the rooms API
+  /// reports it.
+  ///
+  /// It says nothing about the caller: the server additionally requires an
+  /// administrator to upload here, which is a property of the user rather than
+  /// of the room. A server that reports nothing reads as `false`.
+  final bool acceptsRoomUploads;
+
+  /// Whether the server accepts uploads scoped to threads in this room, as the
+  /// rooms API reports it.
+  ///
+  /// Unlike a room upload, the server does not additionally require an
+  /// administrator. A server that reports nothing reads as `false`.
+  final bool acceptsThreadUploads;
+
   /// Quiz IDs available in this room.
   List<String> get quizIds => quizzes.keys.toList();
 
@@ -94,22 +110,6 @@ class Room {
   /// Whether the room has any AG-UI feature names.
   bool get hasAguiFeatures => aguiFeatureNames.isNotEmpty;
 
-  /// Whether this room can accept uploads scoped to the room itself.
-  ///
-  /// Covers only the room-level condition — the room carries the
-  /// [sandboxSkillName] skill. The server also requires a configured room
-  /// upload path and an administrator caller, neither of which the rooms API
-  /// reports, so `true` means "not ruled out by anything readable here".
-  bool get supportsRoomAttachments => skills.containsKey(sandboxSkillName);
-
-  /// Whether this room can accept uploads scoped to one of its threads.
-  ///
-  /// Covers only the room-level condition — the room carries the
-  /// [sandboxSkillName] skill. The server also requires a configured thread
-  /// upload path, which the rooms API does not report, so `true` means "not
-  /// ruled out by anything readable here".
-  bool get supportsThreadAttachments => skills.containsKey(sandboxSkillName);
-
   /// Creates a copy of this room with the given fields replaced.
   Room copyWith({
     String? id,
@@ -126,6 +126,8 @@ class Room {
     Map<String, McpClientToolset>? mcpClientToolsets,
     List<Map<String, dynamic>>? toolDefinitions,
     List<String>? aguiFeatureNames,
+    bool? acceptsRoomUploads,
+    bool? acceptsThreadUploads,
   }) {
     return Room(
       id: id ?? this.id,
@@ -142,9 +144,16 @@ class Room {
       mcpClientToolsets: mcpClientToolsets ?? this.mcpClientToolsets,
       toolDefinitions: toolDefinitions ?? this.toolDefinitions,
       aguiFeatureNames: aguiFeatureNames ?? this.aguiFeatureNames,
+      acceptsRoomUploads: acceptsRoomUploads ?? this.acceptsRoomUploads,
+      acceptsThreadUploads: acceptsThreadUploads ?? this.acceptsThreadUploads,
     );
   }
 
+  /// Identity, not value: two rooms with the same [id] are equal however much
+  /// else differs. [acceptsRoomUploads] and [acceptsThreadUploads] are among
+  /// what it ignores, so a refetch that changes what the user may upload is
+  /// equal to the room it replaces — do not use this to decide whether a room
+  /// changed.
   @override
   bool operator ==(Object other) {
     if (identical(this, other)) return true;

--- a/packages/soliplex_client/lib/src/utils/parse_utils.dart
+++ b/packages/soliplex_client/lib/src/utils/parse_utils.dart
@@ -45,6 +45,17 @@ int? intOrNull(Object? value, String field) {
   return null;
 }
 
+/// An optional bool field: a present-but-non-bool is logged and dropped rather
+/// than thrown, so one drifted field costs its own value and not the whole
+/// object it belongs to.
+bool? boolOrNull(Object? value, String field) {
+  if (value == null || value is bool) return value as bool?;
+  _logDropped(
+    'field "$field": expected bool, got ${value.runtimeType}; dropped.',
+  );
+  return null;
+}
+
 /// An optional list-of-strings field: a present-but-non-list degrades to empty
 /// and any non-string element is dropped. Both cases are logged; an absent
 /// field is normal and silent.

--- a/packages/soliplex_client/test/api/mappers_test.dart
+++ b/packages/soliplex_client/test/api/mappers_test.dart
@@ -78,6 +78,44 @@ void main() {
   });
 
   group('Room mappers', () {
+    group('roomOmitsUploadCapability', () {
+      Map<String, dynamic> room({
+        Object? roomUploads,
+        Object? threadUploads,
+      }) =>
+          <String, dynamic>{
+            'id': 'r',
+            if (roomUploads != null) 'has_room_uploads': roomUploads,
+            if (threadUploads != null) 'has_thread_uploads': threadUploads,
+          };
+
+      test('is true when a scope is present but null', () {
+        // Absent and explicitly null both have to read as an omission, and the
+        // null fixture is the one that says so: an implementation keying off
+        // `containsKey` passes an absent-field case and fails this one.
+        expect(
+          roomOmitsUploadCapability(<String, dynamic>{
+            'id': 'r',
+            'has_room_uploads': null,
+            'has_thread_uploads': null,
+          }),
+          isTrue,
+        );
+      });
+
+      test('is false when either scope is reported', () {
+        expect(roomOmitsUploadCapability(room(threadUploads: false)), isFalse);
+        expect(roomOmitsUploadCapability(room(roomUploads: false)), isFalse);
+      });
+
+      test('is false when a scope is present but wrongly typed', () {
+        // Not an omission — the server did say. `boolOrNull` records the drift
+        // against the field it arrived in, and saying "omitted" here would
+        // contradict it.
+        expect(roomOmitsUploadCapability(room(roomUploads: 'yes')), isFalse);
+      });
+    });
+
     group('roomFromJson', () {
       test('parses correctly with all fields', () {
         final json = <String, dynamic>{
@@ -95,6 +133,34 @@ void main() {
         expect(room.metadata, equals({'key': 'value'}));
       });
 
+      test('survives a wrong-typed upload capability flag', () {
+        // Throwing here would drop the entire room from the lobby.
+        final json = <String, dynamic>{
+          'id': 'room-1',
+          'name': 'Test Room',
+          'has_room_uploads': 'yes',
+        };
+
+        final room = roomFromJson(json);
+
+        expect(room.id, equals('room-1'));
+        expect(room.acceptsRoomUploads, isFalse);
+      });
+
+      test('parses the upload capability flags', () {
+        final json = <String, dynamic>{
+          'id': 'room-1',
+          'name': 'Test Room',
+          'has_room_uploads': true,
+          'has_thread_uploads': false,
+        };
+
+        final room = roomFromJson(json);
+
+        expect(room.acceptsRoomUploads, isTrue);
+        expect(room.acceptsThreadUploads, isFalse);
+      });
+
       test('parses correctly with only required fields', () {
         final json = <String, dynamic>{'id': 'room-1', 'name': 'Test Room'};
 
@@ -103,6 +169,8 @@ void main() {
         expect(room.id, equals('room-1'));
         expect(room.name, equals('Test Room'));
         expect(room.description, equals(''));
+        expect(room.acceptsRoomUploads, isFalse);
+        expect(room.acceptsThreadUploads, isFalse);
         expect(room.metadata, equals(const <String, dynamic>{}));
       });
 

--- a/packages/soliplex_client/test/api/soliplex_api_test.dart
+++ b/packages/soliplex_client/test/api/soliplex_api_test.dart
@@ -5,6 +5,7 @@ import 'package:mocktail/mocktail.dart';
 // Hide ag_ui's CancelToken to avoid ambiguity.
 import 'package:soliplex_client/soliplex_client.dart' hide CancelToken;
 import 'package:soliplex_client/src/utils/cancel_token.dart';
+import 'package:soliplex_logging/soliplex_logging.dart';
 import 'package:test/test.dart';
 
 class MockHttpTransport extends Mock implements HttpTransport {}
@@ -26,6 +27,17 @@ void main() {
 
     when(() => mockTransport.close()).thenReturn(null);
   });
+
+  /// Attaches a sink for the duration of one test and returns the upload
+  /// capability records written into it.
+  List<LogRecord> Function() captureCapabilityRecords() {
+    final sink = MemorySink();
+    LogManager.instance.addSink(sink);
+    addTearDown(() => LogManager.instance.removeSink(sink));
+    return () => sink.records
+        .where((r) => r.message.contains('upload capability'))
+        .toList();
+  }
 
   tearDown(() {
     api.close();
@@ -232,6 +244,64 @@ void main() {
         expect(rooms, isEmpty);
       });
 
+      test('records once that the server reported no upload capability',
+          () async {
+        // Absence withholds every upload control, which looks exactly like an
+        // installation that has no upload path. Nothing else survives to say
+        // which of the two it was.
+        final capabilityRecords = captureCapabilityRecords();
+        when(
+          () => mockTransport.request<Map<String, dynamic>>(
+            'GET',
+            any(),
+            cancelToken: any(named: 'cancelToken'),
+            fromJson: any(named: 'fromJson'),
+            body: any(named: 'body'),
+            headers: any(named: 'headers'),
+            timeout: any(named: 'timeout'),
+          ),
+        ).thenAnswer(
+          (_) async => {
+            'room-1': {'id': 'room-1', 'name': 'Room 1'},
+            'room-2': {'id': 'room-2', 'name': 'Room 2'},
+          },
+        );
+
+        await api.getRooms();
+        await api.getRooms();
+
+        // Once per server, not once per room per response: the omission
+        // belongs to the release the server runs.
+        expect(capabilityRecords(), hasLength(1));
+      });
+
+      test('says nothing when the server reported a capability', () async {
+        final capabilityRecords = captureCapabilityRecords();
+        when(
+          () => mockTransport.request<Map<String, dynamic>>(
+            'GET',
+            any(),
+            cancelToken: any(named: 'cancelToken'),
+            fromJson: any(named: 'fromJson'),
+            body: any(named: 'body'),
+            headers: any(named: 'headers'),
+            timeout: any(named: 'timeout'),
+          ),
+        ).thenAnswer(
+          (_) async => {
+            'room-1': {
+              'id': 'room-1',
+              'name': 'Room 1',
+              'has_thread_uploads': false,
+            },
+          },
+        );
+
+        await api.getRooms();
+
+        expect(capabilityRecords(), isEmpty);
+      });
+
       test('propagates exceptions', () async {
         when(
           () => mockTransport.request<Map<String, dynamic>>(
@@ -351,6 +421,34 @@ void main() {
 
       test('validates non-empty roomId', () {
         expect(() => api.getRoom(''), throwsA(isA<ArgumentError>()));
+      });
+
+      test('records the omission for a room reached without the listing',
+          () async {
+        // A deep link opens a room without ever listing one, so checking only
+        // the listing would leave the whole path silent.
+        final capabilityRecords = captureCapabilityRecords();
+        when(
+          () => mockTransport.request<Room>(
+            'GET',
+            any(),
+            cancelToken: any(named: 'cancelToken'),
+            fromJson: any(named: 'fromJson'),
+            body: any(named: 'body'),
+            headers: any(named: 'headers'),
+            timeout: any(named: 'timeout'),
+          ),
+        ).thenAnswer((invocation) async {
+          // The transport is what applies `fromJson`, and the capability is
+          // read there so a malformed payload still surfaces as one.
+          final fromJson = invocation.namedArguments[#fromJson]! as Room
+              Function(Map<String, dynamic>);
+          return fromJson(<String, dynamic>{'id': 'room-1', 'name': 'Room 1'});
+        });
+
+        await api.getRoom('room-1');
+
+        expect(capabilityRecords(), hasLength(1));
       });
 
       test('propagates NotFoundException', () async {
@@ -6220,6 +6318,76 @@ void main() {
     // ============================================================
     // Installation Info
     // ============================================================
+
+    group('getIsAdminUser', () {
+      for (final verdict in [true, false]) {
+        test('reports the flag the server sent ($verdict)', () async {
+          // Both directions: answering a fixed verdict would withdraw the
+          // capability from an administrator, or hand it to everyone.
+          when(
+            () => mockTransport.request<Map<String, dynamic>>(
+              'GET',
+              Uri.parse('https://api.example.com/api/v1/user/authz'),
+              cancelToken: any(named: 'cancelToken'),
+              fromJson: any(named: 'fromJson'),
+              body: any(named: 'body'),
+              headers: any(named: 'headers'),
+              timeout: any(named: 'timeout'),
+            ),
+          ).thenAnswer((_) async => {'is_admin_user': verdict});
+
+          expect(await api.getIsAdminUser(), verdict);
+        });
+      }
+
+      test('bounds the wait well below the transport default', () async {
+        // The caller bounds its own wait at three seconds and goes live on a
+        // guess when that expires, so the spinner is never the cost. This
+        // timeout is what keeps the answer that overturns the guess from
+        // arriving minutes later and pulling two live controls out from under
+        // the user mid-session.
+        final captured = <Object?>[];
+        when(
+          () => mockTransport.request<Map<String, dynamic>>(
+            'GET',
+            any(),
+            cancelToken: any(named: 'cancelToken'),
+            fromJson: any(named: 'fromJson'),
+            body: any(named: 'body'),
+            headers: any(named: 'headers'),
+            timeout: any(named: 'timeout'),
+          ),
+        ).thenAnswer((invocation) async {
+          captured.add(invocation.namedArguments[#timeout]);
+          return {'is_admin_user': true};
+        });
+
+        await api.getIsAdminUser();
+
+        expect(captured.single, const Duration(seconds: 15));
+      });
+
+      test('rejects a response with no verdict in it', () async {
+        // Reading a missing flag as "not an admin" would silently withdraw a
+        // capability; the caller must be able to tell it was never answered.
+        when(
+          () => mockTransport.request<Map<String, dynamic>>(
+            'GET',
+            any(),
+            cancelToken: any(named: 'cancelToken'),
+            fromJson: any(named: 'fromJson'),
+            body: any(named: 'body'),
+            headers: any(named: 'headers'),
+            timeout: any(named: 'timeout'),
+          ),
+        ).thenAnswer((_) async => <String, dynamic>{});
+
+        expect(
+          () => api.getIsAdminUser(),
+          throwsA(isA<MalformedResponseException>()),
+        );
+      });
+    });
 
     group('getBackendVersionInfo', () {
       test('returns version info', () async {

--- a/packages/soliplex_client/test/domain/attachments_test.dart
+++ b/packages/soliplex_client/test/domain/attachments_test.dart
@@ -1,8 +1,0 @@
-import 'package:soliplex_client/soliplex_client.dart';
-import 'package:test/test.dart';
-
-void main() {
-  test('sandboxSkillName matches the backend wire key', () {
-    expect(sandboxSkillName, 'bubble-sandbox');
-  });
-}

--- a/packages/soliplex_client/test/domain/room_test.dart
+++ b/packages/soliplex_client/test/domain/room_test.dart
@@ -183,42 +183,5 @@ void main() {
       expect(str, contains('room-1'));
       expect(str, contains('Test Room'));
     });
-
-    // Both scopes read the same room-level condition, so every case asserts
-    // both. That is what makes a later divergence between them deliberate.
-    group('attachment scopes', () {
-      test('both are true when the sandbox skill is present', () {
-        const room = Room(
-          id: 'r1',
-          name: 'Test',
-          skills: {
-            sandboxSkillName: RoomSkill(
-              name: sandboxSkillName,
-              description: 'Sandbox',
-            ),
-          },
-        );
-        expect(room.supportsRoomAttachments, isTrue);
-        expect(room.supportsThreadAttachments, isTrue);
-      });
-
-      test('both are false when the sandbox skill is absent', () {
-        const room = Room(id: 'r1', name: 'Test');
-        expect(room.supportsRoomAttachments, isFalse);
-        expect(room.supportsThreadAttachments, isFalse);
-      });
-
-      test('both are false when only a different skill is present', () {
-        const room = Room(
-          id: 'r1',
-          name: 'Test',
-          skills: {
-            'other-skill': RoomSkill(name: 'other-skill', description: 'Other'),
-          },
-        );
-        expect(room.supportsRoomAttachments, isFalse);
-        expect(room.supportsThreadAttachments, isFalse);
-      });
-    });
   });
 }

--- a/packages/soliplex_client/test/utils/parse_utils_test.dart
+++ b/packages/soliplex_client/test/utils/parse_utils_test.dart
@@ -51,6 +51,20 @@ void main() {
     });
   });
 
+  group('boolOrNull', () {
+    test('returns the value when it is a bool', () {
+      expect(boolOrNull(true, 'field'), isTrue);
+    });
+
+    test('returns null when absent', () {
+      expect(boolOrNull(null, 'field'), isNull);
+    });
+
+    test('degrades a wrong-typed value to null', () {
+      expect(boolOrNull('true', 'field'), isNull);
+    });
+  });
+
   group('stringList', () {
     test('returns an empty list when absent', () {
       expect(stringList(null, 'field'), isEmpty);

--- a/test/helpers/fakes.dart
+++ b/test/helpers/fakes.dart
@@ -1,4 +1,6 @@
 import 'dart:async';
+import 'dart:convert';
+import 'dart:typed_data';
 
 import 'package:soliplex_agent/soliplex_agent.dart' hide AuthException;
 import 'package:soliplex_client/soliplex_client.dart'
@@ -30,6 +32,31 @@ AppIdentity testIdentity() => const AppIdentity(
       appName: 'Test App',
       logoLight: Icon(Icons.bolt),
     );
+
+/// Hands out clients that answer only `GET /user/authz`, counting the asks
+/// across all of them.
+///
+/// One client per server, because a `ServerManager` builds one per entry and a
+/// shared instance would let a second server's unrelated request reach the
+/// stub. The count is shared, and is what a test asserts when it cares whether
+/// an answer was reused or re-fetched — the backend writes an audit record per
+/// ask, so a second ask is a server-side side effect, not a wasted round trip.
+class AuthzOnlyClients {
+  int calls = 0;
+
+  FakeHttpClient create() => FakeHttpClient()
+    ..onRequest = (method, uri) async {
+      if (!uri.path.endsWith('/user/authz')) {
+        throw UnimplementedError(uri.path);
+      }
+      calls++;
+      return HttpResponse(
+        statusCode: 200,
+        bodyBytes: Uint8List.fromList(utf8.encode('{"is_admin_user": true}')),
+        headers: const {'content-type': 'application/json'},
+      );
+    };
+}
 
 /// Minimal HTTP client with configurable responses.
 ///
@@ -205,6 +232,31 @@ class FakeSoliplexApi extends SoliplexApi {
   /// When set, [getRooms] awaits this before returning, letting a test hold a
   /// rooms fetch in flight (e.g. to exercise the rail's staleness guard).
   Completer<void>? roomsGate;
+
+  /// The answer [getIsAdminUser] returns. Defaults to an administrator, so a
+  /// test that does not set it still exercises the upload controls.
+  bool nextIsAdminUser = true;
+
+  /// Thrown by [getIsAdminUser] when set and [isAdminUserGate] is not — a
+  /// gated request fails through its own completer instead. Not typed
+  /// [Exception]: a closed client throws an [Error], and that path is the one
+  /// worth feeding.
+  Object? nextIsAdminUserThrow;
+
+  /// When set, [getIsAdminUser] awaits this before answering, so a test can
+  /// hold a request in flight.
+  Completer<bool>? isAdminUserGate;
+
+  int getIsAdminUserCallCount = 0;
+
+  @override
+  Future<bool> getIsAdminUser({CancelToken? cancelToken}) async {
+    getIsAdminUserCallCount++;
+    final gate = isAdminUserGate;
+    if (gate != null) return gate.future;
+    if (nextIsAdminUserThrow != null) throw nextIsAdminUserThrow!;
+    return nextIsAdminUser;
+  }
 
   List<RagDocument>? nextDocuments;
   Exception? nextDocumentsError;

--- a/test/helpers/test_server_entry.dart
+++ b/test/helpers/test_server_entry.dart
@@ -1,6 +1,7 @@
 import 'dart:convert';
 
 import 'package:soliplex_agent/soliplex_agent.dart';
+import 'package:soliplex_frontend/src/modules/auth/admin_status.dart';
 import 'package:soliplex_frontend/src/modules/auth/auth_session.dart';
 import 'package:soliplex_frontend/src/modules/auth/auth_tokens.dart';
 import 'package:soliplex_frontend/src/modules/auth/server_entry.dart';
@@ -28,6 +29,7 @@ ServerEntry createTestServerEntry({
       api: fakeApi,
       agUiStreamClient: FakeAgUiStreamClient(),
     ),
+    adminStatus: AdminStatus(api: fakeApi, serverId: serverId),
     requiresAuth: requiresAuth,
     name: name,
   );

--- a/test/modules/auth/admin_status_test.dart
+++ b/test/modules/auth/admin_status_test.dart
@@ -1,0 +1,116 @@
+import 'dart:async';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:soliplex_client/soliplex_client.dart';
+import 'package:soliplex_frontend/src/modules/auth/admin_status.dart';
+
+import '../../helpers/fakes.dart';
+
+void main() {
+  late FakeSoliplexApi api;
+  late AdminStatus status;
+
+  setUp(() {
+    api = FakeSoliplexApi();
+    status = AdminStatus(api: api, serverId: 'test');
+  });
+
+  test('asks once and answers every later read from that', () async {
+    api.nextIsAdminUser = true;
+
+    expect(await status.read(), isTrue);
+    expect(await status.read(), isTrue);
+
+    // The backend writes an audit record per call, so a second ask is not a
+    // wasted round trip but a spurious record.
+    expect(api.getIsAdminUserCallCount, 1);
+  });
+
+  test('survives an error that is not an exception', () async {
+    // A closed http client throws StateError from outside its own guard. If
+    // that escaped, the rejected future would stay memoised and the caller
+    // would never resolve.
+    api.nextIsAdminUserThrow = StateError('client closed');
+
+    expect(await status.read(), isNull);
+
+    api.nextIsAdminUserThrow = null;
+    api.nextIsAdminUser = true;
+    expect(await status.read(), isTrue);
+    expect(api.getIsAdminUserCallCount, 2);
+  });
+
+  test('a refusal answers, but is asked again next time', () async {
+    // A 403 is the server answering, not failing to. Folding it into `null`
+    // would hand the caller a grant, so the gate would loosen exactly as the
+    // server tightened.
+    api.nextIsAdminUserThrow = const PermissionDeniedException(
+      message: 'forbidden',
+      statusCode: 403,
+    );
+
+    expect(await status.read(), isFalse);
+    expect(await status.read(), isFalse);
+    // Asked again: within one screen the answer is shared, but a refusal is
+    // the one verdict the client cannot attribute — the installation may have
+    // said it, or something in front of it may have. Keeping it for the
+    // session would leave an administrator refused by a gateway with no way
+    // back short of restarting.
+    expect(api.getIsAdminUserCallCount, 2);
+  });
+
+  test('two reads while a request is in flight both get the answer', () async {
+    final gate = Completer<bool>();
+    api.isAdminUserGate = gate;
+
+    final first = status.read();
+    final second = status.read();
+    gate.complete(true);
+
+    expect(await first, isTrue);
+    expect(await second, isTrue);
+    expect(api.getIsAdminUserCallCount, 1);
+  });
+
+  test('clear makes the next read ask again', () async {
+    api.nextIsAdminUser = true;
+    expect(await status.read(), isTrue);
+
+    status.clear();
+    api.nextIsAdminUser = false;
+
+    expect(await status.read(), isFalse);
+    expect(api.getIsAdminUserCallCount, 2);
+  });
+
+  test('an answer that lands after a clear is not delivered', () async {
+    // It describes whoever was signed in when it was asked, so handing it to
+    // the caller still awaiting would answer for the wrong user.
+    final gate = Completer<bool>();
+    api.isAdminUserGate = gate;
+    final stale = status.read();
+
+    status.clear();
+    gate.complete(true);
+
+    expect(await stale, isNull);
+  });
+
+  test('a failed request does not evict a newer one', () async {
+    final first = Completer<bool>();
+    api.isAdminUserGate = first;
+    final stale = status.read();
+
+    status.clear();
+    api.isAdminUserGate = null;
+    api.nextIsAdminUser = true;
+    expect(await status.read(), isTrue);
+
+    first.completeError(NetworkException(message: 'offline'));
+    await stale;
+
+    // The live answer is still remembered, so nothing re-asks.
+    expect(await status.read(), isTrue);
+    expect(api.getIsAdminUserCallCount, 2);
+  });
+}

--- a/test/modules/auth/server_manager_test.dart
+++ b/test/modules/auth/server_manager_test.dart
@@ -20,10 +20,14 @@ AuthTokens _tokens() => AuthTokens(
       expiresAt: DateTime.now().add(const Duration(hours: 1)),
     );
 
-ServerManager _createManager({InMemoryServerStorage? storage}) {
+ServerManager _createManager({
+  InMemoryServerStorage? storage,
+  AuthzOnlyClients? authz,
+}) {
   return ServerManager(
     authFactory: () => AuthSession(refreshService: FakeTokenRefreshService()),
-    clientFactory: ({getToken, tokenRefresher}) => FakeHttpClient(),
+    clientFactory: ({getToken, tokenRefresher}) =>
+        authz?.create() ?? FakeHttpClient(),
     storage: storage ?? InMemoryServerStorage(),
   );
 }
@@ -342,6 +346,48 @@ void main() {
       entry.auth.logout();
 
       expect(manager.authState.value, isA<Unauthenticated>());
+    });
+
+    test('signing out makes the admin answer be asked again', () async {
+      // Signing out leaves the entry, its connection and its api alive, so
+      // without invalidation the next user to sign in on this device would
+      // read the previous user's answer.
+      final authz = AuthzOnlyClients();
+      final manager = _createManager(authz: authz);
+
+      final entry = manager.addServer(
+        serverId: 'test',
+        serverUrl: Uri.parse('https://api.example.com'),
+      );
+      entry.auth.login(provider: _provider, tokens: _tokens());
+      await entry.adminStatus.read();
+      expect(authz.calls, 1);
+
+      entry.auth.logout();
+      await entry.adminStatus.read();
+
+      expect(authz.calls, 2);
+    });
+
+    test('a token refresh keeps the admin answer', () async {
+      // Each ask is audited, so re-asking on every refresh would turn one
+      // record per session into one per refresh cycle.
+      final authz = AuthzOnlyClients();
+      final manager = _createManager(authz: authz);
+
+      final entry = manager.addServer(
+        serverId: 'test',
+        serverUrl: Uri.parse('https://api.example.com'),
+      );
+      entry.auth.login(provider: _provider, tokens: _tokens());
+      await entry.adminStatus.read();
+      expect(authz.calls, 1);
+
+      // A refresh replaces the session with a new instance for the same user.
+      entry.auth.login(provider: _provider, tokens: _tokens());
+      await entry.adminStatus.read();
+
+      expect(authz.calls, 1);
     });
 
     test('authenticated when no-auth server is added', () {

--- a/test/modules/room/agent_runtime_manager_test.dart
+++ b/test/modules/room/agent_runtime_manager_test.dart
@@ -1,6 +1,7 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:soliplex_agent/soliplex_agent.dart';
 
+import 'package:soliplex_frontend/src/modules/auth/admin_status.dart';
 import 'package:soliplex_frontend/src/modules/auth/auth_session.dart';
 import 'package:soliplex_frontend/src/modules/auth/server_entry.dart';
 import 'package:soliplex_frontend/src/modules/room/agent_runtime_manager.dart';
@@ -13,14 +14,18 @@ ServerConnection _connection(String serverId) => ServerConnection(
       agUiStreamClient: FakeAgUiStreamClient(),
     );
 
-ServerEntry _entry(String serverId) => ServerEntry(
-      serverId: serverId,
-      alias: serverId,
-      serverUrl: Uri.parse('https://$serverId.example.com'),
-      auth: AuthSession(refreshService: FakeTokenRefreshService()),
-      httpClient: FakeHttpClient(),
-      connection: _connection(serverId),
-    );
+ServerEntry _entry(String serverId) {
+  final connection = _connection(serverId);
+  return ServerEntry(
+    serverId: serverId,
+    alias: serverId,
+    serverUrl: Uri.parse('https://$serverId.example.com'),
+    auth: AuthSession(refreshService: FakeTokenRefreshService()),
+    httpClient: FakeHttpClient(),
+    connection: connection,
+    adminStatus: AdminStatus(api: connection.api, serverId: serverId),
+  );
+}
 
 void main() {
   late AgentRuntimeManager manager;

--- a/test/modules/room/room_state_test.dart
+++ b/test/modules/room/room_state_test.dart
@@ -5,6 +5,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:soliplex_agent/soliplex_agent.dart';
 
+import 'package:soliplex_frontend/src/modules/auth/admin_status.dart';
 import 'package:soliplex_frontend/src/modules/auth/auth_session.dart';
 import 'package:soliplex_frontend/src/modules/auth/auth_tokens.dart';
 import 'package:soliplex_frontend/src/modules/auth/return_to_storage.dart';
@@ -104,6 +105,10 @@ ServerEntry _fakeServerEntry(ServerConnection connection) => ServerEntry(
       auth: AuthSession(refreshService: FakeTokenRefreshService()),
       httpClient: FakeHttpClient(),
       connection: connection,
+      adminStatus: AdminStatus(
+        api: connection.api,
+        serverId: connection.serverId,
+      ),
     );
 
 void main() {

--- a/test/modules/room/run_registry_test.dart
+++ b/test/modules/room/run_registry_test.dart
@@ -3,6 +3,7 @@ import 'dart:async';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:soliplex_agent/soliplex_agent.dart';
 
+import 'package:soliplex_frontend/src/modules/auth/admin_status.dart';
 import 'package:soliplex_frontend/src/modules/auth/auth_session.dart';
 import 'package:soliplex_frontend/src/modules/auth/server_entry.dart';
 import 'package:soliplex_frontend/src/modules/room/agent_runtime_manager.dart';
@@ -16,18 +17,22 @@ ServerConnection _fakeConnection(FakeSoliplexApi api) => ServerConnection(
       agUiStreamClient: FakeAgUiStreamClient(),
     );
 
-ServerEntry _entry(String serverId) => ServerEntry(
-      serverId: serverId,
-      alias: serverId,
-      serverUrl: Uri.parse('https://$serverId.example.com'),
-      auth: AuthSession(refreshService: FakeTokenRefreshService()),
-      httpClient: FakeHttpClient(),
-      connection: ServerConnection(
-        serverId: serverId,
-        api: FakeSoliplexApi(),
-        agUiStreamClient: FakeAgUiStreamClient(),
-      ),
-    );
+ServerEntry _entry(String serverId) {
+  final connection = ServerConnection(
+    serverId: serverId,
+    api: FakeSoliplexApi(),
+    agUiStreamClient: FakeAgUiStreamClient(),
+  );
+  return ServerEntry(
+    serverId: serverId,
+    alias: serverId,
+    serverUrl: Uri.parse('https://$serverId.example.com'),
+    auth: AuthSession(refreshService: FakeTokenRefreshService()),
+    httpClient: FakeHttpClient(),
+    connection: connection,
+    adminStatus: AdminStatus(api: connection.api, serverId: serverId),
+  );
+}
 
 const _key = (
   serverId: 'test-server',

--- a/test/modules/room/ui/chat_input_test.dart
+++ b/test/modules/room/ui/chat_input_test.dart
@@ -1184,6 +1184,70 @@ void main() {
       expect(ran, ['filter', 'files', 'folder']);
     });
 
+    testWidgets('a collapsed item refuses once a run takes the composer',
+        (tester) async {
+      // The menu route outlives the build that filled it, so the state it was
+      // enabled under can change while it is open. The buttons it stands in
+      // for go read-only in that window, and a pick started here would land in
+      // a composer that cannot show it.
+      final ran = <String>[];
+      final sessionState = signal<AgentSessionState?>(null);
+
+      await tester.pumpWidget(
+        composer(
+          width: SoliplexBreakpoints.mobile,
+          controller: newController(),
+          filter: true,
+          upload: true,
+          onFiles: () => ran.add('files'),
+          sessionState: sessionState,
+        ),
+      );
+
+      await tester.tap(find.byIcon(Icons.more_horiz));
+      await tester.pumpAndSettle();
+
+      sessionState.value = AgentSessionState.running;
+      await tester.pump();
+
+      await tester.tap(find.text('Upload files…'));
+      await tester.pumpAndSettle();
+
+      expect(ran, isEmpty);
+    });
+
+    testWidgets('an attach item refuses once a run takes the composer',
+        (tester) async {
+      // The same window as the collapsed menu above, on the layout that keeps
+      // its own attach menu: wide enough that the actions are not collapsed,
+      // so the choice arrives through the attach submenu rather than the
+      // combined one. Both routes outlive the build that filled them, and only
+      // one of them was covered.
+      final ran = <String>[];
+      final sessionState = signal<AgentSessionState?>(null);
+
+      await tester.pumpWidget(
+        composer(
+          width: SoliplexBreakpoints.desktop,
+          controller: newController(),
+          upload: true,
+          onFiles: () => ran.add('files'),
+          sessionState: sessionState,
+        ),
+      );
+
+      await tester.tap(find.byIcon(Icons.attach_file));
+      await tester.pumpAndSettle();
+
+      sessionState.value = AgentSessionState.running;
+      await tester.pump();
+
+      await tester.tap(find.text('Files…'));
+      await tester.pumpAndSettle();
+
+      expect(ran, isEmpty);
+    });
+
     testWidgets('a composer with no folder picker collapses to two items',
         (tester) async {
       // A caller that offers file upload but no folder pick: the pair still

--- a/test/modules/room/ui/room_info/features_card_test.dart
+++ b/test/modules/room/ui/room_info/features_card_test.dart
@@ -6,6 +6,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:soliplex_client/soliplex_client.dart';
 
 import 'package:soliplex_frontend/src/modules/room/ui/room_info/features_card.dart';
+import 'package:soliplex_frontend/src/modules/room/ui/room_info/room_info_widgets.dart';
 
 import '../../../../helpers/fakes.dart';
 
@@ -27,44 +28,39 @@ void main() {
   const baseRoom = Room(id: 'r1', name: 'Test Room');
 
   group('FeaturesCard', () {
-    testWidgets('shows a status row per attachment scope', (tester) async {
-      final api = FakeSoliplexApi();
-      await tester.pumpWidget(wrap(
-        FeaturesCard(
-          room: baseRoom.copyWith(
-            skills: const {
-              sandboxSkillName: RoomSkill(
-                name: sandboxSkillName,
-                description: 'Sandbox',
-              ),
-            },
+    // The two rows differ only in which field they read, so a fixture that
+    // sets both alike cannot catch them swapped. Mirrored cases cover all four
+    // cells.
+    for (final (room, thread) in const [(true, false), (false, true)]) {
+      testWidgets('reports room=$room thread=$thread from its own field',
+          (tester) async {
+        final api = FakeSoliplexApi();
+        await tester.pumpWidget(wrap(
+          FeaturesCard(
+            room: baseRoom.copyWith(
+              acceptsRoomUploads: room,
+              acceptsThreadUploads: thread,
+            ),
+            api: api,
+            roomId: 'r1',
           ),
-          api: api,
-          roomId: 'r1',
-        ),
-      ));
-      await tester.pump();
+        ));
+        await tester.pump();
 
-      expect(find.text('Room attachments'), findsOneWidget);
-      expect(find.text('Thread attachments'), findsOneWidget);
-      expect(find.text('Enabled'), findsNWidgets(2));
-    });
+        Finder valueOf(String label, String value) => find.descendant(
+              of: find.ancestor(
+                of: find.text(label),
+                matching: find.byType(InfoRow),
+              ),
+              matching: find.text(value),
+            );
 
-    testWidgets('shows attachments disabled', (tester) async {
-      final api = FakeSoliplexApi();
-      await tester.pumpWidget(wrap(
-        FeaturesCard(
-          room: baseRoom,
-          api: api,
-          roomId: 'r1',
-        ),
-      ));
-      await tester.pump();
-
-      expect(find.text('Room attachments'), findsOneWidget);
-      expect(find.text('Thread attachments'), findsOneWidget);
-      expect(find.text('Disabled'), findsNWidgets(2));
-    });
+        expect(valueOf('Room attachments', room ? 'Enabled' : 'Disabled'),
+            findsOneWidget);
+        expect(valueOf('Thread attachments', thread ? 'Enabled' : 'Disabled'),
+            findsOneWidget);
+      });
+    }
 
     testWidgets('shows MCP row when allowMcp is true', (tester) async {
       final api = FakeSoliplexApi();

--- a/test/modules/room/ui/room_info_screen_test.dart
+++ b/test/modules/room/ui/room_info_screen_test.dart
@@ -224,45 +224,74 @@ void main() {
         );
       });
 
-      testWidgets('an unanswerable request leaves them usable', (tester) async {
-        // Withholding them on a failed request would strip an administrator of
-        // a capability they have; the server still refuses anyone else. The
-        // answer resolves before the bound here, so `onTimeout` never fires —
-        // the sibling below covers the request that outruns it. Asserts the
-        // controls are live rather than merely present, since present-but-
-        // loading is disabled and would read as a refusal.
+      testWidgets('an unanswerable check says so and offers a retry',
+          (tester) async {
+        // The upload POST authorizes through the same installation-side check
+        // this answer comes from, so a check that cannot answer cannot
+        // authorize either. Offering the controls would offer an action whose
+        // every use fails.
         final api = FakeSoliplexApi()
           ..nextIsAdminUserThrow = NetworkException(message: 'offline');
 
         await pumpAs(tester, api);
 
-        expect(buttonFor(tester, 'Upload files to room').isLoading, isFalse);
-        expect(buttonFor(tester, 'Upload folder to room').isLoading, isFalse);
+        expect(find.text('Upload files to room'), findsNothing);
+        expect(
+          find.text("Couldn't check whether you can add files here."),
+          findsOneWidget,
+        );
+        // Not the refusal copy: it names who does add the files, which is a
+        // claim about the user that nothing here established.
+        expect(
+          find.text('An administrator adds files to this room.'),
+          findsNothing,
+        );
       });
 
-      testWidgets('a failure that lands after the bound leaves the guess alone',
+      testWidgets('the retry asks again', (tester) async {
+        // An unanswered check is never kept, so this is a real second request
+        // rather than a replayed non-answer.
+        final api = FakeSoliplexApi()
+          ..nextIsAdminUserThrow = NetworkException(message: 'offline');
+
+        await pumpAs(tester, api);
+        expect(api.getIsAdminUserCallCount, 1);
+
+        api
+          ..nextIsAdminUserThrow = null
+          ..nextIsAdminUser = true;
+        await tester.tap(find.text('Retry'));
+        await tester.pumpAndSettle();
+
+        expect(api.getIsAdminUserCallCount, 2);
+        // The answer that arrives replaces the unknown, so the controls appear.
+        expect(buttonFor(tester, 'Upload files to room').isLoading, isFalse);
+      });
+
+      testWidgets('a check still queued at the bound withholds the controls',
           (tester) async {
-        // The under-load shape: the request outruns the bound, the controls go
-        // live on the guess, and the request then fails outright. Writing that
-        // non-answer over the guess would put the controls back into their
-        // loading state — disabled, with nothing left to resolve them.
+        // The under-load shape: the request's own timeout starts only once it
+        // holds one of six shared connection slots, so an upload already
+        // running can keep it queued far past that timeout.
         final gate = Completer<bool>();
         final api = FakeSoliplexApi()..isAdminUserGate = gate;
 
         await tester.pumpWidget(_buildScreen(api: api));
         await tester.pump();
         await tester.pump(const Duration(seconds: 5));
-        expect(buttonFor(tester, 'Upload files to room').isLoading, isFalse);
 
-        gate.completeError(NetworkException(message: 'offline'));
-        // Pumped rather than settled: were the guess overwritten, the spinner
-        // that replaced it would animate forever and settling would hang
-        // instead of failing the assertion below.
-        await tester.pump();
-        await tester.pump();
+        expect(find.text('Upload files to room'), findsNothing);
+        expect(
+          find.text("Couldn't check whether you can add files here."),
+          findsOneWidget,
+        );
+
+        // The bound does not end the request: an answer arriving later still
+        // replaces what the bound wrote, in either direction.
+        gate.complete(true);
+        await tester.pumpAndSettle();
 
         expect(buttonFor(tester, 'Upload files to room').isLoading, isFalse);
-        expect(buttonFor(tester, 'Upload folder to room').isLoading, isFalse);
       });
 
       testWidgets('they are present but not usable until the answer arrives',
@@ -288,31 +317,30 @@ void main() {
         expect(buttonFor(tester, 'Upload folder to room').isLoading, isFalse);
       });
 
-      testWidgets(
-          'they go live at the bound, and a later refusal withdraws '
-          'them', (tester) async {
-        // Loading is disabled, and the request's own timeout starts only once
-        // it holds one of six shared connection slots — so uploads already
-        // running can keep it queued well past that timeout, and waiting
-        // unbounded would strip an administrator of a capability they have.
-        //
-        // The guess that bound produces must not then stand for the life of
-        // the screen: left standing, it hands a non-administrator two controls
-        // whose every use the server refuses once they have chosen a file.
+      testWidgets('a refusal after the bound replaces the unknown',
+          (tester) async {
+        // The other polarity of the late answer: the check outruns the bound,
+        // then the installation says no. The client may name who adds the
+        // files only once it has been told.
         final gate = Completer<bool>();
         final api = FakeSoliplexApi()..isAdminUserGate = gate;
 
         await tester.pumpWidget(_buildScreen(api: api));
         await tester.pump();
         await tester.pump(const Duration(seconds: 5));
-        // Live, not merely present — this is the guess the answer overturns.
-        expect(buttonFor(tester, 'Upload files to room').isLoading, isFalse);
 
         gate.complete(false);
         await tester.pumpAndSettle();
 
         expect(find.text('Upload files to room'), findsNothing);
-        expect(find.text('Upload folder to room'), findsNothing);
+        expect(
+          find.text('An administrator adds files to this room.'),
+          findsOneWidget,
+        );
+        expect(
+          find.text("Couldn't check whether you can add files here."),
+          findsNothing,
+        );
       });
     });
 

--- a/test/modules/room/ui/room_info_screen_test.dart
+++ b/test/modules/room/ui/room_info_screen_test.dart
@@ -3,6 +3,7 @@ import 'dart:async';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:soliplex_agent/soliplex_agent.dart';
+import 'package:soliplex_design/soliplex_design.dart';
 
 import 'package:soliplex_frontend/src/modules/auth/server_entry.dart';
 import 'package:soliplex_frontend/src/shared/selectable_content.dart';
@@ -12,14 +13,13 @@ import 'package:soliplex_frontend/src/modules/room/upload_tracker_registry.dart'
 import '../../../helpers/fakes.dart';
 import '../../../helpers/test_server_entry.dart';
 
-const _sandboxSkill = RoomSkill(name: sandboxSkillName, description: 'Sandbox');
-
 const _testRoom = Room(
   id: 'room-1',
   name: 'Test Room',
   description: 'A test room',
-  skills: {sandboxSkillName: _sandboxSkill},
   allowMcp: true,
+  acceptsRoomUploads: true,
+  acceptsThreadUploads: true,
   agent: DefaultRoomAgent(
     id: 'agent-1',
     modelName: 'gpt-4o',
@@ -142,8 +142,192 @@ void main() {
       await tester.pumpAndSettle();
 
       expect(find.text('FEATURES'), findsOneWidget);
-      // One attachments row per scope.
-      expect(find.text('Enabled'), findsNWidgets(2));
+    });
+
+    group('room upload controls', () {
+      // Uploading to a room needs an administrator; reading the list does not.
+      Future<void> pumpAs(WidgetTester tester, FakeSoliplexApi api) async {
+        await tester.pumpWidget(_buildScreen(api: api));
+        await tester.pumpAndSettle();
+        await tester.scrollUntilVisible(
+          // Not the exact string: the card titles itself 'UPLOADED FILES (n)'
+          // once it has any, and this group scrolls to it with and without.
+          find.textContaining('UPLOADED FILES'),
+          200,
+          scrollable: find.byType(Scrollable).first,
+        );
+      }
+
+      SoliplexButton buttonFor(WidgetTester tester, String label) =>
+          tester.widget<SoliplexButton>(
+            find.ancestor(
+              of: find.text(label),
+              matching: find.byType(SoliplexButton),
+            ),
+          );
+
+      testWidgets('an administrator gets the plain empty message',
+          (tester) async {
+        // The other arm names who adds the files. Saying that to the person
+        // who does would be wrong, and it is the only thing that tells the two
+        // empty states apart.
+        final api = FakeSoliplexApi()..nextIsAdminUser = true;
+
+        await pumpAs(tester, api);
+
+        expect(find.text('No uploaded files in this room.'), findsOneWidget);
+        expect(
+          find.text('An administrator adds files to this room.'),
+          findsNothing,
+        );
+      });
+
+      testWidgets('everyone else gets the list and an explanation',
+          (tester) async {
+        final api = FakeSoliplexApi()..nextIsAdminUser = false;
+
+        await pumpAs(tester, api);
+
+        expect(find.text('Upload files to room'), findsNothing);
+        expect(find.text('Upload folder to room'), findsNothing);
+        // The card itself stays: members see what the agent can cite.
+        expect(find.text('UPLOADED FILES'), findsOneWidget);
+        expect(find.text('No uploaded files in this room.'), findsOneWidget);
+        expect(
+          find.text('An administrator adds files to this room.'),
+          findsOneWidget,
+        );
+      });
+
+      testWidgets('the explanation does not depend on the list being empty',
+          (tester) async {
+        // It stands in for the controls, so it belongs wherever they were
+        // withdrawn. Carried by the empty message it would be unreachable in
+        // exactly the rooms that have something to show, and the controls
+        // would vanish with nothing anywhere saying why.
+        final api = FakeSoliplexApi()
+          ..nextIsAdminUser = false
+          ..nextRoomUploads = [
+            FileUpload(
+              filename: 'shared.pdf',
+              url: Uri.parse('https://example.com/shared.pdf'),
+            ),
+          ];
+
+        await pumpAs(tester, api);
+
+        expect(find.text('shared.pdf'), findsOneWidget);
+        expect(find.text('Upload files to room'), findsNothing);
+        expect(
+          find.text('An administrator adds files to this room.'),
+          findsOneWidget,
+        );
+      });
+
+      testWidgets('an unanswerable request leaves them usable', (tester) async {
+        // Withholding them on a failed request would strip an administrator of
+        // a capability they have; the server still refuses anyone else. The
+        // answer resolves before the bound here, so `onTimeout` never fires —
+        // the sibling below covers the request that outruns it. Asserts the
+        // controls are live rather than merely present, since present-but-
+        // loading is disabled and would read as a refusal.
+        final api = FakeSoliplexApi()
+          ..nextIsAdminUserThrow = NetworkException(message: 'offline');
+
+        await pumpAs(tester, api);
+
+        expect(buttonFor(tester, 'Upload files to room').isLoading, isFalse);
+        expect(buttonFor(tester, 'Upload folder to room').isLoading, isFalse);
+      });
+
+      testWidgets('a failure that lands after the bound leaves the guess alone',
+          (tester) async {
+        // The under-load shape: the request outruns the bound, the controls go
+        // live on the guess, and the request then fails outright. Writing that
+        // non-answer over the guess would put the controls back into their
+        // loading state — disabled, with nothing left to resolve them.
+        final gate = Completer<bool>();
+        final api = FakeSoliplexApi()..isAdminUserGate = gate;
+
+        await tester.pumpWidget(_buildScreen(api: api));
+        await tester.pump();
+        await tester.pump(const Duration(seconds: 5));
+        expect(buttonFor(tester, 'Upload files to room').isLoading, isFalse);
+
+        gate.completeError(NetworkException(message: 'offline'));
+        // Pumped rather than settled: were the guess overwritten, the spinner
+        // that replaced it would animate forever and settling would hang
+        // instead of failing the assertion below.
+        await tester.pump();
+        await tester.pump();
+
+        expect(buttonFor(tester, 'Upload files to room').isLoading, isFalse);
+        expect(buttonFor(tester, 'Upload folder to room').isLoading, isFalse);
+      });
+
+      testWidgets('they are present but not usable until the answer arrives',
+          (tester) async {
+        // An absent control would read as a refusal, so the wait renders as a
+        // control on its way instead.
+        final gate = Completer<bool>();
+        final api = FakeSoliplexApi()..isAdminUserGate = gate;
+
+        // Pumped rather than settled: the loading spinner animates forever, so
+        // there is no quiet frame to settle to until the answer lands.
+        await tester.pumpWidget(_buildScreen(api: api));
+        await tester.pump();
+        await tester.pump();
+
+        expect(buttonFor(tester, 'Upload files to room').isLoading, isTrue);
+        expect(buttonFor(tester, 'Upload folder to room').isLoading, isTrue);
+
+        gate.complete(true);
+        await tester.pumpAndSettle();
+
+        expect(buttonFor(tester, 'Upload files to room').isLoading, isFalse);
+        expect(buttonFor(tester, 'Upload folder to room').isLoading, isFalse);
+      });
+
+      testWidgets(
+          'they go live at the bound, and a later refusal withdraws '
+          'them', (tester) async {
+        // Loading is disabled, and the request's own timeout starts only once
+        // it holds one of six shared connection slots — so uploads already
+        // running can keep it queued well past that timeout, and waiting
+        // unbounded would strip an administrator of a capability they have.
+        //
+        // The guess that bound produces must not then stand for the life of
+        // the screen: left standing, it hands a non-administrator two controls
+        // whose every use the server refuses once they have chosen a file.
+        final gate = Completer<bool>();
+        final api = FakeSoliplexApi()..isAdminUserGate = gate;
+
+        await tester.pumpWidget(_buildScreen(api: api));
+        await tester.pump();
+        await tester.pump(const Duration(seconds: 5));
+        // Live, not merely present — this is the guess the answer overturns.
+        expect(buttonFor(tester, 'Upload files to room').isLoading, isFalse);
+
+        gate.complete(false);
+        await tester.pumpAndSettle();
+
+        expect(find.text('Upload files to room'), findsNothing);
+        expect(find.text('Upload folder to room'), findsNothing);
+      });
+    });
+
+    testWidgets(
+        'hides the uploaded files card when the room accepts no room '
+        'uploads', (tester) async {
+      // Thread capability on, room capability off: the card is room-scoped, so
+      // reading the wrong field would show it and fetch a list the server has
+      // no path for.
+      await tester.pumpWidget(_buildScreen(
+        room: _testRoom.copyWith(acceptsRoomUploads: false),
+      ));
+      await tester.pumpAndSettle();
+
+      expect(find.text('UPLOADED FILES'), findsNothing);
     });
 
     testWidgets('shows tools section', (tester) async {

--- a/test/modules/room/ui/room_screen_test.dart
+++ b/test/modules/room/ui/room_screen_test.dart
@@ -23,6 +23,7 @@ import 'package:soliplex_frontend/src/modules/room/thread_read_markers.dart';
 import 'package:soliplex_frontend/src/modules/room/ui/chat_classification.dart';
 import 'package:soliplex_frontend/src/modules/room/ui/chat_input.dart';
 import 'package:soliplex_frontend/src/modules/room/ui/room_rail.dart';
+import 'package:soliplex_frontend/src/modules/room/ui/upload_event_banner.dart';
 import 'package:soliplex_frontend/src/shared/type_to_focus.dart';
 import 'package:soliplex_frontend/src/modules/room/ui/room_screen.dart';
 import 'package:soliplex_frontend/src/modules/room/ui/thread_sidebar.dart';
@@ -33,8 +34,6 @@ import 'package:soliplex_frontend/src/modules/auth/server_entry.dart';
 
 import '../../../helpers/fakes.dart';
 import '../../../helpers/test_server_entry.dart';
-
-const _sandboxSkill = RoomSkill(name: sandboxSkillName, description: 'Sandbox');
 
 class _BlockingThreadsApi extends FakeSoliplexApi {
   final _completer = Completer<List<ThreadInfo>>();
@@ -670,7 +669,8 @@ void main() {
       api.nextRoom = const Room(
         id: 'room-1',
         name: 'Attachable',
-        skills: {sandboxSkillName: _sandboxSkill},
+        acceptsRoomUploads: true,
+        acceptsThreadUploads: true,
       );
       api.nextThreads = const [];
       api.nextRoomUploads = [
@@ -1076,7 +1076,8 @@ void main() {
     api.nextRoom = const Room(
       id: 'room-1',
       name: 'Attachable',
-      skills: {sandboxSkillName: _sandboxSkill},
+      acceptsRoomUploads: true,
+      acceptsThreadUploads: true,
     );
     api.nextThreads = const [];
     // nextRoomUploads / nextThreadUploads default to empty → the chip
@@ -1110,7 +1111,8 @@ void main() {
     api.nextRoom = const Room(
       id: 'room-1',
       name: 'Attachable',
-      skills: {sandboxSkillName: _sandboxSkill},
+      acceptsRoomUploads: true,
+      acceptsThreadUploads: true,
     );
     api.nextThreads = const [];
     api.nextRoomUploads = [
@@ -1151,7 +1153,8 @@ void main() {
     api.nextRoom = const Room(
       id: 'room-1',
       name: 'Attachable',
-      skills: {sandboxSkillName: _sandboxSkill},
+      acceptsRoomUploads: true,
+      acceptsThreadUploads: true,
     );
     api.nextThreads = const [];
     api.nextRoomUploads = [
@@ -1188,7 +1191,8 @@ void main() {
     api.nextRoom = const Room(
       id: 'room-1',
       name: 'Attachable',
-      skills: {sandboxSkillName: _sandboxSkill},
+      acceptsRoomUploads: true,
+      acceptsThreadUploads: true,
     );
     api.nextThreads = const [];
     api.nextRoomUploadsError =
@@ -1245,16 +1249,25 @@ void main() {
   });
 
   group('attachment detection', () {
-    testWidgets('welcome composer shows attach when room has sandbox skill',
-        (tester) async {
+    testWidgets(
+        'the room scope renders when only threads '
+        'accept uploads', (tester) async {
+      // Records into the scope directly rather than through a pick: there is
+      // no seam to drive the picker, so what this pins is the rendering gate,
+      // not the routing into it. The routing is why the gate matters — a pick
+      // made in the welcome composer is filed against the room scope, there
+      // being no thread yet to route it to — and it has no coverage.
+      //
+      // The surface is the attached-files control and its panel, not the event
+      // banner, which only reports transitions of uploads it saw start.
       tester.view.physicalSize = const Size(1200, 800);
       tester.view.devicePixelRatio = 1.0;
       addTearDown(tester.view.resetPhysicalSize);
 
       api.nextRoom = const Room(
         id: 'room-1',
-        name: 'Attachable',
-        skills: {sandboxSkillName: _sandboxSkill},
+        name: 'Plain',
+        acceptsThreadUploads: true,
       );
       api.nextThreads = const [];
 
@@ -1271,16 +1284,224 @@ void main() {
       ));
       await tester.pumpAndSettle();
 
-      expect(find.byIcon(Icons.attach_file), findsOneWidget);
+      uploadRegistry
+          .trackerFor(entry: entry, roomId: 'room-1')
+          .recordClientError(
+            roomId: 'room-1',
+            filename: 'notes.pdf',
+            message: 'Could not read the file.',
+          );
+      await tester.pumpAndSettle();
+
+      // The control reports the failure before it is opened, and opening it
+      // names the file that failed.
+      await tester.tap(find.byIcon(Icons.error_outline));
+      await tester.pumpAndSettle();
+
+      expect(find.text('notes.pdf'), findsOneWidget);
+      expect(find.text('Could not read the file.'), findsOneWidget);
     });
 
-    testWidgets('welcome composer hides attach without the sandbox skill',
+    testWidgets('the attached-files panel closes with its last row',
+        (tester) async {
+      // The control that opens the panel is the only thing that closes it, and
+      // it is withdrawn once neither scope has anything to show. Dismissing
+      // the last row is the ordinary way to reach that, so a panel that
+      // outlived the control would hold the viewport for the rest of the visit.
+      tester.view.physicalSize = const Size(1200, 800);
+      tester.view.devicePixelRatio = 1.0;
+      addTearDown(tester.view.resetPhysicalSize);
+
+      api.nextRoom = const Room(
+        id: 'room-1',
+        name: 'Plain',
+        acceptsThreadUploads: true,
+      );
+      api.nextThreads = const [];
+
+      await tester.pumpWidget(MaterialApp(
+        home: RoomScreen(
+          serverEntry: entry,
+          roomId: 'room-1',
+          threadId: null,
+          runtimeManager: runtimeManager,
+          registry: registry,
+          uploadRegistry: uploadRegistry,
+          documentSelections: DocumentSelections(),
+        ),
+      ));
+      await tester.pumpAndSettle();
+
+      uploadRegistry
+          .trackerFor(entry: entry, roomId: 'room-1')
+          .recordClientError(
+            roomId: 'room-1',
+            filename: 'notes.pdf',
+            message: 'Could not read the file.',
+          );
+      await tester.pumpAndSettle();
+      await tester.tap(find.byIcon(Icons.error_outline));
+      await tester.pumpAndSettle();
+      expect(find.text('notes.pdf'), findsOneWidget);
+
+      await tester.tap(find.byTooltip('Dismiss'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('notes.pdf'), findsNothing);
+      // The panel renders nothing of its own once both scopes are empty, so
+      // its absence is only observable through its key.
+      expect(find.byKey(filePanelKey), findsNothing);
+
+      // And the ask lapsed with it. Left set, the flag would reopen the panel
+      // over the conversation the moment anything landed in either scope —
+      // taking 40% of the viewport with no tap behind it.
+      uploadRegistry
+          .trackerFor(entry: entry, roomId: 'room-1')
+          .recordClientError(
+            roomId: 'room-1',
+            filename: 'later.pdf',
+            message: 'Could not read the file.',
+          );
+      await tester.pumpAndSettle();
+
+      expect(find.byKey(filePanelKey), findsNothing);
+      // The control is back, so the user can still open it deliberately.
+      expect(find.byIcon(Icons.error_outline), findsOneWidget);
+    });
+
+    testWidgets(
+        'the attached-files panel does not follow the user into '
+        'another thread', (tester) async {
+      // The panel is opened over one conversation, and the flag that holds it
+      // open is not the panel. A scope fetched for the first time reads as
+      // content while it loads, so a flag left set would pop a spinner over
+      // the arriving thread and close again when the fetch landed.
+      tester.view.physicalSize = const Size(1200, 800);
+      tester.view.devicePixelRatio = 1.0;
+      addTearDown(tester.view.resetPhysicalSize);
+
+      api.nextRoom = const Room(
+        id: 'room-1',
+        name: 'Plain',
+        acceptsThreadUploads: true,
+      );
+      api.nextThreads = const [];
+
+      Widget screen(String? threadId) => MaterialApp(
+            home: RoomScreen(
+              serverEntry: entry,
+              roomId: 'room-1',
+              threadId: threadId,
+              runtimeManager: runtimeManager,
+              registry: registry,
+              uploadRegistry: uploadRegistry,
+              documentSelections: DocumentSelections(),
+            ),
+          );
+
+      await tester.pumpWidget(screen(null));
+      await tester.pumpAndSettle();
+
+      uploadRegistry
+          .trackerFor(entry: entry, roomId: 'room-1')
+          .recordClientError(
+            roomId: 'room-1',
+            filename: 'notes.pdf',
+            message: 'Could not read the file.',
+          );
+      await tester.pumpAndSettle();
+      await tester.tap(find.byIcon(Icons.error_outline));
+      await tester.pumpAndSettle();
+      expect(find.byKey(filePanelKey), findsOneWidget);
+
+      await tester.pumpWidget(screen('thread-1'));
+      await tester.pump();
+
+      expect(find.byKey(filePanelKey), findsNothing);
+    });
+
+    testWidgets('the thread view keeps the room-scope banner', (tester) async {
+      // Inside a thread there is only one banner, and it subscribes to both
+      // scopes. Gating it on the thread capability alone drops room-scope
+      // events in a room that takes room uploads and not thread ones — the
+      // shape the welcome view's banner comment reasons about, which does not
+      // transfer here because that one subscribes to the room scope only.
+      tester.view.physicalSize = const Size(1200, 800);
+      tester.view.devicePixelRatio = 1.0;
+      addTearDown(tester.view.resetPhysicalSize);
+
+      api.nextRoom = const Room(
+        id: 'room-1',
+        name: 'RoomUploadsOnly',
+        acceptsRoomUploads: true,
+      );
+      api.nextThreads = const [];
+
+      await tester.pumpWidget(MaterialApp(
+        home: RoomScreen(
+          serverEntry: entry,
+          roomId: 'room-1',
+          threadId: 'thread-1',
+          runtimeManager: runtimeManager,
+          registry: registry,
+          uploadRegistry: uploadRegistry,
+          documentSelections: DocumentSelections(),
+        ),
+      ));
+      await tester.pumpAndSettle();
+
+      expect(find.byType(UploadEventBanner), findsOneWidget);
+    });
+
+    testWidgets('the room upload banner is wired into the welcome view',
+        (tester) async {
+      // Presence, deliberately: this pins that the banner is mounted at all.
+      // The gate's other direction is unobservable — the banner reports only
+      // transitions of uploads it saw start, and the sole producer of a
+      // room-scope pending row is the room-info card, which is itself gated on
+      // the room capability. So a room without it has nothing to show whether
+      // the banner is mounted or not.
+      tester.view.physicalSize = const Size(1200, 800);
+      tester.view.devicePixelRatio = 1.0;
+      addTearDown(tester.view.resetPhysicalSize);
+
+      api.nextRoom = const Room(
+        id: 'room-1',
+        name: 'Plain',
+        acceptsRoomUploads: true,
+      );
+      api.nextThreads = const [];
+
+      await tester.pumpWidget(MaterialApp(
+        home: RoomScreen(
+          serverEntry: entry,
+          roomId: 'room-1',
+          threadId: null,
+          runtimeManager: runtimeManager,
+          registry: registry,
+          uploadRegistry: uploadRegistry,
+          documentSelections: DocumentSelections(),
+        ),
+      ));
+      await tester.pumpAndSettle();
+
+      expect(find.byType(UploadEventBanner), findsOneWidget);
+    });
+
+    testWidgets(
+        'welcome composer hides attach when the room accepts no thread uploads',
         (tester) async {
       tester.view.physicalSize = const Size(1200, 800);
       tester.view.devicePixelRatio = 1.0;
       addTearDown(tester.view.resetPhysicalSize);
 
-      api.nextRoom = const Room(id: 'room-1', name: 'Plain');
+      // Room capability on, thread capability off: the composer gate is
+      // thread-scoped, so reading the room field would wrongly show attach.
+      api.nextRoom = const Room(
+        id: 'room-1',
+        name: 'Plain',
+        acceptsRoomUploads: true,
+      );
       api.nextThreads = const [];
 
       await tester.pumpWidget(MaterialApp(
@@ -1338,10 +1559,43 @@ void main() {
       expect(first, isNot(welcome));
     });
 
-    testWidgets('a room without the sandbox skill can still add an image',
+    testWidgets(
+        'welcome composer shows attach when the room accepts thread uploads',
         (tester) async {
-      // An inline image is a property of the model, not of the room's skills,
-      // so the affordance this room has no paperclip for must still be here.
+      // The mirror of the hiding case above: room capability off, thread
+      // capability on. The pair is what catches the two fields being swapped,
+      // which either one alone would read as correct.
+      tester.view.physicalSize = const Size(1200, 800);
+      tester.view.devicePixelRatio = 1.0;
+      addTearDown(tester.view.resetPhysicalSize);
+
+      api.nextRoom = const Room(
+        id: 'room-1',
+        name: 'Attachable',
+        acceptsThreadUploads: true,
+      );
+      api.nextThreads = const [];
+
+      await tester.pumpWidget(MaterialApp(
+        home: RoomScreen(
+          serverEntry: entry,
+          roomId: 'room-1',
+          threadId: null,
+          runtimeManager: runtimeManager,
+          registry: registry,
+          uploadRegistry: uploadRegistry,
+          documentSelections: DocumentSelections(),
+        ),
+      ));
+      await tester.pumpAndSettle();
+
+      expect(find.byIcon(Icons.attach_file), findsOneWidget);
+    });
+
+    testWidgets('a room that accepts no uploads can still add an image',
+        (tester) async {
+      // An inline image travels in the message, not as a file uploaded to the
+      // thread, so the affordance this room has no paperclip for must remain.
       tester.view.physicalSize = const Size(1200, 800);
       tester.view.devicePixelRatio = 1.0;
       addTearDown(tester.view.resetPhysicalSize);
@@ -1364,86 +1618,6 @@ void main() {
 
       expect(find.byIcon(Icons.attach_file), findsNothing);
       expect(find.byTooltip('Add image'), findsOneWidget);
-    });
-
-    // A thread's replayed AG-UI state does not decide attachment support; the
-    // room capability does. Both fixtures were shipped bugs: `{}` is the
-    // freshly created thread whose only run is unfinished, and `{'rag': ...}`
-    // is what a real sandbox+RAG room replays.
-    for (final (label, aguiState) in const <(String, Map<String, dynamic>)>[
-      ('empty', {}),
-      ('rag-only', {'rag': <String, dynamic>{}}),
-    ]) {
-      testWidgets(
-          'active thread with $label AG-UI state shows attach when the room '
-          'has the skill', (tester) async {
-        tester.view.physicalSize = const Size(1200, 800);
-        tester.view.devicePixelRatio = 1.0;
-        addTearDown(tester.view.resetPhysicalSize);
-
-        api.nextRoom = const Room(
-          id: 'room-1',
-          name: 'Attachable',
-          skills: {sandboxSkillName: _sandboxSkill},
-        );
-        api.nextThreads = const [];
-        api.nextThreadHistory = ThreadHistory(
-          messages: const [],
-          aguiState: aguiState,
-        );
-
-        await tester.pumpWidget(MaterialApp(
-          home: RoomScreen(
-            serverEntry: entry,
-            roomId: 'room-1',
-            threadId: 'thread-1',
-            runtimeManager: runtimeManager,
-            registry: registry,
-            uploadRegistry: uploadRegistry,
-            documentSelections: DocumentSelections(),
-          ),
-        ));
-        await tester.pumpAndSettle();
-
-        expect(find.byIcon(Icons.attach_file), findsOneWidget);
-      });
-    }
-
-    testWidgets('registry-restored thread shows attach from the room skill',
-        (tester) async {
-      tester.view.physicalSize = const Size(1200, 800);
-      tester.view.devicePixelRatio = 1.0;
-      addTearDown(tester.view.resetPhysicalSize);
-
-      // Room has the skill; a live session is pre-registered so ThreadViewState
-      // restores from the registry and never fetches history (the sendToNewThread
-      // / return-to-running-thread path). The gate depends entirely on the room
-      // having loaded, so attach must still show.
-      api.nextRoom = const Room(
-        id: 'room-1',
-        name: 'Attachable',
-        skills: {sandboxSkillName: _sandboxSkill},
-      );
-      api.nextThreads = const [];
-      final key =
-          (serverId: entry.serverId, roomId: 'room-1', threadId: 'thread-1');
-      registry.register(key, ManualAgentSession(key));
-
-      await tester.pumpWidget(MaterialApp(
-        home: RoomScreen(
-          serverEntry: entry,
-          roomId: 'room-1',
-          threadId: 'thread-1',
-          runtimeManager: runtimeManager,
-          registry: registry,
-          uploadRegistry: uploadRegistry,
-          documentSelections: DocumentSelections(),
-        ),
-      ));
-      await tester.pump();
-      await tester.pump();
-
-      expect(find.byIcon(Icons.attach_file), findsOneWidget);
     });
   });
 

--- a/test/modules/room/upload_tracker_registry_test.dart
+++ b/test/modules/room/upload_tracker_registry_test.dart
@@ -2,6 +2,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:soliplex_agent/soliplex_agent.dart';
 import 'package:soliplex_client/soliplex_client.dart';
+import 'package:soliplex_frontend/src/modules/auth/admin_status.dart';
 import 'package:soliplex_frontend/src/modules/auth/auth_session.dart';
 import 'package:soliplex_frontend/src/modules/auth/server_entry.dart';
 import 'package:soliplex_frontend/src/modules/room/upload_tracker_registry.dart';
@@ -20,13 +21,15 @@ class _FakeServerConnection extends Fake implements ServerConnection {
 class _MockSoliplexApi extends Mock implements SoliplexApi {}
 
 ServerEntry _entry(String serverId, {SoliplexApi? api}) {
+  final entryApi = api ?? _MockSoliplexApi();
   return ServerEntry(
     serverId: serverId,
     alias: serverId,
     serverUrl: Uri.parse('https://$serverId.example.com'),
     auth: AuthSession(refreshService: FakeTokenRefreshService()),
     httpClient: _FakeHttpClient(),
-    connection: _FakeServerConnection(api ?? _MockSoliplexApi()),
+    connection: _FakeServerConnection(entryApi),
+    adminStatus: AdminStatus(api: entryApi, serverId: serverId),
   );
 }
 

--- a/test/modules/room/upload_tracker_test.dart
+++ b/test/modules/room/upload_tracker_test.dart
@@ -117,6 +117,89 @@ void main() {
   });
 
   group('fetch failure', () {
+    test('a 404 is an empty shelf, not a failure', () async {
+      // The scope's upload path is not configured, which the server reports by
+      // having no list to give rather than by failing to give one. Rendering
+      // that as an error puts a permanent red row on every visit to a room
+      // that is simply not set up for uploads to this scope.
+      when(() => mockApi.getRoomUploads(
+            any(),
+            cancelToken: any(named: 'cancelToken'),
+          )).thenThrow(
+        const NotFoundException(message: 'Room uploads not configured'),
+      );
+
+      unawaited(tracker.refreshRoom('room-1'));
+      await _pump();
+
+      final status = tracker.roomUploads('room-1').value;
+      expect(status, isA<UploadsLoaded>());
+      expect((status as UploadsLoaded).uploads, isEmpty);
+    });
+
+    test('a 404 after a successful load keeps the list', () async {
+      // The same bare 404 answers three server conditions: no upload path, an
+      // unknown room, and a room this user may no longer read — the membership
+      // check runs ahead of the path check. Only the first is an empty shelf,
+      // and it never reaches a loaded scope. Reading the others as empty would
+      // retract rows already on screen and say nothing about why.
+      when(() => mockApi.getRoomUploads(
+            any(),
+            cancelToken: any(named: 'cancelToken'),
+          )).thenAnswer((_) async => [_fileUpload('shared.pdf')]);
+
+      unawaited(tracker.refreshRoom('room-1'));
+      await _pump();
+      expect(
+        (tracker.roomUploads('room-1').value as UploadsLoaded).uploads,
+        hasLength(1),
+      );
+
+      when(() => mockApi.getRoomUploads(
+            any(),
+            cancelToken: any(named: 'cancelToken'),
+          )).thenThrow(const NotFoundException(message: 'No such room'));
+
+      unawaited(tracker.refreshRoom('room-1'));
+      await _pump();
+
+      final status = tracker.roomUploads('room-1').value;
+      expect(status, isA<UploadsLoaded>());
+      expect((status as UploadsLoaded).uploads, hasLength(1));
+    });
+
+    test('a 404 on a scope carrying only a local failure is still empty',
+        () async {
+      // The arm asks `persisted == null` — has a server list ever been shown —
+      // and a pick failure filed against the scope is not one. Asking instead
+      // whether the signal is Loaded conflates the two: such a scope would take
+      // the keep-the-list path and leave `persisted` null, so dismissing that
+      // row would leave nothing to emit and `_emit`'s no-list-and-nothing-local
+      // guard would hold the dismissed row on screen.
+      when(() => mockApi.getRoomUploads(
+            any(),
+            cancelToken: any(named: 'cancelToken'),
+          )).thenThrow(const NotFoundException(message: 'not configured'));
+
+      tracker.recordClientError(
+        roomId: 'room-1',
+        filename: 'notes.pdf',
+        message: 'Could not read the file.',
+      );
+      unawaited(tracker.refreshRoom('room-1'));
+      await _pump();
+
+      final failed = (tracker.roomUploads('room-1').value as UploadsLoaded)
+          .uploads
+          .whereType<FailedUpload>()
+          .single;
+      tracker.dismissFailed(failed.id);
+
+      final status = tracker.roomUploads('room-1').value;
+      expect(status, isA<UploadsLoaded>());
+      expect((status as UploadsLoaded).uploads, isEmpty);
+    });
+
     test('emits UploadsFailed from a non-Loaded state', () async {
       when(() => mockApi.getRoomUploads(
             any(),

--- a/test/modules/room/user_switch_teardown_test.dart
+++ b/test/modules/room/user_switch_teardown_test.dart
@@ -35,6 +35,7 @@ void _login(ServerEntry entry, String sub) {
 typedef _Wired = ({
   ServerManager manager,
   ServerEntry entry,
+  AuthzOnlyClients authz,
   AgentRuntimeManager runtimeManager,
   RunRegistry registry,
   UploadTrackerRegistry uploadRegistry,
@@ -46,9 +47,10 @@ void main() {
   // the server signal but NOT yet populated, and NO coordinator yet — so a test
   // controls exactly when the coordinator first sees the identity.
   _Wired wire({String initialSub = 'alice'}) {
+    final authz = AuthzOnlyClients();
     final manager = ServerManager(
       authFactory: () => AuthSession(refreshService: FakeTokenRefreshService()),
-      clientFactory: ({getToken, tokenRefresher}) => FakeHttpClient(),
+      clientFactory: ({getToken, tokenRefresher}) => authz.create(),
       storage: InMemoryServerStorage(),
     );
     manager.addServer(
@@ -78,6 +80,7 @@ void main() {
     return (
       manager: manager,
       entry: entry,
+      authz: authz,
       runtimeManager: runtimeManager,
       registry: registry,
       uploadRegistry: uploadRegistry,
@@ -151,6 +154,25 @@ void main() {
       _login(w.entry, 'bob');
 
       expectEvicted(w, captured.runtime, captured.tracker);
+    });
+
+    test(
+        'a different user signing in from an expired session clears the '
+        'admin answer', () async {
+      // The path with no sign-out in it: a token expires, someone else uses
+      // the "sign in again" affordance, and the entry — with its cached
+      // authorization answer — survives. Reading the prior user's verdict here
+      // would offer them room uploads they cannot perform.
+      final w = wire(initialSub: 'alice');
+      coordinator(w);
+      expect(await w.entry.adminStatus.read(), isTrue);
+      expect(w.authz.calls, 1);
+
+      w.entry.auth.markSessionExpired();
+      _login(w.entry, 'bob');
+
+      await w.entry.adminStatus.read();
+      expect(w.authz.calls, 2);
     });
 
     test('a same-user token refresh evicts nothing', () {


### PR DESCRIPTION
Replaces the thread-level attachment gate with the server's per-scope upload
capability, and gates room uploads on the administrator the server has always
required.

## Why

The thread attach gate asked whether a thread's replayed AG-UI state carried a
`bubble-sandbox` namespace. Nothing writes that namespace any more, so a thread
whose state carried any other one resolved to a hard "unsupported" and lost its
attach button as soon as it had a finished run.

## What changed

- **Capability per scope.** `Room.acceptsRoomUploads` / `acceptsThreadUploads`
  carry `has_room_uploads` / `has_thread_uploads`, each folding in the sandbox
  skill and the installation's upload path for that scope. Every gate reads the
  scope it belongs to.
- **Room uploads are offered only to administrators.** The server has always
  required one; the refusal used to arrive after the user had chosen a file.
  Members still see the room's files — the agent cites them — with a line
  naming who adds them in the controls' own slot.
- **A check that cannot answer withholds the controls and says so.** The upload
  authorizes through the same `check_admin_access` the answer comes from, so a
  check that cannot answer cannot authorize either — offering the controls would
  offer an action whose every use fails. It does not borrow the refusal's
  wording ("An administrator adds files to this room"), which asserts something
  about the user nothing established; it carries a retry instead. Four states —
  checking / permitted / refused / unknown — because a `bool?` had to collapse
  "not answered" into a verdict, and collapsing it into *permission* is the bug.
- **The wait is bounded at 3s.** The request's own timeout starts only after it
  acquires one of six shared connection slots. The bound does not end the
  request: an answer arriving later replaces what it wrote, in either direction.
- **A 404 upload list is an empty shelf, not a failure** — but only where nothing
  has loaded yet. The same bare 404 also answers an unknown room and one the
  caller may no longer read, so a list already on screen is kept and recorded.

### Breaking (library)

`Room.supportsAttachments`, `ThreadHistory.supportsAttachments` and
`sandboxSkillName` are removed. **Requires a backend publishing
`has_room_uploads` / `has_thread_uploads`** — soliplex#1303, merged as
`b2a98c66`. A server that publishes neither is recorded once, from both the
listing and a single-room fetch, so a deep link is covered.

## Verification

- `flutter analyze` clean; **2445** app tests, **1663** client tests passing.
- Every backend claim checked against merged backend source rather than the PR
  description: the field derivation, `GET /v1/user/authz` returning 200 with
  `false` for a non-admin (never 403), and the 404-on-`GET` / 405-on-`POST`
  split.
- Reviewed by four specialised agents (correctness, silent failures, comment
  accuracy, test value). One real regression was found and fixed — the new 404
  arm discarded an already-loaded list silently — plus four comment
  inaccuracies. Two agent findings were refuted with backend evidence.
- Behaviour-critical guards are mutation-tested: each fails when its guard is
  removed, verified by running the mutant.

## Notes for the reviewer

- `Room` equality is identity-by-id and ignores both new fields; the doc says so.
- `roomToJson` does not serialize them — it has no production caller.
- Room Information still reads "Disabled" for a capability an older server never
  published. Known and accepted: `bool?` on the domain model was rejected rather
  than push a transport versioning quirk into it to serve one label.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

