### PR TITLE
feat(room): let the user read and extend the note filed for a failed run

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,15 @@ Versions follow the `version+build` scheme from `pubspec.yaml`, bumped via
 
 ### Added
 
+- A run that ended without an answer now offers to report it, from the failure's
+  own place in the transcript rather than from a banner that can be dismissed
+  and does not survive a reload. A run the backend reported as failed offers to
+  view or add to the note already filed for it; a run that finished without
+  saying anything offers to report the problem. The note on file is read before
+  it is shown, because submitting replaces it — so an edit adds to what is there
+  instead of destroying it, and a note that could not be read is said to be
+  unread rather than shown as absent. A report that does not reach the server
+  leaves the dialog open with the text intact.
 - A run that fails now files a thumbs-down feedback record for itself, so the
   failure becomes discoverable. The backend records the error as it streams but
   keeps no queryable run status, and feedback is the only table an

--- a/lib/src/modules/room/thread_view_state.dart
+++ b/lib/src/modules/room/thread_view_state.dart
@@ -194,30 +194,66 @@ class ThreadViewState {
         ?.respond(request, approved);
   }
 
-  void submitFeedback(String runId, FeedbackType feedback, String? reason) {
-    unawaited(
-      _connection.api
-          .submitFeedback(_roomId, threadId, runId, feedback, reason: reason)
-          .then((_) {}, onError: (Object e, StackTrace st) {
-        if (e is AuthException) {
-          _logger.warning(
-            'submitFeedback hit AuthException; funneling to markSessionExpired',
-            error: e,
-            stackTrace: st,
-          );
-          _auth.markSessionExpired();
-          return;
-        }
-        // Fire-and-forget UX: surface nothing inline (thumbs-up is
-        // ambient), but keep the failure debuggable so 5xx / decode /
-        // programmer errors don't vanish.
-        _logger.warning(
-          'Feedback submission failed',
-          error: e,
-          stackTrace: st,
-        );
-      }),
-    );
+  /// Reads the reason on file for [runId]. Null means the run carries no
+  /// reason — either no record at all, or a record that never had one.
+  ///
+  /// Throws whatever the request threw: a note that could not be read is not
+  /// an absent note, and the write that follows is an upsert, so the caller
+  /// must be able to tell the two apart. A 401 is funnelled the way
+  /// [submitFeedback] funnels it before the throw continues, so a dead grant
+  /// does not leave the user reading "couldn't check" on a signed-in screen.
+  Future<String?> fetchRunFeedback(String runId) async {
+    try {
+      final record =
+          await _connection.api.getRunFeedback(_roomId, threadId, runId);
+      return record?.reason;
+    } on AuthException {
+      _auth.markSessionExpired();
+      rethrow;
+    }
+  }
+
+  /// Submits feedback for [runId] and answers whether the record landed.
+  ///
+  /// Does not throw for a rejected write: callers show the outcome instead. A
+  /// caller with nothing to show can ignore the answer, which is why this
+  /// stays assignable to the `void`-returning callback the message wire
+  /// carries — a `Future<bool>`-returning function is a subtype of a
+  /// `void`-returning one.
+  Future<bool> submitFeedback(
+    String runId,
+    FeedbackType feedback,
+    String? reason,
+  ) async {
+    // The whole handler sits inside the guard: markSessionExpired writes a
+    // signal and notifies subscribers, so it can throw, and this future is
+    // discarded by the message wire — an escape there is unhandled.
+    try {
+      await _connection.api
+          .submitFeedback(_roomId, threadId, runId, feedback, reason: reason);
+      return true;
+    } on Object catch (e, st) {
+      // These requests carry a body — the user's own free text — so an
+      // exception that echoes what the server rejected would render that text
+      // into the exportable log buffer. Only a NetworkException, whose host
+      // and OS error are the whole diagnosis, is forwarded whole; anything
+      // else keeps its shape plus the status code, which is a protocol
+      // constant rather than a value the server chose.
+      _logger.warning(
+        e is AuthException
+            ? 'submitFeedback hit AuthException; '
+                'funneling to markSessionExpired'
+            : 'Feedback submission failed',
+        error: e is NetworkException ? e : null,
+        stackTrace: st,
+        attributes: {
+          if (e is ApiException) 'statusCode': e.statusCode,
+          if (e is! NetworkException) 'failure': describeFailure(e),
+        },
+      );
+      if (e is AuthException) _auth.markSessionExpired();
+      return false;
+    }
   }
 
   void clearSendError() => _lastSendError.value = null;

--- a/lib/src/modules/room/ui/message_tile.dart
+++ b/lib/src/modules/room/ui/message_tile.dart
@@ -20,6 +20,7 @@ class MessageTile extends StatelessWidget {
     this.runId,
     this.sourceReferences,
     this.onFeedbackSubmit,
+    this.onReportRun,
     this.onInspect,
     this.onShowChunkVisualization,
     this.onFetchWorkdirFiles,
@@ -35,6 +36,7 @@ class MessageTile extends StatelessWidget {
   final List<SourceReference>? sourceReferences;
   final void Function(String runId, FeedbackType feedback, String? reason)?
       onFeedbackSubmit;
+  final void Function(String runId)? onReportRun;
   final void Function(String runId)? onInspect;
   final void Function(SourceReference)? onShowChunkVisualization;
   final FetchWorkdirFiles? onFetchWorkdirFiles;
@@ -70,6 +72,8 @@ class MessageTile extends StatelessWidget {
         final NoResponseTile m => NoResponseTileWidget(
             roomId: roomId,
             message: m,
+            runId: runId,
+            onReportRun: onReportRun,
             executionTracker: executionTracker,
             streamingPhase: streamingPhase,
           ),

--- a/lib/src/modules/room/ui/message_timeline.dart
+++ b/lib/src/modules/room/ui/message_timeline.dart
@@ -28,6 +28,7 @@ class MessageTimeline extends StatefulWidget {
     this.streamingState,
     this.executionTrackers = const {},
     this.onFeedbackSubmit,
+    this.onReportRun,
     this.onInspect,
     this.onShowChunkVisualization,
     this.onFetchWorkdirFiles,
@@ -46,6 +47,7 @@ class MessageTimeline extends StatefulWidget {
   final Map<String, ExecutionTracker> executionTrackers;
   final void Function(String runId, FeedbackType feedback, String? reason)?
       onFeedbackSubmit;
+  final void Function(String runId)? onReportRun;
   final void Function(String runId)? onInspect;
   final void Function(SourceReference)? onShowChunkVisualization;
   final FetchWorkdirFiles? onFetchWorkdirFiles;
@@ -431,6 +433,7 @@ class _MessageTimelineState extends State<MessageTimeline> {
                                   : null),
                           sourceReferences: _sourceReferencesMap[message.id],
                           onFeedbackSubmit: widget.onFeedbackSubmit,
+                          onReportRun: widget.onReportRun,
                           onInspect: widget.onInspect,
                           onShowChunkVisualization:
                               widget.onShowChunkVisualization,

--- a/lib/src/modules/room/ui/no_response_tile_widget.dart
+++ b/lib/src/modules/room/ui/no_response_tile_widget.dart
@@ -14,12 +14,21 @@ class NoResponseTileWidget extends StatelessWidget {
     super.key,
     required this.roomId,
     required this.message,
+    this.runId,
+    this.onReportRun,
     this.executionTracker,
     this.streamingPhase,
   });
 
   final String roomId;
   final NoResponseTile message;
+
+  /// The run this tile reports on, or null when none could be resolved.
+  final String? runId;
+
+  /// Opens the note the run carries, for reading, extending or replacing.
+  final void Function(String runId)? onReportRun;
+
   final ExecutionTracker? executionTracker;
   final RunPhase? streamingPhase;
 
@@ -27,6 +36,7 @@ class NoResponseTileWidget extends StatelessWidget {
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
     final hasTracker = executionTracker != null;
+    final reportLabel = _reportLabel(message.reason);
 
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
@@ -61,11 +71,38 @@ class NoResponseTileWidget extends StatelessWidget {
           reason: message.reason,
           errorDetail: message.errorDetail,
         ),
+        if (reportLabel != null && runId != null && onReportRun != null)
+          SoliplexButton.text(
+            isCompact: true,
+            onPressed: () => onReportRun!(runId!),
+            child: Text(reportLabel),
+          ),
         if (message.createdAt != null) MessageCaption(time: message.createdAt!),
       ],
     );
   }
 }
+
+/// What the report affordance offers for a run that ended this way, or null
+/// when it offers nothing.
+///
+/// Derived from the tile's own reason rather than stored, so it survives the
+/// tile being scrolled out of the sliver's cache extent, a thread switch, a
+/// history reload and a restart.
+///
+/// A `failed` tile is only ever synthesized from a `RunErrorEvent`, which the
+/// registry attempts to auto-file, so a note usually exists — but the POST is
+/// best-effort and a tile replayed from history may predate any attempt, so
+/// the label describes the affordance rather than a stored record, and the
+/// dialog copes with finding nothing. Nothing is filed for `finished` at
+/// all — but a run that ends saying nothing is a failure from the user's point
+/// of view, and a common thing to report.
+String? _reportLabel(TerminalReason reason) => switch (reason) {
+      TerminalReason.failed => 'View or add a note',
+      TerminalReason.finished => 'Report a problem',
+      // The user stopped this themselves; there is nothing to tell them.
+      TerminalReason.cancelled => null,
+    };
 
 class _TerminalReasonBubble extends StatelessWidget {
   const _TerminalReasonBubble({required this.reason, this.errorDetail});

--- a/lib/src/modules/room/ui/room_screen.dart
+++ b/lib/src/modules/room/ui/room_screen.dart
@@ -13,6 +13,7 @@ import 'package:soliplex_client/soliplex_client.dart'
     show
         AuthException,
         CancelToken,
+        FeedbackType,
         MalformedResponseException,
         PermissionDeniedException,
         RagDocument,
@@ -58,6 +59,7 @@ import 'chunk_visualization_page.dart';
 import 'copy_button.dart';
 import 'document_picker.dart';
 import 'error_retry_panel.dart';
+import 'feedback_reason_dialog.dart';
 import 'inline_image_composer_controller.dart';
 import 'message_timeline.dart';
 import 'async_action_dialog.dart';
@@ -1587,6 +1589,28 @@ class _RoomScreenState extends State<RoomScreen> {
     );
   }
 
+  /// Opens the note on file for [runId] so the user can read it, add to it, or
+  /// replace it.
+  ///
+  /// The dialog reads the note itself rather than being handed the text: the
+  /// tap then opens something immediately instead of waiting a round trip on a
+  /// tile that has no state to show a spinner in, and being modal it stops a
+  /// second tap from starting a second exchange.
+  Future<void> _reportRun(ThreadViewState threadView, String runId) async {
+    await showDialog<void>(
+      context: context,
+      barrierDismissible: false,
+      builder: (_) => FeedbackReasonDialog(
+        loadInitialText: () => threadView.fetchRunFeedback(runId),
+        onSubmit: (reason) => threadView.submitFeedback(
+          runId,
+          FeedbackType.thumbsDown,
+          reason.trim().isEmpty ? null : reason.trim(),
+        ),
+      ),
+    );
+  }
+
   Future<void> _showRenameDialog(String threadId, String currentName) async {
     await showDialog<void>(
       context: context,
@@ -2395,6 +2419,7 @@ class _RoomScreenState extends State<RoomScreen> {
                           unreadBoundary: _anchorTracker.boundary,
                           executionTrackers: threadView.executionTrackers,
                           onFeedbackSubmit: threadView.submitFeedback,
+                          onReportRun: (runId) => _reportRun(threadView, runId),
                           onInspect: (runId) => context.push(
                             AppRoutes.diagnosticsForRun(runId),
                           ),

--- a/test/helpers/fakes.dart
+++ b/test/helpers/fakes.dart
@@ -214,6 +214,13 @@ class RecordingAuthFlow implements AuthFlow {
   }
 }
 
+/// One recorded [FakeSoliplexApi.getRunFeedback] call.
+typedef RequestedRunFeedback = ({
+  String roomId,
+  String threadId,
+  String runId,
+});
+
 /// One recorded [FakeSoliplexApi.submitFeedback] call.
 typedef SubmittedFeedback = ({
   String roomId,
@@ -480,6 +487,28 @@ class FakeSoliplexApi extends SoliplexApi {
     throw StateError(
       'FakeSoliplexApi: set nextQuizAnswerResult or nextQuizAnswerError',
     );
+  }
+
+  /// The record [getRunFeedback] answers with. Null means no record on file.
+  RunFeedback? nextRunFeedback;
+
+  /// Thrown by [getRunFeedback] when set.
+  Object? nextRunFeedbackError;
+
+  /// Every [getRunFeedback] call, in order.
+  final List<RequestedRunFeedback> requestedRunFeedback = [];
+
+  @override
+  Future<RunFeedback?> getRunFeedback(
+    String roomId,
+    String threadId,
+    String runId, {
+    CancelToken? cancelToken,
+  }) async {
+    requestedRunFeedback
+        .add((roomId: roomId, threadId: threadId, runId: runId));
+    if (nextRunFeedbackError != null) throw nextRunFeedbackError!;
+    return nextRunFeedback;
   }
 
   Object? nextSubmitFeedbackError;

--- a/test/modules/room/thread_view_state_test.dart
+++ b/test/modules/room/thread_view_state_test.dart
@@ -1613,4 +1613,102 @@ void main() {
       state.dispose();
     });
   });
+
+  group('feedback outcomes', () {
+    void activate(AuthSession a) {
+      a.login(
+        provider: const OidcProvider(
+          discoveryUrl: 'https://sso/.well-known/openid-configuration',
+          clientId: 'c',
+        ),
+        tokens: AuthTokens(
+          accessToken: 'a',
+          refreshToken: 'r',
+          expiresAt: DateTime.now().add(const Duration(hours: 1)),
+        ),
+      );
+    }
+
+    Future<ThreadViewState> open() async {
+      api.nextThreadHistory = ThreadHistory(messages: const []);
+      final state = ThreadViewState(
+        connection: connection,
+        auth: auth,
+        roomId: 'room-1',
+        threadId: 'thread-1',
+        registry: registry,
+      );
+      await Future<void>.delayed(Duration.zero);
+      addTearDown(state.dispose);
+      return state;
+    }
+
+    test('submitFeedback reports that the record landed', () async {
+      final state = await open();
+
+      expect(
+        await state.submitFeedback('run-1', FeedbackType.thumbsDown, 'why'),
+        isTrue,
+      );
+      expect(api.submittedFeedback.single.reason, 'why');
+    });
+
+    test('submitFeedback reports a rejected record instead of throwing',
+        () async {
+      api.nextSubmitFeedbackError = const NetworkException(message: 'offline');
+      final state = await open();
+
+      expect(
+        await state.submitFeedback('run-1', FeedbackType.thumbsDown, 'why'),
+        isFalse,
+      );
+    });
+
+    test('fetchRunFeedback answers the reason on file', () async {
+      api.nextRunFeedback = const RunFeedback(reason: 'boom');
+      final state = await open();
+
+      expect(await state.fetchRunFeedback('run-1'), 'boom');
+      expect(
+        api.requestedRunFeedback.single,
+        (roomId: 'room-1', threadId: 'thread-1', runId: 'run-1'),
+      );
+    });
+
+    test('fetchRunFeedback answers null when no record is on file', () async {
+      final state = await open();
+
+      expect(await state.fetchRunFeedback('run-1'), isNull);
+    });
+
+    test('fetchRunFeedback expires the session on a dead grant', () async {
+      // Its sibling submitFeedback funnels a 401; without the same funnel
+      // here, a user who reads "couldn't check" and cancels is left on a
+      // signed-in screen with a dead grant.
+      activate(auth);
+      api.nextRunFeedbackError =
+          const AuthException(message: 'expired', statusCode: 401);
+      final state = await open();
+
+      await expectLater(
+        state.fetchRunFeedback('run-1'),
+        throwsA(isA<AuthException>()),
+      );
+
+      expect(auth.session.value, isA<ExpiredSession>());
+    });
+
+    test('fetchRunFeedback rethrows so the dialog can say it could not read',
+        () async {
+      // Swallowing this would let the dialog show an unread note as an absent
+      // one, and the write is an upsert.
+      api.nextRunFeedbackError = const NetworkException(message: 'offline');
+      final state = await open();
+
+      expect(
+        () => state.fetchRunFeedback('run-1'),
+        throwsA(isA<NetworkException>()),
+      );
+    });
+  });
 }

--- a/test/modules/room/ui/message_tile_test.dart
+++ b/test/modules/room/ui/message_tile_test.dart
@@ -13,6 +13,7 @@ import 'package:soliplex_frontend/src/modules/room/ui/execution/phase_indicator.
 import 'package:soliplex_frontend/src/modules/room/ui/execution/execution_timeline.dart';
 import 'package:soliplex_frontend/src/modules/room/ui/execution/thinking_block.dart';
 import 'package:soliplex_frontend/src/modules/room/ui/loading_message_tile.dart';
+import 'package:soliplex_frontend/src/modules/room/ui/message_tile.dart';
 import 'package:soliplex_frontend/src/modules/room/ui/text_message_tile.dart';
 import 'package:soliplex_frontend/src/modules/room/ui/tool_call_tile.dart';
 
@@ -251,6 +252,30 @@ void main() {
       await tester.tap(find.text('search'));
       await tester.pumpAndSettle();
       expect(find.text('Found results'), findsOneWidget);
+    });
+  });
+
+  group('NoResponseTile', () {
+    testWidgets('reports the run the tile was resolved to', (tester) async {
+      // MessageTile is where the tile learns its runId; without the forward
+      // the affordance never appears.
+      final reported = <String>[];
+      await tester.pumpWidget(_wrap(MessageTile(
+        roomId: 'r',
+        message: NoResponseTile.failed(
+          id: 'no-response-run-4',
+          createdAt: DateTime(2026, 3, 1),
+          thinkingText: 'reasoning',
+          errorDetail: 'upstream exploded',
+        ),
+        runId: 'run-4',
+        onReportRun: reported.add,
+      )));
+
+      await tester.tap(find.text('View or add a note'));
+      await tester.pump();
+
+      expect(reported, ['run-4']);
     });
   });
 }

