### PR TITLE
feat(room): file feedback for a run the backend reported as failed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,19 @@ Versions follow the `version+build` scheme from `pubspec.yaml`, bumped via
 
 ## [Unreleased]
 
+### Added
+
+- A run that fails now files a thumbs-down feedback record for itself, so the
+  failure becomes discoverable. The backend records the error as it streams but
+  keeps no queryable run status, and feedback is the only table an
+  application-level query reaches — so a failed run was recorded and invisible
+  to every such query. Only failures the backend itself reported are filed: a
+  dropped connection is not, because the backend keeps such a run alive for the
+  client to reconnect to and it often completes, and filing would record a
+  successful run as failed. An unclassified failure is logged against its run
+  instead of filed, since it may name a fault on this side rather than a
+  backend outcome.
+
 ### Fixed
 
 - The attached-files panel no longer strands open, and no longer reopens by

--- a/lib/src/modules/room/run_registry.dart
+++ b/lib/src/modules/room/run_registry.dart
@@ -44,10 +44,12 @@ class RunRegistry {
   /// the signal, its tracked runs are cancelled and dropped so they don't
   /// linger until the whole registry is disposed. Eviction is driven entirely by
   /// the signal, so a signal that never changes simply never evicts.
-  RunRegistry({required ReadonlySignal<Map<String, ServerEntry>> servers}) {
+  RunRegistry({required ReadonlySignal<Map<String, ServerEntry>> servers})
+      : _servers = servers {
     _unsubscribe = servers.subscribe(_evictRemoved);
   }
 
+  final ReadonlySignal<Map<String, ServerEntry>> _servers;
   final Map<ThreadKey, _TrackedRun> _runs = {};
   final Signal<Set<ThreadKey>> _activeKeys = Signal({});
   late final void Function() _unsubscribe;
@@ -100,6 +102,10 @@ class RunRegistry {
     unawaited(session.result.then((result) {
       unsubscribe();
       if (_isDisposed) return;
+      // Above the supersession bail: a superseded run that had already
+      // failed is exactly a run whose failure should be recorded, and
+      // filing touches neither _runs nor _activeKeys.
+      _autoFileFailure(key, terminalState);
       // Bail if a newer registration superseded this run. The
       // superseded run can only resolve as cancelled-by-replacement;
       // the new session owns the key and produces its own outcome.
@@ -108,6 +114,150 @@ class RunRegistry {
       run.session = null;
       _activeKeys.value = _activeKeys.value.difference({key});
     }));
+  }
+
+  /// Files a thumbs-down for a run the backend failed, so that failure becomes
+  /// discoverable: the backend writes `RUN_ERROR` to its event log but keeps no
+  /// queryable run status, and feedback is the only table an application-level
+  /// query reaches.
+  ///
+  /// This lives in the registry rather than the UI because a view unmounts. A
+  /// run that fails after the user navigates away must still be recorded, and
+  /// the registry outlives that navigation.
+  ///
+  /// Filing needs no dedup flag: one `result.then` per [register] call, and
+  /// each session is registered once, at spawn. That is exact at dispatch, not
+  /// at record existence — the record appears only when the POST lands, so
+  /// within one round trip a reader can still find nothing.
+  ///
+  /// A run whose session was disposed before publishing a terminal state
+  /// arrives here with [terminalState] null and goes unfiled. [_outcomeFrom]
+  /// recovers that case from the [AgentResult], but nothing can be filed
+  /// against it: [AgentFailure] carries no runId.
+  void _autoFileFailure(ThreadKey key, RunState? terminalState) {
+    if (terminalState is! FailedState) return;
+    final runId = terminalState.runId;
+    // Null iff the failure preceded any backend run, leaving no row to
+    // attach feedback to.
+    if (runId == null) return;
+    final recording = _recordingFor(terminalState.reason);
+    final failure = recording.filedAs;
+    if (failure == null) {
+      if (recording.logUnfiled) {
+        // Not the backend's run outcome, so not filed — but still a run the
+        // user got no answer from, and the orchestrator's own 'Run failed'
+        // record names no run. This is what ties it to one.
+        _logger.warning(
+          'Run failed without filing feedback',
+          attributes: {
+            'key': key.toString(),
+            'runId': runId,
+            'reason': terminalState.reason.name,
+          },
+        );
+      }
+      return;
+    }
+    final api = _servers.value[key.serverId]?.connection.api;
+    // The server was removed while the run was in flight, so there is nothing
+    // left to POST to. Signing out does not reach here — it leaves the entry
+    // in place, so that path files and meets a 401 below.
+    if (api == null) return;
+
+    unawaited(
+      api
+          .submitFeedback(
+        key.roomId,
+        key.threadId,
+        runId,
+        FeedbackType.thumbsDown,
+        reason: '[auto] Run failed: $failure',
+      )
+          .then((_) {}, onError: (Object error, StackTrace stackTrace) {
+        // At most once, attempted: the record is best-effort and a lost POST
+        // leaves the failure unrecorded rather than crashing the run that
+        // already failed.
+        //
+        // This request carries a body, and that body is generated text that
+        // a later edit replaces with the user's own, so an exception echoing
+        // what the server rejected would render it into the exportable log
+        // buffer. Only a NetworkException — whose host and OS error are the
+        // whole diagnosis — is forwarded whole; anything else keeps its shape
+        // plus the status code, a protocol constant rather than a value the
+        // server chose.
+        _logger.warning(
+          error is AuthException
+              ? 'Auto-filing feedback hit AuthException; '
+                  'funneling to markSessionExpired'
+              : 'Failed to auto-file feedback for a failed run',
+          error: error is NetworkException ? error : null,
+          stackTrace: stackTrace,
+          attributes: {
+            'key': key.toString(),
+            'runId': runId,
+            if (error is ApiException) 'statusCode': error.statusCode,
+            if (error is! NetworkException) 'failure': describeFailure(error),
+          },
+        );
+        if (error is AuthException) {
+          // The grant is dead, so send the user to re-auth now rather than
+          // leaving them on a signed-in UI until their next action fails.
+          // Only on a 401: flipping the session for a recoverable failure
+          // would lock them out (see AuthSession.refreshIfExpiringSoon).
+          // Re-read rather than capture: an eviction in the interval means
+          // there is no session left to expire, which is the right answer.
+          _servers.value[key.serverId]?.auth.markSessionExpired();
+        }
+      }),
+    );
+  }
+
+  /// How a failed run is recorded: [filedAs] is the failure description filed
+  /// as feedback, or null when the failure is not filed, and [logUnfiled] asks
+  /// for a log line naming the run when it is not.
+  ///
+  /// Auto-filing needs a whitelist because filing the wrong thing writes wrong
+  /// data into a human triage queue. Manual filing needs no equivalent: a
+  /// human choosing to report something is the judgement we wanted.
+  static ({String? filedAs, bool logUnfiled}) _recordingFor(
+    FailureReason reason,
+  ) {
+    return switch (reason) {
+      // The backend said it failed, so it is the backend's run outcome.
+      FailureReason.serverError => (filedAs: 'server error', logUnfiled: false),
+      // The orchestrator gave up after exhausting tool retries; the run is
+      // dead either way.
+      FailureReason.toolExecutionFailed => (
+          filedAs: 'tool execution failed',
+          logUnfiled: false
+        ),
+      // `classifyError`'s fallback, so it names a client-side or as-yet
+      // unclassified failure rather than a backend run outcome — and the
+      // client disconnects, which the backend answers by keeping the run
+      // alive, so it may well complete. Filing would send a reviewer to a
+      // run that succeeded. Logged instead, because it is still a run the
+      // user got no answer from.
+      FailureReason.internalError => (filedAs: null, logUnfiled: true),
+      // Unreachable on a FailedState — a cancel publishes CancelledState,
+      // which the guard above drops. Present for exhaustiveness.
+      FailureReason.cancelled => (filedAs: null, logUnfiled: false),
+      // Session expiry and authz verdicts, not run quality.
+      FailureReason.authExpired || FailureReason.permissionDenied => (
+          filedAs: null,
+          logUnfiled: false
+        ),
+      // The backend deliberately keeps a run alive across a client
+      // disconnect so the client can reconnect and watch it finish. Filing
+      // would record successfully-completed runs as failed.
+      FailureReason.networkLost || FailureReason.streamResumeFailed => (
+          filedAs: null,
+          logUnfiled: false
+        ),
+      // Capacity, not answer quality. Nothing reaches these runs afterwards
+      // either: a 429 surfaces as a transient send-error banner, never as a
+      // tile, so there is no manual path to fall back on.
+      FailureReason.rateLimited => (filedAs: null, logUnfiled: false),
+    };
   }
 
   /// Returns the active (non-terminal) session for a thread.

--- a/test/helpers/fakes.dart
+++ b/test/helpers/fakes.dart
@@ -214,6 +214,15 @@ class RecordingAuthFlow implements AuthFlow {
   }
 }
 
+/// One recorded [FakeSoliplexApi.submitFeedback] call.
+typedef SubmittedFeedback = ({
+  String roomId,
+  String threadId,
+  String runId,
+  FeedbackType feedback,
+  String? reason,
+});
+
 /// SoliplexApi with a controllable getRooms response.
 ///
 /// All other methods throw [UnimplementedError].
@@ -475,6 +484,9 @@ class FakeSoliplexApi extends SoliplexApi {
 
   Object? nextSubmitFeedbackError;
 
+  /// Every [submitFeedback] call, in order.
+  final List<SubmittedFeedback> submittedFeedback = [];
+
   @override
   Future<void> submitFeedback(
     String roomId,
@@ -484,6 +496,13 @@ class FakeSoliplexApi extends SoliplexApi {
     String? reason,
     CancelToken? cancelToken,
   }) async {
+    submittedFeedback.add((
+      roomId: roomId,
+      threadId: threadId,
+      runId: runId,
+      feedback: feedback,
+      reason: reason,
+    ));
     if (nextSubmitFeedbackError != null) throw nextSubmitFeedbackError!;
   }
 }
@@ -543,6 +562,33 @@ class ManualAgentSession implements AgentSession {
       threadKey: threadKey,
       reason: FailureReason.cancelled,
       error: 'cancelled',
+    ));
+  }
+
+  /// Drives [runState] to a failure and resolves [result] to match, the way
+  /// `AgentSession` does: the terminal state is published first, then the
+  /// result completes in the same synchronous turn.
+  void completeAsFailed({
+    required FailureReason reason,
+    String? runId,
+    String error = 'boom',
+  }) {
+    _runState.value = runId == null
+        ? FailedState.preRun(
+            threadKey: threadKey,
+            reason: reason,
+            error: error,
+          )
+        : FailedState.duringRun(
+            threadKey: threadKey,
+            runId: runId,
+            reason: reason,
+            error: error,
+          );
+    _resultCompleter.complete(AgentFailure(
+      threadKey: threadKey,
+      reason: reason,
+      error: error,
     ));
   }
 

