### PR TITLE
feat(room): read a run's feedback record, and let the dialog own the exchange

### DIFF
--- a/lib/src/modules/room/ui/feedback_buttons.dart
+++ b/lib/src/modules/room/ui/feedback_buttons.dart
@@ -95,19 +95,30 @@ class _FeedbackButtonsState extends State<FeedbackButtons>
     _controller.stop();
     setState(() => _phase = _FeedbackPhase.modal);
 
-    final reason = await showDialog<String>(
+    var didSubmit = false;
+    await showDialog<void>(
       context: context,
       barrierDismissible: false,
-      builder: (context) => const FeedbackReasonDialog(),
+      builder: (context) => FeedbackReasonDialog(
+        onSubmit: (reason) async {
+          // This tile lives in a sliver and can be destroyed while the modal
+          // is up, at which point dispose has already submitted for this
+          // direction and _submit's setState would throw. Refusing keeps the
+          // dialog open and honest rather than reporting a send that cannot
+          // happen.
+          if (!mounted) return false;
+          didSubmit = true;
+          _submit(reason.trim().isEmpty ? null : reason.trim());
+          // onFeedbackSubmit reports no outcome, so `true` says only that the
+          // dialog may close — there is nothing here to stay open for.
+          return true;
+        },
+      ),
     );
 
     if (!mounted) return;
 
-    if (reason != null) {
-      _submit(reason.trim().isEmpty ? null : reason.trim());
-    } else {
-      _startCountdown(_direction!);
-    }
+    if (!didSubmit) _startCountdown(_direction!);
   }
 
   void _submit(String? reason) {

--- a/lib/src/modules/room/ui/feedback_reason_dialog.dart
+++ b/lib/src/modules/room/ui/feedback_reason_dialog.dart
@@ -1,8 +1,38 @@
 import 'package:flutter/material.dart';
+import 'package:soliplex_client/soliplex_client.dart'
+    show ApiException, NetworkException;
 import 'package:soliplex_design/soliplex_design.dart';
+import 'package:soliplex_logging/soliplex_logging.dart';
 
+final Logger _logger =
+    LogManager.instance.getLogger('soliplex.feedback_reason_dialog');
+
+/// Collects the reason for a piece of feedback, and owns the whole exchange:
+/// reading what is already on file, submitting, and reporting a submission
+/// that did not land.
+///
+/// It owns that state because it lives in an overlay route rather than in the
+/// message sliver, so — unlike a tile — it is not destroyed by scrolling past
+/// the cache extent. A caller whose own state lives in the sliver still has to
+/// guard its [onSubmit] against being called after that state is gone.
 class FeedbackReasonDialog extends StatefulWidget {
-  const FeedbackReasonDialog({super.key});
+  const FeedbackReasonDialog({
+    required this.onSubmit,
+    this.loadInitialText,
+    super.key,
+  });
+
+  /// Submits [reason]. Returning false keeps this dialog open with the typed
+  /// text intact so the user can retry; true closes it.
+  final Future<bool> Function(String reason) onSubmit;
+
+  /// Reads the note already on file, so the user extends or replaces it
+  /// knowingly — the write is an upsert, so submitting over an unread note
+  /// destroys it. Resolving null means nothing is on file; throwing means it
+  /// could not be read, which is said out loud rather than shown as absence.
+  ///
+  /// Null when the caller has no note to read.
+  final Future<String?> Function()? loadInitialText;
 
   @override
   State<FeedbackReasonDialog> createState() => _FeedbackReasonDialogState();
@@ -10,9 +40,97 @@ class FeedbackReasonDialog extends StatefulWidget {
 
 class _FeedbackReasonDialogState extends State<FeedbackReasonDialog> {
   final _controller = TextEditingController();
+  final _focusNode = FocusNode();
+  bool _isLoading = false;
+  bool _isSubmitting = false;
+  String? _unreadNote;
+  String? _error;
+
+  @override
+  void initState() {
+    super.initState();
+    final load = widget.loadInitialText;
+    if (load != null) {
+      _isLoading = true;
+      _load(load);
+    }
+  }
+
+  Future<void> _load(Future<String?> Function() load) async {
+    String? onFile;
+    String? failure;
+    try {
+      onFile = await load();
+    } on Object catch (error, stackTrace) {
+      // The caller rethrows precisely so absence and unreadability stay
+      // distinguishable; saying only "couldn't check" to the user would throw
+      // that away, and a decode break would silently empty every prefill.
+      _logger.warning(
+        'Could not read the feedback already on file',
+        error: error is NetworkException ? error : null,
+        stackTrace: stackTrace,
+        attributes: {
+          if (error is ApiException) 'statusCode': error.statusCode,
+          if (error is! NetworkException) 'failure': describeFailure(error),
+        },
+      );
+      failure = "Couldn't check for an earlier note. "
+          'Submitting replaces any that exists.';
+    }
+    if (!mounted) return;
+    setState(() {
+      _isLoading = false;
+      _unreadNote = failure;
+      if (onFile != null) _controller.text = onFile;
+    });
+    // The field was disabled while loading, so autofocus never took effect.
+    _focusNode.requestFocus();
+  }
+
+  Future<void> _submit() async {
+    if (_isSubmitting) return;
+    setState(() {
+      _isSubmitting = true;
+      _error = null;
+    });
+    bool sent;
+    try {
+      sent = await widget.onSubmit(_controller.text);
+    } on Object catch (error, stackTrace) {
+      // onSubmit is documented not to throw, so a throw here is a defect in
+      // the caller rather than a rejected write. Without this the user is told
+      // the send failed and no record says it was never attempted.
+      _logger.error(
+        'Feedback submit callback threw',
+        error: error is NetworkException ? error : null,
+        stackTrace: stackTrace,
+        attributes: {
+          if (error is ApiException) 'statusCode': error.statusCode,
+          if (error is! NetworkException) 'failure': describeFailure(error),
+        },
+      );
+      sent = false;
+    }
+    if (!mounted) return;
+    // `mounted` does not say this route is still the one on top: the platform
+    // back button pops a non-dismissible dialog, and this State stays mounted
+    // for the whole pop transition, so popping again would take the screen
+    // underneath with it.
+    if (sent) {
+      if (ModalRoute.of(context)?.isCurrent ?? false) {
+        Navigator.of(context).pop();
+      }
+      return;
+    }
+    setState(() {
+      _isSubmitting = false;
+      _error = "Couldn't send that. Try again.";
+    });
+  }
 
   @override
   void dispose() {
+    _focusNode.dispose();
     _controller.dispose();
     super.dispose();
   }
@@ -23,18 +141,28 @@ class _FeedbackReasonDialogState extends State<FeedbackReasonDialog> {
       title: const Text('Tell us why'),
       content: SoliplexInput(
         controller: _controller,
+        focusNode: _focusNode,
         autofocus: true,
         maxLines: 5,
         hintText: 'Add a reason (optional)',
+        // The unread-note warning is the ordinary state, not an error, and it
+        // has to outlive a failed submit — so the two occupy different slots.
+        helperText: _unreadNote,
+        errorText: _error,
+        isLoading: _isLoading,
+        // Not `isLoading` while submitting: that disables the field, greying
+        // out the text the user may still need to retry with.
+        readOnly: _isSubmitting,
         textInputAction: TextInputAction.newline,
       ),
       actions: [
         SoliplexButton.text(
-          onPressed: () => Navigator.of(context).pop(),
+          onPressed: _isSubmitting ? null : () => Navigator.of(context).pop(),
           child: const Text('Cancel'),
         ),
         SoliplexButton.filled(
-          onPressed: () => Navigator.of(context).pop(_controller.text),
+          onPressed: _isLoading || _isSubmitting ? null : _submit,
+          isLoading: _isSubmitting,
           child: const Text('Send'),
         ),
       ],

--- a/packages/soliplex_client/lib/src/api/mappers.dart
+++ b/packages/soliplex_client/lib/src/api/mappers.dart
@@ -10,6 +10,7 @@ import 'package:soliplex_client/src/domain/room_agent.dart';
 import 'package:soliplex_client/src/domain/room_skill.dart';
 import 'package:soliplex_client/src/domain/room_stats.dart';
 import 'package:soliplex_client/src/domain/room_tool.dart';
+import 'package:soliplex_client/src/domain/run_feedback.dart';
 import 'package:soliplex_client/src/domain/run_info.dart';
 import 'package:soliplex_client/src/domain/thread_info.dart';
 import 'package:soliplex_client/src/domain/workdir_file.dart';
@@ -632,6 +633,19 @@ RunStatus runStatusFromString(String? value) {
     (e) => e.name == value.toLowerCase(),
     orElse: () => RunStatus.unknown,
   );
+}
+
+// ============================================================
+// Run feedback mappers
+// ============================================================
+
+/// Creates a [RunFeedback] from JSON.
+///
+/// The record's `feedback` rating is deliberately not decoded: the only reader
+/// is the dialog that prefills the reason, and a field nothing consumes is a
+/// field that rots. Decode it here when a caller needs the rating.
+RunFeedback runFeedbackFromJson(Map<String, dynamic> json) {
+  return RunFeedback(reason: json['reason'] as String?);
 }
 
 // ============================================================

--- a/packages/soliplex_client/lib/src/api/soliplex_api.dart
+++ b/packages/soliplex_client/lib/src/api/soliplex_api.dart
@@ -20,6 +20,7 @@ import 'package:soliplex_client/src/domain/quiz.dart';
 import 'package:soliplex_client/src/domain/rag_document.dart';
 import 'package:soliplex_client/src/domain/room.dart';
 import 'package:soliplex_client/src/domain/room_stats.dart';
+import 'package:soliplex_client/src/domain/run_feedback.dart';
 import 'package:soliplex_client/src/domain/run_info.dart';
 import 'package:soliplex_client/src/domain/source_reference.dart';
 import 'package:soliplex_client/src/domain/thread_history.dart';
@@ -702,6 +703,49 @@ class SoliplexApi {
   // ============================================================
   // Feedback
   // ============================================================
+
+  /// Fetches the feedback record on file for a run.
+  ///
+  /// Parameters:
+  /// - [roomId]: The room ID (must not be empty)
+  /// - [threadId]: The thread ID (must not be empty)
+  /// - [runId]: The run ID (must not be empty)
+  ///
+  /// Returns null when the backend answers a JSON `null` or an empty body,
+  /// which is how it reports a run with no feedback record. A run with no
+  /// record is not guaranteed to reach that path: an installation that reports
+  /// absence some other way — a 404, or a 500 — throws instead, so a caller
+  /// that must distinguish absence from unreadability has to treat a throw as
+  /// unreadable rather than as absence.
+  ///
+  /// Throws:
+  /// - [ArgumentError] if any ID is empty
+  /// - [AuthException] if not authenticated (401)
+  /// - [PermissionDeniedException] if authenticated but not permitted (403)
+  /// - [NotFoundException] if the room, thread or run is unknown (404)
+  /// - [NetworkException] if connection fails
+  /// - [MalformedResponseException] if the body is not a feedback record
+  /// - [ApiException] for other server errors
+  /// - [CancelledException] if cancelled via [cancelToken]
+  Future<RunFeedback?> getRunFeedback(
+    String roomId,
+    String threadId,
+    String runId, {
+    CancelToken? cancelToken,
+  }) async {
+    _requireNonEmpty(roomId, 'roomId');
+    _requireNonEmpty(threadId, 'threadId');
+    _requireNonEmpty(runId, 'runId');
+
+    return _transport.request<RunFeedback?>(
+      'GET',
+      _urlBuilder.build(
+        pathSegments: ['rooms', roomId, 'agui', threadId, runId, 'feedback'],
+      ),
+      cancelToken: cancelToken,
+      fromJson: runFeedbackFromJson,
+    );
+  }
 
   /// Submits feedback for a run.
   ///

--- a/packages/soliplex_client/lib/src/domain/domain.dart
+++ b/packages/soliplex_client/lib/src/domain/domain.dart
@@ -18,6 +18,7 @@ export 'room_agent.dart';
 export 'room_skill.dart';
 export 'room_stats.dart';
 export 'room_tool.dart';
+export 'run_feedback.dart';
 export 'run_info.dart';
 export 'server_info.dart';
 export 'source_reference.dart';

--- a/packages/soliplex_client/lib/src/domain/run_feedback.dart
+++ b/packages/soliplex_client/lib/src/domain/run_feedback.dart
@@ -1,0 +1,28 @@
+import 'package:meta/meta.dart';
+
+/// The feedback record on file for a run.
+///
+/// At most one exists per run: submitting replaces any earlier record. The
+/// record's existence is the point — an absent record is an absent
+/// [RunFeedback], which a bare reason string could not express.
+@immutable
+class RunFeedback {
+  /// Creates a run feedback record.
+  const RunFeedback({this.reason});
+
+  /// The free-text reason on file, or null when the record carries none.
+  final String? reason;
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) || other is RunFeedback && reason == other.reason;
+
+  @override
+  int get hashCode => reason.hashCode;
+
+  /// Deliberately omits [reason]: it is free text the user or the backend
+  /// supplied, and this renders into the exportable diagnostics buffer.
+  @override
+  String toString() =>
+      'RunFeedback(reason: ${reason == null ? 'none' : 'set'})';
+}

--- a/packages/soliplex_client/test/api/mappers_test.dart
+++ b/packages/soliplex_client/test/api/mappers_test.dart
@@ -2124,4 +2124,25 @@ void main() {
       });
     });
   });
