### PR TITLE
fix(room): repair the run-feedback dialog and say what actually failed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,10 @@ Versions follow the `version+build` scheme from `pubspec.yaml`, bumped via
   it is shown, because submitting replaces it — so an edit adds to what is there
   instead of destroying it, and a note that could not be read is said to be
   unread rather than shown as absent. A report that does not reach the server
-  leaves the dialog open with the text intact.
+  leaves the dialog open with the text intact, and the warning that submitting
+  replaces an existing note stays on screen while that error shows — a retry is
+  when it matters most. The dialog is wide enough for that warning to be read
+  in full.
 - A run that fails now files a thumbs-down feedback record for itself, so the
   failure becomes discoverable. The backend records the error as it streams but
   keeps no queryable run status, and feedback is the only table an
@@ -28,10 +31,18 @@ Versions follow the `version+build` scheme from `pubspec.yaml`, bumped via
   client to reconnect to and it often completes, and filing would record a
   successful run as failed. An unclassified failure is logged against its run
   instead of filed, since it may name a fault on this side rather than a
-  backend outcome.
+  backend outcome. The record names the failure's classification, the run's own
+  error text and the client version, so two failed runs can be told apart in a
+  review queue without opening either.
 
 ### Fixed
 
+- Stopping a run while it was still thinking no longer blanks the exchange. The
+  transcript kept nothing at all — no tile, no reasoning, no error row —
+  whenever the stop landed before the first reasoning content arrived or while
+  a tool call was still in flight, because the only copy of what was on screen
+  lived in streaming state that the stop discarded. A cancelled run now keeps
+  whatever had been shown, and still records nothing when nothing had been.
 - The attached-files panel no longer strands open, and no longer reopens by
   itself. The control that opens it is the only one that closes it, and it is
   withdrawn once neither upload scope has anything left to show — so dismissing