--- a/test/modules/room/run_registry_test.dart
+++ b/test/modules/room/run_registry_test.dart
@@ -2,9 +2,11 @@ import 'dart:async';
 
 import 'package:flutter_test/flutter_test.dart';
 import 'package:soliplex_agent/soliplex_agent.dart';
+import 'package:soliplex_logging/soliplex_logging.dart';
 
 import 'package:soliplex_frontend/src/modules/auth/admin_status.dart';
 import 'package:soliplex_frontend/src/modules/auth/auth_session.dart';
+import 'package:soliplex_frontend/src/modules/auth/auth_tokens.dart';
 import 'package:soliplex_frontend/src/modules/auth/server_entry.dart';
 import 'package:soliplex_frontend/src/modules/room/agent_runtime_manager.dart';
 import 'package:soliplex_frontend/src/modules/room/run_registry.dart';
@@ -27,11 +29,27 @@ ServerEntry _entry(String serverId) {
     serverId: serverId,
     alias: serverId,
     serverUrl: Uri.parse('https://$serverId.example.com'),
-    auth: AuthSession(refreshService: FakeTokenRefreshService()),
+    auth: _authInActiveSession(),
     httpClient: FakeHttpClient(),
     connection: connection,
     adminStatus: AdminStatus(api: connection.api, serverId: serverId),
   );