+
+  group('RunFeedback mappers', () {
+    group('runFeedbackFromJson', () {
+      test('parses the reason on file', () {
+        final record = runFeedbackFromJson({
+          'feedback': 'thumbs_down',
+          'reason': '[auto] Run failed: server error',
+        });
+
+        expect(record.reason, '[auto] Run failed: server error');
+      });
+
+      test('parses a record whose reason is absent', () {
+        // A record with no reason is still a record — the caller distinguishes
+        // it from an absent one by the RunFeedback itself, not by the reason.
+        final record = runFeedbackFromJson({'feedback': 'thumbs_up'});
+
+        expect(record.reason, isNull);
+      });
+    });
+  });
 }

--- a/packages/soliplex_client/test/api/soliplex_api_test.dart
+++ b/packages/soliplex_client/test/api/soliplex_api_test.dart
@@ -1,4 +1,5 @@
 import 'dart:convert';
+import 'dart:typed_data';
 
 import 'package:mocktail/mocktail.dart';
 // SoliplexApi uses our local CancelToken, not ag_ui's.
@@ -9,6 +10,8 @@ import 'package:soliplex_logging/soliplex_logging.dart';
 import 'package:test/test.dart';
 
 class MockHttpTransport extends Mock implements HttpTransport {}
+
+class MockSoliplexHttpClient extends Mock implements SoliplexHttpClient {}
 
 void main() {
   late MockHttpTransport mockTransport;
@@ -6130,6 +6133,90 @@ void main() {
             timeout: any(named: 'timeout'),
           ),
         ).called(1);