--- a/lib/src/modules/room/run_registry.dart
+++ b/lib/src/modules/room/run_registry.dart
@@ -143,18 +143,24 @@ class RunRegistry {
     final recording = _recordingFor(terminalState.reason);
     final failure = recording.filedAs;
     if (failure == null) {
+      final attributes = {
+        'key': key.toString(),
+        'runId': runId,
+        'reason': terminalState.reason.name,
+      };
       if (recording.logUnfiled) {
         // Not the backend's run outcome, so not filed — but still a run the
         // user got no answer from, and the orchestrator's own 'Run failed'
         // record names no run. This is what ties it to one.
         _logger.warning(
           'Run failed without filing feedback',
-          attributes: {
-            'key': key.toString(),
-            'runId': runId,
-            'reason': terminalState.reason.name,
-          },
+          attributes: attributes,
         );
+      } else {
+        // One line per failure the whitelist declines, so which failures file
+        // is answerable from a running installation and not only from tests.
+        _logger.info('Not filing feedback for a failed run',
+            attributes: attributes);
       }
       return;
     }
@@ -173,7 +179,16 @@ class RunRegistry {
         FeedbackType.thumbsDown,
         reason: '[auto] Run failed: $failure',
       )
-          .then((_) {}, onError: (Object error, StackTrace stackTrace) {
+          .then((_) {
+        _logger.info(
+          'Auto-filed feedback for a failed run',
+          attributes: {
+            'key': key.toString(),
+            'runId': runId,
+            'reason': terminalState.reason.name,
+          },
+        );
+      }, onError: (Object error, StackTrace stackTrace) {
         // At most once, attempted: the record is best-effort and a lost POST
         // leaves the failure unrecorded rather than crashing the run that
         // already failed.

--- a/lib/src/modules/room/run_registry.dart
+++ b/lib/src/modules/room/run_registry.dart
@@ -3,9 +3,15 @@ import 'dart:async' show unawaited;
 import 'package:soliplex_agent/soliplex_agent.dart';
 import 'package:soliplex_logging/soliplex_logging.dart';
 
+import '../../../version.dart';
 import '../auth/server_entry.dart';
 
 final Logger _logger = LogManager.instance.getLogger('soliplex.run_registry');
+
+/// What becomes of a failed run: filed as feedback, declined but logged
+/// against the run, or declined silently because it is not a run-quality
+/// signal at all.
+enum _Recording { file, declineAndLog, decline }
 
 /// Terminal outcome of an agent run.
 sealed class RunOutcome {
@@ -141,14 +147,13 @@ class RunRegistry {
     // attach feedback to.
     if (runId == null) return;
     final recording = _recordingFor(terminalState.reason);
-    final failure = recording.filedAs;
-    if (failure == null) {
+    if (recording != _Recording.file) {
       final attributes = {
         'key': key.toString(),
         'runId': runId,
         'reason': terminalState.reason.name,
       };
-      if (recording.logUnfiled) {
+      if (recording == _Recording.declineAndLog) {
         // Not the backend's run outcome, so not filed — but still a run the
         // user got no answer from, and the orchestrator's own 'Run failed'
         // record names no run. This is what ties it to one.
@@ -177,7 +182,7 @@ class RunRegistry {
         key.threadId,
         runId,
         FeedbackType.thumbsDown,
-        reason: '[auto] Run failed: $failure',
+        reason: _autoFiledReason(terminalState),
       )
           .then((_) {
         _logger.info(
@@ -227,51 +232,71 @@ class RunRegistry {
     );
   }
 
-  /// How a failed run is recorded: [filedAs] is the failure description filed
-  /// as feedback, or null when the failure is not filed, and [logUnfiled] asks
-  /// for a log line naming the run when it is not.
+  /// The record a triager reads, built from what only the client holds.
+  ///
+  /// The classification leads, spelled as [FailureReason.name] so the record
+  /// and the log line that announced it share a token, and so a queue can be
+  /// grouped or sorted by it. The failure's own message follows, which is the
+  /// part that actually distinguishes two runs of the same class — the tile
+  /// shows it and the record used to drop it. The client build comes last: the
+  /// row can be joined to its run for the prompt and the events, but not to the
+  /// version that produced them.
+  ///
+  /// The message is the server's own text, not the user's, and a triager
+  /// reaching this record can already read the prompt through the run. It is
+  /// collapsed to one line and capped because the record is prefilled into a
+  /// dialog the user edits, and a message that is really a response body would
+  /// run away with the field.
+  static String _autoFiledReason(FailedState state) {
+    final detail = state.error.replaceAll(RegExp(r'\s+'), ' ').trim();
+    final capped = detail.length > _maxErrorChars
+        ? '${detail.substring(0, _maxErrorChars)}…'
+        : detail;
+    final detailed = capped.isEmpty ? '' : ' — $capped';
+    return '[auto] ${state.reason.name}$detailed, v$soliplexVersion';
+  }
+
+  /// Long enough for a sentence naming what broke, short enough that the user
+  /// can still see their own words in the dialog it prefills.
+  static const _maxErrorChars = 200;
+
+  /// Whether a failed run is filed as feedback, and if not, whether it is still
+  /// logged against the run.
   ///
   /// Auto-filing needs a whitelist because filing the wrong thing writes wrong
   /// data into a human triage queue. Manual filing needs no equivalent: a
   /// human choosing to report something is the judgement we wanted.
-  static ({String? filedAs, bool logUnfiled}) _recordingFor(
-    FailureReason reason,
-  ) {
+  static _Recording _recordingFor(FailureReason reason) {
     return switch (reason) {
       // The backend said it failed, so it is the backend's run outcome.
-      FailureReason.serverError => (filedAs: 'server error', logUnfiled: false),
+      FailureReason.serverError => _Recording.file,
       // The orchestrator gave up after exhausting tool retries; the run is
       // dead either way.
-      FailureReason.toolExecutionFailed => (
-          filedAs: 'tool execution failed',
-          logUnfiled: false
-        ),
+      FailureReason.toolExecutionFailed => _Recording.file,
       // `classifyError`'s fallback, so it names a client-side or as-yet
       // unclassified failure rather than a backend run outcome — and the
       // client disconnects, which the backend answers by keeping the run
       // alive, so it may well complete. Filing would send a reviewer to a
       // run that succeeded. Logged instead, because it is still a run the
       // user got no answer from.
-      FailureReason.internalError => (filedAs: null, logUnfiled: true),
+      FailureReason.internalError => _Recording.declineAndLog,
       // Unreachable on a FailedState — a cancel publishes CancelledState,
       // which the guard above drops. Present for exhaustiveness.
-      FailureReason.cancelled => (filedAs: null, logUnfiled: false),
+      FailureReason.cancelled => _Recording.decline,
       // Session expiry and authz verdicts, not run quality.
-      FailureReason.authExpired || FailureReason.permissionDenied => (
-          filedAs: null,
-          logUnfiled: false
-        ),
+      FailureReason.authExpired ||
+      FailureReason.permissionDenied =>
+        _Recording.decline,
       // The backend deliberately keeps a run alive across a client
       // disconnect so the client can reconnect and watch it finish. Filing
       // would record successfully-completed runs as failed.
-      FailureReason.networkLost || FailureReason.streamResumeFailed => (
-          filedAs: null,
-          logUnfiled: false
-        ),
+      FailureReason.networkLost ||
+      FailureReason.streamResumeFailed =>
+        _Recording.decline,
       // Capacity, not answer quality. Nothing reaches these runs afterwards
       // either: a 429 surfaces as a transient send-error banner, never as a
       // tile, so there is no manual path to fall back on.
-      FailureReason.rateLimited => (filedAs: null, logUnfiled: false),
+      FailureReason.rateLimited => _Recording.decline,
     };
   }
 

--- a/lib/src/modules/room/thread_view_state.dart
+++ b/lib/src/modules/room/thread_view_state.dart
@@ -206,6 +206,14 @@ class ThreadViewState {
     try {
       final record =
           await _connection.api.getRunFeedback(_roomId, threadId, runId);
+      _logger.info(
+        'Read the feedback on file for a run',
+        attributes: {
+          'runId': runId,
+          'hasRecord': record != null,
+          'hasReason': record?.reason != null,
+        },
+      );
       return record?.reason;
     } on AuthException {
       _auth.markSessionExpired();
@@ -231,6 +239,14 @@ class ThreadViewState {
     try {
       await _connection.api
           .submitFeedback(_roomId, threadId, runId, feedback, reason: reason);
+      _logger.info(
+        'Submitted feedback for a run',
+        attributes: {
+          'runId': runId,
+          'feedback': feedback.name,
+          'hasReason': reason != null,
+        },
+      );
       return true;
     } on Object catch (e, st) {
       // These requests carry a body — the user's own free text — so an

--- a/lib/src/modules/room/ui/feedback_buttons.dart
+++ b/lib/src/modules/room/ui/feedback_buttons.dart
@@ -2,9 +2,13 @@ import 'dart:async';
 
 import 'package:flutter/material.dart';
 import 'package:soliplex_client/soliplex_client.dart' show FeedbackType;
+import 'package:soliplex_logging/soliplex_logging.dart';
 
 import 'feedback_reason_dialog.dart';
 import 'package:soliplex_design/soliplex_design.dart';
+
+final Logger _logger =
+    LogManager.instance.getLogger('soliplex.feedback_buttons');
 
 enum _FeedbackPhase { idle, countdown, modal, submitted }
 
@@ -103,10 +107,18 @@ class _FeedbackButtonsState extends State<FeedbackButtons>
         onSubmit: (reason) async {
           // This tile lives in a sliver and can be destroyed while the modal
           // is up, at which point dispose has already submitted for this
-          // direction and _submit's setState would throw. Refusing keeps the
-          // dialog open and honest rather than reporting a send that cannot
-          // happen.
-          if (!mounted) return false;
+          // direction and _submit's setState would throw. Answering true lets
+          // the dialog close: false would hold it open inviting a retry that
+          // can never succeed, since mounted does not come back.
+          if (!mounted) {
+            // Nothing on screen can report this, and dispose has already filed
+            // for the direction without a reason, so the log is the only
+            // account that the text the user typed went nowhere.
+            _logger.warning(
+              'Discarded a feedback reason: the tile was gone before submit',
+            );
+            return true;
+          }
           didSubmit = true;
           _submit(reason.trim().isEmpty ? null : reason.trim());
           // onFeedbackSubmit reports no outcome, so `true` says only that the

--- a/lib/src/modules/room/ui/feedback_reason_dialog.dart
+++ b/lib/src/modules/room/ui/feedback_reason_dialog.dart
@@ -149,42 +149,52 @@ class _FeedbackReasonDialogState extends State<FeedbackReasonDialog> {
     super.dispose();
   }
 
+  /// Material's own `AlertDialog` maximum. Without a width the dialog sits at
+  /// its 280 px minimum however wide the window is, because neither a text
+  /// field nor this content states an intrinsic width preference. A `SizedBox`
+  /// still yields to the incoming constraints, so a narrower window shrinks it
+  /// rather than overflowing.
+  static const _contentWidth = 560.0;
+
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
     return AlertDialog(
       title: const Text('Tell us why'),
-      content: Column(
-        mainAxisSize: MainAxisSize.min,
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          SoliplexInput(
-            controller: _controller,
-            focusNode: _focusNode,
-            autofocus: true,
-            maxLines: 5,
-            hintText: 'Add a reason (optional)',
-            errorText: _error,
-            isLoading: _isLoading,
-            // Not `isLoading` while submitting: that disables the field,
-            // greying out the text the user may still need to retry with.
-            readOnly: _isSubmitting,
-            textInputAction: TextInputAction.newline,
-          ),
-          if (_unreadNote != null) ...[
-            const SizedBox(height: SoliplexSpacing.s2),
-            // Outside the input rather than its `helperText`: that slot is
-            // capped at two lines, which ellipsizes away the clause naming
-            // what a submit replaces, and `errorText` renders in place of it,
-            // so a failed send would hide the warning at the moment the user
-            // is most likely to send again.
-            Text(
-              _unreadNote!,
-              style: theme.textTheme.bodySmall
-                  ?.copyWith(color: theme.colorScheme.onSurfaceVariant),
+      content: SizedBox(
+        width: _contentWidth,
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            SoliplexInput(
+              controller: _controller,
+              focusNode: _focusNode,
+              autofocus: true,
+              maxLines: 5,
+              hintText: 'Add a reason (optional)',
+              errorText: _error,
+              isLoading: _isLoading,
+              // Not `isLoading` while submitting: that disables the field,
+              // greying out the text the user may still need to retry with.
+              readOnly: _isSubmitting,
+              textInputAction: TextInputAction.newline,
             ),
+            if (_unreadNote != null) ...[
+              const SizedBox(height: SoliplexSpacing.s2),
+              // Outside the input rather than its `helperText`: that slot is
+              // capped at two lines, which ellipsizes away the clause naming
+              // what a submit replaces, and `errorText` renders in place of it,
+              // so a failed send would hide the warning at the moment the user
+              // is most likely to send again.
+              Text(
+                _unreadNote!,
+                style: theme.textTheme.bodySmall
+                    ?.copyWith(color: theme.colorScheme.onSurfaceVariant),
+              ),
+            ],
           ],
-        ],
+        ),
       ),
       actions: [
         SoliplexButton.text(

--- a/lib/src/modules/room/ui/feedback_reason_dialog.dart
+++ b/lib/src/modules/room/ui/feedback_reason_dialog.dart
@@ -151,23 +151,40 @@ class _FeedbackReasonDialogState extends State<FeedbackReasonDialog> {
 
   @override
   Widget build(BuildContext context) {
+    final theme = Theme.of(context);
     return AlertDialog(
       title: const Text('Tell us why'),
-      content: SoliplexInput(
-        controller: _controller,
-        focusNode: _focusNode,
-        autofocus: true,
-        maxLines: 5,
-        hintText: 'Add a reason (optional)',
-        // The unread-note warning is the ordinary state, not an error, and it
-        // has to outlive a failed submit — so the two occupy different slots.
-        helperText: _unreadNote,
-        errorText: _error,
-        isLoading: _isLoading,
-        // Not `isLoading` while submitting: that disables the field, greying
-        // out the text the user may still need to retry with.
-        readOnly: _isSubmitting,
-        textInputAction: TextInputAction.newline,
+      content: Column(
+        mainAxisSize: MainAxisSize.min,
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          SoliplexInput(
+            controller: _controller,
+            focusNode: _focusNode,
+            autofocus: true,
+            maxLines: 5,
+            hintText: 'Add a reason (optional)',
+            errorText: _error,
+            isLoading: _isLoading,
+            // Not `isLoading` while submitting: that disables the field,
+            // greying out the text the user may still need to retry with.
+            readOnly: _isSubmitting,
+            textInputAction: TextInputAction.newline,
+          ),
+          if (_unreadNote != null) ...[
+            const SizedBox(height: SoliplexSpacing.s2),
+            // Outside the input rather than its `helperText`: that slot is
+            // capped at two lines, which ellipsizes away the clause naming
+            // what a submit replaces, and `errorText` renders in place of it,
+            // so a failed send would hide the warning at the moment the user
+            // is most likely to send again.
+            Text(
+              _unreadNote!,
+              style: theme.textTheme.bodySmall
+                  ?.copyWith(color: theme.colorScheme.onSurfaceVariant),
+            ),
+          ],
+        ],
       ),
       actions: [
         SoliplexButton.text(

--- a/lib/src/modules/room/ui/feedback_reason_dialog.dart
+++ b/lib/src/modules/room/ui/feedback_reason_dialog.dart
@@ -83,8 +83,16 @@ class _FeedbackReasonDialogState extends State<FeedbackReasonDialog> {
       _unreadNote = failure;
       if (onFile != null) _controller.text = onFile;
     });
-    // The field was disabled while loading, so autofocus never took effect.
-    _focusNode.requestFocus();
+    // The field was disabled while loading, so autofocus never took effect and
+    // the node still refuses focus until the rebuild above re-enables it —
+    // hence after the frame, not now.
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      // Not while covered: a modal scope keeps requesting focus even when it
+      // is no longer on top, which would open the keyboard against whatever
+      // route is above this one.
+      if (!mounted) return;
+      if (ModalRoute.of(context)?.isCurrent ?? true) _focusNode.requestFocus();
+    });
   }
 
   Future<void> _submit() async {
@@ -112,13 +120,19 @@ class _FeedbackReasonDialogState extends State<FeedbackReasonDialog> {
       sent = false;
     }
     if (!mounted) return;
-    // `mounted` does not say this route is still the one on top: the platform
-    // back button pops a non-dismissible dialog, and this State stays mounted
-    // for the whole pop transition, so popping again would take the screen
-    // underneath with it.
     if (sent) {
-      if (ModalRoute.of(context)?.isCurrent ?? false) {
+      // Close by identity, not by position. `mounted` does not say this route
+      // is still on top: the platform back button pops a non-dismissible
+      // dialog and this State stays mounted for the whole pop transition, so
+      // `pop()` would take the screen underneath with it — and a route pushed
+      // *over* this one reaches here too, where leaving the dialog behind
+      // would show the user an unsent-looking dialog for a note already filed.
+      final route = ModalRoute.of(context);
+      if (route == null) return;
+      if (route.isCurrent) {
         Navigator.of(context).pop();
+      } else if (route.isActive) {
+        Navigator.of(context).removeRoute(route);
       }
       return;
     }
@@ -157,8 +171,12 @@ class _FeedbackReasonDialogState extends State<FeedbackReasonDialog> {
       ),
       actions: [
         SoliplexButton.text(
-          onPressed: _isSubmitting ? null : () => Navigator.of(context).pop(),
-          child: const Text('Cancel'),
+          // Never disabled: the barrier is not dismissible and the send has no
+          // deadline short enough to wait out, so this is the only way off a
+          // request that hangs. It says Close rather than Cancel because a
+          // send already dispatched keeps going — nothing here can recall it.
+          onPressed: () => Navigator.of(context).pop(),
+          child: const Text('Close'),
         ),
         SoliplexButton.filled(
           onPressed: _isLoading || _isSubmitting ? null : _submit,

--- a/packages/soliplex_client/lib/src/api/soliplex_api.dart
+++ b/packages/soliplex_client/lib/src/api/soliplex_api.dart
@@ -704,6 +704,14 @@ class SoliplexApi {
   // Feedback
   // ============================================================
 
+  /// How long [getRunFeedback] waits before reporting the note unreadable.
+  ///
+  /// It bounds the request only once it holds a concurrency slot, and applies
+  /// per phase — connect, then body — and again on the retry after a token
+  /// refresh. So it shortens the common slow answer; it is not a ceiling on
+  /// the caller's total wait.
+  static const Duration _feedbackReadTimeout = Duration(seconds: 15);
+
   /// Fetches the feedback record on file for a run.
   ///
   /// Parameters:
@@ -723,7 +731,8 @@ class SoliplexApi {
   /// - [AuthException] if not authenticated (401)
   /// - [PermissionDeniedException] if authenticated but not permitted (403)
   /// - [NotFoundException] if the room, thread or run is unknown (404)
-  /// - [NetworkException] if connection fails
+  /// - [NetworkException] if connection fails, including on
+  ///   [_feedbackReadTimeout]
   /// - [MalformedResponseException] if the body is not a feedback record
   /// - [ApiException] for other server errors
   /// - [CancelledException] if cancelled via [cancelToken]
@@ -743,6 +752,12 @@ class SoliplexApi {
         pathSegments: ['rooms', roomId, 'agui', threadId, runId, 'feedback'],
       ),
       cancelToken: cancelToken,
+      // Far below the transport default: this read gates a modal, and a caller
+      // waiting on it can offer nothing but a spinner. Failing is recoverable —
+      // the caller reports the note as unread — so a shorter wait is the safer
+      // trade here. The write keeps the default, since a POST that timed out
+      // may still have landed.
+      timeout: _feedbackReadTimeout,
       fromJson: runFeedbackFromJson,
     );
   }

--- a/packages/soliplex_client/lib/src/application/no_response_synthesis.dart
+++ b/packages/soliplex_client/lib/src/application/no_response_synthesis.dart
@@ -48,6 +48,7 @@ NoResponseSynthesisResult synthesizeFinishedNoResponse({
       conversation: conversation,
       streaming: streaming,
       runId: runId,
+      preserveWhateverWasShown: false,
       buildTile: (id, thinking) => NoResponseTile.finished(
         id: id,
         thinkingText: thinking,
@@ -70,6 +71,7 @@ NoResponseSynthesisResult synthesizeFailedNoResponse({
       conversation: conversation,
       streaming: streaming,
       runId: runId,
+      preserveWhateverWasShown: false,
       buildTile: (id, thinking) => NoResponseTile.failed(
         id: id,
         thinkingText: thinking,
@@ -78,8 +80,9 @@ NoResponseSynthesisResult synthesizeFailedNoResponse({
       ),
     );
 
-/// Appends a synthesized [NoResponseTile.cancelled] when a run was
-/// cancelled with buffered thinking but no assistant text reply.
+/// Appends a synthesized [NoResponseTile.cancelled] when a run was cancelled
+/// after thinking began — buffered or merely streaming — with no assistant
+/// text reply.
 NoResponseSynthesisResult synthesizeCancelledNoResponse({
   required Conversation conversation,
   required StreamingState streaming,
@@ -90,6 +93,10 @@ NoResponseSynthesisResult synthesizeCancelledNoResponse({
       conversation: conversation,
       streaming: streaming,
       runId: runId,
+      // Whatever the user was already looking at has to outlive the Stop —
+      // a Thinking indicator with no content yet, or thinking beside a tool
+      // call still in flight. Declining either blanks the exchange.
+      preserveWhateverWasShown: true,
       buildTile: (id, thinking) => NoResponseTile.cancelled(
         id: id,
         thinkingText: thinking,
@@ -99,21 +106,40 @@ NoResponseSynthesisResult synthesizeCancelledNoResponse({
 
 /// Shared decline gate for the three terminal entries.
 ///
-/// Declines (returning the input conversation and `synthesized: false`) when:
-/// - [streaming] is not [AwaitingText] (a reply was in progress).
-/// - The buffered thinking text is empty (no model output to preserve).
-/// - The conversation has any tool call with status `pending`, `streaming`,
-///   or `executing` (the run is yielding to client tools — the tool call
-///   IS the response, not a missing one).
+/// Always declines when [streaming] is not [AwaitingText]: a reply was in
+/// progress, and the caller commits that partial text instead.
+///
+/// [preserveWhateverWasShown] then chooses between two policies.
+///
+/// A cancel sets it. The user stopped a run they were watching, so anything
+/// already on screen has to survive, and only the streaming state holds it —
+/// the tile is what carries it afterwards. That includes the window after the
+/// reasoning-start event but before its first content, which
+/// [AwaitingText.hasThinkingContent] covers and an empty buffer does not, and
+/// it includes a tool call still in flight.
+///
+/// The two backend outcomes clear it. They require real thinking text, since a
+/// run that emitted nothing has no missing reply to report, and they decline
+/// while any tool call is `pending`, `streaming` or `executing`, because there
+/// the run is yielding to client tools and the tool call IS the response. That
+/// yield never reaches the cancel path: `cancelRun` handles
+/// `ToolYieldingState` in its own branch, so an unresolved tool call seen here
+/// after a cancel is a backend call mid-flight, which shows the user nothing.
 NoResponseSynthesisResult _synthesize({
   required Conversation conversation,
   required StreamingState streaming,
   required String runId,
+  required bool preserveWhateverWasShown,
   required NoResponseTile Function(String id, String thinkingText) buildTile,
 }) {
-  if (streaming is! AwaitingText ||
-      streaming.bufferedThinkingText.isEmpty ||
-      _hasUnresolvedToolCalls(conversation)) {
+  if (streaming is! AwaitingText) {
+    return (conversation: conversation, synthesized: false);
+  }
+  final synthesize = preserveWhateverWasShown
+      ? streaming.hasThinkingContent
+      : streaming.bufferedThinkingText.isNotEmpty &&
+          !_hasUnresolvedToolCalls(conversation);
+  if (!synthesize) {
     return (conversation: conversation, synthesized: false);
   }
   final tile = buildTile(

--- a/packages/soliplex_client/test/api/soliplex_api_test.dart
+++ b/packages/soliplex_client/test/api/soliplex_api_test.dart
@@ -6141,6 +6141,7 @@ void main() {
       late SoliplexApi liveApi;
       String? capturedMethod;
       Uri? capturedUri;
+      Duration? capturedTimeout;
 
       setUp(() {
         mockClient = MockSoliplexHttpClient();
@@ -6151,6 +6152,7 @@ void main() {
         when(() => mockClient.close()).thenReturn(null);
         capturedMethod = null;
         capturedUri = null;
+        capturedTimeout = null;
       });
 
       tearDown(() {
@@ -6174,6 +6176,7 @@ void main() {
         ).thenAnswer((invocation) async {
           capturedMethod = invocation.positionalArguments[0] as String;
           capturedUri = invocation.positionalArguments[1] as Uri;
+          capturedTimeout = invocation.namedArguments[#timeout] as Duration?;
           return HttpResponse(
             statusCode: 200,
             bodyBytes: Uint8List.fromList(utf8.encode(body)),
@@ -6210,6 +6213,17 @@ void main() {
           await liveApi.getRunFeedback('room-123', 'thread-456', 'run-789'),
           isNull,
         );
+      });
+
+      test('bounds the read well below the transport default', () async {
+        // This read gates a modal, so the caller can offer nothing but a
+        // spinner while it runs. Failing is recoverable — the caller reports
+        // the note as unread — where waiting out the 600s default is not.
+        answerWithJson('null');
+
+        await liveApi.getRunFeedback('room-123', 'thread-456', 'run-789');
+
+        expect(capturedTimeout, const Duration(seconds: 15));
       });
 
       test('validates non-empty runId', () {

--- a/packages/soliplex_client/test/application/no_response_synthesis_test.dart
+++ b/packages/soliplex_client/test/application/no_response_synthesis_test.dart
@@ -173,7 +173,72 @@ void main() {
         expect(result.synthesized, isTrue);
         final tile = result.conversation.messages.last as NoResponseTile;
         expect(tile.reason, equals(TerminalReason.cancelled));
+        // Buffered thinking is the only thing a cancelled run produced, so the
+        // tile is what carries it — the streaming buffer is reset behind it.
+        expect(tile.thinkingText, equals('partial'));
         expect(tile.errorDetail, isNull);
+      });
+
+      test(
+          'synthesizeCancelledNoResponse appends a tile once thinking is '
+          'streaming, before any content arrives', () {
+        // The UI shows a Thinking indicator from the reasoning-start event, so
+        // a Stop pressed before the first content event must still leave an
+        // account of the run. Declining here blanks the whole exchange: the
+        // buffered thinking is what the tile would have carried, and without a
+        // tile there is nothing else holding it.
+        final result = synthesizeCancelledNoResponse(
+          conversation: conversation,
+          streaming: const AwaitingText(isThinkingStreaming: true),
+          runId: 'run-42',
+        );
+
+        expect(result.synthesized, isTrue);
+        final tile = result.conversation.messages.last as NoResponseTile;
+        expect(tile.reason, equals(TerminalReason.cancelled));
+        expect(tile.hasThinkingText, isFalse);
+      });
+
+      test(
+          'synthesizeCancelledNoResponse appends a tile with a tool call still '
+          'open', () {
+        // A cancel taken while a backend tool call is in flight still has
+        // thinking the user was reading, and nothing else keeps it: the
+        // tool-call guard exists for a client-side yield, where the tool card
+        // is the response — and that path never reaches here, because
+        // cancelRun handles ToolYieldingState in its own branch.
+        final convo = conversation.withToolCall(
+          const ToolCallInfo(id: 'tc1', name: 'search'),
+        );
+
+        final result = synthesizeCancelledNoResponse(
+          conversation: convo,
+          streaming: const AwaitingText(bufferedThinkingText: 'I considered'),
+          runId: 'run-42',
+        );
+
+        expect(result.synthesized, isTrue);
+        final tile = result.conversation.messages.last as NoResponseTile;
+        expect(tile.reason, equals(TerminalReason.cancelled));
+        expect(tile.thinkingText, equals('I considered'));
+      });
+
+      test(
+          'synthesizeCancelledNoResponse still declines before thinking '
+          'starts', () {
+        // Nothing has been shown yet, so there is nothing to preserve and the
+        // user knows they pressed Stop.
+        final result = synthesizeCancelledNoResponse(
+          conversation: conversation,
+          streaming: const AwaitingText(),
+          runId: 'run-42',
+        );
+
+        expect(result.synthesized, isFalse);
+        expect(
+          result.conversation.messages.whereType<NoResponseTile>(),
+          isEmpty,
+        );
       });
     });
   });

--- a/test/modules/room/run_registry_test.dart
+++ b/test/modules/room/run_registry_test.dart
@@ -10,6 +10,7 @@ import 'package:soliplex_frontend/src/modules/auth/auth_tokens.dart';
 import 'package:soliplex_frontend/src/modules/auth/server_entry.dart';
 import 'package:soliplex_frontend/src/modules/room/agent_runtime_manager.dart';
 import 'package:soliplex_frontend/src/modules/room/run_registry.dart';
+import 'package:soliplex_frontend/version.dart';
 
 import '../../helpers/fakes.dart';
 
@@ -354,8 +355,9 @@ void main() {
       ManualAgentSession session, {
       required FailureReason reason,
       String? runId,
+      String error = 'boom',
     }) async {
-      session.completeAsFailed(reason: reason, runId: runId);
+      session.completeAsFailed(reason: reason, runId: runId, error: error);
       await Future<void>.delayed(Duration.zero);
     }
 
@@ -377,10 +379,10 @@ void main() {
     });
 
     // Every whitelisted reason, so dropping any one of them fails here.
-    const filedReasons = {
-      FailureReason.serverError: '[auto] Run failed: server error',
+    final filedReasons = {
+      FailureReason.serverError: '[auto] serverError — boom, v$soliplexVersion',
       FailureReason.toolExecutionFailed:
-          '[auto] Run failed: tool execution failed',
+          '[auto] toolExecutionFailed — boom, v$soliplexVersion',
     };
     for (final entry in filedReasons.entries) {
       test('names ${entry.key.name} in the reason it files', () async {
@@ -392,6 +394,66 @@ void main() {
         expect(serverApi.submittedFeedback.single.reason, entry.value);
       });
     }
+
+    test('leads with the backend message, since that is what differs',
+        () async {
+      // Every auto-filed row carries the same classification in practice, so a
+      // triager scanning the queue needs the server's own words first.
+      final session = ManualAgentSession(_key);
+      filing.register(_key, session);
+
+      await fail(
+        session,
+        reason: FailureReason.serverError,
+        runId: 'run-1',
+        error: 'upstream model returned 503',
+      );
+
+      expect(
+        serverApi.submittedFeedback.single.reason,
+        '[auto] serverError — upstream model returned 503, v$soliplexVersion',
+      );
+    });
+
+    test('collapses and caps a sprawling server message', () async {
+      // The record is prefilled into a dialog the user edits, so an error that
+      // is really a response body must not run away with the field.
+      final session = ManualAgentSession(_key);
+      filing.register(_key, session);
+
+      await fail(
+        session,
+        reason: FailureReason.serverError,
+        runId: 'run-1',
+        error: 'Traceback\n\n   most recent call last${'x' * 400}',
+      );
+
+      final reason = serverApi.submittedFeedback.single.reason!;
+      expect(
+        reason,
+        startsWith('[auto] serverError — Traceback most recent call last'),
+      );
+      expect(reason, contains('…'));
+      expect(reason, endsWith('v$soliplexVersion'));
+      expect(reason.length, lessThan(280));
+    });
+
+    test('says only the classification when the run gave no message', () async {
+      final session = ManualAgentSession(_key);
+      filing.register(_key, session);
+
+      await fail(
+        session,
+        reason: FailureReason.serverError,
+        runId: 'run-1',
+        error: '   ',
+      );
+
+      expect(
+        serverApi.submittedFeedback.single.reason,
+        '[auto] serverError, v$soliplexVersion',
+      );
+    });
 
     test('files nothing for a failure that never started a run', () async {
       final session = ManualAgentSession(_key);

--- a/test/modules/room/ui/feedback_buttons_test.dart
+++ b/test/modules/room/ui/feedback_buttons_test.dart
@@ -167,7 +167,7 @@ void main() {
         (tester) async {
       final submitted = await openDialog(tester);
 
-      await tester.tap(find.text('Cancel'));
+      await tester.tap(find.text('Close'));
       // Bounded pumps: pumpAndSettle would run the resumed countdown to
       // completion and submit, which is the behaviour under test.
       await tester.pump();
@@ -180,7 +180,7 @@ void main() {
       expect(submitted, [(FeedbackType.thumbsDown, null)]);
     });
 
-    testWidgets('a send after the tile is gone refuses instead of throwing',
+    testWidgets('a send after the tile is gone closes instead of throwing',
         (tester) async {
       // The tile lives in a sliver, so it can be destroyed while the modal is
       // still up. Submitting then reaches setState on a defunct State, which
@@ -223,15 +223,19 @@ void main() {
       await tester.pump();
 
       expect(tester.takeException(), isNull);
+      await tester.pumpAndSettle();
+      // Closed, not held open inviting a retry: mounted does not come back, so
+      // every retry would fail identically.
+      expect(find.text('Tell us why'), findsNothing);
       expect(
         sink.records.where((r) => r.level >= LogLevel.error),
         isEmpty,
         reason: 'An expected teardown must not be logged as a caller defect.',
       );
       // dispose already submitted for the pending direction; the reason typed
-      // after teardown cannot be delivered, and the dialog says so.
+      // after teardown cannot be delivered and is discarded silently, which is
+      // the honest end — there is no retry that could deliver it.
       expect(submitted, [(FeedbackType.thumbsDown, null)]);
-      expect(find.text("Couldn't send that. Try again."), findsOneWidget);
     });
   });
 }

--- a/test/modules/room/ui/feedback_reason_dialog_test.dart
+++ b/test/modules/room/ui/feedback_reason_dialog_test.dart
@@ -53,6 +53,33 @@ void main() {
     expect(find.text('Send'), findsOneWidget);
   });
 
+  group('width', () {
+    // The field states no intrinsic width preference, so without a width the
+    // dialog sits at Material's 280 minimum however wide the window is.
+    testWidgets('uses the dialog width on a wide window', (tester) async {
+      tester.view.physicalSize = const Size(1600, 1200);
+      tester.view.devicePixelRatio = 1;
+      addTearDown(tester.view.reset);
+
+      await _open(tester);
+
+      expect(tester.getSize(find.byType(TextField)).width, greaterThan(400));
+    });
+
+    testWidgets('stays inside a narrow window', (tester) async {
+      // A fixed width must still yield to the incoming constraints, or the
+      // dialog overflows the screen on a phone.
+      tester.view.physicalSize = const Size(360, 800);
+      tester.view.devicePixelRatio = 1;
+      addTearDown(tester.view.reset);
+
+      await _open(tester);
+
+      expect(tester.getSize(find.byType(TextField)).width, lessThan(360));
+      expect(tester.takeException(), isNull);
+    });
+  });
+
   testWidgets('Send submits the typed text and closes', (tester) async {
     final submitted = await _open(tester);
 

--- a/test/modules/room/ui/feedback_reason_dialog_test.dart
+++ b/test/modules/room/ui/feedback_reason_dialog_test.dart
@@ -40,6 +40,9 @@ Future<List<String>> _open(
   return submitted;
 }
 
+const _unreadableNote = "Couldn't check for an earlier note. "
+    'Submitting replaces any that exists.';
+
 void main() {
   testWidgets('renders the prompt, the hint and both actions', (tester) async {
     await _open(tester);
@@ -127,19 +130,33 @@ void main() {
         loadInitialText: () async => throw Exception('offline'),
       );
 
-      expect(
-        find.text(
-          'Couldn\'t check for an earlier note. '
-          'Submitting replaces any that exists.',
-        ),
-        findsOneWidget,
-      );
+      expect(find.text(_unreadableNote), findsOneWidget);
 
       await tester.enterText(find.byType(TextField), 'still worth saying');
       await tester.tap(find.text('Send'));
       await tester.pumpAndSettle();
 
       expect(submitted, ['still worth saying']);
+    });
+
+    testWidgets('shows the warning outside the input, uncapped',
+        (tester) async {
+      // As the input's helperText the warning is clamped to two lines and
+      // ellipsized, which drops the clause naming what a submit replaces —
+      // and the error text displaces it entirely. Neither is survivable in a
+      // slot the input owns.
+      await _open(
+        tester,
+        loadInitialText: () async => throw Exception('offline'),
+      );
+
+      expect(
+        find.descendant(
+          of: find.byType(TextField),
+          matching: find.text(_unreadableNote),
+        ),
+        findsNothing,
+      );
     });
   });
 
@@ -155,6 +172,25 @@ void main() {
       expect(find.text('Tell us why'), findsOneWidget);
       expect(find.text('worth keeping'), findsOneWidget);
       expect(find.text('Couldn\'t send that. Try again.'), findsOneWidget);
+    });
+
+    testWidgets('keeps the unreadable-note warning through a failed send',
+        (tester) async {
+      // A failed send is when the user is most likely to press Send again, so
+      // it is exactly when the warning that a submit replaces whatever is on
+      // file matters most. The error must not take its place.
+      await _open(
+        tester,
+        loadInitialText: () async => throw Exception('offline'),
+        onSubmit: (_) async => false,
+      );
+
+      await tester.enterText(find.byType(TextField), 'worth keeping');
+      await tester.tap(find.text('Send'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Couldn\'t send that. Try again.'), findsOneWidget);
+      expect(find.text(_unreadableNote), findsOneWidget);
     });
 
     testWidgets('a retry after a failure can succeed', (tester) async {

--- a/test/modules/room/ui/feedback_reason_dialog_test.dart
+++ b/test/modules/room/ui/feedback_reason_dialog_test.dart
@@ -46,7 +46,7 @@ void main() {
 
     expect(find.text('Tell us why'), findsOneWidget);
     expect(find.text('Add a reason (optional)'), findsOneWidget);
-    expect(find.text('Cancel'), findsOneWidget);
+    expect(find.text('Close'), findsOneWidget);
     expect(find.text('Send'), findsOneWidget);
   });
 
@@ -65,7 +65,7 @@ void main() {
     final submitted = await _open(tester);
 
     await tester.enterText(find.byType(TextField), 'never mind');
-    await tester.tap(find.text('Cancel'));
+    await tester.tap(find.text('Close'));
     await tester.pumpAndSettle();
 
     expect(submitted, isEmpty);
@@ -104,6 +104,18 @@ void main() {
       await tester.tap(find.text('Send'));
       await tester.pumpAndSettle();
       expect(submitted, ['on file']);
+    });
+
+    testWidgets('puts the cursor in the field once the note is loaded',
+        (tester) async {
+      // The field is disabled while loading, so autofocus is dropped and the
+      // node refuses focus until the rebuild re-enables it. Without a cursor
+      // the user has to tap before they can extend the note, which is the
+      // whole point of this entry point.
+      await _open(tester, loadInitialText: () async => 'on file');
+
+      final field = tester.widget<TextField>(find.byType(TextField));
+      expect(field.focusNode?.hasFocus, isTrue);
     });
 
     testWidgets('says so when it could not be read, and still submits',
@@ -159,6 +171,76 @@ void main() {
       await tester.pumpAndSettle();
 
       expect(submitted, ['worth keeping', 'worth keeping']);
+      expect(find.text('Tell us why'), findsNothing);
+    });
+
+    testWidgets('stays escapable while the send is in flight', (tester) async {
+      // The barrier is not dismissible and the request has no deadline short
+      // enough to wait out, so a disabled Cancel would be the only way out of
+      // a hung send — on iOS there is no back button to fall back on.
+      final gate = Completer<bool>();
+      await _open(tester, onSubmit: (_) => gate.future);
+
+      await tester.enterText(find.byType(TextField), 'worth keeping');
+      await tester.tap(find.text('Send'));
+      await tester.pump();
+
+      await tester.tap(find.text('Close'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Tell us why'), findsNothing);
+      gate.complete(true);
+      await tester.pumpAndSettle();
+    });
+
+    testWidgets('closes even when a route covered it mid-send', (tester) async {
+      // A route pushed over the dialog (the inactivity warning does this on a
+      // timer) means the send resolves while this is not the current route.
+      // Without releasing the flag the dialog is left with every control
+      // disabled once that route goes.
+      final gate = Completer<bool>();
+      final navigatorKey = GlobalKey<NavigatorState>();
+      await tester.pumpWidget(MaterialApp(
+        navigatorKey: navigatorKey,
+        home: Scaffold(
+          body: Builder(
+            builder: (context) => ElevatedButton(
+              onPressed: () => showDialog<void>(
+                context: context,
+                barrierDismissible: false,
+                builder: (_) => FeedbackReasonDialog(
+                  onSubmit: (_) => gate.future,
+                ),
+              ),
+              child: const Text('Open'),
+            ),
+          ),
+        ),
+      ));
+      await tester.tap(find.text('Open'));
+      await tester.pumpAndSettle();
+      await tester.enterText(find.byType(TextField), 'covered');
+      await tester.tap(find.text('Send'));
+      await tester.pump();
+
+      navigatorKey.currentState!.push(
+        DialogRoute<void>(
+          context: navigatorKey.currentContext!,
+          builder: (_) => const AlertDialog(title: Text('On top')),
+        ),
+      );
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 400));
+
+      gate.complete(true);
+      await tester.pump();
+
+      navigatorKey.currentState!.pop();
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 400));
+
+      // Gone, not left looking unsent: the note is on file, so a dialog still
+      // showing the typed text would invite the user to conclude it never went.
       expect(find.text('Tell us why'), findsNothing);
     });
 


### PR DESCRIPTION
# Summary

Fixes found by manually testing the auto-filed run feedback end to end, plus one
improvement to what the auto-filed record says. 29 of 39 planned cases passed;
the 10 blocked are blocked by the test environment, not the feature.

## Changes

- The warning that submitting replaces an existing note was clipped at two
  lines, dropping the clause naming what gets replaced, and a failed send
  displaced it entirely — at the moment a retry makes it matter most. It now
  lives in the dialog content rather than the input's `helperText`, which is
  capped at two lines and is rendered *in place of* by `errorText`.
- The dialog collapsed to Material's 280 px minimum at any window size, because
  neither a text field nor the content states an intrinsic width preference.
- Stopping a run while it was still thinking could blank the exchange
  completely — no tile, no reasoning, no error row — when the stop landed before
  the first reasoning content event, or while a tool call was still in flight.
  The only copy of what was on screen lived in streaming state that the stop
  discarded. A cancel now keeps whatever had been shown, and still records
  nothing when nothing had been.
- An auto-filed record read `[auto] Run failed: server error` for every
  failure, dropping the one part that distinguishes two runs of the same class.
  It now names the classification, the run's own error text, and the client
  version.

## Test Plan

- [x] Tests pass locally: app 2493, `soliplex_client` 1672, `soliplex_agent` 514
- [x] `flutter analyze` and `dart analyze --fatal-infos` clean
- [x] Manual testing completed — each fix confirmed in the running macOS app
      against a live backend, with the before/after window timed from the
      backend's stored run events

## Notes for review

Two behaviours were deliberately left alone after weighing them:

- A cancel is client-side only, so the backend runs to completion and a restart
  replays its outcome. A cancelled run whose server side also failed therefore
  returns as a failed tile offering to report it.
- Reopening a submitted thumbs-up/down to amend its reason stays unsupported.
  An implementation was written and reverted: every version either could not
  show what it was about to replace, or added a round trip and a new failure
  mode to a one-tap interaction.

Not fixed here, and not frontend work: the backend answers 500 rather than null
for a run with no feedback record, and its feedback upsert has no unique
constraint on the run, so two overlapping writes duplicate the row and later
reads silently return the wrong one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)