--- a/test/modules/room/ui/no_response_tile_widget_test.dart
+++ b/test/modules/room/ui/no_response_tile_widget_test.dart
@@ -138,4 +138,67 @@ void main() {
 
     expect(find.text('Thinking...'), findsNothing);
   });
+
+  group('report affordance', () {
+    testWidgets('failed offers reading or adding to the filed note',
+        (tester) async {
+      await tester.pumpWidget(_wrap(NoResponseTileWidget(
+        roomId: 'r',
+        message: _tile(reason: TerminalReason.failed),
+        runId: 'run-1',
+        onReportRun: (_) {},
+      )));
+
+      expect(find.text('View or add a note'), findsOneWidget);
+    });
+
+    testWidgets('finished offers reporting a problem', (tester) async {
+      await tester.pumpWidget(_wrap(NoResponseTileWidget(
+        roomId: 'r',
+        message: _tile(reason: TerminalReason.finished),
+        runId: 'run-1',
+        onReportRun: (_) {},
+      )));
+
+      expect(find.text('Report a problem'), findsOneWidget);
+    });
+
+    testWidgets('cancelled offers nothing — it was the user\'s own stop',
+        (tester) async {
+      await tester.pumpWidget(_wrap(NoResponseTileWidget(
+        roomId: 'r',
+        message: _tile(reason: TerminalReason.cancelled),
+        runId: 'run-1',
+        onReportRun: (_) {},
+      )));
+
+      expect(find.text('View or add a note'), findsNothing);
+      expect(find.text('Report a problem'), findsNothing);
+    });
+
+    testWidgets('offers nothing without a run to file against', (tester) async {
+      await tester.pumpWidget(_wrap(NoResponseTileWidget(
+        roomId: 'r',
+        message: _tile(reason: TerminalReason.failed),
+        onReportRun: (_) {},
+      )));
+
+      expect(find.text('View or add a note'), findsNothing);
+    });
+
+    testWidgets('reports the run the tile belongs to', (tester) async {
+      final reported = <String>[];
+      await tester.pumpWidget(_wrap(NoResponseTileWidget(
+        roomId: 'r',
+        message: _tile(reason: TerminalReason.failed),
+        runId: 'run-7',
+        onReportRun: reported.add,
+      )));
+
+      await tester.tap(find.text('View or add a note'));
+      await tester.pump();
+
+      expect(reported, ['run-7']);
+    });
+  });
 }