+      });
+    });
+
+    group('getRunFeedback', () {
+      late MockSoliplexHttpClient mockClient;
+      late SoliplexApi liveApi;
+      String? capturedMethod;
+      Uri? capturedUri;
+
+      setUp(() {
+        mockClient = MockSoliplexHttpClient();
+        liveApi = SoliplexApi(
+          transport: HttpTransport(client: mockClient),
+          urlBuilder: urlBuilder,
+        );
+        when(() => mockClient.close()).thenReturn(null);
+        capturedMethod = null;
+        capturedUri = null;
+      });
+
+      tearDown(() {
+        liveApi.close();
+        reset(mockClient);
+      });
+
+      /// Answers every request with [body] as a JSON payload. The transport is
+      /// real here: decoding an absent record is the behaviour under test, and
+      /// a mocked transport would never run the decode.
+      void answerWithJson(String body) {
+        when(
+          () => mockClient.request(
+            any(),
+            any(),
+            headers: any(named: 'headers'),
+            body: any(named: 'body'),
+            timeout: any(named: 'timeout'),
+            cancelToken: any(named: 'cancelToken'),
+          ),
+        ).thenAnswer((invocation) async {
+          capturedMethod = invocation.positionalArguments[0] as String;
+          capturedUri = invocation.positionalArguments[1] as Uri;
+          return HttpResponse(
+            statusCode: 200,
+            bodyBytes: Uint8List.fromList(utf8.encode(body)),
+            headers: const {'content-type': 'application/json'},
+          );
+        });
+      }
+
+      test('GETs the run feedback path and decodes the record on file',
+          () async {
+        // Feeds a record rather than `null`, so the null-answer test below is
+        // the only one covering the nullable return and can actually fail.
+        answerWithJson(
+          jsonEncode({'feedback': 'thumbs_down', 'reason': '[auto] boom'}),
+        );
+
+        final record =
+            await liveApi.getRunFeedback('room-123', 'thread-456', 'run-789');
+
+        expect(capturedMethod, 'GET');
+        expect(
+          capturedUri?.path,
+          equals('/api/v1/rooms/room-123/agui/thread-456/run-789/feedback'),
+        );
+        expect(record?.reason, '[auto] boom');
+      });
+
+      test('answers null when no feedback is on file', () async {
+        // Requesting a non-nullable RunFeedback would make the cast throw a
+        // MalformedResponseException here instead.
+        answerWithJson('null');
+
+        expect(
+          await liveApi.getRunFeedback('room-123', 'thread-456', 'run-789'),
+          isNull,
+        );
+      });
+
+      test('validates non-empty runId', () {
+        expect(
+          () => liveApi.getRunFeedback('room-123', 'thread-456', ''),
+          throwsA(isA<ArgumentError>()),
+        );
       });
     });
 