+}
+
+AuthSession _authInActiveSession() {
+  final auth = AuthSession(refreshService: FakeTokenRefreshService());
+  auth.login(
+    provider: const OidcProvider(
+      discoveryUrl: 'https://auth.example.com/.well-known/openid-configuration',
+      clientId: 'test-client',
+    ),
+    tokens: AuthTokens(
+      accessToken: 'access',
+      refreshToken: 'refresh',
+      expiresAt: DateTime.now().add(const Duration(hours: 1)),
+    ),
+  );
+  return auth;
 }
 
 const _key = (
@@ -310,6 +328,214 @@ void main() {
     );
     expect(session.cancelCalled, isTrue);
     expect(registry.activeSession(_key), isNull);
+  });
+
+  group('auto-files feedback on failure', () {
+    late FakeSoliplexApi serverApi;
+    late Signal<Map<String, ServerEntry>> servers;
+    late RunRegistry filing;
+
+    late AuthSession serverAuth;
+
+    setUp(() {
+      final entry = _entry('test-server');
+      serverApi = entry.connection.api as FakeSoliplexApi;
+      serverAuth = entry.auth;
+      servers = Signal({'test-server': entry});
+      filing = RunRegistry(servers: servers);
+      addTearDown(() {
+        filing.dispose();
+        servers.dispose();
+      });
+    });
+
+    /// Fails [session] and lets the registry's `result.then` microtask run.
+    Future<void> fail(
+      ManualAgentSession session, {
+      required FailureReason reason,
+      String? runId,
+    }) async {
+      session.completeAsFailed(reason: reason, runId: runId);
+      await Future<void>.delayed(Duration.zero);
+    }
+
+    // No ThreadViewState exists anywhere in this group: every case here
+    // proves the trigger lives in the registry, not the UI. Moving it into
+    // a widget makes the whole group fail.
+    test('files one thumbs-down naming the failed run', () async {
+      final session = ManualAgentSession(_key);
+      filing.register(_key, session);
+
+      await fail(session, reason: FailureReason.serverError, runId: 'run-1');
+
+      expect(serverApi.submittedFeedback, hasLength(1));
+      final filed = serverApi.submittedFeedback.single;
+      expect(filed.roomId, 'room-1');
+      expect(filed.threadId, 'thread-1');
+      expect(filed.runId, 'run-1');
+      expect(filed.feedback, FeedbackType.thumbsDown);
+    });
+
+    // Every whitelisted reason, so dropping any one of them fails here.
+    const filedReasons = {
+      FailureReason.serverError: '[auto] Run failed: server error',
+      FailureReason.toolExecutionFailed:
+          '[auto] Run failed: tool execution failed',
+    };
+    for (final entry in filedReasons.entries) {
+      test('names ${entry.key.name} in the reason it files', () async {
+        final session = ManualAgentSession(_key);
+        filing.register(_key, session);
+
+        await fail(session, reason: entry.key, runId: 'run-1');
+
+        expect(serverApi.submittedFeedback.single.reason, entry.value);
+      });
+    }
+
+    test('files nothing for a failure that never started a run', () async {
+      final session = ManualAgentSession(_key);
+      filing.register(_key, session);
+
+      await fail(session, reason: FailureReason.serverError);
+
+      expect(serverApi.submittedFeedback, isEmpty);
+    });
+
+    test('files nothing when the connection dropped', () async {
+      // The backend keeps a run alive after a client disconnect, so these
+      // often go on to succeed: filing would record a completed run as failed.
+      final lost = ManualAgentSession(_key);
+      filing.register(_key, lost);
+      await fail(lost, reason: FailureReason.networkLost, runId: 'run-1');
+
+      final resumeFailed = ManualAgentSession(_key2);
+      filing.register(_key2, resumeFailed);
+      await fail(
+        resumeFailed,
+        reason: FailureReason.streamResumeFailed,
+        runId: 'run-2',
+      );
+
+      expect(serverApi.submittedFeedback, isEmpty);
+    });
+
+    test('logs an unclassified failure against its run instead of filing',
+        () async {
+      // internalError is classifyError's fallback, so the backend may still
+      // complete the run — filing would send a reviewer to a run that
+      // succeeded. The log is what keeps it findable, and the orchestrator's
+      // own record does not name the run.
+      final sink = MemorySink();
+      LogManager.instance.addSink(sink);
+      addTearDown(() => LogManager.instance.removeSink(sink));
+
+      final session = ManualAgentSession(_key);
+      filing.register(_key, session);
+
+      await fail(session, reason: FailureReason.internalError, runId: 'run-1');
+
+      expect(serverApi.submittedFeedback, isEmpty);
+      final record = sink.records.singleWhere(
+        (r) => r.message == 'Run failed without filing feedback',
+      );
+      expect(record.attributes['runId'], 'run-1');
+      expect(record.attributes['reason'], 'internalError');
+    });
+
+    test('does not log a failure it deliberately ignores', () async {
+      // A dropped connection is not ours to answer for, so it gets neither a
+      // record nor a log line.
+      final sink = MemorySink();
+      LogManager.instance.addSink(sink);
+      addTearDown(() => LogManager.instance.removeSink(sink));
+
+      final session = ManualAgentSession(_key);
+      filing.register(_key, session);
+
+      await fail(session, reason: FailureReason.networkLost, runId: 'run-1');
+
+      expect(
+        sink.records.where(
+          (r) => r.message == 'Run failed without filing feedback',
+        ),
+        isEmpty,
+      );
+    });
+
+    test('files nothing when the run was throttled', () async {
+      final session = ManualAgentSession(_key);
+      filing.register(_key, session);
+
+      await fail(session, reason: FailureReason.rateLimited, runId: 'run-1');
+
+      expect(serverApi.submittedFeedback, isEmpty);
+    });
+
+    test('files nothing when the failure was an authz verdict', () async {
+      final expired = ManualAgentSession(_key);
+      filing.register(_key, expired);
+      await fail(expired, reason: FailureReason.authExpired, runId: 'run-1');
+
+      final denied = ManualAgentSession(_key2);
+      filing.register(_key2, denied);
+      await fail(
+        denied,
+        reason: FailureReason.permissionDenied,
+        runId: 'run-2',
+      );
+
+      expect(serverApi.submittedFeedback, isEmpty);
+    });
+
+    test('files for a run superseded after it had already failed', () async {
+      // A superseded run that already failed is exactly a failure worth
+      // recording, so the trigger sits above the supersession bail.
+      final failed = ManualAgentSession(_key);
+      filing.register(_key, failed);
+      filing.register(_key, ManualAgentSession(_key));
+
+      await fail(failed, reason: FailureReason.serverError, runId: 'run-1');
+
+      expect(serverApi.submittedFeedback.single.runId, 'run-1');
+    });
+
+    test('files nothing once the run\'s server is gone', () async {
+      final session = ManualAgentSession(_key);
+      filing.register(_key, session);
+      servers.value = {};
+
+      await fail(session, reason: FailureReason.serverError, runId: 'run-1');
+
+      expect(serverApi.submittedFeedback, isEmpty);
+    });
+
+    test('expires the session when the filing meets a dead grant', () async {
+      // Matches ThreadViewState.submitFeedback: a 401 anywhere is proof the
+      // grant is dead, and the user must be sent to re-auth rather than left
+      // looking at a signed-in UI until their next action fails.
+      serverApi.nextSubmitFeedbackError =
+          const AuthException(message: 'expired', statusCode: 401);
+      final session = ManualAgentSession(_key);
+      filing.register(_key, session);
+
+      await fail(session, reason: FailureReason.serverError, runId: 'run-1');
+
+      expect(serverAuth.session.value, isA<ExpiredSession>());
+    });
+
+    test('keeps the session on a filing failure that is not a 401', () async {
+      // Flipping to ExpiredSession on any throw would lock the user out for a
+      // recoverable failure — see AuthSession.refreshIfExpiringSoon.
+      serverApi.nextSubmitFeedbackError =
+          const NetworkException(message: 'offline');
+      final session = ManualAgentSession(_key);
+      filing.register(_key, session);
+
+      await fail(session, reason: FailureReason.serverError, runId: 'run-1');
+
+      expect(serverAuth.session.value, isA<ActiveSession>());
+    });
   });
 
   test('evicts runs whose server is removed from the signal', () async {


### PR DESCRIPTION
## Why

A failed run is recorded but invisible to every application-level query.

- Every AG-UI event, `RUN_ERROR` included, is written to `run_event` as it streams.
- The `run` table has no `status` or `error` column. Its only terminal field is `finished`, stamped on success *and* failure alike; the `ERROR` status the backend computes is a local variable that feeds logfire and is never written.
- No endpoint, storage method, CLI command or AI tool lists failed runs. Finding one needs a raw scan of `run_event.data->>'type' = 'RUN_ERROR'`.

The only "look back at past runs" facility is the feedback machinery, and it joins `Run.run_feedback` — so it surfaces only runs a human rated. Filing a thumbs-down on failure creates the row that makes the failure discoverable.

This is knowingly a client-side workaround for a missing backend column. The structurally cleaner fixes — a `status`/`error` column, or wiring `BackendLogSink` to the already-live `POST /v1/logs` — are both larger and neither is frontend-only.

## Where the trigger lives

`RunRegistry`, not the UI. A view unmounts: if the user navigates away mid-run, `ThreadViewState` drops its subscription and a later failure would never be seen. The registry is created once at flavor scope and survives that.

It is hoisted **above** the supersession bail, because a superseded run that had already failed is exactly a failure worth recording. Filing touches neither `_runs` nor `_activeKeys`, so it is safe there.

Exactly-once needs no flag: one `result.then` per `register`, and a session is registered once, at spawn. That is exact at dispatch, not at record existence — noted in the code.

## What is and isn't filed

One exhaustive switch returns both halves of the decision, so the compiler asks about filing *and* logging when a `FailureReason` is added.

| Reason | Filed | Why |
| --- | --- | --- |
| `serverError` | yes | the backend said it failed |
| `toolExecutionFailed` | yes | tool retries exhausted; the run is dead |
| `internalError` | **no — logged instead** | the classifier's fallback, so it may name a fault on this side; the client disconnects, and the backend keeps the run alive, so it may complete |
| `networkLost`, `streamResumeFailed` | no | the backend deliberately keeps the run alive to be reconnected to; filing would record successful runs as failed |
| `rateLimited` | no | capacity, not answer quality |
| `authExpired`, `permissionDenied` | no | authz verdicts, not run quality |
| `cancelled` | no | unreachable on a `FailedState`; present for exhaustiveness |

`internalError` is logged with its `runId` because the orchestrator already records the error but names no run — and naming the run is what makes a failure findable.

## Accepted cost

Feedback rows feed a **human triage queue**, and there is no source column separating machine records from human ones — the `[auto]` prefix is the only signal, by convention. `list_recent_run_feedback` defaults to `limit = 20`, so auto-filed records compete with genuine complaints. Acceptable while failures are rare; if the rate is high, prefer `since`-based queries or ask for a source column first.

## Logging

These requests carry a body, so an exception echoing what the server rejected would render it into the exportable diagnostics buffer. Only a `NetworkException` — whose host and OS error are the whole diagnosis — is forwarded whole; anything else keeps its shape plus the status code.

## Tests

13 tests, all mutation-verified — including that moving the call below the supersession bail fails, that removing any whitelisted reason fails, and that both log dispositions fail when flipped. No `ThreadViewState` exists anywhere in the group, so the whole group fails if the trigger moves into the UI.

## Follow-up

A UI for reading and editing the filed record is the next PR. Two gaps are written up separately: `ErrorMessage` tiles carry no runId of their own, and `toolExecutionFailed`/`internalError` produce no transcript tile at all — so several filed records are not yet reachable from the transcript.

🤖 Generated with [Claude Code](https://claude.com/claude-code)