--- a/test/modules/room/ui/room_screen_test.dart
+++ b/test/modules/room/ui/room_screen_test.dart
@@ -6,6 +6,7 @@ import 'package:flutter/foundation.dart'
     show debugDefaultTargetPlatformOverride;
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:go_router/go_router.dart';
 import 'package:shared_preferences/shared_preferences.dart';
@@ -17,6 +18,8 @@ import 'package:soliplex_frontend/src/modules/lobby/lobby_read_markers.dart';
 import 'package:soliplex_frontend/src/modules/lobby/ui/unread_dot.dart';
 import 'package:soliplex_frontend/src/modules/room/agent_runtime_manager.dart';
 import 'package:soliplex_frontend/src/modules/room/document_selections.dart';
+import 'package:soliplex_frontend/src/modules/room/message_expansions.dart';
+import 'package:soliplex_frontend/src/modules/room/room_providers.dart';
 import 'package:soliplex_frontend/src/modules/room/run_registry.dart';
 import 'package:soliplex_frontend/src/modules/room/thread_anchor_storage.dart';
 import 'package:soliplex_frontend/src/modules/room/thread_read_markers.dart';
@@ -3566,6 +3569,138 @@ void main() {
       await tester.pumpAndSettle();
 
       expect(composer.controller!.text, 'X');
+    });
+  });
+
+  group('reporting a failed run', () {
+    /// A thread whose transcript carries one failed run, with the runId the
+    /// resolver needs on the preceding user message.
+    void seedFailedRun() {
+      api.nextThreadHistory = ThreadHistory(
+        messages: [
+          TextMessage(
+            id: 'user-1',
+            user: ChatUser.user,
+            createdAt: DateTime(2026, 3, 1),
+            text: 'summarise the report',
+          ),
+          NoResponseTile.failed(
+            id: 'no-response-run-9',
+            createdAt: DateTime(2026, 3, 1),
+            thinkingText: 'thinking',
+            errorDetail: 'upstream exploded',
+          ),
+        ],
+        messageStates: {
+          'user-1': MessageState(
+            userMessageId: 'user-1',
+            sourceReferences: const [],
+            runId: 'run-9',
+          ),
+        },
+      );
+    }
+
+    Future<void> openRoom(WidgetTester tester) async {
+      tester.view.physicalSize = const Size(1200, 900);
+      tester.view.devicePixelRatio = 1.0;
+      addTearDown(tester.view.resetPhysicalSize);
+      await tester.pumpWidget(ProviderScope(
+        overrides: [
+          messageExpansionsProvider.overrideWithValue(MessageExpansions()),
+        ],
+        child: MaterialApp(
+          home: RoomScreen(
+            serverEntry: entry,
+            roomId: 'room-1',
+            threadId: 'thread-1',
+            runtimeManager: runtimeManager,
+            registry: registry,
+            uploadRegistry: uploadRegistry,
+            documentSelections: DocumentSelections(),
+          ),
+        ),
+      ));
+      await tester.pumpAndSettle();
+    }
+
+    /// The dialog's field, not the composer's — both are on screen.
+    final dialogField = find.descendant(
+      of: find.byType(AlertDialog),
+      matching: find.byType(TextField),
+    );
+
+    /// The transcript sliver places the tile far below the viewport, so the
+    /// affordance has to be scrolled into view before it can be tapped.
+    Future<void> tapReport(WidgetTester tester) async {
+      final report = find.text('View or add a note');
+      await tester.ensureVisible(report);
+      await tester.pumpAndSettle();
+      await tester.tap(report);
+      await tester.pumpAndSettle();
+    }
+
+    testWidgets('files a thumbs-down against the run the tile names',
+        (tester) async {
+      // The whole wire, end to end: the timeline and tile forwards, the runId
+      // the resolver supplied, and the polarity room_screen hard-codes. A
+      // thumbs-up here would replace the auto-filed failure and drop the run
+      // out of the triage queue this feature exists to fill.
+      seedFailedRun();
+      await openRoom(tester);
+
+      await tapReport(tester);
+
+      expect(
+        api.requestedRunFeedback.single,
+        (roomId: 'room-1', threadId: 'thread-1', runId: 'run-9'),
+      );
+
+      await tester.enterText(dialogField, 'it lost my attachment');
+      await tester.tap(find.text('Send'));
+      await tester.pumpAndSettle();
+
+      final filed = api.submittedFeedback.single;
+      expect(filed.roomId, 'room-1');
+      expect(filed.threadId, 'thread-1');
+      expect(filed.runId, 'run-9');
+      expect(filed.feedback, FeedbackType.thumbsDown);
+      expect(filed.reason, 'it lost my attachment');
+      expect(find.text('Tell us why'), findsNothing);
+    });
+
+    testWidgets('prefills the note already on file', (tester) async {
+      seedFailedRun();
+      api.nextRunFeedback =
+          const RunFeedback(reason: '[auto] Run failed: server error');
+      await openRoom(tester);
+
+      await tapReport(tester);
+
+      // Submitting untouched sends back exactly what was on file, which is
+      // what stops an edit from destroying the auto-filed record.
+      await tester.tap(find.text('Send'));
+      await tester.pumpAndSettle();
+
+      expect(
+        api.submittedFeedback.single.reason,
+        '[auto] Run failed: server error',
+      );
+    });
+
+    testWidgets('keeps the dialog open when the write is rejected',
+        (tester) async {
+      seedFailedRun();
+      api.nextSubmitFeedbackError = const NetworkException(message: 'offline');
+      await openRoom(tester);
+
+      await tapReport(tester);
+      await tester.enterText(dialogField, 'worth keeping');
+      await tester.tap(find.text('Send'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Tell us why'), findsOneWidget);
+      expect(find.text('worth keeping'), findsOneWidget);
     });
   });
 }


### PR DESCRIPTION
The last of three. [#530](https://github.com/soliplex/frontend/pull/530) files a record when a run fails; [#531](https://github.com/soliplex/frontend/pull/531) added the read and gave the dialog ownership of the exchange. **This is where the feature becomes visible.**

## Where the affordance goes, and why not the banner

A failure was recorded where nobody could see it. `_SendErrorBanner` was the obvious candidate and is wrong for this: it is dismissible, holds only the *latest* failure, and **does not exist at all after a reload** — `_fetch` populates messages but never sets `lastSendError`. A durable action does not belong on a transient single-slot notification.

The transcript tile is where a failure lives permanently and is anchored to its own run.

## The label is derived, never stored

A tile inside `SliverList.builder` is destroyed when scrolled past the cache extent, so anything it held would silently reset. `_reportLabel` is a pure function of the terminal reason the tile already carries, so the offer survives scrolling, a thread switch, a history reload and a restart.

| Reason | Offer |
| --- | --- |
| `failed` | *View or add a note* — the registry attempted to file one |
| `finished` | *Report a problem* — nothing was filed, but a run that ends saying nothing is a failure from the user's point of view |
| `cancelled` | nothing — the user's own stop |

## Reading before showing is not a nicety

The write is an **upsert**. A dialog that opened empty over an existing note would destroy it on submit — the read is what makes offering the edit safe at all.

So `fetchRunFeedback` **rethrows** rather than reporting absence, letting the dialog say a note was *unread* instead of showing it as *absent*. And it funnels a 401 the way `submitFeedback` does, so a dead grant is not left sitting behind that notice on a signed-in screen.

`submitFeedback` now answers whether the record landed. It stays assignable to the `void`-returning callback the message wire carries, so the existing thumbs-up/down keeps its type and behaviour and nothing rippled through `TextMessageTile`.

## `ErrorMessage` tiles get no affordance

`buildRunIdMap` attributes a message to the **preceding user message's** run. That is right for a tile synthesized at a run's own terminal event, and wrong for an error minted before any run started — that message has no run of its own, so the map hands it the previous turn's id. Filing there would destroy an unrelated run's record. Fixing it properly means the message carrying its own runId, which is separate work.

## Tests

`room_screen` is covered end to end: tap the tile's link, the prefill request is asserted for the right room/thread/run, the submitted record is asserted for polarity and reason.

That polarity assertion is the one worth a second reader. `_reportRun` hard-codes `FeedbackType.thumbsDown`; flipping it to `thumbsUp` would — via the upsert — **replace the auto-filed failure with a thumbs-up and remove the run from the triage queue #530 exists to fill.** Before this test, nothing would have caught it. Deleting the `MessageTimeline` forward is likewise caught.

## Verification of the split

This branch reassembles to the state that was reviewed: with #530 and #531 on `main`, `git diff` against the original pre-split branch is **empty across every file but `CHANGELOG.md`**. Nothing was dropped or altered while moving ~1900 lines through three PRs.

## Known limits, unchanged

At most once, *attempted* — the auto-file POST is not retried. Several filed records are still unreachable from the transcript (`ErrorMessage` tiles, and `toolExecutionFailed`, which produces no tile at all); both are written up as follow-up work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)