### PR TITLE
chore: version 0.102.0+85

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 Versions follow the `version+build` scheme from `pubspec.yaml`, bumped via
 `dart run tool/bump_version.dart`.
 
-## [Unreleased]
+## [0.102.0+85] - 2026-08-28
 
 ### Added
 

--- a/lib/version.dart
+++ b/lib/version.dart
@@ -2,4 +2,4 @@
 ///
 /// Generated from pubspec.yaml. Run `dart run tool/update_version.dart` after
 /// changing the version in pubspec.yaml.
-const String soliplexVersion = '0.101.0+84';
+const String soliplexVersion = '0.102.0+85';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,7 +3,7 @@ description: Modular Flutter frontend framework for Soliplex
 publish_to: none
 # To update version, run:
 # dart run tool/bump_version.dart <major|minor|patch|build>
-version: 0.101.0+84
+version: 0.102.0+85
 
 environment:
   sdk: ^3.6.0


### PR DESCRIPTION
Version bump to `0.102.0+85` (minor).

- `pubspec.yaml` / `lib/version.dart` bumped via `dart run tool/bump_version.dart minor`
- `CHANGELOG.md`: `[Unreleased]` section closed as `[0.102.0+85] - 2026-08-28`

🤖 Generated with [Claude Code](https://claude.com/claude-code)