--- a/test/modules/room/ui/feedback_buttons_test.dart
+++ b/test/modules/room/ui/feedback_buttons_test.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:soliplex_client/soliplex_client.dart' show FeedbackType;
+import 'package:soliplex_logging/soliplex_logging.dart';
 
 import 'package:soliplex_frontend/src/modules/room/ui/feedback_buttons.dart';
 
@@ -113,5 +114,124 @@ void main() {
     );
 
     expect(submittedType, FeedbackType.thumbsUp);
+  });
+
+  group('the reason dialog', () {
+    /// Pumps the buttons, starts a countdown, and opens the reason dialog.
+    Future<List<(FeedbackType, String?)>> openDialog(
+      WidgetTester tester,
+    ) async {
+      final submitted = <(FeedbackType, String?)>[];
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: FeedbackButtons(
+              onFeedbackSubmit: (type, reason) => submitted.add((type, reason)),
+              countdownSeconds: 30,
+            ),
+          ),
+        ),
+      );
+      await tester.tap(find.byTooltip('Thumbs down'));
+      await tester.pump();
+      await tester.tap(find.text('Tell us why!'));
+      await tester.pumpAndSettle();
+      return submitted;
+    }
+
+    testWidgets('Send submits the typed reason once', (tester) async {
+      final submitted = await openDialog(tester);
+
+      await tester.enterText(find.byType(TextField), 'wrong citation');
+      await tester.tap(find.text('Send'));
+      await tester.pumpAndSettle();
+
+      expect(submitted, [(FeedbackType.thumbsDown, 'wrong citation')]);
+      // Submitted, so the countdown must not restart and re-submit.
+      await tester.pump(const Duration(seconds: 31));
+      expect(submitted, hasLength(1));
+    });
+
+    testWidgets('an all-whitespace reason submits as no reason',
+        (tester) async {
+      final submitted = await openDialog(tester);
+
+      await tester.enterText(find.byType(TextField), '   ');
+      await tester.tap(find.text('Send'));
+      await tester.pumpAndSettle();
+
+      expect(submitted, [(FeedbackType.thumbsDown, null)]);
+    });
+
+    testWidgets('Cancel resumes the countdown instead of submitting',
+        (tester) async {
+      final submitted = await openDialog(tester);
+
+      await tester.tap(find.text('Cancel'));
+      // Bounded pumps: pumpAndSettle would run the resumed countdown to
+      // completion and submit, which is the behaviour under test.
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 400));
+
+      expect(submitted, isEmpty);
+      expect(find.text('Tell us why!'), findsOneWidget);
+
+      await tester.pump(const Duration(seconds: 31));
+      expect(submitted, [(FeedbackType.thumbsDown, null)]);
+    });
+
+    testWidgets('a send after the tile is gone refuses instead of throwing',
+        (tester) async {
+      // The tile lives in a sliver, so it can be destroyed while the modal is
+      // still up. Submitting then reaches setState on a defunct State, which
+      // throws — the dialog's guard would swallow it as a caller defect and
+      // log at error level, burying the real defects that log is for.
+      final sink = MemorySink();
+      LogManager.instance.addSink(sink);
+      addTearDown(() => LogManager.instance.removeSink(sink));
+
+      final submitted = <(FeedbackType, String?)>[];
+      final showTile = ValueNotifier<bool>(true);
+      addTearDown(showTile.dispose);
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: ValueListenableBuilder<bool>(
+              valueListenable: showTile,
+              builder: (_, visible, __) => visible
+                  ? FeedbackButtons(
+                      onFeedbackSubmit: (type, reason) =>
+                          submitted.add((type, reason)),
+                      countdownSeconds: 30,
+                    )
+                  : const SizedBox.shrink(),
+            ),
+          ),
+        ),
+      );
+      await tester.tap(find.byTooltip('Thumbs down'));
+      await tester.pump();
+      await tester.tap(find.text('Tell us why!'));
+      await tester.pumpAndSettle();
+      await tester.enterText(find.byType(TextField), 'typed after teardown');
+
+      // Drop the tile, keeping the dialog's route on the navigator above it.
+      showTile.value = false;
+      await tester.pump();
+
+      await tester.tap(find.text('Send'));
+      await tester.pump();
+
+      expect(tester.takeException(), isNull);
+      expect(
+        sink.records.where((r) => r.level >= LogLevel.error),
+        isEmpty,
+        reason: 'An expected teardown must not be logged as a caller defect.',
+      );
+      // dispose already submitted for the pending direction; the reason typed
+      // after teardown cannot be delivered, and the dialog says so.
+      expect(submitted, [(FeedbackType.thumbsDown, null)]);
+      expect(find.text("Couldn't send that. Try again."), findsOneWidget);
+    });
   });
 }

--- a/test/modules/room/ui/feedback_reason_dialog_test.dart
+++ b/test/modules/room/ui/feedback_reason_dialog_test.dart
@@ -1,15 +1,48 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 import 'package:soliplex_frontend/src/modules/room/ui/feedback_reason_dialog.dart';
 
-void main() {
-  testWidgets('renders dialog with text field and actions', (tester) async {
-    await tester.pumpWidget(
-      const MaterialApp(
-        home: Scaffold(body: FeedbackReasonDialog()),
+/// Opens the dialog over a trivial host and returns the reasons [onSubmit]
+/// received, so assertions read the text the dialog actually submitted rather
+/// than the controller it holds.
+Future<List<String>> _open(
+  WidgetTester tester, {
+  Future<bool> Function(String reason)? onSubmit,
+  Future<String?> Function()? loadInitialText,
+}) async {
+  final submitted = <String>[];
+  await tester.pumpWidget(
+    MaterialApp(
+      home: Scaffold(
+        body: Builder(
+          builder: (context) => ElevatedButton(
+            onPressed: () => showDialog<void>(
+              context: context,
+              builder: (_) => FeedbackReasonDialog(
+                loadInitialText: loadInitialText,
+                onSubmit: (reason) async {
+                  submitted.add(reason);
+                  return onSubmit == null ? true : await onSubmit(reason);
+                },
+              ),
+            ),
+            child: const Text('Open'),
+          ),
+        ),
       ),
-    );
+    ),
+  );
+  await tester.tap(find.text('Open'));
+  await tester.pumpAndSettle();
+  return submitted;
+}
+
+void main() {
+  testWidgets('renders the prompt, the hint and both actions', (tester) async {
+    await _open(tester);
 
     expect(find.text('Tell us why'), findsOneWidget);
     expect(find.text('Add a reason (optional)'), findsOneWidget);
@@ -17,64 +50,133 @@ void main() {
     expect(find.text('Send'), findsOneWidget);
   });
 
-  testWidgets('Send returns entered text', (tester) async {
-    String? result;
-
-    await tester.pumpWidget(
-      MaterialApp(
-        home: Scaffold(
-          body: Builder(
-            builder: (context) => ElevatedButton(
-              onPressed: () async {
-                result = await showDialog<String>(
-                  context: context,
-                  builder: (_) => const FeedbackReasonDialog(),
-                );
-              },
-              child: const Text('Open'),
-            ),
-          ),
-        ),
-      ),
-    );
-
-    await tester.tap(find.text('Open'));
-    await tester.pumpAndSettle();
+  testWidgets('Send submits the typed text and closes', (tester) async {
+    final submitted = await _open(tester);
 
     await tester.enterText(find.byType(TextField), 'Bad citation');
     await tester.tap(find.text('Send'));
     await tester.pumpAndSettle();
 
-    expect(result, 'Bad citation');
+    expect(submitted, ['Bad citation']);
+    expect(find.text('Tell us why'), findsNothing);
   });
 
-  testWidgets('Cancel returns null', (tester) async {
-    String? result = 'sentinel';
+  testWidgets('Cancel submits nothing and closes', (tester) async {
+    final submitted = await _open(tester);
 
-    await tester.pumpWidget(
-      MaterialApp(
-        home: Scaffold(
-          body: Builder(
-            builder: (context) => ElevatedButton(
-              onPressed: () async {
-                result = await showDialog<String>(
-                  context: context,
-                  builder: (_) => const FeedbackReasonDialog(),
-                );
-              },
-              child: const Text('Open'),
-            ),
-          ),
-        ),
-      ),
-    );
-
-    await tester.tap(find.text('Open'));
-    await tester.pumpAndSettle();
-
+    await tester.enterText(find.byType(TextField), 'never mind');
     await tester.tap(find.text('Cancel'));
     await tester.pumpAndSettle();
 
-    expect(result, isNull);
+    expect(submitted, isEmpty);
+    expect(find.text('Tell us why'), findsNothing);
+  });
+
+  group('the note already on file', () {
+    testWidgets('withholds Send until the note has been read', (tester) async {
+      // Submitting mid-load would upsert over a note nobody has seen yet.
+      final gate = Completer<String?>();
+      final submitted = <String>[];
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: FeedbackReasonDialog(
+              loadInitialText: () => gate.future,
+              onSubmit: (reason) async {
+                submitted.add(reason);
+                return true;
+              },
+            ),
+          ),
+        ),
+      );
+      await tester.pump();
+
+      expect(find.byType(CircularProgressIndicator), findsOneWidget);
+      await tester.tap(find.text('Send'), warnIfMissed: false);
+      await tester.pump();
+      expect(submitted, isEmpty);
+
+      gate.complete('on file');
+      await tester.pumpAndSettle();
+
+      expect(find.byType(CircularProgressIndicator), findsNothing);
+      await tester.tap(find.text('Send'));
+      await tester.pumpAndSettle();
+      expect(submitted, ['on file']);
+    });
+
+    testWidgets('says so when it could not be read, and still submits',
+        (tester) async {
+      // Never claims nothing is on file: an unreadable note is not an absent
+      // one, and submitting replaces whatever is there.
+      final submitted = await _open(
+        tester,
+        loadInitialText: () async => throw Exception('offline'),
+      );
+
+      expect(
+        find.text(
+          'Couldn\'t check for an earlier note. '
+          'Submitting replaces any that exists.',
+        ),
+        findsOneWidget,
+      );
+
+      await tester.enterText(find.byType(TextField), 'still worth saying');
+      await tester.tap(find.text('Send'));
+      await tester.pumpAndSettle();
+
+      expect(submitted, ['still worth saying']);
+    });
+  });
+
+  group('submitting', () {
+    testWidgets('stays open with the text intact when the send fails',
+        (tester) async {
+      await _open(tester, onSubmit: (_) async => false);
+
+      await tester.enterText(find.byType(TextField), 'worth keeping');
+      await tester.tap(find.text('Send'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Tell us why'), findsOneWidget);
+      expect(find.text('worth keeping'), findsOneWidget);
+      expect(find.text('Couldn\'t send that. Try again.'), findsOneWidget);
+    });
+
+    testWidgets('a retry after a failure can succeed', (tester) async {
+      var attempts = 0;
+      final submitted = await _open(
+        tester,
+        onSubmit: (_) async => ++attempts > 1,
+      );
+
+      await tester.enterText(find.byType(TextField), 'worth keeping');
+      await tester.tap(find.text('Send'));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('Send'));
+      await tester.pumpAndSettle();
+
+      expect(submitted, ['worth keeping', 'worth keeping']);
+      expect(find.text('Tell us why'), findsNothing);
+    });
+
+    testWidgets('ignores a second tap while the first is in flight',
+        (tester) async {
+      final gate = Completer<bool>();
+      final submitted = await _open(tester, onSubmit: (_) => gate.future);
+
+      await tester.enterText(find.byType(TextField), 'once');
+      await tester.tap(find.text('Send'));
+      await tester.pump();
+      await tester.tap(find.text('Send'), warnIfMissed: false);
+      await tester.pump();
+
+      expect(submitted, ['once']);
+
+      gate.complete(true);
+      await tester.pumpAndSettle();
+    });
   });
 }


### PR DESCRIPTION
Groundwork for annotating the records [#530](https://github.com/soliplex/frontend/pull/530) files. **Nothing here is user-visible** — the client gains a read nobody calls yet, and the dialog gains state its one existing caller cannot exercise. The affordance that uses both is the next PR.

Two commits, reviewable independently.

## `feat(client)` — read the feedback record on file

The client could write feedback but never read it. The write is an **upsert** — `save_run_feedback` deletes any existing row before inserting — so a caller that offers to edit a run's note without first reading it destroys whatever was there. Reading is the precondition for offering the edit at all.

`RunFeedback` carries only the reason. The record's rating is deliberately not decoded: the only reader is a prefill, and a field nothing consumes is a field that rots. The class survives with one field because it expresses what a bare `String?` cannot — whether a record exists, which is distinct from a record whose reason is empty.

Absence decodes to null, from an empty body or a JSON `null`. An installation that reports absence some other way throws instead, so the doc says plainly that a caller needing to tell absence from unreadability must treat a throw as unreadable rather than as absence.

## `refactor(room)` — the dialog owns the exchange it reports on

It popped a string and left the caller to interpret it, so nothing could report a submission that did not land, and there was nowhere to put a note read from the backend.

It now takes a submit callback and answers for the outcome: **on a rejected write it stays open with the typed text intact** rather than closing over a record that was never written.

It also reads what is already on file before the user edits it. That read belongs here, not in the caller: the caller has no state to host a spinner and no way to stop a second tap opening a second exchange, while this lives in an overlay route above the message sliver and is not destroyed by scrolling.

**An unread note is said out loud rather than shown as absence.** Because the write is an upsert, submitting over a note nobody could read destroys it — so the two conditions occupy different slots. The unread-note warning is the ordinary state and must outlive a failed submit, so it is helper text; only a rejected send is an error. Submitting marks the field read-only rather than disabled, which would grey out the text the user may need to retry with.

Both failure paths log. The read's caller rethrows precisely so absence and unreadability stay distinguishable; swallowing that silently would let a decode break empty every prefill with no record of why.

### The existing thumbs-up/down is unchanged

It reports no outcome, so its callback answers only that the dialog may close. It refuses once its tile is gone — the tile lives in a sliver and can be destroyed while the modal is up, where submitting would reach `setState` on a defunct `State` and be logged as a caller defect rather than the ordinary teardown it is.

## Tests

20 tests. The load-gating one is the only test whose submitted text comes from the *loaded* note rather than from `enterText`, so it is the one that fails if the prefill assignment is removed — an earlier pair that appeared to cover this could not fail, because `enterText` replaces the whole field.

## Not here

No CHANGELOG entry: nothing a user can observe changes. That entry lands with the affordance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)